### PR TITLE
Replace torch.testing.assert_allclose with torch.testing.assert_close()

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -384,7 +384,7 @@ def test_fold(act_shape, stride_h, stride_w, device):
     tt_out = ttnn.fold(tt_input, stride_h, stride_w)
     actual = tt2torch_tensor(tt_out)
 
-    torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
+    assert torch.equal(actual, expected)
 
 
 def test_fold_sharded(device):
@@ -422,4 +422,4 @@ def test_fold_sharded(device):
         tt_out = ttnn.fold(tt_input, stride_h, stride_w)
         actual = tt2torch_tensor(tt_out)
 
-        torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
+        assert torch.equal(actual, expected)

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -384,7 +384,7 @@ def test_fold(act_shape, stride_h, stride_w, device):
     tt_out = ttnn.fold(tt_input, stride_h, stride_w)
     actual = tt2torch_tensor(tt_out)
 
-    torch.testing.assert_allclose(actual, expected)
+    torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
 
 
 def test_fold_sharded(device):
@@ -422,4 +422,4 @@ def test_fold_sharded(device):
         tt_out = ttnn.fold(tt_input, stride_h, stride_w)
         actual = tt2torch_tensor(tt_out)
 
-        torch.testing.assert_allclose(actual, expected)
+        torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)


### PR DESCRIPTION
### Ticket
#25139

### Problem description

`torch.testing.assert_allclose()` has been deprecated, and produces warnings:

```
torch.testing.assert_allclose()is deprecated since 1.12 and will be removed in a future release. Please use torch.testing.assert_close()
```

### What's changed

This PR replaces `torch.testing.assert_allclose()` with `torch.testing.assert_close()`, as [recommended by torch](https://github.com/pytorch/pytorch/issues/61844). 

The only that used this is `test_fold_op.py`.

Both `atol` and `rtol` thresholds have been set to 0 to match behavior of `torch.testing.assert_allclose()` (as per torch's porting instructions).

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes