### PR TITLE
[skip ci] Fix broken post-commit wrappers

### DIFF
--- a/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-large-stable },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
     with:

--- a/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
@@ -2,8 +2,6 @@ name: "[post-commit] Fabric unit tests"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 * * * *" # Run every hour
 
 jobs:
   build-artifact:

--- a/.github/workflows/models-post-commit-wrapper.yaml
+++ b/.github/workflows/models-post-commit-wrapper.yaml
@@ -5,9 +5,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  static-checks:
-    uses: ./.github/workflows/all-static-checks.yaml
-    secrets: inherit
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -5,9 +5,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  static-checks:
-    uses: ./.github/workflows/all-static-checks.yaml
-    secrets: inherit
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -29,3 +29,4 @@ jobs:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
A bunch of post-commit wrappers are broken (would instantly fail due to perms/input issues)

### What's changed

- models post-commit wrapper & tt-train post-commit wrapper: remove unneeded all-static-checks job (requires additional perms that the workflow doesn't need)
- fabric wrapper: fix the label, remove hourly cronjob (the tests run in APC on push already)

### Checklist
- [x] models wrapper: https://github.com/tenstorrent/tt-metal/actions/runs/16328180576
- [x] tt-train wrapper: https://github.com/tenstorrent/tt-metal/actions/runs/16328221012
- [x] fabric wrapper: https://github.com/tenstorrent/tt-metal/actions/runs/16328172102