### PR TITLE
Let DeepSeek team review their code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -213,6 +213,7 @@ models/common @yieldthought @mtairum @uaydonat
 models/utility_functions.py @yieldthought @mtairum @uaydonat
 models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat
 models/demos @uaydonat @yieldthought @cglagovichTT
+models/demos/deepseek_v3 @uaydonat @yieldthought @avoraTT @kpaigwar @barci2
 models/**/bert*/ @TT-BrianLiu @uaydonat
 models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu
 models/*/convnet_mnist/ @sjameelTT @uaydonat


### PR DESCRIPTION
### Problem description
DeepSeek development slowed down by not having reviewers in enough time zones

### What's changed
Allow the DeepSeek team to review each other's code.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes