### PR TITLE
Reenabled Conv2dOpIfTest

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -779,7 +779,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 class Conv2dOpIfTest : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(Conv2dOpIfTest, Conv2d) {
-    GTEST_SKIP();
     const auto input_spec = ttnn::TensorSpec(
         ttnn::Shape{1, 1, 50176, 3},
         tt::tt_metal::TensorLayout(
@@ -810,9 +809,6 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
     const uint32_t groups = 1;
 
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-        GTEST_SKIP();
-    }
 
     // Run the test
     {

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -76,6 +76,8 @@ public:
 
     virtual bool hook_program(Program* program) = 0;
 
+    virtual bool hook_write_to_device(tt::tt_metal::Buffer* buffer) = 0;
+
     virtual ~IGraphHooks() = default;
 };
 
@@ -145,6 +147,8 @@ public:
     bool hook_allocate(const Buffer* buffer);
 
     bool hook_deallocate(Buffer* buffer);
+
+    bool hook_write_to_device(Buffer* buffer);
 
     bool hook_program(tt::tt_metal::Program* program);
 

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -76,8 +76,6 @@ public:
 
     virtual bool hook_program(Program* program) = 0;
 
-    virtual bool hook_write_to_device(tt::tt_metal::Buffer* buffer) = 0;
-
     virtual bool hook_write_to_device(const tt::tt_metal::Buffer* buffer) = 0;
 
     virtual bool hook_read_from_device(tt::tt_metal::Buffer* buffer) = 0;
@@ -151,8 +149,6 @@ public:
     bool hook_allocate(const Buffer* buffer);
 
     bool hook_deallocate(Buffer* buffer);
-
-    bool hook_write_to_device(Buffer* buffer);
 
     bool hook_write_to_device(const Buffer* buffer);
 

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -19,6 +19,7 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 
 namespace tt {
 namespace tt_metal {
@@ -79,6 +80,10 @@ public:
     virtual bool hook_write_to_device(const tt::tt_metal::Buffer* buffer) = 0;
 
     virtual bool hook_read_from_device(tt::tt_metal::Buffer* buffer) = 0;
+
+    virtual bool hook_read_from_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) = 0;
+
+    virtual bool hook_write_to_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) = 0;
 
     virtual ~IGraphHooks() = default;
 };
@@ -152,7 +157,11 @@ public:
 
     bool hook_write_to_device(const Buffer* buffer);
 
+    bool hook_write_to_device(const distributed::MeshBuffer* mesh_buffer);
+
     bool hook_read_from_device(Buffer* buffer);
+
+    bool hook_read_from_device(const distributed::MeshBuffer* mesh_buffer);
 
     bool hook_program(tt::tt_metal::Program* program);
 

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -78,6 +78,10 @@ public:
 
     virtual bool hook_write_to_device(tt::tt_metal::Buffer* buffer) = 0;
 
+    virtual bool hook_write_to_device(const tt::tt_metal::Buffer* buffer) = 0;
+
+    virtual bool hook_read_from_device(tt::tt_metal::Buffer* buffer) = 0;
+
     virtual ~IGraphHooks() = default;
 };
 
@@ -149,6 +153,10 @@ public:
     bool hook_deallocate(Buffer* buffer);
 
     bool hook_write_to_device(Buffer* buffer);
+
+    bool hook_write_to_device(const Buffer* buffer);
+
+    bool hook_read_from_device(Buffer* buffer);
 
     bool hook_program(tt::tt_metal::Program* program);
 

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -7,6 +7,7 @@
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/graph_tracking.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -25,6 +26,10 @@ void SDMeshCommandQueue::write_shard_to_device(
     auto shard_view = device_buffer->view(region_value);
 
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
+    if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
+        return;
+    }
+
     tt::tt_metal::detail::WriteToBuffer(
         *shard_view,
         tt::stl::Span<const uint8_t>(static_cast<const uint8_t*>(src) + region_value.offset, region_value.size));
@@ -41,6 +46,10 @@ void SDMeshCommandQueue::read_shard_from_device(
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
 
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
+    if (tt::tt_metal::GraphTracker::instance().hook_read_from_device(&buffer)) {
+        return;
+    }
+
     tt::tt_metal::detail::ReadFromBuffer(*shard_view, static_cast<uint8_t*>(dst));
 }
 

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -116,6 +116,13 @@ bool GraphTracker::hook_deallocate(Buffer* buffer) {
     return hooked;
 }
 
