### PR TITLE
Update test_llama_model_prefill.py

### DIFF
--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
@@ -85,10 +85,10 @@ def test_llama_model_inference(
 
     # This sets the minimum PCC for each iteration based on optimization mode
     if optimizations == LlamaOptimizations.accuracy:
-        pcc = 0.917  # TODO Look on improving PCC
+        pcc = 0.915  # TODO Look on improving PCC
     else:  # performance mode
         assert optimizations == LlamaOptimizations.performance
-        pcc = 0.917  # TODO Look on improving PCC
+        pcc = 0.915  # TODO Look on improving PCC
 
     # Use instruct weights instead of general weights
     instruct = True


### PR DESCRIPTION
Update PCC after matmul optimisation. PCC on 6U is lower than on 4U.

### Ticket
Link to Github Issue

### Problem description
PCC is still failing on Galaxy Quick in CI.

### What's changed
Relaxed PCC 0.917 -> 0.915