### PR TITLE
Remove GlobalControlPlane construct

### DIFF
--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -278,21 +278,4 @@ private:
     LocalMeshBinding local_mesh_binding_;
 };
 
-class GlobalControlPlane {
-public:
-    explicit GlobalControlPlane(const std::string& mesh_graph_desc_yaml_file);
-    explicit GlobalControlPlane(
-        const std::string& mesh_graph_desc_yaml_file,
-        const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
-    ~GlobalControlPlane();
-
-    tt::tt_fabric::ControlPlane& get_local_node_control_plane() { return *control_plane_; }
-
-private:
-    std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
-    std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
-
-    std::string mesh_graph_desc_file_;
-};
-
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2113,20 +2113,4 @@ bool ControlPlane::is_local_mesh(MeshId mesh_id) const {
 
 ControlPlane::~ControlPlane() = default;
 
-GlobalControlPlane::GlobalControlPlane(const std::string& mesh_graph_desc_file) {
-    mesh_graph_desc_file_ = mesh_graph_desc_file;
-    // Initialize host mappings
-    control_plane_ = std::make_unique<ControlPlane>(mesh_graph_desc_file);
-}
-
-GlobalControlPlane::GlobalControlPlane(
-    const std::string& mesh_graph_desc_file,
-    const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
-    mesh_graph_desc_file_ = mesh_graph_desc_file;
-    control_plane_ =
-        std::make_unique<ControlPlane>(mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-}
-
-GlobalControlPlane::~GlobalControlPlane() = default;
-
 }  // namespace tt::tt_fabric

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -25,7 +25,6 @@
 #include <vector>
 
 namespace tt::tt_fabric {
-class GlobalControlPlane;
 class ControlPlane;
 }  // namespace tt::tt_fabric
 
@@ -143,7 +142,7 @@ private:
     std::unique_ptr<DPrintServer> dprint_server_;
     std::unique_ptr<WatcherServer> watcher_server_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
-    std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
+    std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -40,7 +40,6 @@ class RunTimeOptions;
 }
 namespace tt_fabric {
 class ControlPlane;
-class GlobalControlPlane;
 class FabricNodeId;
 }
 namespace tt_metal {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`GlobalControlPlane` no longer serve any purpose. I think the original intention was that `GlobalControlPlane` would capture global context and MPI related operations, but design instead favored having `ControlPlane` being distributed-aware.

### What's changed
Simple clean-up by removing `GlobalControlPlane` entirely.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16366252217
- [x] [T3K Unit Tests]: https://github.com/tenstorrent/tt-metal/actions/runs/16366268804