### PR TITLE
fix rms norm for mesh change from  (8, 4) -> (4, 8)

### DIFF
--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -70,7 +70,7 @@ def reference_model(hf_config, request):
 @pytest.mark.parametrize(
     "mode, batch, seq_len, norm_category",
     [
-        ("decode", 64, 1, "attention_norm"),  # Batch decode with distributed and sharded inputs
+        ("decode", 32, 1, "attention_norm"),  # Batch decode with distributed and sharded inputs
         ("prefill", 1, 128, "attention_norm"),  # Prefill with distributed and interleaved inputs
         ("decode", 32, 1, "q_norm"),  # Q norm test (uses q_lora_rank)
         ("prefill", 1, 128, "q_norm"),  # Q norm prefill test
@@ -123,7 +123,7 @@ def test_rmsnorm_forward_pass(
     tt_input = ttnn.from_torch(
         torch_input,
         device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-1, -2), mesh_shape=list(mesh_device.shape))
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, -1), mesh_shape=list(mesh_device.shape))
         if is_decoder_norm
         else ttnn.ReplicateTensorToMesh(mesh_device),
         dtype=ttnn.bfloat16,
@@ -153,7 +153,7 @@ def test_rmsnorm_forward_pass(
     if is_decoder_norm:
         tt_output_torch = ttnn.to_torch(
             tt_output,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-1, -2), mesh_shape=list(mesh_device.shape)),
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=list(mesh_device.shape)),
         )
     else:
         tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_output)[0])

--- a/models/demos/deepseek_v3/tt/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm.py
@@ -57,7 +57,7 @@ class RMSNorm(AbstractModule):
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(2, None), mesh_shape=list(mesh_device.shape))
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 2), mesh_shape=list(mesh_device.shape))
             if decoder_norm
             else ttnn.ReplicateTensorToMesh(mesh_device),
         )
@@ -187,7 +187,7 @@ class RMSNorm(AbstractModule):
             tt_stats,
             dim=3,
             num_links=1,
-            cluster_axis=0,
+            cluster_axis=1,
             mesh_device=mesh_device,
             memory_config=stats_memcfg,
             topology=topology,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes