### PR TITLE
#19685: Enable Width Sharded Row Major Conv2D

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -71,9 +71,6 @@ def test_conv_features(
     packer_l1_acc,
     input_dtype,
 ):
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and shard_layout == WS:
-        pytest.skip("Bug in Width Sharded Row Major Tensor Creation when height%32!=0. #19408")
-
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
 


### PR DESCRIPTION
### Ticket
#19685 

### Problem description
Conv2D Width Sharded Row Major Output Tensor creation fails because physical height != physical_shard_height.

### What's changed
Used the newly exposed Alignment parameter in TensorLayout to set Alignment to Tile size in Conv2d, regardless of output layout.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16377531684)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16340126288)
- [x] Blackhole Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16340129380)
- [x] Blackhole Demo [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16340132866)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16340154602)
- [x] Frequent Models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16367496896)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16340139706) (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16340148390)
- [x] New/Existing tests provide coverage for changes