### PR TITLE
Add 1x8 MGDs for T3K and Nano-Exabox

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing.cpp
@@ -155,7 +155,7 @@ TEST_F(InterMeshDual2x4FabricFixture, MultiMesh_EW_MulticastWithTurns) {
 
 // ========= Data-Movement Tests for NanoExabox Machines  =========
 
-TEST_F(IntermeshNanoExaboxFabricFixture, RandomizedIntermeshUnicastBwd) {
+TEST_F(IntermeshNanoExabox2x4FabricFixture, RandomizedIntermeshUnicastBwd) {
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
 
     constexpr uint32_t sender_rank = 1;
@@ -180,7 +180,7 @@ TEST_F(IntermeshNanoExaboxFabricFixture, RandomizedIntermeshUnicastBwd) {
     distributed_context->barrier();
 }
 
-TEST_F(IntermeshNanoExaboxFabricFixture, RandomizedIntermeshUnicastFwd) {
+TEST_F(IntermeshNanoExabox2x4FabricFixture, RandomizedIntermeshUnicastFwd) {
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
 
     constexpr uint32_t recv_rank = 1;

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -38,8 +38,8 @@ void validate_and_setup_control_plane_config(Fixture* fixture) {
         "Multi-Host Routing tests require multiple hosts in the system");
 }
 
-inline const std::vector<eth_coord_t>& get_eth_coords_for_t3k() {
-    static const std::vector<eth_coord_t> t3k_eth_coords = {
+inline const std::vector<eth_coord_t>& get_eth_coords_for_2x4_t3k() {
+    static const std::vector<eth_coord_t> t3k_2x4_eth_coords = {
         {0, 0, 0, 0, 0},
         {0, 1, 0, 0, 0},
         {0, 2, 0, 0, 0},
@@ -49,7 +49,21 @@ inline const std::vector<eth_coord_t>& get_eth_coords_for_t3k() {
         {0, 2, 1, 0, 0},
         {0, 3, 1, 0, 0}};
 
-    return t3k_eth_coords;
+    return t3k_2x4_eth_coords;
+}
+
+inline const std::vector<eth_coord_t>& get_eth_coords_for_1x8_t3k() {
+    static const std::vector<eth_coord_t> t3k_1x8_eth_coords = {
+        {0, 0, 0, 0, 0},
+        {0, 1, 0, 0, 0},
+        {0, 2, 0, 0, 0},
+        {0, 3, 0, 0, 0},
+        {0, 3, 1, 0, 0},
+        {0, 2, 1, 0, 0},
+        {0, 1, 1, 0, 0},
+        {0, 0, 1, 0, 0}};
+
+    return t3k_1x8_eth_coords;
 }
 
 inline const std::vector<std::vector<eth_coord_t>>& get_eth_coords_for_split_2x2_t3k() {
@@ -184,24 +198,41 @@ class Dual2x4FabricFixture : public Fixture {
     }
 
     std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
-        return {get_eth_coords_for_t3k(), get_eth_coords_for_t3k()};
+        return {get_eth_coords_for_2x4_t3k(), get_eth_coords_for_2x4_t3k()};
     }
 };
 
-// Generic Fixture for Nano-Exabox systems using Fabric
+// Generic Fixture for Nano-Exabox systems using Fabric (each T3K is initialized as a 2x4 Mesh)
 template <typename Fixture>
-class NanoExaboxFabricFixture : public Fixture {
+class NanoExabox2x4FabricFixture : public Fixture {
     std::string get_path_to_mesh_graph_desc() override {
         return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_mesh_graph_descriptor.yaml";
     }
 
     std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
         return {
-            get_eth_coords_for_t3k(),
-            get_eth_coords_for_t3k(),
-            get_eth_coords_for_t3k(),
-            get_eth_coords_for_t3k(),
-            get_eth_coords_for_t3k()};
+            get_eth_coords_for_2x4_t3k(),
+            get_eth_coords_for_2x4_t3k(),
+            get_eth_coords_for_2x4_t3k(),
+            get_eth_coords_for_2x4_t3k(),
+            get_eth_coords_for_2x4_t3k()};
+    }
+};
+
+// Generic Fixture for Nano-Exabox systems using Fabric (each T3K is initialized as a 1x8 Mesh)
+template <typename Fixture>
+class NanoExabox1x8FabricFixture : public Fixture {
+    std::string get_path_to_mesh_graph_desc() override {
+        return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_1x8_mesh_graph_descriptor.yaml";
+    }
+
+    std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
+        return {
+            get_eth_coords_for_1x8_t3k(),
+            get_eth_coords_for_1x8_t3k(),
+            get_eth_coords_for_1x8_t3k(),
+            get_eth_coords_for_1x8_t3k(),
+            get_eth_coords_for_1x8_t3k()};
     }
 };
 
@@ -218,8 +249,11 @@ using MeshDeviceDual2x2Fixture = Dual2x2FabricFixture<MultiMeshDeviceFabricFixtu
 using InterMeshDual2x4FabricFixture = Dual2x4FabricFixture<InterMeshRoutingFabric2DFixture>;
 using MeshDeviceDual2x4Fixture = Dual2x4FabricFixture<MultiMeshDeviceFabricFixture>;
 
-using IntermeshNanoExaboxFabricFixture = NanoExaboxFabricFixture<InterMeshRoutingFabric2DFixture>;
-using MeshDeviceNanoExaboxFixture = NanoExaboxFabricFixture<MultiMeshDeviceFabricFixture>;
+using IntermeshNanoExabox2x4FabricFixture = NanoExabox2x4FabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceNanoExabox2x4Fixture = NanoExabox2x4FabricFixture<MultiMeshDeviceFabricFixture>;
+
+using IntermeshNanoExabox1x8FabricFixture = NanoExabox1x8FabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceNanoExabox1x8Fixture = NanoExabox1x8FabricFixture<MultiMeshDeviceFabricFixture>;
 
 }  // namespace fabric_router_tests
 }  // namespace tt::tt_fabric

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
@@ -111,13 +111,16 @@ std::string generate_multihost_socket_test_name(const testing::TestParamInfo<Par
 
 using MultiHostSocketTestSplitT3K = MultiHostSocketTest<MeshDeviceSplit2x2Fixture>;
 using MultiHostSocketTestDualT3K = MultiHostSocketTest<MeshDeviceDual2x4Fixture>;
-using MultiHostSocketTestNanoExabox = MultiHostSocketTest<MeshDeviceNanoExaboxFixture>;
+using MeshDeviceNanoExabox2x4Fixture = MultiHostSocketTest<MeshDeviceNanoExabox2x4Fixture>;
+using MeshDeviceNanoExabox1x8Fixture = MultiHostSocketTest<MeshDeviceNanoExabox1x8Fixture>;
 
 TEST_P(MultiHostSocketTestSplitT3K, SocketTests) { RunTest(); }
 
 TEST_P(MultiHostSocketTestDualT3K, SocketTests) { RunTest(); }
 
-TEST_P(MultiHostSocketTestNanoExabox, SocketTests) { RunTest(); }
+TEST_P(MeshDeviceNanoExabox2x4Fixture, SocketTests) { RunTest(); }
+
+TEST_P(MeshDeviceNanoExabox1x8Fixture, SocketTests) { RunTest(); }
 
 INSTANTIATE_TEST_SUITE_P(
     MultiHostSocketTestsSplitT3K,
@@ -132,12 +135,18 @@ INSTANTIATE_TEST_SUITE_P(
     generate_multihost_socket_test_name<MultiHostSocketTestDualT3K::ParamType>);
 
 INSTANTIATE_TEST_SUITE_P(
-    MultiHostSocketTestsNanoExabox,
-    MultiHostSocketTestNanoExabox,
+    MeshDeviceNanoExabox2x4Fixture,
+    MeshDeviceNanoExabox2x4Fixture,
     ::testing::ValuesIn(generate_socket_test_configs(SystemConfig::NANO_EXABOX)),
     generate_multihost_socket_test_name<MultiHostSocketTestDualT3K::ParamType>);
 
-TEST_F(MultiHostSocketTestNanoExabox, MultiContextSocketHandshake) {
+INSTANTIATE_TEST_SUITE_P(
+    MeshDeviceNanoExabox1x8Fixture,
+    MeshDeviceNanoExabox1x8Fixture,
+    ::testing::ValuesIn(generate_socket_test_configs(SystemConfig::NANO_EXABOX)),
+    generate_multihost_socket_test_name<MultiHostSocketTestDualT3K::ParamType>);
+
+TEST_F(MeshDeviceNanoExabox2x4Fixture, MultiContextSocketHandshake) {
     std::vector<int> sender_node_ranks_ctx0 = {0, 2, 3, 4};
     uint32_t recv_rank_ctx0 = 1;
 

--- a/tests/tt_metal/tt_fabric/common/t3k_mesh_descriptor_chip_mappings.hpp
+++ b/tests/tt_metal/tt_fabric/common/t3k_mesh_descriptor_chip_mappings.hpp
@@ -14,57 +14,66 @@ namespace tt::tt_fabric {
 
 namespace fabric_router_tests {
 
-static const std::array<std::tuple<std::string, std::vector<std::vector<eth_coord_t>>>, 5>
-    t3k_mesh_descriptor_chip_mappings = {
-        std::tuple{
-            "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
-            std::vector<std::vector<eth_coord_t>>{
-                {{0, 0, 0, 0, 0},
-                 {0, 1, 0, 0, 0},
-                 {0, 2, 0, 0, 0},
-                 {0, 3, 0, 0, 0},
-                 {0, 0, 1, 0, 0},
-                 {0, 1, 1, 0, 0},
-                 {0, 2, 1, 0, 0},
-                 {0, 3, 1, 0, 0}}}},
-        std::tuple{
-            "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml",
-            std::vector<std::vector<eth_coord_t>>{
-                {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
-                {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}, {0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
-        std::tuple{
-            "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml",
-            std::vector<std::vector<eth_coord_t>>{
-                {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}},
-                {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}},
-                {{0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
-                {{0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
-        std::tuple{
-            "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml",
-            std::vector<std::vector<eth_coord_t>>{
-                {{0, 0, 0, 0, 0}},
-                {{0, 1, 0, 0, 0}},
-                {{0, 2, 0, 0, 0}},
-                {{0, 3, 0, 0, 0}},
-                {{0, 0, 1, 0, 0}},
-                {{0, 1, 1, 0, 0}},
-                {{0, 2, 1, 0, 0}},
-                {{0, 3, 1, 0, 0}}}},
-        std::tuple{
-            "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml",
-            std::vector<std::vector<eth_coord_t>>{
-                {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
-                {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}},
-                {{0, 2, 1, 0, 0}},
-                {{0, 3, 1, 0, 0}}}}};
+static const std::array t3k_mesh_descriptor_chip_mappings = {
+    std::tuple{
+        std::string("tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0},
+             {0, 1, 0, 0, 0},
+             {0, 2, 0, 0, 0},
+             {0, 3, 0, 0, 0},
+             {0, 0, 1, 0, 0},
+             {0, 1, 1, 0, 0},
+             {0, 2, 1, 0, 0},
+             {0, 3, 1, 0, 0}}}},
+    std::tuple{
+        std::string("tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0},
+             {0, 1, 0, 0, 0},
+             {0, 2, 0, 0, 0},
+             {0, 3, 0, 0, 0},
+             {0, 3, 1, 0, 0},
+             {0, 2, 1, 0, 0},
+             {0, 1, 1, 0, 0},
+             {0, 0, 1, 0, 0}}}},
+    std::tuple{
+        std::string("tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+            {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}, {0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
+    std::tuple{
+        std::string("tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}},
+            {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}},
+            {{0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+            {{0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
+    std::tuple{
+        std::string("tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0}},
+            {{0, 1, 0, 0, 0}},
+            {{0, 2, 0, 0, 0}},
+            {{0, 3, 0, 0, 0}},
+            {{0, 0, 1, 0, 0}},
+            {{0, 1, 1, 0, 0}},
+            {{0, 2, 1, 0, 0}},
+            {{0, 3, 1, 0, 0}}}},
+    std::tuple{
+        std::string("tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+            {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}},
+            {{0, 2, 1, 0, 0}},
+            {{0, 3, 1, 0, 0}}}}};
 
-static const std::array<std::tuple<std::string, std::vector<std::vector<eth_coord_t>>>, 1>
-    t3k_disjoint_mesh_descriptor_chip_mappings = {
-        std::tuple{
-            "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml",
-            std::vector<std::vector<eth_coord_t>>{
-                {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
-                {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}, {0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
+static const std::array t3k_disjoint_mesh_descriptor_chip_mappings = {
+    std::tuple{
+        std::string("tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml"),
+        std::vector<std::vector<eth_coord_t>>{
+            {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+            {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}, {0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
 };
 
 }  // namespace fabric_router_tests

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_1x8_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_1x8_mesh_graph_descriptor.yaml
@@ -1,0 +1,68 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+Board: [
+  { name: 1x8,
+    type: Mesh,
+    topology: [1, 8]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: 1x8,
+  device_topology: [1, 8],
+  host_topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 1,
+  board: 1x8,
+  device_topology: [1, 8],
+  host_topology: [1, 1],
+
+  host_ranks: [[0]]},
+{
+  id: 2,
+  board: 1x8,
+  device_topology: [1, 8],
+  host_topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 3,
+  board: 1x8,
+  device_topology: [1, 8],
+  host_topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 4,
+  board: 1x8,
+  device_topology: [1, 8],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+  [[0, N12], [1, S10]],
+  [[0, N13], [1, S11]],
+  [[1, S10], [0, N12]],
+  [[1, S11], [0, N13]],
+  [[0, N10], [2, S10]],
+  [[0, N11], [2, S11]],
+  [[2, S10], [0, N10]],
+  [[2, S11], [0, N11]],
+  [[0, N4], [3, S10]],
+  [[0, N5], [3, S11]],
+  [[3, S10], [0, N4]],
+  [[3, S11], [0, N5]],
+  [[0, N2], [4, S10]],
+  [[0, N3], [4, S11]],
+  [[4, S10], [0, N2]],
+  [[4, S11], [0, N3]],
+]

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml
@@ -1,0 +1,28 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+
+Board: [
+  { name: T3K,
+    type: Mesh,
+    topology: [1, 8]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: T3K,
+  device_topology: [1, 8],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
TT-Train workloads currently rely on Legacy CCLs. For multi-host/multi-mesh training, we will need these workloads to use 2D Fabric based async CCLs.

To simplify the 1D Fabric to 2D Fabric CCL porting process, it makes sense to initialize 2D Fabric in a 1x8 Topology.

### What's changed
- Add custom Mesh Graph Descriptors for 1x8 T3K and Nano-Exabox topologies
- Add Fabric and Multi-Mesh tests using this topology to ensure that we regress on this particular use case


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes