### PR TITLE
Configure edm builder for dispatch only if there is tunneling

### DIFF
--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1416,6 +1416,15 @@ void build_tt_fabric_program(
     const auto topology = fabric_context.get_fabric_topology();
     const bool is_2D_routing = topology == Topology::Mesh;
 
+    const auto device_has_dispatch_tunnel = [&]() -> bool {
+        auto mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id);
+        // results are inclusive of the mmio_device_id
+        return (tunnels_from_mmio.size() - 1) > 0;
+    }();
+
     for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
         auto active_eth_chans =
             control_plane.get_active_fabric_eth_routing_planes_in_direction(fabric_node_id, direction);
@@ -1496,9 +1505,9 @@ void build_tt_fabric_program(
             edm_builders.insert({eth_chan, edm_builder});
         }
 
-        // Last link may be used by dispatch
+        // Last link may be used by dispatch if there is tunneling
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
-        if (!active_fabric_eth_channels[direction].empty()) {
+        if (!active_fabric_eth_channels[direction].empty() && device_has_dispatch_tunnel) {
             const auto dispatch_eth_chan = active_fabric_eth_channels[direction].back();
             configure_edm_builder_for_dispatch(edm_builders.at(dispatch_eth_chan));
         }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1421,7 +1421,8 @@ void build_tt_fabric_program(
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
         auto tunnels_from_mmio =
             tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id);
-        // results are inclusive of the mmio_device_id
+        // results are inclusive of the mmio_device_id so they will never be zero
+        TT_ASSERT(tunnels_from_mmio.size() > 0);
         return (tunnels_from_mmio.size() - 1) > 0;
     }();
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25118)

### Problem description
- Fixes 6U perf regression

### What's changed
- We should only configure the EDM Builder for dispatch only if the device is participating in a dispatch tunnel

Before:
Iteration : 0, Prefill Iteration : 0, tok/s/user : 191.26, Throughput : 6120.28 tok/s, Iteration Time : 5.23 ms
80L T/s/u estimate: 64.58306858713429

After:
Iteration : 0, Prefill Iteration : 0, tok/s/user : 284.32, Throughput : 9098.27 tok/s, Iteration Time : 3.52 ms
80L T/s/u estimate: 66.42449839842752

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16327087096
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16327090741
T3K Unit
https://github.com/tenstorrent/tt-metal/actions/runs/16328342742
TG
https://github.com/tenstorrent/tt-metal/actions/runs/16327092161
TG Unit
https://github.com/tenstorrent/tt-metal/actions/runs/16328341561