### PR TITLE
#0: Unpad width in tiled slice_write

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -122,10 +122,7 @@ SliceWidth = ttnn.Conv2dSliceWidth
         (2, 64,   64,   384,   64,    SliceHeight,   6,  ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 0,       ttnn.MathFidelity.LoFi  ),
         (1, 4,    32,   1024,  1024,  SliceWidth,    4,  ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 32,      ttnn.MathFidelity.LoFi  ),
         (1, 64,   128,  992,   992,   SliceWidth,   64,  ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32 * 4,  ttnn.MathFidelity.LoFi  ),
-
-        # Test fails due to limitation in Tensor Infra to accurately represent padded shapes.
-        # https://github.com/tenstorrent/tt-metal/issues/24425git
-        # (1, 2904, 2904,  48,    48,   SliceWidth,   4,  ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (1, 1), 32,  ttnn.MathFidelity.HiFi4  ),
+        (1, 2904, 2904,  48,    48,   SliceWidth,   4,  ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (1, 1), 32,  ttnn.MathFidelity.HiFi4  ),
         (1, 2944, 2944,  48,    48,   SliceWidth,   4,  ttnn.bfloat8_b,  (3, 3), (1, 1), (0, 0), (1, 1), 32,  ttnn.MathFidelity.HiFi4  ),
     )
     # fmt: on

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -222,6 +222,7 @@ def test_slice_write_height_sharded(device, dims, slice_dim, slice_size, cores, 
     [
         [[2, 64, 64, 2048], 32, 64],
         [[2, 48, 48, 2944], 32, 46],
+        [[2, 48, 48, 2904], 32, 46],
     ],
 )
 @pytest.mark.parametrize("slice_dim", [1, 2])
@@ -245,7 +246,7 @@ def test_slice_write_width_sharded(device, dims, slice_dim, slice_size, cores, l
         grid=core_range, shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED, shard_orientation=orientation
     )
     num_slices = round_up(dims[slice_dim], slice_size) // slice_size
-    padded_channels = round_up(dims[-1], 32)
+    padded_channels = round_up(dims[-1], 32 * cores)
 
     padded_torch_input = torch.nn.functional.pad(torch_input, (0, padded_channels - dims[-1]))
 

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -290,8 +290,8 @@ def test_slice_write_width_sharded(device, dims, slice_dim, slice_size, cores, l
 @pytest.mark.parametrize(
     "dims, slice_size, core_x, core_y, layout",
     [
-        [[2, 256, 256, 64], 128, 8, 2, ttnn.ROW_MAJOR_LAYOUT],
-        [[2, 256, 128, 32], 16, 4, 4, ttnn.ROW_MAJOR_LAYOUT],
+        [[2, 256, 256, 64], 128, 2, 8, ttnn.ROW_MAJOR_LAYOUT],
+        [[2, 256, 128, 128], 16, 4, 4, ttnn.ROW_MAJOR_LAYOUT],
         [[2, 32, 32, 128], 32, 2, 2, ttnn.ROW_MAJOR_LAYOUT],
         [[2, 256, 256, 64], 64, 2, 4, ttnn.TILE_LAYOUT],
         [[2, 256, 128, 128], 32, 4, 4, ttnn.TILE_LAYOUT],

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -524,7 +524,7 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
     bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
     uint32_t num_cores_channels = get_num_cores_channels_from_sharded_tensor(input_tensor);
-    uint32_t num_tiles_channel_per_core = shard_spec.shape[1] / TILE_HEIGHT;
+    uint32_t num_tiles_channel_per_core = shard_spec.shape[1] / TILE_WIDTH;
 
     uint32_t output_row_size_bytes = output_shape[-1] * input_tensor.element_size();
     uint32_t input_row_size_bytes = input_shard_shape[1] * input_tensor.element_size();


### PR DESCRIPTION
### Ticket
#24425 

### Problem description
Width Sharded L1 Tensors have extra width when the width is not divisble by number of cores. Slice write of such an input to an Interleaved Tensor without this extra width causes errors.

### What's changed
Slice write op ignores the extra width of width sharded tensors. 
Enabled tests in test_slice and test_conv_dram for these scenarios.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16370702789)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16315782763) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16375687349) (if applicable)
- [x] Blackhole Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16315788508) 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16375713906)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16364372926) (if applicable)
- [x] Frequent Models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16375581023)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes