### PR TITLE
Llama70B TG - Update BinaryDeviceOperation target in perf unit test

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -17,7 +17,7 @@ from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
         ("PagedUpdateCacheDeviceOperation", 4.5, 0.16),
         ("RotaryEmbeddingLlamaFusedQK", 4.15, 0.05),
         ("Embeddings", 3.8, 0.1),
-        ("BinaryDeviceOperation", 3.1, 0.05),
+        ("BinaryDeviceOperation", 2.78, 0.05),
     ],
 )
 def test_llama_tg_ops_perf_device(op_name, expected_kernel_duration_us, perf_margin):


### PR DESCRIPTION
### Problem description
BinaryDeviceOp got improved and perf target started failing for outside the range.

### What's changed
BinaryDeviceOp device_time 3.1us -> 2.78us target
### Checklist
- [ ] [TG Perf Unit Test](https://github.com/tenstorrent/tt-metal/actions/runs/16340007001)