### PR TITLE
enable fabric scatter write on blackhole

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -156,8 +156,6 @@ FORCE_INLINE void send_packets<tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE>(
     send_packets_unicast_write_impl<false>(fabric_connection, pkt_hdr_fwd, pkt_hdr_bwd, params, source_buffer_address);
 }
 
-#ifdef ARCH_WORMHOLE
-
 template <>
 FORCE_INLINE void send_packets<tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE>(
     FabricConnectionManager& fabric_connection,
@@ -167,8 +165,6 @@ FORCE_INLINE void send_packets<tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_W
     size_t source_buffer_address) {
     send_packets_unicast_write_impl<true>(fabric_connection, pkt_hdr_fwd, pkt_hdr_bwd, params, source_buffer_address);
 }
-
-#endif
 
 template <>
 void send_packets<tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC>(
@@ -459,12 +455,10 @@ void kernel_main() {
                         send_packets<NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC>(
                             fabric_connection, fwd_packet_header, bwd_packet_header, params, source_l1_buffer_address);
                         break;
-#ifdef ARCH_WORMHOLE
                     case NocSendType::NOC_UNICAST_SCATTER_WRITE:
                         send_packets<NocSendType::NOC_UNICAST_SCATTER_WRITE>(
                             fabric_connection, fwd_packet_header, bwd_packet_header, params, source_l1_buffer_address);
                         break;
-#endif
                     default: ASSERT(false); break;
                 }
             }

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -146,7 +146,6 @@ void kernel_main() {
                 ->to_noc_unicast_write(
                     tt::tt_fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         } else {
-#ifdef ARCH_WORMHOLE
             if (write_scatter_mode && pages_to_send == 2) {
                 uint64_t dest_noc_address2 = get_noc_addr(p + 1, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
                 packet_header->to_chip_unicast(config.unicast.distance)
@@ -154,9 +153,7 @@ void kernel_main() {
                         tt::tt_fabric::NocUnicastScatterCommandHeader{
                             {dest_noc_address, dest_noc_address2}, (uint16_t)page_size},
                         (pages_to_send * page_size));
-            } else
-#endif
-            {
+            } else {
                 packet_header->to_chip_unicast(config.unicast.distance)
                     ->to_noc_unicast_write(
                         tt::tt_fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -85,6 +85,8 @@ protected:
     MeshShape GetDeterminedMeshShape() const {
         if (num_devices_ == TG_NUM_DEVICES || num_devices_ == GALAXY_6U_NUM_DEVICES) {
             return MeshShape{8, 4};
+        } else if (num_devices_ == 4) {
+            return MeshShape{1, 4};
         } else {
             return MeshShape{2, 4};
         }
@@ -100,10 +102,22 @@ protected:
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
 
-        if (!(num_devices_ >= 8 &&
-              (tt::tt_metal::GetNumPCIeDevices() == 4 || tt::tt_metal::GetNumPCIeDevices() == GALAXY_6U_NUM_DEVICES))) {
-            TT_THROW("This suite can only be run on T3000 or TG Wormhole devices");
-        }
+        switch (arch_) {
+            case tt::ARCH::WORMHOLE_B0:
+                if (!(num_devices_ >= 8 && (tt::tt_metal::GetNumPCIeDevices() == 4 ||
+                                            tt::tt_metal::GetNumPCIeDevices() == GALAXY_6U_NUM_DEVICES))) {
+                    TT_THROW("This suite can only be run on T3000 or TG Wormhole devices");
+                }
+                break;
+
+            case tt::ARCH::BLACKHOLE:
+                if (num_devices_ != 4) {
+                    TT_THROW("This suite can only be run on LLMBox");
+                }
+                break;
+
+            default: TT_THROW("Only Wormhole or Blackhole devices are supported in this test suite");
+        };
     }
 
 public:

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -91,7 +91,7 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_Persiste
     auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
     ASSERT_EQ(result, 0);
 }
-#ifdef ARCH_WORMHOLE
+
 // Will wrapp sender but not receiver buffers
 TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric_Scatter) {
     const uint32_t page_size = 2048;
@@ -131,7 +131,7 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_Persist
     auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
     ASSERT_EQ(result, 0);
 }
-#endif
+
 // Will wrapp sender but not receiver buffers
 TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric) {
     const uint32_t page_size = 2048;

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -90,13 +90,11 @@ static_assert(
 struct NocUnicastCommandHeader {
     uint64_t noc_address;
 };
-#ifdef ARCH_WORMHOLE
 #define NOC_SCATTER_WRITE_MAX_CHUNKS 2
 struct NocUnicastScatterCommandHeader {
     uint64_t noc_address[NOC_SCATTER_WRITE_MAX_CHUNKS];
     uint16_t chunk_size[NOC_SCATTER_WRITE_MAX_CHUNKS - 1];  // last chunk size is implicit
 };
-#endif
 struct NocUnicastInlineWriteCommandHeader {
     uint64_t noc_address;
     uint32_t value;
@@ -151,9 +149,7 @@ union NocCommandFields {
     NocUnicastAtomicIncCommandHeader unicast_seminc;
     NocUnicastAtomicIncFusedCommandHeader unicast_seminc_fused;
     NocMulticastAtomicIncCommandHeader mcast_seminc;
-#ifdef ARCH_WORMHOLE
     NocUnicastScatterCommandHeader unicast_scatter_write;
-#endif
 };
 static_assert(sizeof(NocCommandFields) == 24, "CommandFields size is not 24 bytes");
 
@@ -304,7 +300,6 @@ struct PacketHeaderBase {
         return static_cast<volatile Derived*>(this);
     }
 
-#ifdef ARCH_WORMHOLE
     inline volatile Derived* to_noc_unicast_scatter_write(
         const NocUnicastScatterCommandHeader& noc_unicast_scatter_command_header, size_t payload_size_bytes) volatile {
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
@@ -327,7 +322,6 @@ struct PacketHeaderBase {
 #endif
         return static_cast<volatile Derived*>(this);
     }
-#endif
 
     inline volatile Derived* to_noc_unicast_inline_write(
         const NocUnicastInlineWriteCommandHeader& noc_unicast_command_header) volatile {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -197,7 +197,6 @@ FORCE_INLINE
                 tt::tt_fabric::forward_and_local_write_noc_vc);
         } break;
 
-#ifdef ARCH_WORMHOLE
         case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE: {
             size_t offset = 0;
             size_t chunk_size;
@@ -218,9 +217,6 @@ FORCE_INLINE
                 offset += chunk_size;
             }
         } break;
-#else
-        case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE:
-#endif
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE:
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_ATOMIC_INC:
         default: {


### PR DESCRIPTION
The fabric scatter write feature was disabled for Blackhole due to an at the time hang on some Blackhole tests. This change re-enables the scatter write feature for Blackhole


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16356870040
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16356871313
- [x] LLMBox Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/16356873469\

Closes #24648