### PR TITLE
Compress tensix_routing_l1_info_t size

### DIFF
--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -186,6 +186,9 @@ struct fabric_router_l1_config_t {
 
 struct tensix_routing_l1_info_t {
     uint32_t mesh_id;           // Current mesh ID
+    // NOTE: Compressed version has additional overhead (2x slower) to read values,
+    //       but raw data is too huge (2048 bytes) to fit in L1 memory.
+    //       Need to evaluate once actual workloads are available
     compressed_routing_table_t<MAX_MESH_SIZE> intra_mesh_routing_table;   // 384 bytes
     compressed_routing_table_t<MAX_NUM_MESHES> inter_mesh_routing_table;  // 384 bytes
     uint8_t padding[12];                                  // pad to 16-byte alignment

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -55,9 +55,11 @@ inline eth_chan_directions get_next_hop_router_direction(uint32_t dst_mesh_id, u
     tt_l1_ptr tensix_routing_l1_info_t* routing_table =
         reinterpret_cast<tt_l1_ptr tensix_routing_l1_info_t*>(MEM_TENSIX_ROUTING_TABLE_BASE);
     if (dst_mesh_id == routing_table->mesh_id) {
-        return routing_table->intra_mesh_routing_table[dst_dev_id];
+        return static_cast<eth_chan_directions>(
+            routing_table->intra_mesh_routing_table.get_original_direction(dst_dev_id));
     } else {
-        return routing_table->inter_mesh_routing_table[dst_mesh_id];
+        return static_cast<eth_chan_directions>(
+            routing_table->inter_mesh_routing_table.get_original_direction(dst_mesh_id));
     }
 }
 

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -106,7 +106,7 @@
 
 // Tensix routing table for fabric networking
 #define MEM_TENSIX_ROUTING_TABLE_BASE (MEM_NOC_COUNTER_BASE + MEM_NOC_COUNTER_L1_SIZE)
-#define MEM_TENSIX_ROUTING_TABLE_SIZE 2064
+#define MEM_TENSIX_ROUTING_TABLE_SIZE 784
 #if (MEM_TENSIX_ROUTING_TABLE_BASE % 16 != 0) || (MEM_TENSIX_ROUTING_TABLE_SIZE % 16 != 0)
 #error "Tensix routing table base and size must be 16-byte aligned"
 #endif

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -100,7 +100,7 @@
 
 // Tensix routing table for fabric networking
 #define MEM_TENSIX_ROUTING_TABLE_BASE (MEM_NOC_COUNTER_BASE + MEM_NOC_COUNTER_L1_SIZE)
-#define MEM_TENSIX_ROUTING_TABLE_SIZE 2064
+#define MEM_TENSIX_ROUTING_TABLE_SIZE 784
 #if (MEM_TENSIX_ROUTING_TABLE_BASE % 16 != 0) || (MEM_TENSIX_ROUTING_TABLE_SIZE % 16 != 0)
 #error "Tensix routing table base and size must be 16-byte aligned"
 #endif


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24850
https://github.com/tenstorrent/tt-metal/issues/24880

### Problem description
Tensix L1 is now fully utilized by newly added `fabric_connection_info_t` and `tensix_fabric_connections_l1_info_t`. This cause some workload to get OoM by Circular buffer allocation.

### What's changed
Compress `fabric_connection_info_t` by 3 bit encoding.
Reduced size from 2064 bytes -> 784 bytes. (1280 bytes reduction)

NOTE: Compressed version has additional overhead (2x slower) to read values, but raw data is too huge (2048 bytes) to fit in L1 memory.  Need to evaluate once actual workloads are available

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes