### PR TITLE
Sweep build configs in Merge Gate

### DIFF
--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -26,29 +26,21 @@ jobs:
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Debug"
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-            build-type: "RelWithDebInfo"
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-            build-type: "Release"
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-            build-type: "Release"
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-            build-type: "Debug"
-          - version: "24.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+            build-type: "Release"
+          - version: "22.04"
+            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"
           - version: "24.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
           - version: "24.04"
             toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
-            build-type: "RelWithDebInfo"
+            build-type: "Release"
     with:
       version: ${{ matrix.config.version }}
       toolchain: ${{ matrix.config.toolchain }}
       build-type: ${{ matrix.config.build-type }}
       publish-artifact: false
       skip-tt-train: true
+      tracy: false

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -5,12 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
-  contents: write
-  pages: write
-  id-token: write
   packages: write
-  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -105,6 +105,17 @@ jobs:
       skip-tt-train: false
       publish-artifact: false
 
+  build-sweeps:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true'
+        }}
+    needs: find-changes
+    uses: ./.github/workflows/build-wrapper.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+
   metalium-smoke-tests:
     needs: [find-changes, build-tsan]
     if: ${{ github.ref_name == 'main' ||
@@ -225,13 +236,13 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, code-analysis, find-changes, build, build-docs, build-tsan, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests]
+    needs: [static-checks, code-analysis, find-changes, build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, code-analysis, find-changes"
-          optional-jobs: "build, build-docs, build-tsan, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
+          optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'

--- a/tt_metal/logging/logging.cpp
+++ b/tt_metal/logging/logging.cpp
@@ -9,7 +9,6 @@ namespace tt::tt_metal::logging {
 // TODO: Figure out how to expose this set_level API to consumers.
 // The idea here is to allow clients to set log level without using environment variables.
 // For instance, they may not want to see info messages at all, but only CRITICAL errors
-// REVERT THIS LINE
 
 /**
  * @brief Logging severity levels

--- a/tt_metal/logging/logging.cpp
+++ b/tt_metal/logging/logging.cpp
@@ -9,6 +9,7 @@ namespace tt::tt_metal::logging {
 // TODO: Figure out how to expose this set_level API to consumers.
 // The idea here is to allow clients to set log level without using environment variables.
 // For instance, they may not want to see info messages at all, but only CRITICAL errors
+// REVERT THIS LINE
 
 /**
  * @brief Logging severity levels


### PR DESCRIPTION
### Ticket
NA

### Problem description
Its pretty easy to break certain build configs on main, if you don't run APC, assuming it couldn't possibly break.

### What's changed
- Add build jobs to Merge Gate to ensure they are always functional.
- Reduce scope of what things are ran by build-wrapper, to keep only high value add jobs

### Checklist
- [x] [Merge Gate](https://github.com/tenstorrent/tt-metal/actions/runs/16341895060) CI passes
- [x] New/Existing tests provide coverage for changes