### PR TITLE
Provide int32 support for multiply op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -524,8 +524,5 @@ def test_binary_mul_int32_edge_cases(use_legacy, device):
 
     output_tensor = ttnn.mul(input_tensor_a, input_tensor_b, use_legacy=use_legacy)
     output_tensor = ttnn.to_torch(output_tensor)
-    print(torch_input_tensor_a)
-    print(torch_output_tensor)
-    print(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void mul_int32(const uint dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+        // operand A - int32
+        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        // operand B - int32
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_offset * dst_tile_size);
+
+        // INT32 split into 8-bit inputs
+        // mask
+        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0xFF);
+
+        // Copy A
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+
+        // Extract A = [a3:a2:a1:a0] where each is 8-bit.
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);               // LREG0 = a0 = A[7:0]
+        TTI_SFPSHFT((-8) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);   // LREG2 = a1 = A[15:8]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG2, 0);               // clear other bits
+        TTI_SFPSHFT((-16) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);  // LREG3 = a2 = A[23:16]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG3, 0);
+
+        // Copy B
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG4, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+
+        // Extract B = [b3:b2:b1:b0] where each is 8-bit
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);              // LREG1 = b0 = B[7:0]
+        TTI_SFPSHFT((-8) & 0xfff, p_sfpu::LREG4, p_sfpu::LREG4, 1);  // LREG5 = b1 = B[15:8]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG4, 0);
+        TTI_SFPSHFT((-16) & 0xfff, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // LREG6 = b2 = B[23:16]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG5, 0);
+        // a3 and b3 will be extracted on the go due to limited registers.
+
+        // Cast all 8-bit values to FP32
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+        TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+        TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+        TTI_SFPCAST(p_sfpu::LREG4, p_sfpu::LREG4, 0);
+        TTI_SFPCAST(p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+        // a0*b0 (bits 0-15)
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG7, p_sfpu::LREG7, 6);  // fp32 -> uint16
+
+        // a0*b1 (bits 8-23)
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);  // Accumulate in LREG7
+
+        // a0*b2 (bits 16-31)
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a1*b0 (bits 8-23)
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 8
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a1*b1 (bits 16-31)
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a2*b0 (bits 16-31)
+        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        TTI_SFPLOADI(p_sfpu::LREG6, SFPLOADI_MOD0_USHORT, 0x00FF);  // load 00FF to LREG6
+
+        // a1*b2 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);  // store result to LREG5
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a2*b1 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // Load operands again to extract a3 and b3
+        // operand A - int32
+        TTI_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_7, 0);
+        // operand B - int32
+        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_7, dst_offset * dst_tile_size);
+        // mask
+        TTI_SFPLOADI(p_sfpu::LREG4, SFPLOADI_MOD0_USHORT, 0xFF);
+
+        // Extract A3
+        TTI_SFPSHFT((-24) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);  // LREG2 = a3 = A[31:24]
+        TTI_SFPAND(0, p_sfpu::LREG4, p_sfpu::LREG2, 0);
+
+        // Extract B3
+        TTI_SFPSHFT((-24) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);  // LREG3 = b3 = B[31:24]
+        TTI_SFPAND(0, p_sfpu::LREG4, p_sfpu::LREG3, 0);
+
+        // Cast to FP32
+        TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+        TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+
+        // a0*b3 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a3*b0 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        TTI_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_7, 0);
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -57,41 +57,41 @@ inline void mul_int32(const uint dst_offset) {
 
         // a0*b0 (bits 0-15)
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG7, p_sfpu::LREG7, 6);  // fp32 -> uint16
+        TTI_SFP_STOCH_RND(
+            SFPSTOCHRND_RND_EVEN,
+            0,
+            0,
+            p_sfpu::LREG7,
+            p_sfpu::LREG7,
+            SFPSTOCHRND_MOD1_FP32_TO_UINT16);  // fp32 -> uint16
 
         // a0*b1 (bits 8-23)
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);  // Accumulate in LREG7
 
         // a0*b2 (bits 16-31)
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a1*b0 (bits 8-23)
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 8
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a1*b1 (bits 16-31)
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a2*b0 (bits 16-31)
         TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
@@ -99,16 +99,14 @@ inline void mul_int32(const uint dst_offset) {
 
         // a1*b2 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);  // store result to LREG5
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a2*b1 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
@@ -135,16 +133,14 @@ inline void mul_int32(const uint dst_offset) {
 
         // a0*b3 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a3*b0 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_mul_int32.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -78,6 +78,7 @@ enum SfpuType {
     sub_int32,
     sub_uint16,
     mul_uint16,
+    mul_int32,
     topk_local_sort,
     topk_merge,
     topk_rebuild,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void mul_int32(const uint dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+        // operand A - int32
+        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        // operand B - int32
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_offset * dst_tile_size);
+
+        // INT32 split into 8-bit inputs
+        // mask
+        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0xFF);
+
+        // Copy A
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+
+        // Extract A = [a3:a2:a1:a0] where each is 8-bit.
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);               // LREG0 = a0 = A[7:0]
+        TTI_SFPSHFT((-8) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);   // LREG2 = a1 = A[15:8]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG2, 0);               // clear other bits
+        TTI_SFPSHFT((-16) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);  // LREG3 = a2 = A[23:16]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG3, 0);
+
+        // Copy B
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG4, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+
+        // Extract B = [b3:b2:b1:b0] where each is 8-bit
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);              // LREG1 = b0 = B[7:0]
+        TTI_SFPSHFT((-8) & 0xfff, p_sfpu::LREG4, p_sfpu::LREG4, 1);  // LREG5 = b1 = B[15:8]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG4, 0);
+        TTI_SFPSHFT((-16) & 0xfff, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // LREG6 = b2 = B[23:16]
+        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG5, 0);
+        // a3 and b3 will be extracted on the go due to limited registers.
+
+        // Cast all 8-bit values to FP32
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+        TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+        TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+        TTI_SFPCAST(p_sfpu::LREG4, p_sfpu::LREG4, 0);
+        TTI_SFPCAST(p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+        // a0*b0 (bits 0-15)
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG7, p_sfpu::LREG7, 6);  // fp32 -> uint16
+
+        // a0*b1 (bits 8-23)
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);  // Accumulate in LREG7
+
+        // a0*b2 (bits 16-31)
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);                    // Shift left by 16
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a1*b0 (bits 8-23)
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a1*b1 (bits 16-31)
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);                    // Shift left by 16
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a2*b0 (bits 16-31)
+        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);                    // Shift left by 16
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        TTI_SFPLOADI(p_sfpu::LREG6, SFPLOADI_MOD0_USHORT, 0x00FF);  // load 00FF to LREG6
+
+        // a1*b2 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);  // store result to LREG5
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);                      // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);                    // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a2*b1 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);                      // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);                    // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // Load operands again to extract a3 and b3
+        // operand A - int32
+        TTI_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_3, 0);
+        // operand B - int32
+        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_3, dst_offset * dst_tile_size);
+        // mask
+        TTI_SFPLOADI(p_sfpu::LREG4, SFPLOADI_MOD0_USHORT, 0xFF);
+
+        // Extract A3
+        TTI_SFPSHFT((-24) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);  // LREG2 = a3 = A[31:24]
+        TTI_SFPAND(0, p_sfpu::LREG4, p_sfpu::LREG2, 0);
+
+        // Extract B3
+        TTI_SFPSHFT((-24) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);  // LREG3 = b3 = B[31:24]
+        TTI_SFPAND(0, p_sfpu::LREG4, p_sfpu::LREG3, 0);
+
+        // Cast to FP32
+        TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+        TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+
+        // a0*b3 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // a3*b0 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+        TTI_SFPNOP;
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        TTI_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_3, 0);
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -58,41 +58,47 @@ inline void mul_int32(const uint dst_offset) {
         // a0*b0 (bits 0-15)
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG7, p_sfpu::LREG7, 6);  // fp32 -> uint16
+        TTI_SFP_STOCH_RND(
+            SFPSTOCHRND_RND_EVEN,
+            0,
+            0,
+            p_sfpu::LREG7,
+            p_sfpu::LREG7,
+            SFPSTOCHRND_MOD1_FP32_TO_UINT16);  // fp32 -> uint16
 
         // a0*b1 (bits 8-23)
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);  // Accumulate in LREG7
 
         // a0*b2 (bits 16-31)
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
-        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);                    // Shift left by 16
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a1*b0 (bits 8-23)
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
-        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 8
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a1*b1 (bits 16-31)
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
-        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);                    // Shift left by 16
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a2*b0 (bits 16-31)
         TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
