### PR TITLE
Optimize fold for better reads for Row Major DRAM tensor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "tt-metalium/kernel_types.hpp"
@@ -75,6 +77,13 @@ struct Fold {
             tt::tt_metal::KernelHandle writer_kernel_id;
             tt::tt_metal::KernelHandle reader_kernel_id;
             std::vector<CoreCoord> cores_with_rtargs;
+            std::optional<tt::tt_metal::CBHandle> config_cb;
+            std::optional<uint32_t> batch_size;
+            std::optional<uint32_t> input_height;
+            std::optional<uint32_t> input_width;
+            std::optional<uint32_t> num_cores_total;
+            std::optional<uint32_t> work_per_core;
+            std::optional<CoreRange> all_cores;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <cstdint>
-#include <optional>
 #include <vector>
 
 #include "tt-metalium/kernel_types.hpp"
@@ -77,13 +75,6 @@ struct Fold {
             tt::tt_metal::KernelHandle writer_kernel_id;
             tt::tt_metal::KernelHandle reader_kernel_id;
             std::vector<CoreCoord> cores_with_rtargs;
-            std::optional<tt::tt_metal::CBHandle> config_cb;
-            std::optional<uint32_t> batch_size;
-            std::optional<uint32_t> input_height;
-            std::optional<uint32_t> input_width;
-            std::optional<uint32_t> num_cores_total;
-            std::optional<uint32_t> work_per_core;
-            std::optional<CoreRange> all_cores;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstddef>
+#include <optional>
+#include <vector>
 #include "hostdevcommon/kernel_structs.h"
+#include "tt-metalium/math.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/tensor/enum_types.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
@@ -20,10 +24,77 @@
 #include "ttnn/types.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include "fold_device_op.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 namespace ttnn::operations::data_movement {
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+
+static Tensor create_fold_mapping_table(
+    IDevice* device,
+    const uint32_t batch_size,
+    const uint32_t input_height,
+    const uint32_t input_width,
+    const uint32_t stride_h,
+    const uint32_t stride_w,
+    const uint32_t total_elems,
+    const uint32_t elems_per_core,
+    const CoreRange& all_cores,
+    const uint32_t num_cores_total) {
+    // Calculate output dimensions
+    const uint32_t output_height = input_height / stride_h;
+    const uint32_t output_width = input_width / stride_w;
+    const uint32_t patch_size = stride_h * stride_w;
+    const uint32_t input_hw = input_height * input_width;
+    const uint32_t output_hw = output_height * output_width;
+
+    // Create vector to store mapping entries (src_index, dst_index, is_padding)
+    const uint32_t total_entries = total_elems * 2;
+    std::vector<uint32_t> config_vector(total_entries, 0);
+    uint32_t entry_idx = 0;
+
+    // Iterate over output dimensions and map back to input
+    for (uint32_t b = 0; b < batch_size; b++) {
+        for (uint32_t oh = 0; oh < output_height; oh++) {
+            for (uint32_t ow = 0; ow < output_width; ow++) {
+                for (uint32_t kh = 0; kh < stride_h; kh++) {
+                    // Calculate destination index in output tensor
+                    uint32_t dst_row = (b * output_height + oh) * output_width + ow;
+                    uint32_t dst_col = kh * stride_w;
+                    uint32_t dst_index = dst_row * patch_size + dst_col;
+
+                    // Calculate corresponding input position
+                    int h = oh * stride_h + kh;
+                    int w = ow * stride_w;
+
+                    uint32_t src_index = b * input_hw + h * input_width + w;
+                    config_vector[entry_idx++] = src_index;
+                    config_vector[entry_idx++] = dst_index;
+                }
+            }
+        }
+    }
+
+    // repeat last entry if needed
+    if (entry_idx < (total_entries)) {
+        auto src_idx = config_vector[entry_idx - 2];
+        auto dst_idx = config_vector[entry_idx - 1];
+        for (uint32_t i = entry_idx; i < total_entries; i += 2) {
+            config_vector[i] = src_idx;
+            config_vector[i + 1] = dst_idx;
+        }
+    }
+
+    ttnn::Shape config_shape({tt::div_up(config_vector.size(), elems_per_core * 2), elems_per_core * 2});
+    auto config_buffer = HostBuffer(std::move(config_vector));
+    auto config_tensor = Tensor(std::move(config_buffer), config_shape, DataType::UINT32, Layout::ROW_MAJOR);
+    auto shard_shape = std::array<uint32_t, 2>({1, (uint32_t)config_tensor.get_logical_shape()[-1]});
+    auto config_tensor_shard_orientation = ShardOrientation::ROW_MAJOR;
+    ShardSpec config_shard_spec(all_cores, shard_shape, config_tensor_shard_orientation);
+    MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, config_shard_spec};
+    auto config_tensor_device = config_tensor.to_device(device, memory_config);
+    return config_tensor_device;
+}
 
 Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
@@ -224,7 +295,18 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         cores_with_rtargs.push_back(core);
     }
 
-    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cores_with_rtargs}};
+    return {
+        std::move(program),
+        {unary_writer_kernel_id,
+         unary_reader_kernel_id,
+         cores_with_rtargs,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt}};
 }
 
 Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
@@ -244,7 +326,8 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
     uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
 
     // Calculate total input work
-    uint32_t total_input_work = batch_size * input_height * input_width;
+    uint32_t total_work =
+        (output.get_logical_shape()[0] * output.get_logical_shape()[1] * output.get_logical_shape()[2]) / stride_w;
 
     // Get compute grid size and calculate work distribution
     auto compute_grid_size = device->compute_with_storage_grid_size();
@@ -256,26 +339,27 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
     log_debug(tt::LogOp, "output_tensor_shape: {}", output.padded_shape());
 
     // Calculate work per core based on input dimensions
-    uint32_t work_per_core = (total_input_work + num_cores_total - 1) / num_cores_total;
+    uint32_t work_per_core = tt::div_up(total_work, num_cores_total);
 
     log_debug(
         tt::LogOp,
-        "total_input_work: {}, num_cores_total: {}, work_per_core: {}",
-        total_input_work,
+        "total_work: {}, num_cores_total: {}, work_per_core: {}",
+        total_work,
         num_cores_total,
         work_per_core);
 
     // Create core ranges
-    auto all_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    CoreRange all_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, true);
 
     // Setup circular buffers
     uint32_t cb_src0_index = tt::CBIndex::c_0;
+    uint32_t cb_src1_index = tt::CBIndex::c_1;
 
     // Calculate buffer sizes
     uint32_t stick_nbytes = input_tensor.padded_shape()[3] * tt::datum_size(cb_data_format);
     // align to DRAM read alignment.
-    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, hal::get_dram_alignment());
+    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, hal::get_dram_alignment()) * stride_w;
 
     log_debug(
         tt::LogOp,
@@ -286,44 +370,61 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
 
     int double_buffer = 2;
     // Create source circular buffer - sized for input work per core
-    auto src_cb_config = CircularBufferConfig(double_buffer * aligned_stick_nbytes, {{cb_src0_index, cb_data_format}})
-                             .set_page_size(cb_src0_index, aligned_stick_nbytes);
+    auto src_cb_config =
+        CircularBufferConfig(double_buffer * aligned_stick_nbytes * stride_w, {{cb_src0_index, cb_data_format}})
+            .set_page_size(cb_src0_index, aligned_stick_nbytes * stride_w);
     auto cb_src0 = CreateCircularBuffer(program, all_cores, src_cb_config);
+
+    Tensor config_tensor_device = create_fold_mapping_table(
+        device,
+        batch_size,
+        input_height,
+        input_width,
+        stride_h,
+        stride_w,
+        work_per_core * num_cores_total,
+        work_per_core,
+        all_cores,
+        num_cores_total);
+
+    tt::DataFormat config_df = tt::DataFormat::RawUInt32;
+    auto config_storage = config_tensor_device.device_storage();
+    auto config_buffer = config_storage.get_buffer();
+    auto config_buffer_page_size = config_buffer->page_size();
+
+    auto [config_cb_id, config_cb] = tt::tt_metal::create_cb(
+        tt::CBIndex::c_2, program, all_cores, config_buffer_page_size, 1, config_df, &*config_buffer);
 
     bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_nbytes);
     uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (std::uint32_t)std::log2(stick_nbytes) : 0;
     // Create reader kernel
+    std::vector<uint32_t> compile_time_args(
+        {stick_nbytes,
+         cb_src0_index,
+         config_cb_id,
+         src_stick_size_is_power_of_two,
+         src_log2_stick_size,
+         aligned_stick_nbytes,
+         stride_w});
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            {cb_src0_index, 1, src_stick_size_is_power_of_two, src_log2_stick_size}));
+        tt::tt_metal::ReaderDataMovementConfig(compile_time_args));
     // Create writer kernel
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp",
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            {batch_size,
-             input_width,
-             input_height,
-             stride_h,
-             stride_w,
-             stick_nbytes,
-             cb_src0_index,
-             src_stick_size_is_power_of_two,
-             src_log2_stick_size}));
+        tt::tt_metal::WriterDataMovementConfig(compile_time_args));
 
     // Set runtime arguments for each core
     std::vector<CoreCoord> cores_with_rtargs;
     for (uint32_t i = 0; i < cores.size(); i++) {
         CoreCoord core = cores[i];
         uint32_t start_input_work = i * work_per_core;
-        uint32_t end_input_work = std::min(start_input_work + work_per_core, total_input_work);
-
-        std::vector<uint32_t> reader_runtime_args = {
-            src0_buffer->address(), stick_nbytes, end_input_work - start_input_work + 1, start_input_work};
+        uint32_t end_input_work = std::min(start_input_work + work_per_core, total_work);
+        std::vector<uint32_t> reader_runtime_args = {src0_buffer->address(), start_input_work, end_input_work};
         std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), start_input_work, end_input_work};
 
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
@@ -331,7 +432,18 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
         cores_with_rtargs.push_back(core);
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, cores_with_rtargs}};
+    return {
+        std::move(program),
+        {writer_kernel_id,
+         reader_kernel_id,
+         cores_with_rtargs,
+         config_cb,
+         batch_size,
+         input_height,
+         input_width,
+         num_cores_total,
+         work_per_core,
+         all_cores}};
 }
 
 Fold::MultiCoreDRAMFold::cached_program_t Fold::MultiCoreDRAMFold::create(
@@ -364,6 +476,30 @@ void Fold::MultiCoreDRAMFold::override_runtime_arguments(
 
     auto dst_dram_buffer = output_tensor.buffer();
 
+    if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
+        auto stride_h = operation_attributes.stride_h;
+        auto stride_w = operation_attributes.stride_w;
+        auto config_cb = cached_program.shared_variables.config_cb.value();
+        auto batch_size = cached_program.shared_variables.batch_size.value();
+        auto input_height = cached_program.shared_variables.input_height.value();
+        auto input_width = cached_program.shared_variables.input_width.value();
+        auto num_cores_total = cached_program.shared_variables.num_cores_total.value();
+        auto work_per_core = cached_program.shared_variables.work_per_core.value();
+        CoreRange all_cores = cached_program.shared_variables.all_cores.value();
+        Tensor config_tensor_device = create_fold_mapping_table(
+            input_tensor.device(),
+            batch_size,
+            input_height,
+            input_width,
+            stride_h,
+            stride_w,
+            work_per_core * num_cores_total,
+            work_per_core,
+            all_cores,
+            num_cores_total);
+
+        UpdateDynamicCircularBufferAddress(program, config_cb, *(config_tensor_device.buffer()));
+    }
     // Update runtime arguments for each core
     for (auto i = 0; i < cores_with_rtargs.size(); i++) {
         CoreCoord core = cores_with_rtargs[i];

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <optional>
 #include <vector>
 #include "hostdevcommon/kernel_structs.h"
@@ -48,7 +47,7 @@ static Tensor create_fold_mapping_table(
     const uint32_t input_hw = input_height * input_width;
     const uint32_t output_hw = output_height * output_width;
 
-    // Create vector to store mapping entries (src_index, dst_index, is_padding)
+    // Create vector to store mapping entries (src_index, dst_index)
     const uint32_t total_entries = total_elems * 2;
     std::vector<uint32_t> config_vector(total_entries, 0);
     uint32_t entry_idx = 0;
@@ -354,12 +353,11 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
 
     // Setup circular buffers
     uint32_t cb_src0_index = tt::CBIndex::c_0;
-    uint32_t cb_src1_index = tt::CBIndex::c_1;
 
     // Calculate buffer sizes
     uint32_t stick_nbytes = input_tensor.padded_shape()[3] * tt::datum_size(cb_data_format);
     // align to DRAM read alignment.
-    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, hal::get_dram_alignment()) * stride_w;
+    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, hal::get_dram_alignment());
 
     log_debug(
         tt::LogOp,
@@ -369,7 +367,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
         hal::get_dram_alignment());
 
     int double_buffer = 2;
-    // Create source circular buffer - sized for input work per core
+    // Create source circular buffer
     auto src_cb_config =
         CircularBufferConfig(double_buffer * aligned_stick_nbytes * stride_w, {{cb_src0_index, cb_data_format}})
             .set_page_size(cb_src0_index, aligned_stick_nbytes * stride_w);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -337,9 +337,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
     uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
 
     // Calculate total input work
-    uint32_t total_work =
-        (output.get_logical_shape()[0] * output.get_logical_shape()[1] * output.get_logical_shape()[2]) /
-        (stride_h * stride_w);
+    uint32_t total_work = (batch_size * input_height * input_width) / (stride_h * stride_w);
 
     // Get compute grid size and calculate work distribution
     auto compute_grid_size = device->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+#include "dataflow_api.h"
+
+inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
+    for (uint32_t page = 0; page < npages; ++page) {
+        DPRINT << start + page << ": ";
+        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
+            DPRINT << BF16(*ptr) << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
+    constexpr uint32_t config_cb_id = get_compile_time_arg_val(2);
+    constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(4);
+    constexpr uint32_t aligned_stick_nbytes_l1 = get_compile_time_arg_val(5);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
+
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_input_work = get_arg_val<uint32_t>(1);
+    uint32_t end_input_work = get_arg_val<uint32_t>(2);
+    const auto s0 =
+        get_interleaved_addr_gen<true, src_stick_size_is_power_of_two>(src_addr, stick_nbytes, src_log2_stick_size);
+
+    uint32_t config_l1_addr = get_read_ptr(config_cb_id);
+    volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
+
+    DPRINT << "aligned_stick_nbytes_l1: " << aligned_stick_nbytes_l1 << ENDL();
+    for (uint32_t input_idx = start_input_work; input_idx < end_input_work; input_idx++) {
+        // Each mapping takes 3 entries: src_idx, dst_idx, is_padding
+        uint32_t mapping_offset = (input_idx - start_input_work) * 2;
+        uint32_t src_index = config_data[mapping_offset];
+
+        cb_reserve_back(cb_id_in0, 1);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        uint32_t l1_write_addr_orig = l1_write_addr;
+        for (uint32_t i = 0; i < stride_w; i++) {
+            uint64_t src_noc_addr = get_noc_addr(src_index, s0);
+            noc_async_read(src_noc_addr, l1_write_addr, stick_nbytes);
+            src_index++;
+            l1_write_addr += aligned_stick_nbytes_l1;
+        }
+        // Read from NOC and write to L1
+        noc_async_read_barrier();
+        print_bf16_pages(l1_write_addr_orig, stick_nbytes / 2, stride_w);
+        cb_push_back(cb_id_in0, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -14,31 +14,31 @@ void kernel_main() {
     constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(4);
     constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
     constexpr uint32_t stride_w = get_compile_time_arg_val(6);
+    constexpr uint32_t work_per_core = get_compile_time_arg_val(7);
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_input_work = get_arg_val<uint32_t>(1);
-    uint32_t end_input_work = get_arg_val<uint32_t>(2);
     const auto s0 =
         get_interleaved_addr_gen<true, src_stick_size_is_power_of_two>(src_addr, stick_nbytes, src_log2_stick_size);
 
     uint32_t config_l1_addr = get_read_ptr(config_cb_id);
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
-    for (uint32_t input_idx = start_input_work; input_idx < end_input_work; input_idx++) {
-        // Each mapping takes 2 entries: src_idx, dst_idx
-        uint32_t mapping_offset = (input_idx - start_input_work) * 2;
-        uint32_t src_index = config_data[mapping_offset];
+    constexpr uint32_t config_buffer_entries = work_per_core * 2;
+    for (uint32_t input_idx = 0; input_idx < config_buffer_entries; input_idx += 2) {
+        // The fold mapping table(config_data) stores (src_index, dst_index) pairs that define how to extract
+        // spatial patches(in_channels * stride_w) from the input tensor and reorganize them into the output tensor.
+        // READER uses src_index (first entry at mapping_offset) to locate the input patch position,
+        // Each table entry uses 2 uint32_t values, so we step by 2 for each transformation.
+        uint32_t src_index = config_data[input_idx];
 
         cb_reserve_back(cb_id_in0, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint32_t l1_write_addr_orig = l1_write_addr;
         for (uint32_t i = 0; i < stride_w; i++) {
             uint64_t src_noc_addr = get_noc_addr(src_index, s0);
             noc_async_read(src_noc_addr, l1_write_addr, stick_nbytes);
             src_index++;
             l1_write_addr += aligned_stick_nbytes_dram;
         }
-        // Read from NOC and write to L1
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, 1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -6,24 +6,13 @@
 #include <cstdint>
 #include "dataflow_api.h"
 
-inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
-    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
-    for (uint32_t page = 0; page < npages; ++page) {
-        DPRINT << start + page << ": ";
-        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
-            DPRINT << BF16(*ptr) << " ";
-        }
-        DPRINT << ENDL();
-    }
-}
-
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
     constexpr uint32_t config_cb_id = get_compile_time_arg_val(2);
     constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
     constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(4);
-    constexpr uint32_t aligned_stick_nbytes_l1 = get_compile_time_arg_val(5);
+    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
     constexpr uint32_t stride_w = get_compile_time_arg_val(6);
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -35,9 +24,8 @@ void kernel_main() {
     uint32_t config_l1_addr = get_read_ptr(config_cb_id);
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
-    DPRINT << "aligned_stick_nbytes_l1: " << aligned_stick_nbytes_l1 << ENDL();
     for (uint32_t input_idx = start_input_work; input_idx < end_input_work; input_idx++) {
-        // Each mapping takes 3 entries: src_idx, dst_idx, is_padding
+        // Each mapping takes 2 entries: src_idx, dst_idx
         uint32_t mapping_offset = (input_idx - start_input_work) * 2;
         uint32_t src_index = config_data[mapping_offset];
 
@@ -48,11 +36,10 @@ void kernel_main() {
             uint64_t src_noc_addr = get_noc_addr(src_index, s0);
             noc_async_read(src_noc_addr, l1_write_addr, stick_nbytes);
             src_index++;
-            l1_write_addr += aligned_stick_nbytes_l1;
+            l1_write_addr += aligned_stick_nbytes_dram;
         }
         // Read from NOC and write to L1
         noc_async_read_barrier();
-        print_bf16_pages(l1_write_addr_orig, stick_nbytes / 2, stride_w);
         cb_push_back(cb_id_in0, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <cstdint>
+#include "dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -59,7 +59,7 @@ void kernel_main() {
         // print_bf16_pages(get_write_ptr(cb_id_in0), aligned_stick_nbytes_dram / 2, stride_h * stride_w);
         cb_push_back(cb_id_in0, 1);
 
-        if (curr_src_row_index >= (input_width - 1)) {
+        if (curr_src_row_index >= (input_width)) {
             curr_src_offset += input_width * (stride_h - 1);
             // DPRINT << "Updating curr_src_offset to: " << curr_src_offset << ENDL();
             curr_src_row_index = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -35,10 +35,10 @@ void kernel_main() {
             }
             curr_src_offset += input_width - stride_w;
         }
-        curr_src_row_index += stride_w;
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, 1);
 
+        curr_src_row_index += stride_w;
         if (curr_src_row_index >= (input_width)) {
             src_index += input_width * (stride_h - 1);
             curr_src_row_index = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -4,66 +4,45 @@
 
 #include <stdint.h>
 #include <cstdint>
-// #include "dataflow_api.h"
-
-// inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
-//     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start *
-//     elts_per_page; for (uint32_t page = 0; page < npages; ++page) {
-//         DPRINT << start + page << ": ";
-//         for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
-//             DPRINT << BF16(*ptr) << " ";
-//         }
-//         DPRINT << ENDL();
-//     }
-// }
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(2);
-    constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(4);
-    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(6);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(7);
-    constexpr uint32_t input_width = get_compile_time_arg_val(8);
-    constexpr uint32_t work_per_core = get_compile_time_arg_val(9);
+    constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(3);
+    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(4);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(5);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr uint32_t work_per_core = get_compile_time_arg_val(8);
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const auto s0 =
+    const auto s_in =
         get_interleaved_addr_gen<true, src_stick_size_is_power_of_two>(src_addr, stick_nbytes, src_log2_stick_size);
 
-    uint32_t config_l1_addr = get_read_ptr(config_cb_id);
-    volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
-
-    uint32_t curr_src_offset = config_data[0];
-    uint32_t curr_src_row_index = config_data[2];
-    DPRINT << "work_per_core: " << work_per_core << ", curr_src_offset: " << curr_src_offset
-           << ", curr_src_row_index: " << curr_src_row_index << ENDL();
+    uint32_t src_index = get_arg_val<uint32_t>(1);
+    uint32_t curr_src_row_index = get_arg_val<uint32_t>(2);
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
-        uint32_t src_index = curr_src_offset;
+        uint32_t curr_src_offset = src_index;
         cb_reserve_back(cb_id_in0, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
         for (uint32_t i = 0; i < stride_h; i++) {
             for (uint32_t j = 0; j < stride_w; j++) {
-                uint64_t src_noc_addr = get_noc_addr(src_index, s0);
+                uint64_t src_noc_addr = get_noc_addr(curr_src_offset, s_in);
                 noc_async_read(src_noc_addr, l1_write_addr, stick_nbytes);
-                src_index++;
+                curr_src_offset++;
                 l1_write_addr += aligned_stick_nbytes_dram;
             }
-            src_index += input_width - stride_w;
+            curr_src_offset += input_width - stride_w;
         }
         curr_src_row_index += stride_w;
-        DPRINT << "curr_src_index: " << curr_src_offset << ENDL();
         noc_async_read_barrier();
-        // print_bf16_pages(get_write_ptr(cb_id_in0), aligned_stick_nbytes_dram / 2, stride_h * stride_w);
         cb_push_back(cb_id_in0, 1);
 
         if (curr_src_row_index >= (input_width)) {
-            curr_src_offset += input_width * (stride_h - 1);
-            // DPRINT << "Updating curr_src_offset to: " << curr_src_offset << ENDL();
+            src_index += input_width * (stride_h - 1);
             curr_src_row_index = 0;
         }
-        curr_src_offset += stride_w;
+        src_index += stride_w;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -4,7 +4,18 @@
 
 #include <stdint.h>
 #include <cstdint>
-#include "dataflow_api.h"
+// #include "dataflow_api.h"
+
+// inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
+//     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start *
+//     elts_per_page; for (uint32_t page = 0; page < npages; ++page) {
+//         DPRINT << start + page << ": ";
+//         for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
+//             DPRINT << BF16(*ptr) << " ";
+//         }
+//         DPRINT << ENDL();
+//     }
+// }
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
@@ -13,8 +24,8 @@ void kernel_main() {
     constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
     constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(4);
     constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(7);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(6);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(7);
     constexpr uint32_t input_width = get_compile_time_arg_val(8);
     constexpr uint32_t work_per_core = get_compile_time_arg_val(9);
 
@@ -25,14 +36,12 @@ void kernel_main() {
     uint32_t config_l1_addr = get_read_ptr(config_cb_id);
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
-    constexpr uint32_t config_buffer_entries = work_per_core * 2;
-    for (uint32_t input_idx = 0; input_idx < config_buffer_entries; input_idx += 2) {
-        // The fold mapping table(config_data) stores (src_index, dst_index) pairs that define how to extract
-        // spatial patches(in_channels * stride_w) from the input tensor and reorganize them into the output tensor.
-        // READER uses src_index (first entry at mapping_offset) to locate the input patch position,
-        // Each table entry uses 2 uint32_t values, so we step by 2 for each transformation.
-        uint32_t src_index = config_data[input_idx];
-
+    uint32_t curr_src_offset = config_data[0];
+    uint32_t curr_src_row_index = config_data[2];
+    DPRINT << "work_per_core: " << work_per_core << ", curr_src_offset: " << curr_src_offset
+           << ", curr_src_row_index: " << curr_src_row_index << ENDL();
+    for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
+        uint32_t src_index = curr_src_offset;
         cb_reserve_back(cb_id_in0, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
         for (uint32_t i = 0; i < stride_h; i++) {
@@ -44,7 +53,17 @@ void kernel_main() {
             }
             src_index += input_width - stride_w;
         }
+        curr_src_row_index += stride_w;
+        DPRINT << "curr_src_index: " << curr_src_offset << ENDL();
         noc_async_read_barrier();
+        // print_bf16_pages(get_write_ptr(cb_id_in0), aligned_stick_nbytes_dram / 2, stride_h * stride_w);
         cb_push_back(cb_id_in0, 1);
+
+        if (curr_src_row_index >= (input_width - 1)) {
+            curr_src_offset += input_width * (stride_h - 1);
+            // DPRINT << "Updating curr_src_offset to: " << curr_src_offset << ENDL();
+            curr_src_row_index = 0;
+        }
+        curr_src_offset += stride_w;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -14,20 +14,22 @@ void kernel_main() {
     constexpr uint32_t dst_log2_stick_size = get_compile_time_arg_val(4);
     constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
     constexpr uint32_t stride_w = get_compile_time_arg_val(6);
+    constexpr uint32_t work_per_core = get_compile_time_arg_val(7);
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_input_work = get_arg_val<uint32_t>(1);
-    uint32_t end_input_work = get_arg_val<uint32_t>(2);
     const auto s_out =
         get_interleaved_addr_gen<true, dst_stick_size_is_power_of_two>(dst_addr, stick_nbytes, dst_log2_stick_size);
+
     uint32_t config_l1_addr = get_read_ptr(config_cb_id);
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
-    for (uint32_t input_idx = start_input_work; input_idx < end_input_work; input_idx++) {
-        // Each mapping takes 2 entries: src_idx, dst_idx
-        uint32_t mapping_offset = (input_idx - start_input_work) * 2;
-        uint32_t src_index = config_data[mapping_offset];
-        uint32_t dst_index = config_data[mapping_offset + 1];
+    constexpr uint32_t config_buffer_entries = work_per_core * 2;
+    for (uint32_t input_idx = 1; input_idx < config_buffer_entries; input_idx += 2) {
+        // The fold mapping table(config_data) stores (src_index, dst_index) pairs that define how to extract
+        // spatial patches(in_channels * stride_w) from the input tensor and reorganize them into the output tensor.
+        // WRITER uses dst_index (second entry at mapping_offset) for output tensor placement.
+        // Each table entry uses 2 uint32_t values, so we step by 2 per transformation.
+        uint32_t dst_index = config_data[input_idx];
 
         cb_wait_front(cb_id_in0, 1);
         uint32_t l1_addr = get_read_ptr(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -12,7 +12,7 @@ void kernel_main() {
     constexpr uint32_t config_cb_id = get_compile_time_arg_val(2);
     constexpr bool dst_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
     constexpr uint32_t dst_log2_stick_size = get_compile_time_arg_val(4);
-    constexpr uint32_t aligned_stick_nbytes_l1 = get_compile_time_arg_val(5);
+    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
     constexpr uint32_t stride_w = get_compile_time_arg_val(6);
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -22,15 +22,9 @@ void kernel_main() {
         get_interleaved_addr_gen<true, dst_stick_size_is_power_of_two>(dst_addr, stick_nbytes, dst_log2_stick_size);
     uint32_t config_l1_addr = get_read_ptr(config_cb_id);
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
-    // Handle padding: Write zeros to padding locations
-    // Create a zero buffer
-    uint8_t zero_buffer[stick_nbytes];
-    for (uint32_t i = 0; i < stick_nbytes; i++) {
-        zero_buffer[i] = 0;
-    }
 
     for (uint32_t input_idx = start_input_work; input_idx < end_input_work; input_idx++) {
-        // Each mapping takes 3 entries: src_idx, dst_idx, is_padding
+        // Each mapping takes 2 entries: src_idx, dst_idx
         uint32_t mapping_offset = (input_idx - start_input_work) * 2;
         uint32_t src_index = config_data[mapping_offset];
         uint32_t dst_index = config_data[mapping_offset + 1];
@@ -41,10 +35,9 @@ void kernel_main() {
             uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
             noc_async_write(l1_addr, dst_noc_addr, stick_nbytes);
             dst_index++;
-            l1_addr += aligned_stick_nbytes_l1;
+            l1_addr += aligned_stick_nbytes_dram;
         }
         noc_async_write_barrier();
         cb_pop_front(cb_id_in0, 1);
     }
-    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -4,61 +4,33 @@
 
 #include <stdint.h>
 #include <cstdint>
-// #include "dataflow_api.h"
-
-// inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
-//     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start *
-//     elts_per_page; for (uint32_t page = 0; page < npages; ++page) {
-//         DPRINT << start + page << ": ";
-//         for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
-//             DPRINT << BF16(*ptr) << " ";
-//         }
-//         DPRINT << ENDL();
-//     }
-// }
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(2);
-    constexpr bool dst_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t dst_log2_stick_size = get_compile_time_arg_val(4);
-    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(6);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(7);
-    constexpr uint32_t input_width = get_compile_time_arg_val(8);
-    constexpr uint32_t work_per_core = get_compile_time_arg_val(9);
+    constexpr bool dst_stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t dst_log2_stick_size = get_compile_time_arg_val(3);
+    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(4);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(5);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr uint32_t work_per_core = get_compile_time_arg_val(8);
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const auto s_out =
         get_interleaved_addr_gen<true, dst_stick_size_is_power_of_two>(dst_addr, stick_nbytes, dst_log2_stick_size);
-
-    uint32_t config_l1_addr = get_read_ptr(config_cb_id);
-    volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
-
-    uint32_t dst_index = config_data[1];
-    // DPRINT << "work_per_core: " << work_per_core << ", dst_index: " << dst_index << ENDL();
-    // DPRINT << "stick_nbytes: " << stick_nbytes
-    //        << ", aligned_stick_nbytes_dram: " << aligned_stick_nbytes_dram
-    //        << ", dst_log2_stick_size: " << dst_log2_stick_size
-    //        << ", stride_w: " << stride_w
-    //        << ", stride_h: " << stride_h
-    //        << ", input_width: " << input_width
-    //        << ENDL();
-    // DPRINT << "dst_index: " << dst_index << ENDL();
+    uint32_t dst_index = get_arg_val<uint32_t>(1);
+    constexpr uint32_t patch_size = stride_h * stride_w;
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         cb_wait_front(cb_id_in0, 1);
         uint32_t l1_addr = get_read_ptr(cb_id_in0);
-        for (uint32_t i = 0; i < stride_h; i++) {
-            for (uint32_t j = 0; j < stride_w; j++) {
-                uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
-                noc_async_write(l1_addr, dst_noc_addr, stick_nbytes);
-                dst_index++;
-                l1_addr += aligned_stick_nbytes_dram;
-            }
+        for (uint32_t i = 0; i < patch_size; i++) {
+            uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
+            noc_async_write(l1_addr, dst_noc_addr, stick_nbytes);
+            dst_index++;
+            l1_addr += aligned_stick_nbytes_dram;
         }
         noc_async_write_barrier();
-        // print_bf16_pages(get_read_ptr(cb_id_in0), stick_nbytes / 2 , stride_h * stride_w);
         cb_pop_front(cb_id_in0, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <cstdint>
+#include "dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -4,7 +4,18 @@
 
 #include <stdint.h>
 #include <cstdint>
-#include "dataflow_api.h"
+// #include "dataflow_api.h"
+
+// inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
+//     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start *
+//     elts_per_page; for (uint32_t page = 0; page < npages; ++page) {
+//         DPRINT << start + page << ": ";
+//         for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
+//             DPRINT << BF16(*ptr) << " ";
+//         }
+//         DPRINT << ENDL();
+//     }
+// }
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
@@ -13,8 +24,8 @@ void kernel_main() {
     constexpr bool dst_stick_size_is_power_of_two = get_compile_time_arg_val(3) == 1;
     constexpr uint32_t dst_log2_stick_size = get_compile_time_arg_val(4);
     constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(5);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(7);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(6);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(7);
     constexpr uint32_t input_width = get_compile_time_arg_val(8);
     constexpr uint32_t work_per_core = get_compile_time_arg_val(9);
 
@@ -25,14 +36,17 @@ void kernel_main() {
     uint32_t config_l1_addr = get_read_ptr(config_cb_id);
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
-    constexpr uint32_t config_buffer_entries = work_per_core * 2;
-    for (uint32_t input_idx = 1; input_idx < config_buffer_entries; input_idx += 2) {
-        // The fold mapping table(config_data) stores (src_index, dst_index) pairs that define how to extract
-        // spatial patches(in_channels * stride_w) from the input tensor and reorganize them into the output tensor.
-        // WRITER uses dst_index (second entry at mapping_offset) for output tensor placement.
-        // Each table entry uses 2 uint32_t values, so we step by 2 per transformation.
-        uint32_t dst_index = config_data[input_idx];
-
+    uint32_t dst_index = config_data[1];
+    // DPRINT << "work_per_core: " << work_per_core << ", dst_index: " << dst_index << ENDL();
+    // DPRINT << "stick_nbytes: " << stick_nbytes
+    //        << ", aligned_stick_nbytes_dram: " << aligned_stick_nbytes_dram
+    //        << ", dst_log2_stick_size: " << dst_log2_stick_size
+    //        << ", stride_w: " << stride_w
+    //        << ", stride_h: " << stride_h
+    //        << ", input_width: " << input_width
+    //        << ENDL();
+    // DPRINT << "dst_index: " << dst_index << ENDL();
+    for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         cb_wait_front(cb_id_in0, 1);
         uint32_t l1_addr = get_read_ptr(cb_id_in0);
         for (uint32_t i = 0; i < stride_h; i++) {
@@ -44,6 +58,7 @@ void kernel_main() {
             }
         }
         noc_async_write_barrier();
+        // print_bf16_pages(get_read_ptr(cb_id_in0), stick_nbytes / 2 , stride_h * stride_w);
         cb_pop_front(cb_id_in0, 1);
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
The fold operation was performing inefficient memory reads from DRAM for Row Major tensors, reading data element by element. Also, indexes for source and destination were being calculated on the fly in kernels.

### What's changed
Implemented optimization with the following key improvements:
- Coalesced Memory Access
    - New reader kernel: reader_dram2cb_for_rm_input.cpp performs multiple NOC reads before barrier calls.
    - Optimized writer kernel: writer_cb2dram_for_rm_input.cpp with improved memory access patterns

### Some perf numbers for device kernel duration.

Input Size | Stride | Before (ns) | After (ns) | Improvement (ns) | Performance Gain
-- | -- | -- | -- | -- | --
224×224×3 | 16×16 | 414,330 | 103,643 | -310,687 | +75.0%
384×512×3 | 16×16 | 1,492,097 | 493,776 | -998,321 | +66.9%
512×672×3 | 16×16 | 2,931,690 | 589,565 | -2,342,125 | +79.9%
224×224×3 | 32×32 | 418,076 | 114,447 | -303,629 | +72.6%
384×512×3 | 32×32 | 1,485,194 | 446,223 | -1,038,971 | +69.9%
512×672×3 | 32×32 | 2,930,218 | 880,592 | -2,049,626 | +69.9%


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16461691895) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16461693758) CI with demo tests passes
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/16461695905) Failure not related to change