### PR TITLE
#17785: Add Swin_S eval and data parallel support

### DIFF
--- a/models/demos/swin_s/demo/demo.py
+++ b/models/demos/swin_s/demo/demo.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.swin_s.demo.demo_utils import get_batch, get_data_loader
+from models.experimental.swin_s.runner.performant_runner import SwinSPerformantRunner
+from models.sample_data.huggingface_imagenet_classes import IMAGENET2012_CLASSES
+from models.utility_functions import disable_persistent_kernel_cache, run_for_wormhole_b0
+
+imagenet_label_dict = {i: label for i, label in enumerate(IMAGENET2012_CLASSES)}
+from loguru import logger
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+def test_run_swin_s_trace_2cqs_inference(
+    device,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    disable_persistent_kernel_cache()
+
+    swin_s_trace_2cq = SwinSPerformantRunner(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=None,
+    )
+
+    batch_size = 1
+    iterations = 100
+
+    logger.info("ImageNet-1k validation Dataset")
+    input_loc = "models/demos/swin_s/demo/ImageNet_data"
+    data_loader = get_data_loader(input_loc, batch_size, iterations)
+    inputs, labels = get_batch(data_loader)
+    output_tensor = swin_s_trace_2cq.run(inputs)
+
+    output_tensor = ttnn.to_torch(output_tensor).to(torch.float)
+
+    prediction = output_tensor.argmax(dim=-1)
+    predictions = []
+    correct = 0
+    for i in range(batch_size):
+        predictions.append(imagenet_label_dict[prediction[i].item()])
+        logger.info(
+            f"Iter: {iter} Sample: {i} - Expected Label: {imagenet_label_dict[labels[i]]} -- Predicted Label: {predictions[-1]}"
+        )
+        if imagenet_label_dict[labels[i]] == predictions[-1]:
+            correct += 1
+
+        del output_tensor, inputs, labels, predictions
+
+    swin_s_trace_2cq.release()

--- a/models/demos/swin_s/demo/demo.py
+++ b/models/demos/swin_s/demo/demo.py
@@ -9,6 +9,7 @@ import torch
 import ttnn
 from models.demos.swin_s.demo.demo_utils import get_batch, get_data_loader
 from models.experimental.swin_s.runner.performant_runner import SwinSPerformantRunner
+from models.experimental.swin_s.tt.common import get_mesh_mappers
 from models.sample_data.huggingface_imagenet_classes import IMAGENET2012_CLASSES
 from models.utility_functions import disable_persistent_kernel_cache, run_for_wormhole_b0
 
@@ -16,37 +17,30 @@ imagenet_label_dict = {i: label for i, label in enumerate(IMAGENET2012_CLASSES)}
 from loguru import logger
 
 
-@run_for_wormhole_b0()
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
-)
-@pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype",
-    ((1, ttnn.bfloat16, ttnn.bfloat16),),
-)
-@pytest.mark.parametrize(
-    "resolution",
-    [
-        (512, 512),
-    ],
-)
-def test_run_swin_s_trace_2cqs_inference(
+def run_swin_s_demo(
     device,
-    batch_size,
+    batch_size_per_device,
     act_dtype,
     weight_dtype,
-    model_location_generator,
     resolution,
 ):
     disable_persistent_kernel_cache()
 
+    num_devices = device.get_num_devices()
+    batch_size_per_device = 1
+    batch_size = batch_size_per_device * num_devices
+    logger.info(f"Running with batch_size={batch_size} across {num_devices} devices")
+    inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(device)
+
     swin_s_trace_2cq = SwinSPerformantRunner(
         device,
-        batch_size,
+        batch_size_per_device,
         act_dtype,
         weight_dtype,
         resolution=resolution,
-        model_location_generator=None,
+        mesh_mapper=inputs_mesh_mapper,
+        weights_mesh_mapper=weights_mesh_mapper,
+        mesh_composer=output_mesh_composer,
     )
 
     batch_size = 1
@@ -54,11 +48,11 @@ def test_run_swin_s_trace_2cqs_inference(
 
     logger.info("ImageNet-1k validation Dataset")
     input_loc = "models/demos/swin_s/demo/ImageNet_data"
-    data_loader = get_data_loader(input_loc, batch_size, iterations)
+    data_loader = get_data_loader(input_loc, batch_size_per_device * (device.get_num_devices()), iterations)
     inputs, labels = get_batch(data_loader)
     output_tensor = swin_s_trace_2cq.run(inputs)
 
-    output_tensor = ttnn.to_torch(output_tensor).to(torch.float)
+    output_tensor = ttnn.to_torch(output_tensor, mesh_composer=output_mesh_composer).to(torch.float)
 
     prediction = output_tensor.argmax(dim=-1)
     predictions = []
@@ -74,3 +68,63 @@ def test_run_swin_s_trace_2cqs_inference(
         del output_tensor, inputs, labels, predictions
 
     swin_s_trace_2cq.release()
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size_per_device, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+def test_swin_s_demo(
+    device,
+    batch_size_per_device,
+    act_dtype,
+    weight_dtype,
+    resolution,
+):
+    run_swin_s_demo(
+        device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        resolution,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size_per_device, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+def test_swin_s_demo_dp(
+    mesh_device,
+    batch_size_per_device,
+    act_dtype,
+    weight_dtype,
+    resolution,
+):
+    run_swin_s_demo(
+        mesh_device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        resolution,
+    )

--- a/models/demos/swin_s/demo/demo_utils.py
+++ b/models/demos/swin_s/demo/demo_utils.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.Add commentMore actions
+
+# SPDX-License-Identifier: Apache-2.0
+
+import glob
+import os
+
+import torch
+from datasets import load_dataset
+from PIL import Image
+from torchvision import transforms
+
+from models.sample_data.huggingface_imagenet_classes import IMAGENET2012_CLASSES
+
+transform = transforms.Compose(
+    [
+        transforms.Resize(512),
+        transforms.CenterCrop(512),
+        transforms.ToTensor(),
+        transforms.Normalize(
+            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+        ),  # Normalize with ImageNet mean and std
+    ]
+)
+
+
+class InputExample(object):
+    def __init__(self, image, label=None):
+        self.image = image
+        self.label = label
+
+
+def get_input(image_path):
+    img = Image.open(image_path)
+    return img
+
+
+def get_label(image_path):
+    _, image_name = image_path.rsplit("/", 1)
+    image_name_exact, _ = image_name.rsplit(".", 1)
+    _, label_id = image_name_exact.rsplit("_", 1)
+    label = list(IMAGENET2012_CLASSES).index(label_id)
+    return label
+
+
+def get_batch(data_loader):
+    loaded_images = next(data_loader)
+    images = None
+    labels = []
+    for image in loaded_images:
+        img = image.image
+        labels.append(image.label)
+        if img.mode == "L":
+            img = img.convert(mode="RGB")
+        img = transform(img)
+        img = torch.unsqueeze(img, 0)
+        if images is None:
+            images = img
+        else:
+            images = torch.cat((images, img), dim=0)
+
+    return images, labels
+
+
+def get_data_loader(input_loc, batch_size, iterations):
+    img_dir = input_loc + "/"
+    data_path = os.path.join(img_dir, "*G")
+    files = glob.glob(data_path)
+
+    def loader():
+        examples = []
+        for f1 in files:
+            examples.append(
+                InputExample(
+                    image=get_input(f1),
+                    label=get_label(f1),
+                )
+            )
+            if len(examples) == batch_size:
+                yield examples
+                del examples
+                examples = []
+
+    def loader_hf():
+        examples = []
+        for f1 in files:
+            examples.append(
+                InputExample(
+                    image=f1["image"],
+                    label=f1["label"],
+                )
+            )
+            if len(examples) == batch_size:
+                yield examples
+                del examples
+                examples = []
+
+    if len(files) == 0:
+        files_raw = iter(load_dataset("imagenet-1k", split="validation", use_auth_token=True, streaming=True))
+        files = []
+        sample_count = batch_size * iterations
+        for _ in range(sample_count):
+            files.append(next(files_raw))
+        del files_raw
+        return loader_hf()
+
+    return loader()
+
+
+def get_data(input_loc):
+    img_dir = input_loc + "/"
+    data_path = os.path.join(img_dir, "*G")
+    files = sorted(glob.glob(data_path))
+    examples = []
+    for f1 in files:
+        examples.append(
+            InputExample(
+                image=get_input(f1),
+                label=get_label(f1),
+            )
+        )
+    image_examples = examples
+
+    return image_examples

--- a/models/experimental/classification_eval/README.md
+++ b/models/experimental/classification_eval/README.md
@@ -4,11 +4,12 @@
 
 ## Evaluation Table
 
-| Model        | Resolution | Batch Size | Samples | TTNN Accuracy | Torch Accuracy |
-|--------------|------------|------------|---------|-------------------------------|-------------------------------|
-| ViT          | (224, 224) | 8          | 512     | 81.25%               | 82.23%                 |
-| ResNet50     | (224, 224) | 16         | 512     | 78.52%                 | 75.59%                |
+| Model        | Resolution | Batch Size | Samples | TTNN Accuracy         | Torch Accuracy        |
+|--------------|------------|------------|---------|------------------------|------------------------|
+| ViT          | (224, 224) | 8          | 512     | 81.25%                 | 82.23%                 |
+| ResNet50     | (224, 224) | 16         | 512     | 78.52%                 | 75.59%                 |
 | MobileNetV2  | (224, 224) | 8          | 512     | 68.36%                 | 65.62%                 |
+| Swin_S       | (512, 512) | 1          | 512     | 80.66%                 | 82.23%                 |
 
 ***Note:*** The accuracy is for the selected random samples from the validation dataset.
 
@@ -36,6 +37,17 @@ Where,
  pytest models/experimental/classification_eval/classification_eval.py::test_mobilenetv2_image_classification_eval[8-224-tt_model-device_params0]
  ```
 
+**Swin_S:** <br>
+**_For 512x512,_**<br>
+**_Single-Device (BS-1):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_s_image_classification_eval[1-512-tt_model-device_params0]
+ ```
+**_Multi-Device (DP-2,N300):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_s_image_classification_eval_dp[wormhole_b0-1-512-tt_model-device_params0]
+ ```
+
 ## To run the test of torch vs ground truth, please follow the following commands:
 
 **Vit:** <br>
@@ -54,4 +66,15 @@ Where,
 **_For 224x224,_**<br>
  ```sh
  pytest models/experimental/classification_eval/classification_eval.py::test_mobilenetv2_image_classification_eval[8-224-torch_model-device_params0]
+ ```
+
+**Swin_S:** <br>
+**_For 512x512,_**<br>
+**_Single-Device (BS-1):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_s_image_classification_eval[1-512-torch_model-device_params0]
+ ```
+**_Multi-Device (DP-2,N300):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_s_image_classification_eval_dp[wormhole_b0-1-512-torch_model-device_params0]
  ```

--- a/models/experimental/classification_eval/classification_eval.py
+++ b/models/experimental/classification_eval/classification_eval.py
@@ -38,6 +38,8 @@ def evaluation(
     for i in range(iterations // batch_size):
         if model_name in ["vit", "resnet50", "mobilenetv2"]:
             inputs, labels = get_batch(data_loader, image_processor)
+        elif model_name == "swin_s":
+            inputs, labels = get_batch(data_loader)
         else:
             inputs, labels = get_batch(data_loader)
             inputs = image_processor(inputs, return_tensors="pt")
@@ -65,6 +67,8 @@ def evaluation(
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     mesh_mapper=model.test_infra.inputs_mesh_mapper,
                 )
+        elif model_name == "swin_s":
+            torch_input_tensor = inputs
         else:
             torch_input_tensor = inputs
             if model_type == "tt_model":
@@ -89,6 +93,8 @@ def evaluation(
                 output = model.execute_vit_trace_2cqs_inference(tt_inputs_host)
             elif model_name == "resnet50":
                 output = model.execute_resnet50_trace_2cqs_inference(tt_inputs_host)
+            elif model_name == "swin_s":
+                output = model.run(inputs)
         elif model_type == "torch_model":
             output = model(torch_input_tensor)
 
@@ -128,6 +134,15 @@ def evaluation(
             for i in range(batch_size):
                 pred_id.append(predicted_id[i].item())
                 gt_id.append(labels[i])
+        elif model_name == "swin_s":
+            if model_type == "tt_model":
+                final_output = ttnn.to_torch(output, mesh_composer=model.runner_infra.mesh_composer).to(torch.float)
+                predicted_id = final_output.argmax(dim=-1)
+            else:
+                predicted_id = output.argmax(dim=-1)
+            for i in range(batch_size):
+                pred_id.append(predicted_id[i].item())
+                gt_id.append(labels[i])
 
     if model_type == "tt_model":
         if model_name == "mobilenetv2":
@@ -136,6 +151,8 @@ def evaluation(
             model.release_resnet50_trace_2cqs_inference()
         elif model_name == "vit":
             model.release_vit_trace_2cqs_inference()
+        elif model_name == "swin_s":
+            model.release()
 
     # Evaluation : Here we use correct_predection/total items
     correct_prediction = 0
@@ -312,4 +329,80 @@ def test_mobilenetv2_image_classification_eval(
         get_batch=get_batch,
         batch_size=batch_size,
         res=res,
+    )
+
+
+def run_swin_s_image_classification_eval(
+    device, model_type, device_batch_size, res, model_location_generator, reset_seeds
+):
+    from models.experimental.swin_s.reference.swin_transformer import SwinTransformer
+    from models.experimental.swin_s.runner.performant_runner import SwinSPerformantRunner
+    from models.demos.swin_s.demo.demo_utils import get_batch
+    from models.experimental.swin_s.tt.common import get_mesh_mappers
+    from torchvision import models
+
+    if model_type == "torch_model":
+        model = models.swin_s(weights="IMAGENET1K_V1")
+        state_dict = model.state_dict()
+        torch_model = SwinTransformer(
+            patch_size=[4, 4], embed_dim=96, depths=[2, 2, 18, 2], num_heads=[3, 6, 12, 24], window_size=[7, 7]
+        )
+        torch_model.load_state_dict(state_dict)
+        torch_model.eval()
+    else:
+        inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(device)
+        swin_s_trace_2cq = SwinSPerformantRunner(
+            device,
+            device_batch_size,
+            ttnn.bfloat16,
+            ttnn.bfloat16,
+            resolution=(512, 512),
+            mesh_mapper=inputs_mesh_mapper,
+            weights_mesh_mapper=weights_mesh_mapper,
+            mesh_composer=output_mesh_composer,
+        )
+
+    evaluation(
+        device=device,
+        model=swin_s_trace_2cq if model_type == "tt_model" else torch_model,
+        model_location_generator=model_location_generator,
+        model_type=model_type,
+        model_name="swin_s",
+        get_batch=get_batch,
+        batch_size=device_batch_size * device.get_num_devices(),
+        res=res,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        ("tt_model"),
+        ("torch_model"),
+    ],
+)
+@pytest.mark.parametrize("batch_size, res", [[1, 512]])
+def test_swin_s_image_classification_eval(device, model_type, batch_size, res, model_location_generator, reset_seeds):
+    run_swin_s_image_classification_eval(device, model_type, batch_size, res, model_location_generator, reset_seeds)
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        ("tt_model"),
+        ("torch_model"),
+    ],
+)
+@pytest.mark.parametrize("batch_size, res", [[1, 512]])
+def test_swin_s_image_classification_eval_dp(
+    mesh_device, model_type, batch_size, res, model_location_generator, reset_seeds
+):
+    run_swin_s_image_classification_eval(
+        mesh_device, model_type, batch_size, res, model_location_generator, reset_seeds
     )

--- a/models/experimental/swin_s/README.md
+++ b/models/experimental/swin_s/README.md
@@ -22,8 +22,17 @@ To obtain the perf reports through profiler, please build with the following com
 ```
 
 ### To run the Swin_S model of 512x512 resolution:
-```
+```sh
 pytest --disable-warnings tests/ttnn/integration_tests/swin_s/test_ttnn_swin_transformer.py
 ```
+
+## Model performant running with Trace+2CQ
+Use the following command to run the e2e perf:
+
+-  For overall rutime inference (end-2-end), use the following command to run the demo:
+```sh
+pytest --disable-warnings models/experimental/swin_s/tests/perf/test_e2e_performant.py
+```
+- end-2-end perf is 5 FPS
 
 ### Owner: [HariniMohan0102](https://github.com/HariniMohan0102)

--- a/models/experimental/swin_s/README.md
+++ b/models/experimental/swin_s/README.md
@@ -35,4 +35,14 @@ pytest --disable-warnings models/experimental/swin_s/tests/perf/test_e2e_perform
 ```
 - end-2-end perf is 5 FPS
 
+## Model demo with trace
+
+- When running the ImageNet demo for the first time, you need to authenticate with Hugging Face by either running `huggingface-cli login` or setting the token directly using `export HF_TOKEN=<your_token>`.
+- To obtain a huggingface token visit: https://huggingface.co/docs/hub/security-tokens.
+
+- Use the following command to run the demo for Imagenet-1K:
+```sh
+pytest --disable-warnings models/demos/swin_s/demo/demo.py::test_run_swin_s_trace_2cqs_inference
+```
+
 ### Owner: [HariniMohan0102](https://github.com/HariniMohan0102)

--- a/models/experimental/swin_s/README.md
+++ b/models/experimental/swin_s/README.md
@@ -29,11 +29,19 @@ pytest --disable-warnings tests/ttnn/integration_tests/swin_s/test_ttnn_swin_tra
 ## Model performant running with Trace+2CQ
 Use the following command to run the e2e perf:
 
--  For overall rutime inference (end-2-end), use the following command to run the demo:
+### Single Device (BS=1):
+-  For overall rutime inference (end-2-end), use the following command to run for single device:
 ```sh
-pytest --disable-warnings models/experimental/swin_s/tests/perf/test_e2e_performant.py
+pytest --disable-warnings models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
 - end-2-end perf is 5 FPS
+
+### Multi Device (DP=2, N300):
+-  For overall rutime inference (end-2-end), use the following command to run for multi device:
+```sh
+pytest --disable-warnings models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_performant_dp
+```
+- end-2-end perf is 19 FPS
 
 ## Model demo with trace
 
@@ -41,8 +49,16 @@ pytest --disable-warnings models/experimental/swin_s/tests/perf/test_e2e_perform
 - To obtain a huggingface token visit: https://huggingface.co/docs/hub/security-tokens.
 
 - Use the following command to run the demo for Imagenet-1K:
+
+### Single Device (BS=1):
+- Use the following command to run demo for single device:
 ```sh
-pytest --disable-warnings models/demos/swin_s/demo/demo.py::test_run_swin_s_trace_2cqs_inference
+pytest --disable-warnings models/demos/swin_s/demo/demo.py::test_swin_s_demo[resolution0-1-act_dtype0-weight_dtype0-device_params0]
 ```
 
+### Multi Device (DP=2, N300):
+- Use the following command to run demo for multi device:
+```sh
+pytest --disable-warnings models/demos/swin_s/demo/demo.py::test_swin_s_demo_dp[wormhole_b0-resolution0-1-act_dtype0-weight_dtype0-device_params0]
+```
 ### Owner: [HariniMohan0102](https://github.com/HariniMohan0102)

--- a/models/experimental/swin_s/runner/performant_runner.py
+++ b/models/experimental/swin_s/runner/performant_runner.py
@@ -14,19 +14,26 @@ class SwinSPerformantRunner:
         device_batch_size=1,
         act_dtype=ttnn.bfloat16,
         weight_dtype=ttnn.bfloat16,
-        model_location_generator=None,
         resolution=(512, 512),
         torch_input_tensor=None,
+        mesh_mapper=None,
+        weights_mesh_mapper=None,
+        mesh_composer=None,
     ):
         self.device = device
         self.resolution = resolution
+        self.mesh_mapper = mesh_mapper
+        self.weights_mesh_mapper = weights_mesh_mapper
+        self.mesh_composer = mesh_composer
         self.runner_infra = SwinSPerformanceRunnerInfra(
             device,
             device_batch_size,
             act_dtype,
             weight_dtype,
-            model_location_generator,
             resolution=resolution,
+            mesh_mapper=mesh_mapper,
+            weights_mesh_mapper=weights_mesh_mapper,
+            mesh_composer=mesh_composer,
         )
 
         (
@@ -100,7 +107,6 @@ class SwinSPerformantRunner:
         n, h, w, c = torch_input_tensor.shape
         tt_inputs_host, input_mem_config = self.runner_infra._setup_l1_sharded_input(self.device, torch_input_tensor)
         output = self._execute_swins_trace_2cqs_inference(tt_inputs_host)
-        print(output)
         if check_pcc:
             torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)
             torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)

--- a/models/experimental/swin_s/runner/performant_runner.py
+++ b/models/experimental/swin_s/runner/performant_runner.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.swin_s.runner.performant_runner_infra import SwinSPerformanceRunnerInfra
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+class SwinSPerformantRunner:
+    def __init__(
+        self,
+        device,
+        device_batch_size=1,
+        act_dtype=ttnn.bfloat16,
+        weight_dtype=ttnn.bfloat16,
+        model_location_generator=None,
+        resolution=(512, 512),
+        torch_input_tensor=None,
+    ):
+        self.device = device
+        self.resolution = resolution
+        self.runner_infra = SwinSPerformanceRunnerInfra(
+            device,
+            device_batch_size,
+            act_dtype,
+            weight_dtype,
+            model_location_generator,
+            resolution=resolution,
+        )
+
+        (
+            self.tt_inputs_host,
+            sharded_mem_config_DRAM,
+            self.input_mem_config,
+        ) = self.runner_infra.setup_dram_sharded_input(device)
+        self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
+        self._capture_swins_trace_2cqs()
+
+    def _capture_swins_trace_2cqs(self):
+        # Initialize the op event so we can write
+        self.op_event = ttnn.record_event(self.device, 0)
+
+        # First run configures convs JIT
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        spec = self.runner_infra.input_tensor.spec
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+        self.runner_infra.dealloc_output()
+
+        # Optimized run
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+
+        # Capture
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.dealloc_output()
+        trace_input_addr = self.runner_infra.input_tensor.buffer_address()
+        self.tid = ttnn.begin_trace_capture(self.device, cq_id=0)
+        self.runner_infra.run()
+        self.input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
+        ttnn.end_trace_capture(self.device, self.tid, cq_id=0)
+        assert trace_input_addr == self.input_tensor.buffer_address()
+
+    def _execute_swins_trace_2cqs_inference(self, tt_inputs_host=None):
+        tt_inputs_host = self.tt_inputs_host if tt_inputs_host is None else tt_inputs_host
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        # TODO: Add in place support to ttnn to_memory_config
+
+        self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        self.op_event = ttnn.record_event(self.device, 0)
+        ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(self.device)
+        return self.runner_infra.output_tensor
+
+    def _validate(self, input_tensor, result_output_tensor):
+        torch_output_tensor = self.runner_infra.torch_output_tensor
+        assert_with_pcc(torch_output_tensor, result_output_tensor, 0.99)
+
+    def run(self, torch_input_tensor, check_pcc=False):
+        n, h, w, c = torch_input_tensor.shape
+        tt_inputs_host, input_mem_config = self.runner_infra._setup_l1_sharded_input(self.device, torch_input_tensor)
+        output = self._execute_swins_trace_2cqs_inference(tt_inputs_host)
+        print(output)
+        if check_pcc:
+            torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)
+            torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)
+            self._validate(torch_input_tensor, output)
+
+        return output
+
+    def release(self):
+        ttnn.release_trace(self.device, self.tid)

--- a/models/experimental/swin_s/runner/performant_runner_infra.py
+++ b/models/experimental/swin_s/runner/performant_runner_infra.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+from loguru import logger
+import ttnn
+from torchvision import models
+from tests.ttnn.integration_tests.swin_s.test_ttnn_swin_transformer import (
+    create_custom_preprocessor,
+    preprocess_attn_mask,
+)
+from models.experimental.swin_s.reference.swin_transformer import SwinTransformer
+from models.experimental.swin_s.tt.tt_swin_transformer import TtSwinTransformer
+from models.utility_functions import divup, is_wormhole_b0
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+
+def load_torch_model():
+    model = models.swin_s(weights="IMAGENET1K_V1")
+    state_dict = model.state_dict()
+
+    model.load_state_dict(state_dict)
+    model.eval()
+    torch_model = SwinTransformer(
+        patch_size=[4, 4], embed_dim=96, depths=[2, 2, 18, 2], num_heads=[3, 6, 12, 24], window_size=[7, 7]
+    )
+
+    torch_model.load_state_dict(state_dict)
+    torch_model.eval()
+
+    return torch_model
+
+
+class SwinSPerformanceRunnerInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        model_location_generator=None,
+        resolution=(512, 512),
+        torch_input_tensor=None,
+    ):
+        torch.manual_seed(0)
+        self.resolution = resolution
+        self.pcc_passed = False
+        self.pcc_message = "Did you forget to call validate()?"
+        self.device = device
+        self.batch_size = batch_size
+        self.act_dtype = act_dtype
+        self.weight_dtype = weight_dtype
+        self.model_location_generator = model_location_generator
+        self.torch_input_tensor = torch_input_tensor
+
+        self.torch_model = load_torch_model()
+
+        self.torch_input_tensor = (
+            torch.randn((1, 3, 512, 512), dtype=torch.float32)
+            if self.torch_input_tensor is None
+            else self.torch_input_tensor
+        )
+
+        self.parameters = preprocess_model_parameters(
+            initialize_model=lambda: self.torch_model,
+            custom_preprocessor=create_custom_preprocessor(self.device),
+            device=self.device,
+        )
+
+        attn_mask_tuple = preprocess_attn_mask([1, 3, 512, 512], [4, 4], [7, 7], [3, 3], device)
+
+        self.ttnn_swin_model = TtSwinTransformer(
+            self.device,
+            self.parameters,
+            patch_size=[4, 4],
+            embed_dim=96,
+            depths=[2, 2, 18, 2],
+            num_heads=[3, 6, 12, 24],
+            window_size=[7, 7],
+            attn_mask_tuple=attn_mask_tuple,
+        )
+
+        self.torch_output_tensor = self.torch_model(self.torch_input_tensor)
+
+    def _setup_l1_sharded_input(self, device, torch_input_tensor=None):
+        if is_wormhole_b0():
+            core_grid = ttnn.CoreGrid(y=8, x=8)
+        else:
+            exit("Unsupported device")
+
+        num_devices = device.get_num_devices()
+        torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
+
+        n, c, h, w = torch_input_tensor.shape
+        if c == 3:
+            c = 16
+        input_mem_config = ttnn.create_sharded_memory_config(
+            [n, c, h, w],
+            ttnn.CoreGrid(x=8, y=8),
+            ttnn.ShardStrategy.HEIGHT,
+        )
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        return tt_inputs_host, input_mem_config
+
+    def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
+        tt_inputs_host, input_mem_config = self._setup_l1_sharded_input(device)
+        dram_grid_size = device.dram_grid_size()
+        dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+            ),
+            [
+                divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], (dram_grid_size.x * dram_grid_size.y)),
+                tt_inputs_host.shape[-1],
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded_mem_config_DRAM = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+        )
+
+        return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+    def run(self):
+        self.output_tensor = self.ttnn_swin_model(self.input_tensor)
+
+    def validate(self, output_tensor=None, torch_output_tensor=None):
+        ttnn_output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
+        output_tensor = ttnn.to_torch(ttnn_output_tensor)
+        self.pcc_passed, self.pcc_message = assert_with_pcc(
+            self.torch_output_tensor, output_tensor, pcc=0.95
+        )  # PCC:0.953924198820544
+
+        logger.info(
+            f"Swin S - batch_size={self.batch_size}, act_dtype={self.act_dtype}, weight_dtype={self.weight_dtype}, PCC={self.pcc_message}"
+        )
+
+    def dealloc_output(self):
+        ttnn.deallocate(self.output_tensor)

--- a/models/experimental/swin_s/tests/perf/test_e2e_performant.py
+++ b/models/experimental/swin_s/tests/perf/test_e2e_performant.py
@@ -9,6 +9,48 @@ from loguru import logger
 import ttnn
 from models.experimental.swin_s.runner.performant_runner import SwinSPerformantRunner
 from models.utility_functions import run_for_wormhole_b0
+from models.experimental.swin_s.tt.common import get_mesh_mappers
+
+
+def run_swin_s_inference(
+    device,
+    batch_size_per_device,
+    resolution,
+    act_dtype=ttnn.bfloat8_b,
+    weight_dtype=ttnn.bfloat8_b,
+):
+    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+    performant_runner = SwinSPerformantRunner(
+        device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        mesh_mapper=inputs_mesh_mapper,
+        weights_mesh_mapper=weights_mesh_mapper,
+        mesh_composer=outputs_mesh_composer,
+    )
+    performant_runner._capture_swins_trace_2cqs()
+
+    num_devices = device.get_num_devices()
+    batch_size = batch_size_per_device * num_devices
+
+    input_shape = (batch_size, 3, *resolution)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+
+    inference_times = []
+    for _ in range(10):
+        t0 = time.time()
+        _ = performant_runner.run(torch_input_tensor)
+        t1 = time.time()
+        inference_times.append(t1 - t0)
+
+    performant_runner.release()
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    logger.info(
+        f"ttnn_swin_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size * num_devices/inference_time_avg)}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -32,31 +74,44 @@ def test_e2e_performant(
     batch_size,
     act_dtype,
     weight_dtype,
-    model_location_generator,
     resolution,
 ):
-    performant_runner = SwinSPerformantRunner(
+    run_swin_s_inference(
         device,
         batch_size,
-        act_dtype,
-        weight_dtype,
-        resolution=resolution,
-        model_location_generator=None,
+        resolution,
+        act_dtype=ttnn.bfloat8_b,
+        weight_dtype=ttnn.bfloat8_b,
     )
-    performant_runner._capture_swins_trace_2cqs()
 
-    inference_times = []
-    for _ in range(10):
-        input_shape = (1, 3, 512, 512)
-        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-        t0 = time.time()
-        _ = performant_runner.run(torch_input_tensor)
-        t1 = time.time()
-        inference_times.append(t1 - t0)
 
-    performant_runner.release()
-
-    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
-    logger.info(
-        f"ttnn_swin_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+def test_e2e_performant_dp(
+    mesh_device,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    resolution,
+):
+    run_swin_s_inference(
+        mesh_device,
+        batch_size,
+        resolution,
+        act_dtype=ttnn.bfloat8_b,
+        weight_dtype=ttnn.bfloat8_b,
     )

--- a/models/experimental/swin_s/tests/perf/test_e2e_performant.py
+++ b/models/experimental/swin_s/tests/perf/test_e2e_performant.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from models.experimental.swin_s.runner.performant_runner import SwinSPerformantRunner
+from models.utility_functions import run_for_wormhole_b0
+
+
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 16998400, "num_command_queues": 2}], indirect=True
+)
+def test_e2e_performant(
+    device,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    performant_runner = SwinSPerformantRunner(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=None,
+    )
+    performant_runner._capture_swins_trace_2cqs()
+
+    inference_times = []
+    for _ in range(10):
+        input_shape = (1, 3, 512, 512)
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+        t0 = time.time()
+        _ = performant_runner.run(torch_input_tensor)
+        t1 = time.time()
+        inference_times.append(t1 - t0)
+
+    performant_runner.release()
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    logger.info(
+        f"ttnn_swin_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+    )

--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from torchvision import models
+from ttnn.model_preprocessing import (
+    preprocess_model_parameters,
+)
+from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
+from models.perf.perf_utils import prep_perf_report
+from models.utility_functions import disable_persistent_kernel_cache, profiler
+from models.experimental.swin_s.reference.swin_transformer import SwinTransformer
+
+# from models.experimental.swin_v2.tt.model_preprocessing import create_swinv2_model_parameters, preprocess_attn_mask
+from tests.ttnn.integration_tests.swin_s.test_ttnn_swin_transformer import (
+    create_custom_preprocessor,
+    preprocess_attn_mask,
+)
+from models.experimental.swin_s.tt.tt_swin_transformer import TtSwinTransformer
+
+
+def load_torch_model():
+    model = models.swin_s(weights="IMAGENET1K_V1")
+    state_dict = model.state_dict()
+
+    model.load_state_dict(state_dict)
+    model.eval()
+    torch_model = SwinTransformer(
+        patch_size=[4, 4], embed_dim=96, depths=[2, 2, 18, 2], num_heads=[3, 6, 12, 24], window_size=[7, 7]
+    )
+
+    torch_model.load_state_dict(state_dict)
+    torch_model.eval()
+
+    return torch_model
+
+
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape, expected_compile_time, expected_inference_time",
+    [
+        ((1, 3, 512, 512), 91, 0.19),
+    ],
+)
+def test_swin_s(
+    device,
+    input_shape,
+    expected_compile_time,
+    expected_inference_time,
+    model_location_generator,
+):
+    disable_persistent_kernel_cache()
+    profiler.clear()
+
+    torch_model = load_torch_model()
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    batch_size = input_shape[0]
+    resolution = input_shape[1:3]
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: torch_model, custom_preprocessor=create_custom_preprocessor(device), device=device
+    )
+
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, device=device)
+    attn_mask_tuple = preprocess_attn_mask([1, 3, 512, 512], [4, 4], [7, 7], [3, 3], device)
+
+    ttnn_model = TtSwinTransformer(
+        device,
+        parameters,
+        patch_size=[4, 4],
+        embed_dim=96,
+        depths=[2, 2, 18, 2],
+        num_heads=[3, 6, 12, 24],
+        window_size=[7, 7],
+        attn_mask_tuple=attn_mask_tuple,
+    )
+
+    logger.info(f"Compiling model with warmup run")
+    profiler.start(f"inference_and_compile_time")
+    ttnn_output_tensor = ttnn_model(ttnn_input)
+    ttnn.deallocate(ttnn_output_tensor)
+
+    profiler.end(f"inference_and_compile_time")
+
+    inference_and_compile_time = profiler.get("inference_and_compile_time")
+    logger.info(
+        f"Model with input resolution {resolution} compiled with warmup run in {(inference_and_compile_time):.2f} s"
+    )
+
+    iterations = 16
+
+    outputs = []
+    logger.info(f"Running inference for {iterations} iterations")
+    for idx in range(iterations):
+        profiler.start("inference_time")
+        profiler.start(f"inference_time_{idx}")
+        ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, device=device)
+        ttnn_output_tensor = ttnn_model(ttnn_input)
+        ttnn.deallocate(ttnn_output_tensor)
+        profiler.end(f"inference_time_{idx}")
+        profiler.end("inference_time")
+
+    mean_inference_time = profiler.get("inference_time")
+    inference_time = profiler.get(f"inference_time_{iterations - 1}")
+    compile_time = inference_and_compile_time - inference_time
+    logger.info(f"Model compilation of resolution {resolution} took {compile_time:.1f} s")
+    logger.info(
+        f"Inference time on last iterations for resolution: {resolution} was completed in {(inference_time * 1000.0):.2f} ms"
+    )
+    logger.info(
+        f"Mean inference time for {batch_size} (batch), resolution {resolution} images was {(mean_inference_time * 1000.0):.2f} ms ({batch_size / mean_inference_time:.2f} fps)"
+    )
+
+    prep_perf_report(
+        model_name="Swin_s",
+        batch_size=batch_size,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="",
+        inference_time_cpu=0.0,
+    )
+
+    logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
+    logger.info(f"Inference time: {inference_time}")
+    logger.info(f"Samples per second: {1 / inference_time * batch_size}")
+
+
+@pytest.mark.parametrize(
+    "batch_size, model_name, expected_perf",
+    [
+        (1, "Swin_s", 5.3),
+    ],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_perf_device_bare_metal_swin_s(batch_size, model_name, expected_perf):
+    subdir = model_name
+    num_iterations = 1
+    margin = 0.03
+
+    command = f"pytest tests/ttnn/integration_tests/swin_s/test_ttnn_swin_transformer.py::test_swin_s_transformer[pretrained_weight_true-0]"
+
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_perf}
+
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols)
+    prep_device_perf_report(
+        model_name=f"ttnn_functional_{model_name}_{batch_size}",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )

--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -18,7 +18,7 @@ from models.experimental.swin_s.reference.swin_transformer import SwinTransforme
 
 # from models.experimental.swin_v2.tt.model_preprocessing import create_swinv2_model_parameters, preprocess_attn_mask
 from tests.ttnn.integration_tests.swin_s.test_ttnn_swin_transformer import (
-    create_custom_preprocessor,
+    create_custom_mesh_preprocessor,
     preprocess_attn_mask,
 )
 from models.experimental.swin_s.tt.tt_swin_transformer import TtSwinTransformer
@@ -63,7 +63,7 @@ def test_swin_s(
     batch_size = input_shape[0]
     resolution = input_shape[1:3]
     parameters = preprocess_model_parameters(
-        initialize_model=lambda: torch_model, custom_preprocessor=create_custom_preprocessor(device), device=device
+        initialize_model=lambda: torch_model, custom_preprocessor=create_custom_mesh_preprocessor(), device=device
     )
 
     ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, device=device)

--- a/models/experimental/swin_s/tt/common.py
+++ b/models/experimental/swin_s/tt/common.py
@@ -83,3 +83,15 @@ class Conv:
         del _out_height, _out_width
 
         return output_tensor
+
+
+def get_mesh_mappers(device):
+    if device.get_num_devices() > 1:
+        inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+        weights_mesh_mapper = None
+        output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+    else:
+        inputs_mesh_mapper = None
+        weights_mesh_mapper = None
+        output_mesh_composer = None
+    return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer

--- a/models/experimental/swin_s/tt/tt_patchmerging.py
+++ b/models/experimental/swin_s/tt/tt_patchmerging.py
@@ -43,13 +43,10 @@ class TtPatchMerging:
         input_tensor_1 = input_tensor[..., 1::2, 0::2, :]  # ... H/2 W/2 C
         input_tensor_2 = input_tensor[..., 0::2, 1::2, :]  # ... H/2 W/2 C
         input_tensor_3 = input_tensor[..., 1::2, 1::2, :]  # ... H/2 W/2 C
-        input_tensor_0 = ttnn.to_layout(input_tensor_0, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
-        input_tensor_1 = ttnn.to_layout(input_tensor_1, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
-        input_tensor_2 = ttnn.to_layout(input_tensor_2, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
-        input_tensor_3 = ttnn.to_layout(input_tensor_3, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
         output_tensor = ttnn.concat(
             [input_tensor_0, input_tensor_1, input_tensor_2, input_tensor_3], -1, memory_config=ttnn.L1_MEMORY_CONFIG
         )
+        output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
         output_tensor = ttnn.layer_norm(
             output_tensor,
             weight=self.parameters.norm["weight"],

--- a/tests/ttnn/integration_tests/swin_s/test_ttnn_mlp.py
+++ b/tests/ttnn/integration_tests/swin_s/test_ttnn_mlp.py
@@ -7,35 +7,60 @@ from torch import nn
 import pytest
 from ttnn.model_preprocessing import (
     preprocess_model_parameters,
-    preprocess_linear_weight,
-    preprocess_layernorm_parameter,
-    preprocess_linear_bias,
 )
 from models.utility_functions import skip_for_grayskull
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.swin_s.reference.mlp import MLP
 from models.experimental.swin_s.tt.tt_mlp import TtMLP
+from models.experimental.swin_s.tt.common import get_mesh_mappers
 from torchvision import models
 import ttnn
 
 
-def create_custom_preprocessor(device):
-    def custom_preprocessor(torch_model, name, ttnn_module_args):
-        parameters = {}
-        if isinstance(torch_model, MLP):
-            parameters[0] = {}
-            parameters[3] = {}
-            parameters[0]["weight"] = preprocess_linear_weight(torch_model[0].weight, dtype=ttnn.bfloat16)
-            parameters[0]["bias"] = preprocess_linear_bias(torch_model[0].bias, dtype=ttnn.bfloat16)
-            parameters[3]["weight"] = preprocess_linear_weight(torch_model[3].weight, dtype=ttnn.bfloat16)
-            parameters[3]["bias"] = preprocess_linear_bias(torch_model[3].bias, dtype=ttnn.bfloat16)
-            if torch.layer_norm in torch_model:
-                parameters[1] = {}
-                parameters[1]["weight"] = preprocess_layernorm_parameter(torch_model[1].weight, dtype=ttnn.bfloat16)
-                parameters[1]["bias"] = preprocess_layernorm_parameter(torch_model[1].bias, dtype=ttnn.bfloat16)
-        return parameters
+def preprocess_linear_weight(weight, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    weight = weight.T.contiguous()
+    weight = ttnn.from_torch(weight, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return weight
 
-    return custom_preprocessor
+
+def preprocess_linear_bias(bias, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    bias = bias.reshape((1, -1))
+    bias = ttnn.from_torch(bias, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return bias
+
+
+def preprocess_layernorm_parameter(parameter, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    parameter = parameter.reshape((1, -1))
+    parameter = ttnn.from_torch(parameter, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return parameter
+
+
+def custom_preprocessor(torch_model, name, mesh_mapper=None):
+    parameters = {}
+    if isinstance(torch_model, MLP):
+        parameters[0] = {}
+        parameters[3] = {}
+        parameters[0]["weight"] = preprocess_linear_weight(
+            torch_model[0].weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters[0]["bias"] = preprocess_linear_bias(
+            torch_model[0].bias, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters[3]["weight"] = preprocess_linear_weight(
+            torch_model[3].weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters[3]["bias"] = preprocess_linear_bias(
+            torch_model[3].bias, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        if torch.layer_norm in torch_model:
+            parameters[1] = {}
+            parameters[1]["weight"] = preprocess_layernorm_parameter(
+                torch_model[1].weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+            )
+            parameters[1]["bias"] = preprocess_layernorm_parameter(
+                torch_model[1].bias, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+            )
+    return parameters
 
 
 @skip_for_grayskull()
@@ -79,8 +104,12 @@ def test_mlp(device, in_channels, hidden_channels, batch_size, seq_len, i, j, re
     torch_input_tensor = torch.randn(batch_size, seq_len, seq_len, in_channels)  # Sample input tensor
     torch_output_tensor = torch_model(torch_input_tensor)
 
+    _, weights_mesh_mapper, _ = get_mesh_mappers(device)
+
     parameters = preprocess_model_parameters(
-        initialize_model=lambda: torch_model, custom_preprocessor=create_custom_preprocessor(device), device=device
+        initialize_model=lambda: torch_model,
+        custom_preprocessor=create_custom_mesh_preprocessor(weights_mesh_mapper),
+        device=device,
     )
 
     # Convert the model to TTNN
@@ -96,3 +125,10 @@ def test_mlp(device, in_channels, hidden_channels, batch_size, seq_len, i, j, re
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+def create_custom_mesh_preprocessor(mesh_mapper=None):
+    def custom_mesh_preprocessor(model, name):
+        return custom_preprocessor(model, name, mesh_mapper)
+
+    return custom_mesh_preprocessor

--- a/tests/ttnn/integration_tests/swin_s/test_ttnn_patchmerging.py
+++ b/tests/ttnn/integration_tests/swin_s/test_ttnn_patchmerging.py
@@ -6,31 +6,41 @@ import torch
 from torchvision import models
 import pytest
 import ttnn
-from ttnn.model_preprocessing import (
-    preprocess_model_parameters,
-    preprocess_linear_weight,
-    preprocess_layernorm_parameter,
-)
+from ttnn.model_preprocessing import preprocess_model_parameters
 from models.utility_functions import skip_for_grayskull
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.swin_s.reference.patchmerging import PatchMerging
 from models.experimental.swin_s.tt.tt_patchmerging import TtPatchMerging
+from models.experimental.swin_s.tt.common import get_mesh_mappers
 
 
-def create_custom_preprocessor(device):
-    def custom_preprocessor(torch_model, name, ttnn_module_args):
-        parameters = {}
-        if isinstance(torch_model, PatchMerging):
-            parameters["reduction"] = {}
-            parameters["reduction"]["weight"] = preprocess_linear_weight(
-                torch_model.reduction.weight, dtype=ttnn.bfloat16
-            )
-            parameters["norm"] = {}
-            parameters["norm"]["weight"] = preprocess_layernorm_parameter(torch_model.norm.weight, dtype=ttnn.bfloat16)
-            parameters["norm"]["bias"] = preprocess_layernorm_parameter(torch_model.norm.bias, dtype=ttnn.bfloat16)
-        return parameters
+def preprocess_linear_weight(weight, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    weight = weight.T.contiguous()
+    weight = ttnn.from_torch(weight, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return weight
 
-    return custom_preprocessor
+
+def preprocess_layernorm_parameter(parameter, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    parameter = parameter.reshape((1, -1))
+    parameter = ttnn.from_torch(parameter, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return parameter
+
+
+def custom_preprocessor(torch_model, name, mesh_mapper=None):
+    parameters = {}
+    if isinstance(torch_model, PatchMerging):
+        parameters["reduction"] = {}
+        parameters["reduction"]["weight"] = preprocess_linear_weight(
+            torch_model.reduction.weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters["norm"] = {}
+        parameters["norm"]["weight"] = preprocess_layernorm_parameter(
+            torch_model.norm.weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters["norm"]["bias"] = preprocess_layernorm_parameter(
+            torch_model.norm.bias, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+    return parameters
 
 
 @skip_for_grayskull()
@@ -73,9 +83,13 @@ def test_patchmerging(device, batch_size, dim, seq_len, i, reset_seeds):
     torch_input_tensor = torch.randn(batch_size, seq_len, seq_len, dim)  # Sample input tensor
     torch_output_tensor = torch_model(torch_input_tensor)
 
+    _, weights_mesh_mapper, _ = get_mesh_mappers(device)
+
     # Preprocess the model parameters for TTNN
     parameters = preprocess_model_parameters(
-        initialize_model=lambda: torch_model, custom_preprocessor=create_custom_preprocessor(device), device=device
+        initialize_model=lambda: torch_model,
+        custom_preprocessor=create_custom_mesh_preprocessor(weights_mesh_mapper),
+        device=device,
     )
 
     # Convert the model to TTNN
@@ -91,3 +105,10 @@ def test_patchmerging(device, batch_size, dim, seq_len, i, reset_seeds):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+def create_custom_mesh_preprocessor(mesh_mapper=None):
+    def custom_mesh_preprocessor(model, name):
+        return custom_preprocessor(model, name, mesh_mapper)
+
+    return custom_mesh_preprocessor

--- a/tests/ttnn/integration_tests/swin_s/test_ttnn_swin_transformer.py
+++ b/tests/ttnn/integration_tests/swin_s/test_ttnn_swin_transformer.py
@@ -6,25 +6,21 @@ import torch
 from torchvision import models
 import pytest
 import ttnn
-from ttnn.model_preprocessing import (
-    preprocess_model_parameters,
-    preprocess_linear_weight,
-    preprocess_layernorm_parameter,
-    preprocess_linear_bias,
-)
+from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import skip_for_grayskull
 from models.experimental.swin_s.reference.swin_transformer import SwinTransformer
 from models.experimental.swin_s.tt.tt_swin_transformer import TtSwinTransformer
 from tests.ttnn.integration_tests.swin_s.test_ttnn_swin_transformer_block import (
-    create_custom_preprocessor as create_custom_preprocessor_transformer_block,
+    create_custom_mesh_preprocessor as create_custom_mesh_preprocessor_transformer_block,
 )
 from tests.ttnn.integration_tests.swin_s.test_ttnn_patchmerging import (
-    create_custom_preprocessor as create_custom_preprocessor_patch_merging,
+    create_custom_mesh_preprocessor as create_custom_mesh_preprocessor_patch_merging,
 )
+from models.experimental.swin_s.tt.common import get_mesh_mappers
 
 
-def preprocess_attn_mask(input_shape, patch_size, window_size, shift_size, device):
+def preprocess_attn_mask(input_shape, patch_size, window_size, shift_size, device, weights_mesh_mapper=None):
     h, w = input_shape[2], input_shape[3]
     attention_h = ((h - (patch_size[0] - 1) - 1) // patch_size[0]) + 1
     attention_w = ((w - (patch_size[0] - 1) - 1) // patch_size[0]) + 1
@@ -57,7 +53,7 @@ def preprocess_attn_mask(input_shape, patch_size, window_size, shift_size, devic
         attn_mask = attn_mask.unsqueeze(1) - attn_mask.unsqueeze(2)
         attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
         attn_mask = attn_mask.unsqueeze(1).unsqueeze(0)
-        attn_mask = ttnn.from_torch(attn_mask, device=device, layout=ttnn.TILE_LAYOUT)
+        attn_mask = ttnn.from_torch(attn_mask, device=device, layout=ttnn.TILE_LAYOUT, mesh_mapper=weights_mesh_mapper)
         attention_h = attention_h // 2
         attention_w = attention_w // 2
 
@@ -66,54 +62,77 @@ def preprocess_attn_mask(input_shape, patch_size, window_size, shift_size, devic
     return attn_mask_tuple
 
 
-def create_custom_preprocessor(device):
-    def custom_preprocessor(torch_model, name, ttnn_module_args):
-        parameters = {}
-        if isinstance(torch_model, SwinTransformer):
-            parameters["features"] = {}
-            parameters["features"][0] = {}
-            parameters["features"][0][0] = {}
-            parameters["features"][0][2] = {}
-            parameters["features"][0][0]["weight"] = ttnn.from_torch(
-                torch_model.features[0][0].weight, dtype=ttnn.bfloat16
-            )
-            parameters["features"][0][0]["bias"] = ttnn.from_torch(
-                torch.reshape(torch_model.features[0][0].bias, (1, 1, 1, -1)), dtype=ttnn.bfloat16
-            )
-            parameters["features"][0][2]["weight"] = preprocess_layernorm_parameter(
-                torch_model.features[0][2].weight, dtype=ttnn.bfloat8_b
-            )
-            parameters["features"][0][2]["bias"] = preprocess_layernorm_parameter(
-                torch_model.features[0][2].bias, dtype=ttnn.bfloat8_b
-            )
+def preprocess_linear_weight(weight, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    weight = weight.T.contiguous()
+    weight = ttnn.from_torch(weight, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return weight
 
-            tranformer_block_preprocessor = create_custom_preprocessor_transformer_block(device)
-            patch_merging_preprocessor = create_custom_preprocessor_patch_merging(device)
-            depths_list = [2, 2, 18, 2]
-            for i_stage in range(len(depths_list)):
-                index_list = [1, 3, 5, 7]
-                parameters["features"][index_list[i_stage]] = {}
-                for i_layer in range(depths_list[i_stage]):
-                    parameters["features"][index_list[i_stage]][i_layer] = {}
-                    parameters["features"][index_list[i_stage]][i_layer] = tranformer_block_preprocessor(
-                        torch_model.features[index_list[i_stage]][i_layer], None, None
-                    )
-            for i_patch_merging in range(2, 7, 2):
-                parameters["features"][i_patch_merging] = {}
-                parameters["features"][i_patch_merging] = patch_merging_preprocessor(
-                    torch_model.features[i_patch_merging], None, None
+
+def preprocess_linear_bias(bias, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    bias = bias.reshape((1, -1))
+    bias = ttnn.from_torch(bias, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return bias
+
+
+def preprocess_layernorm_parameter(parameter, *, dtype, layout=ttnn.TILE_LAYOUT, mesh_mapper=None):
+    parameter = parameter.reshape((1, -1))
+    parameter = ttnn.from_torch(parameter, dtype=dtype, layout=layout, mesh_mapper=mesh_mapper)
+    return parameter
+
+
+def custom_preprocessor(torch_model, name, mesh_mapper=None):
+    parameters = {}
+    if isinstance(torch_model, SwinTransformer):
+        parameters["features"] = {}
+        parameters["features"][0] = {}
+        parameters["features"][0][0] = {}
+        parameters["features"][0][2] = {}
+        parameters["features"][0][0]["weight"] = ttnn.from_torch(
+            torch_model.features[0][0].weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters["features"][0][0]["bias"] = ttnn.from_torch(
+            torch.reshape(torch_model.features[0][0].bias, (1, 1, 1, -1)), dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters["features"][0][2]["weight"] = preprocess_layernorm_parameter(
+            torch_model.features[0][2].weight, dtype=ttnn.bfloat8_b, mesh_mapper=mesh_mapper
+        )
+        parameters["features"][0][2]["bias"] = preprocess_layernorm_parameter(
+            torch_model.features[0][2].bias, dtype=ttnn.bfloat8_b, mesh_mapper=mesh_mapper
+        )
+
+        tranformer_block_preprocessor = create_custom_mesh_preprocessor_transformer_block(mesh_mapper)
+        patch_merging_preprocessor = create_custom_mesh_preprocessor_patch_merging(mesh_mapper)
+        depths_list = [2, 2, 18, 2]
+        for i_stage in range(len(depths_list)):
+            index_list = [1, 3, 5, 7]
+            parameters["features"][index_list[i_stage]] = {}
+            for i_layer in range(depths_list[i_stage]):
+                parameters["features"][index_list[i_stage]][i_layer] = {}
+                parameters["features"][index_list[i_stage]][i_layer] = tranformer_block_preprocessor(
+                    torch_model.features[index_list[i_stage]][i_layer], None
                 )
+        for i_patch_merging in range(2, 7, 2):
+            parameters["features"][i_patch_merging] = {}
+            parameters["features"][i_patch_merging] = patch_merging_preprocessor(
+                torch_model.features[i_patch_merging], None
+            )
 
-            parameters["norm"] = {}
-            parameters["head"] = {}
-            parameters["norm"]["weight"] = preprocess_layernorm_parameter(torch_model.norm.weight, dtype=ttnn.bfloat16)
-            parameters["norm"]["bias"] = preprocess_layernorm_parameter(torch_model.norm.bias, dtype=ttnn.bfloat16)
-            parameters["head"]["weight"] = preprocess_linear_weight(torch_model.head.weight, dtype=ttnn.bfloat8_b)
-            parameters["head"]["bias"] = preprocess_linear_bias(torch_model.head.bias, dtype=ttnn.bfloat8_b)
+        parameters["norm"] = {}
+        parameters["head"] = {}
+        parameters["norm"]["weight"] = preprocess_layernorm_parameter(
+            torch_model.norm.weight, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters["norm"]["bias"] = preprocess_layernorm_parameter(
+            torch_model.norm.bias, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper
+        )
+        parameters["head"]["weight"] = preprocess_linear_weight(
+            torch_model.head.weight, dtype=ttnn.bfloat8_b, mesh_mapper=mesh_mapper
+        )
+        parameters["head"]["bias"] = preprocess_linear_bias(
+            torch_model.head.bias, dtype=ttnn.bfloat8_b, mesh_mapper=mesh_mapper
+        )
 
-        return parameters
-
-    return custom_preprocessor
+    return parameters
 
 
 @skip_for_grayskull()
@@ -145,11 +164,17 @@ def test_swin_s_transformer(device, use_pretrained_weight, reset_seeds):
     torch_input_tensor = torch.randn(1, 3, 512, 512)  # Sample input tensor
     torch_output_tensor = torch_model(torch_input_tensor)
 
+    _, weights_mesh_mapper, _ = get_mesh_mappers(device)
+
     parameters = preprocess_model_parameters(
-        initialize_model=lambda: torch_model, custom_preprocessor=create_custom_preprocessor(device), device=device
+        initialize_model=lambda: torch_model,
+        custom_preprocessor=create_custom_mesh_preprocessor(weights_mesh_mapper),
+        device=device,
     )
 
-    attn_mask_tuple = preprocess_attn_mask([1, 3, 512, 512], [4, 4], [7, 7], [3, 3], device)
+    attn_mask_tuple = preprocess_attn_mask(
+        [1, 3, 512, 512], [4, 4], [7, 7], [3, 3], device, weights_mesh_mapper=weights_mesh_mapper
+    )
 
     # Convert the model to TTNN
     ttnn_model = TtSwinTransformer(
@@ -182,3 +207,10 @@ def test_swin_s_transformer(device, use_pretrained_weight, reset_seeds):
     assert_with_pcc(
         torch_output_tensor, output_tensor, pcc=0.96 if use_pretrained_weight else 0.99  # pcc=0.9611514804078299
     )  # The drop starts as we use shard MM in patch_mergig & mlp sub_module sub_module
+
+
+def create_custom_mesh_preprocessor(mesh_mapper=None):
+    def custom_mesh_preprocessor(model, name):
+        return custom_preprocessor(model, name, mesh_mapper)
+
+    return custom_mesh_preprocessor

--- a/tests/ttnn/integration_tests/swin_s/test_ttnn_swin_transformer.py
+++ b/tests/ttnn/integration_tests/swin_s/test_ttnn_swin_transformer.py
@@ -117,7 +117,7 @@ def create_custom_preprocessor(device):
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True, ids=["0"])
 @pytest.mark.parametrize(
     "use_pretrained_weight",
     [
@@ -180,5 +180,5 @@ def test_swin_s_transformer(device, use_pretrained_weight, reset_seeds):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(
-        torch_output_tensor, output_tensor, pcc=0.96 if use_pretrained_weight else 0.99  # pcc=0.9614840639526093
+        torch_output_tensor, output_tensor, pcc=0.96 if use_pretrained_weight else 0.99  # pcc=0.9611514804078299
     )  # The drop starts as we use shard MM in patch_mergig & mlp sub_module sub_module


### PR DESCRIPTION
### Ticket
[#17785](https://github.com/tenstorrent/tt-metal/issues/17785)

### Problem description
Add DataParallel support for Swin_S model.

### What's changed
Added data parallel support for Swin_S model to :
- Demo
- e2e performant

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml):
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml):
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml):
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml):