### PR TITLE
pin pyarrow

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -42,6 +42,7 @@ pytest-xdist==3.6.1
 pytest-benchmark==4.0.0
 jsbeautifier==1.14.7
 datasets==2.9.0
+pyarrow==20.0.0
 torch==2.2.1.0+cpu ; platform_machine == 'x86_64'
 torch==2.2.1.0 ; platform_machine == 'aarch64'
 networkx==3.1


### PR DESCRIPTION
### Ticket
#25420

### Problem description
pyarrow error on ci: `AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?`. The error comes from pyarrow version 21 since we don't pin it. it is used by datasets package that apparently doesn't pin it as well.

### What's changed
pin to 20.0.0 until the issues are resolved

### Checklist

- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/16419080344)
- [ ] [Frequent ttnn](https://github.com/tenstorrent/tt-metal/actions/runs/16418889375)
