### PR TITLE
Init vars

### DIFF
--- a/tt_metal/jit_build/jit_build_options.hpp
+++ b/tt_metal/jit_build/jit_build_options.hpp
@@ -30,14 +30,14 @@ public:
     std::string path;
 
     // HLK config
-    tt::tt_hlk_desc hlk_desc;
+    tt::tt_hlk_desc hlk_desc{};
 
     // We can keep for future WH support, otherwise not used in GS
-    bool fp32_dest_acc_en;
+    bool fp32_dest_acc_en{};
     std::vector<UnpackToDestMode> unpack_to_dest_mode;
-    bool bfp8_pack_precise;
+    bool bfp8_pack_precise{};
 
-    bool dst_full_sync_en;
+    bool dst_full_sync_en{};
 
     JitBuildOptions(const JitBuildEnv& env);
     void set_name(const std::string& name);


### PR DESCRIPTION
### Ticket
Fixes #25271

### Problem description
Uninitialized read leads to non-det behaviour and a hard failure when run with UBSan enabled (read: Smoke / Basic tests).
This failes Merge Gate sometimes (eg: https://github.com/tenstorrent/tt-metal/actions/runs/16326935152/job/46121753816#step:6:10178 )

### What's changed
Initialize variables so they always have valid values.
Verified by running the ttnn-basic tests repeatedly for 6hrs on a CI machine without fail: https://github.com/tenstorrent/tt-metal/actions/runs/16333359760/job/46141048532

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16348936866)