### PR TITLE
Add extra-tag field to CYO pipeline

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -12,7 +12,10 @@ on:
       docker-image:
         required: true
         type: string
-
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
 jobs:
   fd-nightly:
     strategy:
@@ -25,14 +28,14 @@ jobs:
             {
               name: "WH N150 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "N150", "${{ inputs.extra-tag }}"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             }, # Nathan Sidwell
             {
               name: "WH N300 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+              runs-on: ["cloud-virtual-machine", "N300", "${{ inputs.extra-tag }}"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             }, # Nathan Sidwell
@@ -100,7 +103,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
+    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
@@ -174,7 +177,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
+    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -16,6 +16,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
 
 jobs:
   device-perf:
@@ -25,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
+          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
         ]
     name: "${{ matrix.test-info.name }} device perf"

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -12,6 +12,10 @@ on:
       docker-image:
         required: true
         type: string
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
 
 jobs:
   models-perf:
@@ -21,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal"},
         ]
         model-type: [llm_javelin, cnn_javelin, other]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -13,6 +13,10 @@ on:
           - ASan
           - TSan
         default: "Release"
+      extra-tag:
+        required: true
+        type: string
+        default: "in-service"
       build-with-tracy:
         required: false
         type: boolean
@@ -67,6 +71,7 @@ jobs:
     if: ${{ inputs.single-card-demo }}
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml
     with:
+      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -76,6 +81,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
+      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -86,6 +92,7 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     if: ${{ inputs.single-card-perf-device-models }}
     with:
+      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -94,6 +101,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     with:
+      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -15,6 +15,10 @@ on:
       arch:
         required: true
         type: string
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
 
 jobs:
   single-card-demo-tests:
@@ -98,7 +102,7 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ matrix.test-group.runner-label }}
-      - in-service
+      - ${{ inputs.extra-tag }}
       - ${{ (matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && 'bare-metal') || 'cloud-virtual-machine' }}
       - ${{ (matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && 'pipeline-perf') || 'cloud-virtual-machine' }}
     steps:


### PR DESCRIPTION
### Ticket


### Problem description
Single card CYO is the last CYO pipeline that does not expose extra-tag to allow for targeting specific CI machines

### What's changed
Add extra-tag field to all single card pipelines used in single card CYO pipeline

### Checklist

- [x] Single card CYO (checking yaml syntax) https://github.com/tenstorrent/tt-metal/actions/runs/16356501193