### PR TITLE
[tt-train] SiLU backward kernel implementation

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -81,6 +81,14 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.cpp
+    # SiLU Backward
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/silu_bw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/silu_bw.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_device_operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_program_factory.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_program_factory.cpp
 )
 
 list(APPEND SOURCES ${METAL_OPS_FILES})

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -9,6 +9,7 @@
 #include "ops/profiler_no_op/profiler_no_op.hpp"
 #include "ops/rmsnorm_bw/rmsnorm_bw.hpp"
 #include "ops/rmsnorm_fw/rmsnorm_fw.hpp"
+#include "ops/silu_bw/silu_bw.hpp"
 #include "ops/softmax/softmax.hpp"
 
 namespace ttml::metal {
@@ -32,5 +33,8 @@ constexpr auto softmax =
 
 constexpr auto profiler_no_op =
     ttnn::register_operation<"ttml::metal::profiler_no_op", ttml::metal::ops::profiler_no_op::ProfilerNoopOperation>();
+
+constexpr auto silu_bw =
+    ttnn::register_operation<"ttml::metal::silu_bw", ttml::metal::ops::silu_bw::SiLUBackwardOperation>();
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/compute/silu_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/compute/silu_bw_kernel.cpp
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/cb_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/negative.h"
+#include "compute_kernel_api/reg_api.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/ops/common/compute_utils.hpp"
+
+namespace NAMESPACE {
+
+constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
+constexpr uint32_t block_size = get_compile_time_arg_val(1);
+constexpr uint32_t Wt = get_compile_time_arg_val(2);
+
+// #define THREE_PACKS true
+
+// CBs with input data
+constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
+constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_1;
+// CBs with output data
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_2;
+// CBs with intermediate computations
+#ifdef THREE_PACKS
+constexpr uint32_t cb_neg_sigmoid_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_x_plus_x_times_neg_sigmoid_plus_one_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_times_neg_sigmoid_and_neg_idx = tt::CBIndex::c_5;
+#else
+constexpr uint32_t cb_sigmoid_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_one_minus_sigmoid_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_times_input_plus_one_idx = tt::CBIndex::c_5;
+constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
+#endif
+
+// ============================================================================
+// Functions below compute final results for a pipeline stage and write them to
+// circular buffers (CBs). These functions produce outputs that are consumed by
+// later stages.
+// ============================================================================
+
+#ifdef THREE_PACKS
+inline void compute_neg_sigmoid() {
+    // Compute: -sigmoid(x)
+    // The result is stored in cb_neg_sigmoid_idx.
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_input_idx, cb_input_idx);
+        copy_tile_init(cb_input_idx);
+        copy_tile(cb_input_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
+
+        sigmoid_tile_init();
+        sigmoid_tile(/* register_idx */ block_idx);
+
+        negative_tile_init();
+        negative_tile(/* register_idx */ block_idx);
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_neg_sigmoid_idx, /* tile_index */ block_size);
+}
+
+inline void compute_x_plus_x_times_neg_sigmoid_plus_one() {
+    // Compute: x + x * (-sigmoid(x)) + 1
+    // The result is stored in cb_x_plus_x_times_neg_sigmoid_plus_one_idx.
+    cb_wait_front(cb_neg_sigmoid_idx, block_size);
+
+    const uint32_t one = 0x3F800000;  // FP32 encoding of 1.0
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_input_idx, cb_input_idx);
+        copy_tile_init(cb_input_idx);
+        copy_tile(cb_input_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
+
+        reconfig_data_format(cb_input_idx, cb_neg_sigmoid_idx);
+        // NOTE: mul_tiles_init does not support accumulating the result in the destination register (i.e., dest += a *
+        // b). Therefore, we use binary_tiles_init to enable accumulation in the destination register as a workaround.
+        binary_tiles_init<true, ELWMUL>(cb_input_idx, cb_neg_sigmoid_idx, /* dest_accum */ true);
+        mul_tiles(
+            cb_input_idx,
+            cb_neg_sigmoid_idx,
+            /* tile_index */ block_idx,
+            /* tile_index */ block_idx,
+            /* register_idx */ block_idx);
+
+        add_unary_tile(block_idx, one);
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, block_size);
+}
+
+inline void compute_times_neg_sigmoid_and_neg() {
+    // Compute: -((x + x * (-sigmoid(x)) + 1) * (-sigmoid(x))) = (x - x * sigmoid(x) + 1) * sigmoid(x)
+    // The result is stored in cb_times_neg_sigmoid_and_neg_idx.
+    cb_wait_front(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, block_size);
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, cb_neg_sigmoid_idx);
+        mul_tiles_init(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, cb_neg_sigmoid_idx);
+        mul_tiles(
+            cb_x_plus_x_times_neg_sigmoid_plus_one_idx,
+            cb_neg_sigmoid_idx,
+            /* tile_index */ block_idx,
+            /* tile_index */ block_idx,
+            /* register_idx */ block_idx);
+
+        negative_tile_init();
+        negative_tile(/* register_idx */ block_idx);  // Negate the result.
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_times_neg_sigmoid_and_neg_idx, block_size);
+}
+
+inline void compute_times_grad() {
+    // Compute: ((x - x * sigmoid(x) + 1) * sigmoid(x)) * dL_dout
+    // The result is stored in cb_dL_da_idx.
+    cb_wait_front(cb_times_neg_sigmoid_and_neg_idx, block_size);
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_times_neg_sigmoid_and_neg_idx, cb_dL_out_idx);
+        mul_tiles_init(cb_times_neg_sigmoid_and_neg_idx, cb_dL_out_idx);
+        mul_tiles(
+            cb_times_neg_sigmoid_and_neg_idx,
+            cb_dL_out_idx,
+            /* tile_index */ block_idx,
+            /* tile_index */ block_idx,
+            /* register_idx */ block_idx);
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_dL_da_idx, block_size);
+}
+
+#else
+inline void compute_sigmoid() {
+    // Compute: sigmoid(x) = 1 / (1 + exp(-x))
+    // The result is stored in cb_sigmoid_idx.
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_input_idx, cb_input_idx);
+        copy_tile_init(cb_input_idx);
+        copy_tile(cb_input_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
+
+        sigmoid_tile_init();
+        sigmoid_tile(/* register_idx */ block_idx);
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_sigmoid_idx, block_size);
+}
+
+inline void compute_one_minus_sigmoid() {
+    // Compute: 1 - sigmoid(x)
+    // The result is stored in cb_one_minus_sigmoid_idx.
+    cb_wait_front(cb_sigmoid_idx, block_size);
+
+    const uint32_t one = 0x3F800000;  // FP32 encoding of 1.0
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_sigmoid_idx, cb_sigmoid_idx);
+        copy_tile_init(cb_sigmoid_idx);
+        copy_tile(cb_sigmoid_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
+
+        binop_with_scalar_tile_init();
+        rsub_unary_tile(/* register_idx */ block_idx, one);  // 1.0F is the constant to subtract from.
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_one_minus_sigmoid_idx, block_size);
+}
+
+inline void compute_times_input_plus_one() {
+    // Compute: (1 - sigmoid(x)) * input + 1
+    // The result is stored in cb_times_input_plus_one_idx.
+    cb_wait_front(cb_one_minus_sigmoid_idx, block_size);
+
+    const uint32_t one = 0x3F800000;  // FP32 encoding of 1.0
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_input_idx, cb_one_minus_sigmoid_idx);
+        mul_tiles_init(cb_input_idx, cb_one_minus_sigmoid_idx);
+        mul_tiles(
+            cb_input_idx,
+            cb_one_minus_sigmoid_idx,
+            /* tile_index */ block_idx,
+            /* tile_index */ block_idx,
+            /* register_idx */ block_idx);
+
+        binop_with_scalar_tile_init();
+        add_unary_tile(/* register_idx */ block_idx, one);  // Add 1.0F to the result.
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_times_input_plus_one_idx, block_size);
+}
+
+inline void compute_times_sigmoid() {
+    // Compute: ((1 - sigmoid(x)) * input + 1) * sigmoid(x)
+    // The result is stored in cb_times_sigmoid_idx.
+    cb_wait_front(cb_times_input_plus_one_idx, block_size);
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_times_input_plus_one_idx, cb_sigmoid_idx);
+        mul_tiles_init(cb_sigmoid_idx, cb_times_input_plus_one_idx);
+        mul_tiles(
+            cb_sigmoid_idx,
+            cb_times_input_plus_one_idx,
+            /* tile_index */ block_idx,
+            /* tile_index */ block_idx,
+            /* register_idx */ block_idx);
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_times_sigmoid_idx, block_size);
+}
+
+inline void compute_times_grad() {
+    // Compute: ((1 - sigmoid(x)) * input + 1) * sigmoid(x) * dL_dout
+    // The result is stored in cb_dL_da_idx.
+    cb_wait_front(cb_times_sigmoid_idx, block_size);
+
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        reconfig_data_format(cb_times_sigmoid_idx, cb_dL_out_idx);
+        mul_tiles_init(cb_times_sigmoid_idx, cb_dL_out_idx);
+        mul_tiles(
+            cb_times_sigmoid_idx,
+            cb_dL_out_idx,
+            /* tile_index */ block_idx,
+            /* tile_index */ block_idx,
+            /* register_idx */ block_idx);
+    }
+    tile_regs_commit();
+
+    pack_and_push_block(cb_dL_da_idx, block_size);
+}
+#endif
+
+inline void MAIN {
+    init_sfpu(cb_input_idx, cb_dL_da_idx);
+    binary_op_init_common(cb_input_idx, cb_dL_out_idx, cb_dL_da_idx);
+    for (uint32_t row = 0; row < num_rows_per_core; ++row) {
+        for (uint32_t col = 0; col < Wt; col += block_size) {
+            cb_wait_front(cb_input_idx, block_size);
+            cb_wait_front(cb_dL_out_idx, block_size);
+#ifdef THREE_PACKS
+            // Compute dL_da with 3 packs.
+            {
+                compute_neg_sigmoid();
+                compute_x_plus_x_times_neg_sigmoid_plus_one();
+                compute_times_neg_sigmoid_and_neg();
+                compute_times_grad();
+
+                cb_pop_front(cb_neg_sigmoid_idx, block_size);
+                cb_pop_front(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, block_size);
+                cb_pop_front(cb_times_neg_sigmoid_and_neg_idx, block_size);
+            }
+#else
+            // Compute dL_da with 4 packs.
+            {
+                compute_sigmoid();
+                compute_one_minus_sigmoid();
+                compute_times_input_plus_one();
+                compute_times_sigmoid();
+                compute_times_grad();
+
+                cb_pop_front(cb_sigmoid_idx, block_size);
+                cb_pop_front(cb_one_minus_sigmoid_idx, block_size);
+                cb_pop_front(cb_times_input_plus_one_idx, block_size);
+                cb_pop_front(cb_times_sigmoid_idx, block_size);
+            }
+#endif
+
+            cb_pop_front(cb_input_idx, block_size);
+            cb_pop_front(cb_dL_out_idx, block_size);
+        }
+    }
+}
+}  // namespace NAMESPACE
+// namespace NAMESPACE

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/compute/silu_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/compute/silu_bw_kernel.cpp
@@ -19,24 +19,16 @@ constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
 constexpr uint32_t block_size = get_compile_time_arg_val(1);
 constexpr uint32_t Wt = get_compile_time_arg_val(2);
 
-// #define THREE_PACKS true
-
 // CBs with input data
 constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
 constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_1;
 // CBs with output data
 constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_2;
 // CBs with intermediate computations
-#ifdef THREE_PACKS
-constexpr uint32_t cb_neg_sigmoid_idx = tt::CBIndex::c_3;
-constexpr uint32_t cb_x_plus_x_times_neg_sigmoid_plus_one_idx = tt::CBIndex::c_4;
-constexpr uint32_t cb_times_neg_sigmoid_and_neg_idx = tt::CBIndex::c_5;
-#else
 constexpr uint32_t cb_sigmoid_idx = tt::CBIndex::c_3;
 constexpr uint32_t cb_one_minus_sigmoid_idx = tt::CBIndex::c_4;
 constexpr uint32_t cb_times_input_plus_one_idx = tt::CBIndex::c_5;
 constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
-#endif
 
 // ============================================================================
 // Functions below compute final results for a pipeline stage and write them to
@@ -44,112 +36,12 @@ constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
 // later stages.
 // ============================================================================
 
-#ifdef THREE_PACKS
-inline void compute_neg_sigmoid() {
-    // Compute: -sigmoid(x)
-    // The result is stored in cb_neg_sigmoid_idx.
-
-    tile_regs_acquire();
-    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_input_idx, cb_input_idx);
-        copy_tile_init(cb_input_idx);
-        copy_tile(cb_input_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
-
-        sigmoid_tile_init();
-        sigmoid_tile(/* register_idx */ block_idx);
-
-        negative_tile_init();
-        negative_tile(/* register_idx */ block_idx);
-    }
-    tile_regs_commit();
-
-    pack_and_push_block(cb_neg_sigmoid_idx, /* tile_index */ block_size);
-}
-
-inline void compute_x_plus_x_times_neg_sigmoid_plus_one() {
-    // Compute: x + x * (-sigmoid(x)) + 1
-    // The result is stored in cb_x_plus_x_times_neg_sigmoid_plus_one_idx.
-    cb_wait_front(cb_neg_sigmoid_idx, block_size);
-
-    const uint32_t one = 0x3F800000;  // FP32 encoding of 1.0
-
-    tile_regs_acquire();
-    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_input_idx, cb_input_idx);
-        copy_tile_init(cb_input_idx);
-        copy_tile(cb_input_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
-
-        reconfig_data_format(cb_input_idx, cb_neg_sigmoid_idx);
-        // NOTE: mul_tiles_init does not support accumulating the result in the destination register (i.e., dest += a *
-        // b). Therefore, we use binary_tiles_init to enable accumulation in the destination register as a workaround.
-        binary_tiles_init<true, ELWMUL>(cb_input_idx, cb_neg_sigmoid_idx, /* dest_accum */ true);
-        mul_tiles(
-            cb_input_idx,
-            cb_neg_sigmoid_idx,
-            /* tile_index */ block_idx,
-            /* tile_index */ block_idx,
-            /* register_idx */ block_idx);
-
-        add_unary_tile(block_idx, one);
-    }
-    tile_regs_commit();
-
-    pack_and_push_block(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, block_size);
-}
-
-inline void compute_times_neg_sigmoid_and_neg() {
-    // Compute: -((x + x * (-sigmoid(x)) + 1) * (-sigmoid(x))) = (x - x * sigmoid(x) + 1) * sigmoid(x)
-    // The result is stored in cb_times_neg_sigmoid_and_neg_idx.
-    cb_wait_front(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, block_size);
-
-    tile_regs_acquire();
-    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, cb_neg_sigmoid_idx);
-        mul_tiles_init(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, cb_neg_sigmoid_idx);
-        mul_tiles(
-            cb_x_plus_x_times_neg_sigmoid_plus_one_idx,
-            cb_neg_sigmoid_idx,
-            /* tile_index */ block_idx,
-            /* tile_index */ block_idx,
-            /* register_idx */ block_idx);
-
-        negative_tile_init();
-        negative_tile(/* register_idx */ block_idx);  // Negate the result.
-    }
-    tile_regs_commit();
-
-    pack_and_push_block(cb_times_neg_sigmoid_and_neg_idx, block_size);
-}
-
-inline void compute_times_grad() {
-    // Compute: ((x - x * sigmoid(x) + 1) * sigmoid(x)) * dL_dout
-    // The result is stored in cb_dL_da_idx.
-    cb_wait_front(cb_times_neg_sigmoid_and_neg_idx, block_size);
-
-    tile_regs_acquire();
-    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_times_neg_sigmoid_and_neg_idx, cb_dL_out_idx);
-        mul_tiles_init(cb_times_neg_sigmoid_and_neg_idx, cb_dL_out_idx);
-        mul_tiles(
-            cb_times_neg_sigmoid_and_neg_idx,
-            cb_dL_out_idx,
-            /* tile_index */ block_idx,
-            /* tile_index */ block_idx,
-            /* register_idx */ block_idx);
-    }
-    tile_regs_commit();
-
-    pack_and_push_block(cb_dL_da_idx, block_size);
-}
-
-#else
 inline void compute_sigmoid() {
     // Compute: sigmoid(x) = 1 / (1 + exp(-x))
     // The result is stored in cb_sigmoid_idx.
 
     tile_regs_acquire();
     for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_input_idx, cb_input_idx);
         copy_tile_init(cb_input_idx);
         copy_tile(cb_input_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
 
@@ -170,7 +62,6 @@ inline void compute_one_minus_sigmoid() {
 
     tile_regs_acquire();
     for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_sigmoid_idx, cb_sigmoid_idx);
         copy_tile_init(cb_sigmoid_idx);
         copy_tile(cb_sigmoid_idx, /* tile_index */ block_idx, /* register_idx */ block_idx);
 
@@ -191,7 +82,6 @@ inline void compute_times_input_plus_one() {
 
     tile_regs_acquire();
     for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_input_idx, cb_one_minus_sigmoid_idx);
         mul_tiles_init(cb_input_idx, cb_one_minus_sigmoid_idx);
         mul_tiles(
             cb_input_idx,
@@ -215,7 +105,6 @@ inline void compute_times_sigmoid() {
 
     tile_regs_acquire();
     for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_times_input_plus_one_idx, cb_sigmoid_idx);
         mul_tiles_init(cb_sigmoid_idx, cb_times_input_plus_one_idx);
         mul_tiles(
             cb_sigmoid_idx,
@@ -236,7 +125,6 @@ inline void compute_times_grad() {
 
     tile_regs_acquire();
     for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
-        reconfig_data_format(cb_times_sigmoid_idx, cb_dL_out_idx);
         mul_tiles_init(cb_times_sigmoid_idx, cb_dL_out_idx);
         mul_tiles(
             cb_times_sigmoid_idx,
@@ -249,7 +137,6 @@ inline void compute_times_grad() {
 
     pack_and_push_block(cb_dL_da_idx, block_size);
 }
-#endif
 
 inline void MAIN {
     init_sfpu(cb_input_idx, cb_dL_da_idx);
@@ -258,38 +145,22 @@ inline void MAIN {
         for (uint32_t col = 0; col < Wt; col += block_size) {
             cb_wait_front(cb_input_idx, block_size);
             cb_wait_front(cb_dL_out_idx, block_size);
-#ifdef THREE_PACKS
-            // Compute dL_da with 3 packs.
-            {
-                compute_neg_sigmoid();
-                compute_x_plus_x_times_neg_sigmoid_plus_one();
-                compute_times_neg_sigmoid_and_neg();
-                compute_times_grad();
 
-                cb_pop_front(cb_neg_sigmoid_idx, block_size);
-                cb_pop_front(cb_x_plus_x_times_neg_sigmoid_plus_one_idx, block_size);
-                cb_pop_front(cb_times_neg_sigmoid_and_neg_idx, block_size);
-            }
-#else
-            // Compute dL_da with 4 packs.
-            {
-                compute_sigmoid();
-                compute_one_minus_sigmoid();
-                compute_times_input_plus_one();
-                compute_times_sigmoid();
-                compute_times_grad();
+            compute_sigmoid();
+            compute_one_minus_sigmoid();
+            compute_times_input_plus_one();
+            compute_times_sigmoid();
+            compute_times_grad();
 
-                cb_pop_front(cb_sigmoid_idx, block_size);
-                cb_pop_front(cb_one_minus_sigmoid_idx, block_size);
-                cb_pop_front(cb_times_input_plus_one_idx, block_size);
-                cb_pop_front(cb_times_sigmoid_idx, block_size);
-            }
-#endif
+            cb_pop_front(cb_sigmoid_idx, block_size);
+            cb_pop_front(cb_one_minus_sigmoid_idx, block_size);
+            cb_pop_front(cb_times_input_plus_one_idx, block_size);
+            cb_pop_front(cb_times_sigmoid_idx, block_size);
 
             cb_pop_front(cb_input_idx, block_size);
             cb_pop_front(cb_dL_out_idx, block_size);
         }
     }
 }
+
 }  // namespace NAMESPACE
-// namespace NAMESPACE

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/reader_silu_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/reader_silu_bw_interleaved_start_id.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
+
+// #define THREE_PACKS true
+
+// CBs with input data
+constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
+constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_1;
+// CBs with output data
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_2;
+// CBs with intermediate computations
+#ifdef THREE_PACKS
+constexpr uint32_t cb_neg_sigmoid_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_x_plus_x_times_neg_sigmoid_plus_one_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_times_neg_sigmoid_and_neg_idx = tt::CBIndex::c_5;
+#else
+constexpr uint32_t cb_sigmoid_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_one_minus_sigmoid_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_times_input_plus_one_idx = tt::CBIndex::c_5;
+constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
+#endif
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+
+#ifdef DO_MASK_W
+constexpr bool do_mask_w = true;
+#else
+constexpr bool do_mask_w = false;
+#endif
+
+inline void read_tiles(
+    uint32_t cb_idx,
+    const InterleavedAddrGenFast</* is dram */ true>& addr_gen,
+    uint32_t start_idx,
+    uint32_t block_size,
+    uint32_t current_block_size,
+    const uint32_t tile_bytes) {
+    // Reads `num_tiles` tiles from DRAM starting at logical tile index `start_tile` into circular buffer `cb_idx`.
+    cb_reserve_back(cb_idx, block_size);
+    uint32_t l1_write_addr = get_write_ptr(cb_idx);
+    for (uint32_t block_idx = 0; block_idx < current_block_size; ++block_idx) {
+        noc_async_read_tile(start_idx + block_idx, addr_gen, l1_write_addr);
+        l1_write_addr += tile_bytes;
+    }
+}
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    uint32_t input_address = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dL_out_address = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_rows_to_process = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t start_row = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint16_t one = 0x00003F80;  // (bfloat16)1.0 -> uint16_t
+    constexpr uint16_t five = 0x40A0;     // (bfloat16)5.0 -> uint16_t
+    // Here might be called generate tile for one, but hope it's not needed because we fiugure this out in a different
+    // way
+
+    const uint32_t tile_bytes = get_tile_size(cb_input_idx);
+    const DataFormat data_format = get_dataformat(cb_input_idx);
+
+    const InterleavedAddrGenFast</* is_dram */ true> input_address_generator = {
+        .bank_base_address = input_address, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast</* is_dram */ true> dL_out_address_generator = {
+        .bank_base_address = dL_out_address, .page_size = tile_bytes, .data_format = data_format};
+
+    // Read input tensors row by row, reading each row's data twice due to compute requirements
+    uint32_t end_row = start_row + num_rows_to_process;
+    for (uint32_t r = start_row; r < end_row; ++r) {
+        for (uint32_t c = 0; c < Wt; c += block_size) {
+            uint32_t row_tile_idx = (r * Wt) + c;
+            uint32_t current_block_size = (c + block_size <= Wt) ? block_size : (Wt - c);
+
+            read_tiles(cb_input_idx, input_address_generator, row_tile_idx, block_size, current_block_size, tile_bytes);
+            read_tiles(
+                cb_dL_out_idx, dL_out_address_generator, row_tile_idx, block_size, current_block_size, tile_bytes);
+            noc_async_read_barrier();
+            cb_push_back(cb_input_idx, block_size);
+            cb_push_back(cb_dL_out_idx, block_size);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/reader_silu_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/reader_silu_bw_interleaved_start_id.cpp
@@ -5,24 +5,16 @@
 #include "dataflow_api.h"
 #include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
 
-// #define THREE_PACKS true
-
 // CBs with input data
 constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
 constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_1;
 // CBs with output data
 constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_2;
 // CBs with intermediate computations
-#ifdef THREE_PACKS
-constexpr uint32_t cb_neg_sigmoid_idx = tt::CBIndex::c_3;
-constexpr uint32_t cb_x_plus_x_times_neg_sigmoid_plus_one_idx = tt::CBIndex::c_4;
-constexpr uint32_t cb_times_neg_sigmoid_and_neg_idx = tt::CBIndex::c_5;
-#else
 constexpr uint32_t cb_sigmoid_idx = tt::CBIndex::c_3;
 constexpr uint32_t cb_one_minus_sigmoid_idx = tt::CBIndex::c_4;
 constexpr uint32_t cb_times_input_plus_one_idx = tt::CBIndex::c_5;
 constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
-#endif
 
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
@@ -55,11 +47,6 @@ void kernel_main() {
     uint32_t dL_out_address = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t num_rows_to_process = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t start_row = get_arg_val<uint32_t>(runtime_args_counter++);
-
-    constexpr uint16_t one = 0x00003F80;  // (bfloat16)1.0 -> uint16_t
-    constexpr uint16_t five = 0x40A0;     // (bfloat16)5.0 -> uint16_t
-    // Here might be called generate tile for one, but hope it's not needed because we fiugure this out in a different
-    // way
 
     const uint32_t tile_bytes = get_tile_size(cb_input_idx);
     const DataFormat data_format = get_dataformat(cb_input_idx);

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp
@@ -1,0 +1,77 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <debug/dprint.h>
+
+#include "dataflow_api.h"
+#include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"  // this is prob obsolete once debugged
+
+// #define THREE_PACKS true
+
+// CBs with input data
+constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
+constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_1;
+// CBs with output data
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_2;
+// CBs with intermediate computations
+#ifdef THREE_PACKS
+constexpr uint32_t cb_neg_sigmoid_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_x_plus_x_times_neg_sigmoid_plus_one_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_times_neg_sigmoid_and_neg_idx = tt::CBIndex::c_5;
+#else
+constexpr uint32_t cb_sigmoid_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_one_minus_sigmoid_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_times_input_plus_one_idx = tt::CBIndex::c_5;
+constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
+#endif
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+
+inline void write_cb_block_to_dram(
+    uint32_t cb_idx,
+    const InterleavedAddrGenFast</* is dram */ true>& addr_gen,
+    uint32_t start_idx,
+    uint32_t block_size,
+    uint32_t current_block_size,
+    uint32_t tile_bytes) {
+    cb_wait_front(cb_idx, block_size);
+    uint32_t l1_read_addr = get_read_ptr(cb_idx);
+    // We wait for the block_size tiles to be available in the CB, but we only write the current_block_size tiles
+    // because C % block_size may not be zero.
+    for (uint32_t block_idx = 0; block_idx < current_block_size; ++block_idx) {
+        noc_async_write_tile(start_idx + block_idx, addr_gen, l1_read_addr);
+        l1_read_addr += tile_bytes;
+    }
+}
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0;
+    uint32_t da_output_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_rows_to_process = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t start_row = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    const uint32_t tile_bytes = get_tile_size(cb_dL_da_idx);
+    const DataFormat data_format = get_dataformat(cb_dL_da_idx);
+
+    const InterleavedAddrGenFast</* is dram */ true> da_output_addr_generator = {
+        .bank_base_address = da_output_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    uint32_t end_row = start_row + num_rows_to_process;
+    for (uint32_t r = start_row; r < end_row; ++r) {
+        // Write da (gradient w.r.t. input) in blocks.
+        // We interleave the writes to avoid waiting for the entire Wt tiles at once.
+        for (uint32_t c = 0; c < Wt; c += block_size) {
+            uint32_t current_block_size = (c + block_size <= Wt) ? block_size : (Wt - c);
+            uint32_t start_idx = (r * Wt) + c;
+
+            // Write dL_da block
+            write_cb_block_to_dram(
+                cb_dL_da_idx, da_output_addr_generator, start_idx, block_size, current_block_size, tile_bytes);
+            noc_async_write_barrier();
+            cb_pop_front(cb_dL_da_idx, block_size);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp
@@ -8,24 +8,16 @@
 #include "dataflow_api.h"
 #include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"  // this is prob obsolete once debugged
 
-// #define THREE_PACKS true
-
 // CBs with input data
 constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
 constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_1;
 // CBs with output data
 constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_2;
 // CBs with intermediate computations
-#ifdef THREE_PACKS
-constexpr uint32_t cb_neg_sigmoid_idx = tt::CBIndex::c_3;
-constexpr uint32_t cb_x_plus_x_times_neg_sigmoid_plus_one_idx = tt::CBIndex::c_4;
-constexpr uint32_t cb_times_neg_sigmoid_and_neg_idx = tt::CBIndex::c_5;
-#else
 constexpr uint32_t cb_sigmoid_idx = tt::CBIndex::c_3;
 constexpr uint32_t cb_one_minus_sigmoid_idx = tt::CBIndex::c_4;
 constexpr uint32_t cb_times_input_plus_one_idx = tt::CBIndex::c_5;
 constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
-#endif
 
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "silu_bw_device_operation.hpp"
+
+#include "silu_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::silu_bw::device {
+
+SiLUBackwardDeviceOperation::program_factory_t SiLUBackwardDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return SiLUBackwardProgramFactory{};
+}
+
+void SiLUBackwardDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void SiLUBackwardDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
+            "SiLUBackward operation is only supported on Wormhole. Device arch: {}. Tensor name {}",
+            magic_enum::enum_name(tensor.device()->arch()),
+            name);
+
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "SiLUBackward operation requires {} to be on Device. Input storage type: {}",
+            name,
+            static_cast<int>(tensor.storage_type()));
+
+        TT_FATAL(
+            tensor.buffer() != nullptr,
+            "Operands to SiLUBackward need to be allocated in buffers on the device. Buffer is null. Tensor name {}",
+            name);
+
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "SiLUBackward operation requires tensor to be in Tile layout. {} tensor layout: {}",
+            name,
+            static_cast<int>(tensor.layout()));
+
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "SiLUBackward operation requires tensor to be of BFLOAT16 data type. {} tensor data type: {}",
+            name,
+            static_cast<int>(tensor.dtype()));
+
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "SiLUBackward operation requires Interleaved memory layout. {} "
+            "memory layout: `{}`",
+            name,
+            static_cast<int>(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& input_tensor = tensor_args.input;
+    const auto& dL_dout_tensor = tensor_args.dL_dout;
+    const auto& preallocated_da_tensor = tensor_args.preallocated_da;
+
+    check_tensor(input_tensor, "Input");
+    check_tensor(dL_dout_tensor, "dL_dout");
+    if (preallocated_da_tensor.has_value()) {
+        check_tensor(preallocated_da_tensor.value(), "Preallocated dL_da");
+    }
+}
+
+spec_return_value_t SiLUBackwardDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(2U);
+
+    if (tensor_args.preallocated_da.has_value()) {
+        output_specs.push_back(tensor_args.preallocated_da->tensor_spec());
+    } else {
+        output_specs.emplace_back(
+            tensor_args.input.logical_shape(),
+            tt::tt_metal::TensorLayout(
+                tensor_args.input.dtype(), tt::tt_metal::Layout::TILE, tensor_args.input.memory_config()));
+    }
+
+    return output_specs;
+}
+
+tensor_return_value_t SiLUBackwardDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    tensor_return_value_t output_tensors;
+    output_tensors.reserve(2U);
+
+    spec_return_value_t output_specs = compute_output_specs(args, tensor_args);
+
+    if (tensor_args.preallocated_da.has_value()) {
+        output_tensors.push_back(tensor_args.preallocated_da.value());
+    } else {
+        output_tensors.push_back(create_device_tensor(output_specs[0], tensor_args.input.device()));
+    }
+
+    return output_tensors;
+}
+
+ttsl::hash::hash_t SiLUBackwardDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_logical_shape = input_tensor.logical_shape();
+    auto program_factory = select_program_factory(args, tensor_args);
+    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<SiLUBackwardDeviceOperation>(
+        args, program_factory.index(), input_tensor.dtype(), input_logical_shape);
+
+    return hash;
+}
+
+std::tuple<SiLUBackwardDeviceOperation::operation_attributes_t, SiLUBackwardDeviceOperation::tensor_args_t>
+SiLUBackwardDeviceOperation::invoke(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& dL_dout_tensor,
+    const std::optional<ttnn::Tensor>& preallocated_da) {
+    return {
+        operation_attributes_t{},
+        tensor_args_t{
+            .input = input_tensor,
+            .dL_dout = dL_dout_tensor,
+            .preallocated_da = preallocated_da,
+        }};
+}
+
+}  // namespace ttml::metal::ops::silu_bw::device

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
@@ -88,18 +88,13 @@ spec_return_value_t SiLUBackwardDeviceOperation::compute_output_specs(
 
 tensor_return_value_t SiLUBackwardDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    tensor_return_value_t output_tensors;
-    output_tensors.reserve(2U);
-
     spec_return_value_t output_specs = compute_output_specs(args, tensor_args);
 
     if (tensor_args.preallocated_da.has_value()) {
-        output_tensors.push_back(tensor_args.preallocated_da.value());
+        return tensor_args.preallocated_da.value();
     } else {
-        output_tensors.push_back(create_device_tensor(output_specs[0], tensor_args.input.device()));
+        return create_device_tensor(output_specs[0], tensor_args.input.device());
     }
-
-    return output_tensors;
 }
 
 ttsl::hash::hash_t SiLUBackwardDeviceOperation::compute_program_hash(

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.hpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "metal/ttnn_all_includes.hpp"
+#include "silu_bw_device_operation_types.hpp"
+#include "silu_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::silu_bw::device {
+
+struct SiLUBackwardDeviceOperation {
+    using operation_attributes_t = operation_attributes_t;
+    using tensor_args_t = tensor_args_t;
+    using spec_return_value_t = spec_return_value_t;
+    using tensor_return_value_t = tensor_return_value_t;
+    using program_factory_t = std::variant<SiLUBackwardProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& dL_dout_tensor,
+        const std::optional<ttnn::Tensor>& preallocated_da = std::nullopt);
+};
+
+}  // namespace ttml::metal::ops::silu_bw::device
+
+namespace ttnn::prim {
+constexpr auto ttml_silu_bw = ttnn::
+    register_operation<"ttnn::prim::ttml_silu_bw", ttml::metal::ops::silu_bw::device::SiLUBackwardDeviceOperation>();
+}

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::silu_bw::device {
+
+// Attributes for the backward operation (add more if needed)
+struct operation_attributes_t {};
+
+// Tensors required for backward
+struct tensor_args_t {
+    ttnn::Tensor input;
+    ttnn::Tensor dL_dout;
+    std::optional<ttnn::Tensor> preallocated_da = std::nullopt;
+};
+
+// Output tensor specs and tensors
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+using tensor_return_value_t = std::vector<ttnn::Tensor>;
+
+}  // namespace ttml::metal::ops::silu_bw::device

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
@@ -20,6 +20,6 @@ struct tensor_args_t {
 
 // Output tensor specs and tensors
 using spec_return_value_t = std::vector<ttnn::TensorSpec>;
-using tensor_return_value_t = std::vector<ttnn::Tensor>;
+using tensor_return_value_t = ttnn::Tensor;
 
 }  // namespace ttml::metal::ops::silu_bw::device

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.cpp
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "silu_bw_program_factory.hpp"
+
+#include <cstdint>
+
+#include "metal/ops/common/program_utils.hpp"
+
+namespace {
+
+constexpr auto kWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp";
+
+constexpr auto kReaderKernelPath =
+    "tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/reader_silu_bw_interleaved_start_id.cpp";
+
+constexpr auto kComputeKernelPath = "tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/compute/silu_bw_kernel.cpp";
+
+// #define THREE_PACKS true
+#define PRECISE_DATA_FORMAT true
+
+// Buffer indices
+constexpr uint32_t kInputBufferIdx = 0;
+constexpr uint32_t kDLdoutBufferIdx = 1U;
+
+// Writer buffer indices
+constexpr uint32_t kDaBufferIdx = 0;
+
+// CBs with input data
+constexpr auto kInputCbIndex = tt::CBIndex::c_0;
+constexpr auto kDLoutCbIndex = tt::CBIndex::c_1;
+// CBs with output data
+constexpr auto kDLdaCbIndex = tt::CBIndex::c_2;
+// CBs with intermediate computations
+#ifdef THREE_PACKS
+constexpr uint32_t kNegSigmoidCbIndex = tt::CBIndex::c_3;
+constexpr uint32_t kXPlusXTimesNegSigmoidPlusOneCbIndex = tt::CBIndex::c_4;
+constexpr uint32_t kTimesNegSigmoidAndNegCbIndex = tt::CBIndex::c_5;
+#else
+constexpr uint32_t kSigmoidCbIndex = tt::CBIndex::c_3;
+constexpr uint32_t kOneMinusSigmoidCbIndex = tt::CBIndex::c_4;
+constexpr uint32_t kTimesInputPlusOneCbIndex = tt::CBIndex::c_5;
+constexpr uint32_t kTimesSigmoidCbIndex = tt::CBIndex::c_6;
+#endif
+
+// Some of the below constants are set to 2U because we might need to push a new value before poping the old one.
+constexpr uint32_t kNumOneTiles =
+    1U;  // in the end we do not want to have one in CB - to be figured later how to handle it
+
+}  // namespace
+
+namespace ttml::metal::ops::silu_bw::device {
+
+struct SiLUBackwardKernels {
+    tt::tt_metal::KernelHandle reader;
+    tt::tt_metal::KernelHandle writer;
+    tt::tt_metal::KernelHandle compute_group_1;
+    tt::tt_metal::KernelHandle compute_group_2;
+};
+
+void assign_per_core_runtime_args(
+    tt::tt_metal::Program& program,
+    const SiLUBackwardKernels& kernels,
+    const tt::tt_metal::Buffer* input_buffer,
+    const tt::tt_metal::Buffer* dLdout_buffer,
+    const tt::tt_metal::Buffer* da_buffer,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    uint32_t num_rows_per_core_group_1,
+    uint32_t num_rows_per_core_group_2,
+    const tt::tt_metal::CoreRangeSet& core_group_1,
+    const tt::tt_metal::CoreRangeSet& core_group_2) {
+    for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        // Determine how many rows this core will process
+        uint32_t num_rows_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_FATAL(false, "Core not in specified core ranges");
+        }
+
+        // Reader kernel: (input_addr, dLdout_addr, num_rows, offset)
+        SetRuntimeArgs(
+            program,
+            kernels.reader,
+            core,
+            {input_buffer->address(), dLdout_buffer->address(), num_rows_per_core, num_rows_written});
+
+        // Writer kernel: (da_addr, num_rows, offset)
+        SetRuntimeArgs(program, kernels.writer, core, {da_buffer->address(), num_rows_per_core, num_rows_written});
+
+        num_rows_written += num_rows_per_core;
+    }
+}
+
+SiLUBackwardProgramFactory::cached_program_t SiLUBackwardProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    // -------------------------------------------------------------------------
+    // 1) Setup device, data formats, tile sizes, and compute split
+    // -------------------------------------------------------------------------
+    const auto& input = tensor_args.input;
+    const auto& dLdout = tensor_args.dL_dout;
+
+    auto* device = input.device();
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat input_data_format = datatype_to_dataformat_converter(input.dtype());
+
+    uint32_t bfloat16_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
+    // Not sure if needed
+    uint32_t float32_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float32);
+
+    auto padded_tensor_shape = input.padded_shape();
+    auto padded_tensor_volume = input.physical_volume();
+    TT_FATAL(
+        padded_tensor_volume % tt::constants::TILE_HW == 0, "Padded input tensor volume must be divisible by TILE_HW");
+    TT_FATAL(padded_tensor_shape.rank() == 4U, "Input tensor must be 4D");
+    uint32_t Wt = padded_tensor_shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t Ht = padded_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t NC = padded_tensor_shape[0] * padded_tensor_shape[1];
+    uint32_t total_rows_to_process = NC * Ht;
+
+    // Get the number of inner dimension
+    uint32_t num_inner = input.logical_shape()[-1];
+
+    // Get number of free cores
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    // Compile arguments
+    uint32_t block_size =
+        4U;  // We enforce to use block_size of 4. If C % 4 != 0, we will take care of it in the kernels.
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_rows_to_process);
+
+    // -------------------------------------------------------------------------
+    // 2) Create and configure circular buffers
+    // -------------------------------------------------------------------------
+    const uint32_t twice_block_size = 2U * block_size;
+
+    auto data_format = input_data_format;  // tt::DataFormat::Float16_b
+    auto precise_data_format = tt::DataFormat::Float32;
+
+    auto cb_input = create_circular_buffer(
+        program, all_cores, kInputCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    auto cb_dLdout = create_circular_buffer(
+        program, all_cores, kDLoutCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    auto cb_dL_da = create_circular_buffer(
+        program, all_cores, kDLdaCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+#ifdef THREE_PACKS
+
+#ifdef PRECISE_DATA_FORMAT
+    auto cb_neg_sigmoid = create_circular_buffer(
+        program, all_cores, kNegSigmoidCbIndex, precise_data_format, float32_single_tile_size_bytes, twice_block_size);
+    auto cb_x_plus_x_times_neg_sigmoid_plus_one = create_circular_buffer(
+        program,
+        all_cores,
+        kXPlusXTimesNegSigmoidPlusOneCbIndex,
+        precise_data_format,
+        float32_single_tile_size_bytes,
+        twice_block_size);
+    auto cb_times_neg_sigmoid_and_neg = create_circular_buffer(
+        program,
+        all_cores,
+        kTimesNegSigmoidAndNegCbIndex,
+        precise_data_format,
+        float32_single_tile_size_bytes,
+        twice_block_size);
+#else
+    auto cb_neg_sigmoid = create_circular_buffer(
+        program, all_cores, kNegSigmoidCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    auto cb_x_plus_x_times_neg_sigmoid_plus_one = create_circular_buffer(
+        program,
+        all_cores,
+        kXPlusXTimesNegSigmoidPlusOneCbIndex,
+        data_format,
+        bfloat16_single_tile_size_bytes,
+        twice_block_size);
+    auto cb_times_neg_sigmoid_and_neg = create_circular_buffer(
+        program,
+        all_cores,
+        kTimesNegSigmoidAndNegCbIndex,
+        data_format,
+        bfloat16_single_tile_size_bytes,
+        twice_block_size);
+#endif
+#else
+
+#ifdef PRECISE_DATA_FORMAT
+    auto cb_sigmoid = create_circular_buffer(
+        program, all_cores, kSigmoidCbIndex, precise_data_format, float32_single_tile_size_bytes, twice_block_size);
+    auto cb_one_minus_sigmoid = create_circular_buffer(
+        program,
+        all_cores,
+        kOneMinusSigmoidCbIndex,
+        precise_data_format,
+        float32_single_tile_size_bytes,
+        twice_block_size);
+    auto cb_times_input_plus_one = create_circular_buffer(
+        program,
+        all_cores,
+        kTimesInputPlusOneCbIndex,
+        precise_data_format,
+        float32_single_tile_size_bytes,
+        twice_block_size);
+    auto cb_times_sigmoid = create_circular_buffer(
+        program,
+        all_cores,
+        kTimesSigmoidCbIndex,
+        precise_data_format,
+        float32_single_tile_size_bytes,
+        twice_block_size);
+#else
+    auto cb_sigmoid = create_circular_buffer(
+        program, all_cores, kSigmoidCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    auto cb_one_minus_sigmoid = create_circular_buffer(
+        program, all_cores, kOneMinusSigmoidCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    auto cb_times_input_plus_one = create_circular_buffer(
+        program, all_cores, kTimesInputPlusOneCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    auto cb_times_sigmoid = create_circular_buffer(
+        program, all_cores, kTimesSigmoidCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+#endif
+#endif
+    // -------------------------------------------------------------------------
+    // 3) Create reader/writer kernels
+    // -------------------------------------------------------------------------
+    // We shouldnt need them
+    // defines["REDUCE_OP"] = "PoolType::SUM";
+    // defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
+
+    auto* input_buffer = input.buffer();
+    TT_FATAL(
+        input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "Input buffer must be in DRAM. Input buffer of type {}",
+        magic_enum::enum_name(input_buffer->buffer_type()));
+
+    auto* dLdout_buffer = dLdout.buffer();
+    TT_FATAL(
+        dLdout_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "dL_dout buffer must be in DRAM. dL_dout buffer of type {}",
+        magic_enum::enum_name(dLdout_buffer->buffer_type()));
+
+    auto* dL_da_buffer = output[0].buffer();
+    TT_FATAL(
+        dL_da_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "dL_da buffer must be in DRAM. dL_da buffer of type {}",
+        magic_enum::enum_name(dL_da_buffer->buffer_type()));
+
+    SiLUBackwardKernels kernels;
+    kernels.reader = create_reader_kernel(program, all_cores, {block_size, Wt}, {}, kReaderKernelPath);
+
+    kernels.writer = create_writer_kernel(program, all_cores, {block_size, Wt}, {}, kWriterKernelPath);
+
+    // -------------------------------------------------------------------------
+    // 4) Create compute kernels for cross_entropy_bw
+    // -------------------------------------------------------------------------
+
+    // Group 1 compile-time arguments
+    std::vector<uint32_t> compute_group_1_args = {
+        num_rows_per_core_group_1,  // per_core_block_cnt
+        block_size,                 // per_core_block_size
+        Wt                          // num_inner / TILE_W
+    };
+
+    kernels.compute_group_1 = create_compute_kernel(
+        program, core_group_1, compute_group_1_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+
+    // Group 2 (if present) compile-time arguments
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_group_2_args = {
+            num_rows_per_core_group_2,  // per_core_block_cnt
+            block_size,                 // per_core_block_size
+            Wt                          // num_inner / TILE_W
+        };
+
+        kernels.compute_group_2 = create_compute_kernel(
+            program, core_group_2, compute_group_2_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+    }
+    // -------------------------------------------------------------------------
+    // 5) Assign runtime args for each core
+    // -------------------------------------------------------------------------
+    assign_per_core_runtime_args(
+        program,
+        kernels,
+        input_buffer,
+        dLdout_buffer,
+        dL_da_buffer,
+        num_cores,
+        num_cores_y,
+        num_rows_per_core_group_1,
+        num_rows_per_core_group_2,
+        core_group_1,
+        core_group_2);
+
+    // -------------------------------------------------------------------------
+    // 6) Return the fully configured program & relevant shared variables
+    // -------------------------------------------------------------------------
+    return cached_program_t{
+        std::move(program),
+        {/* silu_bw_reader_kernel_id  = */ kernels.reader,
+         /* silu_bw_writer_kernel_id  = */ kernels.writer,
+         /* silu_bw_kernel_group_1_id = */ kernels.compute_group_1,
+         /* silu_bw_kernel_group_2_id = */ kernels.compute_group_2,
+         /* core_group_1              = */ core_group_1,
+         /* core_group_2              = */ core_group_2,
+         /* num_cores                 = */ num_cores,
+         /* num_cores_y               = */ num_cores_y}};
+}
+
+void SiLUBackwardProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& shared_variables = cached_program.shared_variables;
+    auto& silu_bw_reader_kernel_id = shared_variables.silu_bw_reader_kernel_id;
+    auto& silu_bw_writer_kernel_id = shared_variables.silu_bw_writer_kernel_id;
+    auto& silu_bw_kernel_group_1_id = shared_variables.silu_bw_kernel_group_1_id;
+    auto& silu_bw_kernel_group_2_id = shared_variables.silu_bw_kernel_group_2_id;
+    auto& core_group_1 = shared_variables.core_group_1;
+    auto& core_group_2 = shared_variables.core_group_2;
+
+    uint32_t num_cores = shared_variables.num_cores;
+    uint32_t num_cores_y = shared_variables.num_cores_y;
+
+    auto* input_buffer = tensor_args.input.buffer();
+    auto* dLdout_buffer = tensor_args.dL_dout.buffer();
+
+    auto* da_buffer = output[0].buffer();
+
+    // Only address arguments need updating here; tile counts remain the same as in create().
+    auto& reader_runtime_args = GetRuntimeArgs(program, silu_bw_reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, silu_bw_writer_kernel_id);
+
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        // Update input buffers for the reader kernel
+        {
+            auto& runtime_args = reader_runtime_args[core.x][core.y];
+            runtime_args[kInputBufferIdx] = input_buffer->address();
+            runtime_args[kDLdoutBufferIdx] = dLdout_buffer->address();
+        }
+
+        // Update output buffers for the writer kernel
+        {
+            auto& runtime_args = writer_runtime_args[core.x][core.y];
+            runtime_args[kDaBufferIdx] = da_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::silu_bw::device

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "silu_bw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::silu_bw::device {
+
+struct SiLUBackwardProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle silu_bw_reader_kernel_id;
+        tt::tt_metal::KernelHandle silu_bw_writer_kernel_id;
+        tt::tt_metal::KernelHandle silu_bw_kernel_group_1_id;
+        tt::tt_metal::KernelHandle silu_bw_kernel_group_2_id;
+        CoreRangeSet core_group_1;
+        CoreRangeSet core_group_2;
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::silu_bw::device

--- a/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "silu_bw.hpp"
+
+#include "core/compute_kernel_config.hpp"
+#include "device/silu_bw_device_operation.hpp"
+
+namespace ttml::metal::ops::silu_bw {
+
+std::vector<std::optional<ttnn::Tensor>> SiLUBackwardOperation::invoke(
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor) {
+    return {ttnn::prim::ttml_silu_bw(
+        input_tensor,   // [B,1,S,C]
+        dL_dout_tensor  //[B,1,S,C]
+        )[0]};
+}
+
+}  // namespace ttml::metal::ops::silu_bw

--- a/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.cpp
@@ -9,12 +9,11 @@
 
 namespace ttml::metal::ops::silu_bw {
 
-std::vector<std::optional<ttnn::Tensor>> SiLUBackwardOperation::invoke(
-    const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor) {
-    return {ttnn::prim::ttml_silu_bw(
+ttnn::Tensor SiLUBackwardOperation::invoke(const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor) {
+    return ttnn::prim::ttml_silu_bw(
         input_tensor,   // [B,1,S,C]
         dL_dout_tensor  //[B,1,S,C]
-        )[0]};
+    );
 }
 
 }  // namespace ttml::metal::ops::silu_bw

--- a/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::silu_bw {
+
+struct SiLUBackwardOperation {
+    static std::vector<std::optional<ttnn::Tensor>> invoke(
+        const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor);
+};
+
+}  // namespace ttml::metal::ops::silu_bw

--- a/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.hpp
@@ -9,8 +9,7 @@
 namespace ttml::metal::ops::silu_bw {
 
 struct SiLUBackwardOperation {
-    static std::vector<std::optional<ttnn::Tensor>> invoke(
-        const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor);
 };
 
 }  // namespace ttml::metal::ops::silu_bw

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -55,7 +55,8 @@ autograd::TensorPtr silu(const autograd::TensorPtr& tensor, bool use_composite_b
     auto out = autograd::create_tensor(ttnn::silu(tensor->get_value()));
     autograd::GradFunction grad = [tensor, out, use_composite_bw]() {
         auto res = use_composite_bw ? ttnn::silu_bw(out->get_grad(), tensor->get_value())
-                                    : ttml::metal::silu_bw(tensor->get_value(), out->get_grad());
+                                    : std::vector<std::optional<ttnn::Tensor>>(
+                                          {ttml::metal::silu_bw(tensor->get_value(), out->get_grad())});
         assert(res.size() == 1U && "Silu backward should return only one gradient");
         tensor->add_grad(res.front().value());
     };

--- a/tt-train/sources/ttml/ops/unary_ops.hpp
+++ b/tt-train/sources/ttml/ops/unary_ops.hpp
@@ -10,7 +10,7 @@ namespace ttml::ops {
 
 autograd::TensorPtr relu(const autograd::TensorPtr& tensor);
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor);
-autograd::TensorPtr silu(const autograd::TensorPtr& tensor);
+autograd::TensorPtr silu(const autograd::TensorPtr& tensor, bool use_composite_bw = false);
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor);
 autograd::TensorPtr sum(const autograd::TensorPtr& tensor);
 autograd::TensorPtr broadcast_batch(const autograd::TensorPtr& tensor, uint32_t new_batch_dim);

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCES
     ops/unary_ops_test.cpp
     ops/embedding_op_test.cpp
     ops/softmax_test.cpp
+    ops/silu_op_test.cpp
 )
 
 add_executable(ttml_tests ${SOURCES})

--- a/tt-train/tests/ops/silu_op_test.cpp
+++ b/tt-train/tests/ops/silu_op_test.cpp
@@ -1,0 +1,379 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cassert>
+#include <core/ttnn_all_includes.hpp>
+#include <iostream>
+#include <numeric>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "ops/losses.hpp"
+#include "ops/unary_ops.hpp"
+
+class SiLUOpTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+    }
+
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+    }
+};
+
+// ============================================================================
+// Section 1: SiLU Kernel vs Reference Implementation
+// ============================================================================
+// These tests validate the SiLU kernel implementation against
+// a reference implementation using basic operations: silu(x) = x * sigmoid(x)
+//
+// Test methodology:
+// 1. Create test tensor `x` of shape [B,N,S,C] with x.requires_grad = True
+// 2. Compute SiLU using both kernel and reference implementations
+// 3. Compare forward and backward results for numerical correctness
+// ============================================================================
+
+namespace {
+
+/**
+ * Reference implementation of SiLU forward pass using xt library
+ * SiLU(x) = x * sigmoid(x)
+ *
+ * @param x Input tensor
+ * @return SiLU activation result
+ */
+xt::xarray<float> silu_forward_reference(const xt::xarray<float>& x) {
+    auto sigmoid_x = 1.0f / (1.0f + xt::exp(-x));
+    return x * sigmoid_x;
+}
+
+/**
+ * Reference implementation of SiLU backward pass using xt library
+ * SiLU'(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
+ *
+ * @param x Input tensor (original input to SiLU)
+ * @param grad Gradient from upstream
+ * @return Gradient with respect to input
+ */
+xt::xarray<float> silu_backward_reference(const xt::xarray<float>& x, const xt::xarray<float>& grad) {
+    auto sigmoid_x = 1.0f / (1.0f + xt::exp(-x));
+    auto silu_grad = sigmoid_x * (1.0f + x * (1.0f - sigmoid_x));
+    return grad * silu_grad;
+}
+
+/**
+ * Helper function to compute precision metrics between two tensors
+ * Returns a struct with various precision metrics
+ */
+struct PrecisionMetrics {
+    float max_abs_error;
+    float mean_abs_error;
+    float relative_error;
+    float rmse;
+    bool allclose_strict;
+    bool allclose_loose;
+};
+
+PrecisionMetrics compute_precision_metrics(const xt::xarray<float>& reference, const xt::xarray<float>& test) {
+    PrecisionMetrics metrics;
+
+    auto abs_diff = xt::abs(reference - test);
+    auto rel_diff = abs_diff / (xt::abs(reference) + 1e-8f);
+
+    metrics.max_abs_error = xt::amax(abs_diff)();
+    metrics.mean_abs_error = xt::mean(abs_diff)();
+    metrics.relative_error = xt::mean(rel_diff)();
+    metrics.rmse = xt::sqrt(xt::mean(xt::square(abs_diff)))();
+    metrics.allclose_strict = xt::allclose(reference, test, 1e-4f, 1e-3f);  // Moderate precision
+    metrics.allclose_loose = xt::allclose(reference, test, 1e-3f, 3e-2f);   // Same as CompareKernelVsReference
+
+    return metrics;
+}
+
+void CompareKernelVsReference(const xt::xarray<float>& input_data) {
+    using namespace ttml;
+
+    // Create input tensors for kernel and reference implementations
+    auto input_kernel = autograd::create_tensor(core::from_xtensor(input_data, &autograd::ctx().get_device()));
+    auto input_reference = autograd::create_tensor(core::from_xtensor(input_data, &autograd::ctx().get_device()));
+
+    // Forward pass - kernel implementation
+    auto result_kernel = ops::silu(input_kernel);
+    auto result_kernel_xtensor = core::to_xtensor(result_kernel->get_value());
+
+    // Forward pass - reference implementation
+    auto result_reference = ops::silu(input_reference, /*use_composite_bw=*/true);
+    auto result_reference_xtensor = core::to_xtensor(result_reference->get_value());
+
+    // Compare forward results
+    // NOTE: This comparison does not much make sense for SiLU, because there is no forward SiLU composite if I am not
+    // mistaken, but we still do it for consistency.
+    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_reference_xtensor, 1.0e-3F, 3e-2F));
+
+    // Backward pass - create target and compute gradients
+    auto target_kernel = autograd::create_tensor(core::zeros_like(result_kernel->get_value()));
+    auto target_reference = autograd::create_tensor(core::zeros_like(result_reference->get_value()));
+
+    auto mse_kernel = ops::mse_loss(result_kernel, target_kernel);
+    auto mse_reference = ops::mse_loss(result_reference, target_reference);
+
+    mse_kernel->backward();
+    mse_reference->backward();
+
+    // Compare backward results
+    auto input_grad_kernel = core::to_xtensor(input_kernel->get_grad());
+    auto input_grad_reference = core::to_xtensor(input_reference->get_grad());
+
+    EXPECT_TRUE(xt::allclose(input_grad_kernel, input_grad_reference, 1.0e-3F, 3e-2F));
+}
+
+/**
+ * Helper function to compare kernel vs reference implementations of SiLU
+ *
+ * This function tests both forward and backward passes to ensure:
+ * 1. Forward pass: kernel and reference produce identical results
+ * 2. Backward pass: gradients computed by both implementations match
+ * 3. All outputs and gradients are finite (no NaN/Inf values)
+ *
+ * @param shape Input tensor shape [B, N, S, C] where:
+ *   - B: batch size
+ *   - N: number of channels (usually 1 for transformers)
+ *   - S: sequence length (height for transformers)
+ *   - C: feature dimension (width/embedding dimension)
+ *
+ * Test cases cover various scenarios:
+ * - Block size alignment: Wt % block_size patterns (0, 1, 2, 3)
+ * - Memory patterns: small vs large tensors
+ * - Realistic shapes: transformer model dimensions
+ */
+static void CompareKernelVsReferenceWithShape(const std::vector<uint32_t>& shape) {
+    using namespace ttml;
+
+    // Generate random input data with range [-2, 2] to test SiLU behavior across saturation regions
+    xt::random::seed(42);
+    xt::xarray<float> input_data = xt::random::rand<float>(shape, -2.0F, 2.0F);
+
+    CompareKernelVsReference(input_data);
+}
+
+}  // namespace
+
+// ============================================================================
+// Section 2: SiLU Kernel vs Reference Implementation - Comprehensive Tests
+// ============================================================================
+// These tests systematically compare the SiLU kernel implementation against
+// the reference implementation across different scenarios:
+//
+// - Block size patterns: Wt % block_size = 0, 1, 2, 3 (where block_size = 4)
+// - Memory patterns: small tensors vs large tensors
+// - Training scenarios: realistic model shapes (NanoLlama, etc.)
+// - Batch patterns: single vs multiple batches and sequences
+//
+// Note: Wt = ceil(C / 32), so we test different C values to cover all
+// block_size remainder patterns.
+// Shape notation: [B, N, S, C] where C is the feature dimension
+// ============================================================================
+
+// Test small tensor - basic functionality
+TEST_F(SiLUOpTest, SiLU_Compare_Small) {
+    // C=8, Wt=1, Wt%4=1
+    CompareKernelVsReferenceWithShape({1, 1, 1, 8});
+}
+
+// Test block_size alignment patterns
+// Wt % block_size = 0 (perfectly aligned)
+TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder0) {
+    // C=128, Wt=4, Wt%4=0
+    CompareKernelVsReferenceWithShape({1, 1, 1, 128});
+}
+
+// Wt % block_size = 1
+TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder1) {
+    // C=160, Wt=5, Wt%4=1
+    CompareKernelVsReferenceWithShape({1, 1, 1, 160});
+}
+
+// Wt % block_size = 2
+TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder2) {
+    // C=192, Wt=6, Wt%4=2
+    CompareKernelVsReferenceWithShape({1, 1, 1, 192});
+}
+
+// Wt % block_size = 3
+TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder3) {
+    // C=224, Wt=7, Wt%4=3
+    CompareKernelVsReferenceWithShape({1, 1, 1, 224});
+}
+
+// Test large tensor - memory stress test
+TEST_F(SiLUOpTest, SiLU_Compare_Large) {
+    // Large C dimension to test memory handling
+    // C=32768, Wt=1024, Wt%4=0
+    CompareKernelVsReferenceWithShape({1, 1, 1, 32768});
+}
+
+// Test very large tensor - extreme memory test
+TEST_F(SiLUOpTest, SiLU_Compare_VeryLarge) {
+    // Very large C dimension ~1M elements
+    // C=1048576, Wt=32768, Wt%4=0
+    CompareKernelVsReferenceWithShape({1, 1, 1, 1048576});
+}
+
+// Test NanoLlama-like shape - realistic transformer model
+TEST_F(SiLUOpTest, SiLU_Compare_NanoLlama_Shape) {
+    // Typical NanoLlama dimensions: multiple batches and sequences
+    // B=2, N=1, S=64, C=512 (hidden dimension)
+    // C=512, Wt=16, Wt%4=0
+    CompareKernelVsReferenceWithShape({2, 1, 64, 512});
+}
+
+// Test batch processing with different sequence lengths
+TEST_F(SiLUOpTest, SiLU_Compare_MultiBatch_MultiSeq) {
+    // Multiple batches with longer sequences
+    // B=4, N=1, S=128, C=768
+    // C=768, Wt=24, Wt%4=0
+    CompareKernelVsReferenceWithShape({4, 1, 128, 768});
+}
+
+// Test smaller model dimensions with unaligned C
+TEST_F(SiLUOpTest, SiLU_Compare_SmallModel_Unaligned) {
+    // Smaller model with unaligned channel dimension
+    // B=2, N=1, S=32, C=100
+    // C=100, Wt=4, Wt%4=0 (but C is not multiple of 32)
+    CompareKernelVsReferenceWithShape({2, 1, 32, 100});
+}
+
+// ============================================================================
+// Section 3: Backward Pass Precision Comparison Test
+// ============================================================================
+// This test compares the precision of kernel vs composite implementations
+// against a reference xt implementation for backward pass only to determine
+// which is more accurate for gradient computation
+// ============================================================================
+
+TEST_F(SiLUOpTest, SiLU_Precision_Comparison) {
+    using namespace ttml;
+
+    // Test with 3 different shapes
+    std::vector<std::vector<uint32_t>> test_shapes = {
+        {1, 1, 1, 8},     // small
+        {2, 1, 64, 512},  // nanollama like
+        {1, 1, 1, 32768}  // large
+    };
+
+    std::vector<std::string> shape_names = {"small", "nanollama-like", "large"};
+
+    // Test range: moderate range that covers typical activation values
+    const float min_val = -2.0f;
+    const float max_val = 2.0f;
+
+    // Run the test multiple times with different seeds for statistical confidence
+    const int num_runs = 10;
+
+    for (size_t shape_idx = 0; shape_idx < test_shapes.size(); ++shape_idx) {
+        const auto& shape = test_shapes[shape_idx];
+        const auto& shape_name = shape_names[shape_idx];
+
+        // Collect metrics across all runs
+        std::vector<float> kernel_rmse_values, kernel_max_error_values, kernel_mean_error_values;
+        std::vector<float> composite_rmse_values, composite_max_error_values, composite_mean_error_values;
+        int kernel_wins = 0, composite_wins = 0;
+
+        for (int run = 0; run < num_runs; ++run) {
+            // Generate test data with different seed for each run
+            xt::random::seed(42 + run);
+            xt::xarray<float> input_data = xt::random::rand<float>(shape, min_val, max_val);
+
+            // Create input tensors
+            auto input_kernel = autograd::create_tensor(core::from_xtensor(input_data, &autograd::ctx().get_device()));
+            auto input_composite =
+                autograd::create_tensor(core::from_xtensor(input_data, &autograd::ctx().get_device()));
+
+            // Forward pass - kernel implementation
+            auto result_kernel = ops::silu(input_kernel, /*use_composite_bw=*/false);
+
+            // Forward pass - composite implementation
+            auto result_composite = ops::silu(input_composite, /*use_composite_bw=*/true);
+
+            // Backward pass - create target and compute gradients (same as CompareKernelVsReference)
+            auto target_kernel = autograd::create_tensor(core::zeros_like(result_kernel->get_value()));
+            auto target_composite = autograd::create_tensor(core::zeros_like(result_composite->get_value()));
+
+            auto mse_kernel = ops::mse_loss(result_kernel, target_kernel);
+            auto mse_composite = ops::mse_loss(result_composite, target_composite);
+
+            mse_kernel->backward();
+            mse_composite->backward();
+
+            // Get computed gradients
+            auto input_grad_kernel = core::to_xtensor(input_kernel->get_grad());
+            auto input_grad_composite = core::to_xtensor(input_composite->get_grad());
+
+            // Reference backward pass - compute what the gradient should be
+            // For MSE loss with zero target: loss = mean((result - 0)^2) = mean(result^2)
+            // Gradient: d_loss/d_input = d_loss/d_result * d_result/d_input
+            // d_loss/d_result = 2 * result / N (where N is total number of elements)
+            // d_result/d_input = silu_derivative
+            // So: d_loss/d_input = (2 * result / N) * silu_derivative
+            auto result_ref = silu_forward_reference(input_data);
+            auto total_elements = static_cast<float>(input_data.size());
+            auto mse_grad = (2.0f / total_elements) * result_ref;  // MSE gradient with mean reduction
+            auto grad_reference = silu_backward_reference(input_data, mse_grad);
+
+            // Compare backward precision
+            auto backward_metrics_kernel = compute_precision_metrics(grad_reference, input_grad_kernel);
+            auto backward_metrics_composite = compute_precision_metrics(grad_reference, input_grad_composite);
+
+            // Collect metrics for consolidation
+            kernel_rmse_values.push_back(backward_metrics_kernel.rmse);
+            kernel_max_error_values.push_back(backward_metrics_kernel.max_abs_error);
+            kernel_mean_error_values.push_back(backward_metrics_kernel.mean_abs_error);
+
+            composite_rmse_values.push_back(backward_metrics_composite.rmse);
+            composite_max_error_values.push_back(backward_metrics_composite.max_abs_error);
+            composite_mean_error_values.push_back(backward_metrics_composite.mean_abs_error);
+
+            // Count wins
+            if (backward_metrics_kernel.rmse < backward_metrics_composite.rmse) {
+                kernel_wins++;
+            } else {
+                composite_wins++;
+            }
+
+            // Sanity check - both should be reasonably close to reference
+            EXPECT_TRUE(backward_metrics_kernel.allclose_loose) << "Kernel backward pass too inaccurate";
+            EXPECT_TRUE(backward_metrics_composite.allclose_loose) << "Composite backward pass too inaccurate";
+        }
+
+        // Compute consolidated statistics
+        auto compute_mean = [](const std::vector<float>& values) {
+            return std::accumulate(values.begin(), values.end(), 0.0f) / values.size();
+        };
+
+        float kernel_mean_rmse = compute_mean(kernel_rmse_values);
+        float kernel_mean_max_error = compute_mean(kernel_max_error_values);
+        float kernel_mean_mean_error = compute_mean(kernel_mean_error_values);
+
+        float composite_mean_rmse = compute_mean(composite_rmse_values);
+        float composite_mean_max_error = compute_mean(composite_max_error_values);
+        float composite_mean_mean_error = compute_mean(composite_mean_error_values);
+
+        // Print consolidated results for this shape
+        std::cout << "=== CONSOLIDATED RESULTS - " << shape_name << " shape [" << shape[0] << ", " << shape[1] << ", "
+                  << shape[2] << ", " << shape[3] << "] (Average across " << num_runs << " runs) ===\n";
+        std::cout << "Kernel (4 packs, float36)  - Mean Max Error: " << kernel_mean_max_error
+                  << ", Mean Mean Error: " << kernel_mean_mean_error << ", Mean RMSE: " << kernel_mean_rmse << "\n";
+        std::cout << "Composite                  - Mean Max Error: " << composite_mean_max_error
+                  << ", Mean Mean Error: " << composite_mean_mean_error << ", Mean RMSE: " << composite_mean_rmse
+                  << "\n";
+        std::cout << "Overall Winner             - "
+                  << (kernel_mean_rmse < composite_mean_rmse ? "Kernel" : "Composite") << " (based on mean RMSE)\n";
+        std::cout << "Win Count                  - Kernel: " << kernel_wins << "/" << num_runs
+                  << ", Composite: " << composite_wins << "/" << num_runs << "\n\n";
+    }
+}


### PR DESCRIPTION
### Problem description
The SiLU backward operation was previously using a high-level composite `ttnn` [implementation](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp#L919-L948). This approach resulted in creating performance slowdown in training workloads.

This PR replaces the composite implementation with a custom fused kernel that computes the entire SiLU backward operation in a single kernel launch improving overall training performance.

### What's changed
- **Added custom SiLU backward kernel** with fused compute operations in `tt-metal/tt-train/sources/ttml/metal/ops/silu_bw/`
- **Replaced composite ttnn implementation** with direct kernel calls in `tt-metal/tt-train/sources/ttml/ops/unary_ops.cpp`
- **Added comprehensive test coverage** in `tests/ops/silu_op_test.cpp` including:
  - Kernel vs reference implementation validation across different scenarios
  - Block size alignment patterns: Wt % block_size = 0, 1, 2, 3 (where block_size = 4)
  - Memory patterns: small tensors (C=8) to very large tensors (C=1M elements)
  - Realistic training shapes: NanoLlama-like dimensions (B=2, S=64, C=512)
  - Multiple batch and sequence configurations for transformer workloads
  - Unaligned channel dimensions (C % 32 != 0)
- **Integrated kernel into training pipeline** with backward compatibility maintained

### 3-packing vs 4-packing approaches
The SiLU backward operation can be computed using two different mathematical formulations, each requiring different numbers of intermediate circular buffer (CB) packs:

#### 4-packing approach:
Uses the standard formula: `grad * sigmoid_result * (1 + input * (1 - sigmoid_result))`
1. `sigmoid(x)` → PACK
2. `1 - sigmoid(x)` → PACK  
3. `(1 - sigmoid(x)) * x + 1` → PACK
4. `sigmoid(x) * ((1 - sigmoid(x)) * x + 1)` → PACK
5. `grad * result`

#### 3-packing approach:
Uses the equivalent formula: `grad * (-1) * (x + x * (-sigmoid) + 1) * (-sigmoid)`
1. `-sigmoid(x)` → PACK
2. `x + x*(-sigmoid(x)) + 1` (utilizing `mul_tiles` accumulation) → PACK
3. `(x + x*(-sigmoid(x)) + 1) * (-sigmoid(x))` with negation → PACK
4. `grad * result`

**Performance comparison results:**
Both approaches showed nearly identical performance improvements in NanoLlama training (see results below), so we selected the **4-pack implementation** due to **its more intuitive pipeline structure**. In fact, neither option demonstrated significant advantages in terms of precision, robustness, or speed over the other.

### Performance results
Mean step times across different configurations (5000 steps for NanoLlama):
- **Forward-only kernel**: 238.11 ms (baseline for forward pass)
- **Forward + backward 4-packs kernel**: 228.50 ms (**4.0% improvement** over forward-only)
- **Forward + backward 3-packs kernel**: 228.51 ms (**4.0% improvement** over forward-only)

**Key observations:**
- Both 3-packing and 4-packing approaches provide nearly identical performance improvements
- The backward kernel integration shows measurable training speedup
- Performance improvements are consistent across the entire training run (5000 steps)

The implementation maintains full numerical correctness while providing significant performance improvements for SiLU operations in the training pipeline.

Step time comparison across all configurations (5000 steps for NanoLlama):
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/aa6c4b0d-ce35-47c8-b0b1-85b8c48db9bc" />

Performance comparison (5000 steps for NanoLlama):
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/0ffd8df6-8354-4cbd-940c-23bb25f43420" />


Loss comparison showing numerical correctness (5000 steps for NanoLlama):
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/1d92cda8-1a3c-4415-a180-5defd1b1ae2a" />


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes