### PR TITLE
MLA Prefill TP=8 support

### DIFF
--- a/models/demos/deepseek_v3/reference/deepseek/model.py
+++ b/models/demos/deepseek_v3/reference/deepseek/model.py
@@ -254,7 +254,7 @@ class MLA(nn.Module):
             if param.requires_grad:
                 print(f"Initializing {name} with torch.randn")
                 with torch.no_grad():
-                    param.copy_(torch.randn_like(param))
+                    param.copy_(torch.randn_like(param) * 0.1)
 
     def forward(self, x: torch.Tensor, start_pos: int, freqs_cis: torch.Tensor, mask: Optional[torch.Tensor]):
         bsz, seqlen, _ = x.size()

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -81,7 +81,7 @@ def get_cache_on_host(tt_cache, mesh_device):
     "mode, seq_len, batch_size",
     [
         ("decode", 1, 32),
-        # ("prefill", 128, 1),
+        ("prefill", 128, 1),
     ],
 )
 @pytest.mark.parametrize(
@@ -168,6 +168,7 @@ def test_forward_pass(
     ############################
     ### TTNN inputs
     ############################
+    logger.info("Preparing TTNN inputs")
     if mode == "decode":
         # TT Shape: [1, seq_len, batch_size, hidden_size]
         torch_input = torch_input.permute(1, 0, 2)
@@ -230,14 +231,18 @@ def test_forward_pass(
     ############################
     ### TTNN forward pass
     ############################
+    logger.info("Running TTNN forward pass")
     if mode == "prefill":
         tt_output = MLA1D.forward_prefill(tt_input, user_id, rope_tensors, run_config)
-        tt_output_torch = ttnn.to_torch(tt_output)
     else:
         tt_output = MLA1D.forward_decode(tt_input, position_idxs_tensor, rope_tensors, run_config)
-        tt_output_torch = ttnn.to_torch(
-            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(0, -1), mesh_shape=mesh_shape)
-        )[:1, ...]
+
+    tt_output_torch = ttnn.to_torch(
+        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(0, -1), mesh_shape=mesh_shape)
+    )[:1, ...]
+
+    if mode == "decode":
+        # Torch Shape: [batch_size, seq_len, hidden_size]
         tt_output_torch = tt_output_torch.squeeze(0).permute(1, 0, 2)
 
     ############################

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -268,10 +268,12 @@ class MLA1D(AbstractModule):
         original_seq_len = hf_config.rope_scaling["original_max_position_embeddings"]
         max_seq_len = hf_config.max_seq_len
 
+        mesh_shape = list(mesh_device.shape)
+
         config: ModelPrefillConfig = {}
 
         config["hf_config"] = hf_config
-        config["mesh_shape"] = list(mesh_device.shape)
+        config["mesh_shape"] = mesh_shape
 
         config["wq_a"] = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -314,7 +316,7 @@ class MLA1D(AbstractModule):
         k_chunk_size = 128  # TODO: Make dynamic?
 
         sdpa_program_config = ttnn.SDPAProgramConfig(
-            compute_with_storage_grid_size=grid_size,
+            compute_with_storage_grid_size=(8, 7),
             q_chunk_size=q_chunk_size,
             k_chunk_size=k_chunk_size,
             exp_approx_mode=False,
@@ -345,6 +347,63 @@ class MLA1D(AbstractModule):
         # Norms
         config["q_norm"] = RMSNorm.prefill_model_config(hf_config, mesh_device, norm_category="q_norm")
         config["kv_norm"] = RMSNorm.prefill_model_config(hf_config, mesh_device, norm_category="k_norm")
+
+        # Set up CCLs
+        # **Must be in order of execution**
+
+        # Q
+        config["wq_a_rs"] = ReduceScatterAsyncConfig(
+            mesh_device=MeshDeviceStub(mesh_shape),
+            cluster_axis=1,
+            dim=3,
+            from_remote_multi_device_global_semaphore=ccl.get_semaphore(1),
+            to_remote_multi_device_global_semaphore=ccl.get_semaphore(1),
+            math_op=ttnn.ReduceType.Sum,
+            num_links=ccl.get_max_links(1),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+        )
+        config["wq_a_ag"] = AllGatherAsyncConfig(
+            mesh_device=MeshDeviceStub(mesh_shape),
+            cluster_axis=1,
+            dim=3,
+            multi_device_global_semaphore=ccl.get_semaphore(1),
+            num_links=ccl.get_max_links(1),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+        )
+
+        # KV
+        config["wkv_a_ag"] = AllGatherAsyncConfig(
+            mesh_device=MeshDeviceStub(mesh_shape),
+            cluster_axis=1,
+            dim=1,
+            multi_device_global_semaphore=ccl.get_semaphore(1),
+            num_links=ccl.get_max_links(1),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+        )
+        config["wkv_a_r"] = {
+            "dims": [1],
+            "output": None,
+            "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=True,
+            ),
+        }
+
+        # WO
+        config["wo_ag"] = AllGatherAsyncConfig(
+            mesh_device=MeshDeviceStub(mesh_shape),
+            cluster_axis=1,
+            dim=1,
+            multi_device_global_semaphore=ccl.get_semaphore(1),
+            num_links=ccl.get_max_links(1),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+        )
 
         return config
 
@@ -540,33 +599,33 @@ class MLA1D(AbstractModule):
 
         # Q
         config["wq_a_rs"] = ReduceScatterAsyncConfig(
-            mesh_device=MeshDeviceStub(list(mesh_device.shape)),
+            mesh_device=MeshDeviceStub(mesh_shape),
             cluster_axis=1,
             dim=3,
-            from_remote_multi_device_global_semaphore=ccl.get_semaphore(0),
-            to_remote_multi_device_global_semaphore=ccl.get_semaphore(0),
+            from_remote_multi_device_global_semaphore=ccl.get_semaphore(1),
+            to_remote_multi_device_global_semaphore=ccl.get_semaphore(1),
             math_op=ttnn.ReduceType.Sum,
-            num_links=ccl.get_max_links(0),
+            num_links=ccl.get_max_links(1),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
         config["wq_a_ag"] = AllGatherAsyncConfig(
-            mesh_device=MeshDeviceStub(list(mesh_device.shape)),
+            mesh_device=MeshDeviceStub(mesh_shape),
             cluster_axis=1,
             dim=3,
-            multi_device_global_semaphore=ccl.get_semaphore(0),
-            num_links=ccl.get_max_links(0),
+            multi_device_global_semaphore=ccl.get_semaphore(1),
+            num_links=ccl.get_max_links(1),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
 
         # KV
         config["wkv_a_ag"] = AllGatherAsyncConfig(
-            mesh_device=MeshDeviceStub(list(mesh_device.shape)),
+            mesh_device=MeshDeviceStub(mesh_shape),
             cluster_axis=1,
             dim=1,
-            multi_device_global_semaphore=ccl.get_semaphore(0),
-            num_links=ccl.get_max_links(0),
+            multi_device_global_semaphore=ccl.get_semaphore(1),
+            num_links=ccl.get_max_links(1),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -583,11 +642,11 @@ class MLA1D(AbstractModule):
 
         # WO
         config["wo_ag"] = AllGatherAsyncConfig(
-            mesh_device=MeshDeviceStub(list(mesh_device.shape)),
+            mesh_device=MeshDeviceStub(mesh_shape),
             cluster_axis=1,
             dim=1,
-            multi_device_global_semaphore=ccl.get_semaphore(0),
-            num_links=ccl.get_max_links(0),
+            multi_device_global_semaphore=ccl.get_semaphore(1),
+            num_links=ccl.get_max_links(1),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -779,10 +838,10 @@ class MLA1D(AbstractModule):
         Returns:
             Output tensor after MLP computation
         """
-        assert False, "MLA1D prefill forward is untested!"
 
         hf_config = cfg["hf_config"]
         num_heads = hf_config.num_attention_heads
+        num_heads_local = num_heads // cfg["mesh_shape"][1]
         kv_lora_rank = hf_config.kv_lora_rank
         qk_nope_head_dim = hf_config.qk_nope_head_dim
         qk_rope_head_dim = hf_config.qk_rope_head_dim
@@ -795,18 +854,21 @@ class MLA1D(AbstractModule):
 
         # wq_a and wq_b
         tt_q = ttnn.linear(x, **cfg["wq_a"])
-        # TODO: Add norm
+
+        tt_q = ttnn.experimental.reduce_scatter_async(tt_q, **cfg["wq_a_rs"])
+        tt_q = ttnn.experimental.all_gather_async(tt_q, **cfg["wq_a_ag"])
+
+        tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
         tt_q = ttnn.linear(tt_q, **cfg["wq_b"])
 
-        # TODO: Use local heads here
-        tt_q = ttnn.reshape(tt_q, (1, seq_len, num_heads, qk_head_dim))
-        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, num_heads, seq_len, qk_head_dim]
+        tt_q = ttnn.reshape(tt_q, (1, seq_len, num_heads_local, qk_head_dim))
+        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, num_heads_local, seq_len, qk_head_dim]
 
-        tt_q_nope = ttnn.slice(tt_q, [0, 0, 0, 0], [1, num_heads, seq_len, qk_nope_head_dim])
-        tt_q_rope = ttnn.slice(tt_q, [0, 0, 0, qk_nope_head_dim], [1, num_heads, seq_len, qk_head_dim])
+        tt_q_nope = ttnn.slice(tt_q, [0, 0, 0, 0], [1, num_heads_local, seq_len, qk_nope_head_dim])
+        tt_q_rope = ttnn.slice(tt_q, [0, 0, 0, qk_nope_head_dim], [1, num_heads_local, seq_len, qk_head_dim])
 
         # wkv_b1
-        tt_q_nope = ttnn.linear(tt_q_nope, **cfg["wkv_b1"])  # [1, num_heads, seq_len, kv_lora_rank]
+        tt_q_nope = ttnn.linear(tt_q_nope, **cfg["wkv_b1"])  # [1, num_heads_local, seq_len, kv_lora_rank]
 
         # Q RoPE
         tt_q_rope = ttnn.experimental.rotary_embedding_llama(
@@ -822,9 +884,20 @@ class MLA1D(AbstractModule):
 
         # KVPE Stuff
         tt_kv = ttnn.linear(x, **cfg["wkv_a"])
+
+        tt_kv = ttnn.experimental.all_gather_async(
+            tt_kv, **cfg["wkv_a_ag"]
+        )  # [1, 1, seq_len / num_devices, kv_lora_rank + qk_rope_head_dim]
+        tt_kv = ttnn.experimental.fast_reduce_nc(
+            tt_kv, **cfg["wkv_a_r"]
+        )  # [1, 1, seq_len, kv_lora_rank + qk_rope_head_dim]
+
         tt_kv_nope = ttnn.slice(tt_kv, [0, 0, 0, 0], [1, 1, seq_len, kv_lora_rank])
         tt_kv_rope = ttnn.slice(tt_kv, [0, 0, 0, kv_lora_rank], [1, 1, seq_len, kv_lora_rank + qk_rope_head_dim])
         ttnn.deallocate(tt_kv)
+
+        # KV Norm
+        tt_kv_nope = RMSNorm.forward_prefill(tt_kv_nope, cfg["kv_norm"])
 
         # KV RoPE
         tt_kv_rope = ttnn.experimental.rotary_embedding_llama(
@@ -854,14 +927,15 @@ class MLA1D(AbstractModule):
             tt_q,
             tt_kvpe,
             **cfg["flash_mla"],
-        )  # [1, num_heads, seq_len, kv_lora_rank]
+        )  # [1, num_heads_local, seq_len, kv_lora_rank]
         ttnn.deallocate(tt_q)
 
         # wkv_b2
-        v_out = ttnn.linear(attn_out, **cfg["wkv_b2"])  # [1, num_heads, seq_len, v_head_dim]
-        v_out = ttnn.permute(v_out, (0, 2, 1, 3))  # [1, seq_len, num_heads, v_head_dim]
+        v_out = ttnn.linear(attn_out, **cfg["wkv_b2"])  # [1, num_heads_local, seq_len, v_head_dim]
+        v_out = ttnn.experimental.all_gather_async(v_out, **cfg["wo_ag"])  # [1, num_heads, seq_len, v_head_dim]
 
         # wo
+        v_out = ttnn.permute(v_out, (0, 2, 1, 3))  # [1, seq_len, num_heads, v_head_dim]
         v_out = ttnn.reshape(v_out, (1, 1, seq_len, num_heads * v_head_dim))
         out = ttnn.linear(v_out, **cfg["wo"])  # [1, 1, seq_len, dim]
 

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -316,7 +316,7 @@ class MLA1D(AbstractModule):
         k_chunk_size = 128  # TODO: Make dynamic?
 
         sdpa_program_config = ttnn.SDPAProgramConfig(
-            compute_with_storage_grid_size=(8, 7),
+            compute_with_storage_grid_size=grid_size,
             q_chunk_size=q_chunk_size,
             k_chunk_size=k_chunk_size,
             exp_approx_mode=False,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -451,8 +451,7 @@ Tensor all_gather_async_impl(
     const auto& mesh_view = mesh_device.get_view();
     TT_FATAL(
         mesh_view.is_mesh_2d(), "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
-    // std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
-    std::size_t num_devices = (cluster_axis == 0) ? 8 : 4;
+    std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
 
     int32_t rank = input_tensor.logical_shape().rank();
 


### PR DESCRIPTION
### Ticket
- #23022 

### Problem description
MLA Prefill is disabled because it's unsupported for TP=8

### What's changed
- Add Prefill MLA TP=8
- Change the randn weight inits to be `randn * 0.1`, otherwise leads to lower PCC for prefill

### TODO
- [x] (done in this PR) ⚠️ Wait for [bug](https://github.com/tenstorrent/tt-metal/pull/25010/files#diff-2d56e6b92a8045baa30280ef192042eea2cb030bdd827b957f8fb9a0dfd0d8b4R455) fix for all_gather_async to be merged to main before merging this PR ⚠️

### Checklist
- [x] [TG Deepseek](https://github.com/tenstorrent/tt-metal/actions/runs/16357242613) CI passes
- [x] [TG Llama Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16381201865) CI passes
- [x] [TG Llama Demo 6u](https://github.com/tenstorrent/tt-metal/actions/runs/16381518793) CI passes