### PR TITLE
[skip ci] Fix Clang Tidy Light to work with generated files

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -200,7 +200,8 @@ jobs:
         pip install pyyaml # Needed for clang-tidy-diff-20.py
     - name: Prepare compile_commands.json
       run: |
-        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+        cmake --build build --target all_generated_files
     - name: 'Install jq'
       uses: dcarbone/install-jq-action@v2
     - name: Create results directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,10 @@ if(ENABLE_BUILD_TIME_TRACE)
     endif()
 endif()
 
+# Top-level target to build all generated files
+# Useful for eg: ensuring all files exist before linting
+add_custom_target(all_generated_files)
+
 include(CPM)
 if(CMAKE_VERSION VERSION_LESS 3.25)
     # FIXME(14681): `SYSTEM` was introduced in v3.25; remove this when we can require v3.25

--- a/cmake/flatbuffers.cmake
+++ b/cmake/flatbuffers.cmake
@@ -38,4 +38,9 @@ function(GENERATE_FBS_HEADER FBS_FILE)
         COMMAND_EXPAND_LISTS
     )
     set(FBS_GENERATED_HEADER_FILE ${FBS_GENERATED_HEADER_FILE} PARENT_SCOPE)
+
+    if(TARGET all_generated_files)
+        add_custom_target(${FBS_FILE_NAME} DEPENDS ${FBS_GENERATED_HEADER_FILE})
+        add_dependencies(all_generated_files ${FBS_FILE_NAME})
+    endif()
 endfunction()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Clang Tidy Light wasn't generating any files, so was unable to scan files that #included a generated file since it's missing.

### What's changed
Generate the files first before scanning.