### PR TITLE
Add support to fabric test infra for 6U 

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -605,6 +605,9 @@ struct SenderKernelTrafficConfig {
                 (uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
 
             if constexpr (!BENCHMARK_MODE) {
+                // avoid race condition where we update the ptrs but fabric write is not done yet.
+                noc_async_writes_flushed();
+
                 if (payload_size_bytes > 0 && payload_buffer_) {
                     payload_buffer_->advance();
                     update_header_for_next_packet();
@@ -633,10 +636,10 @@ struct SenderKernelTrafficConfig {
         fabric_connection_handle->send_payload_flush_non_blocking_from_address(
             (uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
 
-        // avoid race condition where we update the ptrs but fabric write is not done yet.
-        noc_async_write_barrier();
-
         if constexpr (!BENCHMARK_MODE) {
+            // avoid race condition where we update the ptrs but fabric write is not done yet.
+            noc_async_writes_flushed();
+
             if (payload_size_bytes > 0 && payload_buffer_) {
                 payload_buffer_->advance();
                 update_header_for_next_packet();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -633,6 +633,9 @@ struct SenderKernelTrafficConfig {
         fabric_connection_handle->send_payload_flush_non_blocking_from_address(
             (uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
 
+        // avoid race condition where we update the ptrs but fabric write is not done yet.
+        noc_async_write_barrier();
+
         if constexpr (!BENCHMARK_MODE) {
             if (payload_size_bytes > 0 && payload_buffer_) {
                 payload_buffer_->advance();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
@@ -5,18 +5,14 @@
 #include "debug/dprint.h"
 #include "tt_fabric_test_kernels_utils.hpp"
 
-constexpr uint32_t LOCAL_ARGS_BASE = get_compile_time_arg_val(0);
-constexpr uint32_t LOCAL_ARGS_SIZE = get_compile_time_arg_val(1);
-constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(2);
-constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(3);
+constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(0);
+constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(1);
 
 void kernel_main() {
-    // Initialize local args system with base address and buffer size
-    tt::tt_fabric::fabric_tests::init_local_args<LOCAL_ARGS_BASE, LOCAL_ARGS_SIZE>();
+    size_t rt_args_idx = 0;
 
     using ReceiverKernelConfig = tt::tt_fabric::fabric_tests::ReceiverKernelConfig<NUM_TRAFFIC_CONFIGS>;
 
-    size_t rt_args_idx = 0;
     auto receiver_config = ReceiverKernelConfig::build_from_args(rt_args_idx);
 
     // Clear test results area and mark as started

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
@@ -5,10 +5,15 @@
 #include "debug/dprint.h"
 #include "tt_fabric_test_kernels_utils.hpp"
 
-constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(0);
-constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(1);
+constexpr uint32_t LOCAL_ARGS_BASE = get_compile_time_arg_val(0);
+constexpr uint32_t LOCAL_ARGS_SIZE = get_compile_time_arg_val(1);
+constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(2);
+constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(3);
 
 void kernel_main() {
+    // Initialize local args system with base address and buffer size
+    tt::tt_fabric::fabric_tests::init_local_args<LOCAL_ARGS_BASE, LOCAL_ARGS_SIZE>();
+
     using ReceiverKernelConfig = tt::tt_fabric::fabric_tests::ReceiverKernelConfig<NUM_TRAFFIC_CONFIGS>;
 
     size_t rt_args_idx = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -4,15 +4,13 @@
 
 #include "tt_fabric_test_kernels_utils.hpp"
 
-constexpr uint32_t LOCAL_ARGS_BASE = get_compile_time_arg_val(0);
-constexpr uint32_t LOCAL_ARGS_SIZE = get_compile_time_arg_val(1);
-constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(2);
-constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(3);
-constexpr uint8_t NUM_FABRIC_CONNECTIONS = get_compile_time_arg_val(4);
-constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(5);
-constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(6);
-constexpr bool LINE_SYNC = get_compile_time_arg_val(7);
-constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(8);
+constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(0);
+constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(1);
+constexpr uint8_t NUM_FABRIC_CONNECTIONS = get_compile_time_arg_val(2);
+constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(3);
+constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(4);
+constexpr bool LINE_SYNC = get_compile_time_arg_val(5);
+constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(6);
 
 using SenderKernelConfig = tt::tt_fabric::fabric_tests::SenderKernelConfig<
     NUM_FABRIC_CONNECTIONS,
@@ -23,9 +21,6 @@ using SenderKernelConfig = tt::tt_fabric::fabric_tests::SenderKernelConfig<
     NUM_LOCAL_SYNC_CORES>;
 
 void kernel_main() {
-    // Initialize local args system with base address and buffer size
-    tt::tt_fabric::fabric_tests::init_local_args<LOCAL_ARGS_BASE, LOCAL_ARGS_SIZE>();
-
     size_t rt_args_idx = 0;
     auto sender_config = SenderKernelConfig::build_from_args(rt_args_idx);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -4,13 +4,15 @@
 
 #include "tt_fabric_test_kernels_utils.hpp"
 
-constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(0);
-constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(1);
-constexpr uint8_t NUM_FABRIC_CONNECTIONS = get_compile_time_arg_val(2);
-constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(3);
-constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(4);
-constexpr bool LINE_SYNC = get_compile_time_arg_val(5);
-constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(6);
+constexpr uint32_t LOCAL_ARGS_BASE = get_compile_time_arg_val(0);
+constexpr uint32_t LOCAL_ARGS_SIZE = get_compile_time_arg_val(1);
+constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(2);
+constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(3);
+constexpr uint8_t NUM_FABRIC_CONNECTIONS = get_compile_time_arg_val(4);
+constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(5);
+constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(6);
+constexpr bool LINE_SYNC = get_compile_time_arg_val(7);
+constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(8);
 
 using SenderKernelConfig = tt::tt_fabric::fabric_tests::SenderKernelConfig<
     NUM_FABRIC_CONNECTIONS,
@@ -21,6 +23,9 @@ using SenderKernelConfig = tt::tt_fabric::fabric_tests::SenderKernelConfig<
     NUM_LOCAL_SYNC_CORES>;
 
 void kernel_main() {
+    // Initialize local args system with base address and buffer size
+    tt::tt_fabric::fabric_tests::init_local_args<LOCAL_ARGS_BASE, LOCAL_ARGS_SIZE>();
+
     size_t rt_args_idx = 0;
     auto sender_config = SenderKernelConfig::build_from_args(rt_args_idx);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
@@ -4,20 +4,15 @@
 
 #include "tt_fabric_test_kernels_utils.hpp"
 
-constexpr uint32_t LOCAL_ARGS_BASE = get_compile_time_arg_val(0);
-constexpr uint32_t LOCAL_ARGS_SIZE = get_compile_time_arg_val(1);
-constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(2);
-constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(3);
-constexpr uint8_t NUM_SYNC_FABRIC_CONNECTIONS = get_compile_time_arg_val(4);
-constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(5);
+constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(0);
+constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(1);
+constexpr uint8_t NUM_SYNC_FABRIC_CONNECTIONS = get_compile_time_arg_val(2);
+constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(3);
 
 using SyncKernelConfig = tt::tt_fabric::fabric_tests::
     SyncKernelConfig<NUM_SYNC_FABRIC_CONNECTIONS, IS_2D_FABRIC, USE_DYNAMIC_ROUTING, NUM_LOCAL_SYNC_CORES>;
 
 void kernel_main() {
-    // Initialize local args system with base address and buffer size
-    tt::tt_fabric::fabric_tests::init_local_args<LOCAL_ARGS_BASE, LOCAL_ARGS_SIZE>();
-
     size_t rt_args_idx = 0;
     auto sync_config = SyncKernelConfig::build_from_args(rt_args_idx);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
@@ -21,11 +21,22 @@ void kernel_main() {
         sync_config.get_result_buffer_address(), sync_config.get_result_buffer_size());
     tt::tt_fabric::fabric_tests::write_test_status(sync_config.get_result_buffer_address(), TT_FABRIC_STATUS_STARTED);
 
-    // Perform global sync (master sync core)
-    sync_config.global_sync();
+    // Perform global sync (master sync core) for start of sync
+    uint8_t local_sync_iter = 0, global_sync_iter = 0;
+    sync_config.global_sync(global_sync_iter++);
 
-    // Perform local sync
-    sync_config.local_sync();
+    // Perform local sync for start of sync
+    sync_config.local_sync(local_sync_iter++);
+
+    // Perform local sync for end of sync
+    // first sync tells sync core to start global sync, second sync is waiting for global sync done
+    sync_config.local_sync(local_sync_iter++);
+
+    // Perform global sync (master sync core) for end of sync
+    sync_config.global_sync(global_sync_iter++);
+
+    // Perform local sync for end of sync
+    sync_config.local_sync(local_sync_iter++);
 
     // Mark test as passed. TODO: might need a local sync after all test done (TBD).
     tt::tt_fabric::fabric_tests::write_test_status(sync_config.get_result_buffer_address(), TT_FABRIC_STATUS_PASS);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
@@ -4,15 +4,20 @@
 
 #include "tt_fabric_test_kernels_utils.hpp"
 
-constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(0);
-constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(1);
-constexpr uint8_t NUM_SYNC_FABRIC_CONNECTIONS = get_compile_time_arg_val(2);
-constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(3);
+constexpr uint32_t LOCAL_ARGS_BASE = get_compile_time_arg_val(0);
+constexpr uint32_t LOCAL_ARGS_SIZE = get_compile_time_arg_val(1);
+constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(2);
+constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(3);
+constexpr uint8_t NUM_SYNC_FABRIC_CONNECTIONS = get_compile_time_arg_val(4);
+constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(5);
 
 using SyncKernelConfig = tt::tt_fabric::fabric_tests::
     SyncKernelConfig<NUM_SYNC_FABRIC_CONNECTIONS, IS_2D_FABRIC, USE_DYNAMIC_ROUTING, NUM_LOCAL_SYNC_CORES>;
 
 void kernel_main() {
+    // Initialize local args system with base address and buffer size
+    tt::tt_fabric::fabric_tests::init_local_args<LOCAL_ARGS_BASE, LOCAL_ARGS_SIZE>();
+
     size_t rt_args_idx = 0;
     auto sync_config = SyncKernelConfig::build_from_args(rt_args_idx);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
@@ -3,6 +3,9 @@ Tests:
     fabric_setup:
       topology: Linear
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -16,6 +19,9 @@ Tests:
     fabric_setup:
       topology: Linear
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -28,6 +34,9 @@ Tests:
   - name: "SingleSenderLinearUnicastAllDevices"
     fabric_setup:
       topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
 
     defaults:
       ftype: unicast
@@ -58,6 +67,9 @@ Tests:
     fabric_setup:
       topology: Ring
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -70,6 +82,10 @@ Tests:
   - name: "HalfRingMulticast"
     fabric_setup:
       topology: Ring
+      num_links: 1
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
 
     defaults:
       ftype: mcast
@@ -83,6 +99,8 @@ Tests:
   - name: "MeshMulticast"
     fabric_setup:
       topology: Mesh
+      # more links caused rt args exceed 256
+      num_links: 1
 
     defaults:
       ftype: mcast
@@ -97,6 +115,8 @@ Tests:
     fabric_setup:
       topology: Mesh
       routing_type: Dynamic
+      # more links caused rt args exceed 256
+      num_links: 1
 
     defaults:
       ftype: mcast
@@ -110,6 +130,9 @@ Tests:
   - name: "SingleSenderMeshUnicastAllDevices"
     fabric_setup:
       topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
 
     defaults:
       ftype: unicast

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k_ubench.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k_ubench.yaml
@@ -5,6 +5,9 @@ Tests:
     fabric_setup:
       topology: Linear
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -20,6 +23,9 @@ Tests:
     fabric_setup:
       topology: Linear
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -34,6 +40,9 @@ Tests:
     sync: true
     fabric_setup:
       topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
 
     defaults:
       ftype: unicast
@@ -65,6 +74,9 @@ Tests:
     fabric_setup:
       topology: Ring
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -80,6 +92,9 @@ Tests:
     fabric_setup:
       topology: Ring
 
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -94,6 +109,8 @@ Tests:
     sync: true
     fabric_setup:
       topology: Mesh
+      # more links caused rt args exceed 256
+      num_links: 1
 
     defaults:
       ftype: mcast
@@ -110,6 +127,8 @@ Tests:
     fabric_setup:
       topology: Mesh
       routing_type: Dynamic
+      # more links caused rt args exceed 256
+      num_links: 1
 
     defaults:
       ftype: mcast
@@ -125,6 +144,9 @@ Tests:
     sync: true
     fabric_setup:
       topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
 
     defaults:
       ftype: unicast

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -28,6 +28,8 @@ const std::unordered_map<std::pair<Topology, RoutingType>, FabricConfig, tt::tt_
 };
 
 int main(int argc, char** argv) {
+    log_info(tt::LogTest, "Starting Test");
+
     std::vector<std::string> input_args(argv, argv + argc);
 
     auto fixture = std::make_shared<TestFixture>();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
@@ -394,6 +394,15 @@ public:
 
 private:
     TestDeviceResources& get_or_create_device_resources(const FabricNodeId& node_id);
+    void allocate_link_group(
+        std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>>& group_patterns,
+        uint32_t link_id);
+    void allocate_multicast_patterns_uniform(
+        std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>>& multicast_patterns,
+        uint32_t link_id);
+    void allocate_unicast_patterns(
+        std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>>& unicast_patterns,
+        uint32_t link_id);
 
     const IDeviceInfoProvider& device_info_provider_;
     const IRouteManager& route_manager_;
@@ -467,10 +476,15 @@ inline void GlobalAllocator::allocate_resources(TestConfig& test_config) {
 
     // PASS 2: Allocate receivers and their memory. Now that all senders are known, the
     // remaining pristine cores on all devices can form the receiver pool.
+
+    // Group ALL patterns by link ID for separate allocation (both unicast and multicast), we dont need to have a
+    // uniform address space allocated to all links, since each link works indepedently.
+    std::map<uint32_t, std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>>> link_groups;
     for (auto& sender : test_config.senders) {
         for (auto& pattern : sender.patterns) {
             auto& dest = pattern.destination.value();
 
+            // skip the current pattern since address has been assigned
             if (dest.core.has_value() && dest.target_address.has_value() &&
                 ((pattern.ntype.value() != NocSendType::NOC_UNICAST_ATOMIC_INC &&
                   pattern.ntype.value() != NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC) ||
@@ -482,15 +496,11 @@ inline void GlobalAllocator::allocate_resources(TestConfig& test_config) {
                 continue;
             }
 
-            if (pattern.ftype.value() == ChipSendType::CHIP_MULTICAST) {
-                std::vector<FabricNodeId> dst_node_ids;
-                if (dest.hops.has_value()) {
-                    dst_node_ids = route_manager_.get_dst_node_ids_from_hops(
-                        sender.device, dest.hops.value(), pattern.ftype.value());
-                } else {
-                    TT_FATAL(dest.device.has_value(), "Multicast destination requires hops");
-                    dst_node_ids.push_back(dest.device.value());
-                }
+            // Group ALL patterns by link_id (both unicast and multicast)
+            uint32_t link_id = sender.link_id.value_or(0);
+            link_groups[link_id].emplace_back(&sender, &pattern, &dest);
+        }
+    }
 
                 uint32_t chunk_size = policies_.default_payload_chunk_size;
                 TT_FATAL(
@@ -499,31 +509,32 @@ inline void GlobalAllocator::allocate_resources(TestConfig& test_config) {
                     pattern.size.value(),
                     chunk_size);
 
-                // Use histogram analysis to find uniform receiver core and memory address
-                std::map<CoreCoord, uint32_t> core_counts;
-                std::map<CoreCoord, std::map<uint32_t, uint32_t>> memory_histograms;
+inline void GlobalAllocator::allocate_link_group(
+    std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>>& group_patterns,
+    uint32_t link_id) {
+    // Separate unicast and multicast patterns within this link group
+    std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>> multicast_patterns;
+    std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>> unicast_patterns;
 
-                // Build histograms for all destination devices
-                for (const auto& device_id : dst_node_ids) {
-                    auto& device_resources = get_or_create_device_resources(device_id);
+    for (auto& pattern_tuple : group_patterns) {
+        auto& pattern = *std::get<1>(pattern_tuple);
+        if (pattern.ftype.value() == ChipSendType::CHIP_MULTICAST) {
+            multicast_patterns.push_back(pattern_tuple);
+        } else {
+            unicast_patterns.push_back(pattern_tuple);
+        }
+    }
 
-                    const auto& receiver_pool = device_resources.core_pools_[RECEIVER_TYPE_IDX];
-                    if (!receiver_pool.initialized) {
-                        device_resources.initialize_receiver_pool();
-                    }
+    // Allocate multicast patterns with uniform allocation
+    if (!multicast_patterns.empty()) {
+        allocate_multicast_patterns_uniform(multicast_patterns, link_id);
+    }
 
-                    const auto available_cores = receiver_pool.get_available_cores(device_resources.core_workload_);
-                    for (const auto& core : available_cores) {
-                        core_counts[core]++;
-                        auto& core_resources = device_resources.get_or_create_core_resources(core, CoreType::RECEIVER);
-                        if (core_resources.has_available_payload_chunk()) {
-                            const auto& available_chunks = core_resources.get_available_payload_chunks();
-                            for (auto addr : available_chunks) {
-                                memory_histograms[core][addr]++;
-                            }
-                        }
-                    }
-                }
+    // Allocate unicast patterns individually
+    if (!unicast_patterns.empty()) {
+        allocate_unicast_patterns(unicast_patterns, link_id);
+    }
+}
 
                 std::optional<std::pair<CoreCoord, uint32_t>> uniform_receiver = std::nullopt;
                 for (const auto& [core, device_count] : core_counts) {
@@ -541,70 +552,167 @@ inline void GlobalAllocator::allocate_resources(TestConfig& test_config) {
                     }
                 }
 
-                if (!uniform_receiver.has_value()) {
-                    TT_THROW("Could not find a uniform core and memory address for multicast pattern.");
-                }
+    std::vector<FabricNodeId> dst_node_ids(unique_destinations.begin(), unique_destinations.end());
 
-                dest.core = uniform_receiver->first;
-                if (pattern.ntype.value() == NocSendType::NOC_UNICAST_WRITE) {
-                    dest.target_address = uniform_receiver->second;
-                } else {
-                    TT_THROW("Multicast atomic/fused atomic not supported yet");
-                }
+    uint32_t chunk_size = policies_.default_payload_chunk_size.value_or(detail::DEFAULT_PAYLOAD_CHUNK_SIZE_BYTES);
 
-                // Reserve resources on all destination devices
-                for (const auto& node_id : dst_node_ids) {
-                    auto& device_resources = get_or_create_device_resources(node_id);
-                    device_resources.reserve_receiver_core(dest.core);
-                    auto& core_resources =
-                        device_resources.get_or_create_core_resources(dest.core.value(), CoreType::RECEIVER);
-                    if (pattern.ntype.value() == NocSendType::NOC_UNICAST_ATOMIC_INC ||
-                        pattern.ntype.value() == NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC) {
-                        // TODO: need to allocate from a separate pool?
-                        TT_THROW("Multicast atomic/fused atomic not supported yet");
-                    } else {
-                        core_resources.reserve_payload_chunk(dest.target_address.value());
-                    }
-                }
-            } else {  // Unicast
-                TT_FATAL(dest.device.has_value(), "Unicast destination requires a device ID.");
-                auto& device_resources = get_or_create_device_resources(dest.device.value());
+    // Validate payload sizes for this group
+    for (auto& [sender_ptr, pattern_ptr, dest_ptr] : multicast_patterns) {
+        auto& pattern = *pattern_ptr;
+        TT_FATAL(
+            pattern.size.value() <= chunk_size,
+            "Requested payload size {} exceeds the per-worker buffer chunk size of {}",
+            pattern.size.value(),
+            chunk_size);
+    }
 
-                if (!dest.core.has_value()) {
-                    dest.core = device_resources.reserve_receiver_core(std::nullopt);
-                } else {
-                    device_resources.reserve_receiver_core(dest.core);
-                }
+    // Use histogram analysis to find uniform receiver core and memory address for this link group
+    std::map<CoreCoord, uint32_t> core_counts;
+    std::map<CoreCoord, std::map<uint32_t, uint32_t>> memory_histograms;
 
-                auto& core_resources =
-                    device_resources.get_or_create_core_resources(dest.core.value(), CoreType::RECEIVER);
+    // Build histograms for all destination devices in this link group
+    for (const auto& device_id : dst_node_ids) {
+        auto& device_resources = get_or_create_device_resources(device_id);
 
-                bool allocate_write_address = true;
-                bool allocate_atomic_inc_address = true;
-                if (pattern.ntype.value() == NocSendType::NOC_UNICAST_WRITE) {
-                    allocate_atomic_inc_address = false;
-                } else if (pattern.ntype.value() == NocSendType::NOC_UNICAST_ATOMIC_INC) {
-                    allocate_write_address = false;
-                }
+        const auto& receiver_pool = device_resources.core_pools_[RECEIVER_TYPE_IDX];
+        if (!receiver_pool.initialized) {
+            device_resources.initialize_receiver_pool();
+        }
 
-                if (allocate_write_address) {
-                    TT_FATAL(
-                        pattern.size.value() <= core_resources.payload_chunk_size,
-                        "Requested payload size {} exceeds the per-worker buffer chunk size of {}",
-                        pattern.size.value(),
-                        core_resources.payload_chunk_size);
-                    if (!core_resources.has_available_payload_chunk()) {
-                        TT_THROW(
-                            "No payload buffer chunk available on device {} core {} for allocation.",
-                            dest.device.value(),
-                            dest.core.value());
-                    }
-                    dest.target_address = core_resources.allocate_payload_chunk();
-                }
-                if (allocate_atomic_inc_address) {
-                    dest.atomic_inc_address = core_resources.allocate_atomic_counter();
+        const auto available_cores = receiver_pool.get_available_cores(device_resources.core_workload_);
+
+        for (const auto& core : available_cores) {
+            core_counts[core]++;
+            auto& core_resources = device_resources.get_or_create_core_resources(core, CoreType::RECEIVER);
+            if (core_resources.has_available_payload_chunk()) {
+                const auto& available_chunks = core_resources.get_available_payload_chunks();
+                for (auto addr : available_chunks) {
+                    memory_histograms[core][addr]++;
                 }
             }
+        }
+    }
+
+    // Helper lambda to check if a core has uniform memory addresses
+    auto has_uniform_address = [&](const CoreCoord& core) -> bool {
+        const auto& address_histogram = memory_histograms[core];
+        for (const auto& [addr, addr_count] : address_histogram) {
+            if (addr_count == dst_node_ids.size()) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Find the best core that has uniform memory addresses available for this link group
+    std::optional<CoreCoord> best_core = std::nullopt;
+    uint32_t max_count = 0;
+
+    for (const auto& [core, count] : core_counts) {
+        // Only consider cores with uniform addresses
+        if (!has_uniform_address(core)) {
+            continue;
+        }
+
+        // Among cores with uniform addresses, pick the one available on most devices
+        if (count > max_count) {
+            max_count = count;
+            best_core = core;
+
+            // Early exit if we found the theoretical maximum (available on ALL devices)
+            if (count == dst_node_ids.size()) {
+                break;
+            }
+        }
+    }
+
+    std::optional<std::pair<CoreCoord, uint32_t>> uniform_receiver = std::nullopt;
+    if (best_core.has_value()) {
+        const auto& address_histogram = memory_histograms[best_core.value()];
+        for (const auto& [addr, count] : address_histogram) {
+            if (count == dst_node_ids.size()) {
+                uniform_receiver = std::make_pair(best_core.value(), addr);
+                break;
+            }
+        }
+    }
+
+    if (!uniform_receiver.has_value()) {
+        TT_THROW("Could not find a uniform core and memory address for multicast patterns in link group {}.", link_id);
+    }
+
+    // Apply the uniform allocation to all multicast patterns in this link group
+    for (auto& [sender_ptr, pattern_ptr, dest_ptr] : multicast_patterns) {
+        auto& pattern = *pattern_ptr;
+        auto& dest = *dest_ptr;
+
+        dest.core = uniform_receiver->first;
+        if (pattern.ntype.value() == NocSendType::NOC_UNICAST_WRITE) {
+            dest.target_address = uniform_receiver->second;
+        } else {
+            TT_THROW("Multicast atomic/fused atomic not supported yet");
+        }
+    }
+
+    // Reserve resources on all destination devices for this link group
+    for (const auto& node_id : dst_node_ids) {
+        auto& device_resources = get_or_create_device_resources(node_id);
+        device_resources.reserve_receiver_core(uniform_receiver->first);
+        auto& core_resources =
+            device_resources.get_or_create_core_resources(uniform_receiver->first, CoreType::RECEIVER);
+        if (std::get<1>(multicast_patterns[0])->ntype.value() == NocSendType::NOC_UNICAST_ATOMIC_INC ||
+            std::get<1>(multicast_patterns[0])->ntype.value() == NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC) {
+            // TODO: need to allocate from a separate pool?
+            TT_THROW("Multicast atomic/fused atomic not supported yet");
+        } else {
+            core_resources.reserve_payload_chunk(uniform_receiver->second);
+        }
+    }
+}
+
+inline void GlobalAllocator::allocate_unicast_patterns(
+    std::vector<std::tuple<SenderConfig*, TrafficPatternConfig*, DestinationConfig*>>& unicast_patterns,
+    uint32_t link_id) {
+    for (auto& [sender_ptr, pattern_ptr, dest_ptr] : unicast_patterns) {
+        auto& sender = *sender_ptr;
+        auto& pattern = *pattern_ptr;
+        auto& dest = *dest_ptr;
+
+        TT_FATAL(dest.device.has_value(), "Unicast destination requires a device ID.");
+        auto& device_resources = get_or_create_device_resources(dest.device.value());
+
+        if (!dest.core.has_value()) {
+            dest.core = device_resources.reserve_receiver_core(std::nullopt);
+        } else {
+            device_resources.reserve_receiver_core(dest.core);
+        }
+
+        auto& core_resources = device_resources.get_or_create_core_resources(dest.core.value(), CoreType::RECEIVER);
+
+        bool allocate_write_address = true;
+        bool allocate_atomic_inc_address = true;
+        if (pattern.ntype.value() == NocSendType::NOC_UNICAST_WRITE) {
+            allocate_atomic_inc_address = false;
+        } else if (pattern.ntype.value() == NocSendType::NOC_UNICAST_ATOMIC_INC) {
+            allocate_write_address = false;
+        }
+
+        if (allocate_write_address) {
+            TT_FATAL(
+                pattern.size.value() <= core_resources.payload_chunk_size,
+                "Requested payload size {} exceeds the per-worker buffer chunk size of {}",
+                pattern.size.value(),
+                core_resources.payload_chunk_size);
+            if (!core_resources.has_available_payload_chunk()) {
+                TT_THROW(
+                    "No payload buffer chunk available on device {} core {} for allocation.",
+                    dest.device.value(),
+                    dest.core.value());
+            }
+            dest.target_address = core_resources.allocate_payload_chunk();
+        }
+        if (allocate_atomic_inc_address) {
+            dest.atomic_inc_address = core_resources.allocate_atomic_counter();
         }
     }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -331,21 +331,17 @@ public:
     }
 
     // Local runtime args function - writes args to local args buffer instead of using SetRuntimeArgs
-    void set_local_runtime_args(
+    void write_data_to_core(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const CoreCoord& core,
         uint32_t local_args_address,
         const std::vector<uint32_t>& args) const override {
-        auto mesh_buffer = create_mesh_buffer_helper(cores, local_args_address, args.size() * sizeof(uint32_t));
+        auto mesh_buffer = create_mesh_buffer_helper({core}, local_args_address, args.size() * sizeof(uint32_t));
 
-        const auto total_size = args.size() * sizeof(uint32_t) * cores.size();
+        const auto total_size = args.size() * sizeof(uint32_t);
         std::vector<uint32_t> all_args_buffer;
         all_args_buffer.reserve(total_size / sizeof(uint32_t));
-
-        // Replicate args for each core
-        for (size_t core_idx = 0; core_idx < cores.size(); ++core_idx) {
-            all_args_buffer.insert(all_args_buffer.end(), args.begin(), args.end());
-        }
+        all_args_buffer.insert(all_args_buffer.end(), args.begin(), args.end());
 
         tt::tt_metal::distributed::WriteShard(
             mesh_device_->mesh_command_queue(), mesh_buffer, all_args_buffer, device_coord, true);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -53,6 +53,7 @@ struct ParsedSenderConfig {
     DeviceIdentifier device = FabricNodeId(MeshId{0}, 0);
     std::optional<CoreCoord> core;
     std::vector<ParsedTrafficPatternConfig> patterns;
+    std::optional<uint32_t> link_id;  // Link ID for multi-link tests
 };
 
 // Resolved structures (after resolution) - use FabricNodeId
@@ -79,6 +80,7 @@ struct SenderConfig {
     FabricNodeId device = FabricNodeId(MeshId{0}, 0);
     std::optional<CoreCoord> core;
     std::vector<TrafficPatternConfig> patterns;
+    std::optional<uint32_t> link_id;  // Link ID for multi-link tests
 };
 
 enum class RoutingType {
@@ -98,6 +100,7 @@ enum class HighLevelTrafficPattern {
 struct TestFabricSetup {
     tt::tt_fabric::Topology topology;
     std::optional<RoutingType> routing_type;
+    uint32_t num_links;
 };
 
 struct HighLevelPatternConfig {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -523,6 +523,12 @@ inline TestFabricSetup YamlConfigParser::parse_fabric_setup(const YAML::Node& fa
         fabric_setup.routing_type = RoutingType::LowLatency;
     }
 
+    if (fabric_setup_yaml["num_links"]) {
+        fabric_setup.num_links = parse_scalar<uint32_t>(fabric_setup_yaml["num_links"]);
+    } else {
+        fabric_setup.num_links = 1;
+    }
+
     return fabric_setup;
 }
 
@@ -793,7 +799,7 @@ inline ParametrizationOptionsMap YamlConfigParser::parse_parametrization_params(
 
         if (key == "ftype" || key == "ntype") {
             options[key] = parse_scalar_sequence<std::string>(node);
-        } else if (key == "size" || key == "num_packets") {
+        } else if (key == "size" || key == "num_packets" || key == "num_links") {
             options[key] = parse_scalar_sequence<uint32_t>(node);
         } else {
             TT_THROW("Unsupported parametrization parameter: {}", key);
@@ -878,6 +884,7 @@ private:
         SenderConfig resolved_sender;
         resolved_sender.device = resolve_device_identifier(parsed_sender.device, device_info_provider_);
         resolved_sender.core = parsed_sender.core;
+        resolved_sender.link_id = parsed_sender.link_id;  // Transfer link ID
 
         resolved_sender.patterns.reserve(parsed_sender.patterns.size());
         for (const auto& parsed_pattern : parsed_sender.patterns) {
@@ -973,6 +980,12 @@ private:
                 }
             }
 
+            // After patterns are expanded, duplicate senders for different links if specified
+            if (!expand_link_duplicates(iteration_test)) {
+                // Test was skipped due to insufficient routing planes, continue to next iteration
+                continue;
+            }
+
             // After patterns are expanded, resolve any missing params based on policy
             resolve_missing_params(iteration_test);
 
@@ -1014,6 +1027,8 @@ private:
                         for (const auto& value : values) {
                             next_level_configs.emplace_back(current_config);
                             auto& next_config = next_level_configs.back();
+                            // Explicitly preserve benchmark_mode
+                            next_config.benchmark_mode = current_config.benchmark_mode;
                             // Use optimized string concatenation utility
                             detail::append_with_separator(next_config.name, "_", param_name, value);
 
@@ -1033,17 +1048,22 @@ private:
                         for (const auto& value : values) {
                             next_level_configs.emplace_back(current_config);
                             auto& next_config = next_level_configs.back();
-                            // Use optimized string concatenation utility
-                            detail::append_with_separator(next_config.name, "_", param_name, value);
+                            // Explicitly preserve benchmark_mode
+                            next_config.benchmark_mode = current_config.benchmark_mode;
 
-                            ParsedTrafficPatternConfig param_default;
-                            if (param_name == "size") {
-                                param_default.size = value;
-                            } else if (param_name == "num_packets") {
-                                param_default.num_packets = value;
+                            if (param_name == "num_links") {
+                                // num_links is part of fabric_setup, not traffic pattern defaults
+                                next_config.fabric_setup.num_links = value;
+                            } else {
+                                ParsedTrafficPatternConfig param_default;
+                                if (param_name == "size") {
+                                    param_default.size = value;
+                                } else if (param_name == "num_packets") {
+                                    param_default.num_packets = value;
+                                }
+                                next_config.defaults = merge_patterns(
+                                    current_config.defaults.value_or(ParsedTrafficPatternConfig{}), param_default);
                             }
-                            next_config.defaults = merge_patterns(
-                                current_config.defaults.value_or(ParsedTrafficPatternConfig{}), param_default);
                         }
                     }
                 }
@@ -1500,6 +1520,48 @@ private:
         }
     }
 
+    bool expand_link_duplicates(ParsedTestConfig& test) {
+        // If num_links is 1, no duplication needed
+        if (test.fabric_setup.num_links <= 1) {
+            return true;  // Success - no expansion needed
+        }
+
+        uint32_t num_links = test.fabric_setup.num_links;
+        log_info(LogTest, "Expanding link duplicates for test '{}' with {} links", test.name, num_links);
+
+        // Validate that num_links doesn't exceed available routing planes for any device
+        std::vector<FabricNodeId> devices = device_info_provider_.get_all_node_ids();
+        for (const auto& device : devices) {
+            uint32_t max_routing_planes = route_manager_.get_max_routing_planes_for_device(device);
+            if (num_links > max_routing_planes) {
+                log_warning(
+                    LogTest,
+                    "Skipping test '{}': Requested num_links ({}) exceeds maximum available routing planes ({}) for "
+                    "device {}. "
+                    "Please reduce num_links or check your fabric configuration.",
+                    test.name,
+                    num_links,
+                    max_routing_planes,
+                    device.chip_id);
+                return false;  // Indicate test should be skipped
+            }
+        }
+
+        std::vector<ParsedSenderConfig> new_senders;
+        new_senders.reserve(test.senders.size() * num_links);
+
+        for (const auto& sender : test.senders) {
+            for (uint32_t link_id = 0; link_id < num_links; ++link_id) {
+                ParsedSenderConfig duplicated_sender = sender;
+                duplicated_sender.link_id = link_id;  // Assign link ID
+                new_senders.push_back(duplicated_sender);
+            }
+        }
+
+        test.senders = std::move(new_senders);
+        return true;  // Success
+    }
+
     void resolve_missing_params(ParsedTestConfig& test) {
         if (test.on_missing_param_policy.has_value() && test.on_missing_param_policy.value() == "randomize") {
             for (auto& sender : test.senders) {
@@ -1730,6 +1792,11 @@ private:
             out << YAML::Key << "core";
             out << YAML::Value;
             to_yaml(out, config.core.value());
+        }
+
+        if (config.link_id) {
+            out << YAML::Key << "link_id";
+            out << YAML::Value << config.link_id.value();
         }
 
         out << YAML::Key << "patterns";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -1314,7 +1314,6 @@ private:
         TT_FATAL(!devices.empty(), "Cannot expand full_or_half_ring_multicast because no devices were found.");
 
         bool wrap_around_mesh = this->route_manager_.wrap_around_mesh(devices.front());
-        log_info(LogTest, "wrap_around_mesh {}", wrap_around_mesh);
 
         std::unordered_map<RoutingDirection, uint32_t> hops;
         for (const auto& src_node : devices) {
@@ -1424,8 +1423,6 @@ private:
         auto [multi_directional_hops, global_sync_val] =
             this->route_manager_.get_sync_hops_and_val(src_device, devices);
 
-        log_info(tt::LogTest, "src_device: {} multi_directional_hops: {}, ", src_device, multi_directional_hops);
-
         // Split multi-directional hops into single-direction patterns
         auto split_hops_vec = this->route_manager_.split_multicast_hops(multi_directional_hops);
 
@@ -1530,21 +1527,8 @@ private:
         log_info(LogTest, "Expanding link duplicates for test '{}' with {} links", test.name, num_links);
 
         // Validate that num_links doesn't exceed available routing planes for any device
-        std::vector<FabricNodeId> devices = device_info_provider_.get_all_node_ids();
-        for (const auto& device : devices) {
-            uint32_t max_routing_planes = route_manager_.get_max_routing_planes_for_device(device);
-            if (num_links > max_routing_planes) {
-                log_warning(
-                    LogTest,
-                    "Skipping test '{}': Requested num_links ({}) exceeds maximum available routing planes ({}) for "
-                    "device {}. "
-                    "Please reduce num_links or check your fabric configuration.",
-                    test.name,
-                    num_links,
-                    max_routing_planes,
-                    device.chip_id);
-                return false;  // Indicate test should be skipped
-            }
+        if (!route_manager_.validate_num_links_supported(num_links)) {
+            return false;  // Indicate test should be skipped
         }
 
         std::vector<ParsedSenderConfig> new_senders;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -535,8 +535,19 @@ private:
                 continue;
             }
 
-            // Use the shared ring traversal helper from fixture
-            auto ring_path = fixture_->trace_wrap_around_mesh_ring_path(src_node_id, initial_direction, hop_count);
+            // Use the appropriate ring traversal helper based on mesh type
+            std::vector<std::pair<FabricNodeId, RoutingDirection>> ring_path;
+
+            // Check if this is a wrap-around mesh
+            bool is_wrap_around = fixture_->wrap_around_mesh(src_node_id);
+
+            if (is_wrap_around) {
+                // Use the existing wrap-around mesh logic
+                ring_path = fixture_->trace_wrap_around_mesh_ring_path(src_node_id, initial_direction, hop_count);
+            } else {
+                // Use the new non wrap-around mesh logic
+                ring_path = fixture_->trace_non_wrap_around_mesh_ring_path(src_node_id, initial_direction, hop_count);
+            }
 
             // Count traffic at each device boundary
             // ring_path contains (destination_node, direction_to_reach_it)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -555,7 +555,7 @@ private:
                 ring_path = fixture_->trace_wrap_around_mesh_ring_path(src_node_id, initial_direction, hop_count);
             } else {
                 // Use the new non wrap-around mesh logic
-                ring_path = fixture_->trace_non_wrap_around_mesh_ring_path(src_node_id, initial_direction, hop_count);
+                ring_path = fixture_->trace_ring_path(src_node_id, initial_direction, hop_count);
             }
 
             // Count traffic at each device boundary
@@ -700,23 +700,6 @@ private:
                             link_id);
                     }
                     device_direction_cycles_[device_node_id][direction][link_id] = core_cycles;
-                }
-            }
-        }
-
-        // Print direction-based results
-        log_debug(tt::LogTest, "Performance profiling by direction and link:");
-        // Results are automatically sorted by device ID, direction, and link ID
-        for (const auto& [device_id, direction_map] : device_direction_cycles_) {
-            for (const auto& [direction, link_map] : direction_map) {
-                for (const auto& [link_id, cycles] : link_map) {
-                    log_debug(
-                        tt::LogTest,
-                        "Device {} Direction {} Link {} Cycles: {}",
-                        device_id.chip_id,
-                        direction,
-                        link_id,
-                        cycles);
                 }
             }
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -811,7 +811,7 @@ inline void TestDevice::set_local_runtime_args_for_core(
     CoreCoord logical_core,
     uint32_t local_args_address,
     const std::vector<uint32_t>& args) const {
-    device_info_provider_->set_local_runtime_args(device_coord, {logical_core}, local_args_address, args);
+    device_info_provider_->write_data_to_core(device_coord, logical_core, local_args_address, args);
 }
 
 }  // namespace fabric_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -103,6 +103,7 @@ public:
         const FabricNodeId& src_node_id, const FabricNodeId& dst_node_id, const RoutingDirection& direction) const = 0;
     virtual FabricNodeId get_neighbor_node_id(
         const FabricNodeId& src_node_id, const RoutingDirection& direction) const = 0;
+    virtual uint32_t get_max_routing_planes_for_device(const FabricNodeId& node_id) const = 0;
 };
 
 }  // namespace fabric_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -62,6 +62,7 @@ public:
     virtual ~IRouteManager() = default;
     virtual MeshShape get_mesh_shape() const = 0;
     virtual uint32_t get_num_mesh_dims() const = 0;
+    virtual bool wrap_around_mesh(FabricNodeId node) const = 0;
     virtual std::vector<FabricNodeId> get_dst_node_ids_from_hops(
         FabricNodeId src_node_id,
         std::unordered_map<RoutingDirection, uint32_t>& hops,
@@ -78,12 +79,14 @@ public:
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
     virtual std::optional<std::pair<FabricNodeId, FabricNodeId>> get_wrap_around_mesh_ring_neighbors(
         const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
-    virtual uint32_t get_num_sync_devices() const = 0;
-    virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
+    virtual uint32_t get_num_sync_devices(bool wrap_around_mesh) const = 0;
+    virtual std::unordered_map<RoutingDirection, uint32_t> get_wrap_around_mesh_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,
         const FabricNodeId& dst_node_backward_id,
         HighLevelTrafficPattern pattern_type) const = 0;
+    virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
+        const FabricNodeId& src_node_id, HighLevelTrafficPattern pattern_type, uint32_t dim) const = 0;
     virtual std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_multicast_hops(
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const = 0;
     virtual FabricNodeId get_random_unicast_destination(FabricNodeId src_node_id, std::mt19937& gen) const = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -79,7 +79,6 @@ public:
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
     virtual std::optional<std::pair<FabricNodeId, FabricNodeId>> get_wrap_around_mesh_ring_neighbors(
         const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
-    virtual uint32_t get_num_sync_devices(bool wrap_around_mesh) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_wrap_around_mesh_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,
@@ -103,7 +102,7 @@ public:
         const FabricNodeId& src_node_id, const FabricNodeId& dst_node_id, const RoutingDirection& direction) const = 0;
     virtual FabricNodeId get_neighbor_node_id(
         const FabricNodeId& src_node_id, const RoutingDirection& direction) const = 0;
-    virtual uint32_t get_max_routing_planes_for_device(const FabricNodeId& node_id) const = 0;
+    virtual bool validate_num_links_supported(uint32_t num_links) const = 0;
 };
 
 }  // namespace fabric_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -55,9 +55,9 @@ public:
         const std::vector<CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const = 0;
-    virtual void set_local_runtime_args(
+    virtual void write_data_to_core(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const CoreCoord& cores,
         uint32_t local_args_address,
         const std::vector<uint32_t>& args) const = 0;
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -55,6 +55,11 @@ public:
         const std::vector<CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const = 0;
+    virtual void set_local_runtime_args(
+        const MeshCoordinate& device_coord,
+        const std::vector<CoreCoord>& cores,
+        uint32_t local_args_address,
+        const std::vector<uint32_t>& args) const = 0;
 };
 
 class IRouteManager {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
@@ -44,8 +44,10 @@ struct CommonMemoryMap {
 
     bool is_valid() const { return result_buffer.is_valid() && local_args_buffer.is_valid(); }
 
-    // Returns common kernel arguments: [result_buffer_base, result_buffer_size]
-    std::vector<uint32_t> get_kernel_args() const { return {result_buffer.start, result_buffer.size}; }
+    // Returns common kernel arguments: [local_args_base, local_args_size, result_buffer_base, result_buffer_size]
+    std::vector<uint32_t> get_kernel_args() const {
+        return {local_args_buffer.start, local_args_buffer.size, result_buffer.start, result_buffer.size};
+    }
 
     // Convenience methods for reading results
     uint32_t get_result_buffer_address() const { return result_buffer.start; }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
@@ -28,18 +28,21 @@ struct BaseMemoryRegion {
 struct CommonMemoryMap {
     // Constants for memory region sizes
     static constexpr uint32_t RESULT_BUFFER_SIZE = 0x1000;  // 4KB
+    static constexpr uint32_t LOCAL_ARGS_BUFFER_SIZE = 0x1000;  // 4KB
 
     // Memory regions
     BaseMemoryRegion result_buffer;
+    BaseMemoryRegion local_args_buffer;
 
     // Default constructor
-    CommonMemoryMap() : result_buffer(0, 0) {}
+    CommonMemoryMap() : result_buffer(0, 0), local_args_buffer(0, 0) {}
 
     // Host-side construction
-    CommonMemoryMap(uint32_t result_buffer_base, uint32_t result_buffer_size) :
-        result_buffer(result_buffer_base, result_buffer_size) {}
+    CommonMemoryMap(
+        uint32_t result_buffer_base, uint32_t result_buffer_size, uint32_t local_args_base, uint32_t local_args_size) :
+        result_buffer(result_buffer_base, result_buffer_size), local_args_buffer(local_args_base, local_args_size) {}
 
-    bool is_valid() const { return result_buffer.is_valid(); }
+    bool is_valid() const { return result_buffer.is_valid() && local_args_buffer.is_valid(); }
 
     // Returns common kernel arguments: [result_buffer_base, result_buffer_size]
     std::vector<uint32_t> get_kernel_args() const { return {result_buffer.start, result_buffer.size}; }
@@ -47,6 +50,8 @@ struct CommonMemoryMap {
     // Convenience methods for reading results
     uint32_t get_result_buffer_address() const { return result_buffer.start; }
     uint32_t get_result_buffer_size() const { return result_buffer.size; }
+    uint32_t get_local_args_address() const { return local_args_buffer.start; }
+    uint32_t get_local_args_size() const { return local_args_buffer.size; }
 };
 
 /**
@@ -76,17 +81,26 @@ struct SenderMemoryMap {
 
     SenderMemoryMap(
         uint32_t l1_unreserved_base, uint32_t l1_unreserved_size, uint32_t l1_alignment, uint32_t num_configs) :
-        common(0, 0),           // Will be set below
+        common(0, 0, 0, 0),     // Will be set below
         packet_headers(0, 0),   // Will be set below
         payload_buffers(0, 0),  // Will be set below
         highest_usable_address(l1_unreserved_base + l1_unreserved_size) {
-        // Layout: [result_buffer][packet_headers][payload_buffers]
+        // Layout: [local_args_buffer][result_buffer][packet_headers][payload_buffers]
         uint32_t current_addr = l1_unreserved_base;
+
+        // Local args buffer (at top of memory)
+        uint32_t local_args_base = current_addr;
+        current_addr += CommonMemoryMap::LOCAL_ARGS_BUFFER_SIZE;
 
         // Result buffer
         uint32_t result_buffer_base = current_addr;
         current_addr += CommonMemoryMap::RESULT_BUFFER_SIZE;
-        common = CommonMemoryMap(result_buffer_base, CommonMemoryMap::RESULT_BUFFER_SIZE);
+
+        common = CommonMemoryMap(
+            result_buffer_base,
+            CommonMemoryMap::RESULT_BUFFER_SIZE,
+            local_args_base,
+            CommonMemoryMap::LOCAL_ARGS_BUFFER_SIZE);
 
         // Packet headers
         uint32_t packet_header_base = current_addr;
@@ -139,6 +153,8 @@ struct SenderMemoryMap {
     // Convenience methods for reading results
     uint32_t get_result_buffer_address() const { return common.get_result_buffer_address(); }
     uint32_t get_result_buffer_size() const { return common.get_result_buffer_size(); }
+    uint32_t get_local_args_address() const { return common.get_local_args_address(); }
+    uint32_t get_local_args_size() const { return common.get_local_args_size(); }
 };
 
 /**
@@ -167,17 +183,26 @@ struct ReceiverMemoryMap {
         uint32_t l1_alignment,
         uint32_t payload_chunk_size,
         uint32_t num_configs) :
-        common(0, 0),           // Will be set below
+        common(0, 0, 0, 0),     // Will be set below
         payload_chunks(0, 0),   // Will be set below
         atomic_counters(0, 0),  // Will be set below
         payload_chunk_size_(payload_chunk_size) {
-        // Layout: [result_buffer][atomic_counters][payload_chunks]
+        // Layout: [local_args_buffer][result_buffer][atomic_counters][payload_chunks]
         uint32_t current_addr = l1_unreserved_base;
+
+        // Local args buffer (at top of memory)
+        uint32_t local_args_base = current_addr;
+        current_addr += CommonMemoryMap::LOCAL_ARGS_BUFFER_SIZE;
 
         // Result buffer
         uint32_t result_buffer_base = current_addr;
         current_addr += CommonMemoryMap::RESULT_BUFFER_SIZE;
-        common = CommonMemoryMap(result_buffer_base, CommonMemoryMap::RESULT_BUFFER_SIZE);
+
+        common = CommonMemoryMap(
+            result_buffer_base,
+            CommonMemoryMap::RESULT_BUFFER_SIZE,
+            local_args_base,
+            CommonMemoryMap::LOCAL_ARGS_BUFFER_SIZE);
 
         // Atomic counters
         uint32_t atomic_counter_base = current_addr;
@@ -204,6 +229,8 @@ struct ReceiverMemoryMap {
     // Convenience methods for reading results
     uint32_t get_result_buffer_address() const { return common.get_result_buffer_address(); }
     uint32_t get_result_buffer_size() const { return common.get_result_buffer_size(); }
+    uint32_t get_local_args_address() const { return common.get_local_args_address(); }
+    uint32_t get_local_args_size() const { return common.get_local_args_size(); }
 
     // Getter for payload chunk size used in this memory map
     uint32_t get_payload_chunk_size() const { return payload_chunk_size_; }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
@@ -212,6 +212,7 @@ struct TestTrafficConfig {
     std::optional<CoreCoord> dst_logical_core;
     std::optional<uint32_t> target_address;
     std::optional<uint32_t> atomic_inc_address;
+    std::optional<uint32_t> link_id;  // Link ID for multi-link tests
     // TODO: add later
     // mode - BW, latency etc
 };
@@ -226,6 +227,7 @@ struct TestTrafficSenderConfig {
     std::optional<size_t> atomic_inc_address;
     uint32_t dst_noc_encoding;  // TODO: decide if we should keep it here or not
     uint32_t payload_buffer_size;  // Add payload buffer size field
+    std::optional<uint32_t> link_id;  // Link ID for multi-link tests
 
     std::vector<uint32_t> get_args(bool is_sync_config = false) const;
 };

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -420,7 +420,7 @@ void MetalContext::set_fabric_config(
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED &&
         fabric_config != tt_fabric::FabricConfig::DISABLED) {
         log_info(tt::LogMetal, "Resetting control plane for new fabric config: {}", fabric_config);
-        global_control_plane_.reset();
+        control_plane_.reset();
     }
 
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED || fabric_config == tt_fabric::FabricConfig::DISABLED) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -414,6 +414,15 @@ void MetalContext::set_fabric_config(
     std::optional<uint8_t> num_routing_planes) {
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch config, not through this function exposed in the detail API.
     force_reinit_ = true;
+
+    // Reset control plane when switching from DISABLED to enabled or between different configs
+    // This ensures the correct mesh graph descriptor is used for the new fabric config
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED &&
+        fabric_config != tt_fabric::FabricConfig::DISABLED) {
+        log_info(tt::LogMetal, "Resetting control plane for new fabric config: {}", fabric_config);
+        global_control_plane_.reset();
+    }
+
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED || fabric_config == tt_fabric::FabricConfig::DISABLED) {
         this->fabric_config_ = fabric_config;
         this->fabric_reliability_mode_ = reliability_mode;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25293)

### Problem description
current fabric infra missed the functionality to handle multiple links. Need to add one.

### What's changed
Add multi-link support.
Add allocator changes so that we allocate addresses seperately for different link.
Fix Control plane init order so that we can have correct mesh/torus setup.
Fix profiling logic so that it handles multi-link.
Fix non-wrap-around-mesh case for high level patterns.

### changes on the metal context
need to reset control plane, if the new fabric config is not the same as old one.
This was causing issues when we switch from 2d mesh to 2d torus in 6U, where control plane keeps using 2d mesh, even when the new ring fabric config is passed in.

### Checklist
- [ ] [All post commit]
