### PR TITLE
removed blackhole check for sd demo

### DIFF
--- a/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
+++ b/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
@@ -11,7 +11,6 @@ import torch
 from tqdm.auto import tqdm
 
 import ttnn
-from models.utility_functions import is_blackhole
 
 
 @dataclass
@@ -150,7 +149,6 @@ def run(
     time_step,
     guidance_scale,
     ttnn_scheduler,
-    use_host_decoder=True,
 ):
     ttnn_latents = input_latents
     # Denoising loop
@@ -177,10 +175,6 @@ def run(
 
     # scale and decode the image latents with vae
     latents = 1 / 0.18215 * ttnn_latents
-
-    # on blackhole, we use the original vae decoder until #20760 is fixed
-    if use_host_decoder:
-        return latents
 
     ttnn_output = ttnn.permute(latents, [0, 2, 3, 1])
     ttnn_output = tt_vae.decode(ttnn_output)
@@ -214,7 +208,6 @@ def compile_trace_sd(
             time_step,
             guidance_scale,
             ttnn_scheduler,
-            is_blackhole(),
         )
     )
 
@@ -233,7 +226,6 @@ def compile_trace_sd(
         time_step,
         guidance_scale,
         ttnn_scheduler,
-        is_blackhole(),
     )
     ttnn.end_trace_capture(device, tid, cq_id=0)
     ttnn.synchronize_device(device)

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -33,7 +33,7 @@ def test_demo_sd_db(device, reset_seeds, input_path, num_prompts, num_inference_
 
 
 @pytest.mark.timeout(600)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 11 * 8192, "trace_region_size": 789321728}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 11 * 8192, "trace_region_size": 789835776}], indirect=True)
 @pytest.mark.parametrize(
     "input_path",
     (("models/demos/wormhole/stable_diffusion/demo/input_data.json"),),

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -171,7 +171,7 @@ def test_stable_diffusion_unet_trace(device):
     print(f"SD1.4 is running at {fps} FPS")
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192, "trace_region_size": 6348800}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192, "trace_region_size": 6458368}], indirect=True)
 def test_stable_diffusion_vae_trace(device):
     if is_wormhole_b0():
         os.environ["SLOW_MATMULS"] = "1"
@@ -229,12 +229,10 @@ def test_stable_diffusion_vae_trace(device):
     ttnn.release_trace(device, tid)
 
     pcc = 0.985
-    if is_blackhole():
-        pcc = 0.923
     assert_with_pcc(torch_output, ttnn_out, pcc)
 
     inference_time = profiler.get(f"vae_run_for_inference_{0}")
-    expected_inference_time = 0.749 if is_wormhole_b0() else 0.474
+    expected_inference_time = 0.749 if is_wormhole_b0() else 0.478
 
     assert (
         inference_time <= expected_inference_time
@@ -346,7 +344,6 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
             time_step,
             guidance_scale,
             ttnn_scheduler,
-            is_blackhole(),
         )
     )
 
@@ -366,7 +363,6 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
         time_step,
         guidance_scale,
         ttnn_scheduler,
-        is_blackhole(),
     )
     ttnn.end_trace_capture(device, tid, cq_id=0)
     ttnn.synchronize_device(device)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17138

### Problem description
Previously Host VAE decoder was used on BH due to 
group_norm PCC issue which has since been fixed.

This PR removes that check so both WH and BH take the same code path.

### What's changed
Removed checks which involve `is_blackhole` in SDv1.4

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16369646869)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16387043259)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16455538921)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16455541707)
- [X] [(Blackhole) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16387046254) 