### PR TITLE
Change CoordSystem::PHYSICAL to NOC0

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -161,7 +161,7 @@ private:
         auto physical_eth_core =
             soc_d.get_physical_ethernet_core_from_logical(CoreCoord{logical_eth_core.x, logical_eth_core.y});
 
-        const std::vector<tt::umd::CoreCoord>& tensix_cores = soc_d.get_cores(CoreType::TENSIX, CoordSystem::PHYSICAL);
+        const std::vector<tt::umd::CoreCoord>& tensix_cores = soc_d.get_cores(CoreType::TENSIX, CoordSystem::NOC0);
 
         std::optional<CoreCoord> closest_phys_tensix = std::nullopt;
         for (auto phys_tensix : tensix_cores) {
@@ -181,7 +181,7 @@ private:
         assigned_phys_tensix.insert(closest_phys_tensix.value());
 
         auto logical_tensix = soc_d.translate_coord_to(
-            {closest_phys_tensix.value(), CoreType::TENSIX, CoordSystem::PHYSICAL}, CoordSystem::LOGICAL);
+            {closest_phys_tensix.value(), CoreType::TENSIX, CoordSystem::NOC0}, CoordSystem::LOGICAL);
 
         tt_metal::ShardSpecBuffer shard_spec = tt_metal::ShardSpecBuffer(
             CoreRangeSet(std::set<CoreRange>({CoreRange(logical_tensix)})),

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -74,19 +74,19 @@ int metal_SocDescriptor::get_dram_channel_from_logical_core(const CoreCoord& log
 
 CoreCoord metal_SocDescriptor::get_physical_ethernet_core_from_logical(const CoreCoord& logical_coord) const {
     tt::umd::CoreCoord physical_coord =
-        translate_coord_to({logical_coord, CoreType::ETH, CoordSystem::LOGICAL}, CoordSystem::PHYSICAL);
+        translate_coord_to({logical_coord, CoreType::ETH, CoordSystem::LOGICAL}, CoordSystem::NOC0);
     return {physical_coord.x, physical_coord.y};
 }
 
 CoreCoord metal_SocDescriptor::get_logical_ethernet_core_from_physical(const CoreCoord& physical_coord) const {
     tt::umd::CoreCoord logical_coord =
-        translate_coord_to({physical_coord, CoreType::ETH, CoordSystem::PHYSICAL}, CoordSystem::LOGICAL);
+        translate_coord_to({physical_coord, CoreType::ETH, CoordSystem::NOC0}, CoordSystem::LOGICAL);
     return {logical_coord.x, logical_coord.y};
 }
 
 CoreCoord metal_SocDescriptor::get_physical_tensix_core_from_logical(const CoreCoord& logical_coord) const {
     tt::umd::CoreCoord physical_coord =
-        translate_coord_to({logical_coord, CoreType::TENSIX, CoordSystem::LOGICAL}, CoordSystem::PHYSICAL);
+        translate_coord_to({logical_coord, CoreType::TENSIX, CoordSystem::LOGICAL}, CoordSystem::NOC0);
     return {physical_coord.x, physical_coord.y};
 }
 
@@ -167,7 +167,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
 // UMD expects virtual NOC coordinates for worker cores
 tt_cxy_pair metal_SocDescriptor::convert_to_umd_coordinates(const tt_cxy_pair& physical_cxy) const {
     tt::umd::CoreCoord virtual_coord =
-        translate_coord_to((tt_xy_pair)physical_cxy, CoordSystem::PHYSICAL, get_umd_coord_system());
+        translate_coord_to((tt_xy_pair)physical_cxy, CoordSystem::NOC0, get_umd_coord_system());
     return tt_cxy_pair(physical_cxy.chip, virtual_coord.x, virtual_coord.y);
 }
 
@@ -183,11 +183,11 @@ void metal_SocDescriptor::generate_logical_eth_coords_mapping() {
 
 void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
 #if defined(TRACY_ENABLE)
-    for (auto& core : get_cores(CoreType::TENSIX, CoordSystem::PHYSICAL)) {
+    for (auto& core : get_cores(CoreType::TENSIX, CoordSystem::NOC0)) {
         this->physical_routing_to_profiler_flat_id.emplace((CoreCoord){core.x, core.y}, 0);
     }
 
-    for (auto& core : this->get_cores(CoreType::ETH, CoordSystem::PHYSICAL)) {
+    for (auto& core : this->get_cores(CoreType::ETH, CoordSystem::NOC0)) {
         this->physical_routing_to_profiler_flat_id.emplace((CoreCoord){core.x, core.y}, 0);
     }
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -293,12 +293,12 @@ AllocatorConfig L1BankingAllocator::generate_config(
         config.dram_bank_offsets.push_back(soc_desc.get_address_offset(channel));
     }
     // Initialize core_type_from_noc_coord_table table
-    for (const CoreCoord& core : soc_desc.get_all_cores(CoordSystem::PHYSICAL)) {
+    for (const CoreCoord& core : soc_desc.get_all_cores(CoordSystem::NOC0)) {
         config.core_type_from_noc_coord_table.insert(
             {cluster.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y}),
              AllocCoreType::Invalid});
     }
-    for (const CoreCoord& core : soc_desc.get_all_harvested_cores(CoordSystem::PHYSICAL)) {
+    for (const CoreCoord& core : soc_desc.get_all_harvested_cores(CoordSystem::NOC0)) {
         config.core_type_from_noc_coord_table.insert(
             {cluster.get_virtual_coordinate_from_physical_coordinates(device_id, {core.x, core.y}),
              AllocCoreType::Invalid});

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -951,16 +951,16 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             auto worker_dram_ep = soc_d.get_preferred_worker_core_for_dram_view(dram_channel, noc);
             auto eth_dram_ep = soc_d.get_preferred_eth_core_for_dram_view(dram_channel, noc);
             auto physical_worker_dram_ep =
-                soc_d.translate_coord_to(worker_dram_ep, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+                soc_d.translate_coord_to(worker_dram_ep, CoordSystem::TRANSLATED, CoordSystem::NOC0);
             auto physical_eth_dram_ep =
-                soc_d.translate_coord_to(eth_dram_ep, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+                soc_d.translate_coord_to(eth_dram_ep, CoordSystem::TRANSLATED, CoordSystem::NOC0);
             dram_cores.insert(physical_worker_dram_ep);
             dram_cores.insert(physical_eth_dram_ep);
         }
     }
 
     const std::vector<tt::umd::CoreCoord>& eth_cores =
-        soc_d.get_cores(CoreType::ETH, CoordSystem::PHYSICAL);  // make these translated and then convert to physical
+        soc_d.get_cores(CoreType::ETH, CoordSystem::NOC0);  // make these translated and then convert to physical
 
     TT_ASSERT(
         pcie_cores.size() + dram_cores.size() + eth_cores.size() <= MAX_PHYSICAL_NON_WORKER_CORES,

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -84,8 +84,7 @@ CoreType core_type_from_virtual_core(chip_id_t device_id, const CoreCoord& virtu
         return CoreType::DRAM;
     }
 
-    CoreType core_type =
-        soc_desc.translate_coord_to(virtual_coord, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type;
+    CoreType core_type = soc_desc.translate_coord_to(virtual_coord, CoordSystem::NOC0, CoordSystem::NOC0).core_type;
     if (core_type == CoreType::TENSIX) {
         core_type = CoreType::WORKER;
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -869,7 +869,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
             auto dram_core = this->dram_core_from_dram_channel(i, noc);
             if (dram_is_virtualized) {
                 tt::umd::CoreCoord umd_dram_coord = soc_d.translate_coord_to(
-                    tt_xy_pair(dram_core.x, dram_core.y), CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+                    tt_xy_pair(dram_core.x, dram_core.y), CoordSystem::TRANSLATED, CoordSystem::NOC0);
                 dram_core = CoreCoord(umd_dram_coord.x, umd_dram_coord.y);
             }
             dram_phy_coords.push_back(dram_core);
@@ -900,7 +900,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         // Convert to physical worker coordinates to logical. This gets returned to the user.
         for (auto physical_worker_core : physical_worker_cores) {
             tt::umd::CoreCoord logical_coord_translated =
-                soc_desc.translate_coord_to(physical_worker_core, CoordSystem::PHYSICAL, CoordSystem::LOGICAL);
+                soc_desc.translate_coord_to(physical_worker_core, CoordSystem::NOC0, CoordSystem::LOGICAL);
             this->optimal_dram_bank_to_logical_worker_assignment_.push_back(
                 CoreCoord(logical_coord_translated.x, logical_coord_translated.y));
             TT_ASSERT(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1321,7 +1321,7 @@ CoreCoord DeviceProfiler::getPhysicalAddressFromVirtual(chip_id_t device_id, con
                 tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
             // disable linting here; slicing is __intended__
             // NOLINTBEGIN
-            return soc_desc.translate_coord_to(c, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+            return soc_desc.translate_coord_to(c, CoordSystem::TRANSLATED, CoordSystem::NOC0);
             // NOLINTEND
         } else {
             return c;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -115,7 +115,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     auto core = device->worker_core_from_logical_core(logical_core);
 
     const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
-    auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+    auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
 
     deviceHostTimePair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
     smallestHostime.emplace(device_id, 0);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -579,7 +579,7 @@ tt_cxy_pair Cluster::get_virtual_coordinate_from_logical_coordinates(tt_cxy_pair
 CoreCoord Cluster::get_virtual_coordinate_from_physical_coordinates(chip_id_t chip_id, CoreCoord physical_coord) const {
     auto& soc_desc = this->get_soc_desc(chip_id);
     tt::umd::CoreCoord translated_coord =
-        soc_desc.translate_coord_to(physical_coord, CoordSystem::PHYSICAL, CoordSystem::TRANSLATED);
+        soc_desc.translate_coord_to(physical_coord, CoordSystem::NOC0, CoordSystem::TRANSLATED);
     return {translated_coord.x, translated_coord.y};
 }
 

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -20,7 +20,7 @@
 void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.
     const metal_SocDescriptor& sdesc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(chip_id);
-    for (auto& worker_core : sdesc.get_cores(CoreType::TENSIX, CoordSystem::PHYSICAL)) {
+    for (auto& worker_core : sdesc.get_cores(CoreType::TENSIX, CoordSystem::NOC0)) {
         tt::llrt::write_hex_vec_to_core(chip_id, worker_core, mem_vec, start_addr);
     }
 }

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -53,7 +53,7 @@ public:
             const auto& soc_desc = cluster.get_soc_desc(chip_id_src);
             // Build a mapping of (eth_core --> eth_chan)
             for (auto eth_chan = 0; eth_chan < soc_desc.get_num_eth_channels(); eth_chan++) {
-                auto eth_physical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::PHYSICAL);
+                auto eth_physical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::NOC0);
                 eth_core_to_channel_lookup_.emplace(std::make_tuple(chip_id_src, eth_physical_core), eth_chan);
             }
         }
@@ -145,7 +145,7 @@ inline void dumpRoutingInfo(const std::filesystem::path& filepath) {
     auto physical_chip_id = *(cluster.get_cluster_desc()->get_all_chips().begin());
     for (int j = 0; j < cluster.get_soc_desc(physical_chip_id).get_num_eth_channels(); j++) {
         tt::umd::CoreCoord edm_eth_core =
-            cluster.get_soc_desc(physical_chip_id).get_eth_core_for_channel(j, CoordSystem::PHYSICAL);
+            cluster.get_soc_desc(physical_chip_id).get_eth_core_for_channel(j, CoordSystem::NOC0);
         topology_json["eth_chan_to_coord"][std::to_string(j)] = {edm_eth_core.x, edm_eth_core.y};
     }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-umd/issues/621)

### Problem description
PHYSICAL can be confusing, since this doesn't represent our physical chip layout. Changing to NOC0 enum. It has the same enum value, but we're removing the PHYSICAL in umd.

### What's changed
Changed CoordSystem::PHYSICAL to CoordSystem::NOC0

### Checklist
All runs on brosko/physical_noc0 :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341606253
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341609043
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341611908
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/16341614623
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341617421
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341619522
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341621635
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/16341624240