### PR TITLE
Update Falcon7b-4U/6U targets to fix CI and added glx type to Superset runtype

### DIFF
--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -130,6 +130,7 @@ def run_falcon_demo_kv(
     save_generated_text_path=None,  # If provided, save generated text to this path (e.g. set to expected_greedy_output_path to update expected output)
     json_perf_targets={},  # Optional perf targets for CSV output
     is_ci_env=False,  # Whether is running in CI environment
+    galaxy_type=None,  # "4U" or "6U" when running on WH-Galaxy
 ):
     profiler = BenchmarkProfiler()
     profiler.start("run")
@@ -537,9 +538,12 @@ def run_falcon_demo_kv(
 
     # Save benchmark data (will only save if running in CI environment)
     benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, json_perf_targets)
+    run_type = f"demo_perf_{num_devices}chip" if perf_mode else f"demo_generate_{num_devices}chip"
+    if galaxy_type:
+        run_type += f"_{galaxy_type}"
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"demo_perf_{num_devices}chip" if perf_mode else f"demo_generate_{num_devices}chip",
+        run_type=run_type,
         ml_model_name=model_version,
         ml_model_type="llm",
         num_layers=num_layers,

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -71,14 +71,14 @@ def test_demo_multichip(
         assert max_seq_len in [128, 1024, 2048], f"Unexpected max_seq_len: {max_seq_len} for perf mode"
         expected_perf_dict = {
             "4U": {
-                128: {"prefill_t/s": 23300, "decode_t/s/u": 6.80},
-                1024: {"prefill_t/s": 21900, "decode_t/s/u": 6.30},
-                2048: {"prefill_t/s": 20400, "decode_t/s/u": 6.40},
+                128: {"prefill_t/s": 24800, "decode_t/s/u": 7.12},
+                1024: {"prefill_t/s": 21200, "decode_t/s/u": 6.50},
+                2048: {"prefill_t/s": 20400, "decode_t/s/u": 6.90},
             },
             "6U": {
-                128: {"prefill_t/s": 30600, "decode_t/s/u": 10.90},
-                1024: {"prefill_t/s": 29400, "decode_t/s/u": 10.40},
-                2048: {"prefill_t/s": 27500, "decode_t/s/u": 10.35},
+                128: {"prefill_t/s": 32900, "decode_t/s/u": 12.19},
+                1024: {"prefill_t/s": 33800, "decode_t/s/u": 11.60},
+                2048: {"prefill_t/s": 31100, "decode_t/s/u": 10.97},
             },
         }
         expected_perf_metrics = expected_perf_dict[galaxy_type][max_seq_len]

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -83,6 +83,8 @@ def test_demo_multichip(
         }
         expected_perf_metrics = expected_perf_dict[galaxy_type][max_seq_len]
         expected_perf_metrics["decode_t/s"] = global_batch_size * expected_perf_metrics["decode_t/s/u"]
+    else:
+        expected_perf_metrics = None
 
     if perf_mode:
         json_perf_targets = {

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -71,14 +71,14 @@ def test_demo_multichip(
         assert max_seq_len in [128, 1024, 2048], f"Unexpected max_seq_len: {max_seq_len} for perf mode"
         expected_perf_dict = {
             "4U": {
-                128: {"prefill_t/s": 22160, "decode_t/s/u": 7.20},
-                1024: {"prefill_t/s": 19460, "decode_t/s/u": 6.95},
-                2048: {"prefill_t/s": 18650, "decode_t/s/u": 7.00},
+                128: {"prefill_t/s": 23300, "decode_t/s/u": 6.80},
+                1024: {"prefill_t/s": 21900, "decode_t/s/u": 6.30},
+                2048: {"prefill_t/s": 20400, "decode_t/s/u": 6.40},
             },
             "6U": {
-                128: {"prefill_t/s": 30000, "decode_t/s/u": 12.00},
-                1024: {"prefill_t/s": 29090, "decode_t/s/u": 11.19},
-                2048: {"prefill_t/s": 27230, "decode_t/s/u": 10.90},
+                128: {"prefill_t/s": 30600, "decode_t/s/u": 10.90},
+                1024: {"prefill_t/s": 29400, "decode_t/s/u": 10.40},
+                2048: {"prefill_t/s": 27500, "decode_t/s/u": 10.35},
             },
         }
         expected_perf_metrics = expected_perf_dict[galaxy_type][max_seq_len]
@@ -107,4 +107,5 @@ def test_demo_multichip(
         expected_greedy_output_path=expected_greedy_output_path,
         json_perf_targets=json_perf_targets,
         is_ci_env=is_ci_env,
+        galaxy_type=galaxy_type,
     )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The Falcon7b 4U/6U CI tests are failing on perf checks (higher prefill perf, and slightly lower decode perf on 4U)

### What's changed
- For the Falcon7b 4U/6U demo tests, increased the prefill perf targets and adjusted the decode perf targets (slightly decreased for 4U, slightly increased for 6U)
- Updated the run_type uploaded to Superset to include the galaxy type (4U/6U)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes