### PR TITLE
Fix "metallium" to "metalium"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,11 +134,11 @@ def get_from_precompiled_dir():
 
 
 @dataclass(frozen=True)
-class MetalliumBuildConfig:
+class MetaliumBuildConfig:
     from_precompiled_dir = get_from_precompiled_dir()
 
 
-metal_build_config = MetalliumBuildConfig()
+metal_build_config = MetaliumBuildConfig()
 
 
 class CMakeBuild(build_ext):

--- a/tech_reports/EthernetMultichip/BasicEthernetGuide.md
+++ b/tech_reports/EthernetMultichip/BasicEthernetGuide.md
@@ -40,7 +40,7 @@ The document describes the multichip software stack bottom-up in the following s
 5. A library of software components that can be used to build higher level (CCL) operations
 6. Incorporating the above to build CCL operations, such as *all-gather*
 
-Prior to reading this document, it is recommended the reader is familiar with Tenstorrent single chip programming concepts. This foundational information can be found here in the [TT-Metallium developer guide](https://tenstorrent.github.io/tt-metal/latest/tt-metalium/tt_metal/apis/index.html).
+Prior to reading this document, it is recommended the reader is familiar with Tenstorrent single chip programming concepts. This foundational information can be found here in the [TT-Metalium developer guide](https://tenstorrent.github.io/tt-metal/latest/tt-metalium/tt_metal/apis/index.html).
 
 It is recommended to the reader to be familiar with the following concepts before reading this document:
 
@@ -216,7 +216,7 @@ This asynchronous behavior puts the user at risk of race conditions if certain p
 
 Since Ethernet does not provide a mechanism for the sender to know when packets are sent from L1 over the Ethernet link the user must provide their own flow control.
 
-Although it is possible to implement custom flow-control with only the `eth_send_packet()` function, Metallium’s CCL provides the ethernet dataflow API which implements end to end flow control for a fixed number of ethernet channels with its helper functions. The [`erisc_info`](https://github.com/tenstorrent/tt-metal/blob/97b21652e1a00579882427a21e95db318bc0c079/tt_metal/hw/inc/ethernet/tunneling.h#L41) with [`eth_channel_sync_t`](https://github.com/tenstorrent/tt-metal/blob/97b21652e1a00579882427a21e95db318bc0c079/tt_metal/hw/inc/ethernet/tunneling.h#L17) is also provided as a book-keeping data-structure for the ethernet dataflow API functions to implement end-to-end-flow control.
+Although it is possible to implement custom flow-control with only the `eth_send_packet()` function, Metalium’s CCL provides the ethernet dataflow API which implements end to end flow control for a fixed number of ethernet channels with its helper functions. The [`erisc_info`](https://github.com/tenstorrent/tt-metal/blob/97b21652e1a00579882427a21e95db318bc0c079/tt_metal/hw/inc/ethernet/tunneling.h#L41) with [`eth_channel_sync_t`](https://github.com/tenstorrent/tt-metal/blob/97b21652e1a00579882427a21e95db318bc0c079/tt_metal/hw/inc/ethernet/tunneling.h#L17) is also provided as a book-keeping data-structure for the ethernet dataflow API functions to implement end-to-end-flow control.
 
 The fields used in the `ethernet_channel_sync_t` to implement flow control are the `bytes_sent` and `receiver_ack` fields. The `eth_channel_sync_t` is sent to the receiver to indicate payload status. The fields are used in the following way:
 

--- a/tech_reports/FlashAttention/FlashDecode.md
+++ b/tech_reports/FlashAttention/FlashDecode.md
@@ -88,7 +88,7 @@ There are two extreme cases:
 2. `bsz*n_kv_heads` is 1 or a very small number. In this case, one work is assigned to many cores. This can lead to a new bottleneck from noc traffic, where the reduction step takes more time than compute. We show this phenomenon in the performance analysis section. To mitigate this, we limit the maximum number of cores assigned to one work to 16. `max_cores_per_head_batch` is the parameter that controls this in SDPAProgramConfig.
 
 ### 3.2 Step-by-step Visualization of an Average Case
-To give the reader a better intuition of how FlashDecode works on TT-Metallium, we visualize an average case with `bsz=16`, `n_kv_heads=1`, `n_q_heads=8` (padded to 32), and `n_cores=64`. The input is read from DRAM, and the output is left in L1.
+To give the reader a better intuition of how FlashDecode works on TT-Metalium, we visualize an average case with `bsz=16`, `n_kv_heads=1`, `n_q_heads=8` (padded to 32), and `n_cores=64`. The input is read from DRAM, and the output is left in L1.
 
 ![FlashDecodeStepByStep](images/FlashDecode/steps.png)
 

--- a/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
+++ b/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
@@ -381,7 +381,7 @@ In a single-device context, a CommandQueueHandle is associated with a CQ tied to
 
 **All APIs discussed in this section will be required for V1.**
 
-This section introduces the MeshBuffer and the MeshAllocator, through which memory management mechanisms exposed by TT-Metallium are extended to a distributed address space across a DRAM and SRAM banks in a Virtual Mesh.
+This section introduces the MeshBuffer and the MeshAllocator, through which memory management mechanisms exposed by TT-Metalium are extended to a distributed address space across a DRAM and SRAM banks in a Virtual Mesh.
 
 ### 3.3.1 Background: Device Buffer and Single-Device Allocator
 

--- a/tech_reports/TT-Distributed/TTMeshMigrationGuide.md
+++ b/tech_reports/TT-Distributed/TTMeshMigrationGuide.md
@@ -52,7 +52,7 @@ Replace all usages of `CreateDevice` as follows:
 // Old
 tt::tt_metal::IDevice* device = tt::tt_metal::CreateDevice(device_id);
 // New
-#include <tt-metallium/distributed.hpp>
+#include <tt-metalium/distributed.hpp>
 
 std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 ```

--- a/tech_reports/tensor_layouts/tensor_layouts.md
+++ b/tech_reports/tensor_layouts/tensor_layouts.md
@@ -62,7 +62,7 @@ An individual tensor is represented across several pages, with the distribution 
 
 In an interleaved tensor layout, pages are allocated in a round-robin fashion across multiple banks. Allocation of a new tensor always begins with the first bank, which can lead to some fragmentation between tensors.
 
-For example in *Figure 3*, consider a tensor requiring four pages (P0 to P3) across three banks (0 through 2). The first three pages are allocated to banks 0 through 2, and the fourth page wraps around and is allocated to bank 0. The next tensor will also start allocation at bank 0. 
+For example in *Figure 3*, consider a tensor requiring four pages (P0 to P3) across three banks (0 through 2). The first three pages are allocated to banks 0 through 2, and the fourth page wraps around and is allocated to bank 0. The next tensor will also start allocation at bank 0.
 
 <img src="images/interleaved_2.svg" style="width:500px;"/>
 
@@ -122,5 +122,3 @@ Other sharding parameters include:
 - **Shard Orientation**: Describes the order in which shards are distributed to the cores in the core grid. This can be either `ROW-MAJOR` or `COLUMN-MAJOR`.
 
 - For tensors with a `Row-Major` layout, each page typically represents a single row of the tensor. However, for sharded tensors, the width of each page matches the width of the shard. For tiled tensors, the page shape remains the same as the tile shape (e.g., 32x32).
-
- 

--- a/tech_reports/tensor_layouts/tensor_layouts.md
+++ b/tech_reports/tensor_layouts/tensor_layouts.md
@@ -46,7 +46,7 @@ In a tiled tensor, pages are represented as 2D tiles, with the default tile size
 
 
 #### 3.2.1 Tile Shapes
-The hardware architecture supports tile shapes of `32x32` , `16x32` , `4x32`, `2x32`, `1x32`. **However currently TT-Metallium only supports `32x32`, and other tile shapes will be supported in Q4'2024**
+The hardware architecture supports tile shapes of `32x32` , `16x32` , `4x32`, `2x32`, `1x32`. **However currently TT-Metalium only supports `32x32`, and other tile shapes will be supported in Q4'2024**
 
 
 ## 4. Memory Layout

--- a/ttnn/README.md
+++ b/ttnn/README.md
@@ -1,5 +1,5 @@
 # TT-NN
-TT-NN is an open-source C++ and Python library of neural network operations, built on top of the TT-Metallium programming model.
+TT-NN is an open-source C++ and Python library of neural network operations, built on top of the TT-Metalium programming model.
 It provides a PyTorch-like interface for running machine learning workloads on Tenstorrent AI accelerators, and serves as the primary high-level API for developing and optimizing ML models on Tenstorrent hardware.
 
 ## Purpose


### PR DESCRIPTION
### Ticket

#25393 

### Problem description

During [mesh migration](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/TT-Distributed/TTMeshMigrationGuide.md), I found a typo
`#include <tt-metallium/distributed.hpp>`
and there are actually a bunch of them across the repo.

### What's changed

This PR fixes "metallium" to "metalium".

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes