### PR TITLE
Revert "added cache again for AsyncExecutionWorksCQ0CQ1"

### DIFF
--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -225,6 +225,11 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
         view.get_device(MeshCoordinate(0, 2)),
         view.get_device(MeshCoordinate(0, 3))};
 
+    // https://github.com/tenstorrent/tt-metal/issues/24235
+    for (auto device : devices) {
+        device->disable_and_clear_program_cache();
+    }
+
     const size_t num_devices = devices.size();
     TT_FATAL(
         test_expected_num_devices == num_devices,


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#25089

Causing ~50% ND failure on T3k ttnn tests in test_ccl_multi_cq_multi_device.cpp
```
tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp#L212
/work/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp:376
Expected equality of these values:
  output_data[j].to_float()
    Which is: -32
  (-1.0 * base * 32.0 + 128)
    Which is: 128
  ```

- [x] APC https://github.com/tenstorrent/tt-metal/actions/runs/16424817362