### PR TITLE
DP 8 SDPA support for MLA Decode

### DIFF
--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -130,7 +130,7 @@ def test_forward_pass(
         model_config = MLA1D.decode_model_config(hf_config, mesh_row, ccl)
 
     # Create a new model state
-    model_state = MLA1D.create_state(hf_config, mesh_device=mesh_row)
+    model_state = MLA1D.create_state(hf_config, mesh_device=mesh_row, mode=mode)
 
     # Create RunConfig using both weight_config and model_config
     run_config = create_run_config(model_config, weight_config, model_state)
@@ -192,7 +192,7 @@ def test_forward_pass(
             torch.tensor(position_idxs),
             device=mesh_row,
             mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_row, dims=(None, None), mesh_shape=mesh_shape
+                mesh_row, dims=(None, 0), mesh_shape=mesh_shape
             ),  # TODO: Shard on batch when DP
             dtype=ttnn.int32,
         )

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -130,7 +130,7 @@ def test_forward_pass(
         model_config = MLA1D.decode_model_config(hf_config, mesh_row, ccl)
 
     # Create a new model state
-    model_state = MLA1D.create_state(hf_config, mesh_device=mesh_row, mode=mode)
+    model_state = MLA1D.create_state(hf_config, mesh_device=mesh_row, use_dp_cache=(mode == "decode"))
 
     # Create RunConfig using both weight_config and model_config
     run_config = create_run_config(model_config, weight_config, model_state)


### PR DESCRIPTION
### Ticket
- #23022 
- #25129

### Problem description
In the 1xTG case, we cannot fit a replicated cache. As such, the MLA module needs to support DP around the SDPA op. Currently, we support TP=8 in MLA, but this needs to be extended with DP support.

### What's changed

There are 3 main CCL points that are introduced when supporting DP=8 SDPA inside of the current TP=8 MLA decode module:
- Reduce-Scatter before updating cache
- All-to-All before SDPA
- All-to-All after SDPA

For all of these, we do **not** have full CCL support. Here are the workarounds currently employed:

- Reduce-Scatter
    - Since we do not support sub-tile shapes in reduce scatter, we can do combination of permute + pad + slice alongside the existing reduce-scatter to simulate our use case
- All-toAll
    - For functionality, we've reverted to using an All-Gather + Reduce-Scatter + Scaling methodology. Using this, we can simulate an all-to-all


### Checklist
- [x] [TG Deepseek](https://github.com/tenstorrent/tt-metal/actions/runs/16418927683) CI passes