### PR TITLE
Fixed locations of example binaries in programming example documents

### DIFF
--- a/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
@@ -4,7 +4,7 @@
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/add_2_integers_in_compute
+    ./build/programming_examples/metal_example_add_2_integers_in_compute
 ```
 
 2. Setup the host program:

--- a/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -9,7 +9,7 @@ To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/add_2_integers_in_compute
+    ./build/programming_examples/metal_example_add_2_integers_in_compute
 ```
 ## Set up device and program/collaboration mechanisms
 

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/Tutorial_Add_Two_Integers_in_a_Baby_RISC-V.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/Tutorial_Add_Two_Integers_in_a_Baby_RISC-V.md
@@ -3,7 +3,7 @@
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/add_2_integers_in_riscv
+    ./build/programming_examples/metal_example_add_2_integers_in_riscv
 ```
 2. Setup the host program:
 

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
@@ -10,7 +10,7 @@ To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/add_2_integers_in_riscv
+    ./build/programming_examples/metal_example_add_2_integers_in_riscv
 ```
 ## Set up device and program/collaboration mechanisms
 

--- a/tech_reports/prog_examples/eltwise_binary/eltwise_binary.md
+++ b/tech_reports/prog_examples/eltwise_binary/eltwise_binary.md
@@ -9,7 +9,7 @@ To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/eltwise_binary
+    ./build/programming_examples/metal_example_eltwise_binary
 ```
 ## New buffers
 

--- a/tech_reports/prog_examples/eltwise_sfpu/eltwise_sfpu.md
+++ b/tech_reports/prog_examples/eltwise_sfpu/eltwise_sfpu.md
@@ -8,7 +8,7 @@ To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/eltwise_sfpu
+    ./build/programming_examples/metal_example_eltwise_sfpu
 ```
 
 ## Circular buffers for data movement to/from compute engine

--- a/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
+++ b/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
@@ -8,7 +8,7 @@ To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/hello_world_compute_kernel
+    ./build/programming_examples/metal_example_hello_world_compute_kernel
 ```
 ## Device setup
 

--- a/tech_reports/prog_examples/hello_world_data_movement/hello_world_data_movement.md
+++ b/tech_reports/prog_examples/hello_world_data_movement/hello_world_data_movement.md
@@ -11,7 +11,7 @@ Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/hello_world_datamovement_kernel
+    ./build/programming_examples/metal_example_hello_world_datamovement_kernel
 ```
 
 ## Device setup

--- a/tech_reports/prog_examples/hello_world_data_movement/hello_world_datamovement.md
+++ b/tech_reports/prog_examples/hello_world_data_movement/hello_world_datamovement.md
@@ -18,7 +18,7 @@ need more depending on the most up-to-date installation methods.
     export ARCH_NAME=<arch name>
     export TT_METAL_HOME=<this repo dir>
     ./build_metal.sh --build-tests
-    ./build/programming_examples/hello_world_datamovement_kernel
+    ./build/programming_examples/metal_example_hello_world_datamovement_kernel
 
 # Silicon accelerator setup
 

--- a/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
+++ b/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
@@ -16,7 +16,7 @@ Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/matmul_multi_core
+    ./build/programming_examples/metal_example_matmul_multi_core
 ```
 ## Accessing all the cores
 

--- a/tech_reports/prog_examples/matmul_single_core/matmul_single_core.md
+++ b/tech_reports/prog_examples/matmul_single_core/matmul_single_core.md
@@ -10,7 +10,7 @@ Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/matmul_single_core
+    ./build/programming_examples/metal_example_matmul_single_core
 ```
 
 ## Host Code

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -18,7 +18,7 @@ Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/pad_multi_core
+    ./build/programming_examples/metal_example_pad_multi_core
 ```
 ## Device setup
 

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -7,7 +7,7 @@ To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
-    ./build/programming_examples/shard_data_rm
+    ./build/programming_examples/metal_example_shard_data_rm
 ```
 # Device setup
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
While building for the first time and trying to run the examples mentioned in `tech_reports/prog_examples`, I happened to notice that the documentation is a little stale with respect to naming of the built binaries.

### What's changed
I added the `metal_example_` prefix to the command examples. This is how the binaries are named now.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes