### PR TITLE
Added support for batch_size > 1 in bilinear upsample

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -344,6 +344,9 @@ def test_upsample_multicore_corerange(
         (1, 1024, 8, 8, 2, 2),
         (1, 256, 28, 28, 2, 2),
         (1, 512, 14, 14, 2, 2),
+        (2, 32, 16, 16, 2, 2),
+        (4, 64, 48, 48, 3, 3),
+        (64, 32, 4, 4, 2, 2),
     ),
 )
 @pytest.mark.parametrize("shard_strategy", [ttnn.ShardStrategy.HEIGHT])

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -68,7 +68,11 @@ void kernel_main() {
         nsticks_to_process_on_core =
             (total_nsticks_to_process % 2) ? nsticks_to_process_on_core - 1 : nsticks_to_process_on_core;
     }
-    int32_t accumulated_offset = 0;
+    int32_t accumulated_offset = 0;  // offset used to calculate the position of row in batch
+                                     // every time we encounter a boundary between images, it is increased by
+                                     // in_h (corresponding to height of a single batch) +
+                                     // 2 (corresponding to the 2 skipped padding rows)
+
     for (uint32_t image_row = 0; image_row < in_image_rows_per_core * scale_h; ++image_row) {
         x_coordinate = x_starting_coordinate;
 
@@ -78,7 +82,7 @@ void kernel_main() {
         uint32_t y1 = int(y_coordinate);
         uint32_t y2 = y1 + 1;
 
-        // These two variables represent the indecies of the rows referenced by y1 and y2
+        // These two variables represent the indices of the rows referenced by y1 and y2
         // In the according batch in the input image
         // Value of -1 for either of these corresponds to the top padding row,
         // And value of in_h corresponds to the bottom padding row

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -92,7 +92,7 @@ void kernel_main() {
             dy = 1;
         }
 
-        if (in_batch_index_y2 == int(in_h)) {  // change later to not check with modulus
+        if (in_batch_index_y2 == int(in_h)) {
             // This would would mean that in_batch_index_y2 (the "lower row") corresponds to a padding row(specifically
             // the bottom padding row)
             if (dy > 0.5) {  // Due to math behind bilinear upsampling, dy could never be exactly 0.5, so this check

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -5,7 +5,6 @@
 // #include "dataflow_api.h"
 #include <algorithm>
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
-#include "debug/dprint.h"
 
 #define ALWI inline __attribute__((always_inline))
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// #include "dataflow_api.h"
-#include <algorithm>
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 #define ALWI inline __attribute__((always_inline))
@@ -40,8 +38,8 @@ void kernel_main() {
     // constexpr uint32_t is_reader = get_compile_time_arg_val(2);
     constexpr uint32_t scale_h_inv_comp = get_compile_time_arg_val(3);
     constexpr uint32_t scale_w_inv_comp = get_compile_time_arg_val(4);
-    constexpr uint32_t y_index_comp = get_compile_time_arg_val(5);
-    constexpr uint32_t x_index_compute_comp = get_compile_time_arg_val(6);
+    constexpr uint32_t y_starting_coordinate_u32 = get_compile_time_arg_val(5);
+    constexpr uint32_t x_starting_coordinate_u32 = get_compile_time_arg_val(6);
     constexpr uint32_t is_reader = get_compile_time_arg_val(7);
     constexpr uint32_t blocks = get_compile_time_arg_val(8);
     constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(9);
@@ -54,60 +52,77 @@ void kernel_main() {
     // assuming shard begins with a new row. TODO: generalize?
     float scale_h_inv = uint32_to_float(scale_h_inv_comp);
     float scale_w_inv = uint32_to_float(scale_w_inv_comp);
-    float x, x_index, y_index, dx, dy;
-    y_index = uint32_to_float(y_index_comp);
-    float x_index_compute = uint32_to_float(x_index_compute_comp);
+    float y_coordinate,
+        x_coordinate;  // x and y coordinate of the output pixel, as if it had existed in the input image
+    float x;           // helper variable to avoid out of bound reads in the x direction
+    float dx,
+        dy;  // distance between the output pixel and its closest pixel with lower coordinates (up and to the left)
+    y_coordinate = uint32_to_float(y_starting_coordinate_u32);
+    float x_starting_coordinate = uint32_to_float(x_starting_coordinate_u32);
 
-    // If the current core is a writer core, adjust the x_index_compute to start from the correct position.
+    // If the current core is a writer core, adjust the x_starting_coordinate to start from the correct position.
 
     if (!is_reader) {
-        x_index_compute += scale_w_inv;
+        x_starting_coordinate += scale_w_inv;
         // If the total number of sticks is odd, process one less stick.
         nsticks_to_process_on_core =
             (total_nsticks_to_process % 2) ? nsticks_to_process_on_core - 1 : nsticks_to_process_on_core;
     }
     int32_t accumulated_offset = 0;
     for (uint32_t image_row = 0; image_row < in_image_rows_per_core * scale_h; ++image_row) {
-        x_index = x_index_compute;
+        x_coordinate = x_starting_coordinate;
 
-        uint32_t y1 = int(y_index);
+        // These variables are for referencing the appropriate input rows, specifically
+        // Their coordinates in the halo shard
+
+        uint32_t y1 = int(y_coordinate);
         uint32_t y2 = y1 + 1;
 
-        // After haloing, the last row from the previous core (or a padding row)
-        // Gets inserted into as the first (index 0) row for the current core
-        // So the start_input_row_in_image_id corresponds to the row with index 1
-        // for the current core
+        // These two variables represent the indecies of the rows referenced by y1 and y2
+        // In the according batch in the input image
+        // Value of -1 for either of these corresponds to the top padding row,
+        // And value of in_h corresponds to the bottom padding row
 
         int32_t in_batch_index_y1 = int32_t(y1) - 1 + start_input_row_in_image_id - accumulated_offset;
         int32_t in_batch_index_y2 = int32_t(y2) - 1 + start_input_row_in_image_id - accumulated_offset;
 
-        dy = y_index - y1;
+        dy = y_coordinate - y1;
 
         // In no circumstance should the padding rows have weights greater than 0.5
 
         if (in_batch_index_y1 == -1) {
-            // This would mean that in_batch_index_y1 (the "upper" row) corresponds to a padding row (specifically the
-            // top padding row) Reduce the padding row's weight to 0 and put full weight on the row below it
+            // This case handles the error on the top border of the image, where the top padding row could be wrongly
+            // included
+
+            // Entering this case means that in_batch_index_y1 (the "upper" row) corresponds to a padding row
+            // (specifically the top padding row) Reduce the padding row's weight to 0 and put full weight on the row
+            // below it
             dy = 1;
         }
 
         if (in_batch_index_y2 == int(in_h)) {
-            // This would would mean that in_batch_index_y2 (the "lower row") corresponds to a padding row(specifically
-            // the bottom padding row)
+            // This case handles the error on the bottom border of the image, where the bottom padding could be wrongly
+            // included
+
+            // Entering this case means that in_batch_index_y2 (the "lower row") corresponds to a padding
+            // row(specifically the bottom padding row)
+
             if (dy > 0.5) {  // Due to math behind bilinear upsampling, dy could never be exactly 0.5, so this check
                              // should be numerically safe
+
                 // In this case, a padding row has weight higher than 0.5.
-                // This means we have to skip the next 2 rows (lower padding of current image and upper padding of
-                // previous image) The iteration that enters this case outputs the first row of a new image
+                // This means we  are actually done with the current batch,
+                // and have to skip the next 2 rows (lower padding of current image and upper padding of
+                // previous image) The iteration that enters this case outputs the first row of the next batch
                 y1 += 2;
                 y2 += 2;
-                y_index += 2;
+                y_coordinate += 2;
                 dy = 1;
                 accumulated_offset += 2 + in_h;
             } else {
-                // In this case, a padding row has weight lower than 0.5
-                // We should do no skipping, but just set weight to 0 for this row
-                // The iteration that enters this case outputs the final few rows of the image
+                // In this case, we handle the rows on the bottom border of the image
+
+                // We should do no skipping, but just set weight to 0 for the padding row (y2)
                 dy = 0;
             }
         }
@@ -116,10 +131,10 @@ void kernel_main() {
                 cb_reserve_back(out_cb_id, 4);
                 cb_reserve_back(in_scalar_cb_id, 1);
 
-                x = x_index < 0 ? 0 : x_index;
+                x = x_coordinate < 0 ? 0 : x_coordinate;
                 dx = x - int(x);
                 uint32_t x1 = int(x);
-                uint32_t x2 = std::min(x1 + 1, in_w - 1);
+                uint32_t x2 = (x1 + 1) < (in_w - 1) ? (x1 + 1) : (in_w - 1);
 
                 fill_four_val(
                     get_write_ptr(in_scalar_cb_id),
@@ -162,8 +177,8 @@ void kernel_main() {
                 cb_push_back(out_cb_id, 4);
                 cb_push_back(in_scalar_cb_id, 1);
             }
-            x_index += scale_w_inv * 2;
+            x_coordinate += scale_w_inv * 2;
         }
-        y_index += scale_h_inv;
+        y_coordinate += scale_h_inv;
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <string>
-
 #include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/circular_buffer_config.hpp"
 #include "upsample_op.hpp"

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -290,8 +290,11 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
 
     auto compute_kernel = CreateKernel(program, compute_kernel_fname, all_cores, compute_config);
 
+    uint32_t batch_size = input.padded_shape()[0];
+    uint32_t in_h = input.padded_shape()[1];
+
     // runtime args
-    uint32_t reader_nargs = 10;
+    uint32_t reader_nargs = 8;
     std::vector<uint32_t> reader_rt_args(reader_nargs);
     reader_rt_args[0] = input_stick_nbytes;
     reader_rt_args[1] = input_nsticks_per_core / in_w;
@@ -299,19 +302,20 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     reader_rt_args[3] = scale_factor_w;
     reader_rt_args[4] = in_w;
     reader_rt_args[5] = out_w;
-    reader_rt_args[6] = 0;  // set for each core below
+    reader_rt_args[7] = in_h;
 
-    uint32_t start_input_stick_id = 0;
+    uint32_t num_rows_per_core = div_up(batch_size * in_h, ncores_nhw);
+
+    uint32_t start_input_row_in_image_id = 0;
 
     if (input.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
         for (int32_t core = 0; core < ncores_nhw; ++core) {
             CoreCoord core_coord(core % ncores_x, core / ncores_x);  // logical
-            reader_rt_args[6] = start_input_stick_id;
-            reader_rt_args[8] = (core == 0) ? 1 : 0;
-            reader_rt_args[9] = (core == ncores_nhw - 1) ? 1 : 0;
+            reader_rt_args[6] = start_input_row_in_image_id;
             SetRuntimeArgs(program, reader_kernel, core_coord, reader_rt_args);
             SetRuntimeArgs(program, writer_kernel, core_coord, reader_rt_args);
-            start_input_stick_id += input_nsticks_per_core;
+            start_input_row_in_image_id += num_rows_per_core;
+            start_input_row_in_image_id %= in_h;
         }
     } else {
         TT_FATAL(false, "Unsupported memory layout");

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -302,6 +302,9 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     reader_rt_args[3] = scale_factor_w;
     reader_rt_args[4] = in_w;
     reader_rt_args[5] = out_w;
+    reader_rt_args[6] =
+        0;  // denotes the row position in the batch that corresponds to the first row of the input shard of the
+            // corresponding core first row of the input shard corresponds to the second row (index 1) in the halo shard
     reader_rt_args[7] = in_h;
 
     uint32_t num_rows_per_core = div_up(batch_size * in_h, ncores_nhw);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -301,8 +301,8 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     reader_rt_args[4] = in_w;
     reader_rt_args[5] = out_w;
     reader_rt_args[6] =
-        0;  // denotes the row position in the batch that corresponds to the first row of the input shard of the
-            // corresponding core first row of the input shard corresponds to the second row (index 1) in the halo shard
+        0;  // denotes the position (index) of the first row of the input shard in its corresponding batch
+            // Note: the first row of the input shard corresponds to the second row (index 1) in the halo shard
     reader_rt_args[7] = in_h;
 
     uint32_t num_rows_per_core = div_up(batch_size * in_h, ncores_nhw);


### PR DESCRIPTION
### Ticket
#24621

### Problem description
Previously, batch_size > 1 caused the calculation to be wrong as the boundary between batches (and their respective paddings) was not handled correctly. This caused the interpolation to happen between an image and it's padding causing low pcc. 

### What's changed
The batch boundaries after the halo op are now correctly taken into account. If a boundary of an image happens to be inside of a core, 2 rows are skipped (bottom padding of previous patch and top padding of next batch).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16295367770)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16295376032) 
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16295425605) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16295432882)
- [ ] [Frequent model tests] (https://github.com/tenstorrent/tt-metal/actions/runs/16295412460)
- [ ] [Blackhole nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/16295384669)