### PR TITLE
Remove noc event profiler for ERISC kernels/firmware

### DIFF
--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#if defined(PROFILE_NOC_EVENTS) && (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || \
-                                    defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+#if defined(PROFILE_NOC_EVENTS) && (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC))
 
 #include <utility>
 #include <tuple>


### PR DESCRIPTION
#### Ticket
**See issue https://github.com/tenstorrent/tt-metal/issues/25414**

#### Problem description
ERISC kernels should not compile profiler noc tracing support; this has caused ND hangs within ethernet firmware.

#### What's changed
`noc_event_profiler.hpp` macros are unconditionally stripped while building ERISC kernels, even if noc tracing is enabled otherwise.

#### Checklist
- [X] [All post commit run](https://github.com/tenstorrent/tt-metal/actions/runs/16452366105) CI passes 
- [X] [Blackhole Post commit run](https://github.com/tenstorrent/tt-metal/actions/runs/16418789817) CI with demo tests passes (if applicable)