### PR TITLE
Llama TG Enable test in APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -362,6 +362,12 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: in-service-dedicated-apc },
+        ]
     uses: ./.github/workflows/tg-demo-all-post-commmit-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -368,7 +368,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: in-service-dedicated-apc },
         ]
-    uses: ./.github/workflows/tg-demo-all-post-commmit-impl.yaml
+    uses: ./.github/workflows/tg-demo-all-post-commit-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -232,6 +232,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      runner-label: ${{ matrix.test-group.runner-label}}
   build-docs:
     needs: build-artifact
     uses: ./.github/workflows/docs-latest-public.yaml

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -139,6 +139,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+
   # FD Model Tests
   models-unit-tests:
     needs: build-artifact
@@ -191,7 +192,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   run-profiler-regression:
-    needs: build-artifact-profiler
+    needs: [build-artifact-profiler]
     strategy:
       fail-fast: false
       matrix:
@@ -270,7 +271,7 @@ jobs:
           #  publish-artifact: false
           #  skip-tt-train: true
           - version: "24.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: false

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -70,152 +70,152 @@ jobs:
       version: ${{ inputs.version || '22.04' }}
 
   # Slow Dispatch Unit Tests
-  # sd-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/build-and-unit-tests.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # Fast Dispatch Unit Tests
-  # fast-dispatch-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # Fabric Unit Tests
-  # fabric-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # TTNN FD Unit tests
-  # ttnn-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/ttnn-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # FD Model Tests
-  # models-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/models-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # FD C++ Unit Tests
-  # cpp-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/cpp-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # tt-train-cpp-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/tt-train-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  # run-profiler-regression:
-  #   needs: build-artifact-profiler
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/run-profiler-regression.yaml
-  #   secrets: inherit
-  #   with:
-  #     arch: ${{ matrix.test-group.arch}}
-  #     runner-label: ${{ matrix.test-group.runner-label}}
-  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-  # t3000-fast-tests:
-  #   if: ${{ github.event.pull_request.head.repo.fork == false }}
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/t3000-fast-tests-impl.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  sd-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Fast Dispatch Unit Tests
+  fast-dispatch-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Fabric Unit Tests
+  fabric-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # TTNN FD Unit tests
+  ttnn-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # FD Model Tests
+  models-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/models-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # FD C++ Unit Tests
+  cpp-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  tt-train-cpp-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/tt-train-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  run-profiler-regression:
+    needs: build-artifact-profiler
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit
+    with:
+      arch: ${{ matrix.test-group.arch}}
+      runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  t3000-fast-tests:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/t3000-fast-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   tg-demo-tests:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
@@ -231,60 +231,60 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  # build-docs:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/docs-latest-public.yaml
-  #   secrets: inherit
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # build:
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   permissions:
-  #     packages: write
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       config:
-  #         - version: "22.04"
-  #           toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-  #           build-type: "Debug"
-  #           publish-artifact: false
-  #           skip-tt-train: false
-  #         - version: "22.04"
-  #           toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-  #           build-type: "Release"
-  #           publish-artifact: false
-  #           skip-tt-train: true
-  #         - version: "22.04"
-  #           toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-  #           build-type: "Release"
-  #           publish-artifact: false
-  #           skip-tt-train: true
-  #         #- version: "22.04"
-  #         #  toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-  #         #  build-type: "Debug"
-  #         #  publish-artifact: false
-  #         #  skip-tt-train: true
-  #         - version: "24.04"
-  #           toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-  #           build-type: "Release"
-  #           publish-artifact: false
-  #           skip-tt-train: false
-  #         - version: "24.04"
-  #           toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
-  #           build-type: "Release"
-  #           publish-artifact: false
-  #           skip-tt-train: true # TODO: look into TT-Train with GCC 14
-  #   with:
-  #     version: ${{ matrix.config.version }}
-  #     toolchain: ${{ matrix.config.toolchain }}
-  #     build-type: ${{ matrix.config.build-type }}
-  #     publish-artifact: ${{ matrix.config.publish-artifact }}
-  #     skip-tt-train: ${{ matrix.config.skip-tt-train || false }}
+  build-docs:
+    needs: build-artifact
+    uses: ./.github/workflows/docs-latest-public.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  build:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - version: "22.04"
+            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            build-type: "Debug"
+            publish-artifact: false
+            skip-tt-train: false
+          - version: "22.04"
+            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+            build-type: "Release"
+            publish-artifact: false
+            skip-tt-train: true
+          - version: "22.04"
+            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+            build-type: "Release"
+            publish-artifact: false
+            skip-tt-train: true
+          #- version: "22.04"
+          #  toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+          #  build-type: "Debug"
+          #  publish-artifact: false
+          #  skip-tt-train: true
+          - version: "24.04"
+            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            build-type: "Release"
+            publish-artifact: false
+            skip-tt-train: false
+          - version: "24.04"
+            toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
+            build-type: "Release"
+            publish-artifact: false
+            skip-tt-train: true # TODO: look into TT-Train with GCC 14
+    with:
+      version: ${{ matrix.config.version }}
+      toolchain: ${{ matrix.config.toolchain }}
+      build-type: ${{ matrix.config.build-type }}
+      publish-artifact: ${{ matrix.config.publish-artifact }}
+      skip-tt-train: ${{ matrix.config.skip-tt-train || false }}
   # We used to use this for post-commit, but we didn't have enough runners
   # to support the number of developers running this workflow
   # build-and-test-measure-perf:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -70,147 +70,6 @@ jobs:
       version: ${{ inputs.version || '22.04' }}
 
   # Slow Dispatch Unit Tests
-<<<<<<< HEAD
-  sd-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # Fast Dispatch Unit Tests
-  fast-dispatch-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # Fabric Unit Tests
-  fabric-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # TTNN FD Unit tests
-  ttnn-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/ttnn-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-
-  # FD Model Tests
-  models-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/models-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # FD C++ Unit Tests
-  cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/cpp-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  tt-train-cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/tt-train-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  run-profiler-regression:
-    needs: [build-artifact-profiler]
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/run-profiler-regression.yaml
-    secrets: inherit
-    with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-  t3000-fast-tests:
-=======
   # sd-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -358,7 +217,6 @@ jobs:
   #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   tg-demo-tests:
->>>>>>> #0: Add test to APC
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
     secrets: inherit
@@ -373,55 +231,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-<<<<<<< HEAD
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  build:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-            build-type: "Debug"
-            publish-artifact: false
-            skip-tt-train: false
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "Release"
-            publish-artifact: false
-            skip-tt-train: true
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-            build-type: "Release"
-            publish-artifact: false
-            skip-tt-train: true
-          #- version: "22.04"
-          #  toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-          #  build-type: "Debug"
-          #  publish-artifact: false
-          #  skip-tt-train: true
-          - version: "24.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "Release"
-            publish-artifact: false
-            skip-tt-train: false
-          - version: "24.04"
-            toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
-            build-type: "Release"
-            publish-artifact: false
-            skip-tt-train: true # TODO: look into TT-Train with GCC 14
-    with:
-      version: ${{ matrix.config.version }}
-      toolchain: ${{ matrix.config.toolchain }}
-      build-type: ${{ matrix.config.build-type }}
-      publish-artifact: ${{ matrix.config.publish-artifact }}
-      skip-tt-train: ${{ matrix.config.skip-tt-train || false }}
-=======
   # build-docs:
   #   needs: build-artifact
   #   uses: ./.github/workflows/docs-latest-public.yaml
@@ -476,7 +285,6 @@ jobs:
   #     build-type: ${{ matrix.config.build-type }}
   #     publish-artifact: ${{ matrix.config.publish-artifact }}
   #     skip-tt-train: ${{ matrix.config.skip-tt-train || false }}
->>>>>>> #0: Add test to APC
   # We used to use this for post-commit, but we didn't have enough runners
   # to support the number of developers running this workflow
   # build-and-test-measure-perf:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -70,6 +70,7 @@ jobs:
       version: ${{ inputs.version || '22.04' }}
 
   # Slow Dispatch Unit Tests
+<<<<<<< HEAD
   sd-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -209,21 +210,164 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   t3000-fast-tests:
+=======
+  # sd-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/build-and-unit-tests.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # Fast Dispatch Unit Tests
+  # fast-dispatch-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # Fabric Unit Tests
+  # fabric-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # TTNN FD Unit tests
+  # ttnn-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/ttnn-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # FD Model Tests
+  # models-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/models-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # FD C++ Unit Tests
+  # cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/cpp-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # tt-train-cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/tt-train-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  # run-profiler-regression:
+  #   needs: build-artifact-profiler
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/run-profiler-regression.yaml
+  #   secrets: inherit
+  #   with:
+  #     arch: ${{ matrix.test-group.arch}}
+  #     runner-label: ${{ matrix.test-group.runner-label}}
+  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  # t3000-fast-tests:
+  #   if: ${{ github.event.pull_request.head.repo.fork == false }}
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/t3000-fast-tests-impl.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  tg-demo-tests:
+>>>>>>> #0: Add test to APC
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
     secrets: inherit
-    uses: ./.github/workflows/t3000-fast-tests-impl.yaml
+    uses: ./.github/workflows/tg-demo-all-post-commmit-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  build-docs:
-    needs: build-artifact
-    uses: ./.github/workflows/docs-latest-public.yaml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+<<<<<<< HEAD
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   build:
     uses: ./.github/workflows/build-artifact.yaml
@@ -271,6 +415,62 @@ jobs:
       build-type: ${{ matrix.config.build-type }}
       publish-artifact: ${{ matrix.config.publish-artifact }}
       skip-tt-train: ${{ matrix.config.skip-tt-train || false }}
+=======
+  # build-docs:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/docs-latest-public.yaml
+  #   secrets: inherit
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # build:
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   permissions:
+  #     packages: write
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       config:
+  #         - version: "22.04"
+  #           toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+  #           build-type: "Debug"
+  #           publish-artifact: false
+  #           skip-tt-train: false
+  #         - version: "22.04"
+  #           toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+  #           build-type: "Release"
+  #           publish-artifact: false
+  #           skip-tt-train: true
+  #         - version: "22.04"
+  #           toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+  #           build-type: "Release"
+  #           publish-artifact: false
+  #           skip-tt-train: true
+  #         #- version: "22.04"
+  #         #  toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+  #         #  build-type: "Debug"
+  #         #  publish-artifact: false
+  #         #  skip-tt-train: true
+  #         - version: "24.04"
+  #           toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+  #           build-type: "Release"
+  #           publish-artifact: false
+  #           skip-tt-train: false
+  #         - version: "24.04"
+  #           toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
+  #           build-type: "Release"
+  #           publish-artifact: false
+  #           skip-tt-train: true # TODO: look into TT-Train with GCC 14
+  #   with:
+  #     version: ${{ matrix.config.version }}
+  #     toolchain: ${{ matrix.config.toolchain }}
+  #     build-type: ${{ matrix.config.build-type }}
+  #     publish-artifact: ${{ matrix.config.publish-artifact }}
+  #     skip-tt-train: ${{ matrix.config.skip-tt-train || false }}
+>>>>>>> #0: Add test to APC
   # We used to use this for post-commit, but we didn't have enough runners
   # to support the number of developers running this workflow
   # build-and-test-measure-perf:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -217,7 +217,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  tg-demo-tests:
+  tg-demo-apc-tests:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -232,7 +232,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      runner-label: ${{ matrix.test-group.runner-label}}
+      runner-label: ${{ matrix.test-group.runner-label }}
   build-docs:
     needs: build-artifact
     uses: ./.github/workflows/docs-latest-public.yaml

