### PR TITLE
#0: Only disable kernel cache after compiling FD programs if it wasn't originally enabled

### DIFF
--- a/tt_metal/api/tt-metalium/persistent_kernel_cache.hpp
+++ b/tt_metal/api/tt-metalium/persistent_kernel_cache.hpp
@@ -23,4 +23,11 @@ void EnablePersistentKernelCache();
  */
 void DisablePersistentKernelCache();
 
+/**
+ * Returns true if the kernel compilation cache is enabled.
+ *
+ * Return value: bool
+ */
+bool GetPersistentKernelCacheEnabled();
+
 }  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1172,7 +1172,9 @@ void create_cq_program(IDevice* device) {
 }
 
 void compile_cq_programs() {
-    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+    bool temp_enable_kernel_cache = tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw() &&
+                                    !detail::GetPersistentKernelCacheEnabled();
+    if (temp_enable_kernel_cache) {
         detail::EnablePersistentKernelCache();
     }
 
@@ -1181,7 +1183,7 @@ void compile_cq_programs() {
     // Write runtime args to device
     command_queue_compile_group.write_runtime_args(/*force_slow_dispatch=*/true);
 
-    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+    if (temp_enable_kernel_cache) {
         detail::DisablePersistentKernelCache();
     }
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -231,6 +231,8 @@ void EnablePersistentKernelCache() { enable_persistent_kernel_cache = true; }
 
 void DisablePersistentKernelCache() { enable_persistent_kernel_cache = false; }
 
+bool GetPersistentKernelCacheEnabled() { return enable_persistent_kernel_cache; }
+
 class Internal_ {
    public:
        using map_type = decltype(detail::ProgramImpl::circular_buffer_by_id_);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "assert.hpp"
+#include <tt-metalium/persistent_kernel_cache.hpp>
 #include <umd/device/tt_core_coordinates.h>
 
 using std::vector;
@@ -236,6 +237,10 @@ RunTimeOptions::RunTimeOptions() {
 
     if (getenv("TT_METAL_FORCE_REINIT")) {
         force_context_reinit = true;
+    }
+
+    if (getenv("TT_METAL_ENABLE_PERSISTENT_KERNEL_CACHE")) {
+        tt::tt_metal::detail::EnablePersistentKernelCache();
     }
 }
 


### PR DESCRIPTION
Temporarily enable kernel cache for fabric similar to FD programs

### Ticket
Link to Github Issue

### Problem description
FD program compilation was always setting kernel cache to false after running when skipping fw loading. But this is not correct if the user already manually enabled kernel cache.
Fabric kernels as part of device init should also temporarily use kernel cache similar to FD kernels when skip fw loading is set.

### What's changed
Add a getter for persistent kernel cache state, and only disable kernel cache after compiling the FD kernels if it wasn't already enabled.
Add persistent kernel cache usage to fabric compile similar to FD when skipping fw loading.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes