### PR TITLE
[skip ci] Move all of device unit tests into PR-Gate

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -39,7 +39,6 @@ jobs:
           {name: tools, cmd: ./tests/scripts/run_tools_tests.sh},
 
           {name: debug_tools, cmd: "./build/test/tt_metal/unit_tests_debug_tools"},
-          {name: device, cmd: "./build/test/tt_metal/unit_tests_device"},
           {name: dispatch, cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch"},
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth"},
           {name: misc, cmd: "./build/test/tt_metal/unit_tests_misc"},

--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -2,7 +2,16 @@
 add_library(unit_tests_device_smoke OBJECT)
 add_library(TT::Metalium::Test::Device::Smoke ALIAS unit_tests_device_smoke)
 TT_ENABLE_UNITY_BUILD(unit_tests_device_smoke)
-target_sources(unit_tests_device_smoke PRIVATE test_device_init_and_teardown.cpp)
+target_sources(
+    unit_tests_device_smoke
+    PRIVATE
+        test_device_init_and_teardown.cpp
+        test_device_cluster_api.cpp
+        test_device_pool.cpp
+        test_device.cpp
+        test_simulator_device.cpp
+        test_galaxy_cluster_api.cpp
+)
 target_include_directories(
     unit_tests_device_smoke
     PRIVATE
@@ -14,32 +23,10 @@ target_link_libraries(unit_tests_device_smoke PRIVATE test_metal_common_libs)
 
 # Remaining tests
 add_executable(unit_tests_device)
-TT_ENABLE_UNITY_BUILD(unit_tests_device)
 set_target_properties(
     unit_tests_device
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/test/tt_metal
 )
-target_sources(
-    unit_tests_device
-    PRIVATE
-        test_device_cluster_api.cpp
-        test_device_pool.cpp
-        test_device.cpp
-        test_simulator_device.cpp
-        test_galaxy_cluster_api.cpp
-)
-target_include_directories(
-    unit_tests_device
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/tests
-        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
-        ${CMAKE_CURRENT_SOURCE_DIR}
-)
-target_link_libraries(
-    unit_tests_device
-    PRIVATE
-        test_metal_common_libs
-        TT::Metalium::Test::Device::Smoke
-)
+target_link_libraries(unit_tests_device PRIVATE TT::Metalium::Test::Device::Smoke)


### PR DESCRIPTION
### Ticket
NA

### Problem description
For some reason we only ran a small subset of these tests in PR-Gate. As a result we were spinning up 2 jobs and therefore 2 machines in every APC run for 10 seconds of runtime? Thats very poor efficiency. Also, APC sux.

### What's changed
Move test workload to PR Gate.

### Checklist
- [x] PR-Gate