### PR TITLE
[skip ci] Set LLAMA_DIR for BH-LLMBox upstream tests based on if we're running in VM or BM

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -186,7 +186,7 @@ jobs:
       - get-image-tags
       - build-images
     runs-on:
-      - BH-LLMBox
+      - quad-bh-01
       - in-service
       - cloud-virtual-machine
     steps:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: ${{ contains(runner.hostname, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: ${{ contains(runner.hostname, 'tt-metal-ci') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+          LLAMA_DIR: ${{ contains(runner.hostname, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
+          LLAMA_DIR: ${{ contains(runner.hostname, 'tt-metal-ci') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -186,7 +186,7 @@ jobs:
       - get-image-tags
       - build-images
     runs-on:
-      - quad-bh-01
+      - BH-LLMBox
       - in-service
       - cloud-virtual-machine
     steps:


### PR DESCRIPTION
### Ticket
None

### Problem description
We have llmbox/quad 4xP150 CI VMs now, but the model weights are mounted to `/mnt/MLperf`
The existing LLMBox test looks at `/localdev` for the weights because the current baremetal QBs don't have mlperf mount available 

### What's changed
Read the weights into `LLAMA_DIR` from the correct location depending on if we're running in a LLMBox VM or not.

### Checklist
- [x] BH Upstream tests (VM): https://github.com/tenstorrent/tt-metal/actions/runs/16331053872/job/46134603439
- [ ] Add `BH-LLMBox` label to the VM runners