### PR TITLE
MoE Gate Module

### DIFF
--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -51,6 +51,7 @@ from transformers.utils import (
 from transformers.utils.import_utils import is_torch_fx_available
 
 from .configuration_deepseek import DeepseekV3Config
+from .reference_utils import topk_bitonic
 
 # This makes `_prepare_4d_causal_attention_mask` a leaf function in the FX graph.
 # It means that the function will not be traced through and simply appear as a node in the graph.
@@ -353,6 +354,7 @@ class MoEGate(nn.Module):
         self.topk_method = config.topk_method
         self.n_group = config.n_group
         self.topk_group = config.topk_group
+        self.training = False
 
         # topk selection algorithm
         self.norm_topk_prob = config.norm_topk_prob
@@ -361,6 +363,11 @@ class MoEGate(nn.Module):
         if self.topk_method == "noaux_tc":
             self.e_score_correction_bias = nn.Parameter(torch.empty((self.n_routed_experts)))
         self.reset_parameters()
+        # initatialize whether to use bitonic topk or torch.topk
+        self.use_bitonic_sort = True
+        self.topk_fn = torch.topk
+        if self.use_bitonic_sort:
+            self.topk_fn = topk_bitonic
 
     def reset_parameters(self) -> None:
         import torch.nn.init as init
@@ -381,10 +388,11 @@ class MoEGate(nn.Module):
         if self.topk_method == "noaux_tc":
             assert not self.training
             scores_for_choice = scores.view(bsz * seq_len, -1) + self.e_score_correction_bias.unsqueeze(0)
-            group_scores = (
-                scores_for_choice.view(bsz * seq_len, self.n_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+            group_scores = topk_bitonic(scores_for_choice.view(bsz * seq_len, self.n_group, -1), k=2, dim=-1)[0].sum(
+                dim=-1
             )  # [n, n_group]
-            group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]  # [n, top_k_group]
+
+            group_idx = self.topk_fn(group_scores, k=self.topk_group, dim=-1, sorted=True)[1]  # [n, top_k_group]
             group_mask = torch.zeros_like(group_scores)  # [n, n_group]
             group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
             score_mask = (
@@ -393,7 +401,7 @@ class MoEGate(nn.Module):
                 .reshape(bsz * seq_len, -1)
             )  # [n, e]
             tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
-            _, topk_idx = torch.topk(tmp_scores, k=self.top_k, dim=-1, sorted=False)
+            _, topk_idx = self.topk_fn(tmp_scores, k=self.top_k, dim=-1, sorted=True)
             topk_weight = scores.gather(1, topk_idx)
         else:
             raise NotImplementedError(f"insupportable TopK function for MoE gating: {self.topk_method}")

--- a/models/demos/deepseek_v3/reference/reference_utils.py
+++ b/models/demos/deepseek_v3/reference/reference_utils.py
@@ -1,0 +1,57 @@
+import torch
+
+
+def bitonic_sort(a, indices, up=True):
+    def comp_and_swap(i, j, dir):
+        if dir == (a[i] > a[j]):
+            a[i], a[j] = a[j], a[i]
+            indices[i], indices[j] = indices[j], indices[i]
+
+    def bitonic_merge(low, cnt, dir):
+        if cnt > 1:
+            k = cnt // 2
+            for i in range(low, low + k):
+                comp_and_swap(i, i + k, dir)
+            bitonic_merge(low, k, dir)
+            bitonic_merge(low + k, k, dir)
+
+    def bitonic_sort_rec(low, cnt, dir):
+        if cnt > 1:
+            k = cnt // 2
+            bitonic_sort_rec(low, k, True)
+            bitonic_sort_rec(low + k, k, False)
+            bitonic_merge(low, cnt, dir)
+
+    bitonic_sort_rec(0, len(a), up)
+
+
+def topk_bitonic(input_tensor, k, dim=-1, largest=True, sorted=True):
+    assert dim == -1, "This custom bitonic topK only supports last dimension"
+    orig_shape = input_tensor.shape
+    last_dim = orig_shape[dim]
+
+    if (last_dim & (last_dim - 1)) != 0:
+        raise ValueError("The last dimension must be a power of 2.")
+
+    flat = input_tensor.reshape(-1, last_dim)
+    topk_vals = []
+    topk_indices = []
+
+    for row_idx, row in enumerate(flat):
+        row_vals = row.tolist()
+        row_indices = list(range(len(row_vals)))
+
+        bitonic_sort(row_vals, row_indices, up=not largest)
+
+        selected = list(zip(row_vals[:k], row_indices[:k]))
+        if sorted:
+            selected.sort(reverse=largest, key=lambda x: x[0])
+        vals_row, inds_row = zip(*selected)
+
+        topk_vals.append(torch.tensor(vals_row, dtype=input_tensor.dtype))
+        topk_indices.append(torch.tensor(inds_row, dtype=torch.long))
+
+    # Stack and reshape
+    topk_vals = torch.stack(topk_vals).reshape(*orig_shape[:-1], k)
+    topk_indices = torch.stack(topk_indices).reshape(*orig_shape[:-1], k)
+    return topk_vals, topk_indices

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+# Import from local reference files instead of HuggingFace
+from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate
+from models.demos.deepseek_v3.tt.moe_gate import TTMoEGate
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.utility_functions import comp_pcc
+
+
+@pytest.fixture
+def reference_model(hf_config):
+    """Get the actual DeepSeek MLP model using local implementation."""
+    return MoEGate(hf_config)
+
+
+@pytest.mark.parametrize(
+    "mode,seq_len",
+    [
+        ("decode", 128),
+        ("prefill", 2048),
+    ],
+)
+def test_forward_pass(
+    mode,
+    seq_len,
+    reference_model,
+    hf_config_single_layer,
+    temp_dir,
+    galaxy_or_t3k_mesh,
+):
+    torch.manual_seed(0)
+
+    mesh_device = galaxy_or_t3k_mesh
+
+    """Test forward pass against reference model."""
+    batch_size = 1
+
+    # Get state dict from actual model - pass directly to convert_weights
+    hf_state_dict = reference_model.state_dict()
+
+    # Setup: Convert weights and get weight_config
+    weight_config = TTMoEGate.convert_weights(hf_config_single_layer, hf_state_dict, temp_dir, mesh_device)
+
+    # Generate appropriate config
+    if mode == "prefill":
+        model_config = TTMoEGate.prefill_model_config(hf_config_single_layer, mesh_device)
+    else:
+        model_config = TTMoEGate.decode_model_config(hf_config_single_layer, mesh_device)
+
+    # Create a new model state
+    model_state = TTMoEGate.create_state(hf_config_single_layer, mesh_device=mesh_device)
+
+    # Create RunConfig using both weight_config and model_config
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Create input tensor
+    torch_input = torch.randn(batch_size, seq_len, hf_config_single_layer.hidden_size)
+
+    # Reference forward pass
+    reference_topk_indices, reference_topk_weights = reference_model(torch_input)
+
+    # Convert input to TTNN
+    tt_input = ttnn.from_torch(
+        torch_input.unsqueeze(1),
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=tuple(mesh_device.shape)),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # TTNN forward pass
+    if mode == "prefill":
+        tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+        tt_topk_weights, tt_topk_indices = TTMoEGate.forward_prefill(tt_input, run_config)
+        expected_output_memory_config = run_config["output_memory_config"]
+    else:
+        tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+        tt_topk_weights, tt_topk_indices = TTMoEGate.forward_decode(tt_input, run_config)
+        expected_output_memory_config = run_config["output_memory_config"]
+
+    # Verify output memory config matches expected
+    actual_topk_weights_memory_config = tt_topk_weights.memory_config()
+    assert (
+        actual_topk_weights_memory_config == expected_output_memory_config
+    ), f"TopK experts weights memory config mismatch: expected {expected_output_memory_config}, got {actual_topk_weights_memory_config}"
+
+    actual_topk_indices_memory_config = tt_topk_indices.memory_config()
+    assert (
+        actual_topk_indices_memory_config == expected_output_memory_config
+    ), f"TopK experts indices memory config mismatch: expected {expected_output_memory_config}, got {actual_topk_indices_memory_config}"
+
+    # Convert output back to torch
+    tt_topk_weights_torch = ttnn.to_torch(
+        tt_topk_weights,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
+    )[0].squeeze(0)
+    tt_topk_indices_torch = ttnn.to_torch(
+        tt_topk_indices,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
+    )[0].squeeze(0)
+
+    # Compare outputs
+    logger.info(f"Mode: {mode}, Seq len: {seq_len}")
+
+    pcc_required = 0.98  # Slightly lower due to bfloat conversions
+    passing, pcc_message = comp_pcc(reference_topk_weights, tt_topk_weights_torch, pcc_required)
+
+    logger.info(f"TopK experts weights PCC: {pcc_message}")
+    assert passing, f"TopK experts weights output does not meet PCC requirement {pcc_required}: {pcc_message}"
+
+    passing, pcc_message = comp_pcc(reference_topk_indices, tt_topk_indices_torch, pcc_required)
+    logger.info(f"TopK experts indices PCC: {pcc_message}")
+    assert passing, f"TopK experts indices output does not meet PCC requirement {pcc_required}: {pcc_message}"
+
+    # Cleanup
+    ttnn.deallocate(tt_topk_weights)
+    ttnn.deallocate(tt_topk_indices)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tt/moe_gate.py
+++ b/models/demos/deepseek_v3/tt/moe_gate.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import torch
+from transformers.configuration_utils import PretrainedConfig
+
+import ttnn
+from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
+from models.demos.deepseek_v3.utils.config_dataclass import (
+    BinaryOpConfig,
+    FromWeightConfig,
+    LinearConfig,
+    MeshDeviceStub,
+    MulConfig,
+    ReshapeConfig,
+    ScatterConfig,
+    TopKConfig,
+)
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI2,
+    TOPK_MIN_WIDTH,
+    even_int_div,
+    save_and_get_path,
+)
+from models.demos.deepseek_v3.utils.run_config import (
+    ModelDecodeConfig,
+    ModelPrefillConfig,
+    RunDecodeConfig,
+    RunPrefillConfig,
+    WeightConfig,
+)
+
+
+class TTMoEGate(AbstractModule):
+    """MoE gate module from DeepSeek-R1.
+    See the `AbstractModule` docstring for usage info.
+    """
+
+    @classmethod
+    def convert_weights(
+        cls,
+        hf_config: PretrainedConfig,
+        state_dict: dict[str, torch.Tensor],
+        output_path: Path,
+        mesh_device: ttnn.Device,
+    ) -> WeightConfig:
+        tt_gate_proj_weight = ttnn.from_torch(
+            state_dict["weight"].T.unsqueeze(0).unsqueeze(0),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        tt_e_score_correction_bias = ttnn.from_torch(
+            state_dict["e_score_correction_bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        eps = 1e-20  # no hf config for this
+        tt_norm_eps = ttnn.from_torch(
+            torch.tensor([eps]).repeat(1, hf_config.num_experts_per_tok).unsqueeze(0).unsqueeze(0),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        tt_expert_scale = ttnn.from_torch(
+            torch.tensor([hf_config.routed_scaling_factor])
+            .repeat(1, hf_config.num_experts_per_tok)
+            .unsqueeze(0)
+            .unsqueeze(0),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        torch_expert_group_mask = torch.full((1, 1, 1, hf_config.n_group), -float("inf"))
+        torch_ones_src_tensor = torch.ones((1, 1, 1, hf_config.topk_group))
+        tt_expert_group_mask = ttnn.from_torch(
+            torch_expert_group_mask,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        tt_ones_src_tensor = ttnn.from_torch(
+            torch_ones_src_tensor,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+        return {
+            "gate_proj": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"gate_proj.input_tensor_b",
+                    tt_gate_proj_weight,
+                )
+            },
+            "add_score_correction_bias": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"e_score_correction_bias.input_tensor_b",
+                    tt_e_score_correction_bias,
+                )
+            },
+            "add_norm_eps": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"add_norm_eps.input_tensor_b",
+                    tt_norm_eps,
+                )
+            },
+            "multiply_expert_scale": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"multiply_expert_scale.input_tensor_b",
+                    tt_expert_scale,
+                )
+            },
+            "scatter_top_expert_groups": {
+                "input": save_and_get_path(
+                    output_path / f"scatter_top_expert_groups.input",
+                    tt_expert_group_mask,
+                ),
+                "src": save_and_get_path(
+                    output_path / f"scatter_top_expert_groups.src",
+                    tt_ones_src_tensor,
+                ),
+            },
+        }
+
+    @classmethod
+    def model_config(
+        cls,
+        hf_config: PretrainedConfig,
+        mesh_device: ttnn.Device,
+        mode: str,
+    ) -> ModelDecodeConfig | ModelPrefillConfig:
+        """Generate decode configuration for this module.
+
+        Args:
+            hf_config: HuggingFace model configuration object
+            mesh_device: TTNN mesh device the model will be placed later on
+        Returns:
+            ModelDecodeConfig containing operator configurations for decode mode
+        """
+
+        if mode == "decode":
+            memory_config = ttnn.L1_MEMORY_CONFIG
+        else:
+            memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+        # Construct the config
+        return {
+            "gate_proj": LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=memory_config,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
+            ),
+            "add_score_correction_bias": BinaryOpConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=memory_config,
+                dtype=ttnn.bfloat16,
+            ),
+            "add_norm_eps": BinaryOpConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=memory_config,
+                dtype=ttnn.bfloat16,
+            ),
+            "multiply_expert_scale": BinaryOpConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=memory_config,
+                dtype=ttnn.bfloat16,
+            ),
+            "reshape_scores": ReshapeConfig(
+                shape=(1, -1, hf_config.n_group, even_int_div(hf_config.n_routed_experts, hf_config.n_group)),
+            ),
+            "topk_within_expert_groups": TopKConfig(
+                k=2,  # no hf config for this
+                dim=3,
+            ),
+            "topk_expert_groups": TopKConfig(
+                k=hf_config.topk_group,
+                dim=3,
+            ),
+            "scatter_top_expert_groups": ScatterConfig(
+                input=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                src=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                dim=3,
+            ),
+            "reshape_group_mask": ReshapeConfig(
+                shape=(1, -1, hf_config.n_group, 1),
+            ),
+            "reshape_active_experts": ReshapeConfig(
+                shape=(1, 1, -1, hf_config.n_routed_experts),
+            ),
+            "mul_scores_with_mask": MulConfig(
+                memory_config=memory_config,
+            ),
+            "topk_experts": TopKConfig(
+                k=hf_config.num_experts_per_tok,
+                dim=3,
+            ),
+            "input_memory_config": memory_config,
+            "output_memory_config": memory_config,
+        }
+
+    @classmethod
+    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelDecodeConfig:
+        return cls.model_config(hf_config, mesh_device, "decode")
+
+    @classmethod
+    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
+        return cls.model_config(hf_config, mesh_device, "prefill")
+
+    @classmethod
+    def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        assert x.memory_config() == cfg["input_memory_config"]
+
+        # Gate projections
+        logits = ttnn.linear(x, **cfg["gate_proj"])
+        # Sigmoid activation
+        scores = ttnn.sigmoid(logits)
+        ttnn.deallocate(logits)
+        # Add score correction bias
+        # Expand bias to match scores shape(dynamic shape)
+        scores_correction_bias = cfg["add_score_correction_bias"]["input_tensor_b"]
+        scores_correction_bias = ttnn.repeat(scores_correction_bias, ttnn.Shape((1, 1, scores.shape[2], 1)))
+        scores_correction_bias = ttnn.to_layout(scores_correction_bias, ttnn.TILE_LAYOUT)
+        scores_with_bias = ttnn.add(
+            scores,
+            scores_correction_bias,
+            memory_config=cfg["add_score_correction_bias"]["memory_config"],
+            dtype=cfg["add_score_correction_bias"]["dtype"],
+        )
+        # Reshape scores to expert groups
+        expert_scores_grouped = ttnn.reshape(scores_with_bias, **cfg["reshape_scores"])
+        num_experts_per_group = expert_scores_grouped.shape[3]
+
+        if expert_scores_grouped.shape[3] < TOPK_MIN_WIDTH:
+            # Pad to 64 for topk op
+            expert_scores_grouped = ttnn.pad(
+                expert_scores_grouped,
+                [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_scores_grouped.shape[3])],
+                value=-float("inf"),
+            )
+        # calculate top-2 scores with expert groups
+        topk_scores_within_expert_groups, topk_indices_within_expert_groups = ttnn.topk(
+            expert_scores_grouped, **cfg["topk_within_expert_groups"]
+        )
+        ttnn.deallocate(expert_scores_grouped)
+        ttnn.deallocate(topk_indices_within_expert_groups)
+        # sum top-2 scores within expert groups
+        expert_group_scores = ttnn.sum(topk_scores_within_expert_groups, dim=3)
+        ttnn.deallocate(topk_scores_within_expert_groups)
+        # reshape to 4D tensor
+        expert_group_scores = ttnn.unsqueeze(expert_group_scores, dim=0)
+
+        if expert_group_scores.shape[3] < TOPK_MIN_WIDTH:
+            expert_group_scores = ttnn.pad(
+                expert_group_scores,
+                [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_group_scores.shape[3])],
+                value=-float("inf"),
+            )
+        # calculate top-k expert groups
+        topk_expert_groups_scores, topk_expert_groups_indices = ttnn.topk(
+            expert_group_scores, **cfg["topk_expert_groups"]
+        )
+        ttnn.deallocate(expert_group_scores)
+        ttnn.deallocate(topk_expert_groups_scores)
+
+        # create full expert_groups_mask(dynamic shape)
+        input_mask = cfg["scatter_top_expert_groups"]["input"]
+        input_mask = ttnn.repeat(input_mask, ttnn.Shape((1, 1, scores.shape[2], 1)))
+
+        # create full src tensor of ones
+        src_tensor = cfg["scatter_top_expert_groups"]["src"]
+        src_tensor = ttnn.repeat(src_tensor, ttnn.Shape((1, 1, scores.shape[2], 1)))
+
+        # scatter top-k expert groups indices to full expert_groups_mask
+        active_groups_mask = ttnn.experimental.scatter(
+            input=input_mask,
+            index=topk_expert_groups_indices,
+            src=src_tensor,
+            dim=cfg["scatter_top_expert_groups"]["dim"],
+        )
+        ttnn.deallocate(topk_expert_groups_indices)
+        active_groups_mask = ttnn.reshape(active_groups_mask, **cfg["reshape_group_mask"])
+
+        # expand active_groups_mask to all the experts
+        active_experts_mask = ttnn.repeat(active_groups_mask, ttnn.Shape((1, 1, 1, num_experts_per_group)))
+        ttnn.deallocate(active_groups_mask)
+        active_experts_mask = ttnn.reshape(active_experts_mask, **cfg["reshape_active_experts"])
+        active_experts_scores = ttnn.mul(scores_with_bias, active_experts_mask, **cfg["mul_scores_with_mask"])
+        ttnn.deallocate(scores_with_bias)
+        ttnn.deallocate(active_experts_mask)
+
+        # calculate top-k experts
+        topk_experts_scores_with_bias, topk_experts_indices = ttnn.topk(active_experts_scores, **cfg["topk_experts"])
+        ttnn.deallocate(active_experts_scores)
+        ttnn.deallocate(topk_experts_scores_with_bias)
+
+        # gather original scores without bias
+        topk_experts_scores = ttnn.gather(scores, dim=3, index=topk_experts_indices)
+        ttnn.deallocate(scores)
+
+        # normalize scores
+        topk_expert_scores_sum = ttnn.sum(topk_experts_scores, dim=3, keepdim=True)
+        topk_experts_scores_normalized = ttnn.div(topk_experts_scores, topk_expert_scores_sum)
+        ttnn.deallocate(topk_expert_scores_sum)
+        ttnn.deallocate(topk_experts_scores)
+
+        # add norm eps
+        norm_eps = cfg["add_norm_eps"]["input_tensor_b"]
+        # expand norm_eps to match topk_experts_scores_normalized shape(dynamic shape)
+        norm_eps = ttnn.repeat(norm_eps, ttnn.Shape((1, 1, topk_experts_scores_normalized.shape[2], 1)))
+        norm_eps = ttnn.to_layout(norm_eps, ttnn.TILE_LAYOUT)
+        topk_experts_scores_normalized = ttnn.add(
+            topk_experts_scores_normalized,
+            norm_eps,
+            memory_config=cfg["add_norm_eps"]["memory_config"],
+            dtype=cfg["add_norm_eps"]["dtype"],
+        )
+        ttnn.deallocate(norm_eps)
+
+        # multiply by expert scale
+        expert_scale = cfg["multiply_expert_scale"]["input_tensor_b"]
+        # expand expert_scale to match topk_experts_scores_normalized shape(dynamic shape)
+        expert_scale = ttnn.repeat(expert_scale, ttnn.Shape((1, 1, topk_experts_scores_normalized.shape[2], 1)))
+        expert_scale = ttnn.to_layout(expert_scale, ttnn.TILE_LAYOUT)
+        topk_experts_scores_normalized = ttnn.mul(
+            topk_experts_scores_normalized,
+            expert_scale,
+            memory_config=cfg["multiply_expert_scale"]["memory_config"],
+            dtype=cfg["multiply_expert_scale"]["dtype"],
+        )
+        ttnn.deallocate(expert_scale)
+
+        return topk_experts_scores_normalized, topk_experts_indices
+
+    @classmethod
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        return cls.forward(x, cfg)
+
+    @classmethod
+    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        return cls.forward(x, cfg)

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -164,3 +164,39 @@ class RMSNormConfig(OpConfigBase):
     is_distributed: bool = False
     topology: ttnn.Topology = ttnn.Topology.Linear
     norm_category: str = None
+
+
+@dataclass
+class BinaryOpConfig(OpConfigBase):
+    """Common parameters for a ttnn.add/sub/mul/div op, weights are in input_tensor_b"""
+
+    input_tensor_b: ConfigWeight
+    memory_config: ttnn.MemoryConfig | None = None
+    dtype: ttnn.DataType | None = None
+    activation: ttnn.UnaryOpType | None = None
+
+
+@dataclass
+class ReshapeConfig(OpConfigBase):
+    """Common parameters for a ttnn.reshape op"""
+
+    shape: tuple[int, int, int, int] | None = None
+
+
+@dataclass
+class TopKConfig(OpConfigBase):
+    """Common parameters for a ttnn.topk op"""
+
+    k: int
+    dim: int
+    largest: bool = True
+    sorted: bool = True
+
+
+@dataclass
+class ScatterConfig(OpConfigBase):
+    """Common parameters for a ttnn.experimental.scatter op"""
+
+    input: ttnn.Tensor
+    dim: int
+    src: ttnn.Tensor

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -13,6 +13,7 @@ import ttnn
 NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
 MAX_BATCH_SIZE = 32
 SEQ_LEN_CHUNK_SIZE = 1024  # NOTE: should be 512 for blackhole (in case of future bring-up)
+TOPK_MIN_WIDTH = 64  # Minimum width of the topk input tensor
 
 
 # Compute kernel configurations


### PR DESCRIPTION
### Problem description
Comleted bringup of MoE gate 
Decode ✅ 
Prefill  ✅  (Tested for seq_len=2048)


### What's changed
1. Added custom topK algorithm for CPU which uses bitonic sort similar to ttnn.topK

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes