### PR TITLE
Disable slow test check

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -86,6 +86,7 @@ jobs:
           prefix: "test_reports_"
 
       - name: Check for slow tests
+        if: false # Runtime of tests is all over the map; can try re-enabling this when they are more stable.
         uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@main
         with:
           threshold: ${{ inputs.per-test-timeout }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -91,6 +91,7 @@ jobs:
           prefix: "test_reports_"
 
       - name: Check for slow tests
+        if: false # Runtime of tests is all over the map; can try re-enabling this when they are more stable.
         uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@main
         with:
           threshold: ${{ inputs.per-test-timeout }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We cannot use something that moves around like quicksilver to make pass/fail decisions.  Runtimes of unit tests fluctuate too much from one run to the next.

### What's changed
Disabled the slow test check.
When we fill up Smoke/Basic pools we're going to have to manually hunt for the hogs to kick them out.  That's a problem for future us.