-        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);                    // Shift left by 16
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         TTI_SFPLOADI(p_sfpu::LREG6, SFPLOADI_MOD0_USHORT, 0x00FF);  // load 00FF to LREG6
@@ -100,17 +106,17 @@ inline void mul_int32(const uint dst_offset) {
         // a1*b2 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);  // store result to LREG5
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
-        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);                      // zero out high overflow bits
-        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);                    // Shift left by 24
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // a2*b1 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
-        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);                      // zero out high overflow bits
-        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);                    // Shift left by 24
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
+        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
         // Load operands again to extract a3 and b3
@@ -136,7 +142,7 @@ inline void mul_int32(const uint dst_offset) {
         // a0*b3 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
@@ -144,7 +150,7 @@ inline void mul_int32(const uint dst_offset) {
         // a3*b0 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
         TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
         TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_mul_int32.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -79,6 +79,7 @@ enum SfpuType {
     sub_int32,
     sub_uint16,
     mul_uint16,
+    mul_int32,
     topk_local_sort,
     topk_merge,
     topk_rebuild,

--- a/tt_metal/include/compute_kernel_api/mul_int32_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/mul_int32_sfpu.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_mul_int32.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise mul operation with the two int32 inputs: y = mul(x0,x1)
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void mul_int32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_mul_int32<APPROX>(idst0, idst1)));
+}
+
+/**
+ * Please refer to documentation for mul_int32_tile_init.
+ */
+ALWI void mul_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_mul_int32_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1994,7 +1994,7 @@ void py_module(py::module& module) {
         R"doc(Multiplies :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i * \mathrm{{input\_tensor\_b}}_i)doc",
         R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
-        R"doc(BFLOAT16, BFLOAT8_B, UINT16 (range: 0 - 65535))doc");
+        R"doc(BFLOAT16, BFLOAT8_B, UINT16 (range: 0 - 65535), INT32)doc");
 
     detail::bind_binary_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -217,6 +217,9 @@ std::map<std::string, std::string> get_defines_fp32(
             if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
                 new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init();")});
                 op_name = "mul_uint16_tile";
+            } else if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"MUL_INT32_INIT", fmt::format("mul_int32_tile_init();")});
+                op_name = "mul_int32_tile";
             } else {
                 new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
                 op_name = "mul_binary_tile";

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -23,10 +23,9 @@ namespace utils {
             return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
                 || (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::SUB:
+        case BinaryOpType::MUL:
             return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
                 || (a == DataType::UINT16 && b == DataType::UINT16));
-        case BinaryOpType::MUL:
-            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::DIV:
         case BinaryOpType::RSUB:
         case BinaryOpType::LOGADDEXP:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -15,6 +15,7 @@
 #include "compute_kernel_api/add_int_sfpu.h"
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
+#include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"
 #include "compute_kernel_api/lcm.h"
@@ -123,6 +124,9 @@ void MAIN {
 #endif
 #ifdef MUL_INT_INIT
             MUL_INT_INIT
+#endif
+#ifdef MUL_INT32_INIT
+            MUL_INT32_INIT
 #endif
 #ifdef BITWISE_INIT
             BITWISE_INIT

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -17,8 +17,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
             return (
                 (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT32 && b == UINT32) ||
                 (a == UINT16 && b == UINT16));
-        case SUB: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));
-        case MUL: return ((a == FLOAT32 && b == FLOAT32) || (a == UINT16 && b == UINT16));
+        case SUB:
+        case MUL: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));
         case DIV:
         case RSUB:
         case LOGADDEXP:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -337,6 +337,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case MUL:
             if (dtype == DataType::UINT16) {
                 return {"mul_int_tile_init();", "mul_uint16_tile"};
+            } else if (dtype == DataType::INT32) {
+                return {"mul_int32_tile_init();", "mul_int32_tile"};
             } else {
                 return {"mul_binary_tile_init();", "mul_binary_tile"};
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -13,6 +13,7 @@
 #include "compute_kernel_api/add_int_sfpu.h"
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
+#include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -13,6 +13,7 @@
 #include "compute_kernel_api/add_int_sfpu.h"
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
+#include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -13,6 +13,7 @@
 #include "compute_kernel_api/add_int_sfpu.h"
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
+#include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 
 #include "eltwise_utils_common.hpp"


### PR DESCRIPTION
### Ticket
#18589 
#20860 

### Problem description
Multiply operation does not support int32 operands.

### What's changed
Added kernel implementation for int32 multiplication.
**Perf for a single tile [1, 1, 32, 32]: 7694 ns**


### Checklist
- [x] BH Testing
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16463801468)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16349785561)
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/16349799923)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16440014085)
- [x] New/Existing tests provide coverage for changes