### PR TITLE
SDXL: reorg CI tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -38,6 +38,12 @@ jobs:
           - name: ttnn nightly pool tests
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
             owner: U052J2QDDKQ # Pavle Josipovic
+          - name: ttnn nightly sdxl tests
+            cmd:  if [[ "${{ inputs.runner-label }}" == "N300" ]]; then
+                    export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml;
+                  fi;
+                  pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --loop-iter-num=50 -xv -m "not disable_fast_runtime_mode"
+            owner: U07N3CUUN05 # Iva Potkonjak
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:

--- a/models/experimental/stable_diffusion_xl_base/conftest.py
+++ b/models/experimental/stable_diffusion_xl_base/conftest.py
@@ -18,6 +18,12 @@ def pytest_addoption(parser):
         default=5000,
         help="Number of prompts to process (default: 5000)",
     )
+    parser.addoption(
+        "--loop-iter-num",
+        action="store",
+        default=10,
+        help="Number of iterations of denoising loop (default: 10)",
+    )
 
 
 @pytest.fixture
@@ -35,3 +41,8 @@ def evaluation_range(request):
         num_prompts = 5000
 
     return start_from, num_prompts
+
+
+@pytest.fixture
+def loop_iter_num(request):
+    return int(request.config.getoption("--loop-iter-num"))

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -18,6 +18,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, comp_pcc
 import matplotlib.pyplot as plt
+from models.utility_functions import is_wormhole_b0
 
 
 def run_tt_denoising(
@@ -444,14 +445,11 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, cla
     logger.info(f"PCC of the last iteration is: {pcc_message}")
 
 
+@pytest.mark.skipif(not is_wormhole_b0(), reason="SDXL supported on WH only")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "prompt",
     (("An astronaut riding a green horse"),),
-)
-@pytest.mark.parametrize(
-    "num_inference_steps",
-    ((50),),
 )
 @pytest.mark.parametrize(
     "classifier_free_guidance",
@@ -464,7 +462,7 @@ def test_unet_loop(
     device,
     is_ci_env,
     prompt,
-    num_inference_steps,
+    loop_iter_num,
     classifier_free_guidance,
 ):
-    return run_unet_inference(device, is_ci_env, prompt, num_inference_steps, classifier_free_guidance)
+    return run_unet_inference(device, is_ci_env, prompt, loop_iter_num, classifier_free_guidance)

--- a/tests/nightly/single_card/stable_diffusion_xl_base/conftest.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/conftest.py
@@ -1,0 +1,1 @@
+../../../../models/experimental/stable_diffusion_xl_base/conftest.py


### PR DESCRIPTION
### Problem description
SDXL frequent tests were taking too long to execute.

### What's changed
Moved the long version of [test_unet_loop.py](https://github.com/tenstorrent/tt-metal/blob/ipotkonjak/sdxl_reorg_ci_tests/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py) to L2 nightly pipeline.

### Checklist
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/16346610728/job/46182506315) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16347445646/job/46185468523) CI passes