### PR TITLE
#22090: remove deprecated tensor getters

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -201,19 +201,6 @@ public:
     // ======================================================================================
     //                                      Getters
     // ======================================================================================
-    // TODO: #22090 - Remove the following getters, after giving clients enough time to migrate.
-    [[deprecated("Use storage() instead")]] const Storage& get_storage() const;
-    [[deprecated("Use storage() instead")]] Storage& get_storage();
-    [[deprecated("Use dtype() instead")]] DataType get_dtype() const;
-    [[deprecated("Use layout() instead")]] Layout get_layout() const;
-    [[deprecated("Use logical_shape() instead")]] const ttnn::Shape& get_logical_shape() const;
-    [[deprecated("Use padded_shape() instead")]] const ttnn::Shape& get_padded_shape() const;
-    [[deprecated("Use tensor_spec() instead")]] const TensorSpec& get_tensor_spec() const;
-    [[deprecated("Use logical_volume() instead")]] uint64_t get_logical_volume() const;
-    [[deprecated("Use physical_volume() instead")]] uint32_t volume() const;
-    [[deprecated("Use distributed_tensor_config() instead")]] const DistributedTensorConfig&
-    get_distributed_tensor_config() const;
-
     const Storage& storage() const;
     Storage& storage();
     DataType dtype() const;

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -49,7 +49,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
         std::vector<ttnn::Tensor> tensors;
         const auto& distributed_buffer = tensor.host_storage().buffer();
         distributed_buffer.apply(
-            [&](const HostBuffer& buffer) { tensors.push_back(Tensor{buffer, tensor.get_tensor_spec()}); });
+            [&](const HostBuffer& buffer) { tensors.push_back(Tensor{buffer, tensor.tensor_spec()}); });
         return tensors;
     } else if (std::holds_alternative<tt::tt_metal::DeviceStorage>(tensor.storage())) {
         auto& device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
@@ -85,8 +85,7 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
         distributed_host_buffer.emplace_shard(coord, [&]() { return std::move(buffer); });
     }
 
-    return Tensor(
-        HostStorage{std::move(distributed_host_buffer)}, reference_shard.get_tensor_spec(), AllGatherTensor{});
+    return Tensor(HostStorage{std::move(distributed_host_buffer)}, reference_shard.tensor_spec(), AllGatherTensor{});
 }
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
@@ -95,8 +94,7 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
     for (const auto& shard : tensor_shards) {
         TT_FATAL(shard.storage_type() == StorageType::DEVICE, "All tensor shards must be on device");
         TT_FATAL(
-            shard.get_tensor_spec() == reference_shard.get_tensor_spec(),
-            "All tensor shards must have the same tensor spec");
+            shard.tensor_spec() == reference_shard.tensor_spec(), "All tensor shards must have the same tensor spec");
     }
 
     auto mesh_buffer = reference_shard.device_storage().mesh_buffer;

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -167,26 +167,6 @@ void Tensor::deallocate_impl(bool force) {
     // GraphTracker::instance().track_function_end();
 }
 
-DataType Tensor::get_dtype() const { return dtype(); }
-Layout Tensor::get_layout() const { return layout(); }
-
-const TensorSpec& Tensor::get_tensor_spec() const { return tensor_spec(); }
-
-const ttnn::Shape& Tensor::get_logical_shape() const { return logical_shape(); }
-
-const ttnn::Shape& Tensor::get_padded_shape() const { return padded_shape(); }
-
-uint64_t Tensor::get_logical_volume() const { return logical_shape().volume(); }
-uint32_t Tensor::volume() const { return padded_shape().volume(); }
-
-Storage& Tensor::get_storage() { return this->tensor_attributes->get_storage(); }
-
-const DistributedTensorConfig& Tensor::get_distributed_tensor_config() const {
-    return this->tensor_attributes->get_distributed_tensor_config();
-}
-
-const Storage& Tensor::get_storage() const { return this->tensor_attributes->get_storage(); }
-
 template <>
 Tensor Tensor::from_span<float>(
     tt::stl::Span<const float> buffer,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -23,16 +23,15 @@ void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
     const auto& metadata_tensor = tensor_args.metadata_tensor;
     const auto& mapping_tensor = tensor_args.mapping_tensor;
 
-    TT_FATAL(input_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR, "Input tensor must be in row major layout");
+    TT_FATAL(input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Input tensor must be in row major layout");
     TT_FATAL(
-        metadata_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR, "Metadata tensor must be in row major layout");
+        metadata_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Metadata tensor must be in row major layout");
 
-    TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Input tensor must be bfloat16");
-    TT_FATAL(metadata_tensor.get_dtype() == tt::tt_metal::DataType::UINT16, "Metadata tensor must be uint16");
+    TT_FATAL(input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16, "Input tensor must be bfloat16");
+    TT_FATAL(metadata_tensor.dtype() == tt::tt_metal::DataType::UINT16, "Metadata tensor must be uint16");
 
-    TT_FATAL(mapping_tensor.get_dtype() == tt::tt_metal::DataType::UINT16, "Indices tensor must be uint32");
-    TT_FATAL(
-        mapping_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR, "Metadata tensor must be in row major layout");
+    TT_FATAL(mapping_tensor.dtype() == tt::tt_metal::DataType::UINT16, "Indices tensor must be uint32");
+    TT_FATAL(mapping_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Metadata tensor must be in row major layout");
 
     TT_FATAL(!operation_attributes.output_mem_config.is_sharded(), "Output memory config must not be sharded");
 
@@ -41,18 +40,18 @@ void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
         const auto& output_tensor = tensor_args.optional_output_tensor.value();
 
         TT_FATAL(
-            output_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR, "Output tensor must be in row major layout");
+            output_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Output tensor must be in row major layout");
 
         TT_FATAL(
-            output_spec == output_tensor.get_tensor_spec(),
+            output_spec == output_tensor.tensor_spec(),
             "Optional sparse output token tensor spec {} does not match computed output spec {}",
-            output_tensor.get_tensor_spec(),
+            output_tensor.tensor_spec(),
             output_spec);
     }
 
-    const auto& input_shape = input_tensor.get_tensor_spec().logical_shape();
-    const auto& metadata_shape = metadata_tensor.get_tensor_spec().logical_shape();
-    const auto& mapping_shape = mapping_tensor.get_tensor_spec().logical_shape();
+    const auto& input_shape = input_tensor.tensor_spec().logical_shape();
+    const auto& metadata_shape = metadata_tensor.tensor_spec().logical_shape();
+    const auto& mapping_shape = mapping_tensor.tensor_spec().logical_shape();
 
     const auto mesh_view = input_tensor.mesh_device()->get_view();
     const auto mesh_rows = mesh_view.num_rows();
@@ -107,8 +106,8 @@ AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperati
     using namespace tt::tt_metal;
 
     const auto& input_tensor = tensor_args.input_tensor;
-    const auto& input_shape = input_tensor.get_tensor_spec().logical_shape();
-    const auto& metadata_shape = tensor_args.metadata_tensor.get_tensor_spec().logical_shape();
+    const auto& input_shape = input_tensor.tensor_spec().logical_shape();
+    const auto& metadata_shape = tensor_args.metadata_tensor.tensor_spec().logical_shape();
 
     auto mesh_device = input_tensor.mesh_device();
     const auto& mesh_view = mesh_device->get_view();
@@ -132,8 +131,7 @@ AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperati
     auto mem_config = operation_attributes.output_mem_config;
     return TensorSpec(
         Shape(output_shape),
-        TensorLayout(
-            tensor_args.input_tensor.get_dtype(), PageConfig(tensor_args.input_tensor.get_layout()), mem_config));
+        TensorLayout(tensor_args.input_tensor.dtype(), PageConfig(tensor_args.input_tensor.layout()), mem_config));
 }
 
 AllToAllCombineDeviceOperation::tensor_return_value_t AllToAllCombineDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -53,7 +53,7 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     const auto num_links = operation_attributes.num_links;
     auto topology = operation_attributes.topology;
 
-    const auto input_dtype = input_tensor.get_dtype();
+    const auto input_dtype = input_tensor.dtype();
 
     auto mesh_device = input_tensor.mesh_device();
     const auto& mesh_view = mesh_device->get_view();
@@ -63,9 +63,9 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     const uint32_t src_mesh_id = *fabric_node_id.mesh_id;
     const uint32_t src_chip_id = (uint32_t)fabric_node_id.chip_id;
 
-    const auto& input_shape = input_tensor.get_tensor_spec().logical_shape();
-    const auto& mapping_shape = mapping_tensor.get_tensor_spec().logical_shape();
-    const auto& metadata_shape = metadata_tensor.get_tensor_spec().logical_shape();
+    const auto& input_shape = input_tensor.tensor_spec().logical_shape();
+    const auto& mapping_shape = mapping_tensor.tensor_spec().logical_shape();
+    const auto& metadata_shape = metadata_tensor.tensor_spec().logical_shape();
 
     const uint32_t num_devices = mesh_view.num_devices();
     const uint32_t hidden_size = input_shape[-1];
@@ -77,9 +77,9 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     TT_FATAL(experts % num_devices == 0, "Currently assuming that experts are evenly split among devices");
     const uint32_t experts_per_device = experts / num_devices;
 
-    const auto& input_spec = input_tensor.get_tensor_spec();
-    const auto& mapping_spec = mapping_tensor.get_tensor_spec();
-    const auto& metadata_spec = metadata_tensor.get_tensor_spec();
+    const auto& input_spec = input_tensor.tensor_spec();
+    const auto& mapping_spec = mapping_tensor.tensor_spec();
+    const auto& metadata_spec = metadata_tensor.tensor_spec();
 
     const bool input_is_dram = input_tensor.buffer()->buffer_type() == BufferType::DRAM;
     const bool output_is_dram = output_tensor.buffer()->buffer_type() == BufferType::DRAM;
@@ -97,9 +97,9 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     const auto aligned_mapping_page_size_bytes = tt::align(mapping_page_size_bytes, l1_alignment);
     const auto aligned_metadata_page_size_bytes = tt::align(metadata_page_size_bytes, l1_alignment);
 
-    const auto input_data_format = datatype_to_dataformat_converter(input_tensor.get_dtype());
-    const auto mapping_data_format = datatype_to_dataformat_converter(mapping_tensor.get_dtype());
-    const auto metadata_data_format = datatype_to_dataformat_converter(metadata_tensor.get_dtype());
+    const auto input_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    const auto mapping_data_format = datatype_to_dataformat_converter(mapping_tensor.dtype());
+    const auto metadata_data_format = datatype_to_dataformat_converter(metadata_tensor.dtype());
 
     // Anything less will lead to deadlocks. It's clear why, TODO fix it.
     const uint32_t buffering_factor = experts_per_device;

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -22,12 +22,11 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_miss(
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.expert_indices_tensor;
 
-    TT_FATAL(input_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR, "Input tensor must be in row major layout");
-    TT_FATAL(
-        indices_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR, "Indices tensor must be in row major layout");
+    TT_FATAL(input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Input tensor must be in row major layout");
+    TT_FATAL(indices_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Indices tensor must be in row major layout");
 
-    TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Input tensor must be bfloat16");
-    TT_FATAL(indices_tensor.get_dtype() == tt::tt_metal::DataType::UINT16, "Indices tensor must be uint32");
+    TT_FATAL(input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16, "Input tensor must be bfloat16");
+    TT_FATAL(indices_tensor.dtype() == tt::tt_metal::DataType::UINT16, "Indices tensor must be uint32");
     TT_FATAL(!operation_attributes.output_mem_config.is_sharded(), "Output memory config must not be sharded");
 
     auto output_specs = compute_output_specs(operation_attributes, tensor_args);
@@ -37,27 +36,27 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_miss(
         auto sparse_token_tensor = output_tensors[0];
         auto metadata_tensor = output_tensors[1];
         TT_FATAL(
-            sparse_token_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR,
+            sparse_token_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
             "Output tensor must be in row major layout");
         TT_FATAL(
-            metadata_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR,
+            metadata_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
             "Output metadata tensor must be in row major layout");
 
         TT_FATAL(
-            output_specs[0] == sparse_token_tensor.get_tensor_spec(),
+            output_specs[0] == sparse_token_tensor.tensor_spec(),
             "Optional sparse output token tensor spec {} does not match computed output spec {}",
-            sparse_token_tensor.get_tensor_spec(),
+            sparse_token_tensor.tensor_spec(),
             output_specs[0]);
         TT_FATAL(
-            output_specs[1] == metadata_tensor.get_tensor_spec(),
+            output_specs[1] == metadata_tensor.tensor_spec(),
             "Optional metadata tensor spec {} does not match computed output spec {}",
-            metadata_tensor.get_tensor_spec(),
+            metadata_tensor.tensor_spec(),
             output_specs[1]);
     }
     TT_FATAL(operation_attributes.num_links > 0, "Number of links must be greater than 0");
 
-    auto input_shape = input_tensor.get_tensor_spec().logical_shape();
-    auto indices_shape = indices_tensor.get_tensor_spec().logical_shape();
+    auto input_shape = input_tensor.tensor_spec().logical_shape();
+    auto indices_shape = indices_tensor.tensor_spec().logical_shape();
     TT_FATAL(
         input_shape.rank() == 4 && (input_shape.rank() == indices_shape.rank()),
         "Input and indices tensor must have the same number of dimensions");
@@ -85,9 +84,9 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_hit(
 AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto input_tensor = tensor_args.input_tensor;
-    auto input_shape = input_tensor.get_tensor_spec().logical_shape();
-    auto indices_shape = tensor_args.expert_indices_tensor.get_tensor_spec().logical_shape();
-    auto mapping_shape = tensor_args.expert_mapping_tensor.get_tensor_spec().logical_shape();
+    auto input_shape = input_tensor.tensor_spec().logical_shape();
+    auto indices_shape = tensor_args.expert_indices_tensor.tensor_spec().logical_shape();
+    auto mapping_shape = tensor_args.expert_mapping_tensor.tensor_spec().logical_shape();
 
     auto mesh_device = input_tensor.mesh_device();
     const auto& mesh_view = mesh_device->get_view();
@@ -131,18 +130,17 @@ AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOpera
     auto mem_config = operation_attributes.output_mem_config;
     auto output_tokens_spec = TensorSpec(
         Shape(output_shape),
-        tt::tt_metal::TensorLayout(
-            input_tensor.get_dtype(), tt::tt_metal::PageConfig(input_tensor.get_layout()), mem_config));
+        tt::tt_metal::TensorLayout(input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), mem_config));
     auto metadata_spec = TensorSpec(
         Shape(metadata_shape),
         tt::tt_metal::TensorLayout(
-            tensor_args.expert_indices_tensor.get_dtype(),
-            tt::tt_metal::PageConfig(tensor_args.expert_indices_tensor.get_layout()),
+            tensor_args.expert_indices_tensor.dtype(),
+            tt::tt_metal::PageConfig(tensor_args.expert_indices_tensor.layout()),
             mem_config));
     if (tensor_args.optional_output_tensors.has_value()) {
         auto output_tensors = tensor_args.optional_output_tensors.value();
-        auto preallocated_output_spec = output_tensors[0].get_tensor_spec();
-        auto preallocated_metadata_spec = output_tensors[1].get_tensor_spec();
+        auto preallocated_output_spec = output_tensors[0].tensor_spec();
+        auto preallocated_metadata_spec = output_tensors[1].tensor_spec();
         return {preallocated_output_spec, preallocated_metadata_spec};
     }
     return {output_tokens_spec, metadata_spec};

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -146,9 +146,9 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
     const auto [neighbors, directions] =
         common::get_neighbors(mesh_view, mesh_coordinate, topology, operation_attributes.axis);
 
-    auto input_shape = input_tensor.get_tensor_spec().logical_shape();
-    auto indices_shape = indices_tensor.get_tensor_spec().logical_shape();
-    auto mapping_shape = mapping_tensor.get_tensor_spec().logical_shape();
+    auto input_shape = input_tensor.tensor_spec().logical_shape();
+    auto indices_shape = indices_tensor.tensor_spec().logical_shape();
+    auto mapping_shape = mapping_tensor.tensor_spec().logical_shape();
 
     uint32_t num_devices = mesh_view.num_devices();
     uint32_t dispatch_devices =
@@ -176,9 +176,9 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
     auto output_pages = detail::get_num_pages(output_tensor);
     auto metadata_pages = detail::get_num_pages(metadata_tensor);
 
-    auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
-    auto indices_data_format = tt::tt_metal::datatype_to_dataformat_converter(indices_tensor.get_dtype());
-    auto mapping_data_format = tt::tt_metal::datatype_to_dataformat_converter(mapping_tensor.get_dtype());
+    auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    auto indices_data_format = tt::tt_metal::datatype_to_dataformat_converter(indices_tensor.dtype());
+    auto mapping_data_format = tt::tt_metal::datatype_to_dataformat_converter(mapping_tensor.dtype());
 
     constexpr uint32_t buffering_factor = 2;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -443,7 +443,7 @@ Result conv2d_DRAM(
                 sliced_output_tensor,
                 ttnn::Shape({batch_size, output_slice_height, output_slice_width, out_channels}),
                 ttnn::Shape(
-                    {batch_size, output_slice_height, output_slice_width, sliced_output_tensor.get_padded_shape()[3]}));
+                    {batch_size, output_slice_height, output_slice_width, sliced_output_tensor.padded_shape()[3]}));
         }
         ttnn::experimental::slice_write(
             queue_id,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -21,7 +21,7 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
     if (this->output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
         TT_FATAL(this->output_mem_config.buffer_type() == BufferType::L1, "We don't support DRAM block sharding");
     }
-    if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
         TT_FATAL((*this->output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() % hal::get_l1_alignment() == 0, "Shard page size must currently have L1 aligned page size");
     }
     if (input_tensor.dtype() != this->output_dtype) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -159,7 +159,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
     std::string writer_kernel;
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
     if (dst_is_dram) {
-        if (input.get_layout() == Layout::TILE) {
+        if (input.layout() == Layout::TILE) {
             writer_kernel = std::string("ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp");
         } else {
             writer_kernel = std::string("ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -177,9 +177,9 @@ inline auto preprocess_inputs(BinaryOpType binary_op_type, Tensor a, Tensor b) {
 }
 
 inline auto any_row_broadcasted(const Tensor& a, const auto& b) {
-    if constexpr (requires { b.get_logical_shape(); }) {
-        const auto& a_shape = a.get_logical_shape();
-        const auto& b_shape = b.get_logical_shape();
+    if constexpr (requires { b.logical_shape(); }) {
+        const auto& a_shape = a.logical_shape();
+        const auto& b_shape = b.logical_shape();
 
         return (a_shape[-2] == 1 and b_shape[-2] > 1) or (b_shape[-2] == 1 and a_shape[-2] > 1);
     }
@@ -187,12 +187,12 @@ inline auto any_row_broadcasted(const Tensor& a, const auto& b) {
     return false;
 }
 inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
-    if (a.is_sharded() and is_block_format(a.get_dtype())) {
+    if (a.is_sharded() and is_block_format(a.dtype())) {
         return true;
     }
 
     if constexpr (requires { b.is_sharded(); }) {
-        if (b.is_sharded() and is_block_format(b.get_dtype())) {
+        if (b.is_sharded() and is_block_format(b.dtype())) {
             return true;
         }
     }
@@ -201,16 +201,16 @@ inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
 }
 
 inline auto any_subtile_broadcasted_block_format(const Tensor& a, const auto& b) {
-    if constexpr (requires { b.get_logical_shape(); }) {
-        const auto& a_shape = a.get_logical_shape();
-        const auto& b_shape = b.get_logical_shape();
+    if constexpr (requires { b.logical_shape(); }) {
+        const auto& a_shape = a.logical_shape();
+        const auto& b_shape = b.logical_shape();
 
-        if (is_block_format(a.get_dtype()) and
+        if (is_block_format(a.dtype()) and
             (a_shape[-2] == 1 and b_shape[-2] > 1 or a_shape[-1] == 1 and b_shape[-1] > 1)) {
             return true;
         }
 
-        if (is_block_format(b.get_dtype()) and
+        if (is_block_format(b.dtype()) and
             (b_shape[-2] == 1 and a_shape[-2] > 1 or b_shape[-1] == 1 and a_shape[-1] > 1)) {
             return true;
         }
@@ -220,9 +220,9 @@ inline auto any_subtile_broadcasted_block_format(const Tensor& a, const auto& b)
 }
 
 inline auto is_w_bcast(const Tensor& a, const auto& b) {
-    if constexpr (requires { b.get_padded_shape(); }) {
-        const auto& shape_a = a.get_padded_shape();
-        const auto& shape_b = b.get_padded_shape();
+    if constexpr (requires { b.padded_shape(); }) {
+        const auto& shape_a = a.padded_shape();
+        const auto& shape_b = b.padded_shape();
         return (shape_a[-1] == 1 and shape_b[-1] > 1) or (shape_b[-1] == 1 and shape_a[-1] > 1);
     }
     return false;
@@ -253,7 +253,7 @@ inline auto is_uneven(const Tensor& t) {
         return false;
     }
 
-    const auto& shape = t.get_padded_shape();
+    const auto& shape = t.padded_shape();
     const auto& shard = t.shard_spec()->shape;
 
     return (shape[-4] * shape[-3] * shape[-2] % shard[0]) != 0 or (shape[-1] % shard[1]) != 0;
@@ -281,7 +281,7 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
     if constexpr (requires {
                       b.dtype();
                       b.is_sharded();
-                      b.get_logical_shape();
+                      b.logical_shape();
                   }) {
         if (a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32 or a.dtype() == DataType::UINT32 or
             b.dtype() == DataType::UINT32 or a.dtype() == DataType::UINT16 or b.dtype() == DataType::UINT16 or
@@ -295,20 +295,20 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
             return true;
         }
 
-        if (a.get_logical_shape().rank() > 4 or b.get_logical_shape().rank() > 4) {
+        if (a.logical_shape().rank() > 4 or b.logical_shape().rank() > 4) {
             return true;
         }
 
-        if (a.get_logical_shape()[-2] == 1 && b.get_logical_shape()[-2] > 1 && a.get_logical_shape()[-1] > 1 &&
-            b.get_logical_shape()[-1] == 1) {
+        if (a.logical_shape()[-2] == 1 && b.logical_shape()[-2] > 1 && a.logical_shape()[-1] > 1 &&
+            b.logical_shape()[-1] == 1) {
             return true;
         }
-        if (b.get_logical_shape()[-2] == 1 && a.get_logical_shape()[-2] > 1 && b.get_logical_shape()[-1] > 1 &&
-            a.get_logical_shape()[-1] == 1) {
+        if (b.logical_shape()[-2] == 1 && a.logical_shape()[-2] > 1 && b.logical_shape()[-1] > 1 &&
+            a.logical_shape()[-1] == 1) {
             return true;
         }
 
-        if (any_row_broadcasted(a, b) and (is_block_format(a.get_dtype()) or is_block_format(b.get_dtype()))) {
+        if (any_row_broadcasted(a, b) and (is_block_format(a.dtype()) or is_block_format(b.dtype()))) {
             // TODO
             // return true;
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -298,9 +298,9 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
 
     if (input_tensor_b.has_value()) {
         TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_tensor_b->get_storage()),
+            std::holds_alternative<DeviceStorage>(input_tensor_b->storage()),
             "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_tensor_b->get_storage()));
+            tt::stl::get_active_type_name_in_variant(input_tensor_b->storage()));
 
         return operation::hash_operation<BinaryDeviceOperation>(
             attributes,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -417,9 +417,9 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
 
     if (input_tensor_b.has_value()) {
         TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_tensor_b->get_storage()),
+            std::holds_alternative<DeviceStorage>(input_tensor_b->storage()),
             "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_tensor_b->get_storage()));
+            tt::stl::get_active_type_name_in_variant(input_tensor_b->storage()));
 
         return operation::hash_operation<BinaryNgDeviceOperation>(
             attributes,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -317,7 +317,7 @@ Tensor Identity::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::IDENTITY;
-    DataType input_dtype = input_tensor.get_dtype();
+    DataType input_dtype = input_tensor.dtype();
 
     if (input_dtype != DataType::UINT8) {
         return detail::unary_impl(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.cpp
@@ -15,8 +15,8 @@ void AllBroadcastAsync::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     TT_FATAL(input_tensors.size() == 1, "Error, Input tensor size should be 1 but has {}", input_tensors.size());
     const auto& input_tensor = input_tensors[0];
-    const auto& layout = input_tensors[0].get_layout();
-    const auto& dtype = input_tensors[0].get_dtype();
+    const auto& layout = input_tensors[0].layout();
+    const auto& dtype = input_tensors[0].dtype();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_broadcast need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_broadcast need to be allocated in buffers on device!");
@@ -40,25 +40,25 @@ void AllBroadcastAsync::validate_with_output_tensors(
                 output_tensor.value().storage_type() == StorageType::DEVICE,
                 "Operands to all_broadcast need to be on device!");
             TT_FATAL(
-                output_tensor.value().get_layout() == layout,
+                output_tensor.value().layout() == layout,
                 "Error, Output tensor layout should be same as input tensor layout but has {}",
-                output_tensor.value().get_layout());
+                output_tensor.value().layout());
             TT_FATAL(
-                output_tensor.value().get_dtype() == dtype,
+                output_tensor.value().dtype() == dtype,
                 "Error, Output tensor dtype should be same as input tensor dtype but has {}",
-                output_tensor.value().get_dtype());
+                output_tensor.value().dtype());
             TT_FATAL(
-                output_tensor.value().get_tensor_spec().page_config() == input_tensor.get_tensor_spec().page_config(),
+                output_tensor.value().tensor_spec().page_config() == input_tensor.tensor_spec().page_config(),
                 "Error, Output tensor page config should be same as input tensor page config but has {}",
-                output_tensor.value().get_tensor_spec().page_config());
+                output_tensor.value().tensor_spec().page_config());
             TT_FATAL(
                 output_tensor.value().memory_config() == this->output_mem_config,
                 "Error, Output tensor memory config should be same as output_mem_config but has {}",
                 output_tensor.value().memory_config());
 
             // check the output tensor size
-            auto output_shape = output_tensor.value().get_padded_shape();
-            const auto& input_shape = input_tensor.get_padded_shape();
+            auto output_shape = output_tensor.value().padded_shape();
+            const auto& input_shape = input_tensor.padded_shape();
             TT_FATAL(
                 output_shape.size() == input_shape.size(),
                 "Error, Output tensor shape should have same number of dimensions as input tensor but has {}",
@@ -75,13 +75,12 @@ void AllBroadcastAsync::validate_with_output_tensors(
 
 std::vector<ttnn::TensorSpec> AllBroadcastAsync::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors[0];
-    const auto& shape = input_tensor.get_padded_shape();
+    const auto& shape = input_tensor.padded_shape();
     std::vector<TensorSpec> output_specs;
     output_specs.reserve(this->ring_size);
     for (uint32_t i = 0; i < this->ring_size; ++i) {
         output_specs.push_back(TensorSpec(
-            shape,
-            TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), output_mem_config)));
+            shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), output_mem_config)));
     }
     return output_specs;
 }
@@ -147,9 +146,9 @@ tt::tt_metal::operation::ProgramWithCallbacks AllBroadcastAsync::create_program_
 
 tt::tt_metal::operation::Hash AllBroadcastAsync::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
     log_trace(tt::LogOp, "compute_program_hash is called");
-    auto input_shape = input_tensors[0].get_padded_shape();
-    auto input_memory_layout = input_tensors[0].get_layout();
-    auto input_dtype = input_tensors[0].get_dtype();
+    auto input_shape = input_tensors[0].padded_shape();
+    auto input_memory_layout = input_tensors[0].layout();
+    auto input_dtype = input_tensors[0].dtype();
     auto input_memory_config = input_tensors[0].memory_config();
     return tt::tt_metal::operation::hash_operation<AllBroadcastAsync>(
         this->num_links,
@@ -219,7 +218,7 @@ std::vector<Tensor> all_broadcast_async_impl(
         "all-broadcast invoked with cluster_axis API on >2D mesh, which is currently unsupported");
     std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
 
-    int32_t rank = input_tensor.get_logical_shape().rank();
+    int32_t rank = input_tensor.logical_shape().rank();
 
     std::vector<std::optional<Tensor>> optional_output_tensors = {persistent_output_tensor};
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -63,12 +63,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
         is_last_chip);
 
     bool sharded = input_tensor.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
-    bool tilized = input_tensor.get_layout() == ttnn::TILE_LAYOUT;
+    bool tilized = input_tensor.layout() == ttnn::TILE_LAYOUT;
 
     uint32_t num_width_shards = 1;
     if (!tilized && (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
                      input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED)) {
-        num_width_shards = input_tensor.get_padded_shape()[-1] / input_tensor.memory_config().shard_spec()->shape[1];
+        num_width_shards = input_tensor.padded_shape()[-1] / input_tensor.memory_config().shard_spec()->shape[1];
     }
 
     // Get OP Config, topology config
@@ -84,14 +84,14 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
         choose_worker_cores(num_links, num_workers_per_link, mesh_device, sub_device_id);
 
     // Info for RM tensors
-    uint32_t row_size = input_tensor.get_logical_shape()[-1] * input_tensor.element_size();
+    uint32_t row_size = input_tensor.logical_shape()[-1] * input_tensor.element_size();
     uint32_t page_size = round_up_to_mul32(row_size);
 
-    uint32_t num_rows = input_tensor.get_logical_shape().size() > 2
-                            ? input_tensor.get_logical_shape()[-2] * input_tensor.get_logical_shape()[-3]
-                            : input_tensor.get_logical_shape()[-2];
-    if (input_tensor.get_logical_shape().size() == 4) {
-        num_rows *= input_tensor.get_logical_shape()[0];
+    uint32_t num_rows = input_tensor.logical_shape().size() > 2
+                            ? input_tensor.logical_shape()[-2] * input_tensor.logical_shape()[-3]
+                            : input_tensor.logical_shape()[-2];
+    if (input_tensor.logical_shape().size() == 4) {
+        num_rows *= input_tensor.logical_shape()[0];
     }
 
     // L1 Scratch CB Creation
@@ -102,7 +102,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
     uint32_t cb_num_pages = 3 * num_pages_per_packet;  // tripple buffering
     uint32_t src0_cb_index = tt::CB::c_in0;
-    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     tt::tt_metal::CircularBufferConfig cb_src0_config =
         tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
             .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -93,8 +93,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     const auto output_tensor_layout = output_tensor.buffer()->buffer_layout();
     const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
     const auto output_tensor_page_layout = output_tensor.layout();
-    const auto& input_tensor_shape = input_tensor.get_padded_shape();
-    const auto& output_tensor_shape = output_tensor.get_padded_shape();
+    const auto& input_tensor_shape = input_tensor.padded_shape();
+    const auto& output_tensor_shape = output_tensor.padded_shape();
 
     auto mesh_device = input_tensor.mesh_device();
     const bool enable_async_output_tensor = false;
@@ -159,7 +159,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
     uint32_t num_tiles_to_write_per_packet = std::min(max_target_noc_addresses_per_packet, num_pages_per_packet);
     uint32_t cb_num_pages = 3 * num_tiles_to_write_per_packet;  // triple buffering
-    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
 
     // CBs for transferring data between sender_reader and sender_writer
     uint32_t sender_forward_cb_index = tt::CB::c_in0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_op.cpp
@@ -45,7 +45,7 @@ void AllGatherMatmulAsync::validate_with_output_tensors(
     TT_FATAL(
         this->all_gather_async_struct.dim == 3, "AllGatherMatmulAsync requires dim=3 for the AllGather operaitons.");
     TT_FATAL(
-        input_tensor.get_padded_shape()[0] == 1 && input_tensor.get_padded_shape()[1] == 1,
+        input_tensor.padded_shape()[0] == 1 && input_tensor.padded_shape()[1] == 1,
         "AllGatherMatmulAsync requires input tensor to have batch size of 1.");
     std::visit(
         [&](const auto& config) {
@@ -176,9 +176,9 @@ tt::tt_metal::operation::Hash AllGatherMatmulAsync::compute_program_hash(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const ttnn::Tensor>>& optional_input_tensors) const {
     log_trace(tt::LogOp, "compute_program_hash is called");
-    auto input_shape = input_tensors[0].get_padded_shape();
-    auto input_memory_layout = input_tensors[0].get_layout();
-    auto input_dtype = input_tensors[0].get_dtype();
+    auto input_shape = input_tensors[0].padded_shape();
+    auto input_memory_layout = input_tensors[0].layout();
+    auto input_dtype = input_tensors[0].dtype();
     auto input_memory_config = input_tensors[0].memory_config();
     uint32_t semaphore_address = this->all_gather_async_struct.semaphore.at(0).address();
 
@@ -254,7 +254,7 @@ std::vector<ttnn::Tensor> all_gather_matmul_async(
         all_gather_async_struct.create_output_tensors({input_tensor}, optional_output_tensors)[0];
 
     /* Matmul setup */
-    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.get_logical_shape());
+    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
     std::optional<CoreCoord> user_core_coord;
     if (core_grid.has_value()) {
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
@@ -268,7 +268,7 @@ std::vector<ttnn::Tensor> all_gather_matmul_async(
             program_config,
             /*bcast_batch=*/std::nullopt,
             memory_config_mm.value_or(input_tensor.memory_config()),
-            dtype.value_or(input_tensor.get_dtype()),
+            dtype.value_or(input_tensor.dtype()),
             compute_kernel_config,
             /*untilize_out=*/false,
             user_core_coord,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
@@ -67,7 +67,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_matmul_async_multi_core
         ttnn::ccl::InterleavedRingAllGatherTensorSlicer(input_tensor, all_gather_output_tensor, dim, ring_index);
     bool is_clockwise_direction = true;
     const uint32_t num_transfers = 4;
-    const uint32_t weight_tensor_width = weight_tensor.get_padded_shape()[3] / 32;
+    const uint32_t weight_tensor_width = weight_tensor.padded_shape()[3] / 32;
 
     ////////////////////////////////////////////////////////
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -84,12 +84,12 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
     if (core_grid.has_value()) {
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
     }
-    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.get_logical_shape());
+    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
     return {
         operation_attributes_t{
             rs_struct,
             LlamaReduceScatterDeviceOperation::operation_attributes_t{
-                .dim = (dim < 0 ? uint32_t(rs_tensor.get_logical_shape().rank() + dim) : (uint32_t)dim),
+                .dim = (dim < 0 ? uint32_t(rs_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
                 .cross_device_semaphore = semaphore,
                 .subdevice_id = subdevice_id,
                 .cluster_axis = cluster_axis,
@@ -106,7 +106,7 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
                     program_config,
                     /*bcast_batch=*/std::nullopt,
                     memory_config_mm.value_or(input_tensor.memory_config()),
-                    dtype.value_or(input_tensor.get_dtype()),
+                    dtype.value_or(input_tensor.dtype()),
                     compute_kernel_config,
                     /*untilize_out=*/false,
                     user_core_coord,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_op.cpp
@@ -165,9 +165,9 @@ tt::tt_metal::operation::Hash MatmulReduceScatterAsync::compute_program_hash(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const ttnn::Tensor>>& optional_input_tensors) const {
     log_trace(tt::LogOp, "compute_program_hash is called");
-    auto input_shape = input_tensors[0].get_padded_shape();
-    auto input_memory_layout = input_tensors[0].get_layout();
-    auto input_dtype = input_tensors[0].get_dtype();
+    auto input_shape = input_tensors[0].padded_shape();
+    auto input_memory_layout = input_tensors[0].layout();
+    auto input_dtype = input_tensors[0].dtype();
     auto input_memory_config = input_tensors[0].memory_config();
     uint32_t semaphore_address = this->reduce_scatter_minimal_async_struct.semaphore.at(0).address();
 
@@ -225,7 +225,7 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async(
     }
 
     /* Matmul setup */
-    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.get_logical_shape());
+    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
     std::optional<CoreCoord> user_core_coord;
     if (core_grid.has_value()) {
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
@@ -239,7 +239,7 @@ std::vector<ttnn::Tensor> matmul_reduce_scatter_async(
             program_config,
             /*bcast_batch=*/std::nullopt,
             memory_config_mm.value_or(input_tensor.memory_config()),
-            dtype.value_or(input_tensor.get_dtype()),
+            dtype.value_or(input_tensor.dtype()),
             compute_kernel_config,
             /*untilize_out=*/false,
             user_core_coord,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -15,8 +15,8 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     TT_FATAL(input_tensors.size() == 1, "Error, Input tensor size should be 1 but has {}", input_tensors.size());
     const auto& input_tensor = input_tensors[0];
-    const auto& layout = input_tensors[0].get_layout();
-    const auto& dtype = input_tensors[0].get_dtype();
+    const auto& layout = input_tensors[0].layout();
+    const auto& dtype = input_tensors[0].dtype();
     const auto& page_size = input_tensors[0].buffer()->page_size();
     TT_FATAL(page_size % input_tensors[0].buffer()->alignment() == 0, "All Gather currently requires aligned pages");
 
@@ -24,7 +24,7 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_gather need to be allocated in buffers on device!");
     TT_FATAL(this->num_links > 0, "Error, num_links should be more than 0 but has {}", this->num_links);
 
-    const auto& input_shape = input_tensor.get_padded_shape();
+    const auto& input_shape = input_tensor.padded_shape();
     TT_FATAL(
         (input_shape[this->dim] / tt::constants::TILE_WIDTH) % this->ring_size == 0,
         "Error, The number of tiles at input tensor dimension {} should be divisible by ring_size but the number of "
@@ -49,25 +49,25 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
             output_tensor.value().storage_type() == StorageType::DEVICE,
             "Operands to all_gather need to be on device!");
         TT_FATAL(
-            output_tensor.value().get_layout() == layout,
+            output_tensor.value().layout() == layout,
             "Error, Output tensor layout should be same as input tensor layout but has {}",
-            output_tensor.value().get_layout());
+            output_tensor.value().layout());
         TT_FATAL(
-            output_tensor.value().get_dtype() == dtype,
+            output_tensor.value().dtype() == dtype,
             "Error, Output tensor dtype should be same as input tensor dtype but has {}",
-            output_tensor.value().get_dtype());
+            output_tensor.value().dtype());
         TT_FATAL(
-            output_tensor.value().get_tensor_spec().page_config() == input_tensor.get_tensor_spec().page_config(),
+            output_tensor.value().tensor_spec().page_config() == input_tensor.tensor_spec().page_config(),
             "Error, Output tensor page config should be same as input tensor page config but has {}",
-            output_tensor.value().get_tensor_spec().page_config());
+            output_tensor.value().tensor_spec().page_config());
         TT_FATAL(
             output_tensor.value().memory_config() == this->output_mem_config,
             "Error, Output tensor memory config should be same as output_mem_config but has {}",
             output_tensor.value().memory_config());
 
         // check the output tensor size
-        auto output_shape = output_tensor.value().get_padded_shape();
-        auto input_shape = input_tensor.get_padded_shape();
+        auto output_shape = output_tensor.value().padded_shape();
+        auto input_shape = input_tensor.padded_shape();
         TT_FATAL(
             output_shape.size() == input_shape.size(),
             "Error, Output tensor shape should have same number of dimensions as input tensor but has {}",
@@ -109,16 +109,16 @@ std::vector<ttnn::TensorSpec> ReduceScatterMinimalAsync::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     // TODO: FIXME!
     const auto& input_tensor = input_tensors[0];
-    const auto& inter_shape = input_tensor.get_padded_shape();
+    const auto& inter_shape = input_tensor.padded_shape();
     auto output_shape = inter_shape;
     output_shape[this->dim] /= this->ring_size;
     return {
         TensorSpec(
             inter_shape,
-            TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), output_mem_config)),
+            TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), output_mem_config)),
         TensorSpec(
             output_shape,
-            TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), output_mem_config)),
+            TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), output_mem_config)),
     };
 }
 
@@ -193,9 +193,9 @@ tt::tt_metal::operation::ProgramWithCallbacks ReduceScatterMinimalAsync::create_
 tt::tt_metal::operation::Hash ReduceScatterMinimalAsync::compute_program_hash(
     const std::vector<Tensor>& input_tensors) const {
     log_trace(tt::LogOp, "compute_program_hash is called");
-    auto input_shape = input_tensors[0].get_padded_shape();
-    auto input_memory_layout = input_tensors[0].get_layout();
-    auto input_dtype = input_tensors[0].get_dtype();
+    auto input_shape = input_tensors[0].padded_shape();
+    auto input_memory_layout = input_tensors[0].layout();
+    auto input_dtype = input_tensors[0].dtype();
     auto input_memory_config = input_tensors[0].memory_config();
     uint32_t semaphore_address = this->semaphore.at(0).address();
     return tt::tt_metal::operation::hash_operation<ReduceScatterMinimalAsync>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -1,4 +1,4 @@
-red// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+red// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -178,7 +178,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     // Tensor Info
     const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
     const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
-    const auto& input_tensor_shape = input_tensor.get_padded_shape();
+    const auto& input_tensor_shape = input_tensor.padded_shape();
     const auto intermediate_tensor_buffer_type = intermediate_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
     const auto num_batches = input_tensor_shape[0];
@@ -209,7 +209,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     uint32_t num_tiles_to_write_per_packet = std::min(max_target_noc_addresses_per_packet, num_pages_per_packet);
     uint32_t tile_granularity = num_tiles_to_write_per_packet < 4 ? 4 * num_tiles_to_write_per_packet : 8;
     uint32_t cb_num_pages = 3 * tile_granularity;  // triple buffering
-    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
 
     uint32_t input_cb_index = tt::CB::c_in0;
     tt::tt_metal::CircularBufferConfig cb_input_config =
@@ -549,7 +549,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
     uint32_t tiles_to_write_per_packet = std::min(num_pages_per_packet, max_scatter_write_pages);
     uint32_t tile_granularity = std::min(4 * num_pages_per_packet, max_dst_size);
     uint32_t cb_num_pages = 3 * tile_granularity;  // triple buffering
-    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
 
     uint32_t input_cb_index = tt::CB::c_in0;
     tt::tt_metal::CircularBufferConfig cb_input_config =
@@ -591,7 +591,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
     // Tensor Info
     const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
     const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
-    const auto& input_tensor_shape = input_tensor.get_padded_shape();
+    const auto& input_tensor_shape = input_tensor.padded_shape();
     const auto intermediate_tensor_buffer_type = intermediate_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
     const auto num_batches = input_tensor_shape[0];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
@@ -17,24 +17,24 @@ void RingAttentionAllGatherAsync::validate_with_output_tensors(
         input_tensors.size() > 0, "Error, Input tensor size should be greater than 0 but has {}", input_tensors.size());
 
     const auto& first_input_tensor = input_tensors[0];
-    const auto& layout = first_input_tensor.get_layout();
-    const auto& dtype = first_input_tensor.get_dtype();
+    const auto& layout = first_input_tensor.layout();
+    const auto& dtype = first_input_tensor.dtype();
     const auto& memory_config = first_input_tensor.memory_config();
-    const auto& input_shape = first_input_tensor.get_logical_shape();
+    const auto& input_shape = first_input_tensor.logical_shape();
 
     // Validate all input tensors
     for (size_t i = 0; i < input_tensors.size(); ++i) {
         const auto& input_tensor = input_tensors[i];
 
-        TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Input tensor {} must be tiled", i);
+        TT_FATAL(input_tensor.layout() == Layout::TILE, "Input tensor {} must be tiled", i);
         TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor {} must be on device", i);
         TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor {} must be allocated in buffers on device", i);
 
         TT_FATAL(
-            input_tensor.get_dtype() == dtype,
+            input_tensor.dtype() == dtype,
             "All input tensors must have the same dtype. Input tensor {} has dtype {} but expected {}",
             i,
-            input_tensor.get_dtype(),
+            input_tensor.dtype(),
             dtype);
 
         TT_FATAL(
@@ -43,7 +43,7 @@ void RingAttentionAllGatherAsync::validate_with_output_tensors(
             i);
 
         TT_FATAL(
-            input_tensor.get_logical_shape() == input_shape,
+            input_tensor.logical_shape() == input_shape,
             "All input tensors must have the same shape. Input tensor {} has different shape",
             i);
     }
@@ -67,14 +67,14 @@ void RingAttentionAllGatherAsync::validate_with_output_tensors(
             if (output_tensors[i].has_value()) {
                 const auto& output_tensor = output_tensors[i].value();
 
-                TT_FATAL(output_tensor.get_layout() == Layout::TILE, "Output tensor {} must be tiled", i);
+                TT_FATAL(output_tensor.layout() == Layout::TILE, "Output tensor {} must be tiled", i);
                 TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor {} must be on device", i);
 
                 TT_FATAL(
-                    output_tensor.get_dtype() == dtype,
+                    output_tensor.dtype() == dtype,
                     "Output tensor {} dtype should match input tensors but has {}",
                     i,
-                    output_tensor.get_dtype());
+                    output_tensor.dtype());
 
                 TT_FATAL(
                     output_tensor.memory_config() == this->output_mem_config,
@@ -82,7 +82,7 @@ void RingAttentionAllGatherAsync::validate_with_output_tensors(
                     i);
 
                 // Check output tensor shape
-                auto output_shape = output_tensor.get_logical_shape();
+                auto output_shape = output_tensor.logical_shape();
                 auto expected_output_shape = input_shape;
                 expected_output_shape[this->dim] *= this->ring_size;
 
@@ -100,14 +100,13 @@ void RingAttentionAllGatherAsync::validate_with_output_tensors(
 std::vector<ttnn::TensorSpec> RingAttentionAllGatherAsync::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors[0];
-    auto shape = input_tensor.get_logical_shape();
+    auto shape = input_tensor.logical_shape();
     shape[this->dim] *= this->ring_size;
     std::vector<ttnn::TensorSpec> output_specs;
     output_specs.reserve(input_tensors.size());
     for (uint32_t i = 0; i < input_tensors.size(); i++) {
         output_specs.push_back(TensorSpec(
-            shape,
-            TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), output_mem_config)));
+            shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), output_mem_config)));
     }
     return output_specs;
 }
@@ -176,9 +175,9 @@ tt::tt_metal::operation::ProgramWithCallbacks RingAttentionAllGatherAsync::creat
 tt::tt_metal::operation::Hash RingAttentionAllGatherAsync::compute_program_hash(
     const std::vector<Tensor>& input_tensors) const {
     log_trace(tt::LogOp, "compute_program_hash is called");
-    auto input_shape = input_tensors[0].get_padded_shape();
-    auto input_memory_layout = input_tensors[0].get_layout();
-    auto input_dtype = input_tensors[0].get_dtype();
+    auto input_shape = input_tensors[0].padded_shape();
+    auto input_memory_layout = input_tensors[0].layout();
+    auto input_dtype = input_tensors[0].dtype();
     auto input_memory_config = input_tensors[0].memory_config();
 
     return tt::tt_metal::operation::hash_operation<RingAttentionAllGatherAsync>(
@@ -217,7 +216,7 @@ std::vector<Tensor> ring_attention_all_gather_async_impl(
         mesh_view.is_mesh_2d(),
         "all-gather invoked with cluster_axis API withou 2D mesh, which is currently unsupported");
     std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
-    int32_t rank = input_tensors[0].get_logical_shape().rank();
+    int32_t rank = input_tensors[0].logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;
 
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_program.cpp
@@ -142,7 +142,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     const uint32_t num_pages_per_packet =
         std::min((uint32_t)(packet_size_bytes / l1_scratch_cb_page_size_bytes), max_scatter_write_pages);
     const uint32_t cb_num_pages = 3 * num_pages_per_packet;  // triple buffering
-    const tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor[0].get_dtype());
+    const tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor[0].dtype());
 
     // CBs for transferring data between sender_reader and sender_writer
     uint32_t sender_forward_cb_index = tt::CB::c_in0;
@@ -188,8 +188,8 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     const auto output_tensor_layout = output_tensor[0].buffer()->buffer_layout();
     const auto output_tensor_buffer_type = output_tensor[0].buffer()->buffer_type();
     const auto output_tensor_page_layout = output_tensor[0].layout();
-    const auto input_tensor_shape = input_tensor[0].get_padded_shape();
-    const auto output_tensor_shape = output_tensor[0].get_padded_shape();
+    const auto input_tensor_shape = input_tensor[0].padded_shape();
+    const auto output_tensor_shape = output_tensor[0].padded_shape();
     const uint32_t num_inputs = input_tensor.size();
 
     uint32_t tiles_to_write_per_packet = 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_program.cpp
@@ -71,7 +71,7 @@ tt::tt_metal::operation::ProgramWithCallbacks send_async_multicore(
     uint32_t cb_num_pages = 2;
     uint32_t cb_page_size = fabric_max_payload_size;
 
-    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
 
     auto src0_cb_index = tt::CBIndex::c_0;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_op.cpp
@@ -78,7 +78,7 @@ std::vector<ttnn::TensorSpec> PaddedSliceDeviceOperation::compute_output_specs(
     }
 
     ttnn::Shape output_tensor_shape(std::move(out_shape));
-    auto output_dtype = input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.get_dtype();
+    auto output_dtype = input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.dtype();
     auto tensor_layout = TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), this->output_mem_config);
     return {ttnn::TensorSpec(output_tensor_shape, tensor_layout)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -361,8 +361,8 @@ get_padded_slice_runtime_args_tile_sharded_output(
 
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_padded_shape = input_tensor.get_padded_shape();
-    auto input_shape = input_tensor.get_logical_shape();
+    auto input_padded_shape = input_tensor.padded_shape();
+    auto input_shape = input_tensor.logical_shape();
     auto output_shard_spec = output_tensor.shard_spec().value();
     auto output_shard_shape = output_shard_spec.shape;
 
@@ -380,9 +380,9 @@ get_padded_slice_runtime_args_tile_sharded_output(
         }
     }
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
     uint32_t output_row_size_bytes = output_shard_shape[1] * input_tensor.element_size();
@@ -628,18 +628,18 @@ get_padded_slice_runtime_args_tile_sharded_output(
 
 static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    const ttnn::Shape output_shape = output.get_logical_shape();
+    const ttnn::Shape output_shape = output.logical_shape();
     ttnn::Shape actual_output_shape = output_tensor_end;
     for (int i = 0; i < output_shape.rank(); i++) {
         actual_output_shape[i] = output_tensor_end[i] - output_tensor_start[i];
     }
 
-    const ttnn::Shape& input_padded_shape = a.get_padded_shape();
+    const ttnn::Shape& input_padded_shape = a.padded_shape();
     TT_FATAL(
         input_padded_shape.rank() == 4, "Input tensor must be rank 4 for padded_slice operation with tiled inputs");
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -74,8 +74,8 @@ ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_outp
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     using namespace tt::tt_metal;
     return TensorSpec{
-        tensor_args.input_tensor.get_logical_shape(),
-        TensorLayout{tensor_args.input_tensor.get_dtype(), PageConfig{Layout::ROW_MAJOR}, args.output_memory_config}};
+        tensor_args.input_tensor.logical_shape(),
+        TensorLayout{tensor_args.input_tensor.dtype(), PageConfig{Layout::ROW_MAJOR}, args.output_memory_config}};
 }
 
 ScatterDeviceOperation::tensor_return_value_t ScatterDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
@@ -117,10 +117,10 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     const uint32_t source_page_size_bytes = ceil32(source_chunk_size_bytes);
     const uint32_t output_page_size_bytes = ceil32(input_and_output_chunk_size_bytes);
 
-    create_cb(program, input_tensor.get_dtype(), ScatterCB::INPUT, all_cores, input_page_size_bytes);
-    create_cb(program, index_tensor.get_dtype(), ScatterCB::INDEX, all_cores, index_page_size_bytes);
-    create_cb(program, src_tensor.get_dtype(), ScatterCB::SRC, all_cores, source_page_size_bytes);
-    create_cb(program, output_tensor.get_dtype(), ScatterCB::DST, all_cores, output_page_size_bytes);
+    create_cb(program, input_tensor.dtype(), ScatterCB::INPUT, all_cores, input_page_size_bytes);
+    create_cb(program, index_tensor.dtype(), ScatterCB::INDEX, all_cores, index_page_size_bytes);
+    create_cb(program, src_tensor.dtype(), ScatterCB::SRC, all_cores, source_page_size_bytes);
+    create_cb(program, output_tensor.dtype(), ScatterCB::DST, all_cores, output_page_size_bytes);
 
     constexpr const char* reader_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/reader_scatter.cpp";

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -70,9 +70,9 @@ void check_support(
     const auto& input_layout = input_tensor.layout();
     const auto& index_layout = index_tensor.layout();
     const auto& source_layout = source_tensor.layout();
-    const auto& input_shape = input_tensor.get_logical_shape();
-    const auto& index_shape = index_tensor.get_logical_shape();
-    const auto& source_shape = source_tensor.get_logical_shape();
+    const auto& input_shape = input_tensor.logical_shape();
+    const auto& index_shape = index_tensor.logical_shape();
+    const auto& source_shape = source_tensor.logical_shape();
     // check if transpose int garbage case
     TT_FATAL(
         !(is_i32(input_dtype) && !is_last_dim(input_shape, dim)),
@@ -194,9 +194,9 @@ Tensor post_scatter_transform_tensor(
     }
 
     TT_FATAL(
-        output_tensor.get_logical_shape() == original_logical_shape,
+        output_tensor.logical_shape() == original_logical_shape,
         "Output tensor transformation did not create correct output shape! Got: {}, expected: {}",
-        output_tensor.get_logical_shape(),
+        output_tensor.logical_shape(),
         original_logical_shape);
 
     // if the output tensor's original layout is not row-major, convert the output tensor back

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa_scatter.cpp
@@ -124,9 +124,9 @@ Tensor TOSAScatterOperation::invoke(
     const Tensor& index_tensor,
     const Tensor& source_tensor,
     const std::optional<MemoryConfig>& output_memory_config) {
-    const auto& input_shape{input_tensor.get_logical_shape()};
-    const auto& index_shape{index_tensor.get_logical_shape()};
-    const auto& source_shape{source_tensor.get_logical_shape()};
+    const auto& input_shape{input_tensor.logical_shape()};
+    const auto& index_shape{index_tensor.logical_shape()};
+    const auto& source_shape{source_tensor.logical_shape()};
 
     CMAKE_UNIQUE_NAMESPACE::validate_tensors(input_shape, index_shape, source_shape);
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -510,9 +510,9 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
     auto output_shape = output_tensor.padded_shape();
     log_debug(tt::LogOp, "Slice Write Output Shape: {}", output_shape);
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
     auto shard_spec = input_tensor.shard_spec().value();
@@ -697,9 +697,9 @@ static operation::ProgramWithCallbacks slice_write_tiled_sharded_input_multi_cor
         actual_input_shape[index] = output_tensor_end[index] - output_tensor_start[index];
     }
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
     log_debug(tt::LogOp, "Slice Write Input Shape : {} ,Actual Input Shape: {}", input_shape, input_shape);

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/element_wise_multi_core_where_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/element_wise_multi_core_where_program.cpp
@@ -27,26 +27,25 @@ ElementWiseMultiCoreWhereProgram::cached_program_t ElementWiseMultiCoreWhereProg
     using namespace tt::constants;
 
     TT_FATAL(
-        args.condition_tensor.get_dtype() == args.true_value_tensor.get_dtype(),
+        args.condition_tensor.dtype() == args.true_value_tensor.dtype(),
         "Mismatched data types: 'condition_tensor' and 'true_values_tensor' must have the same dtype.");
 
     TT_FATAL(
-        args.condition_tensor.get_dtype() == args.false_value_tensor.get_dtype(),
+        args.condition_tensor.dtype() == args.false_value_tensor.dtype(),
         "Mismatched data types: 'condition_tensor' and 'false_values_tensor' must have the same dtype.");
 
     TT_FATAL(
-        args.condition_tensor.get_dtype() == output.get_dtype(),
+        args.condition_tensor.dtype() == output.dtype(),
         "Mismatched data types: 'condition_tensor' and 'output' tensor must have the same dtype.");
 
     TT_FATAL(
-        args.condition_tensor.get_dtype() == DataType::BFLOAT16 ||
-            args.condition_tensor.get_dtype() == DataType::FLOAT32 ||
-            args.condition_tensor.get_dtype() == DataType::BFLOAT8_B,
+        args.condition_tensor.dtype() == DataType::BFLOAT16 || args.condition_tensor.dtype() == DataType::FLOAT32 ||
+            args.condition_tensor.dtype() == DataType::BFLOAT8_B,
         "Invalid data type: expected BFLOAT16 or FLOAT32 or BFLOAT8_B for 'condition_tensor'.");
 
     Program program{};
     const auto& all_device_cores = operation_attributes.worker_grid;
-    auto dtype = tt_metal::datatype_to_dataformat_converter(args.condition_tensor.get_dtype());
+    auto dtype = tt_metal::datatype_to_dataformat_converter(args.condition_tensor.dtype());
 
     auto createCircularBuffer = [&program, &all_device_cores, dtype = dtype](
                                     tt::CBIndex cb_idx, uint32_t tile_size, uint32_t num_input_tiles = 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/elemwise_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/elemwise_factory_common.hpp
@@ -50,7 +50,7 @@ inline void set_eltwise_ternary_runtime_args(
         }
     }
 
-    uint32_t num_tiles = condition_tensor.volume() / TILE_HW;
+    uint32_t num_tiles = static_cast<uint32_t>(condition_tensor.physical_volume() / TILE_HW);
     bool row_major = true;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         zero_start_grid ? tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles, row_major)

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.cpp
@@ -70,7 +70,7 @@ void WhereDeviceOperation::validate_on_program_cache_miss(
     WhereDeviceOperation::validate_on_program_cache_hit(attributes, args);
 
     TT_FATAL(
-        args.condition_tensor.get_layout() == Layout::TILE,
+        args.condition_tensor.layout() == Layout::TILE,
         "Condition tensor used in the where operation is required to be tiled!");
 }
 
@@ -82,7 +82,7 @@ void WhereDeviceOperation::validate_on_program_cache_hit(
 WhereDeviceOperation::spec_return_value_t WhereDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& args) {
     if (args.output_tensor.has_value()) {
-        return args.output_tensor->get_tensor_spec();
+        return args.output_tensor->tensor_spec();
     }
 
     fail_on_shape_mismatch(args.condition_tensor, args.true_value_tensor, args.false_value_tensor);
@@ -153,7 +153,7 @@ WhereDeviceOperation::invoke(
         operation_attributes_t{
             .memory_config = memory_config.value_or(
                 output_tensor.has_value() ? output_tensor->memory_config() : condition_tensor.memory_config()),
-            .dtype = dtype.value_or(condition_tensor.get_dtype()),
+            .dtype = dtype.value_or(condition_tensor.dtype()),
             .worker_grid = std::move(worker_grid),
             .compute_kernel_config = std::nullopt},
         tensor_args_t{

--- a/ttnn/cpp/ttnn/operations/experimental/where/where.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/where.hpp
@@ -27,7 +27,7 @@ struct WhereOperation {
         std::optional<Tensor> output_tensor = std::nullopt) {
         if (output_dtype.has_value() && output_tensor.has_value()) {
             TT_FATAL(
-                output_dtype.value() == output_tensor.value().get_dtype(),
+                output_dtype.value() == output_tensor.value().dtype(),
                 "Both output dtype and output tensor provided dtype should match");
         }
 

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -144,7 +144,7 @@ uint32_t calculate_L1_usage(
     Pool2DType pool_type,
     bool count_include_pad,
     std::optional<int32_t> divisor_override) {
-    const auto& input_shape = input.get_padded_shape();
+    const auto& input_shape = input.padded_shape();
 
     auto in_dtype = input.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input.dtype();
     tt::DataFormat in_df = datatype_to_dataformat_converter(in_dtype);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -129,7 +129,7 @@ std::vector<TensorSpec> TopK::compute_output_specs(
     const auto& input_tensor = input_tensors.at(0);
     auto output_shape = input_tensors.at(0).logical_shape();
     output_shape[-1] = this->k;
-    ttnn::Shape input_shape = input_tensors.at(0).get_padded_shape();
+    ttnn::Shape input_shape = input_tensors.at(0).padded_shape();
     bool uint16_output = (input_shape[this->dim] < 65536);
 
     auto values_spec =
@@ -161,7 +161,7 @@ operation::ProgramWithCallbacks TopK::create_program(
     bool multicore_supported = true;
     multicore_supported &= (input_tensor.padded_shape()[dim] >= topk::constants::multi_core_min_width);
 
-    ttnn::Shape input_shape = input_tensors.at(0).get_padded_shape();
+    ttnn::Shape input_shape = input_tensors.at(0).padded_shape();
     bool uint16_output = (input_shape[this->dim] < 65536);
     multicore_supported &= uint16_output;    // for now multicore does not support uint32 output, so if uint16 is not
                                              // supported, we default to single core

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_op.cpp
@@ -58,30 +58,30 @@ void RingJointScaledDotProductAttention::validate(const std::vector<Tensor>& inp
     TT_FATAL(this->joint_strategy == "rear", "Joint strategy must be 'rear'. Got: {}", this->joint_strategy);
 
     // Validate all tensors have the same dtype
-    const auto dtype = input_tensor_q.get_dtype();
+    const auto dtype = input_tensor_q.dtype();
     for (const auto& tensor : sdpa_input_tensors) {
         TT_FATAL(
-            tensor.get_dtype() == dtype,
+            tensor.dtype() == dtype,
             "All tensors must have the same dtype. Expected {}, got {}",
             dtype,
-            tensor.get_dtype());
+            tensor.dtype());
     }
 
     // Get shapes
-    const auto& q_shape = input_tensor_q.get_logical_shape();
-    const auto& k_shape = persistent_output_buffer_k.get_logical_shape();
-    const auto& v_shape = persistent_output_buffer_v.get_logical_shape();
-    const auto& joint_q_shape = joint_tensor_q.get_logical_shape();
-    const auto& joint_k_shape = joint_tensor_k.get_logical_shape();
-    const auto& joint_v_shape = joint_tensor_v.get_logical_shape();
+    const auto& q_shape = input_tensor_q.logical_shape();
+    const auto& k_shape = persistent_output_buffer_k.logical_shape();
+    const auto& v_shape = persistent_output_buffer_v.logical_shape();
+    const auto& joint_q_shape = joint_tensor_q.logical_shape();
+    const auto& joint_k_shape = joint_tensor_k.logical_shape();
+    const auto& joint_v_shape = joint_tensor_v.logical_shape();
 
     // Validate storage types and buffers
     for (auto& tensor : sdpa_input_tensors) {
         TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Operands to Joint SDPA need to be on device");
         TT_FATAL(tensor.buffer() != nullptr, "Operands to Joint SDPA need to be allocated in buffers on device");
-        TT_FATAL(tensor.get_layout() == Layout::TILE, "Inputs to Joint SDPA must be tilized");
+        TT_FATAL(tensor.layout() == Layout::TILE, "Inputs to Joint SDPA must be tilized");
         TT_FATAL(
-            tensor.get_dtype() == DataType::BFLOAT16 || tensor.get_dtype() == DataType::BFLOAT8_B,
+            tensor.dtype() == DataType::BFLOAT16 || tensor.dtype() == DataType::BFLOAT8_B,
             "Inputs to Joint SDPA must be BF16 or BF8");
         TT_FATAL(
             tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
@@ -199,8 +199,8 @@ void RingJointScaledDotProductAttention::validate(const std::vector<Tensor>& inp
 
     // Validate padding: Only the sequence dimension may be padded
     auto validate_padding = [](const Tensor& tensor) {
-        const auto& logical_shape = tensor.get_logical_shape();
-        const auto& padded_shape = tensor.get_padded_shape();
+        const auto& logical_shape = tensor.logical_shape();
+        const auto& padded_shape = tensor.padded_shape();
         TT_FATAL(logical_shape[0] == padded_shape[0], "Padding is not supported on the batch dimension");
         TT_FATAL(logical_shape[1] == padded_shape[1], "Padding is not supported on the num_heads dimension");
         TT_FATAL(logical_shape[3] == padded_shape[3], "Padding is not supported on the head_dim dimension");
@@ -223,17 +223,16 @@ std::vector<TensorSpec> RingJointScaledDotProductAttention::compute_output_specs
     const std::vector<Tensor>& input_tensors) const {
     auto& input = input_tensors.at(0);
     auto& joint_input = input_tensors.at(3);
-    auto lse_shape = input.get_logical_shape();
+    auto lse_shape = input.logical_shape();
     lse_shape[3] = 1;
-    lse_shape[2] = input.get_padded_shape()[2] + joint_input.get_padded_shape()[2];
+    lse_shape[2] = input.padded_shape()[2] + joint_input.padded_shape()[2];
 
     return {
+        TensorSpec(input.logical_shape(), TensorLayout(input.dtype(), PageConfig(Layout::TILE), output_mem_config)),
         TensorSpec(
-            input.get_logical_shape(), TensorLayout(input.get_dtype(), PageConfig(Layout::TILE), output_mem_config)),
-        TensorSpec(
-            joint_input.get_logical_shape(),
-            TensorLayout(joint_input.get_dtype(), PageConfig(Layout::TILE), output_mem_config)),
-        TensorSpec(lse_shape, TensorLayout(input.get_dtype(), PageConfig(Layout::TILE), output_mem_config))};
+            joint_input.logical_shape(),
+            TensorLayout(joint_input.dtype(), PageConfig(Layout::TILE), output_mem_config)),
+        TensorSpec(lse_shape, TensorLayout(input.dtype(), PageConfig(Layout::TILE), output_mem_config))};
 }
 
 operation::MeshWorkloadWithCallbacks RingJointScaledDotProductAttention::create_mesh_workload(
@@ -309,7 +308,7 @@ operation::ProgramWithCallbacks RingJointScaledDotProductAttention::create_progr
 
     auto scale = this->scale;
     if (not scale.has_value()) {
-        scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.get_logical_shape()[-1]));
+        scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.logical_shape()[-1]));
     }
 
     std::size_t q_chunk_size = this->get_q_chunk_size();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -54,9 +54,9 @@ operation::ProgramWithCallbacks ring_joint_sdpa(
     may be less than padded length. K, V are gathered, so logical_n tells the true length of K and V.
     */
 
-    const auto& q_shape = input_tensor_q.get_logical_shape();
-    const auto& k_shape = gathered_input_tensor_k.get_logical_shape();
-    const auto& joint_q_shape = joint_tensor_q.get_logical_shape();
+    const auto& q_shape = input_tensor_q.logical_shape();
+    const auto& k_shape = gathered_input_tensor_k.logical_shape();
+    const auto& joint_q_shape = joint_tensor_q.logical_shape();
     const uint32_t B = q_shape[0], NH = q_shape[1], local_N = q_shape[2], DH = q_shape[3];
     const uint32_t global_N = k_shape[2];
     const uint32_t L = joint_q_shape[2];
@@ -426,11 +426,11 @@ operation::ProgramWithCallbacks ring_joint_sdpa(
 
     // Create circular buffers
 
-    tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.get_dtype());
-    tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.get_dtype());
-    tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.get_dtype());
+    tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
+    tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
+    tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
     tt::DataFormat mask_df = tt::DataFormat::Bfp4_b;
-    tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
                                                        // tt::DataFormat::Float32 : tt::DataFormat::Float16_b;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -223,7 +223,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
         mesh_view.is_mesh_2d(),
         "all-gather invoked with cluster_axis API withou 2D mesh, which is currently unsupported");
     std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
-    int32_t rank = input_tensor_k.get_logical_shape().rank();
+    int32_t rank = input_tensor_k.logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;
 
     TT_FATAL(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22090)

### Problem description
The deprecated tensor getters with the format `get_<x>` are redundant because getters of the format `<x>` exist with the same functionality. Both are used throughout the repo, which could cause confusion. 

### What's changed
Changed all from `get_<x>()` to their `<x>()` equivalents (`volume()` --> `physical_volume()` is the exception) in ttnn cpp source files, and removed deprecated functions and headers from tensor header and source files. Now it is more standardized and less confusing (less characters in lines with stringed getter calls is a minor added benefit).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (Link to pending CI run: https://github.com/tenstorrent/tt-metal/actions/runs/16348089441)