### PR TITLE
Fix metal pytests to not include ttnn and launch cluster to get arch

### DIFF
--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -14,7 +14,20 @@ from operator import ne, truth
 
 from loguru import logger
 
-from models.utility_functions import is_wormhole_b0, is_grayskull, is_blackhole
+
+def is_blackhole():
+    ARCH_NAME = os.getenv("ARCH_NAME")
+    return "blackhole" in ARCH_NAME
+
+
+def is_wormhole_b0():
+    ARCH_NAME = os.getenv("ARCH_NAME")
+    return "wormhole_b0" in ARCH_NAME
+
+
+def is_grayskull():
+    ARCH_NAME = os.getenv("ARCH_NAME")
+    return "grayskull" in ARCH_NAME
 
 
 class TestSuiteType(Enum):


### PR DESCRIPTION
This is a problem since metal pytests use subprocesses to run each test, but the main process was leaving a UMD instance running, and it's not safe to run UMD from two processes at the same time.

This is one of the issues blocking new UMD feature in https://github.com/tenstorrent/tt-metal/issues/23749

CI: https://github.com/tenstorrent/tt-metal/actions/runs/16381226247