### PR TITLE
increase qwen2.5 perf target

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1089,7 +1089,7 @@ def test_demo_text(
                 # T3K targets
                 "T3K_Llama3.1-70B": 14,
                 "T3K_Qwen2.5-72B": 13,
-                "T3K_Qwen2.5-Coder-32B": 19,
+                "T3K_Qwen2.5-Coder-32B": 21,
                 "T3K_Qwen3-32B": 20,
             }
 


### PR DESCRIPTION
### Problem description
T3K demo tests were [failing in CI](https://github.com/tenstorrent/tt-metal/actions/runs/16358730442/job/46263760838#step:9:25199) due to perf target being set too low for Qwen2.5-Coder-32B

### What's changed
Increased t/s/u target from 19 to 21

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/16445143879/job/46475661601