--- a/.github/workflows/tg-demo-all-post-commit-impl.yaml
+++ b/.github/workflows/tg-demo-all-post-commit-impl.yaml
@@ -1,0 +1,78 @@
+name: "[internal] TG demo all post commit"
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
+      topology:
+        required: false
+        type: string
+        default: "config-tg"
+
+jobs:
+  tg-demo-all-post-commit-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {
+            name: "Galaxy Llama3 demo tests",
+            arch: wormhole_b0,
+            cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/demo/text_demo.py -k apc',
+            model: llama3,
+            timeout: 7,
+            owner_id: U053W15B6JF
+          }, # Djordje Ivanovic
+        ]
+    runs-on:
+      - arch-wormhole_b0
+      - ${{ inputs.topology }}
+      - bare-metal
+      - pipeline-functional
+      - ${{ inputs.extra-tag }}
+    container:
+        image: ${{ inputs.docker-image }}
+        env:
+          TT_METAL_HOME: /work
+          PYTHONPATH: /work
+          LD_LIBRARY_PATH: /work/build/lib
+          LOGURU_LEVEL: INFO
+          ARCH_NAME: ${{ matrix.test-group.arch }}
+        volumes:
+          - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+          - /dev/hugepages-1G:/dev/hugepages-1G
+          - /mnt/MLPerf:/mnt/MLPerf:ro
+        options: "--device /dev/tenstorrent"
+    defaults:
+        run:
+          shell: bash
+          working-directory: /work # https://github.com/actions/runner/issues/878ujiiu
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Run TG all-post-commit tests
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          echo "Running command: ${{ matrix.test-group.cmd }}"
+          eval "${{ matrix.test-group.cmd }}"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/tg-demo-all-post-commit-impl.yaml
+++ b/.github/workflows/tg-demo-all-post-commit-impl.yaml
@@ -12,7 +12,7 @@ on:
       build-artifact-name:
         required: true
         type: string
-      extra-tag:
+      runner-label:
         required: false
         type: string
         default: "in-service"
@@ -41,6 +41,7 @@ jobs:
       - ${{ inputs.topology }}
       - bare-metal
       - pipeline-functional
+      - ${{ inputs.runner-label }}
     container:
         image: ${{ inputs.docker-image }}
         env:

--- a/.github/workflows/tg-demo-all-post-commit-impl.yaml
+++ b/.github/workflows/tg-demo-all-post-commit-impl.yaml
@@ -58,7 +58,7 @@ jobs:
     defaults:
         run:
           shell: bash
-          working-directory: /work # https://github.com/actions/runner/issues/878ujiiu
+          working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main

--- a/.github/workflows/tg-demo-all-post-commit-impl.yaml
+++ b/.github/workflows/tg-demo-all-post-commit-impl.yaml
@@ -32,7 +32,7 @@ jobs:
             arch: wormhole_b0,
             cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/demo/text_demo.py -k apc',
             model: llama3,
-            timeout: 7,
+            timeout: 10,
             owner_id: U053W15B6JF
           }, # Djordje Ivanovic
         ]

--- a/.github/workflows/tg-demo-all-post-commit-impl.yaml
+++ b/.github/workflows/tg-demo-all-post-commit-impl.yaml
@@ -41,7 +41,6 @@ jobs:
       - ${{ inputs.topology }}
       - bare-metal
       - pipeline-functional
-      - ${{ inputs.extra-tag }}
     container:
         image: ${{ inputs.docker-image }}
         env:

--- a/.github/workflows/tg-demo-all-post-commit.yaml
+++ b/.github/workflows/tg-demo-all-post-commit.yaml
@@ -1,0 +1,22 @@
+name: "(TG) TG demo all-post-commit tests"
+
+on:
+  workflow_dispatch:  # Manual trigger only used to test TG demo all-post-commit tests
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      version: 22.04
+      build-wheel: true
+  tg-demo-all-post-commit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/tg-demo-all-post-commit-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}


### PR DESCRIPTION
### Problem description
TG Llama has frequent bugs introduced by lot of commits. Adding APC should prevent that from happening.

### What's changed
- Added TG test to APC that tests prefill and decode PCC and t/s/u on specific token.
- Added workflow for on-demand testing when it's failing so devs can run locally and in CI before running whole APC 
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16417743793)
- [ ] [APC TG only](https://github.com/tenstorrent/tt-metal/actions/runs/16417684085)