### PR TITLE
Fix Llama70b 6U Galaxy demo

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -377,7 +377,7 @@ def test_demo_text(
         pytest.skip("Skipping test since there is no 6U machines dedicated for APC")
     if apc_test and not pcc_check:
         raise ValueError("APC test requires PCC check to be enabled")
-    if pcc_check:
+    if apc_test:
         demo_targets = load_demo_targets("models/demos/llama3_subdevices/demo/text_demo_targets.json", galaxy_type)
 
     # Override parameters from command line if they are provided

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -637,13 +637,13 @@ def test_demo_text(
             logger.info(
                 f"Teacher forced token at prefill {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
             )
-	    if apc_test
-            	assert_message = (
-                	f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"
-                	f"If it is expected to be different in Llama model, please update the text_demo_targets.json file.\n"
-                	f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
-            	)
-                assert pcc_message == demo_targets["prefill_pcc"], assert_message
+        if apc_test:
+            assert_message = (
+                f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"
+                f"If it is expected to be different in Llama model, please update the text_demo_targets.json file.\n"
+                f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
+            )
+            assert pcc_message == demo_targets["prefill_pcc"], assert_message
 
         # Save prefill token
         prefilled_token = toks.view(-1, 1)
@@ -762,13 +762,13 @@ def test_demo_text(
                     logger.info(
                         f"Teacher forced token at decode iteration {iteration} {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
                     )
-                    if apc_test:
-		    	assert_message = (
-                        	f"Decode PCC check failed: {pcc_message}, while expected {demo_targets['decode_pcc']}.\n"
-                        	f"If any ops in Llama model might be impacted, please update decode_pcc in the text_demo_targets.json file.\n"
-                        	f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
-                    	)
-                        assert pcc_message == demo_targets["decode_pcc"], assert_message
+                if apc_test:
+                    assert_message = (
+                        f"Decode PCC check failed: {pcc_message}, while expected {demo_targets['decode_pcc']}.\n"
+                        f"If any ops in Llama model might be impacted, please update decode_pcc in the text_demo_targets.json file.\n"
+                        f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
+                    )
+                    assert pcc_message == demo_targets["decode_pcc"], assert_message
 
                 if teacher_forcing:
                     _, tt_top5_tokens = torch.topk(tt_out_logits_saved, k=5, dim=-1)

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -631,18 +631,18 @@ def test_demo_text(
             torch_output_logits = torch_output[0]
             logits = tt_out_logits_all_users[0, 0, :vocab_size]
             does_pass, pcc_message = comp_pcc(
-                logits, torch_output_logits, demo_targets["prefill_pcc"] if apc_test else 0.91
+                logits, torch_output_logits, 0.91 if not apc_test else demo_targets["prefill_pcc"]
             )
             logger.info(f"PCC: {pcc_message}")
             logger.info(
                 f"Teacher forced token at prefill {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
             )
-            assert_message = (
-                f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"
-                f"If it is expected to be different in Llama model, please update the text_demo_targets.json file.\n"
-                f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
-            )
-            if apc_test:
+	    if apc_test
+            	assert_message = (
+                	f"Prefill PCC check failed: {pcc_message}, while expected {demo_targets['prefill_pcc']}.\n"
+                	f"If it is expected to be different in Llama model, please update the text_demo_targets.json file.\n"
+                	f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
+            	)
                 assert pcc_message == demo_targets["prefill_pcc"], assert_message
 
         # Save prefill token
@@ -756,18 +756,18 @@ def test_demo_text(
                     else:
                         torch_output_logits = torch_output[iteration + 1]
                     does_pass, pcc_message = comp_pcc(
-                        tt_out_logits_saved, torch_output_logits, demo_targets["decode_pcc"] if apc_test else 0.91
+                        tt_out_logits_saved, torch_output_logits, 0.91 if not apc_test else demo_targets["decode_pcc"]
                     )
                     logger.info(f"PCC: {pcc_message}")
                     logger.info(
                         f"Teacher forced token at decode iteration {iteration} {'PASSED' if does_pass else 'FAILED'} PCC check with torch reference model"
                     )
-                    assert_message = (
-                        f"Decode PCC check failed: {pcc_message}, while expected {demo_targets['decode_pcc']}.\n"
-                        f"If any ops in Llama model might be impacted, please update decode_pcc in the text_demo_targets.json file.\n"
-                        f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
-                    )
                     if apc_test:
+		    	assert_message = (
+                        	f"Decode PCC check failed: {pcc_message}, while expected {demo_targets['decode_pcc']}.\n"
+                        	f"If any ops in Llama model might be impacted, please update decode_pcc in the text_demo_targets.json file.\n"
+                        	f"Instructions: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/README.md#updating-apc-test-target-values"
+                    	)
                         assert pcc_message == demo_targets["decode_pcc"], assert_message
 
                 if teacher_forcing:


### PR DESCRIPTION
### Problem description
Test is trying to open demo targets for APC in 6U but we don't have it nor we use it.

### What's changed
Updated condition to skip if it's not apc_test instead of pcc_check that is enabled on 6U.

### Checklist
- [ ] [Galaxy Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16372211827)