### PR TITLE
#0: Change test fixtures to rely on `SystemMesh` shape

### DIFF
--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -110,14 +110,13 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
 
 namespace tt::tt_metal::distributed::test {
 
-using MeshEndToEndT3kTests = MeshDevice2x4Fixture;
+using MeshEndToEnd2x4Tests = MeshDevice2x4Fixture;
 using ::testing::Each;
 using ::testing::Eq;
 using ::testing::FloatEq;
 using ::testing::Pointwise;
 
-TEST_F(MeshEndToEndT3kTests, ProgramDispatchTest) {
-
+TEST_F(MeshEndToEnd2x4Tests, ProgramDispatchTest) {
     auto& cq = mesh_device_->mesh_command_queue();
 
     uint8_t cq_id = cq.id();
@@ -155,7 +154,7 @@ TEST_F(MeshEndToEndT3kTests, ProgramDispatchTest) {
     Finish(cq);
 }
 
-TEST_F(MeshEndToEndT3kTests, BufferRoundtripTest) {
+TEST_F(MeshEndToEnd2x4Tests, BufferRoundtripTest) {
     using tt::tt_metal::distributed::ShardedBufferConfig;
 
     auto& cq = mesh_device_->mesh_command_queue();
@@ -190,7 +189,7 @@ TEST_F(MeshEndToEndT3kTests, BufferRoundtripTest) {
     EXPECT_THAT(read_back_data, Pointwise(Eq(), src_data));
 }
 
-TEST_F(MeshEndToEndT3kTests, UntracedEltwiseAddTest) {
+TEST_F(MeshEndToEnd2x4Tests, UntracedEltwiseAddTest) {
     constexpr uint8_t kAddOpId = 0;
 
     auto shard_shape = Shape2D{32, 32};

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -110,7 +110,7 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
 
 namespace tt::tt_metal::distributed::test {
 
-using MeshEndToEndT3kTests = T3000MeshDeviceFixture;
+using MeshEndToEndT3kTests = MeshDevice2x4Fixture;
 using ::testing::Each;
 using ::testing::Eq;
 using ::testing::FloatEq;
@@ -243,17 +243,17 @@ TEST_F(MeshEndToEndT3kTests, UntracedEltwiseAddTest) {
     }
 }
 
-class MeshEndToEndT3kTraceTests : public MeshDeviceFixtureBase {
+class MeshEndToEnd2x4TraceTests : public MeshDeviceFixtureBase {
 protected:
-    MeshEndToEndT3kTraceTests() :
+    MeshEndToEnd2x4TraceTests() :
         MeshDeviceFixtureBase(Config{
-            .mesh_device_types = {MeshDeviceFixtureBase::MeshDeviceType::T3000},
+            .system_mesh_shape = MeshShape{2, 4},
             .num_cqs = 2,
             .trace_region_size = 3072,  // 1024 per workload necessary
         }) {}
 };
 
-TEST_F(MeshEndToEndT3kTraceTests, EltwiseAddTest) {
+TEST_F(MeshEndToEnd2x4TraceTests, EltwiseAddTest) {
     constexpr uint8_t kAddOpId = 0;
 
     auto shard_shape = Shape2D{32, 32};
@@ -317,7 +317,7 @@ TEST_F(MeshEndToEndT3kTraceTests, EltwiseAddTest) {
     }
 }
 
-TEST_F(MeshEndToEndT3kTraceTests, EltwiseMulTest) {
+TEST_F(MeshEndToEnd2x4TraceTests, EltwiseMulTest) {
     constexpr uint8_t kMulOpId = 1;
 
     auto shard_shape = Shape2D{32, 32};
@@ -382,7 +382,7 @@ TEST_F(MeshEndToEndT3kTraceTests, EltwiseMulTest) {
 
 MATCHER_P(Bfloat16Eq, calculated, "") { return arg.to_float() == calculated; }
 
-TEST_F(MeshEndToEndT3kTraceTests, SimulEltwiseTest) {
+TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
 

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -41,7 +41,7 @@
 namespace tt::tt_metal::distributed::test {
 namespace {
 
-using MeshBufferTestT3000 = T3000MeshDeviceFixture;
+using MeshBufferTest2x4 = MeshDevice2x4Fixture;
 using MeshBufferTestSuite = GenericMeshDeviceFixture;
 
 struct DeviceLocalShardedBufferTestConfig {
@@ -79,8 +79,7 @@ struct DeviceLocalShardedBufferTestConfig {
     }
 };
 
-// MeshBuffer tests on T3000
-TEST_F(MeshBufferTestT3000, ShardedBufferInitialization) {
+TEST_F(MeshBufferTest2x4, ShardedBufferInitialization) {
     const DeviceLocalBufferConfig device_local_config{
         .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
 
@@ -94,7 +93,7 @@ TEST_F(MeshBufferTestT3000, ShardedBufferInitialization) {
     EXPECT_EQ(sharded_buffer->device_local_size(), 2 << 10);
 }
 
-TEST_F(MeshBufferTestT3000, ReplicatedBufferInitialization) {
+TEST_F(MeshBufferTest2x4, ReplicatedBufferInitialization) {
     const DeviceLocalBufferConfig device_local_config{
         .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
 
@@ -106,7 +105,7 @@ TEST_F(MeshBufferTestT3000, ReplicatedBufferInitialization) {
     EXPECT_EQ(replicated_buffer->device_local_size(), 16 << 10);
 }
 
-TEST_F(MeshBufferTestT3000, Deallocation) {
+TEST_F(MeshBufferTest2x4, Deallocation) {
     // Verify that a buffer is deallocated on the MeshDevice when it goes
     // out of scope on host. Create a buffer with a certain config in limited
     // scope. Record its address. Create another buffer with the same config
@@ -186,7 +185,7 @@ TEST(MeshBufferTest, DeallocationWithMeshDeviceClosed) {
     }
 }
 
-TEST_F(MeshBufferTestT3000, GetDeviceBuffer) {
+TEST_F(MeshBufferTest2x4, GetDeviceBuffer) {
     const DeviceLocalBufferConfig device_local_config{
         .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
 
@@ -200,7 +199,7 @@ TEST_F(MeshBufferTestT3000, GetDeviceBuffer) {
 }
 
 class DeviceLocalMeshBufferShardingTest
-    : public MeshBufferTestT3000,
+    : public MeshBufferTest2x4,
       public testing::WithParamInterface<
           std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>, TensorMemoryLayout>> {};
 
@@ -265,7 +264,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(
             TensorMemoryLayout::HEIGHT_SHARDED, TensorMemoryLayout::WIDTH_SHARDED, TensorMemoryLayout::BLOCK_SHARDED)));
 
-TEST_F(MeshBufferTestT3000, SweepShardAndConcat) {
+TEST_F(MeshBufferTest2x4, SweepShardAndConcat) {
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
 
     DeviceLocalBufferConfig per_device_buffer_config{
@@ -300,7 +299,6 @@ TEST_F(MeshBufferTestT3000, SweepShardAndConcat) {
     }
 }
 
-// MeshBuffer tests on N300 and T3000
 TEST_F(MeshBufferTestSuite, ConfigValidation) {
     const DeviceLocalBufferConfig device_local_config{
         .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -44,10 +44,10 @@ TEST(MeshDeviceInitTest, Init1x1Mesh) {
     });
 }
 
-using MeshDeviceT3000Test = T3000MeshDeviceFixture;
+using MeshDevice2x4Test = MeshDevice2x4Fixture;
 using MeshDeviceTest = GenericMeshDeviceFixture;
 
-TEST_F(MeshDeviceT3000Test, SystemMeshTearDownWithoutClose) {
+TEST_F(MeshDevice2x4Test, SystemMeshTearDownWithoutClose) {
     auto& sys = SystemMesh::instance();
 
     const auto system_shape = sys.shape();
@@ -56,7 +56,7 @@ TEST_F(MeshDeviceT3000Test, SystemMeshTearDownWithoutClose) {
     EXPECT_EQ(system_shape[1], 4);
 }
 
-TEST_F(MeshDeviceT3000Test, MemoryAllocationStatistics) {
+TEST_F(MeshDevice2x4Test, MemoryAllocationStatistics) {
     auto stats = mesh_device_->allocator()->get_statistics(tt::tt_metal::BufferType::DRAM);
     for (auto* device : mesh_device_->get_devices()) {
         auto device_stats = device->allocator()->get_statistics(tt::tt_metal::BufferType::DRAM);
@@ -64,7 +64,7 @@ TEST_F(MeshDeviceT3000Test, MemoryAllocationStatistics) {
     }
 }
 
-TEST_F(MeshDeviceT3000Test, ViewIs2D) {
+TEST_F(MeshDevice2x4Test, ViewIs2D) {
     std::vector<IDevice*> devices = mesh_device_->get_devices();
 
     MeshContainer<IDevice*> container_1d(MeshShape(8), devices);
@@ -80,7 +80,7 @@ TEST_F(MeshDeviceT3000Test, ViewIs2D) {
     EXPECT_FALSE(view_3d.is_mesh_2d());
 }
 
-TEST_F(MeshDeviceT3000Test, CreateSubmeshInvalidConfig) {
+TEST_F(MeshDevice2x4Test, CreateSubmeshInvalidConfig) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
 
     EXPECT_ANY_THROW(mesh_device_->create_submesh(MeshShape{1, 3}, MeshCoordinate{1}));
@@ -89,7 +89,7 @@ TEST_F(MeshDeviceT3000Test, CreateSubmeshInvalidConfig) {
     EXPECT_ANY_THROW(mesh_device_->create_submesh(MeshShape{2, 4, 1}, MeshCoordinate{0, 0}));
 }
 
-TEST_F(MeshDeviceT3000Test, CreateSubmesh) {
+TEST_F(MeshDevice2x4Test, CreateSubmesh) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
     EXPECT_THAT(mesh_device_->get_devices(), SizeIs(8));
     EXPECT_TRUE(mesh_device_->is_parent_mesh());
@@ -108,12 +108,12 @@ TEST_F(MeshDeviceT3000Test, CreateSubmesh) {
     EXPECT_EQ(submesh->get_device(MeshCoordinate{1, 1}), nullptr);
 }
 
-TEST_F(MeshDeviceT3000Test, CreateSubmeshesNonDivisibleSubshape) {
+TEST_F(MeshDevice2x4Test, CreateSubmeshesNonDivisibleSubshape) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
     EXPECT_ANY_THROW(mesh_device_->create_submeshes(MeshShape{1, 3}));
 }
 
-TEST_F(MeshDeviceT3000Test, CreateSubmeshes) {
+TEST_F(MeshDevice2x4Test, CreateSubmeshes) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
 
     auto submeshes = mesh_device_->create_submeshes(MeshShape{1, 2});

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -129,13 +129,20 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
 
     auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, src0_bufs, src1_bufs, output_bufs);
-    uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
+    uint32_t num_cols_in_workload = mesh_device_->num_cols() / 2;
     auto mesh_workload = CreateMeshWorkload();
     MeshCoordinateRange devices_0(
-        MeshCoordinate{0, 0}, MeshCoordinate{num_rows_in_workload - 1, mesh_device_->num_cols() - 1});
+        MeshCoordinate{0, 0},
+        MeshCoordinate{
+            mesh_device_->num_rows() - 1,
+            num_cols_in_workload - 1,
+        });
     MeshCoordinateRange devices_1(
-        MeshCoordinate{num_rows_in_workload, 0},
-        MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
+        MeshCoordinate{0, num_cols_in_workload},
+        MeshCoordinate{
+            mesh_device_->num_rows() - 1,
+            mesh_device_->num_cols() - 1,
+        });
 
     AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), devices_0);
     AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), devices_1);
@@ -185,7 +192,7 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
                         dst_vec,
                         output_bufs[col_idx * worker_grid_size.y + row_idx],
                         device_coord);
-                    if (device_coord[0] <= num_rows_in_workload - 1) {
+                    if (device_coord[1] <= num_cols_in_workload - 1) {
                         for (int i = 0; i < dst_vec.size(); i++) {
                             EXPECT_EQ(dst_vec[i].to_float(), (2 * iter + 5));
                         }
@@ -220,8 +227,8 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
     for (std::size_t i = 0; i < num_iterations; i++) {
         std::vector<uint32_t> src_vec(NUM_TILES * single_tile_size / sizeof(uint32_t), i);
         std::iota(src_vec.begin(), src_vec.end(), i);
-        MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{0, mesh_device_->num_cols() - 1});
-        MeshCoordinateRange devices_1(MeshCoordinate{1, 0}, MeshCoordinate{1, mesh_device_->num_cols() - 1});
+        MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{mesh_device_->num_rows() - 1, 0});
+        MeshCoordinateRange devices_1(MeshCoordinate{0, 1}, MeshCoordinate{mesh_device_->num_rows() - 1, 1});
 
         std::vector<std::vector<uint32_t>> readback_vecs = {};
 

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -32,7 +32,7 @@
 namespace tt::tt_metal::distributed::test {
 namespace {
 
-using MeshEventsTestT3000 = T3000MultiCQMeshDeviceFixture;
+using MeshEventsTest2x4 = MultiCQMeshDevice2x4Fixture;
 using MeshEventsTestSuite = GenericMultiCQMeshDeviceFixture;
 
 TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
@@ -73,7 +73,7 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
     }
 }
 
-TEST_F(MeshEventsTestT3000, ShardedAsyncIO) {
+TEST_F(MeshEventsTest2x4, ShardedAsyncIO) {
     uint32_t num_iterations = 20;
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
 

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -22,9 +22,9 @@
 
 namespace tt::tt_metal::distributed {
 
-using MeshSocketTest = T3000MeshDeviceFixture;
-using MeshSocketTest1DFabric = T3000MeshDevice1DFabricFixture;
-using MeshSocketTest2DFabric = T3000MeshDevice2DFabricFixture;
+using MeshSocketTest = MeshDevice2x4Fixture;
+using MeshSocketTest1DFabric = MeshDevice2x4Fabric1DFixture;
+using MeshSocketTest2DFabric = MeshDevice2x4Fabric2DFixture;
 
 struct SocketCoreMapping {
     CoreCoord sender_core;

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -88,16 +88,16 @@ protected:
     MeshTraceTestSuite() : MeshDeviceFixtureBase(Config{.num_cqs = 1, .trace_region_size = (64 << 20)}) {}
 };
 
-class MeshTraceTestT3000 : public MeshDeviceFixtureBase {
+class MeshTraceTest2x4 : public MeshDeviceFixtureBase {
 protected:
-    MeshTraceTestT3000() :
-        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::T3000}, .trace_region_size = (64 << 20)}) {}
+    MeshTraceTest2x4() :
+        MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}, .trace_region_size = (64 << 20)}) {}
 };
 
-class MeshTraceTestTG : public MeshDeviceFixtureBase {
+class MeshTraceTest4x8 : public MeshDeviceFixtureBase {
 protected:
-    MeshTraceTestTG() :
-        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::TG}, .trace_region_size = (64 << 20)}) {}
+    MeshTraceTest4x8() :
+        MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{4, 8}, .trace_region_size = (64 << 20)}) {}
 };
 
 TEST_F(MeshTraceTestSuite, Sanity) {
@@ -149,7 +149,7 @@ TEST_F(MeshTraceTestSuite, Sanity) {
     }
 }
 
-TEST_F(MeshTraceTestT3000, EltwiseBinaryMeshTrace) {
+TEST_F(MeshTraceTest2x4, EltwiseBinaryMeshTrace) {
     std::vector<std::shared_ptr<MeshBuffer>> src0_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> src1_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> intermed_bufs_0 = {};
@@ -557,19 +557,19 @@ void run_heterogenous_trace_sweep(
     ReleaseTrace(mesh_device.get(), trace_id);
 }
 
-class T3KMeshTraceSweepTest : public MeshTraceTestT3000,
+class MeshTraceSweepTest2x4 : public MeshTraceTest2x4,
                               public testing::WithParamInterface<std::vector<std::vector<MeshCoordinateRange>>> {};
 
-class TGMeshTraceSweepTest : public MeshTraceTestTG,
-                             public testing::WithParamInterface<std::vector<std::vector<MeshCoordinateRange>>> {};
+class MeshTraceSweepTest4x8 : public MeshTraceTest4x8,
+                              public testing::WithParamInterface<std::vector<std::vector<MeshCoordinateRange>>> {};
 
-TEST_P(T3KMeshTraceSweepTest, Sweep) { run_heterogenous_trace_sweep(mesh_device_, GetParam()); }
+TEST_P(MeshTraceSweepTest2x4, Sweep) { run_heterogenous_trace_sweep(mesh_device_, GetParam()); }
 
-TEST_P(TGMeshTraceSweepTest, Sweep) { run_heterogenous_trace_sweep(mesh_device_, GetParam()); }
+TEST_P(MeshTraceSweepTest4x8, Sweep) { run_heterogenous_trace_sweep(mesh_device_, GetParam()); }
 
 INSTANTIATE_TEST_SUITE_P(
-    T3KMeshTraceSweepTests,
-    T3KMeshTraceSweepTest,
+    MeshTraceSweepTest2x4Tests,
+    MeshTraceSweepTest2x4,
     ::testing::Values(
         std::vector<std::vector<MeshCoordinateRange>>({
             {t3k_full_grid()},
@@ -668,8 +668,8 @@ INSTANTIATE_TEST_SUITE_P(
         })));
 
 INSTANTIATE_TEST_SUITE_P(
-    TGMeshTraceSweepTests,
-    TGMeshTraceSweepTest,
+    MeshTraceSweepTest4x8Tests,
+    MeshTraceSweepTest4x8,
     ::testing::Values(
         std::vector<std::vector<MeshCoordinateRange>>({
             // Run on full grid

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -176,8 +176,8 @@ void validate_sems(
     }
 }
 
-using MeshWorkloadTestT3000 = T3000MeshDeviceFixture;
-using MeshWorkloadTestTG = TGMeshDeviceFixture;
+using MeshWorkloadTest2x4 = MeshDevice2x4Fixture;
+using MeshWorkloadTest4x8 = MeshDevice4x8Fixture;
 using MeshWorkloadTestSuite = GenericMeshDeviceFixture;
 
 TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
@@ -227,8 +227,7 @@ TEST_F(MeshWorkloadTestSuite, OverlappingProgramRanges) {
         ThrowsMessage<std::runtime_error>(HasSubstr("overlaps with the previously added range")));
 }
 
-// Test running different configurations of heterogenous MeshWorkloads on T3000.
-TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
+TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
     uint32_t num_programs = 100;
     uint32_t num_heterogeneous_programs = 64;
     uint32_t num_iterations = 1000;
@@ -311,8 +310,7 @@ TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-// Test running different configurations of heterogenous MeshWorkloads on TG.
-TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
+TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {
     uint32_t num_programs_0 = 16;
     uint32_t num_programs_1 = 24;
     uint32_t num_iterations = 1000;

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -454,12 +454,12 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
 
     auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, src0_bufs, src1_bufs, output_bufs);
-    uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
+    uint32_t num_cols_in_workload = mesh_device_->num_cols() / 2;
     auto mesh_workload = CreateMeshWorkload();
     MeshCoordinateRange devices_0(
-        MeshCoordinate{0, 0}, MeshCoordinate{num_rows_in_workload - 1, mesh_device_->num_cols() - 1});
+        MeshCoordinate{0, 0}, MeshCoordinate{mesh_device_->num_rows() - 1, num_cols_in_workload - 1});
     MeshCoordinateRange devices_1(
-        MeshCoordinate{num_rows_in_workload, 0},
+        MeshCoordinate{0, num_cols_in_workload},
         MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
     AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), devices_0);
     AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), devices_1);
@@ -489,7 +489,7 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
                     dst_vec,
                     output_bufs[col_idx * worker_grid_size.y + row_idx],
                     device_coord);
-                if (device_coord[0] <= num_rows_in_workload - 1) {
+                if (device_coord[1] <= num_cols_in_workload - 1) {
                     for (int i = 0; i < dst_vec.size(); i++) {
                         EXPECT_EQ(dst_vec[i].to_float(), 5);
                     }
@@ -568,9 +568,9 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
     }
     auto program_1 = initialize_dummy_program(worker_grid_size);
     auto mesh_workload = MeshWorkload();
-    MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{0, mesh_device_->num_cols() - 1});
+    MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{mesh_device_->num_rows() - 1, 0});
     MeshCoordinateRange devices_1(
-        MeshCoordinate{mesh_device_->num_rows() - 1, 0},
+        MeshCoordinate{0, mesh_device_->num_cols() - 1},
         MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
     AddProgramToMeshWorkload(mesh_workload, std::move(program), devices_0);
     AddProgramToMeshWorkload(mesh_workload, std::move(*program_1), devices_1);
@@ -690,11 +690,11 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreDifferentPrograms) {
         CreateSemaphore(program1, full_grid, sem + 1);
         expected_semaphore_values_1.push_back(sem + 1);
     }
-    uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
+    uint32_t num_cols_in_workload = mesh_device_->num_cols() / 2;
     auto mesh_workload = CreateMeshWorkload();
-    MeshCoordinateRange devices_0({0, 0}, {num_rows_in_workload - 1, mesh_device_->num_cols() - 1});
+    MeshCoordinateRange devices_0({0, 0}, {mesh_device_->num_rows() - 1, num_cols_in_workload - 1});
     MeshCoordinateRange devices_1(
-        {num_rows_in_workload, 0}, {mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
+        {0, num_cols_in_workload}, {mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
 
     AddProgramToMeshWorkload(mesh_workload, std::move(program0), devices_0);
     AddProgramToMeshWorkload(mesh_workload, std::move(program1), devices_1);

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -127,19 +127,19 @@ public:
 };
 
 // Base fixture for Multi-Host MeshDevice tests relying on Inter-Mesh Routing.
-class MultiMeshDeviceFabricFixture : public tt::tt_metal::GenericMeshDevice2DFabricFixture {
+class MultiMeshDeviceFabricFixture : public tt::tt_metal::GenericMeshDeviceFabric2DFixture {
 public:
     void SetUp() override {
         if (not system_supported()) {
             GTEST_SKIP() << "Skipping since this is not a supported system.";
         }
         validate_and_setup_control_plane_config(this);
-        tt::tt_metal::GenericMeshDevice2DFabricFixture::SetUp();
+        tt::tt_metal::GenericMeshDeviceFabric2DFixture::SetUp();
     }
 
     void TearDown() override {
         if (system_supported()) {
-            tt::tt_metal::GenericMeshDevice2DFabricFixture::TearDown();
+            tt::tt_metal::GenericMeshDeviceFabric2DFixture::TearDown();
         }
     }
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/mesh_device.hpp>
 
 #include "dispatch_fixture.hpp"
+#include "system_mesh.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/test_utils/env_vars.hpp"
@@ -91,22 +92,14 @@ protected:
     using MeshDeviceConfig = ::tt::tt_metal::distributed::MeshDeviceConfig;
     using MeshShape = ::tt::tt_metal::distributed::MeshShape;
 
-    enum class MeshDeviceType {
-        // N150/P150 devices opened as 1x1 meshes.
-        N150,
-        P150,
-        N300,
-        P300,
-        N300_2x2,
-        T3000,
-        TG,
-    };
-
     struct Config {
-        // If empty, the mesh device type will be deduced automatically based on the connected devices.
-        // Otherwise, the associated tests will run only if the connected cluster corresponds to one of the
-        // specified mesh device types.
-        std::unordered_set<MeshDeviceType> mesh_device_types;
+        // If specified, the associated tests will run only if SystemMesh shape matches the specified shape.
+        std::optional<tt::tt_metal::distributed::MeshShape> system_mesh_shape;
+
+        // If specified, the associated tests will run only if the machine architecture matches the specified
+        // architecture.
+        std::optional<tt::ARCH> arch;
+
         int num_cqs = 1;
         uint32_t trace_region_size = 0;
         uint32_t worker_l1_size = DEFAULT_WORKER_L1_SIZE;
@@ -122,27 +115,21 @@ protected:
         }
 
         const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-
-        const auto num_devices = tt::tt_metal::GetNumAvailableDevices();
-        const auto mesh_device_type = derive_mesh_device_type(num_devices, arch);
-        if (!mesh_device_type) {
+        if (config_.arch.has_value() && *config_.arch != arch) {
             GTEST_SKIP() << fmt::format(
-                "Skipping MeshDevice test suite on a machine with an unsupported number of devices {}.", num_devices);
+                "Skipping MeshDevice test suite on a machine with architecture {} that does not match the requested "
+                "architecture {}",
+                arch,
+                *config_.arch);
         }
 
-        if (!config_.mesh_device_types.empty() &&
-            config_.mesh_device_types.find(*mesh_device_type) == config_.mesh_device_types.end()) {
-            std::vector<std::string> requested_device_types;
-            std::transform(
-                config_.mesh_device_types.begin(),
-                config_.mesh_device_types.end(),
-                std::back_inserter(requested_device_types),
-                [](const auto t) { return std::string(magic_enum::enum_name(t)); });
+        const auto system_mesh_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
+        if (config_.system_mesh_shape.has_value() && *config_.system_mesh_shape != system_mesh_shape) {
             GTEST_SKIP() << fmt::format(
-                "Skipping MeshDevice test suite on a {} machine that does not match any of the configured mesh device "
-                "types {}",
-                magic_enum::enum_name(*mesh_device_type),
-                boost::algorithm::join(requested_device_types, ", "));
+                "Skipping MeshDevice test suite on a machine with SystemMesh {} that does not match the requested mesh "
+                "shape {}",
+                system_mesh_shape,
+                *config_.system_mesh_shape);
         }
 
         // Use ethernet dispatch for more than 1 CQ on T3K/N300
@@ -155,7 +142,7 @@ protected:
             tt_fabric::SetFabricConfig(config_.fabric_config);
         }
         mesh_device_ = MeshDevice::create(
-            MeshDeviceConfig(get_mesh_shape(*mesh_device_type)),
+            MeshDeviceConfig(system_mesh_shape),
             0,
             config_.trace_region_size,
             config_.num_cqs,
@@ -178,59 +165,6 @@ protected:
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
 
 private:
-    // Returns the mesh shape for a given mesh device type.
-    MeshShape get_mesh_shape(MeshDeviceType mesh_device_type) {
-        switch (mesh_device_type) {
-            case MeshDeviceType::N150:
-            case MeshDeviceType::P150: return MeshShape(1, 1);
-            case MeshDeviceType::N300:
-            case MeshDeviceType::P300: return MeshShape(2, 1);
-            case MeshDeviceType::N300_2x2: return MeshShape(2, 2);
-            case MeshDeviceType::T3000: return MeshShape(2, 4);
-            case MeshDeviceType::TG: return MeshShape(4, 8);
-            default: TT_FATAL(false, "Querying shape for unspecified Mesh Type.");
-        }
-    }
-
-    // Determines the mesh device type based on the number of devices.
-    std::optional<MeshDeviceType> derive_mesh_device_type(size_t num_devices, tt::ARCH arch) {
-        switch (num_devices) {
-            case 1: {
-                switch (arch) {
-                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N150;
-                    case tt::ARCH::BLACKHOLE: return MeshDeviceType::P150;
-                    default: return std::nullopt;
-                }
-            }
-            case 2: {
-                switch (arch) {
-                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N300;
-                    case tt::ARCH::BLACKHOLE: return MeshDeviceType::P300;
-                    default: return std::nullopt;
-                }
-            }
-            case 4: {
-                switch (arch) {
-                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N300_2x2;
-                    default: return std::nullopt;
-                }
-            }
-            case 8: {
-                switch (arch) {
-                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::T3000;
-                    default: return std::nullopt;
-                }
-            }
-            case 32: {
-                switch (arch) {
-                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::TG;
-                    default: return std::nullopt;
-                }
-            }
-            default: return std::nullopt;
-        }
-    }
-
     Config config_;
 };
 
@@ -249,54 +183,41 @@ protected:
 // Fixtures that specify the mesh device type explicitly.
 // The associated test will be run if the cluster topology matches
 // what is specified.
-class T3000MeshDeviceFixture : public MeshDeviceFixtureBase {
+class MeshDevice2x4Fixture : public MeshDeviceFixtureBase {
 protected:
-    T3000MeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::T3000}}) {}
+    MeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}}) {}
 };
 
-class TGMeshDeviceFixture : public MeshDeviceFixtureBase {
+class MeshDevice4x8Fixture : public MeshDeviceFixtureBase {
 protected:
-    TGMeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::TG}}) {}
+    MeshDevice4x8Fixture() : MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{4, 8}}) {}
 };
 
-class T3000MultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {
+class MultiCQMeshDevice2x4Fixture : public MeshDeviceFixtureBase {
 protected:
-    T3000MultiCQMeshDeviceFixture() :
-        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::T3000}, .num_cqs = 2}) {}
+    MultiCQMeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}, .num_cqs = 2}) {}
 };
 
-class TGMultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {
+class MeshDevice2x4Fabric1DFixture : public MeshDeviceFixtureBase {
 protected:
-    TGMultiCQMeshDeviceFixture() :
-        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::TG}, .num_cqs = 2}) {}
-};
-
-class T3000MeshDevice1DFabricFixture : public MeshDeviceFixtureBase {
-protected:
-    T3000MeshDevice1DFabricFixture() :
+    MeshDevice2x4Fabric1DFixture() :
         MeshDeviceFixtureBase(Config{
-            .mesh_device_types = {MeshDeviceType::T3000}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_1D}) {}
+            .system_mesh_shape = MeshShape{2, 4}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_1D}) {}
 };
 
-class GenericMeshDevice2DFabricFixture : public MeshDeviceFixtureBase {
+class GenericMeshDeviceFabric2DFixture : public MeshDeviceFixtureBase {
 protected:
-    GenericMeshDevice2DFabricFixture() :
+    GenericMeshDeviceFabric2DFixture() :
         MeshDeviceFixtureBase(Config{.num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {}
 };
 
-class T3000MeshDevice2DFabricFixture : public MeshDeviceFixtureBase {
+class MeshDevice2x4Fabric2DFixture : public MeshDeviceFixtureBase {
 protected:
-    T3000MeshDevice2DFabricFixture() :
+    MeshDevice2x4Fabric2DFixture() :
         MeshDeviceFixtureBase(Config{
-            .mesh_device_types = {MeshDeviceType::T3000},
+            .system_mesh_shape = MeshShape{2, 4},
             .num_cqs = 1,
             .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {}
-};
-
-class P300MeshDevice2DNoFabricFixture : public MeshDeviceFixtureBase {
-protected:
-    P300MeshDevice2DNoFabricFixture() :
-        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::P300}, .num_cqs = 1}) {}
 };
 
 }  // namespace tt::tt_metal

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -42,11 +42,9 @@ std::vector<IDevice*> get_line_devices(distributed::MeshDevice* mesh_device) {
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-class T3000MultiCQFabricMeshDeviceFixture : public MultiCQMeshDevice2x4Fixture {
+class MultiCQFabricMeshDevice2x4Fixture : public MultiCQMeshDevice2x4Fixture {
 protected:
-    T3000MultiCQFabricMeshDeviceFixture() {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
-    }
+    MultiCQFabricMeshDevice2x4Fixture() { tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D); }
     void TearDown() override {
         MultiCQMeshDevice2x4Fixture::TearDown();
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
@@ -74,7 +72,7 @@ TEST_F(MultiCQMeshDevice2x4Fixture, AllGather) {
     }
 }
 
-TEST_F(T3000MultiCQFabricMeshDeviceFixture, AllGatherAsync) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherAsync) {
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -42,18 +42,18 @@ std::vector<IDevice*> get_line_devices(distributed::MeshDevice* mesh_device) {
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
+class T3000MultiCQFabricMeshDeviceFixture : public MultiCQMeshDevice2x4Fixture {
 protected:
     T3000MultiCQFabricMeshDeviceFixture() {
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
     }
     void TearDown() override {
-        T3000MultiCQMeshDeviceFixture::TearDown();
+        MultiCQMeshDevice2x4Fixture::TearDown();
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 };
 
-TEST_F(T3000MultiCQMeshDeviceFixture, AllGather) {
+TEST_F(MultiCQMeshDevice2x4Fixture, AllGather) {
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;
@@ -97,7 +97,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AllGatherAsync) {
     }
 }
 
-TEST_F(T3000MultiCQMeshDeviceFixture, ReduceScatter) {
+TEST_F(MultiCQMeshDevice2x4Fixture, ReduceScatter) {
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;
@@ -118,7 +118,7 @@ TEST_F(T3000MultiCQMeshDeviceFixture, ReduceScatter) {
     }
 }
 
-TEST_F(T3000MultiCQMeshDeviceFixture, AllReduce) {
+TEST_F(MultiCQMeshDevice2x4Fixture, AllReduce) {
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_send_recv_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_send_recv_ops.cpp
@@ -21,7 +21,7 @@
 
 namespace tt::tt_metal {
 
-class T3K2DFabricSendRecvFixture : public T3000MeshDevice2DFabricFixture,
+class T3K2DFabricSendRecvFixture : public MeshDevice2x4Fabric2DFixture,
                                    public testing::WithParamInterface<SocketTestArgs> {};
 
 template <typename T>

--- a/tests/ttnn/unit_tests/gtests/ccl/test_send_recv_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_send_recv_ops.cpp
@@ -21,8 +21,8 @@
 
 namespace tt::tt_metal {
 
-class T3K2DFabricSendRecvFixture : public MeshDevice2x4Fabric2DFixture,
-                                   public testing::WithParamInterface<SocketTestArgs> {};
+class FabricSendRecv2x4Fixture : public MeshDevice2x4Fabric2DFixture,
+                                 public testing::WithParamInterface<SocketTestArgs> {};
 
 template <typename T>
 void test_send_recv_async_(
@@ -109,7 +109,7 @@ void test_send_recv_async(
     }
 }
 
-TEST_P(T3K2DFabricSendRecvFixture, SendRecvAsync) {
+TEST_P(FabricSendRecv2x4Fixture, SendRecvAsync) {
     auto [tensor_spec, socket_buffer_type] = GetParam();
     auto mesh_device = get_mesh_device();
     auto mesh_shape = distributed::MeshShape(2, 2);
@@ -120,7 +120,6 @@ TEST_P(T3K2DFabricSendRecvFixture, SendRecvAsync) {
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    T3K2DFabricSendRecvTests, T3K2DFabricSendRecvFixture, ::testing::ValuesIn(get_socket_test_args()));
+INSTANTIATE_TEST_SUITE_P(FabricSendRecv2x4Tests, FabricSendRecv2x4Fixture, ::testing::ValuesIn(get_socket_test_args()));
 
 }  // namespace tt::tt_metal

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -51,18 +51,16 @@ using tt::tt_metal::distributed::MeshDeviceView;
 using tt::tt_metal::distributed::MeshShape;
 
 // Custom Fixture using 1D Fabric on a Multi-CQ MeshDevice
-class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
+class MultiCQFabricMeshDevice2x4Fixture : public MultiCQMeshDevice2x4Fixture {
 protected:
-    T3000MultiCQFabricMeshDeviceFixture() {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
-    }
+    MultiCQFabricMeshDevice2x4Fixture() { tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D); }
     void TearDown() override {
-        T3000MultiCQMeshDeviceFixture::TearDown();
+        MultiCQMeshDevice2x4Fixture::TearDown();
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 };
 
-TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
     const size_t dim = 0;
     const size_t num_links = 1;
     constexpr auto layout = Layout::TILE;
@@ -211,7 +209,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
     log_info(tt::LogTest, "Finished");
 }
 
-TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
     const size_t dim = 0;
     const size_t num_links = 1;
     constexpr auto layout = Layout::TILE;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -35,7 +35,7 @@ int count_unique_buffers(const Tensor& tensor) {
 }
 
 using TensorDistributionTest = GenericMeshDeviceFixture;
-using TensorDistributionT3000Test = T3000MeshDeviceFixture;
+using TensorDistribution2x4Test = MeshDevice2x4Fixture;
 
 TEST_F(TensorDistributionTest, DistributeToDevice) {
     Tensor input_tensor = Tensor::from_vector(
@@ -70,7 +70,7 @@ TEST_F(TensorDistributionTest, SingleDeviceTensorReplication) {
     }
 }
 
-TEST_F(TensorDistributionT3000Test, Shard1DInvalidDim) {
+TEST_F(TensorDistribution2x4Test, Shard1DInvalidDim) {
     const int num_devices = mesh_device_->num_devices();
     Tensor input_tensor = Tensor::from_vector(
         std::vector<float>(num_devices, 0), get_tensor_spec(ttnn::Shape{1, 1, 1, num_devices}, DataType::FLOAT32));
@@ -86,7 +86,7 @@ TEST_F(TensorDistributionT3000Test, Shard1DInvalidDim) {
     });
 }
 
-TEST_F(TensorDistributionT3000Test, Shard1DFewerShardsThanDevices) {
+TEST_F(TensorDistribution2x4Test, Shard1DFewerShardsThanDevices) {
     const int num_devices = mesh_device_->num_devices();
     std::vector<float> test_data;
     for (int i = 0; i < num_devices - 1; i++) {
@@ -120,7 +120,7 @@ TEST_F(TensorDistributionT3000Test, Shard1DFewerShardsThanDevices) {
     EXPECT_TRUE(ttnn::allclose<float>(concatenated_tensor, expected_tensor));
 }
 
-TEST_F(TensorDistributionT3000Test, Shard1DNegativeDim) {
+TEST_F(TensorDistribution2x4Test, Shard1DNegativeDim) {
     const int num_devices = mesh_device_->num_devices();
     std::vector<float> test_data(num_devices, 0);
     std::iota(test_data.begin(), test_data.end(), 0);
@@ -142,7 +142,7 @@ TEST_F(TensorDistributionT3000Test, Shard1DNegativeDim) {
     }
 }
 
-TEST_F(TensorDistributionT3000Test, Shard1D) {
+TEST_F(TensorDistribution2x4Test, Shard1D) {
     const int num_devices = mesh_device_->num_devices();
     std::vector<float> test_data;
     for (int i = 0; i < num_devices; i++) {
@@ -175,7 +175,7 @@ TEST_F(TensorDistributionT3000Test, Shard1D) {
     EXPECT_TRUE(ttnn::allclose<float>(concatenated_tensor, expected_tensor));
 }
 
-TEST_F(TensorDistributionT3000Test, PartialConcat) {
+TEST_F(TensorDistribution2x4Test, PartialConcat) {
     constexpr int kNumRows = 2;
     constexpr int kNumCols = 4;
     std::vector<float> test_data;
@@ -225,10 +225,10 @@ TEST_F(TensorDistributionT3000Test, PartialConcat) {
         ElementsAre(0, 1, 2, 10, 11, 12));
 }
 
-class TensorDistributionT3000Test2D : public TensorDistributionT3000Test,
-                                      public ::testing::WithParamInterface<MeshShape> {};
+class TensorDistribution2x4Test2D : public TensorDistribution2x4Test,
+                                    public ::testing::WithParamInterface<MeshShape> {};
 
-TEST_P(TensorDistributionT3000Test2D, FullyReplicated) {
+TEST_P(TensorDistribution2x4Test2D, FullyReplicated) {
     const auto num_rows = GetParam()[0];
     const auto num_cols = GetParam()[1];
     const auto num_devices = num_rows * num_cols;
@@ -262,7 +262,7 @@ TEST_P(TensorDistributionT3000Test2D, FullyReplicated) {
     }
 }
 
-TEST_P(TensorDistributionT3000Test2D, ReplicateDim) {
+TEST_P(TensorDistribution2x4Test2D, ReplicateDim) {
     const auto num_rows = GetParam()[0];
     const auto num_cols = GetParam()[1];
     const auto num_devices = num_rows * num_cols;
@@ -310,7 +310,7 @@ TEST_P(TensorDistributionT3000Test2D, ReplicateDim) {
     }
 }
 
-TEST_P(TensorDistributionT3000Test2D, ShardDims) {
+TEST_P(TensorDistribution2x4Test2D, ShardDims) {
     const auto num_rows = GetParam()[0];
     const auto num_cols = GetParam()[1];
     const int num_devices = num_rows * num_cols;
@@ -357,11 +357,11 @@ TEST_P(TensorDistributionT3000Test2D, ShardDims) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    TensorDistributionT3000Test2D,
-    TensorDistributionT3000Test2D,
+    TensorDistribution2x4Test2D,
+    TensorDistribution2x4Test2D,
     ::testing::Values(MeshShape(1, 1), MeshShape(2, 2), MeshShape(2, 4), MeshShape(1, 3)));
 
-TEST_F(TensorDistributionT3000Test, NdMapperInvalidShape) {
+TEST_F(TensorDistribution2x4Test, NdMapperInvalidShape) {
     EXPECT_ANY_THROW(create_mesh_mapper(
         *mesh_device_,
         MeshMapperConfig{
@@ -370,7 +370,7 @@ TEST_F(TensorDistributionT3000Test, NdMapperInvalidShape) {
         }));
 }
 
-TEST_F(TensorDistributionT3000Test, NdMapperUnevenSharding) {
+TEST_F(TensorDistribution2x4Test, NdMapperUnevenSharding) {
     constexpr int kNumRows = 2;
     constexpr int kNumCols = 4;
 
@@ -391,7 +391,7 @@ TEST_F(TensorDistributionT3000Test, NdMapperUnevenSharding) {
     EXPECT_ANY_THROW({ Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_); });
 }
 
-TEST_F(TensorDistributionT3000Test, NdMapperInvalidPlacements) {
+TEST_F(TensorDistribution2x4Test, NdMapperInvalidPlacements) {
     // Too few placements.
     EXPECT_ANY_THROW(create_mesh_mapper(
         *mesh_device_,
@@ -407,7 +407,7 @@ TEST_F(TensorDistributionT3000Test, NdMapperInvalidPlacements) {
         }));
 }
 
-TEST_F(TensorDistributionT3000Test, NdComposerInvalidShape) {
+TEST_F(TensorDistribution2x4Test, NdComposerInvalidShape) {
     EXPECT_ANY_THROW(create_mesh_composer(
         *mesh_device_,
         MeshComposerConfig{
@@ -416,7 +416,7 @@ TEST_F(TensorDistributionT3000Test, NdComposerInvalidShape) {
         }));
 }
 
-TEST_F(TensorDistributionT3000Test, NdComposerInvalidDims) {
+TEST_F(TensorDistribution2x4Test, NdComposerInvalidDims) {
     EXPECT_ANY_THROW(create_mesh_composer(
         *mesh_device_,
         MeshComposerConfig{
@@ -424,7 +424,7 @@ TEST_F(TensorDistributionT3000Test, NdComposerInvalidDims) {
         }));
 }
 
-TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
+TEST_F(TensorDistribution2x4Test, NdMapperShard3D) {
     constexpr size_t kNumRows = 2;
     constexpr size_t kNumCols = 4;
     constexpr size_t kInnerDim = 7;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -29,7 +29,7 @@ using ::testing::SizeIs;
 using ::testing::ThrowsMessage;
 
 using MeshTensorTest = GenericMeshDeviceFixture;
-using MeshTensorTestT3K = T3000MeshDeviceFixture;
+using MeshTensorTest2x4 = MeshDevice2x4Fixture;
 
 TEST(MeshTensorHostTest, ToHostNonMeshTensor) {
     const ttnn::Shape shape{1, 1, 32, 32};
@@ -221,7 +221,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     EXPECT_THAT(device_shard_coords, ElementsAreArray(coord_matchers));
 }
 
-TEST_F(MeshTensorTestT3K, CombineDeviceTensors) {
+TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
     const ttnn::Shape shape{1, 1, 32, 32};
     const TensorSpec tensor_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
@@ -286,7 +286,7 @@ struct MeshTensorWriteTestParams {
     std::function<std::unique_ptr<ttnn::distributed::TensorToMesh>(MeshDevice*)> get_mapper;
 };
 
-class MeshTensorWriteTest : public MeshTensorTestT3K,
+class MeshTensorWriteTest : public MeshTensorTest2x4,
                             public ::testing::WithParamInterface<MeshTensorWriteTestParams> {};
 
 TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -85,9 +85,9 @@ TEST_F(TensorSerializationFlatbufferTest, ReplicatedTensorDifferentDataTypes) {
     }
 }
 
-using TensorSerializationFlatbufferT3000Test = T3000MeshDeviceFixture;
+using TensorSerializationFlatbuffer2x4Test = MeshDevice2x4Fixture;
 
-TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DTensorRoundtrip) {
+TEST_F(TensorSerializationFlatbuffer2x4Test, Shard1DTensorRoundtrip) {
     TemporaryFile test_file("shard1d_flatbuffer.bin");
     const int num_devices = mesh_device_->num_devices();
     constexpr int kNumElements = 1024;
@@ -125,7 +125,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DTensorRoundtrip) {
     }
 }
 
-TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
+TEST_F(TensorSerializationFlatbuffer2x4Test, Shard2DTensorRoundtrip) {
     TemporaryFile test_file("shard2d_flatbuffer.bin");
     constexpr int kNumRows = 2;
     constexpr int kNumCols = 4;
@@ -173,7 +173,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
     }
 }
 
-TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoundtrip) {
+TEST_F(TensorSerializationFlatbuffer2x4Test, Shard1DFewerShardsThanDevicesRoundtrip) {
     TemporaryFile test_file("shard1d_fewer_flatbuffer.bin");
     const int num_devices = mesh_device_->num_devices();
     constexpr int kNumElements = 1024;
@@ -212,7 +212,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoun
     }
 }
 
-TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
+TEST_F(TensorSerializationFlatbuffer2x4Test, Shard2x3SubmeshRoundtrip) {
     TemporaryFile test_file("shard2x3_flatbuffer.bin");
     constexpr int kNumRows = 2;
     constexpr int kNumCols = 3;
@@ -261,7 +261,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
     }
 }
 
-TEST_F(TensorSerializationFlatbufferT3000Test, PartiallyReplicatedRoundtrip) {
+TEST_F(TensorSerializationFlatbuffer2x4Test, PartiallyReplicatedRoundtrip) {
     TemporaryFile test_file("partially_replicated_flatbuffer.bin");
     constexpr int kNumRows = 2;
     constexpr int kNumCols = 4;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_topology.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_topology.cpp
@@ -19,7 +19,7 @@ using ::testing::HasSubstr;
 using ::testing::ThrowsMessage;
 
 using TensorTopologyTest = GenericMeshDeviceFixture;
-using TensorTopologyT3000Test = T3000MeshDeviceFixture;
+using TensorTopology2x4Test = MeshDevice2x4Fixture;
 
 TEST_F(TensorTopologyTest, SingleDevice) {
     const auto tensor_spec =
@@ -60,7 +60,7 @@ TEST_F(TensorTopologyTest, SingleDevice) {
     EXPECT_EQ(tensor_topology.get_prev_neighbor(coord, 0), coord);
 }
 
-TEST_F(TensorTopologyT3000Test, Replicate2D) {
+TEST_F(TensorTopology2x4Test, Replicate2D) {
     const auto tensor_spec =
         TensorSpec(ttnn::Shape{1, 1, 1, 3}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
     Tensor input_tensor = Tensor::from_vector(std::vector<float>{42.F, 13.F, -99.F}, tensor_spec);
@@ -125,7 +125,7 @@ TEST_F(TensorTopologyT3000Test, Replicate2D) {
     check_neighbors_2d(coord);
 }
 
-TEST_F(TensorTopologyT3000Test, Shard1DRowMajor) {
+TEST_F(TensorTopology2x4Test, Shard1DRowMajor) {
     const int num_devices = mesh_device_->num_devices();
     // Test only works on 8 devices in 2x4 mesh
     ASSERT_EQ(num_devices, 8);

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -152,9 +152,9 @@ TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
         "ExampleDeviceOperation");
 }
 
-using LaunchOperationT3000Test = tt::tt_metal::T3000MeshDeviceFixture;
+using LaunchOperation2x4Test = tt::tt_metal::MeshDevice2x4Fixture;
 
-TEST_F(LaunchOperationT3000Test, UniformTensor) {
+TEST_F(LaunchOperation2x4Test, UniformTensor) {
     const TensorSpec tensor_spec = TensorSpec(
         ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
     auto full_tensor = tt::tt_metal::allocate_tensor_on_device(tensor_spec, mesh_device_.get());
@@ -174,7 +174,7 @@ TEST_F(LaunchOperationT3000Test, UniformTensor) {
             ttnn::MeshCoordinate{1, 3}));
 }
 
-TEST_F(LaunchOperationT3000Test, UnevenTensor) {
+TEST_F(LaunchOperation2x4Test, UnevenTensor) {
     auto uneven_tensor = make_tensor_with_num_shards(2, mesh_device_.get());
 
     EXPECT_THAT(uneven_tensor.device_storage().coords, SizeIs(2));
@@ -187,7 +187,7 @@ TEST_F(LaunchOperationT3000Test, UnevenTensor) {
             ttnn::MeshCoordinate{0, 1}));
 }
 
-TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
+TEST_F(LaunchOperation2x4Test, FilterTensorShards) {
     const TensorSpec tensor_spec = TensorSpec(
         ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
     auto full_tensor = tt::tt_metal::allocate_tensor_on_device(tensor_spec, mesh_device_.get());
@@ -244,7 +244,7 @@ TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
     EXPECT_THAT(extract_tensor_coordinates(full_tensor), IsEmpty());
 }
 
-TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
+TEST_F(LaunchOperation2x4Test, LaunchOpFilterTensorShards) {
     auto full_tensor = make_tensor_with_num_shards(8, mesh_device_.get());
     auto sum = ttnn::add(full_tensor, full_tensor);
 
@@ -272,7 +272,7 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
             ttnn::MeshCoordinate{0, 1}));
 }
 
-TEST_F(LaunchOperationT3000Test, CachingHeterogeneousDispatch) {
+TEST_F(LaunchOperation2x4Test, CachingHeterogeneousDispatch) {
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 0);
 
     auto full_tensor = make_tensor_with_num_shards(8, mesh_device_.get());

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -39,15 +39,6 @@ public:
     // Returns the local shape of the system mesh; this is the local mesh shape in distributed context
     const MeshShape& local_shape() const;
 
-    // Returns the physical device ID for a given logical coordinate
-    int get_physical_device_id(const MeshCoordinate& coord) const;
-
-    // Returns the physical mesh ID for a given logical coordinate
-    uint32_t get_physical_mesh_id(const MeshCoordinate& coord) const;
-
-    // Returns the global device coordinate for a given physical device ID
-    MeshCoordinate get_global_device_coordinate(int physical_device_id) const;
-
     // Returns the physical device IDs mapped to a MeshDevice
     DistributedMeshContainer<int> get_mapped_physical_device_ids(
         const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -41,11 +41,9 @@ public:
 
     const DistributedCoordinateTranslator& coordinate_translator() const;
 
-    MeshCoordinate get_global_device_coordinate(int physical_device_id) const;
     DistributedMeshContainer<chip_id_t> get_mapped_physical_device_ids(
         const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
     chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
-    uint32_t get_physical_mesh_id(const MeshCoordinate& coord) const;
 };
 
 MaybeRemoteDeviceId SystemMesh::Impl::get_maybe_remote_device_id(const MeshCoordinate& coord) const {
@@ -112,23 +110,6 @@ chip_id_t SystemMesh::Impl::get_physical_device_id(const MeshCoordinate& coord) 
     log_debug(LogDistributed, "Global coordinate: {} mapped to physical device ID: {}",
               coord, physical_device_id);
     return physical_device_id;
-}
-
-uint32_t SystemMesh::Impl::get_physical_mesh_id(const MeshCoordinate& coord) const {
-    TT_FATAL(physical_coordinates_.is_local_at(coord), "Coordinate {} is not in the local mesh", coord);
-    const auto& maybe_physical = physical_coordinates_.at(coord);
-    return *maybe_physical->mesh_id();
-}
-
-MeshCoordinate SystemMesh::Impl::get_global_device_coordinate(int physical_device_id) const {
-    for (const auto& [global_coordinate, maybe_physical] : physical_coordinates_) {
-        if (maybe_physical.is_local()) {
-            if (maybe_physical->chip_id() == physical_device_id) {
-                return global_coordinate;
-            }
-        }
-    }
-    TT_THROW("Physical device ID {} not found in the system mesh. Device might be remote.", physical_device_id);
 }
 
 DistributedMeshContainer<int> SystemMesh::Impl::get_mapped_physical_device_ids(
@@ -240,20 +221,8 @@ SystemMesh& SystemMesh::instance() {
     return instance.get();
 }
 
-chip_id_t SystemMesh::get_physical_device_id(const MeshCoordinate& coord) const {
-    return pimpl_->get_physical_device_id(coord);
-}
-
-uint32_t SystemMesh::get_physical_mesh_id(const MeshCoordinate& coord) const {
-    return pimpl_->get_physical_mesh_id(coord);
-}
-
 const MeshShape& SystemMesh::shape() const { return pimpl_->coordinate_translator().global_shape(); }
 const MeshShape& SystemMesh::local_shape() const { return pimpl_->coordinate_translator().local_shape(); }
-
-MeshCoordinate SystemMesh::get_global_device_coordinate(int physical_device_id) const {
-    return pimpl_->get_global_device_coordinate(physical_device_id);
-}
 
 DistributedMeshContainer<chip_id_t> SystemMesh::get_mapped_physical_device_ids(
     const MeshShape& shape, const std::optional<MeshCoordinate>& offset) const {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The tests currently assume single-host physical boards (N300, T3K, TG, etc), however they are written generally, and can be used in multi-host context.

### What's changed
Change mentions of specific boards to a more general form that references device shape.

Also remove unnecessary methods from `SystemMesh`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16433497566)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16428989500)
- [x] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/16428991230)
- [x] New/Existing tests provide coverage for changes