### PR TITLE
TopK Index Passing Model Integration 

### DIFF
--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -353,7 +353,7 @@
         },
         "TopK_0": {
             "op_name": "TopK_0",
-            "kernel_duration": 615934.5340909091,
+            "kernel_duration": 325436,
             "op_to_op": 733.0,
             "non-overlapped-dispatch-time": 5187.35,
             "kernel_duration_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
@@ -186,6 +186,7 @@
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
+
     }
   },
   "model_tail": {

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
@@ -282,7 +282,7 @@
     },
     "TopK_0": {
       "op_name": "TopK_0",
-      "kernel_duration": 554450.3270833333,
+      "kernel_duration": 288709.40625,
       "op_to_op": 671.0,
       "non-overlapped-dispatch-time": 4614.0,
       "kernel_duration_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_sampling.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_sampling.py
@@ -244,7 +244,7 @@ def test_llama_sampling_inference(
 
     else:
         # Random inputs
-        torch_input = torch.randn(1, 1, 32, 512)
+        torch_input = torch.randn(1, 1, 32, 16 * 1024)
 
     tt_input = ttnn.from_torch(
         torch_input,

--- a/models/demos/llama3_subdevices/tt/sampling.py
+++ b/models/demos/llama3_subdevices/tt/sampling.py
@@ -73,8 +73,9 @@ class TTSampling(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-        indices_tensor_torch = torch.zeros(1, 1, self.max_batch_size, self.args.padded_vocab_size, dtype=torch.int32)
-        for i in range(indices_tensor_torch.shape[3]):
+        assert per_device_vocab_size == 16 * 1024, "Per device vocab size is incorrect (should be 16k)"
+        indices_tensor_torch = torch.zeros(1, 1, self.max_batch_size, per_device_vocab_size, dtype=torch.int32)
+        for i in range(per_device_vocab_size):
             indices_tensor_torch[:, :, :, i] = i
         self.tt_indices_tensor = ttnn.from_torch(
             indices_tensor_torch,
@@ -115,9 +116,9 @@ class TTSampling(LightweightModule):
             k=self.max_top_k,
             dim=-1,
             sub_core_grids=self.args.sub_core_grid_topk,
-            indices_tensor=self.tt_indices_tensor,
+            # indices_tensor=self.tt_indices_tensor,
         )
-
+        breakpoint()
         # Gather values
         # Note: Persistent output buffer used, do not deallocate output!
         topk_values_gathered = self.tt_ccl.line_all_gather(

--- a/models/demos/llama3_subdevices/tt/sampling.py
+++ b/models/demos/llama3_subdevices/tt/sampling.py
@@ -82,7 +82,7 @@ class TTSampling(LightweightModule):
             dtype=ttnn.uint16,
             layout=ttnn.Layout.TILE,
             device=self.mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(3, None), mesh_shape=self.args.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.args.cluster_shape),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
@@ -118,7 +118,6 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.args.sub_core_grid_topk,
             # indices_tensor=self.tt_indices_tensor,
         )
-        breakpoint()
         # Gather values
         # Note: Persistent output buffer used, do not deallocate output!
         topk_values_gathered = self.tt_ccl.line_all_gather(

--- a/models/demos/llama3_subdevices/tt/sampling.py
+++ b/models/demos/llama3_subdevices/tt/sampling.py
@@ -116,7 +116,7 @@ class TTSampling(LightweightModule):
             k=self.max_top_k,
             dim=-1,
             sub_core_grids=self.args.sub_core_grid_topk,
-            # indices_tensor=self.tt_indices_tensor,
+            indices_tensor=self.tt_indices_tensor,
         )
         # Gather values
         # Note: Persistent output buffer used, do not deallocate output!

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -22,10 +22,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG  RING_6U=1 LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG  RING_6U=1 LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -22,10 +22,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG  RING_6U=1 LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG  RING_6U=1 LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -62,61 +62,61 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
 
 
-# @pytest.mark.parametrize(
-#     "dtype",
-#     (
-#         ttnn.bfloat16,
-#         ttnn.bfloat8_b,
-#         # ttnn.float32, top bits in float32 get cut off somewhere, LLK does not work for this
-#     ),
-#     ids=[
-#         "BFLOAT16_B",
-#         "BFLOAT8_B",
-#         # "FLOAT32",
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "N, C, H, W, dim, k",
-#     (
-#         (1, 1, 32, 8192, 3, 50),  # passed
-#         (1, 1, 64, 64, 2, 32),  # passed
-#         (1, 1, 64, 64, 2, 64),  # passed
-#         (1, 2048, 1, 64, 1, 32),  # skipped
-#         (1, 1, 32, 64, 3, 2),  # passed
-#         (1, 1, 32, 64, 3, 4),  # passed
-#         (1, 1, 32, 8192, 3, 6),  # passed
-#         (1, 2048, 1, 64, 1, 8),  # passed
-#         (1, 1, 32, 32768, 3, 3000),  # passed
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "sorted",
-#     [
-#         True,
-#         False,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "largest",
-#     [
-#         True,
-#         False,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "sub_core_grids",
-#     [
-#         None,
-#     ],
-# )
-# def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids):
-#     if dim == 0 or dim == 1:
-#         # As of now, when we try to get top-k for dim = 0 or 1, we get following error from transpose_op.cpp's validate():
-#         # input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32
-#         # this is because, transpose.cpp always typecasts bf8 to bf16
-#         # and when dim = 0 or 1, transpose converts it into TransposeOpDim::HC & this dim doesnt support bf16 or fp32
-#         pytest.skip()
-#     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+        # ttnn.float32, top bits in float32 get cut off somewhere, LLK does not work for this
+    ),
+    ids=[
+        "BFLOAT16_B",
+        "BFLOAT8_B",
+        # "FLOAT32",
+    ],
+)
+@pytest.mark.parametrize(
+    "N, C, H, W, dim, k",
+    (
+        (1, 1, 32, 8192, 3, 50),  # passed
+        (1, 1, 64, 64, 2, 32),  # passed
+        (1, 1, 64, 64, 2, 64),  # passed
+        (1, 2048, 1, 64, 1, 32),  # skipped
+        (1, 1, 32, 64, 3, 2),  # passed
+        (1, 1, 32, 64, 3, 4),  # passed
+        (1, 1, 32, 8192, 3, 6),  # passed
+        (1, 2048, 1, 64, 1, 8),  # passed
+        (1, 1, 32, 32768, 3, 3000),  # passed
+    ),
+)
+@pytest.mark.parametrize(
+    "sorted",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "largest",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "sub_core_grids",
+    [
+        None,
+    ],
+)
+def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids):
+    if dim == 0 or dim == 1:
+        # As of now, when we try to get top-k for dim = 0 or 1, we get following error from transpose_op.cpp's validate():
+        # input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32
+        # this is because, transpose.cpp always typecasts bf8 to bf16
+        # and when dim = 0 or 1, transpose converts it into TransposeOpDim::HC & this dim doesnt support bf16 or fp32
+        pytest.skip()
+    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids)
 
 
 @pytest.mark.parametrize(
@@ -179,41 +179,41 @@ def test_topk_sub_core_grids(N, C, H, W, dim, k, dtype, sorted, largest, device,
     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)
 
 
-# @pytest.mark.parametrize(
-#     "dtype",
-#     (ttnn.bfloat16,),
-#     ids=[
-#         "BFLOAT16_B",
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "N, C, H, W, dim, k",
-#     (
-#         (1, 1, 32, 151936, 3, 50),  # passed  - customer shape 2
-#         (1, 1, 32, 128256, 3, 50),  # passed  - customer shape 1
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "sorted",
-#     [
-#         True,
-#         False,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "largest",
-#     [
-#         True,
-#         False,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "sub_core_grids",
-#     [
-#         None,
-#     ],
-# )
-# def test_topk_large_2d_shapes(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids, pass_indices_tensor):
-#     if dim == 0 or dim == 1:
-#         pytest.skip()
-#     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+    ids=[
+        "BFLOAT16_B",
+    ],
+)
+@pytest.mark.parametrize(
+    "N, C, H, W, dim, k",
+    (
+        (1, 1, 32, 151936, 3, 50),  # passed  - customer shape 2
+        (1, 1, 32, 128256, 3, 50),  # passed  - customer shape 1
+    ),
+)
+@pytest.mark.parametrize(
+    "sorted",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "largest",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "sub_core_grids",
+    [
+        None,
+    ],
+)
+def test_topk_large_2d_shapes(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids, pass_indices_tensor):
+    if dim == 0 or dim == 1:
+        pytest.skip()
+    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp
@@ -40,10 +40,11 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr bool src_is_dram = (bool)get_compile_time_arg_val(2);
+    // not using indices tensor arg get_compile_time_arg_val(3)
 
-    constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt_local = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt = get_compile_time_arg_val(5);
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t Wt_local = get_compile_time_arg_val(5);
+    constexpr uint32_t Wt = get_compile_time_arg_val(6);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
     const InterleavedAddrGenFast<src_indices_is_dram> s_indices = {
         .bank_base_address = src_indices_addr, .page_size = tile_bytes_indices, .data_format = data_format_indices};
 
-    // Stream in input tensor and indices tensor
+    // Stream in input tensor and index tensor
     // The input buffer has four tiles as we double-buffer for the two tiles needed for topk_local_sort to start
     // We could load in an entire row of tiles at a time but that would require substantially more memory (we would be
     // double buffering four Wt_local sized CBs)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t src_indices_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_ht = get_arg_val<uint32_t>(2);
+    uint32_t start_wt = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+    constexpr bool src_is_dram = (bool)get_compile_time_arg_val(2);
+    constexpr bool src_indices_is_dram = (bool)get_compile_time_arg_val(3);
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t Wt_local = get_compile_time_arg_val(5);
+    constexpr uint32_t Wt = get_compile_time_arg_val(6);
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat data_format = get_dataformat(cb_id_in0);
+
+    constexpr uint32_t tile_bytes_indices = get_tile_size(cb_id_in1);
+    constexpr DataFormat data_format_indices = get_dataformat(cb_id_in1);
+
+    const InterleavedAddrGenFast<src_is_dram> s_input = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast<src_indices_is_dram> s_indices = {
+        .bank_base_address = src_indices_addr, .page_size = tile_bytes_indices, .data_format = data_format_indices};
+
+    // Stream in input tensor and indices tensor
+    // The input buffer has four tiles as we double-buffer for the two tiles needed for topk_local_sort to start
+    // We could load in an entire row of tiles at a time but that would require substantially more memory (we would be
+    // double buffering four Wt_local sized CBs)
+    for (uint32_t i = start_ht; i < Ht; ++i) {
+        for (uint32_t j = start_wt; j < start_wt + Wt_local; ++j) {
+            // Read input tensor and indices tensor
+            cb_reserve_back(cb_id_in0, onetile);
+            cb_reserve_back(cb_id_in1, onetile);
+            uint32_t l1_write_addr_input = get_write_ptr(cb_id_in0);
+            uint32_t l1_write_addr_indices = get_write_ptr(cb_id_in1);
+            noc_async_read_tile(i * Wt + j, s_input, l1_write_addr_input);
+            noc_async_read_tile(i * Wt + j, s_indices, l1_write_addr_indices);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            cb_push_back(cb_id_in1, onetile);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
@@ -20,13 +20,17 @@ struct TopK {
     const CoreRangeSet sub_core_grids;
 
     void validate_with_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<TensorSpec> compute_output_specs(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors) const;
 };
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -19,6 +19,7 @@ tt::tt_metal::operation::ProgramWithCallbacks topk_single_core_interleaved(
 
 tt::tt_metal::operation::ProgramWithCallbacks topk_multicore_interleaved(
     const Tensor& input_tensor,
+    const std::optional<Tensor>& indices_tensor,
     uint32_t k,
     int8_t dim,
     bool largest,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -38,7 +38,8 @@ std::vector<Tensor> post_topk_transform_tensor(
     const uint32_t adjusted_k,
     const Shape& original_lshape,
     const MemoryConfig& input_memory_config,
-    const CoreRangeSet& sub_core_grids) {
+    const CoreRangeSet& sub_core_grids,
+    const std::optional<Tensor>& indices_tensor = std::nullopt) {
     const auto& input_shape = input_tensor.padded_shape();
     const auto orig_rank = input_shape.rank();
 
@@ -109,6 +110,7 @@ std::vector<Tensor> ExecuteTopK::invoke(
     const bool sorted,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& indices_tensor,
     std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
 
@@ -146,10 +148,10 @@ std::vector<Tensor> ExecuteTopK::invoke(
     auto output_tensor_vec = tt::tt_metal::operation::run(
         TopK{adjusted_k, -1, largest, sorted, input_memory_config, used_sub_core_grids},
         {padded_tensor},
-        {},
+        {indices_tensor},
         optional_output_tensors.has_value()
             ? reduction_common::tuple_to_vector_optional(optional_output_tensors.value())
-            : std::vector<std::optional<Tensor>>{},
+            : std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt},
         queue_id);
 
     return CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
@@ -161,7 +163,8 @@ std::vector<Tensor> ExecuteTopK::invoke(
         adjusted_k,
         original_lshape,
         input_memory_config,
-        used_sub_core_grids);
+        used_sub_core_grids,
+        indices_tensor);
 }
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -21,8 +21,9 @@ struct ExecuteTopK {
         int8_t dim,
         bool largest,
         bool sorted,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<CoreRangeSet>& sub_core_grids,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+        const std::optional<Tensor>& indices_tensor = std::nullopt,
         std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -43,6 +43,8 @@ void bind_reduction_topk_operation(py::module& module) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
                 queue_id (int, optional): command queue id. Defaults to `0`.
+                sub_core_grids (ttnn.CoreRangeSet, optional): Core range set to run the operation on. Defaults to `None`.
+                indices_tensor (ttnn.Tensor, optional): Preallocated indices tensor. Defaults to `None`.
 
             Returns:
                 List of ttnn.Tensor: the output tensor.
@@ -64,6 +66,7 @@ void bind_reduction_topk_operation(py::module& module) {
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::CoreRangeSet>& sub_core_grids,
+               const std::optional<ttnn::Tensor>& indices_tensor,
                QueueId queue_id) {
                 return self(
                     queue_id,
@@ -74,6 +77,7 @@ void bind_reduction_topk_operation(py::module& module) {
                     sorted,
                     memory_config,
                     sub_core_grids,
+                    indices_tensor,
                     optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
@@ -85,6 +89,7 @@ void bind_reduction_topk_operation(py::module& module) {
             py::arg("out") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt,
+            py::arg("indices_tensor") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 


### PR DESCRIPTION
### Problem description
Relanding Johanna's PR for integration index tensor passing to Top K kernel, previously there was a `thread '<unnamed>' panicked at 'no entry found for key', src/lib.rs:201:37` due to the decoded index was out of vocabulary size. 

### What's changed
- Reason for above error was because we used `self.args.padded_vocab_size` as the hidden dimension when we should use `per_device_vocab_size`. Moreover, this tensor should be replicated rather than sharded across devices so the Shard2dTensor config was changed. Using `padded_vocab_size` caused the error because indices can only be less than 2^16-1 and the kernel only supports 16 bit indices, and each device should only deal with 16k vocab size

### Checklist
- E2E Perf Gains: 70.13 main -> 71.519 tok/s/u (with Topk index model integration)
- TG pipelines [passing](https://github.com/tenstorrent/tt-metal/actions/runs/16384011372)
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes