### PR TITLE
[Gemma3] Use query_pre_attn_scalar for attention scaling

### DIFF
--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -313,7 +313,10 @@ class Attention(LightweightModule):
             # vLLM provides its own kv cache
             self.init_kv_cache(configuration, weight_cache_path)
 
-        self.scale = self.head_dim**-0.5
+        if configuration.query_pre_attn_scalar is not None:
+            self.scale = configuration.query_pre_attn_scalar**-0.5
+        else:
+            self.scale = self.head_dim**-0.5
 
     def init_kv_cache(self, configuration, weight_cache_path):
         """

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1446,6 +1446,8 @@ class ModelArgs:
             self.rope_scaling_factor = None
             self.orig_context_len = None
 
+        self.query_pre_attn_scalar = text_config.get("query_pre_attn_scalar", None)
+
         # Vision params (Meta-specific)
         self.vision_chunk_size = config.get("vision_chunk_size", -1)
         self.vision_max_num_chunks = config.get("vision_max_num_chunks", 4)


### PR DESCRIPTION
### Ticket
[22810](https://github.com/tenstorrent/tt-metal/issues/22810)

### Problem description
Gemma3 uses query_pre_attn_scalar config parameter to calculate attention scaling

### What's changed
Use the parameter if it exists in config

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16320305616)
- [x] [T3K unit & demo](https://github.com/tenstorrent/tt-metal/actions/runs/16320311720)