+bool GraphTracker::hook_write_to_device(tt::tt_metal::Buffer* buffer) {
+    if (hook == nullptr) {
+        return false;
+    }
+    return hook->hook_write_to_device(buffer);
+}
+
 bool GraphTracker::hook_program(tt::tt_metal::Program* program) {
     if (hook == nullptr) {
         return false;

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -123,11 +123,25 @@ bool GraphTracker::hook_write_to_device(const tt::tt_metal::Buffer* buffer) {
     return hook->hook_write_to_device(buffer);
 }
 
+bool GraphTracker::hook_write_to_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) {
+    if (hook == nullptr) {
+        return false;
+    }
+    return hook->hook_write_to_device(mesh_buffer);
+}
+
 bool GraphTracker::hook_read_from_device(tt::tt_metal::Buffer* buffer) {
     if (hook == nullptr) {
         return false;
     }
     return hook->hook_read_from_device(buffer);
+}
+
+bool GraphTracker::hook_read_from_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) {
+    if (hook == nullptr) {
+        return false;
+    }
+    return hook->hook_read_from_device(mesh_buffer);
 }
 
 bool GraphTracker::hook_program(tt::tt_metal::Program* program) {

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -123,6 +123,20 @@ bool GraphTracker::hook_write_to_device(tt::tt_metal::Buffer* buffer) {
     return hook->hook_write_to_device(buffer);
 }
 
+bool GraphTracker::hook_write_to_device(const tt::tt_metal::Buffer* buffer) {
+    if (hook == nullptr) {
+        return false;
+    }
+    return hook->hook_write_to_device(buffer);
+}
+
+bool GraphTracker::hook_read_from_device(tt::tt_metal::Buffer* buffer) {
+    if (hook == nullptr) {
+        return false;
+    }
+    return hook->hook_read_from_device(buffer);
+}
+
 bool GraphTracker::hook_program(tt::tt_metal::Program* program) {
     if (hook == nullptr) {
         return false;

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -116,13 +116,6 @@ bool GraphTracker::hook_deallocate(Buffer* buffer) {
     return hooked;
 }
 
-bool GraphTracker::hook_write_to_device(tt::tt_metal::Buffer* buffer) {
-    if (hook == nullptr) {
-        return false;
-    }
-    return hook->hook_write_to_device(buffer);
-}
-
 bool GraphTracker::hook_write_to_device(const tt::tt_metal::Buffer* buffer) {
     if (hook == nullptr) {
         return false;

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -29,6 +29,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/event/dispatch.hpp"
 #include "tt_metal/impl/device/dispatch.hpp"
+#include <tt-metalium/graph_tracking.hpp>
 
 enum class CoreType;
 
@@ -698,6 +699,11 @@ void write_to_device_buffer(
     CoreType dispatch_core_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     SystemMemoryManager& sysmem_manager = buffer.device()->sysmem_manager();
+
+    if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
+        return;
+    }
+
     const BufferDispatchConstants buf_dispatch_constants =
         generate_buffer_dispatch_constants(sysmem_manager, dispatch_core_type, cq_id);
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -664,6 +664,10 @@ void write_sharded_buffer_to_core(
     // Currently since writing sharded tensors uses write_linear, we write the padded pages on width
     // Alternative write each page row into separate commands, or have a strided linear write
 
+    if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
+        return;
+    }
+
     dispatch_params.reset_params_for_core(core, core_page_mapping);
 
     while (dispatch_params.core_num_pages_remaining_to_write != 0) {
@@ -795,6 +799,10 @@ BufferReadDispatchParams initialize_interleaved_buf_read_dispatch_params(
 template <typename T>
 void issue_read_buffer_dispatch_command_sequence(
     Buffer& buffer, T& dispatch_params, tt::stl::Span<const SubDeviceId> sub_device_ids, CoreType dispatch_core_type) {
+    if (tt::tt_metal::GraphTracker::instance().hook_read_from_device(&buffer)) {
+        return;
+    }
+
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     uint32_t num_worker_counters = sub_device_ids.size();
     tt::tt_metal::DeviceCommandCalculator calculator;

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -311,7 +311,6 @@ void HWCommandQueue::enqueue_write_buffer(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_write_buffer");
     TT_FATAL(!this->manager_.get_bypass_mode(), "Enqueue Write Buffer cannot be used with tracing");
-
     // Top level API to accept different variants for buffer and src
     // For shared pointer variants, object lifetime is guaranteed at least till the end of this function
     auto* data = std::visit(

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -42,6 +42,7 @@
 #include "data_collection.hpp"
 #include "ringbuffer_cache.hpp"
 #include "program/dispatch.hpp"
+#include <tt-metalium/graph_tracking.hpp>
 
 namespace tt {
 namespace tt_metal {
@@ -310,6 +311,7 @@ void HWCommandQueue::enqueue_write_buffer(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_write_buffer");
     TT_FATAL(!this->manager_.get_bypass_mode(), "Enqueue Write Buffer cannot be used with tracing");
+
     // Top level API to accept different variants for buffer and src
     // For shared pointer variants, object lifetime is guaranteed at least till the end of this function
     auto* data = std::visit(

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -52,6 +52,7 @@
 #include "utils.hpp"
 #include "fabric/hw/inc/fabric_routing_mode.h"
 #include <tt-metalium/graph_tracking.hpp>
+
 namespace tt {
 
 namespace tt_metal {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -51,7 +51,7 @@
 #include <umd/device/types/xy_pair.h>
 #include "utils.hpp"
 #include "fabric/hw/inc/fabric_routing_mode.h"
-
+#include <tt-metalium/graph_tracking.hpp>
 namespace tt {
 
 namespace tt_metal {
@@ -498,6 +498,10 @@ DeviceAddr CalculateAddressDeviceInterleavedContiguous(const Buffer& buffer, uin
 }
 
 void WriteToDeviceInterleavedContiguous(const Buffer& buffer, tt::stl::Span<const uint8_t> host_buffer) {
+    if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
+        return;
+    }
+
     size_t host_buffer_size_bytes = host_buffer.size();
     TT_FATAL(
         host_buffer_size_bytes <= buffer.size(),

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -28,6 +28,8 @@ public:
 
     bool hook_program(tt::tt_metal::Program* program) override;
 
+    bool hook_write_to_device(tt::tt_metal::Buffer* buffer) override;
+
     ~ProcessorHooks() override = default;
 
     void set_block(bool block);

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -32,6 +32,10 @@ public:
 
     bool hook_read_from_device(tt::tt_metal::Buffer* buffer) override;
 
+    bool hook_read_from_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) override;
+
+    bool hook_write_to_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) override;
+
     ~ProcessorHooks() override = default;
 
     void set_block(bool block);

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -28,8 +28,6 @@ public:
 
     bool hook_program(tt::tt_metal::Program* program) override;
 
-    bool hook_write_to_device(tt::tt_metal::Buffer* buffer) override;
-
     bool hook_write_to_device(const tt::tt_metal::Buffer* buffer) override;
 
     bool hook_read_from_device(tt::tt_metal::Buffer* buffer) override;

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -30,6 +30,10 @@ public:
 
     bool hook_write_to_device(tt::tt_metal::Buffer* buffer) override;
 
+    bool hook_write_to_device(const tt::tt_metal::Buffer* buffer) override;
+
+    bool hook_read_from_device(tt::tt_metal::Buffer* buffer) override;
+
     ~ProcessorHooks() override = default;
 
     void set_block(bool block);

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -477,6 +477,8 @@ bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer) { return 
 
 bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) { return do_block; }
 
+bool ProcessorHooks::hook_write_to_device(tt::tt_metal::Buffer* buffer) { return do_block; }
+
 bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
 
 void ProcessorHooks::set_block(bool block) { do_block = block; }

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -479,6 +479,10 @@ bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) { return do_b
 
 bool ProcessorHooks::hook_write_to_device(tt::tt_metal::Buffer* buffer) { return do_block; }
 
+bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::Buffer* buffer) { return do_block; }
+
+bool ProcessorHooks::hook_read_from_device(tt::tt_metal::Buffer* buffer) { return do_block; }
+
 bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
 
 void ProcessorHooks::set_block(bool block) { do_block = block; }

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -479,7 +479,13 @@ bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) { return do_b
 
 bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::Buffer* buffer) { return do_block; }
 
+bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) { return do_block; }
+
 bool ProcessorHooks::hook_read_from_device(tt::tt_metal::Buffer* buffer) { return do_block; }
+
+bool ProcessorHooks::hook_read_from_device(const tt::tt_metal::distributed::MeshBuffer* mesh_buffer) {
+    return do_block;
+}
 
 bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
 

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -477,8 +477,6 @@ bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer) { return 
 
 bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) { return do_block; }
 
-bool ProcessorHooks::hook_write_to_device(tt::tt_metal::Buffer* buffer) { return do_block; }
-
 bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::Buffer* buffer) { return do_block; }
 
 bool ProcessorHooks::hook_read_from_device(tt::tt_metal::Buffer* buffer) { return do_block; }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24010#issuecomment-3089459741)

### Problem description
Graph tracing was not hooking the write operation, so we were trying to write on non allocated memory

### What's changed
Graph tracing is now hooking the memory write that is happening on the dispatch operations

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes