### PR TITLE
build: automate tt_llk header discovery with globbing patterns

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -142,16 +142,6 @@ target_sources(
             ${TT_LLK_HEADERS}
 )
 
-# tt_llk targets (tt-llk::wormhole_b0 and tt-llk::blackhole) are provided by
-# tt_metal/third_party/tt_llk which is processed via add_subdirectory in the main CMakeLists.txt
-# Link tt_llk targets to jitapi
-target_link_libraries(
-    jitapi
-    INTERFACE
-        tt-llk::wormhole_b0
-        tt-llk::blackhole
-)
-
 target_link_libraries(
     tt_metal
     PUBLIC

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -65,7 +65,7 @@ set_target_properties(
 
 file(GLOB_RECURSE COMPUTE_KERNEL_API include/*)
 file(
-    GLOB_RECURSE TT_LLK_HEADERS 
+    GLOB_RECURSE TT_LLK_HEADERS
     third_party/tt_llk/tt_llk_wormhole_b0/**/*.h
     third_party/tt_llk/tt_llk_blackhole/**/*.h
 )

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -64,7 +64,8 @@ set_target_properties(
 )
 
 file(GLOB_RECURSE COMPUTE_KERNEL_API include/*)
-file(GLOB_RECURSE TT_LLK_HEADERS 
+file(
+    GLOB_RECURSE TT_LLK_HEADERS 
     third_party/tt_llk/tt_llk_wormhole_b0/**/*.h
     third_party/tt_llk/tt_llk_blackhole/**/*.h
 )

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -64,6 +64,11 @@ set_target_properties(
 )
 
 file(GLOB_RECURSE COMPUTE_KERNEL_API include/*)
+file(GLOB_RECURSE TT_LLK_HEADERS 
+    third_party/tt_llk/tt_llk_wormhole_b0/**/*.h
+    third_party/tt_llk/tt_llk_blackhole/**/*.h
+)
+
 target_sources(
     jitapi
     INTERFACE
@@ -113,177 +118,6 @@ target_sources(
             ${COMPUTE_KERNEL_API}
             soc_descriptors/blackhole_140_arch.yaml
             soc_descriptors/wormhole_b0_80_arch.yaml
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_addr_map.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_addrmod.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_debug.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_defs.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_globals.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_gpr_map.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_include.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_instr_params.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_main.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_ops.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_pcbuf.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_sfpi.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_sfpu.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_structs.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_template.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_xmov.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/cmath_common.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/cpack_common.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/cunpack_common.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cdf.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_converter.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_max_int32.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_mul_int.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_power.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sub_int.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_topk.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_defs.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_common.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpi.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
-            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_addr_map.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_addrmod.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_debug.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_globals.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_gpr_map.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_include.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_instr_params.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_main.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_ops.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_pcbuf.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_structs.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_template.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_xmov.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cdf.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_converter.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_mul_int.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_shift.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_topk.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpi.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
-            third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_untilize.h
             tools/profiler/kernel_profiler.hpp
             # Kernel sources
             impl/dispatch/kernels/cq_dispatch.cpp
@@ -305,6 +139,17 @@ target_sources(
             kernels/dataflow/writer_unary_1.cpp
             jit_build/genfiles.cpp
             jit_build/genfiles.hpp
+            ${TT_LLK_HEADERS}
+)
+
+# tt_llk targets (tt-llk::wormhole_b0 and tt-llk::blackhole) are provided by
+# tt_metal/third_party/tt_llk which is processed via add_subdirectory in the main CMakeLists.txt
+# Link tt_llk targets to jitapi
+target_link_libraries(
+    jitapi
+    INTERFACE
+        tt-llk::wormhole_b0
+        tt-llk::blackhole
 )
 
 target_link_libraries(


### PR DESCRIPTION
### Ticket
None

### Problem description
Our build system previously relied on manually maintaining a list of tt-llk header files that needed to be included in the metal build. Whenever a new header file was added to the tt-llk repository, developers had to explicitly update this list. If this step was forgotten, it resulted in build failures, creating unnecessary friction.

This manual approach does not scale well as the codebase grows, since it introduces a high risk of human error. It increases maintenance overhead whenever files are added, removed, or reorganized. On top of that, it slows down integration and development.

### What's changed
Replace manual header file lists with GLOB_RECURSE to automatically discover all headers in tt_llk architecture directories.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16355138336) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16355161892) CI with demo tests passes (if applicable)