### PR TITLE
[skip ci] Stop running light metal unit tests

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -47,7 +47,6 @@ jobs:
           {name: sfpi, cmd: "./build/test/tt_metal/unit_tests_sfpi"},
           {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests"},
           {name: distributed_multiprocess, cmd: "./tests/tt_metal/multihost/run_multiprocess_socket_tests.sh"},
-          {name: lightmetal, cmd: "./build/test/tt_metal/unit_tests_lightmetal"},
           {name: dispatch multicmd queue, cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=MultiCommandQueue*Fixture.*"},
           {name: dispatch multicmd queue, cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQ*Fixture.*"},
           {name: ttnn cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn},


### PR DESCRIPTION
### Ticket
NA

### Problem description
Light Metal is deprioritized, and likely will not stay up to speed with tt-metal API changes.

### What's changed
Stop running the tests to save on resources.

### Checklist
- Do nothing