### PR TITLE
[skip ci] Add exception mechanism in slow test detection

### DIFF
--- a/.github/actions/detect-slow-tests/detect-slow-tests.py
+++ b/.github/actions/detect-slow-tests/detect-slow-tests.py
@@ -20,6 +20,11 @@ class SlowTestsExceededError(SlowTestDetectionError):
 
 
 def detect_slow_tests(report_dir, timeout):
+    # Hardcoded list of tests to exclude from slow test detection (Don't use this unless you HAVE TO)
+    exceptions = [
+        "CommandQueueSingleCardProgramFixture.TensixSFPI",
+    ]
+
     # Find all XML files in the report directory
     report_files = [
         os.path.join(root, file) for root, dirs, files in os.walk(report_dir) for file in files if file.endswith(".xml")
@@ -27,6 +32,7 @@ def detect_slow_tests(report_dir, timeout):
     if not report_files:
         raise NoTestReportsFoundError("No test reports found.")
 
+    excluded_tests = []
     slow_tests = []
 
     for report_file in report_files:
@@ -36,11 +42,22 @@ def detect_slow_tests(report_dir, timeout):
             for tc in root.findall(".//testcase"):
                 time = float(tc.get("time", 0))
                 if time > timeout:
-                    slow_tests.append(
-                        f"{report_file}: {tc.get('classname', 'Unknown')}.{tc.get('name', 'Unknown')} ({time:.3f}s)"
-                    )
+                    test_name = f"{tc.get('classname', 'Unknown')}.{tc.get('name', 'Unknown')}"
+
+                    # Check if this test is in the exceptions list
+                    if test_name in exceptions:
+                        excluded_tests.append(f"{report_file}: {test_name} ({time:.3f}s) - EXCLUDED")
+                    else:
+                        slow_tests.append(f"{report_file}: {test_name} ({time:.3f}s)")
         except Exception as e:
             raise TestReportParsingError(f"Error parsing {report_file}: {e}")
+
+    # Print excluded tests for visibility
+    if excluded_tests:
+        print("Excluded slow tests:")
+        for test in excluded_tests:
+            print(f"  {test}")
+        print()
 
     if slow_tests:
         raise SlowTestsExceededError(f"Some tests exceeded {timeout}s:\n" + "\n".join(slow_tests))

--- a/.github/actions/detect-slow-tests/detect-slow-tests.py
+++ b/.github/actions/detect-slow-tests/detect-slow-tests.py
@@ -21,7 +21,9 @@ class SlowTestsExceededError(SlowTestDetectionError):
 
 def detect_slow_tests(report_dir, timeout):
     # Hardcoded list of tests to exclude from slow test detection (Don't use this unless you HAVE TO)
-    exceptions = []
+    exceptions = [
+        "DispatchFixture.TensixFailOnDuplicateKernelCreationDataflow",
+    ]
 
     # Find all XML files in the report directory
     report_files = [

--- a/.github/actions/detect-slow-tests/detect-slow-tests.py
+++ b/.github/actions/detect-slow-tests/detect-slow-tests.py
@@ -21,9 +21,7 @@ class SlowTestsExceededError(SlowTestDetectionError):
 
 def detect_slow_tests(report_dir, timeout):
     # Hardcoded list of tests to exclude from slow test detection (Don't use this unless you HAVE TO)
-    exceptions = [
-        "CommandQueueSingleCardProgramFixture.TensixSFPI",
-    ]
+    exceptions = []
 
     # Find all XML files in the report directory
     report_files = [


### PR DESCRIPTION
### Ticket
NA

### Problem description
Currently, we have a rigid firm rule about PR Gate / Merge Gate. ALL TESTS must abide by time limit.
Without a doubt we will come across tests that we want to run in one of these gates that do not comply. It would not be scalable to move all such tests to other new executables / pipelines, or artifically break them down into smaller tests.

### What's changed
Introduce mechanism to skip time limit check for individual tests.
Example: `CommandQueueSingleCardProgramFixture.TensixSFPI` as the first excepted test.

Why?
```
This test case is actually running several tests in a loop. The time result we get is artificially inflated.
Refactoring the gtest into smaller component tests would take away from the automatic discovery mechanism that is there, and would be largely throw out work. This is a perfect scenario for an exception.
```

### Checklist
- Nothing to do