### PR TITLE
[skip ci] Stop running user kernel tests, until they are fixed

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -36,7 +36,6 @@ jobs:
       matrix:
         test-group: [
           {name: All C++, cmd: ./tests/scripts/run_cpp_unit_tests.sh},
-          {name: user kernel path, cmd: "rm -rf /tmp/kernels && TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*"},
           {name: api, cmd: "./build/test/tt_metal/unit_tests_api"},
           {name: data_movement, cmd: "./build/test/tt_metal/unit_tests_data_movement"},
           {name: debug_tools, cmd: "./build/test/tt_metal/unit_tests_debug_tools"},

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -38,7 +38,6 @@ jobs:
           {name: All C++, cmd: ./tests/scripts/run_cpp_unit_tests.sh},
           {name: tools, cmd: ./tests/scripts/run_tools_tests.sh},
 
-          {name: user kernel path, cmd: "rm -rf /tmp/kernels && TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*"},
           {name: debug_tools, cmd: "./build/test/tt_metal/unit_tests_debug_tools"},
           {name: device, cmd: "./build/test/tt_metal/unit_tests_device"},
           {name: dispatch, cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch"},


### PR DESCRIPTION
### Ticket
These tests are broken: https://github.com/tenstorrent/tt-metal/issues/25411

### Problem description
Today I noticed that we spend 24 minutes of runtime in every APC launch, running these skipped tests.
The tests were skipped because there was no directory `/tmp/kernels`
After enabling the tests by creating that directory, I notice the tests fail.

### What's changed
Stop wasting runtime, by skipping these tests until the associated issue is fixed.

### Checklist
- NA