### PR TITLE
#25251: improve tile exchange in ttnn sort

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
@@ -158,8 +158,8 @@ void MAIN {
                         constexpr uint32_t FIRST_TILE = 0;
 
                         if ((i & 1) == 0) {  // i % 2
-                            cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
-                            cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
+                            cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
+                            cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
 
                             copy_tile_between_cbs(
                                 global_old_cb,
@@ -167,6 +167,7 @@ void MAIN {
                                 tile_id,
                                 index_tensor_intermediate_cb_index);
                             cb_push_back(index_tensor_intermediate_cb_index, one_tile);
+                            cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
 
                             copy_tile_between_cbs(
                                 global_old_cb,
@@ -174,6 +175,7 @@ void MAIN {
                                 tile_id,
                                 value_tensor_intermediate_cb_index);
                             cb_push_back(value_tensor_intermediate_cb_index, one_tile);
+                            cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
 
                             copy_tile_between_cbs(
                                 global_old_cb,

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
@@ -97,7 +97,7 @@ void MAIN {
                     // Determine direction for this comparison block
                     const bool ascending_block = ((i >> stage) & 1) == 0;
                     const bool dir = ascending_block == ascending;
-                    // ---------- FROM here change
+
                     if (j >= global_tile_start && j < global_tile_end) {
                         if (j > i) {
                             // Local sorting - both tiles in core memory
@@ -152,54 +152,11 @@ void MAIN {
                             pack_tile<true>(tile_index_high, index_tensor_transposed_cb_index, right_tile_id);
 
                             tile_regs_release();
-                            // TODO ----- TO BE CHECKED
-                            // if (sub == 1 && (i + 1) >= global_tile_end) {
-                            //     // Next tile will be processed by the next core
-                            //     // Pack and send to reader the first pair of tiles
-                            //     cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
-                            //     copy_tile_between_cbs(
-                            //         global_old_cb,
-                            //         index_tensor_transposed_cb_index,
-                            //         0,
-                            //         index_tensor_intermediate_cb_index);
-                            //     cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                            //     cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                            //     copy_tile_between_cbs(
-                            //         global_old_cb,
-                            //         input_tensor_transposed_cb_index,
-                            //         0,
-                            //         value_tensor_intermediate_cb_index);
-                            //     cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-                            // }
-                            // ----- TOD BE CHECKED -------------
                         }
                     } else {
-                        // Every two tiles we need to pack them and send them to reader
-                        // if this is the first from the pair send both tiles to the reader, then wait for the one tile,
-                        // process it if this is the second from the pair just wait for the tile from the reader,
-                        // process it
-
-                        // --------- DEBUG -------------
-                        // auto number_of_pairs_to_exchange = number_of_tiles_per_core / 2;
-                        // DPRINT << "COMPUTE: number_of_pairs_to_exchange: " << number_of_pairs_to_exchange << ENDL();
-                        // -----------------------------
-
                         const uint32_t tile_id = i - global_tile_start;
                         constexpr uint32_t FIRST_TILE = 0;
 
-                        // ---
-                        // if i == global tile_start
-                        // Send current tile_id
-                        // Send next tile_id
-                        // else if i == global_tile_end
-                        // Don't send anything
-                        // else if i % 2 == 0
-                        // Send current tile_id
-                        // Send for next tile_id from reader
-
-                        // ---
-                        // // Send tiles to other core
                         if ((i & 1) == 0) {  // i % 2
                             cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
                             cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
@@ -211,7 +168,6 @@ void MAIN {
                                 index_tensor_intermediate_cb_index);
                             cb_push_back(index_tensor_intermediate_cb_index, one_tile);
 
-                            // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
                             copy_tile_between_cbs(
                                 global_old_cb,
                                 input_tensor_transposed_cb_index,
@@ -226,7 +182,6 @@ void MAIN {
                                 index_tensor_intermediate_cb_index);
                             cb_push_back(index_tensor_intermediate_cb_index, one_tile);
 
-                            // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
                             copy_tile_between_cbs(
                                 global_old_cb,
                                 input_tensor_transposed_cb_index,
@@ -235,127 +190,6 @@ void MAIN {
                             cb_push_back(value_tensor_intermediate_cb_index, one_tile);
                             sync_packer_unpacker(packer_unpacker_sync_cb_index);
                         }
-                        // NEW VERSION
-                        // if ((sub-- != 1) && i == global_tile_end){
-                        //     cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
-                        //     cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
-
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         index_tensor_transposed_cb_index,
-                        //         0,
-                        //         index_tensor_intermediate_cb_index);
-                        //     cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                        //     // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         input_tensor_transposed_cb_index,
-                        //         0,
-                        //         value_tensor_intermediate_cb_index);
-                        //     cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         index_tensor_transposed_cb_index,
-                        //         1,
-                        //         index_tensor_intermediate_cb_index);
-                        //     cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                        //     // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         input_tensor_transposed_cb_index,
-                        //         1,
-                        //         value_tensor_intermediate_cb_index);
-                        //     cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-                        //     sync_packer_unpacker(packer_unpacker_sync_cb_index);
-                        // } else if ((i % 2 == 0) && (i != (global_tile_end - 1))){
-                        //     cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
-                        //     cb_reserve_back(index_tensor_intermediate_cb_index, 2 * one_tile);
-
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         index_tensor_transposed_cb_index,
-                        //         tile_id+2,
-                        //         index_tensor_intermediate_cb_index);
-                        //     cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                        //     // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         input_tensor_transposed_cb_index,
-                        //         tile_id+2,
-                        //         value_tensor_intermediate_cb_index);
-                        //     cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         index_tensor_transposed_cb_index,
-                        //         tile_id+3,
-                        //         index_tensor_intermediate_cb_index);
-                        //     cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                        //     // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                        //     copy_tile_between_cbs(
-                        //         global_old_cb,
-                        //         input_tensor_transposed_cb_index,
-                        //         tile_id+3,
-                        //         value_tensor_intermediate_cb_index);
-                        //     cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-                        //     sync_packer_unpacker(packer_unpacker_sync_cb_index);
-                        // }
-                        // else if(i == global_tile_end) {
-                        //     // Don't send anything
-                        // } else if() {
-                        //     // Send current tile_id
-                        //     // Send for next tile_id from reader
-                        // }
-
-                        // tile_regs_acquire();
-
-                        // // Copy index tiles to DST register for exchange
-
-                        // cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
-                        // copy_tile_between_cbs(
-                        //     global_old_cb,
-                        //     index_tensor_transposed_cb_index,
-                        //     tile_id,
-                        //     index_tensor_intermediate_cb_index);
-                        // cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                        // copy_tile_to_dst_init_with_cb_update(index_tensor_transposed_cb_index, global_old_cb);
-                        // copy_tile(index_tensor_transposed_cb_index, tile_id, index_dest_start);
-
-                        // Copy value tiles to DST register for exchange
-
-                        // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                        // copy_tile_between_cbs(
-                        //     global_old_cb,
-                        //     input_tensor_transposed_cb_index,
-                        //     tile_id,
-                        //     value_tensor_intermediate_cb_index);
-                        // cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-
-                        // copy_tile_to_dst_init_with_cb_update(input_tensor_transposed_cb_index, global_old_cb);
-                        // copy_tile(input_tensor_transposed_cb_index, tile_id, input_dest_start);
-
-                        // tile_regs_commit();
-                        // tile_regs_wait();
-
-                        // Send current index tile reader for exchange
-                        // cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
-                        // pack_reconfig_data_format(index_tensor_intermediate_cb_index);
-                        // pack_tile(index_dest_start, index_tensor_intermediate_cb_index, FIRST_TILE);
-                        // cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-
-                        // Send current value tile reader for exchange
-                        // cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                        // pack_reconfig_data_format(value_tensor_intermediate_cb_index);
-                        // pack_tile(input_dest_start, value_tensor_intermediate_cb_index, FIRST_TILE);
-                        // cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-
-                        // tile_regs_release();
 
                         // Process received tiles from other core
                         tile_regs_acquire();
@@ -368,7 +202,7 @@ void MAIN {
                         copy_tile_to_dst_init_with_cb_update(input_tensor_transposed_cb_index, global_old_cb);
                         copy_tile(input_tensor_transposed_cb_index, tile_id, input_dest_start);
 
-                        cb_wait_front(index_tensor_peer_cb_index, one_tile);  // TU CZEKANIE
+                        cb_wait_front(index_tensor_peer_cb_index, one_tile);
 
                         // Load new index tile for sorting
                         copy_tile_to_dst_init_with_cb_update(index_tensor_peer_cb_index, global_old_cb);
@@ -377,7 +211,7 @@ void MAIN {
                         cb_pop_front(index_tensor_peer_cb_index, one_tile);
 
                         // Read other tile from writer
-                        cb_wait_front(value_tensor_peer_cb_index, one_tile);  // TU CZEKANIE
+                        cb_wait_front(value_tensor_peer_cb_index, one_tile);
 
                         // Load new value tile for sorting
                         copy_tile_to_dst_init_with_cb_update(value_tensor_peer_cb_index, global_old_cb);
@@ -411,7 +245,6 @@ void MAIN {
 
                         tile_regs_release();
                     }
-                    // --------- TO HERE
                 }  // Wt loop
             }  // sub loop
         }  // stages loop

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
@@ -167,7 +167,6 @@ void MAIN {
                                 tile_id,
                                 index_tensor_intermediate_cb_index);
                             cb_push_back(index_tensor_intermediate_cb_index, one_tile);
-                            cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
 
                             copy_tile_between_cbs(
                                 global_old_cb,
@@ -175,7 +174,9 @@ void MAIN {
                                 tile_id,
                                 value_tensor_intermediate_cb_index);
                             cb_push_back(value_tensor_intermediate_cb_index, one_tile);
+
                             cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
+                            cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
 
                             copy_tile_between_cbs(
                                 global_old_cb,


### PR DESCRIPTION
### Ticket

[#25251](https://github.com/tenstorrent/tt-metal/issues/25251)

### Problem description
- Tests have shown that the biggest bottleneck in the current implementation of the Cross Core Data Exchange strategy in ttnn sort is communication between kernels within a single core. In order to reduce this, two-tile transfer was added so that every second tile did not have to wait for transfer between cores, but was exchanged when the first pair was sorted.

### What's changed
- Added two-tile transfer between kernels.
- Changed copy tile between two CB functionality.

### Performance

Measured on Wormhole

Tiles | Cores used | Tiles per core | Tile Width | DEVICE KERNEL DURATION PER CORE MIN [ms] | DEVICE KERNEL DURATION PER CORE MAX [ms] | DEVICE KERNEL DURATION PER CORE AVG [ms] | Bandwidth MElem/s
-- | -- | -- | -- | -- | -- | -- | --
Current implementation
64 | 32 | 2 | 32 | 0.176 | 0.408 | 0.402 | 11.609
128 | 64 | 2 | 32 | 0.241 | 0.178 | 0.178 | 16.987
256 | 64 | 4 | 32 | 0.553 | 0.563 | 0.558 | 14.821
512 | 64 | 8 | 32 | 1.223 | 1.244 | 1.236 | 13.392
1024 | 64 | 16 | 32 | 2.746 | 2.788 | 2.769 | 11.934
2048 | 64 | 32 | 32 | 6.187 | 29.044 | 28.819 | 10.592
4096 | 64 | 64 | 32 | 13.266 | 6.271 | 6.232 | 9.880
8192 | 64 | 128 | 32 | 28.242 | 28.578 | 28.426 | 9.282
Transfer two tiles at a time
64 | 32 | 2 | 32 | 0.156 | 0.159 | 0.158 | 13.142
128 | 64 | 2 | 32 | 0.214 | 0.220 | 0.218 | 19.140
256 | 64 | 4 | 32 | 0.492 | 0.502 | 0.498 | 16.660
512 | 64 | 8 | 32 | 1.086 | 1.110 | 1.101 | 15.087
1024 | 64 | 16 | 32 | 2.412 | 2.469 | 2.451 | 13.586
2048 | 64 | 32 | 32 | 5.472 | 5.481 | 5.479 | 11.977
4096 | 64 | 64 | 32 | 12.543 | 12.874 | 12.736 | 10.450
8192 | 64 | 128 | 32 | 28.100 | 29.447 | 29.167 | 9.329

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16410572811/job/46370655281
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes