### PR TITLE
#25126: [skip ci] Add didt tests for BHx1 PCIe cards (P100, P150)

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -29,6 +29,14 @@ test_suite_bh_single_pcie_small_ml_model_tests() {
     pytest models/demos/blackhole/resnet50/tests/upstream_pipeline
 }
 
+test_suite_bh_single_pcie_didt_tests() {
+    echo "[upstream-tests] Running BH upstream didt tests"
+    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and 1chips" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and 1chips" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
+}
+
 verify_llama_dir_() {
     if [ -z "${LLAMA_DIR}" ]; then
       echo "Error: LLAMA_DIR environment variable not detected. Please set this environment variable to tell the tests where to find the downloaded Llama weights." >&2
@@ -135,11 +143,13 @@ declare -A hw_topology_test_suites
 # Store test suites as newline-separated lists
 hw_topology_test_suites["blackhole"]="test_suite_bh_single_pcie_python_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests
+test_suite_bh_single_pcie_didt_tests
 test_suite_bh_single_pcie_small_ml_model_tests
 test_suite_bh_single_pcie_llama_demo_tests" # NOTE: This test MUST be last because of the requirements install currently in the llama tests
 
 hw_topology_test_suites["blackhole_no_models"]="test_suite_bh_single_pcie_python_unit_tests
-test_suite_bh_single_pcie_metal_unit_tests"
+test_suite_bh_single_pcie_metal_unit_tests
+test_suite_bh_single_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
 test_suite_bh_llmbox_metal_unit_tests


### PR DESCRIPTION
### Ticket

#25126 

### Problem description

@smohammadiTT wants didt tests for BHx1

### What's changed

You got it, baby

### Checklist
- [ ] upstream tests https://github.com/tenstorrent/tt-metal/actions/runs/16324473639
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes