### PR TITLE
Enalbe new fast tilize LLK impl for Conv2d

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -39,7 +39,7 @@ def test_unet_model(batch, groups, device, iterations, reset_seeds):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1435.0),),
+    ((1, 4, 1563.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -79,7 +79,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1260.0),),
+    ((1, 4, 256, 30.0, 1373.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -134,7 +134,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2400.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2646.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -43,7 +43,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 259_207_833
+    expected_device_perf_cycles_per_iteration = 258_957_806
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -22,17 +22,17 @@
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init(in_cb_id, in_block_w, out_cb_id);
+    fast_tilize_init_with_dt(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);
             cb_reserve_back(out_cb_id, in_block_w);
-            tilize_block(in_cb_id, in_block_w, out_cb_id);
+            fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
             cb_push_back(out_cb_id, in_block_w);
             cb_pop_front(in_cb_id, in_block_w);
         }
     }
-    tilize_uninit(in_cb_id, out_cb_id);
+    fast_tilize_uninit(in_cb_id, out_cb_id);
 }  // tilize_in()
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
@@ -135,12 +135,18 @@ void MAIN {
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
 #ifdef BLOCK_SHARDED
-            reconfig_data_format_srca(in1_cb_id, in0_pretilize_cb_id);
 
             tilize_in(in0_pretilize_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks, tilized_in0_cb_id);
 
-            mm_block_init_short_with_dt(
-                in0_cb_id, in1_cb_id, in0_pretilize_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+            mm_block_init_short_with_both_dt(
+                in0_cb_id,
+                in1_cb_id,
+                in0_pretilize_cb_id,
+                in0_pretilize_cb_id,
+                false,
+                out_subblock_w,
+                out_subblock_h,
+                in0_block_w);
 #endif
 
             bool enable_reload = false;
@@ -157,13 +163,17 @@ void MAIN {
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
 #ifdef WIDTH_SHARDED
                 if (in0_block_w_i % in0_nblocks_w_tilize == 0) {
-                    reconfig_data_format_srca(in1_cb_id, in0_pretilize_cb_id);
-
-                    // DPRINT_MATH(DPRINT<<"Tilize Loop "<<in0_block_h_i<<" "<<in0_block_w_i<<"\n";)
                     tilize_in(in0_pretilize_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks, tilized_in0_cb_id);
 
-                    mm_block_init_short_with_dt(
-                        in0_cb_id, in1_cb_id, in0_pretilize_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+                    mm_block_init_short_with_both_dt(
+                        in0_cb_id,
+                        in1_cb_id,
+                        in0_pretilize_cb_id,
+                        in0_pretilize_cb_id,
+                        false,
+                        out_subblock_w,
+                        out_subblock_h,
+                        in0_block_w);
                 }
 #endif
                 bool last_out = (in0_block_w_i == in0_num_blocks_w - 1);
@@ -178,9 +188,6 @@ void MAIN {
                     pack_reconfig_data_format(curr_matmul_out_cb, tilized_in0_cb_id);
                     pack_reconfig_l1_acc(0);
 #endif
-
-                    reconfig_data_format_srca(in1_cb_id, in0_cb_id);
-
                     tilize_in(in0_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
 #ifdef SPLIT_READER
                     tilize_in(
@@ -191,10 +198,11 @@ void MAIN {
                         tilized_in0_cb_id);
 #endif
 
-                    mm_block_init_short_with_dt(
+                    mm_block_init_short_with_both_dt(
                         mm_in0_cb_id,
                         in1_cb_id,
-                        /*srca_old_operand=*/in0_cb_id,
+                        in0_cb_id,
+                        in0_cb_id,
                         false,
                         out_subblock_w,
                         out_subblock_h,


### PR DESCRIPTION
LLK team provided new fast tilize implementation.
This change enables it for Conv2d.

This provides ~130fps bump on unet shallow perf
device on WH.

On BH this API just fallback on the old tilize impl.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16315756693)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16316459464)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16345319730)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16323373009)
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/16316459464) (LLama3.1 is red unrelated to this change)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/16316471467)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16316584118)