### PR TITLE
Revert "Check for linked transactions in noc sanitizer (#24807)"

### DIFF
--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -47,9 +47,6 @@ Watcher features can be disabled individually using the following environment va
    export TT_METAL_WATCHER_DISABLE_WAYPOINT=1
    export TT_METAL_WATCHER_DISABLE_STACK_USAGE=1
 
-   # This feature is opt-in, set the env var to enable it
-   export TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION=1
-
    # In certain cases enabling watcher can cause the binary to be too large. In this case, disable inlining.
    export TT_METAL_WATCHER_NOINLINE=1
 

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -166,7 +166,6 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_auto_unpause(true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noinline(true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noc_sanitize_linked_transaction(true);
 
         // Parent class initializes devices and any necessary flags
         DebugToolsFixture::SetUp();

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -53,7 +53,6 @@ enum watcher_features_t {
     SanitizeZeroL1Write,
     SanitizeMailboxWrite,
     SanitizeInlineWriteDram,
-    SanitizeLinkedTransaction,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -172,7 +171,6 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     // Write runtime args - update to a core that doesn't exist or an improperly aligned address,
     // depending on the flags passed in.
     bool use_inline_dw_write = false;
-    bool bad_linked_transaction = false;
     switch(feature) {
         case SanitizeAddress:
             output_buf_noc_xy.x = 26;
@@ -193,7 +191,6 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
             buffer_addr = get_address_for_test(is_eth_core, HalL1MemAddrType::MAILBOX);
             break;
         case SanitizeInlineWriteDram: use_inline_dw_write = true; break;
-        case SanitizeLinkedTransaction: bad_linked_transaction = true; break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -212,8 +209,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
          output_buf_noc_xy.x,
          output_buf_noc_xy.y,
          buffer_size,
-         use_inline_dw_write,
-         bad_linked_transaction});
+         use_inline_dw_write});
 
     // Run the kernel, expect an exception here
     try {
@@ -339,23 +335,6 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 virtual_core.y,
                 risc_name,
                 0,
-                output_core_virtual_coords.str(),
-                output_buffer_addr);
-        } break;
-        case SanitizeLinkedTransaction: {
-            expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write {} "
-                "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (submitting a "
-                "non-mcast transaction when there's a linked transaction).",
-                device->id(),
-                (is_eth_core) ? "acteth" : "worker",
-                core.x,
-                core.y,
-                virtual_core.x,
-                virtual_core.y,
-                risc_name,
-                buffer_size,
-                buffer_addr,
                 output_core_virtual_coords.str(),
                 output_buffer_addr);
         } break;
@@ -517,14 +496,5 @@ TEST_F(WatcherFixture, IdleEthTestWatcherSanitizeInlineWriteDram) {
     }
     this->RunTestOnDevice(
         [](WatcherFixture* fixture, IDevice* device) { RunTestIEth(fixture, device, SanitizeInlineWriteDram); },
-        this->devices_[0]);
-}
-
-TEST_F(WatcherFixture, DISABLED_SanitizeLinkedTransaction) {
-    this->RunTestOnDevice(
-        [](WatcherFixture* fixture, IDevice* device) {
-            CoreCoord core{0, 0};
-            RunTestOnCore(fixture, device, core, false, SanitizeLinkedTransaction);
-        },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -24,7 +24,6 @@ void kernel_main() {
     std::uint32_t buffer_size = get_arg_val<uint32_t>(7);
 
     bool use_inline_dw_write = static_cast<bool>(get_arg_val<uint32_t>(8));
-    bool bad_linked_transaction = static_cast<bool>(get_arg_val<uint32_t>(9));
 
 #if defined(SIGNAL_COMPLETION_TO_DISPATCHER)
     // We will assert later. This kernel will hang.
@@ -58,12 +57,6 @@ void kernel_main() {
     noc_async_read_barrier();
 
     // NOC dst address
-    if (bad_linked_transaction) {
-        uint64_t dst_noc_multicast_addr =
-            get_noc_multicast_addr(dst_noc_x, dst_noc_y, dst_noc_x, dst_noc_y, buffer_dst_addr);
-        noc_async_write_multicast(local_buffer_addr, dst_noc_multicast_addr, buffer_size, 1, true);
-        // linked transaction not closed, the next unicast will hang.
-    }
     std::uint64_t buffer_dst_noc_addr = get_noc_addr(dst_noc_x, dst_noc_y, buffer_dst_addr);
     if (use_inline_dw_write) {
         auto src_data = reinterpret_cast<volatile uint32_t*>(local_buffer_addr);

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -105,12 +105,6 @@ inline __attribute__((always_inline)) void set_noc_counter_val(uint32_t noc, uin
 
 inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(
     uint32_t noc, uint32_t buf, uint32_t addr, uint32_t val) {
-#if defined(WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION)
-    if (addr == NOC_CTRL) {
-        auto* watcher_msg = GET_MAILBOX_ADDRESS_DEV(watcher);
-        watcher_msg->noc_linked_status[noc] = (val & NOC_CMD_VC_LINKED) != 0;
-    }
-#endif
     uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     *ptr = val;

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -553,7 +553,6 @@ void noc_async_read_one_packet_set_state(uint64_t src_noc_addr, uint32_t size, u
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, src_noc_addr, size, -1);
 
     WAYPOINT("NASW");
@@ -621,7 +620,6 @@ void noc_async_read_set_state(uint64_t src_noc_addr, uint8_t noc = noc_index) {
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, src_noc_addr, 0, -1);
 
     WAYPOINT("NAUW");
@@ -840,7 +838,6 @@ inline void noc_async_write_multicast(
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
     std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc);
 
     WAYPOINT("NWPW");
@@ -1676,7 +1673,6 @@ FORCE_INLINE void noc_inline_dw_write_set_state(
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NWIW");
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     // DEBUG_SANITIZE_NOC_ADDR is not needed here because it doesn't send out the request
     // The address could be set here or later in noc_inline_dw_write_with_state
 
@@ -1824,7 +1820,6 @@ FORCE_INLINE uint32_t noc_async_read_tile_dram_sharded_set_state(
     uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];
     uint64_t src_noc_addr = get_noc_addr_helper(src_noc_xy, src_addr_);
 
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::READ_DRAM_SHARDED_SET_STATE, uint64_t(src_noc_xy) << 32, page_size, (use_vc) ? vc : -1);
 
@@ -1902,7 +1897,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NAWW");
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, dst_noc_addr, 0, vc);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NAWD");

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -270,30 +270,6 @@ inline void debug_sanitize_post_noc_addr_and_hang(
     }
 }
 
-inline void debug_sanitize_check_linked_transactions(
-    uint8_t noc_id,
-    uint64_t noc_addr,
-    uint32_t l1_addr,
-    uint32_t noc_len,
-    debug_sanitize_noc_cast_t multicast,
-    debug_sanitize_noc_dir_t dir) {
-    if (multicast == DEBUG_SANITIZE_NOC_UNICAST) {
-        // Submitting a non-mcast transaction if there's a linked transaction on any cmd_buf will cause a deadlock.
-        auto* watcher_msg = GET_MAILBOX_ADDRESS_DEV(watcher);
-        if (watcher_msg->noc_linked_status[noc_id]) {
-            debug_sanitize_post_noc_addr_and_hang(
-                noc_id,
-                noc_addr,
-                l1_addr,
-                noc_len,
-                multicast,
-                dir,
-                DEBUG_SANITIZE_NOC_TARGET,
-                DebugSanitizeNocLinkedTransactionViolation);
-        }
-    }
-}
-
 // Return value is the alignment mask for the type of core the noc address points
 // to. Need to do this because L1 alignment needs to match the noc address alignment requirements,
 // even if it's different than the inherent L1 alignment requirements.
@@ -304,8 +280,7 @@ uint32_t debug_sanitize_noc_addr(
     uint32_t l1_addr,
     uint32_t noc_len,
     debug_sanitize_noc_cast_t multicast,
-    debug_sanitize_noc_dir_t dir,
-    bool check_linked) {
+    debug_sanitize_noc_dir_t dir) {
     // Different encoding of noc addr depending on multicast vs unitcast
     uint8_t x, y;
     if (multicast) {
@@ -352,11 +327,6 @@ uint32_t debug_sanitize_noc_addr(
         debug_sanitize_post_noc_addr_and_hang(
             noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, return_code);
     }
-#if defined(WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION)
-    if (check_linked) {
-        debug_sanitize_check_linked_transactions(noc_id, noc_addr, l1_addr, noc_len, multicast, dir);
-    }
-#endif
 
     // Check noc addr, we save the alignment requirement from the noc src/dst because the L1 address
     // needs to match alignment.
@@ -434,10 +404,9 @@ void debug_sanitize_noc_and_worker_addr(
     uint32_t worker_addr,
     uint32_t len,
     debug_sanitize_noc_cast_t multicast,
-    debug_sanitize_noc_dir_t dir,
-    bool check_linked) {
+    debug_sanitize_noc_dir_t dir) {
     // Check noc addr, get any extra alignment req for worker.
-    uint32_t alignment_mask = debug_sanitize_noc_addr(noc_id, noc_addr, worker_addr, len, multicast, dir, check_linked);
+    uint32_t alignment_mask = debug_sanitize_noc_addr(noc_id, noc_addr, worker_addr, len, multicast, dir);
 
     // Check worker addr and alignment, but these don't apply to regs.
     if (!debug_valid_reg_addr(worker_addr, len)) {
@@ -483,99 +452,86 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
 }
 
 // TODO: Clean these up with #7453
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id, read_cmd_buf)                                       \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION_(                                                                          \
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id)                                                     \
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                           \
         noc_id,                                                                                                    \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_MID) << 32) |                      \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_LO)),                              \
         NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_RET_ADDR_LO),                                               \
-        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE),                                                 \
-        false);
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id, cmd_buf)                                     \
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                   \
-        noc_id,                                                                                              \
+        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE));
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id, cmd_buf)                                                    \
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                          \
+        noc_id,                                                                                                    \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_MID) << 32) |                      \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_LO)),                              \
         NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO),                                             \
-        NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_AT_LEN_BE),                                                \
-        false);
+        NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)                                                   \
     DEBUG_SANITIZE_NOC_ADDR(                                                                                  \
         noc_id,                                                                                               \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_MID) << 32) |                      \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO), false),                       \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO)),                              \
         4);
-#define DEBUG_SANITIZE_NOC_ADDR_(noc_id, a, l, check_linked)                                                     \
-    debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
+#define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l)                                                      \
+    debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ); \
     LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l) DEBUG_SANITIZE_NOC_ADDR_(noc_id, a, l, true)
-#define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir)        \
-    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, multicast, dir, true); \
+#define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir)  \
+    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, multicast, dir); \
     LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_(noc_id, noc_a, worker_a, l, check_linked)                  \
-    debug_sanitize_noc_and_worker_addr(                                                                 \
-        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
-    LOG_LEN(l);                                                                                         \
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_id, noc_a, worker_a, l)                   \
+    debug_sanitize_noc_and_worker_addr(                                                   \
+        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ); \
+    LOG_LEN(l);                                                                           \
     debug_insert_delay((uint8_t)TransactionRead);
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_id, noc_a, worker_a, l) \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION_(noc_id, noc_a, worker_a, l, true)
-#define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_id, noc_a, worker_a, l)                     \
-    debug_sanitize_noc_and_worker_addr(                                                           \
-        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ, true); \
-    LOG_LEN(l);                                                                                   \
+#define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_id, noc_a, worker_a, l)               \
+    debug_sanitize_noc_and_worker_addr(                                                     \
+        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ); \
+    LOG_LEN(l);                                                                             \
     debug_insert_delay((uint8_t)TransactionRead);
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(noc_id, noc_a, worker_a, l, check_linked)                  \
-    debug_sanitize_noc_and_worker_addr(                                                                  \
-        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_WRITE, check_linked); \
-    LOG_LEN(l);                                                                                          \
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l)                   \
+    debug_sanitize_noc_and_worker_addr(                                                    \
+        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_WRITE); \
+    LOG_LEN(l);                                                                            \
     debug_insert_delay((uint8_t)TransactionWrite)
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l) \
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(noc_id, noc_a, worker_a, l, true);
-#define DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l)                     \
-    debug_sanitize_noc_and_worker_addr(                                                            \
-        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_WRITE, true); \
-    LOG_LEN(l);                                                                                    \
+#define DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l)               \
+    debug_sanitize_noc_and_worker_addr(                                                      \
+        noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_WRITE); \
+    LOG_LEN(l);                                                                              \
     debug_insert_delay((uint8_t)TransactionWrite);
 
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)                \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION_(                                                                          \
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                           \
         noc_id,                                                                                                    \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
         worker_a,                                                                                                  \
-        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE),                                                 \
-        false);
+        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)                      \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION_(                                                                          \
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                           \
         noc_id,                                                                                                    \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
         worker_a,                                                                                                  \
-        l,                                                                                                         \
-        false);
+        l);
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)                \
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                          \
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                           \
         noc_id,                                                                                                     \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
         worker_a,                                                                                                   \
-        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE),                                                 \
-        false);
+        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)                      \
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                          \
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                           \
         noc_id,                                                                                                     \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
         worker_a,                                                                                                   \
-        l,                                                                                                          \
-        false);
+        l);
 #define DEBUG_INSERT_DELAY(transaction_type) debug_insert_delay(transaction_type)
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) debug_throw_on_dram_addr(noc_id, addr, l)
-#define DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id, multicast) \
-    debug_sanitize_check_linked_transactions(noc_id, 0, 0, 0, multicast, DEBUG_SANITIZE_NOC_WRITE);
 
 // Delay for debugging purposes
 inline void debug_insert_delay(uint8_t transaction_type) {
@@ -608,7 +564,6 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a) \
     LOG_READ_LEN_FROM_STATE(noc_id)
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id, read_cmd_buf)
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a) \
     LOG_WRITE_LEN_FROM_STATE(noc_id)
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l) LOG_LEN(l)
@@ -616,6 +571,5 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)
 #define DEBUG_INSERT_DELAY(transaction_type)
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id, multicast)
 
 #endif  // WATCHER_ENABLED

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <atomic>
-
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
 
@@ -245,7 +243,6 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeNocMixedVirtualandPhysical = 10,
     DebugSanitizeInlineWriteDramUnsupported = 11,
     DebugSanitizeNocAddrMailbox = 12,
-    DebugSanitizeNocLinkedTransactionViolation = 13,
 };
 
 struct debug_assert_msg_t {
@@ -310,8 +307,6 @@ struct watcher_msg_t {
     volatile uint32_t enable;
     struct debug_waypoint_msg_t debug_waypoint[MAX_RISCV_PER_CORE];
     struct debug_sanitize_noc_addr_msg_t sanitize_noc[MAX_NUM_NOCS_PER_CORE];
-    std::atomic<bool> noc_linked_status[MAX_NUM_NOCS_PER_CORE];
-    uint8_t pad_0[2];
     struct debug_assert_msg_t assert_status;
     struct debug_pause_msg_t pause_status;
     struct debug_stack_usage_t stack_usage;

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -596,10 +596,6 @@ void WatcherDeviceReader::DumpNocSanitizeStatus(
             error_msg = get_noc_target_str(device_id, core, noc, san);
             error_msg += string(san->is_target ? " (NOC target" : " (Local L1") + " overwrites mailboxes).";
             break;
-        case DebugSanitizeNocLinkedTransactionViolation:
-            error_msg = get_noc_target_str(device_id, core, noc, san);
-            error_msg += fmt::format(" (submitting a non-mcast transaction when there's a linked transaction).");
-            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -9,8 +9,6 @@
 #include "dataflow_api.h"
 #include "cq_helpers.hpp"
 
-#include "debug/sanitize_noc.h"
-
 // The command queue read interface controls reads from the issue region, host owns the issue region write interface
 // Commands and data to send to device are pushed into the issue region
 struct CQReadInterface {
@@ -218,7 +216,6 @@ FORCE_INLINE void cq_noc_async_write_init_state(
     constexpr bool posted = false;
     constexpr uint32_t vc = mcast ? NOC_DISPATCH_MULTICAST_WRITE_VC : NOC_UNICAST_WRITE_VC;
 
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, mcast ? DEBUG_SANITIZE_NOC_MULTICAST : DEBUG_SANITIZE_NOC_UNICAST);
     constexpr uint32_t noc_cmd_field =
         NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
         (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
@@ -301,7 +298,6 @@ FORCE_INLINE void cq_noc_inline_dw_write_init_state(
     constexpr bool posted = false;
     constexpr uint32_t static_vc = NOC_UNICAST_WRITE_VC;
 
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, mcast ? DEBUG_SANITIZE_NOC_MULTICAST : DEBUG_SANITIZE_NOC_UNICAST);
     constexpr uint32_t noc_cmd_field = (static_vc_alloc ? NOC_CMD_VC_STATIC : 0x0) | NOC_CMD_STATIC_VC(static_vc) |
                                        NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_WR_INLINE |
                                        (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0) |

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -210,9 +210,6 @@ void JitBuildEnv::init(
     if (rtoptions.get_watcher_noinline()) {
         this->defines_ += "-DWATCHER_NOINLINE ";
     }
-    if (rtoptions.get_watcher_noc_sanitize_linked_transaction()) {
-        this->defines_ += "-DWATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION ";
-    }
     for (auto& feature : rtoptions.get_watcher_disabled_features()) {
         this->defines_ += "-DWATCHER_DISABLE_" + feature + " ";
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -282,8 +282,6 @@ void RunTimeOptions::ParseWatcherEnv() {
     watcher_settings.phys_coords = (getenv("TT_METAL_WATCHER_PHYS_COORDS") != nullptr);
     watcher_settings.text_start = (getenv("TT_METAL_WATCHER_TEXT_START") != nullptr);
     watcher_settings.skip_logging = (getenv("TT_METAL_WATCHER_SKIP_LOGGING") != nullptr);
-    watcher_settings.noc_sanitize_linked_transaction =
-        (getenv("TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION") != nullptr);
     // Auto unpause is for testing only, no env var.
     watcher_settings.auto_unpause = false;
 
@@ -313,11 +311,6 @@ void RunTimeOptions::ParseWatcherEnv() {
         TT_ASSERT(
             watcher_disabled_features.find(watcher_noc_sanitize_str) == watcher_disabled_features.end(),
             "TT_METAL_WATCHER_DEBUG_DELAY requires TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=0");
-    }
-    if (watcher_settings.noc_sanitize_linked_transaction) {
-        TT_ASSERT(
-            watcher_disabled_features.find(watcher_noc_sanitize_str) == watcher_disabled_features.end(),
-            "TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION requires TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=0");
     }
 }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -85,7 +85,6 @@ struct WatcherSettings {
     bool phys_coords = false;
     bool text_start = false;
     bool skip_logging = false;
-    bool noc_sanitize_linked_transaction = false;
     int interval_ms = 0;
 };
 
@@ -231,12 +230,6 @@ public:
     inline void set_watcher_text_start(bool text_start) { watcher_settings.text_start = text_start; }
     inline bool get_watcher_skip_logging() const { return watcher_settings.skip_logging; }
     inline void set_watcher_skip_logging(bool skip_logging) { watcher_settings.skip_logging = skip_logging; }
-    inline bool get_watcher_noc_sanitize_linked_transaction() const {
-        return watcher_settings.noc_sanitize_linked_transaction;
-    }
-    inline void set_watcher_noc_sanitize_linked_transaction(bool enabled) {
-        watcher_settings.noc_sanitize_linked_transaction = enabled;
-    }
     inline const std::set<std::string>& get_watcher_disabled_features() const { return watcher_disabled_features; }
     inline bool watcher_status_disabled() const { return watcher_feature_disabled(watcher_waypoint_str); }
     inline bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }


### PR DESCRIPTION
This reverts commit 9afb3d61fa7cbd262e6302d52d2adbbb7c7b30fd.

### Problem description
Provide context for the problem.
So APC is down after this commit. We need to revert it