### PR TITLE
Enable tracing in SD3.5

### DIFF
--- a/models/experimental/stable_diffusion_35_large/fun_demo.py
+++ b/models/experimental/stable_diffusion_35_large/fun_demo.py
@@ -42,7 +42,7 @@ from .tt.parallel_config import StableDiffusionParallelManager
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 15210496}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 20000000}],
     indirect=True,
 )
 def test_sd3(

--- a/models/experimental/stable_diffusion_35_large/fun_demo.py
+++ b/models/experimental/stable_diffusion_35_large/fun_demo.py
@@ -45,6 +45,7 @@ from .tt.parallel_config import StableDiffusionParallelManager
     [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 20000000}],
     indirect=True,
 )
+@pytest.mark.parametrize("traced", [True, False], ids=["yes_traced", "no_traced"])
 def test_sd3(
     *,
     mesh_device: ttnn.MeshDevice,
@@ -60,6 +61,7 @@ def test_sd3(
     num_links,
     no_prompt,
     model_location_generator,
+    traced,
 ) -> None:
     cfg_factor, cfg_axis = cfg
     sp_factor, sp_axis = sp
@@ -121,6 +123,7 @@ def test_sd3(
             negative_prompt_3=[negative_prompt],
             num_inference_steps=num_inference_steps,
             seed=0,
+            traced=traced,
         )
         images[0].save(f"sd35_{image_w}_{image_h}.png")
 
@@ -144,6 +147,7 @@ def test_sd3(
                 negative_prompt_3=[negative_prompt],
                 num_inference_steps=num_inference_steps,
                 seed=0,
+                traced=traced,
             )
 
             images[0].save(f"sd35_{image_w}_{image_h}.png")

--- a/models/experimental/stable_diffusion_35_large/tests/test_performance.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_performance.py
@@ -93,26 +93,34 @@ def test_sd35_performance(
     )
 
     # Test prompts
-    prompt = (
-        "An epic, high-definition cinematic shot of a rustic snowy cabin glowing "
-        "warmly at dusk, nestled in a serene winter landscape. Surrounded by gentle "
-        "snow-covered pines and delicate falling snowflakes - captured in a rich, "
-        "atmospheric, wide-angle scene with deep cinematic depth and warmth."
-    )
+    # prompts = (
+    #     "An epic, high-definition cinematic shot of a rustic snowy cabin glowing "
+    #     "warmly at dusk, nestled in a serene winter landscape. Surrounded by gentle "
+    #     "snow-covered pines and delicate falling snowflakes - captured in a rich, "
+    #     "atmospheric, wide-angle scene with deep cinematic depth and warmth."
+    # )
+    prompts = [
+        """A neon-lit alley in a sprawling cyberpunk metropolis at night, rain-slick streets reflecting glowing holograms, dense atmosphere, flying cars in the sky, people in high-tech streetwear — ultra-detailed, cinematic lighting, 4K""",
+        """A colossal whale floating through a desert sky like a blimp, casting a long shadow over sand dunes, people in ancient robes watching in awe, golden hour lighting, dreamlike color palette — surrealism, concept art, Greg Rutkowski style""",
+        """A Roman general standing on a battlefield at dawn, torn red cape blowing in the wind, distant soldiers forming ranks, painterly brushwork in the style of Caravaggio, chiaroscuro lighting, epic composition""",
+        """A tiny, fluffy dragon curled up in a teacup, warm cozy lighting, big expressive eyes, intricate scale patterns, surrounded by books and potions — high detail, Studio Ghibli meets Pixar""",
+    ]
     negative_prompt = ""
 
     # Warmup run (not timed)
     print("Running warmup iteration...")
-    pipeline(
-        prompt_1=[prompt],
-        prompt_2=[prompt],
-        prompt_3=[prompt],
+    images = pipeline(
+        prompt_1=[prompts[0]],
+        prompt_2=[prompts[0]],
+        prompt_3=[prompts[0]],
         negative_prompt_1=[negative_prompt],
         negative_prompt_2=[negative_prompt],
         negative_prompt_3=[negative_prompt],
         num_inference_steps=num_inference_steps,
         seed=0,
+        traced=True,
     )
+    images[0].save(f"sd35_{image_w}_{image_h}_warmup.png")
 
     # Performance measurement runs
     print("Running performance measurement iterations...")
@@ -132,16 +140,17 @@ def test_sd35_performance(
 
         # Run pipeline
         images = pipeline(
-            prompt_1=[prompt],
-            prompt_2=[prompt],
-            prompt_3=[prompt],
+            prompt_1=[prompts[i + 1]],
+            prompt_2=[prompts[i + 1]],
+            prompt_3=[prompts[i + 1]],
             negative_prompt_1=[negative_prompt],
             negative_prompt_2=[negative_prompt],
             negative_prompt_3=[negative_prompt],
             num_inference_steps=num_inference_steps,
             seed=0,
+            traced=True,
         )
-
+        images[0].save(f"sd35_{image_w}_{image_h}_run{i}.png")
         # Collect timing data
         timing_data = timer.get_timing_data()
         all_timings.append(timing_data)

--- a/models/experimental/stable_diffusion_35_large/tests/test_performance.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_performance.py
@@ -28,7 +28,7 @@ from ..tt.parallel_config import StableDiffusionParallelManager
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 15210496}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 20000000}],
     indirect=True,
 )
 def test_sd35_performance(
@@ -123,7 +123,7 @@ def test_sd35_performance(
     profiler = Profiler()
 
     profiler.enable()
-    for i in range(1):
+    for i in range(3):
         print(f"Performance run {i+1}/3...")
 
         # Create timing collector for this run

--- a/models/experimental/stable_diffusion_35_large/tests/test_performance.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_performance.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import statistics
+import pytest
+import ttnn
+from ..tt.fun_pipeline import TtStableDiffusion3Pipeline, TimingCollector
+from ..tt.parallel_config import StableDiffusionParallelManager
+
+
+@pytest.mark.parametrize(
+    "model_name, image_w, image_h, guidance_scale, num_inference_steps",
+    [
+        ("large", 1024, 1024, 3.5, 28),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device, cfg, sp, tp, topology, num_links",
+    [
+        [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
+        [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 3],
+    ],
+    ids=[
+        "t3k_cfg2_sp2_tp2",
+        "tg_cfg2_sp4_tp4",
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 15210496}],
+    indirect=True,
+)
+def test_sd35_performance(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    model_name,
+    image_w,
+    image_h,
+    guidance_scale,
+    num_inference_steps,
+    cfg,
+    sp,
+    tp,
+    topology,
+    num_links,
+    model_location_generator,
+) -> None:
+    """Performance test for SD35 pipeline with detailed timing analysis."""
+
+    # Setup parallel manager
+    cfg_factor, cfg_axis = cfg
+    sp_factor, sp_axis = sp
+    tp_factor, tp_axis = tp
+    parallel_manager = StableDiffusionParallelManager(
+        mesh_device,
+        cfg_factor,
+        sp_factor,
+        tp_factor,
+        sp_factor,
+        tp_factor,
+        topology,
+        cfg_axis=cfg_axis,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+    )
+
+    if guidance_scale > 1 and cfg_factor == 1:
+        guidance_cond = 2
+    else:
+        guidance_cond = 1
+
+    # Create pipeline
+    pipeline = TtStableDiffusion3Pipeline(
+        checkpoint_name=f"stabilityai/stable-diffusion-3.5-{model_name}",
+        mesh_device=mesh_device,
+        enable_t5_text_encoder=False,
+        guidance_cond=guidance_cond,
+        parallel_manager=parallel_manager,
+        height=image_h,
+        width=image_w,
+        model_location_generator=model_location_generator,
+    )
+
+    pipeline.prepare(
+        batch_size=1,
+        width=image_w,
+        height=image_h,
+        guidance_scale=guidance_scale,
+        prompt_sequence_length=333,
+        spatial_sequence_length=4096,
+    )
+
+    # Test prompts
+    prompt = (
+        "An epic, high-definition cinematic shot of a rustic snowy cabin glowing "
+        "warmly at dusk, nestled in a serene winter landscape. Surrounded by gentle "
+        "snow-covered pines and delicate falling snowflakes - captured in a rich, "
+        "atmospheric, wide-angle scene with deep cinematic depth and warmth."
+    )
+    negative_prompt = ""
+
+    # Warmup run (not timed)
+    print("Running warmup iteration...")
+    pipeline(
+        prompt_1=[prompt],
+        prompt_2=[prompt],
+        prompt_3=[prompt],
+        negative_prompt_1=[negative_prompt],
+        negative_prompt_2=[negative_prompt],
+        negative_prompt_3=[negative_prompt],
+        num_inference_steps=num_inference_steps,
+        seed=0,
+    )
+
+    # Performance measurement runs
+    print("Running performance measurement iterations...")
+    all_timings = []
+
+    from tracy import Profiler
+
+    profiler = Profiler()
+
+    profiler.enable()
+    for i in range(1):
+        print(f"Performance run {i+1}/3...")
+
+        # Create timing collector for this run
+        timer = TimingCollector()
+        pipeline.timing_collector = timer
+
+        # Run pipeline
+        images = pipeline(
+            prompt_1=[prompt],
+            prompt_2=[prompt],
+            prompt_3=[prompt],
+            negative_prompt_1=[negative_prompt],
+            negative_prompt_2=[negative_prompt],
+            negative_prompt_3=[negative_prompt],
+            num_inference_steps=num_inference_steps,
+            seed=0,
+        )
+
+        # Collect timing data
+        timing_data = timer.get_timing_data()
+        all_timings.append(timing_data)
+
+    profiler.disable()
+    # Calculate statistics
+    clip_times = [t.clip_encoding_time for t in all_timings]
+    t5_times = [t.t5_encoding_time for t in all_timings]
+    total_encoding_times = [t.total_encoding_time for t in all_timings]
+    vae_times = [t.vae_decoding_time for t in all_timings]
+    total_times = [t.total_time for t in all_timings]
+
+    # Calculate per-step denoising times
+    all_denoising_steps = []
+    for timing in all_timings:
+        all_denoising_steps.extend(timing.denoising_step_times)
+
+    # Report results
+    print("\n" + "=" * 80)
+    print("STABLE DIFFUSION 3.5 PERFORMANCE RESULTS")
+    print("=" * 80)
+    print(f"Model: {model_name}")
+    print(f"Image Size: {image_w}x{image_h}")
+    print(f"Guidance Scale: {guidance_scale}")
+    print(f"Inference Steps: {num_inference_steps}")
+    print(f"Configuration: cfg={cfg_factor}, sp={sp_factor}, tp={tp_factor}")
+    print("-" * 80)
+
+    def print_stats(name, times):
+        mean_time = statistics.mean(times)
+        std_time = statistics.stdev(times) if len(times) > 1 else 0
+        min_time = min(times)
+        max_time = max(times)
+        print(
+            f"{name:25} | Mean: {mean_time:8.4f}s | Std: {std_time:8.4f}s | Min: {min_time:8.4f}s | Max: {max_time:8.4f}s"
+        )
+
+    print_stats("CLIP Encoding", clip_times)
+    print_stats("T5 Encoding", t5_times)
+    print_stats("Total Encoding", total_encoding_times)
+    print_stats("Denoising (per step)", all_denoising_steps)
+    print_stats("VAE Decoding", vae_times)
+    print_stats("Total Pipeline", total_times)
+
+    print("-" * 80)
+
+    # Additional metrics
+    avg_total_time = statistics.mean(total_times)
+    avg_step_time = statistics.mean(all_denoising_steps)
+    total_denoising_time = avg_step_time * num_inference_steps
+
+    print(f"Average total denoising time: {total_denoising_time:.4f}s")
+    print(f"Denoising throughput: {num_inference_steps / total_denoising_time:.2f} steps/second")
+    print(f"Overall throughput: {1 / avg_total_time:.4f} images/second")
+
+    # Breakdown percentages
+    avg_encoding_time = statistics.mean(total_encoding_times)
+    avg_vae_time = statistics.mean(vae_times)
+
+    print(f"\nTime breakdown:")
+    print(f"  Encoding: {avg_encoding_time/avg_total_time*100:.1f}%")
+    print(f"  Denoising: {total_denoising_time/avg_total_time*100:.1f}%")
+    print(f"  VAE: {avg_vae_time/avg_total_time*100:.1f}%")
+
+    print("=" * 80)
+
+    # Clean up
+    pipeline.timing_collector = None
+
+    for submesh_device in parallel_manager.submesh_devices:
+        ttnn.synchronize_device(submesh_device)

--- a/models/experimental/stable_diffusion_35_large/tt/fun_pipeline.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_pipeline.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import time
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, List
 
 import torch
 import tqdm
@@ -17,6 +18,7 @@ from diffusers.models.transformers.transformer_sd3 import SD3Transformer2DModel
 from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
 from loguru import logger
 from transformers import CLIPTextModelWithProjection, CLIPTokenizer, T5EncoderModel, T5TokenizerFast
+from contextlib import contextmanager, nullcontext
 
 from ..tt.utils import from_torch_fast
 from .t5_encoder import TtT5Encoder, TtT5EncoderParameters
@@ -24,6 +26,48 @@ from .fun_transformer import sd_transformer, TtSD3Transformer2DModelParameters
 from .parallel_config import StableDiffusionParallelManager
 
 TILE_SIZE = 32
+
+
+@dataclass
+class TimingData:
+    clip_encoding_time: float = 0.0
+    t5_encoding_time: float = 0.0
+    total_encoding_time: float = 0.0
+    denoising_step_times: List[float] = field(default_factory=list)
+    vae_decoding_time: float = 0.0
+    total_time: float = 0.0
+
+
+class TimingCollector:
+    def __init__(self):
+        self.timings: Dict[str, float] = {}
+        self.step_timings: Dict[str, List[float]] = {}
+
+    @contextmanager
+    def time_section(self, name: str):
+        start = time.time()
+        yield
+        end = time.time()
+        self.timings[name] = end - start
+
+    @contextmanager
+    def time_step(self, name: str):
+        start = time.time()
+        yield
+        end = time.time()
+        if name not in self.step_timings:
+            self.step_timings[name] = []
+        self.step_timings[name].append(end - start)
+
+    def get_timing_data(self) -> TimingData:
+        return TimingData(
+            clip_encoding_time=self.timings.get("clip_encoding", 0.0),
+            t5_encoding_time=self.timings.get("t5_encoding", 0.0),
+            total_encoding_time=self.timings.get("total_encoding", 0.0),
+            denoising_step_times=self.step_timings.get("denoising_step", []),
+            vae_decoding_time=self.timings.get("vae_decoding", 0.0),
+            total_time=self.timings.get("total", 0.0),
+        )
 
 
 class TtStableDiffusion3Pipeline:
@@ -149,6 +193,7 @@ class TtStableDiffusion3Pipeline:
             )
         else:
             self._text_encoder_3 = None
+        self.timing_collector = None  # Set externally when timing is needed
 
     def prepare(
         self,
@@ -271,182 +316,193 @@ class TtStableDiffusion3Pipeline:
         num_inference_steps: int = 40,
         seed: int | None = None,
     ) -> None:
-        start_time = time.time()
+        timer = self.timing_collector
 
-        batch_size = self._prepared_batch_size
-        num_images_per_prompt = self._prepared_num_images_per_prompt
-        width = self._prepared_width
-        height = self._prepared_height
-        guidance_scale = self._prepared_guidance_scale
-        max_t5_sequence_length = self._prepared_max_t5_sequence_length
+        with timer.time_section("total") if timer else nullcontext():
+            start_time = time.time()
 
-        assert height % (self._vae_scale_factor * self.patch_size) == 0
-        assert width % (self._vae_scale_factor * self.patch_size) == 0
-        assert max_t5_sequence_length <= 512  # noqa: PLR2004
-        assert batch_size == len(prompt_1)
+            batch_size = self._prepared_batch_size
+            num_images_per_prompt = self._prepared_num_images_per_prompt
+            width = self._prepared_width
+            height = self._prepared_height
+            guidance_scale = self._prepared_guidance_scale
+            max_t5_sequence_length = self._prepared_max_t5_sequence_length
 
-        do_classifier_free_guidance = guidance_scale > 1
-        # TODO: pass the patch_size value
-        patch_size = 2
-        latents_shape = (
-            batch_size * num_images_per_prompt,
-            height // self._vae_scale_factor,
-            width // self._vae_scale_factor,
-            self._num_channels_latents,
-        )
+            assert height % (self._vae_scale_factor * self.patch_size) == 0
+            assert width % (self._vae_scale_factor * self.patch_size) == 0
+            assert max_t5_sequence_length <= 512  # noqa: PLR2004
+            assert batch_size == len(prompt_1)
 
-        print(f"Latents shape: {latents_shape}")
-
-        logger.info("encoding prompts...")
-
-        prompt_encoding_start_time = time.time()
-        prompt_embeds, pooled_prompt_embeds = self._encode_prompts(
-            prompt_1=prompt_1,
-            prompt_2=prompt_2,
-            prompt_3=prompt_3,
-            negative_prompt_1=negative_prompt_1,
-            negative_prompt_2=negative_prompt_2,
-            negative_prompt_3=negative_prompt_3,
-            num_images_per_prompt=num_images_per_prompt,
-            max_t5_sequence_length=max_t5_sequence_length,
-            do_classifier_free_guidance=do_classifier_free_guidance,
-        )
-        prompt_encoding_end_time = time.time()
-        logger.info("preparing timesteps...")
-
-        self._scheduler.set_timesteps(num_inference_steps)
-        timesteps = self._scheduler.timesteps
-
-        logger.info("preparing latents...")
-
-        if seed is not None:
-            torch.manual_seed(seed)
-        latents = torch.randn(latents_shape, dtype=prompt_embeds.dtype)  # .permute([0, 2, 3, 1])
-
-        tt_prompt_embeds_list = []
-        tt_pooled_prompt_embeds_list = []
-        tt_latents_step_list = []
-        for i, submesh_device in enumerate(self.parallel_manager.submesh_devices):
-            tt_prompt_embeds = ttnn.from_torch(
-                prompt_embeds[i].unsqueeze(0)
-                if self.parallel_manager.dit_parallel_config.cfg_parallel.factor == 2
-                else prompt_embeds,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                device=submesh_device,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    submesh_device, self.parallel_manager.dit_parallel_config.cfg_parallel.mesh_shape, dims=[None, None]
-                ),
+            do_classifier_free_guidance = guidance_scale > 1
+            # TODO: pass the patch_size value
+            patch_size = 2
+            latents_shape = (
+                batch_size * num_images_per_prompt,
+                height // self._vae_scale_factor,
+                width // self._vae_scale_factor,
+                self._num_channels_latents,
             )
-            tt_prompt_embeds_list.append(tt_prompt_embeds)
 
-            tt_pooled_prompt_embeds = ttnn.from_torch(
-                pooled_prompt_embeds[i].unsqueeze(0)
-                if self.parallel_manager.dit_parallel_config.cfg_parallel.factor == 2
-                else pooled_prompt_embeds,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                device=submesh_device,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    submesh_device, self.parallel_manager.dit_parallel_config.cfg_parallel.mesh_shape, dims=[None, None]
-                ),
-            )
-            tt_pooled_prompt_embeds_list.append(tt_pooled_prompt_embeds)
+            print(f"Latents shape: {latents_shape}")
 
-            tt_initial_latents = ttnn.from_torch(
-                latents,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                device=submesh_device,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    submesh_device,
-                    self.parallel_manager.dit_parallel_config.cfg_parallel.mesh_shape,
-                    dims=[self.parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis + 1, None],
-                ),
-            )
-            latents_step = tt_initial_latents
-            tt_latents_step_list.append(latents_step)
+            logger.info("encoding prompts...")
 
-        logger.info("denoising...")
-        denoising_start_time = time.time()
+            with timer.time_section("total_encoding") if timer else nullcontext():
+                prompt_encoding_start_time = time.time()
+                prompt_embeds, pooled_prompt_embeds = self._encode_prompts(
+                    prompt_1=prompt_1,
+                    prompt_2=prompt_2,
+                    prompt_3=prompt_3,
+                    negative_prompt_1=negative_prompt_1,
+                    negative_prompt_2=negative_prompt_2,
+                    negative_prompt_3=negative_prompt_3,
+                    num_images_per_prompt=num_images_per_prompt,
+                    max_t5_sequence_length=max_t5_sequence_length,
+                    do_classifier_free_guidance=do_classifier_free_guidance,
+                )
+                prompt_encoding_end_time = time.time()
+                logger.info("preparing timesteps...")
 
-        # ttnn.copy_host_to_device_tensor(tt_prompt_embeds, self._trace.prompt_input)
-        # ttnn.copy_host_to_device_tensor(tt_pooled_prompt_embeds, self._trace.pooled_projection_input)
-        # ttnn.copy_host_to_device_tensor(tt_initial_latents, self._trace.spatial_input_output)
+            self._scheduler.set_timesteps(num_inference_steps)
+            timesteps = self._scheduler.timesteps
 
-        for i, t in enumerate(tqdm.tqdm(timesteps)):
-            sigma_difference = self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]
+            logger.info("preparing latents...")
 
-            tt_timestep_list = []
-            tt_sigma_difference_list = []
-            for submesh_device in self.parallel_manager.submesh_devices:
-                tt_timestep = ttnn.full([1, 1], fill_value=t, dtype=ttnn.float32, device=submesh_device)
-                tt_timestep_list.append(tt_timestep)
+            if seed is not None:
+                torch.manual_seed(seed)
+            latents = torch.randn(latents_shape, dtype=prompt_embeds.dtype)  # .permute([0, 2, 3, 1])
 
-                tt_sigma_difference = ttnn.full(
-                    [1, 1],
-                    fill_value=sigma_difference,
+            tt_prompt_embeds_list = []
+            tt_pooled_prompt_embeds_list = []
+            tt_latents_step_list = []
+            for i, submesh_device in enumerate(self.parallel_manager.submesh_devices):
+                tt_prompt_embeds = ttnn.from_torch(
+                    prompt_embeds[i].unsqueeze(0)
+                    if self.parallel_manager.dit_parallel_config.cfg_parallel.factor == 2
+                    else prompt_embeds,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
                     device=submesh_device,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        submesh_device,
+                        self.parallel_manager.dit_parallel_config.cfg_parallel.mesh_shape,
+                        dims=[None, None],
+                    ),
                 )
-                tt_sigma_difference_list.append(tt_sigma_difference)
+                tt_prompt_embeds_list.append(tt_prompt_embeds)
 
-                # ttnn.copy_host_to_device_tensor(tt_timestep, self._trace.timestep_input)
-                # ttnn.copy_host_to_device_tensor(tt_sigma_difference, self._trace.sigma_difference_input)
-                # self._trace.execute()
+                tt_pooled_prompt_embeds = ttnn.from_torch(
+                    pooled_prompt_embeds[i].unsqueeze(0)
+                    if self.parallel_manager.dit_parallel_config.cfg_parallel.factor == 2
+                    else pooled_prompt_embeds,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=submesh_device,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        submesh_device,
+                        self.parallel_manager.dit_parallel_config.cfg_parallel.mesh_shape,
+                        dims=[None, None],
+                    ),
+                )
+                tt_pooled_prompt_embeds_list.append(tt_pooled_prompt_embeds)
 
-            tt_latents_step_list = self._step(
-                timestep=tt_timestep_list,
-                latents=tt_latents_step_list,  # tt_latents,
-                do_classifier_free_guidance=do_classifier_free_guidance,
-                prompt_embeds=tt_prompt_embeds_list,
-                pooled_prompt_embeds=tt_pooled_prompt_embeds_list,
-                guidance_scale=guidance_scale,
-                sigma_difference=tt_sigma_difference_list,
-                prompt_sequence_length=333,
-                spatial_sequence_length=4096,
-            )
+                tt_initial_latents = ttnn.from_torch(
+                    latents,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=submesh_device,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        submesh_device,
+                        self.parallel_manager.dit_parallel_config.cfg_parallel.mesh_shape,
+                        dims=[self.parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis + 1, None],
+                    ),
+                )
+                latents_step = tt_initial_latents
+                tt_latents_step_list.append(latents_step)
 
-        denoising_end_time = time.time()
+            logger.info("denoising...")
+            denoising_start_time = time.time()
 
-        logger.info("decoding image...")
+            # ttnn.copy_host_to_device_tensor(tt_prompt_embeds, self._trace.prompt_input)
+            # ttnn.copy_host_to_device_tensor(tt_pooled_prompt_embeds, self._trace.pooled_projection_input)
+            # ttnn.copy_host_to_device_tensor(tt_initial_latents, self._trace.spatial_input_output)
 
-        image_decoding_start_time = time.time()
+            for i, t in enumerate(tqdm.tqdm(timesteps)):
+                with timer.time_step("denoising_step") if timer else nullcontext():
+                    sigma_difference = self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]
 
-        # latents = ttnn.to_torch(self._trace.spatial_input_output).to(torch.float32)
-        latents = ttnn.to_torch(
-            tt_latents_step_list[0],
-            mesh_composer=ttnn.ConcatMesh2dToTensor(
-                mesh_device=tt_latents_step_list[0].device(),
-                mesh_shape=tuple(tt_latents_step_list[0].device().shape),
-                dims=[
-                    self.parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis + 1,
-                    self.parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis + 1,
-                ],
-            ),
-        ).to(torch.float32)[
-            :,
-            : tt_latents_step_list[0].shape[-3] * self.parallel_manager.dit_parallel_config.sequence_parallel.factor,
-            : tt_latents_step_list[0].shape[-2],
-            : tt_latents_step_list[0].shape[-1],
-        ]
-        latents = (latents.permute([0, 3, 1, 2]) / self._vae_scaling_factor) + self._vae_shift_factor
-        with torch.no_grad():
-            image = self._vae.decoder(latents)
-            image = self._image_processor.postprocess(image, output_type="pt")
-            assert isinstance(image, torch.Tensor)
+                    tt_timestep_list = []
+                    tt_sigma_difference_list = []
+                    for submesh_device in self.parallel_manager.submesh_devices:
+                        tt_timestep = ttnn.full([1, 1], fill_value=t, dtype=ttnn.float32, device=submesh_device)
+                        tt_timestep_list.append(tt_timestep)
 
-        image_decoding_end_time = time.time()
+                        tt_sigma_difference = ttnn.full(
+                            [1, 1],
+                            fill_value=sigma_difference,
+                            layout=ttnn.TILE_LAYOUT,
+                            dtype=ttnn.bfloat16,
+                            device=submesh_device,
+                        )
+                        tt_sigma_difference_list.append(tt_sigma_difference)
 
-        output = self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(image))
+                        # ttnn.copy_host_to_device_tensor(tt_timestep, self._trace.timestep_input)
+                        # ttnn.copy_host_to_device_tensor(tt_sigma_difference, self._trace.sigma_difference_input)
+                        # self._trace.execute()
 
-        end_time = time.time()
+                    tt_latents_step_list = self._step(
+                        timestep=tt_timestep_list,
+                        latents=tt_latents_step_list,  # tt_latents,
+                        do_classifier_free_guidance=do_classifier_free_guidance,
+                        prompt_embeds=tt_prompt_embeds_list,
+                        pooled_prompt_embeds=tt_pooled_prompt_embeds_list,
+                        guidance_scale=guidance_scale,
+                        sigma_difference=tt_sigma_difference_list,
+                        prompt_sequence_length=333,
+                        spatial_sequence_length=4096,
+                    )
 
-        logger.info(f"prompt encoding duration: {prompt_encoding_end_time - prompt_encoding_start_time}")
-        logger.info(f"denoising duration: {denoising_end_time - denoising_start_time}")
-        logger.info(f"image decoding duration: {image_decoding_end_time - image_decoding_start_time}")
-        logger.info(f"total runtime: {end_time - start_time}")
+            denoising_end_time = time.time()
+
+            logger.info("decoding image...")
+
+            with timer.time_section("vae_decoding") if timer else nullcontext():
+                image_decoding_start_time = time.time()
+
+                # latents = ttnn.to_torch(self._trace.spatial_input_output).to(torch.float32)
+                latents = ttnn.to_torch(
+                    tt_latents_step_list[0],
+                    mesh_composer=ttnn.ConcatMesh2dToTensor(
+                        mesh_device=tt_latents_step_list[0].device(),
+                        mesh_shape=tuple(tt_latents_step_list[0].device().shape),
+                        dims=[
+                            self.parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis + 1,
+                            self.parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis + 1,
+                        ],
+                    ),
+                ).to(torch.float32)[
+                    :,
+                    : tt_latents_step_list[0].shape[-3]
+                    * self.parallel_manager.dit_parallel_config.sequence_parallel.factor,
+                    : tt_latents_step_list[0].shape[-2]
+                    * self.parallel_manager.dit_parallel_config.tensor_parallel.factor,
+                    : tt_latents_step_list[0].shape[-1],
+                ]
+                latents = (latents.permute([0, 3, 1, 2]) / self._vae_scaling_factor) + self._vae_shift_factor
+                with torch.no_grad():
+                    image = self._vae.decoder(latents)
+                    image = self._image_processor.postprocess(image, output_type="pt")
+                    assert isinstance(image, torch.Tensor)
+                image_decoding_end_time = time.time()
+
+                output = self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(image))
+
+                end_time = time.time()
+
+                logger.info(f"prompt encoding duration: {prompt_encoding_end_time - prompt_encoding_start_time}")
+                logger.info(f"denoising duration: {denoising_end_time - denoising_start_time}")
+                logger.info(f"image decoding duration: {image_decoding_end_time - image_decoding_start_time}")
+                logger.info(f"total runtime: {end_time - start_time}")
 
         return output
 
@@ -500,32 +556,9 @@ class TtStableDiffusion3Pipeline:
                 cond = noise_pred_list[0][split_pos:]
                 noise_pred_list[0] = uncond + guidance_scale * (cond - uncond)
             else:
-                uncond = ttnn.to_torch(
-                    noise_pred_list[0],
-                    mesh_composer=ttnn.ConcatMesh2dToTensor(
-                        mesh_device=noise_pred_list[0].device(),
-                        mesh_shape=tuple(noise_pred_list[0].device().shape),
-                        dims=[
-                            self.parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis + 1,
-                            self.parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis + 1,
-                        ],
-                    ),
-                ).to(torch.float32)[
-                    ..., : noise_pred_list[0].shape[-3], : noise_pred_list[0].shape[-2], : noise_pred_list[0].shape[-1]
-                ]
-                cond = ttnn.to_torch(
-                    noise_pred_list[1],
-                    mesh_composer=ttnn.ConcatMesh2dToTensor(
-                        mesh_device=noise_pred_list[1].device(),
-                        mesh_shape=tuple(noise_pred_list[1].device().shape),
-                        dims=[
-                            self.parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis + 1,
-                            self.parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis + 1,
-                        ],
-                    ),
-                ).to(torch.float32)[
-                    ..., : noise_pred_list[1].shape[-3], : noise_pred_list[1].shape[-2], : noise_pred_list[1].shape[-1]
-                ]
+                # uncond and cond are replicated, so it is fine to get a single tensor from each
+                uncond = ttnn.to_torch(ttnn.get_device_tensors(noise_pred_list[0])[0]).to(torch.float32)
+                cond = ttnn.to_torch(ttnn.get_device_tensors(noise_pred_list[1])[0]).to(torch.float32)
                 torch_noise_pred = uncond + guidance_scale * (cond - uncond)
                 noise_pred_list[0] = ttnn.from_torch(
                     torch_noise_pred,
@@ -568,34 +601,40 @@ class TtStableDiffusion3Pipeline:
         max_t5_sequence_length: int,
         do_classifier_free_guidance: bool,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        timer = self.timing_collector
+
         tokenizer_max_length = self._tokenizer_1.model_max_length
 
-        prompt_embed, pooled_prompt_embed = _get_clip_prompt_embeds(
-            prompt=prompt_1,
-            num_images_per_prompt=num_images_per_prompt,
-            tokenizer=self._tokenizer_1,
-            text_encoder=self._text_encoder_1,
-            tokenizer_max_length=tokenizer_max_length,
-        )
+        with timer.time_section("clip_encoding") if timer else nullcontext():
+            prompt_embed, pooled_prompt_embed = _get_clip_prompt_embeds(
+                prompt=prompt_1,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_1,
+                text_encoder=self._text_encoder_1,
+                tokenizer_max_length=tokenizer_max_length,
+            )
 
-        prompt_2_embed, pooled_prompt_2_embed = _get_clip_prompt_embeds(
-            prompt=prompt_2,
-            num_images_per_prompt=num_images_per_prompt,
-            tokenizer=self._tokenizer_2,
-            text_encoder=self._text_encoder_2,
-            tokenizer_max_length=tokenizer_max_length,
-        )
-        clip_prompt_embeds = torch.cat([prompt_embed, prompt_2_embed], dim=-1)
-        t5_prompt_embed = _get_t5_prompt_embeds(
-            device=self.parallel_manager.submesh_devices[0],
-            prompt=prompt_3,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_t5_sequence_length,
-            tokenizer=self._tokenizer_3,
-            text_encoder=self._text_encoder_3,
-            tokenizer_max_length=tokenizer_max_length,
-            joint_attention_dim=self._joint_attention_dim,
-        )
+            prompt_2_embed, pooled_prompt_2_embed = _get_clip_prompt_embeds(
+                prompt=prompt_2,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_2,
+                text_encoder=self._text_encoder_2,
+                tokenizer_max_length=tokenizer_max_length,
+            )
+            clip_prompt_embeds = torch.cat([prompt_embed, prompt_2_embed], dim=-1)
+
+        with timer.time_section("t5_encoding") if timer else nullcontext():
+            t5_prompt_embed = _get_t5_prompt_embeds(
+                device=self.parallel_manager.submesh_devices[0],
+                prompt=prompt_3,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_t5_sequence_length,
+                tokenizer=self._tokenizer_3,
+                text_encoder=self._text_encoder_3,
+                tokenizer_max_length=tokenizer_max_length,
+                joint_attention_dim=self._joint_attention_dim,
+            )
+
         clip_prompt_embeds = torch.nn.functional.pad(
             clip_prompt_embeds,
             (0, t5_prompt_embed.shape[-1] - clip_prompt_embeds.shape[-1]),
@@ -607,31 +646,35 @@ class TtStableDiffusion3Pipeline:
         if not do_classifier_free_guidance:
             return prompt_embeds, pooled_prompt_embeds
 
-        negative_prompt_embed, negative_pooled_prompt_embed = _get_clip_prompt_embeds(
-            prompt=negative_prompt_1,
-            num_images_per_prompt=num_images_per_prompt,
-            tokenizer=self._tokenizer_1,
-            text_encoder=self._text_encoder_1,
-            tokenizer_max_length=tokenizer_max_length,
-        )
-        negative_prompt_2_embed, negative_pooled_prompt_2_embed = _get_clip_prompt_embeds(
-            prompt=negative_prompt_2,
-            num_images_per_prompt=num_images_per_prompt,
-            tokenizer=self._tokenizer_2,
-            text_encoder=self._text_encoder_2,
-            tokenizer_max_length=tokenizer_max_length,
-        )
-        negative_clip_prompt_embeds = torch.cat([negative_prompt_embed, negative_prompt_2_embed], dim=-1)
-        t5_negative_prompt_embed = _get_t5_prompt_embeds(
-            device=self.parallel_manager.submesh_devices[0],
-            prompt=negative_prompt_3,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_t5_sequence_length,
-            tokenizer=self._tokenizer_3,
-            text_encoder=self._text_encoder_3,
-            tokenizer_max_length=tokenizer_max_length,
-            joint_attention_dim=self._joint_attention_dim,
-        )
+        with timer.time_section("clip_encoding") if timer else nullcontext():
+            negative_prompt_embed, negative_pooled_prompt_embed = _get_clip_prompt_embeds(
+                prompt=negative_prompt_1,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_1,
+                text_encoder=self._text_encoder_1,
+                tokenizer_max_length=tokenizer_max_length,
+            )
+            negative_prompt_2_embed, negative_pooled_prompt_2_embed = _get_clip_prompt_embeds(
+                prompt=negative_prompt_2,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_2,
+                text_encoder=self._text_encoder_2,
+                tokenizer_max_length=tokenizer_max_length,
+            )
+            negative_clip_prompt_embeds = torch.cat([negative_prompt_embed, negative_prompt_2_embed], dim=-1)
+
+        with timer.time_section("t5_encoding") if timer else nullcontext():
+            t5_negative_prompt_embed = _get_t5_prompt_embeds(
+                device=self.parallel_manager.submesh_devices[0],
+                prompt=negative_prompt_3,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_t5_sequence_length,
+                tokenizer=self._tokenizer_3,
+                text_encoder=self._text_encoder_3,
+                tokenizer_max_length=tokenizer_max_length,
+                joint_attention_dim=self._joint_attention_dim,
+            )
+
         negative_clip_prompt_embeds = torch.nn.functional.pad(
             negative_clip_prompt_embeds,
             (


### PR DESCRIPTION
### What's changed
SD3.5 takes advantage of CFG parallelism, where two submeshes execute independent workloads on each step. In order to avoid any host overheads and to get these two submesh workloads to execute in parallel, we add tracing to the demo.

Depends on PR https://github.com/tenstorrent/tt-metal/pull/25887 which allows tracing `reduce_scatter_minimal_async` in this use case.
