### PR TITLE
Fix mla testing to support mesh_row.

### DIFF
--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -68,7 +68,7 @@ def get_cache_on_host(tt_cache, mesh_device):
     """
     host_cache = []
     for i, t in enumerate(
-        ttnn.get_device_tensors(tt_cache)[: list(mesh_device.shape)[0]]
+        ttnn.get_device_tensors(tt_cache)[: list(mesh_device.shape)[1]]
     ):  # Only get from first row of mesh_device
         host_t = t.cpu().to_torch()
         host_cache.append(host_t)
@@ -97,7 +97,6 @@ def get_cache_on_host(tt_cache, mesh_device):
     ],
     indirect=True,
 )
-@pytest.mark.skip(reason="FIXME: Reduce-scatter was unable to identify either a sender or receiver device ID")
 def test_forward_pass(
     mode,
     seq_len,
@@ -178,7 +177,7 @@ def test_forward_pass(
     tt_input = ttnn.from_torch(
         torch_input,
         device=mesh_row,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_row, dims=(-1, None), mesh_shape=mesh_shape),
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_row, dims=(None, -1), mesh_shape=mesh_shape),
         dtype=ttnn.bfloat16,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
@@ -237,7 +236,7 @@ def test_forward_pass(
     else:
         tt_output = MLA1D.forward_decode(tt_input, position_idxs_tensor, rope_tensors, run_config)
         tt_output_torch = ttnn.to_torch(
-            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(-1, 0), mesh_shape=mesh_shape)
+            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(0, -1), mesh_shape=mesh_shape)
         )[:1, ...]
         tt_output_torch = tt_output_torch.squeeze(0).permute(1, 0, 2)
 

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -117,7 +117,7 @@ class MLA1D(AbstractModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=[-2, None],
+                dims=[None, -2],
                 mesh_shape=list(mesh_device.shape),
             ),
         )
@@ -137,7 +137,7 @@ class MLA1D(AbstractModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=[-1, None],
+                dims=[None, -1],
                 mesh_shape=list(mesh_device.shape),
             ),
         )
@@ -157,7 +157,7 @@ class MLA1D(AbstractModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=[-2, None],
+                dims=[None, -2],
                 mesh_shape=list(mesh_device.shape),
             ),
         )
@@ -185,7 +185,7 @@ class MLA1D(AbstractModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=[-3, None],
+                dims=[None, -3],
                 mesh_shape=list(mesh_device.shape),
             ),
         )
@@ -199,7 +199,7 @@ class MLA1D(AbstractModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=[-3, None],
+                dims=[None, -3],
                 mesh_shape=list(mesh_device.shape),
             ),
         )
@@ -219,7 +219,7 @@ class MLA1D(AbstractModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=[-1, None],
+                dims=[None, -1],
                 mesh_shape=list(mesh_device.shape),
             ),
         )
@@ -377,7 +377,7 @@ class MLA1D(AbstractModule):
         max_seq_len = hf_config.max_seq_len
 
         mesh_shape = list(mesh_device.shape)
-        num_heads_local = num_heads // mesh_shape[0]
+        num_heads_local = num_heads // mesh_shape[1]
 
         config: ModelDecodeConfig = {}
         config["hf_config"] = hf_config
@@ -541,7 +541,7 @@ class MLA1D(AbstractModule):
         # Q
         config["wq_a_rs"] = ReduceScatterAsyncConfig(
             mesh_device=MeshDeviceStub(list(mesh_device.shape)),
-            cluster_axis=0,
+            cluster_axis=1,
             dim=3,
             from_remote_multi_device_global_semaphore=ccl.get_semaphore(0),
             to_remote_multi_device_global_semaphore=ccl.get_semaphore(0),
@@ -552,7 +552,7 @@ class MLA1D(AbstractModule):
         )
         config["wq_a_ag"] = AllGatherAsyncConfig(
             mesh_device=MeshDeviceStub(list(mesh_device.shape)),
-            cluster_axis=0,
+            cluster_axis=1,
             dim=3,
             multi_device_global_semaphore=ccl.get_semaphore(0),
             num_links=ccl.get_max_links(0),
@@ -563,7 +563,7 @@ class MLA1D(AbstractModule):
         # KV
         config["wkv_a_ag"] = AllGatherAsyncConfig(
             mesh_device=MeshDeviceStub(list(mesh_device.shape)),
-            cluster_axis=0,
+            cluster_axis=1,
             dim=1,
             multi_device_global_semaphore=ccl.get_semaphore(0),
             num_links=ccl.get_max_links(0),
@@ -584,7 +584,7 @@ class MLA1D(AbstractModule):
         # WO
         config["wo_ag"] = AllGatherAsyncConfig(
             mesh_device=MeshDeviceStub(list(mesh_device.shape)),
-            cluster_axis=0,
+            cluster_axis=1,
             dim=1,
             multi_device_global_semaphore=ccl.get_semaphore(0),
             num_links=ccl.get_max_links(0),
@@ -648,7 +648,7 @@ class MLA1D(AbstractModule):
 
         hf_config = cfg["hf_config"]
         num_heads = hf_config.num_attention_heads
-        num_heads_local = num_heads // cfg["mesh_shape"][0]
+        num_heads_local = num_heads // cfg["mesh_shape"][1]
         kv_lora_rank = hf_config.kv_lora_rank
         qk_nope_head_dim = hf_config.qk_nope_head_dim
         qk_rope_head_dim = hf_config.qk_rope_head_dim


### PR DESCRIPTION
### Ticket
- #24942 

### Problem description
Currently, the TP=8 testing for MLA is broken because it supports (8, 1) devices instead of (1, 8).

### What's changed
- Support (1, 8) instead of (8, 1)

### Checklist
- [ ] [TG Deepseek CI](https://github.com/tenstorrent/tt-metal/actions/runs/16334798952) passes