### PR TITLE
[skip ci] Give AI tools write permission to push branches

### DIFF
--- a/.github/workflows/ai-tools.yaml
+++ b/.github/workflows/ai-tools.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   call-ai-assistant:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
### Ticket
None

### Problem description
Contents write permissions are required for AI tools to be able to open a PR

### What's changed
Updated