### PR TITLE
[tt_transformers] Show an error for unsupported MLP activations

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1372,7 +1372,7 @@ class ModelArgs:
 
         hidden_activation = hidden_activation.lower()
         if hidden_activation not in activation_map:
-            logger.warning(f"Warning: Unsupported activation '{hidden_activation}', defaulting to SILU")
+            raise NotImplementedError(f"Unsupported activation '{hidden_activation}'")
 
         return activation_map.get(hidden_activation, ttnn.UnaryOpType.SILU)
 


### PR DESCRIPTION
### Ticket
Following up a [comment](https://github.com/tenstorrent/tt-metal/pull/24520#discussion_r2215687736)

### Problem description
Unsupported MLP activations should not be allowed

### What's changed
Switch from a warning and defaulting to SILU to explicitly exiting

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16442886812)