### PR TITLE
#11059 Add get_cluster_type functionality to ttnn

### DIFF
--- a/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
+++ b/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
@@ -97,8 +97,10 @@ std::map<FabricNodeId, chip_id_t> get_dual_host_chip_mapping() {
 class ControlPlaneLocalMeshBinding : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (::tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != ::tt::ClusterType::T3K and
-            ::tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != ::tt::ClusterType::N300_2x2) {
+        if (::tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() !=
+                ::tt::tt_metal::ClusterType::T3K and
+            ::tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() !=
+                ::tt::tt_metal::ClusterType::N300_2x2) {
             GTEST_SKIP() << "Skipping test for non-T3K or N300_2x2 cluster";
         }
     }

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -166,7 +166,7 @@ class T3kCustomMeshGraphFabric2DDynamicFixture
     : public CustomMeshGraphFabric2DDynamicFixture,
       public testing::WithParamInterface<std::tuple<std::string, std::vector<std::vector<eth_coord_t>>>> {
     void SetUp() override {
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::T3K) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::T3K) {
             GTEST_SKIP();
         }
     }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -766,7 +766,7 @@ void RunTestUnicastTGGateways(BaseFabricFixture* fixture) {
         GTEST_SKIP();
     }
 
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::TG) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::TG) {
         log_info(tt::LogTest, "This test is only for TG");
         GTEST_SKIP();
     }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -272,7 +272,7 @@ TEST_P(T3kCustomMeshGraphFabric2DDynamicFixture, TestUnicastRaw) {
 }
 
 TEST_F(Fabric2DDynamicFixture, TestGetNextHopRouterDirection1MeshAllToAll) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
         GTEST_SKIP() << "Test not applicable for TG cluster type";
     }
     RunGetNextHopRouterDirectionTest(this, false);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -120,7 +120,7 @@ std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
 
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     uint32_t chip_id_offset = 0;
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
         chip_id_offset = 4;
     }
     std::vector<chip_id_t> physical_chip_ids(num_devices);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -20,7 +20,7 @@ namespace tt::tt_fabric {
 namespace multi_host_tests {
 
 TEST(MultiHost, TestDualGalaxyControlPlaneInit) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::GALAXY) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
@@ -35,7 +35,7 @@ TEST(MultiHost, TestDualGalaxyControlPlaneInit) {
 }
 
 TEST(MultiHost, TestDualGalaxyFabricSanity) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::GALAXY) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -134,7 +134,8 @@ protected:
 
         // Use ethernet dispatch for more than 1 CQ on T3K/N300
         auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-        bool is_n300_or_t3k_cluster = cluster_type == tt::ClusterType::T3K or cluster_type == tt::ClusterType::N300;
+        bool is_n300_or_t3k_cluster =
+            cluster_type == tt::tt_metal::ClusterType::T3K or cluster_type == tt::tt_metal::ClusterType::N300;
         auto core_type =
             (config_.num_cqs >= 2 and is_n300_or_t3k_cluster) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2595,11 +2595,11 @@ Fabric1DWorkerConfig get_fabric_1d_worker_config(
 }
 
 tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_wormhole(
-    tt::ClusterType cluster_type, FabricTestMode fabric_mode, size_t line_size) {
+    tt::tt_metal::ClusterType cluster_type, FabricTestMode fabric_mode, size_t line_size) {
     tt::tt_fabric::FabricRouterBufferConfig buffer_config{};
     switch (cluster_type) {
-        case tt::ClusterType::TG:
-        case tt::ClusterType::GALAXY:
+        case tt::tt_metal::ClusterType::TG:
+        case tt::tt_metal::ClusterType::GALAXY:
             // long axis, more buffering.
             if (line_size >= tt::tt_fabric::FabricEriscDatamoverConfig::MESH_LONG_AXIS_OPTIMIZATION_THRESHOLD) {
                 if (fabric_mode == FabricTestMode::HalfRing) {
@@ -2625,7 +2625,7 @@ tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_wormhole(
                 }
             }
             break;
-        case tt::ClusterType::T3K:
+        case tt::tt_metal::ClusterType::T3K:
             // Need more tunning on T3K, for now keep the long/short axis the same.
             if (line_size >= tt::tt_fabric::FabricEriscDatamoverConfig::MESH_LONG_AXIS_OPTIMIZATION_THRESHOLD) {
                 if (fabric_mode == FabricTestMode::HalfRing) {
@@ -2657,11 +2657,11 @@ tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_wormhole(
 }
 
 tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_blackhole(
-    tt::ClusterType cluster_type, FabricTestMode fabric_mode, size_t line_size) {
+    tt::tt_metal::ClusterType cluster_type, FabricTestMode fabric_mode, size_t line_size) {
     tt::tt_fabric::FabricRouterBufferConfig buffer_config{};
     switch (cluster_type) {
         // For now just copy the galaxy config to BH since we don't have any data points.
-        case tt::ClusterType::P150_X4:
+        case tt::tt_metal::ClusterType::P150_X4:
             if (line_size >= tt::tt_fabric::FabricEriscDatamoverConfig::MESH_LONG_AXIS_OPTIMIZATION_THRESHOLD) {
                 if (fabric_mode == FabricTestMode::HalfRing) {
                     buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1339,7 +1339,7 @@ TEST(EdmFabric, RingDeadlockStabilityTest) {
     size_t num_links = 1;
     std::vector<size_t> num_devices_vec;
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-    if (cluster_type == tt::ClusterType::GALAXY) {
+    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
         num_devices_vec = {4, 8};
         num_links = 4;
     } else {
@@ -1372,7 +1372,7 @@ TEST(EdmFabric, RingDeadlockStabilityTest_RelaxedFabricStrictness) {
     std::vector<size_t> num_devices;
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
 
-    if (cluster_type != tt::ClusterType::GALAXY) {
+    if (cluster_type != tt::tt_metal::ClusterType::GALAXY) {
         return;
     }
     num_devices = {4, 8};

--- a/tests/ttnn/unit_tests/test_cluster.py
+++ b/tests/ttnn/unit_tests/test_cluster.py
@@ -8,29 +8,18 @@ import ttnn
 
 
 def test_cluster_get_cluster_type():
-    """Test getting cluster type"""
+    """Test getting cluster type returns a valid enum value"""
     cluster_type = ttnn.cluster.get_cluster_type()
 
-    # Verify it's a valid ClusterType enum value
-    assert cluster_type in [
-        ttnn.cluster.ClusterType.INVALID,
-        ttnn.cluster.ClusterType.N150,
-        ttnn.cluster.ClusterType.N300,
-        ttnn.cluster.ClusterType.T3K,
-        ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.TG,
-        ttnn.cluster.ClusterType.P100,
-        ttnn.cluster.ClusterType.P150,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
-        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
-        ttnn.cluster.ClusterType.N300_2x2,
-    ]
+    # Verify it's a ClusterType enum instance
+    assert hasattr(cluster_type, "name"), "Expected cluster_type to be an enum with name attribute"
+    assert hasattr(cluster_type, "value"), "Expected cluster_type to be an enum with value attribute"
 
-    # Verify it's not INVALID when hardware is available
-    if cluster_type != ttnn.cluster.ClusterType.INVALID:
-        print(f"Detected cluster type: {cluster_type}")
+    # Verify string representation works
+    str_repr = str(cluster_type)
+    assert "ClusterType" in str_repr, f"Unexpected string representation: {str_repr}"
+
+    print(f"Detected cluster type: {cluster_type}")
 
 
 def test_cluster_serialize_descriptor():
@@ -43,173 +32,3 @@ def test_cluster_serialize_descriptor():
     except Exception as e:
         # Non-critical, might not be available in all environments
         pytest.skip(f"Cluster descriptor serialization not available: {e}")
-
-
-def test_cluster_type_enum_values():
-    """Test that all cluster type enum values are accessible"""
-    cluster_types = [
-        ttnn.cluster.ClusterType.INVALID,
-        ttnn.cluster.ClusterType.N150,
-        ttnn.cluster.ClusterType.N300,
-        ttnn.cluster.ClusterType.T3K,
-        ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.TG,
-        ttnn.cluster.ClusterType.P100,
-        ttnn.cluster.ClusterType.P150,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
-        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
-        ttnn.cluster.ClusterType.N300_2x2,
-    ]
-
-    # Verify all enum values are different
-    assert len(set(cluster_types)) == len(cluster_types), "Duplicate enum values detected"
-
-    # Verify string representation works
-    for cluster_type in cluster_types:
-        str_repr = str(cluster_type)
-        assert "ClusterType" in str_repr, f"Unexpected string representation: {str_repr}"
-
-
-def test_cluster_type_comparisons():
-    """Test cluster type comparisons and conditionals"""
-    cluster_type = ttnn.cluster.get_cluster_type()
-
-    # Test equality comparison
-    assert cluster_type == cluster_type, "Cluster type should equal itself"
-
-    # Test membership in list
-    all_types = [
-        ttnn.cluster.ClusterType.INVALID,
-        ttnn.cluster.ClusterType.N150,
-        ttnn.cluster.ClusterType.N300,
-        ttnn.cluster.ClusterType.T3K,
-        ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.TG,
-        ttnn.cluster.ClusterType.P100,
-        ttnn.cluster.ClusterType.P150,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
-        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
-        ttnn.cluster.ClusterType.N300_2x2,
-    ]
-    assert cluster_type in all_types, f"Current cluster type {cluster_type} not in known types"
-
-    # Test conditional logic (common use case)
-    if cluster_type == ttnn.cluster.ClusterType.T3K:
-        print("Running on T3K cluster")
-    elif cluster_type in [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]:
-        print("Running on Galaxy cluster")
-    elif cluster_type in [ttnn.cluster.ClusterType.N150, ttnn.cluster.ClusterType.N300]:
-        print("Running on Wormhole cluster")
-    elif cluster_type in [
-        ttnn.cluster.ClusterType.P100,
-        ttnn.cluster.ClusterType.P150,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-    ]:
-        print("Running on Blackhole cluster")
-    else:
-        print(f"Running on other cluster type: {cluster_type}")
-
-
-def test_cluster_type_architecture_detection():
-    """Test cluster type to architecture mapping"""
-    cluster_type = ttnn.cluster.get_cluster_type()
-
-    # Test architecture detection logic
-    wormhole_types = [
-        ttnn.cluster.ClusterType.N150,
-        ttnn.cluster.ClusterType.N300,
-        ttnn.cluster.ClusterType.T3K,
-        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
-    ]
-
-    blackhole_types = [
-        ttnn.cluster.ClusterType.P100,
-        ttnn.cluster.ClusterType.P150,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
-    ]
-
-    galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
-
-    multi_device_types = [
-        ttnn.cluster.ClusterType.T3K,
-        ttnn.cluster.ClusterType.P150_X2,
-        ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.N300_2x2,
-        ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.TG,
-    ]
-
-    # Verify architecture categorization
-    if cluster_type in wormhole_types:
-        print("Detected Wormhole-based cluster")
-    elif cluster_type in blackhole_types:
-        print("Detected Blackhole-based cluster")
-    elif cluster_type in galaxy_types:
-        print("Detected Galaxy cluster")
-    elif cluster_type == ttnn.cluster.ClusterType.INVALID:
-        print("Invalid/unknown cluster type")
-    else:
-        print(f"Unrecognized cluster type: {cluster_type}")
-
-
-@pytest.mark.parametrize(
-    "cluster_type_name",
-    [
-        "INVALID",
-        "N150",
-        "N300",
-        "T3K",
-        "GALAXY",
-        "TG",
-        "P100",
-        "P150",
-        "P150_X2",
-        "P150_X4",
-        "SIMULATOR_WORMHOLE_B0",
-        "SIMULATOR_BLACKHOLE",
-        "N300_2x2",
-    ],
-)
-def test_cluster_type_enum_access(cluster_type_name):
-    """Test accessing cluster type enum values by name"""
-    cluster_type = getattr(ttnn.cluster.ClusterType, cluster_type_name)
-    assert cluster_type is not None, f"Could not access ClusterType.{cluster_type_name}"
-
-    # Verify string representation includes the name
-    str_repr = str(cluster_type)
-    assert cluster_type_name in str_repr or "ClusterType" in str_repr, f"Unexpected representation: {str_repr}"
-
-
-def test_cluster_functions_integration():
-    """Test integration between different cluster functions"""
-    # Get all cluster information
-    cluster_type = ttnn.cluster.get_cluster_type()
-    num_devices = ttnn.GetNumAvailableDevices()
-
-    print(f"Cluster Information:")
-    print(f"  Type: {cluster_type}")
-    print(f"  User Devices: {num_devices}")
-
-    # Verify device count makes sense for cluster type
-    if cluster_type == ttnn.cluster.ClusterType.T3K:
-        # T3K should have 8 devices
-        assert num_devices == 8, f"T3K cluster should have multiple devices, got {num_devices}"
-    elif cluster_type in [ttnn.cluster.ClusterType.P150_X2, ttnn.cluster.ClusterType.N300_2x2]:
-        # X2 variants should have at least 2 devices
-        assert num_devices >= 2, f"{cluster_type} should have at least 2 devices, got {num_devices}"
-    elif cluster_type == ttnn.cluster.ClusterType.P150_X4:
-        # X4 variant should have at least 4 devices
-        assert num_devices >= 4, f"P150_X4 should have at least 4 devices, got {num_devices}"
-    elif cluster_type in [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]:
-        # Galaxy clusters have 32 devices
-        assert num_devices == 32, f"Galaxy cluster should have 32 devices, got {num_devices}"
-    else:
-        # Single device clusters
-        assert num_devices >= 1, f"Cluster should have at least 1 device, got {num_devices}"

--- a/tests/ttnn/unit_tests/test_cluster.py
+++ b/tests/ttnn/unit_tests/test_cluster.py
@@ -33,19 +33,6 @@ def test_cluster_get_cluster_type():
         print(f"Detected cluster type: {cluster_type}")
 
 
-def test_cluster_is_galaxy_cluster():
-    """Test galaxy cluster detection"""
-    is_galaxy = ttnn.cluster.is_galaxy_cluster()
-    cluster_type = ttnn.cluster.get_cluster_type()
-
-    # Verify consistency between is_galaxy_cluster() and cluster type
-    galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
-    expected_is_galaxy = cluster_type in galaxy_types
-    assert (
-        is_galaxy == expected_is_galaxy
-    ), f"is_galaxy_cluster() returned {is_galaxy} but cluster type is {cluster_type}"
-
-
 def test_cluster_number_of_user_devices():
     """Test getting number of user devices"""
     num_devices = ttnn.cluster.number_of_user_devices()
@@ -220,31 +207,25 @@ def test_cluster_functions_integration():
     """Test integration between different cluster functions"""
     # Get all cluster information
     cluster_type = ttnn.cluster.get_cluster_type()
-    is_galaxy = ttnn.cluster.is_galaxy_cluster()
     num_devices = ttnn.cluster.number_of_user_devices()
 
     print(f"Cluster Information:")
     print(f"  Type: {cluster_type}")
-    print(f"  Is Galaxy: {is_galaxy}")
     print(f"  User Devices: {num_devices}")
-
-    # Test consistency checks
-    galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
-    assert is_galaxy == (cluster_type in galaxy_types), "Galaxy detection inconsistent"
 
     # Verify device count makes sense for cluster type
     if cluster_type == ttnn.cluster.ClusterType.T3K:
-        # T3K should have multiple devices (typically 8)
-        assert num_devices > 1, f"T3K cluster should have multiple devices, got {num_devices}"
+        # T3K should have 8 devices
+        assert num_devices == 8, f"T3K cluster should have multiple devices, got {num_devices}"
     elif cluster_type in [ttnn.cluster.ClusterType.P150_X2, ttnn.cluster.ClusterType.N300_2x2]:
         # X2 variants should have at least 2 devices
         assert num_devices >= 2, f"{cluster_type} should have at least 2 devices, got {num_devices}"
     elif cluster_type == ttnn.cluster.ClusterType.P150_X4:
         # X4 variant should have at least 4 devices
         assert num_devices >= 4, f"P150_X4 should have at least 4 devices, got {num_devices}"
-    elif cluster_type in galaxy_types:
-        # Galaxy clusters can have variable numbers of devices
-        assert num_devices >= 1, f"Galaxy cluster should have at least 1 device, got {num_devices}"
+    elif cluster_type in [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]:
+        # Galaxy clusters have 32 devices
+        assert num_devices == 32, f"Galaxy cluster should have 32 devices, got {num_devices}"
     else:
         # Single device clusters
         assert num_devices >= 1, f"Cluster should have at least 1 device, got {num_devices}"

--- a/tests/ttnn/unit_tests/test_cluster.py
+++ b/tests/ttnn/unit_tests/test_cluster.py
@@ -33,14 +33,6 @@ def test_cluster_get_cluster_type():
         print(f"Detected cluster type: {cluster_type}")
 
 
-def test_cluster_number_of_user_devices():
-    """Test getting number of user devices"""
-    num_devices = ttnn.cluster.number_of_user_devices()
-
-    # Should have at least 1 device
-    assert num_devices >= 1, f"Expected at least 1 device, got {num_devices}"
-
-
 def test_cluster_serialize_descriptor():
     """Test cluster descriptor serialization"""
     try:
@@ -166,14 +158,6 @@ def test_cluster_type_architecture_detection():
     else:
         print(f"Unrecognized cluster type: {cluster_type}")
 
-    # Test multi-device detection
-    is_multi_device = cluster_type in multi_device_types
-    num_devices = ttnn.cluster.number_of_user_devices()
-
-    if is_multi_device:
-        assert num_devices > 1, f"Multi-device cluster type {cluster_type} but only {num_devices} devices"
-    print(f"Cluster type {cluster_type}: {num_devices} devices, multi-device: {is_multi_device}")
-
 
 @pytest.mark.parametrize(
     "cluster_type_name",
@@ -207,7 +191,7 @@ def test_cluster_functions_integration():
     """Test integration between different cluster functions"""
     # Get all cluster information
     cluster_type = ttnn.cluster.get_cluster_type()
-    num_devices = ttnn.cluster.number_of_user_devices()
+    num_devices = ttnn.GetNumAvailableDevices()
 
     print(f"Cluster Information:")
     print(f"  Type: {cluster_type}")

--- a/tests/ttnn/unit_tests/test_cluster.py
+++ b/tests/ttnn/unit_tests/test_cluster.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+
+def test_cluster_get_cluster_type():
+    """Test getting cluster type"""
+    cluster_type = ttnn.cluster.get_cluster_type()
+    
+    # Verify it's a valid ClusterType enum value
+    assert cluster_type in [
+        ttnn.cluster.ClusterType.INVALID,
+        ttnn.cluster.ClusterType.N150,
+        ttnn.cluster.ClusterType.N300,
+        ttnn.cluster.ClusterType.T3K,
+        ttnn.cluster.ClusterType.GALAXY,
+        ttnn.cluster.ClusterType.TG,
+        ttnn.cluster.ClusterType.P100,
+        ttnn.cluster.ClusterType.P150,
+        ttnn.cluster.ClusterType.P150_X2,
+        ttnn.cluster.ClusterType.P150_X4,
+        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
+        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
+        ttnn.cluster.ClusterType.N300_2x2,
+    ]
+    
+    # Verify it's not INVALID when hardware is available
+    if cluster_type != ttnn.cluster.ClusterType.INVALID:
+        print(f"Detected cluster type: {cluster_type}")
+
+
+def test_cluster_is_galaxy_cluster():
+    """Test galaxy cluster detection"""
+    is_galaxy = ttnn.cluster.is_galaxy_cluster()
+    cluster_type = ttnn.cluster.get_cluster_type()
+    
+    # Verify consistency between is_galaxy_cluster() and cluster type
+    galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
+    expected_is_galaxy = cluster_type in galaxy_types
+    assert is_galaxy == expected_is_galaxy, f"is_galaxy_cluster() returned {is_galaxy} but cluster type is {cluster_type}"
+
+
+def test_cluster_number_of_user_devices():
+    """Test getting number of user devices"""
+    num_devices = ttnn.cluster.number_of_user_devices()
+    
+    # Should have at least 1 device
+    assert num_devices >= 1, f"Expected at least 1 device, got {num_devices}"
+    
+    # Should be reasonable number (not absurdly high)
+    assert num_devices <= 64, f"Got unexpectedly high device count: {num_devices}"
+
+
+def test_cluster_serialize_descriptor():
+    """Test cluster descriptor serialization"""
+    try:
+        descriptor_path = ttnn.cluster.serialize_cluster_descriptor()
+        assert isinstance(descriptor_path, str), "Expected string path from serialize_cluster_descriptor"
+        assert len(descriptor_path) > 0, "Expected non-empty path"
+        print(f"Cluster descriptor saved to: {descriptor_path}")
+    except Exception as e:
+        # Non-critical, might not be available in all environments
+        pytest.skip(f"Cluster descriptor serialization not available: {e}")
+
+
+def test_cluster_type_enum_values():
+    """Test that all cluster type enum values are accessible"""
+    cluster_types = [
+        ttnn.cluster.ClusterType.INVALID,
+        ttnn.cluster.ClusterType.N150,
+        ttnn.cluster.ClusterType.N300,
+        ttnn.cluster.ClusterType.T3K,
+        ttnn.cluster.ClusterType.GALAXY,
+        ttnn.cluster.ClusterType.TG,
+        ttnn.cluster.ClusterType.P100,
+        ttnn.cluster.ClusterType.P150,
+        ttnn.cluster.ClusterType.P150_X2,
+        ttnn.cluster.ClusterType.P150_X4,
+        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
+        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
+        ttnn.cluster.ClusterType.N300_2x2,
+    ]
+    
+    # Verify all enum values are different
+    assert len(set(cluster_types)) == len(cluster_types), "Duplicate enum values detected"
+    
+    # Verify string representation works
+    for cluster_type in cluster_types:
+        str_repr = str(cluster_type)
+        assert "ClusterType" in str_repr, f"Unexpected string representation: {str_repr}"
+
+
+def test_cluster_type_comparisons():
+    """Test cluster type comparisons and conditionals"""
+    cluster_type = ttnn.cluster.get_cluster_type()
+    
+    # Test equality comparison
+    assert cluster_type == cluster_type, "Cluster type should equal itself"
+    
+    # Test membership in list
+    all_types = [
+        ttnn.cluster.ClusterType.INVALID,
+        ttnn.cluster.ClusterType.N150,
+        ttnn.cluster.ClusterType.N300,
+        ttnn.cluster.ClusterType.T3K,
+        ttnn.cluster.ClusterType.GALAXY,
+        ttnn.cluster.ClusterType.TG,
+        ttnn.cluster.ClusterType.P100,
+        ttnn.cluster.ClusterType.P150,
+        ttnn.cluster.ClusterType.P150_X2,
+        ttnn.cluster.ClusterType.P150_X4,
+        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
+        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
+        ttnn.cluster.ClusterType.N300_2x2,
+    ]
+    assert cluster_type in all_types, f"Current cluster type {cluster_type} not in known types"
+    
+    # Test conditional logic (common use case)
+    if cluster_type == ttnn.cluster.ClusterType.T3K:
+        print("Running on T3K cluster")
+    elif cluster_type in [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]:
+        print("Running on Galaxy cluster")
+    elif cluster_type in [ttnn.cluster.ClusterType.N150, ttnn.cluster.ClusterType.N300]:
+        print("Running on Wormhole cluster")
+    elif cluster_type in [ttnn.cluster.ClusterType.P100, ttnn.cluster.ClusterType.P150, ttnn.cluster.ClusterType.P150_X2, ttnn.cluster.ClusterType.P150_X4]:
+        print("Running on Blackhole cluster")
+    else:
+        print(f"Running on other cluster type: {cluster_type}")
+
+
+def test_cluster_type_architecture_detection():
+    """Test cluster type to architecture mapping"""
+    cluster_type = ttnn.cluster.get_cluster_type()
+    
+    # Test architecture detection logic
+    wormhole_types = [
+        ttnn.cluster.ClusterType.N150,
+        ttnn.cluster.ClusterType.N300, 
+        ttnn.cluster.ClusterType.T3K,
+        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0
+    ]
+    
+    blackhole_types = [
+        ttnn.cluster.ClusterType.P100,
+        ttnn.cluster.ClusterType.P150,
+        ttnn.cluster.ClusterType.P150_X2,
+        ttnn.cluster.ClusterType.P150_X4,
+        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE
+    ]
+    
+    galaxy_types = [
+        ttnn.cluster.ClusterType.GALAXY,
+        ttnn.cluster.ClusterType.TG
+    ]
+    
+    multi_device_types = [
+        ttnn.cluster.ClusterType.T3K,
+        ttnn.cluster.ClusterType.P150_X2,
+        ttnn.cluster.ClusterType.P150_X4,
+        ttnn.cluster.ClusterType.N300_2x2,
+        ttnn.cluster.ClusterType.GALAXY,
+        ttnn.cluster.ClusterType.TG
+    ]
+    
+    # Verify architecture categorization
+    if cluster_type in wormhole_types:
+        print("Detected Wormhole-based cluster")
+    elif cluster_type in blackhole_types:
+        print("Detected Blackhole-based cluster")
+    elif cluster_type in galaxy_types:
+        print("Detected Galaxy cluster")
+    elif cluster_type == ttnn.cluster.ClusterType.INVALID:
+        print("Invalid/unknown cluster type")
+    else:
+        print(f"Unrecognized cluster type: {cluster_type}")
+    
+    # Test multi-device detection
+    is_multi_device = cluster_type in multi_device_types
+    num_devices = ttnn.cluster.number_of_user_devices()
+    
+    if is_multi_device:
+        assert num_devices > 1, f"Multi-device cluster type {cluster_type} but only {num_devices} devices"
+    print(f"Cluster type {cluster_type}: {num_devices} devices, multi-device: {is_multi_device}")
+
+
+@pytest.mark.parametrize("cluster_type_name", [
+    "INVALID", "N150", "N300", "T3K", "GALAXY", "TG", 
+    "P100", "P150", "P150_X2", "P150_X4", 
+    "SIMULATOR_WORMHOLE_B0", "SIMULATOR_BLACKHOLE", "N300_2x2"
+])
+def test_cluster_type_enum_access(cluster_type_name):
+    """Test accessing cluster type enum values by name"""
+    cluster_type = getattr(ttnn.cluster.ClusterType, cluster_type_name)
+    assert cluster_type is not None, f"Could not access ClusterType.{cluster_type_name}"
+    
+    # Verify string representation includes the name
+    str_repr = str(cluster_type)
+    assert cluster_type_name in str_repr or "ClusterType" in str_repr, f"Unexpected representation: {str_repr}"
+
+
+def test_cluster_functions_integration():
+    """Test integration between different cluster functions"""
+    # Get all cluster information
+    cluster_type = ttnn.cluster.get_cluster_type()
+    is_galaxy = ttnn.cluster.is_galaxy_cluster()
+    num_devices = ttnn.cluster.number_of_user_devices()
+    
+    print(f"Cluster Information:")
+    print(f"  Type: {cluster_type}")
+    print(f"  Is Galaxy: {is_galaxy}")
+    print(f"  User Devices: {num_devices}")
+    
+    # Test consistency checks
+    galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
+    assert is_galaxy == (cluster_type in galaxy_types), "Galaxy detection inconsistent"
+    
+    # Verify device count makes sense for cluster type
+    if cluster_type == ttnn.cluster.ClusterType.T3K:
+        # T3K should have multiple devices (typically 8)
+        assert num_devices > 1, f"T3K cluster should have multiple devices, got {num_devices}"
+    elif cluster_type in [ttnn.cluster.ClusterType.P150_X2, ttnn.cluster.ClusterType.N300_2x2]:
+        # X2 variants should have at least 2 devices
+        assert num_devices >= 2, f"{cluster_type} should have at least 2 devices, got {num_devices}"
+    elif cluster_type == ttnn.cluster.ClusterType.P150_X4:
+        # X4 variant should have at least 4 devices
+        assert num_devices >= 4, f"P150_X4 should have at least 4 devices, got {num_devices}"
+    elif cluster_type in galaxy_types:
+        # Galaxy clusters can have variable numbers of devices
+        assert num_devices >= 1, f"Galaxy cluster should have at least 1 device, got {num_devices}"
+    else:
+        # Single device clusters
+        assert num_devices >= 1, f"Cluster should have at least 1 device, got {num_devices}" 

--- a/tests/ttnn/unit_tests/test_cluster.py
+++ b/tests/ttnn/unit_tests/test_cluster.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+
 
 import pytest
 import ttnn
@@ -9,7 +10,7 @@ import ttnn
 def test_cluster_get_cluster_type():
     """Test getting cluster type"""
     cluster_type = ttnn.cluster.get_cluster_type()
-    
+
     # Verify it's a valid ClusterType enum value
     assert cluster_type in [
         ttnn.cluster.ClusterType.INVALID,
@@ -26,7 +27,7 @@ def test_cluster_get_cluster_type():
         ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
         ttnn.cluster.ClusterType.N300_2x2,
     ]
-    
+
     # Verify it's not INVALID when hardware is available
     if cluster_type != ttnn.cluster.ClusterType.INVALID:
         print(f"Detected cluster type: {cluster_type}")
@@ -36,22 +37,21 @@ def test_cluster_is_galaxy_cluster():
     """Test galaxy cluster detection"""
     is_galaxy = ttnn.cluster.is_galaxy_cluster()
     cluster_type = ttnn.cluster.get_cluster_type()
-    
+
     # Verify consistency between is_galaxy_cluster() and cluster type
     galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
     expected_is_galaxy = cluster_type in galaxy_types
-    assert is_galaxy == expected_is_galaxy, f"is_galaxy_cluster() returned {is_galaxy} but cluster type is {cluster_type}"
+    assert (
+        is_galaxy == expected_is_galaxy
+    ), f"is_galaxy_cluster() returned {is_galaxy} but cluster type is {cluster_type}"
 
 
 def test_cluster_number_of_user_devices():
     """Test getting number of user devices"""
     num_devices = ttnn.cluster.number_of_user_devices()
-    
+
     # Should have at least 1 device
     assert num_devices >= 1, f"Expected at least 1 device, got {num_devices}"
-    
-    # Should be reasonable number (not absurdly high)
-    assert num_devices <= 64, f"Got unexpectedly high device count: {num_devices}"
 
 
 def test_cluster_serialize_descriptor():
@@ -83,10 +83,10 @@ def test_cluster_type_enum_values():
         ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
         ttnn.cluster.ClusterType.N300_2x2,
     ]
-    
+
     # Verify all enum values are different
     assert len(set(cluster_types)) == len(cluster_types), "Duplicate enum values detected"
-    
+
     # Verify string representation works
     for cluster_type in cluster_types:
         str_repr = str(cluster_type)
@@ -96,10 +96,10 @@ def test_cluster_type_enum_values():
 def test_cluster_type_comparisons():
     """Test cluster type comparisons and conditionals"""
     cluster_type = ttnn.cluster.get_cluster_type()
-    
+
     # Test equality comparison
     assert cluster_type == cluster_type, "Cluster type should equal itself"
-    
+
     # Test membership in list
     all_types = [
         ttnn.cluster.ClusterType.INVALID,
@@ -117,7 +117,7 @@ def test_cluster_type_comparisons():
         ttnn.cluster.ClusterType.N300_2x2,
     ]
     assert cluster_type in all_types, f"Current cluster type {cluster_type} not in known types"
-    
+
     # Test conditional logic (common use case)
     if cluster_type == ttnn.cluster.ClusterType.T3K:
         print("Running on T3K cluster")
@@ -125,7 +125,12 @@ def test_cluster_type_comparisons():
         print("Running on Galaxy cluster")
     elif cluster_type in [ttnn.cluster.ClusterType.N150, ttnn.cluster.ClusterType.N300]:
         print("Running on Wormhole cluster")
-    elif cluster_type in [ttnn.cluster.ClusterType.P100, ttnn.cluster.ClusterType.P150, ttnn.cluster.ClusterType.P150_X2, ttnn.cluster.ClusterType.P150_X4]:
+    elif cluster_type in [
+        ttnn.cluster.ClusterType.P100,
+        ttnn.cluster.ClusterType.P150,
+        ttnn.cluster.ClusterType.P150_X2,
+        ttnn.cluster.ClusterType.P150_X4,
+    ]:
         print("Running on Blackhole cluster")
     else:
         print(f"Running on other cluster type: {cluster_type}")
@@ -134,37 +139,34 @@ def test_cluster_type_comparisons():
 def test_cluster_type_architecture_detection():
     """Test cluster type to architecture mapping"""
     cluster_type = ttnn.cluster.get_cluster_type()
-    
+
     # Test architecture detection logic
     wormhole_types = [
         ttnn.cluster.ClusterType.N150,
-        ttnn.cluster.ClusterType.N300, 
+        ttnn.cluster.ClusterType.N300,
         ttnn.cluster.ClusterType.T3K,
-        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0
+        ttnn.cluster.ClusterType.SIMULATOR_WORMHOLE_B0,
     ]
-    
+
     blackhole_types = [
         ttnn.cluster.ClusterType.P100,
         ttnn.cluster.ClusterType.P150,
         ttnn.cluster.ClusterType.P150_X2,
         ttnn.cluster.ClusterType.P150_X4,
-        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE
+        ttnn.cluster.ClusterType.SIMULATOR_BLACKHOLE,
     ]
-    
-    galaxy_types = [
-        ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.TG
-    ]
-    
+
+    galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
+
     multi_device_types = [
         ttnn.cluster.ClusterType.T3K,
         ttnn.cluster.ClusterType.P150_X2,
         ttnn.cluster.ClusterType.P150_X4,
         ttnn.cluster.ClusterType.N300_2x2,
         ttnn.cluster.ClusterType.GALAXY,
-        ttnn.cluster.ClusterType.TG
+        ttnn.cluster.ClusterType.TG,
     ]
-    
+
     # Verify architecture categorization
     if cluster_type in wormhole_types:
         print("Detected Wormhole-based cluster")
@@ -176,26 +178,39 @@ def test_cluster_type_architecture_detection():
         print("Invalid/unknown cluster type")
     else:
         print(f"Unrecognized cluster type: {cluster_type}")
-    
+
     # Test multi-device detection
     is_multi_device = cluster_type in multi_device_types
     num_devices = ttnn.cluster.number_of_user_devices()
-    
+
     if is_multi_device:
         assert num_devices > 1, f"Multi-device cluster type {cluster_type} but only {num_devices} devices"
     print(f"Cluster type {cluster_type}: {num_devices} devices, multi-device: {is_multi_device}")
 
 
-@pytest.mark.parametrize("cluster_type_name", [
-    "INVALID", "N150", "N300", "T3K", "GALAXY", "TG", 
-    "P100", "P150", "P150_X2", "P150_X4", 
-    "SIMULATOR_WORMHOLE_B0", "SIMULATOR_BLACKHOLE", "N300_2x2"
-])
+@pytest.mark.parametrize(
+    "cluster_type_name",
+    [
+        "INVALID",
+        "N150",
+        "N300",
+        "T3K",
+        "GALAXY",
+        "TG",
+        "P100",
+        "P150",
+        "P150_X2",
+        "P150_X4",
+        "SIMULATOR_WORMHOLE_B0",
+        "SIMULATOR_BLACKHOLE",
+        "N300_2x2",
+    ],
+)
 def test_cluster_type_enum_access(cluster_type_name):
     """Test accessing cluster type enum values by name"""
     cluster_type = getattr(ttnn.cluster.ClusterType, cluster_type_name)
     assert cluster_type is not None, f"Could not access ClusterType.{cluster_type_name}"
-    
+
     # Verify string representation includes the name
     str_repr = str(cluster_type)
     assert cluster_type_name in str_repr or "ClusterType" in str_repr, f"Unexpected representation: {str_repr}"
@@ -207,16 +222,16 @@ def test_cluster_functions_integration():
     cluster_type = ttnn.cluster.get_cluster_type()
     is_galaxy = ttnn.cluster.is_galaxy_cluster()
     num_devices = ttnn.cluster.number_of_user_devices()
-    
+
     print(f"Cluster Information:")
     print(f"  Type: {cluster_type}")
     print(f"  Is Galaxy: {is_galaxy}")
     print(f"  User Devices: {num_devices}")
-    
+
     # Test consistency checks
     galaxy_types = [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
     assert is_galaxy == (cluster_type in galaxy_types), "Galaxy detection inconsistent"
-    
+
     # Verify device count makes sense for cluster type
     if cluster_type == ttnn.cluster.ClusterType.T3K:
         # T3K should have multiple devices (typically 8)
@@ -232,4 +247,4 @@ def test_cluster_functions_integration():
         assert num_devices >= 1, f"Galaxy cluster should have at least 1 device, got {num_devices}"
     else:
         # Single device clusters
-        assert num_devices >= 1, f"Cluster should have at least 1 device, got {num_devices}" 
+        assert num_devices >= 1, f"Cluster should have at least 1 device, got {num_devices}"

--- a/tt_metal/api/tt-metalium/cluster.hpp
+++ b/tt_metal/api/tt-metalium/cluster.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace tt::tt_metal {
+
+enum class ClusterType : std::uint8_t {
+    INVALID = 0,
+    N150 = 1,                    // Production N150
+    N300 = 2,                    // Production N300
+    T3K = 3,                     // Production T3K, built with 4 N300s
+    GALAXY = 4,                  // Production Galaxy, all chips with mmio
+    TG = 5,                      // Will be deprecated
+    P100 = 6,                    // Blackhole single card, ethernet disabled
+    P150 = 7,                    // Blackhole single card, ethernet enabled
+    P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
+    P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
+    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
+    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
+    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
+};
+
+/**
+ * @brief Get the type of the current cluster
+ *
+ * @return ClusterType The cluster type detected at runtime
+ */
+tt::tt_metal::ClusterType GetClusterType();
+
+/**
+ * @brief Serialize the cluster descriptor to a file and return the path
+ *
+ * @return std::string Path to the serialized cluster descriptor file
+ */
+std::string SerializeClusterDescriptor();
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/cluster.hpp
+++ b/tt_metal/api/tt-metalium/cluster.hpp
@@ -9,6 +9,21 @@
 
 namespace tt::tt_metal {
 
+/**
+ * @brief Represents different types of hardware clusters
+ *
+ * @warning SERIALIZATION NOTE: This enum is exposed to Python bindings and may be
+ * serialized in various contexts (Python pickle, JSON, configuration files, etc.).
+ * The explicit integer values assigned to each enum member are part of the stable
+ * API contract.
+ *
+ * ORDERING CONSTRAINTS:
+ * - DO NOT change existing enum values (breaks backward compatibility)
+ * - DO NOT reorder existing entries (breaks serialized data)
+ * - New enum values MUST be added at the end before the closing brace
+ * - Use the next sequential integer value for new entries
+ * - Mark deprecated entries with comments but DO NOT remove them
+ */
 enum class ClusterType : std::uint8_t {
     INVALID = 0,
     N150 = 1,                    // Production N150

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -15,6 +15,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/cluster.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/mesh_device.hpp>

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -582,7 +582,7 @@ chan_id_t ControlPlane::get_downstream_eth_chan_id(
     // If no match found, return a channel from candidate_target_chans
     // Enabled for TG Dispatch on Fabric
     // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
         while (src_routing_plane_id >= candidate_target_chans.size()) {
             src_routing_plane_id = src_routing_plane_id % candidate_target_chans.size();
         }

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -36,7 +36,7 @@ namespace {
 // checks if the connection b/w src and dst is a connection b/w TG gateway and a remote chip
 bool is_TG_gateway_connection(
     const tt::tt_fabric::FabricNodeId& src_fabric_node_id, const tt::tt_fabric::FabricNodeId& dst_fabric_node_id) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::TG) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::TG) {
         return false;
     }
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -23,7 +23,7 @@ std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() con
     auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mesh_ids = control_plane.get_user_physical_mesh_ids();
     for (const auto& mesh_id : mesh_ids) {
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
             // skip wrapping around mesh for TG since the corner chips connected to the gateway will be
             // using that link to route dispatch or any other traffic
             wrap_around_mesh[mesh_id] = false;

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -55,8 +55,9 @@ uint32_t get_downstream_edm_count(tt::tt_fabric::Topology topology) {
     }
 }
 
-FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, tt::ClusterType cluster_type) {
-    if (cluster_type == tt::ClusterType::GALAXY && fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_RING) {
+FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, tt::tt_metal::ClusterType cluster_type) {
+    if (cluster_type == tt::tt_metal::ClusterType::GALAXY &&
+        fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_RING) {
         return FabricType::TORUS_XY;
     }
     return FabricType::MESH;

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -30,7 +30,7 @@ uint32_t get_downstream_edm_count(tt::tt_fabric::Topology topology);
 void set_routing_mode(uint16_t routing_mode);
 void set_routing_mode(Topology topology, tt::tt_fabric::FabricConfig fabric_config, uint32_t dimension = 1);
 
-FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, tt::ClusterType cluster_type);
+FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, tt::tt_metal::ClusterType cluster_type);
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -515,10 +515,10 @@ void MetalContext::initialize_control_plane() {
     std::string mesh_graph_descriptor;
     auto cluster_type = cluster_->get_cluster_type();
     switch (cluster_type) {
-        case tt::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::GALAXY:
+        case tt::tt_metal::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::GALAXY:
             if (tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_type) ==
                 tt::tt_fabric::FabricType::TORUS_XY) {
                 mesh_graph_descriptor = "single_galaxy_torus_xy_graph_descriptor.yaml";
@@ -526,15 +526,19 @@ void MetalContext::initialize_control_plane() {
                 mesh_graph_descriptor = "single_galaxy_mesh_graph_descriptor.yaml";
             }
             break;
-        case tt::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P100: mesh_graph_descriptor = "p100_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P150_X2: mesh_graph_descriptor = "p150_x2_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::SIMULATOR_WORMHOLE_B0: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::SIMULATOR_BLACKHOLE: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::N300_2x2: mesh_graph_descriptor = "n300_2x2_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::INVALID: TT_THROW("Unknown cluster type");
+        case tt::tt_metal::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::P100: mesh_graph_descriptor = "p100_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::P150_X2: mesh_graph_descriptor = "p150_x2_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0:
+            mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml";
+            break;
+        case tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE:
+            mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml";
+            break;
+        case tt::tt_metal::ClusterType::N300_2x2: mesh_graph_descriptor = "n300_2x2_mesh_graph_descriptor.yaml"; break;
+        case tt::tt_metal::ClusterType::INVALID: TT_THROW("Unknown cluster type");
     }
     const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
                                                        "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -944,7 +944,8 @@ void build_tt_fabric_program(
     using namespace tt_fabric;
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
-    const bool is_TG = (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG);
+    const bool is_TG =
+        (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto& edm_config = fabric_context.get_fabric_router_config();
@@ -1085,7 +1086,7 @@ void build_tt_fabric_program(
     }
 
     const bool is_galaxy =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::GALAXY;
+        tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::GALAXY;
 
     auto connect_downstream_builders = [&](RoutingDirection dir1, RoutingDirection dir2) {
         bool can_connect =

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/fabric_host_interface.h>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
+#include <tt-metalium/cluster.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -63,22 +64,6 @@ enum class TargetDevice : std::uint8_t {
     Invalid = 0xFF,
 };
 
-enum class ClusterType : std::uint8_t {
-    INVALID = 0,
-    N150 = 1,                    // Production N150
-    N300 = 2,                    // Production N300
-    T3K = 3,                     // Production T3K, built with 4 N300s
-    GALAXY = 4,                  // Production Galaxy, all chips with mmio
-    TG = 5,                      // Will be deprecated
-    P100 = 6,                    // Blackhole single card, ethernet disabled
-    P150 = 7,                    // Blackhole single card, ethernet enabled
-    P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
-    P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
-    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
-    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
-    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
-};
-
 enum class EthRouterMode : uint32_t {
     IDLE = 0,
     FABRIC_ROUTER = 1,
@@ -87,9 +72,9 @@ enum class EthRouterMode : uint32_t {
 class Cluster {
 public:
     // TODO: #21245: Remove these workaround APIs and instead refactor UMD component out of Cluster
-    static ClusterType get_cluster_type_from_cluster_desc(
+    static tt::tt_metal::ClusterType get_cluster_type_from_cluster_desc(
         const llrt::RunTimeOptions& rtoptions, const tt_ClusterDescriptor* cluster_desc = nullptr);
-    static bool is_base_routing_fw_enabled(ClusterType cluster_type);
+    static bool is_base_routing_fw_enabled(tt::tt_metal::ClusterType cluster_type);
     Cluster& operator=(const Cluster&) = delete;
     Cluster& operator=(Cluster&& other) noexcept = delete;
     Cluster(const Cluster&) = delete;
@@ -301,7 +286,7 @@ public:
     // Returns Wormhole chip board type.
     BoardType get_board_type(chip_id_t chip_id) const;
 
-    ClusterType get_cluster_type() const;
+    tt::tt_metal::ClusterType get_cluster_type() const;
 
     bool is_base_routing_fw_enabled() const;
 
@@ -390,7 +375,7 @@ private:
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> frequent_retrain_cores_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
-    ClusterType cluster_type_ = ClusterType::INVALID;
+    tt::tt_metal::ClusterType cluster_type_ = tt::tt_metal::ClusterType::INVALID;
 
     // Reserves specified number of ethernet cores for fabric routers
     void reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_planes);

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -44,7 +44,7 @@ public:
         std::sort(physical_chip_ids.begin(), physical_chip_ids.end());
 
         for (chip_id_t chip_id_src : physical_chip_ids) {
-            if (device->is_mmio_capable() && (cluster.get_cluster_type() == tt::ClusterType::TG)) {
+            if (device->is_mmio_capable() && (cluster.get_cluster_type() == tt::tt_metal::ClusterType::TG)) {
                 // skip lauching on gateways for TG
                 continue;
             }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -947,13 +947,7 @@ chip_id_t GetPCIeDeviceID(chip_id_t device_id) {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
 }
 
-ClusterType GetClusterType() {
-    // Get the cluster type from LLRT and convert to public API type
-    tt::tt_metal::ClusterType llrt_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-
-    // Direct cast since the enum values are identical
-    return static_cast<ClusterType>(llrt_type);
-}
+ClusterType GetClusterType() { return tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type(); }
 
 std::string SerializeClusterDescriptor() {
     std::filesystem::path path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -29,6 +29,10 @@
 #include "buffer_types.hpp"
 #include "circular_buffer_config.hpp"
 #include "data_types.hpp"
+#include "llrt/tt_cluster.hpp"
+#include <umd/device/cluster.h>
+#include <umd/device/tt_cluster_descriptor.h>
+#include <filesystem>
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "kernels/kernel_impl.hpp"
@@ -941,6 +945,19 @@ size_t GetNumPCIeDevices() { return tt::tt_metal::MetalContext::instance().get_c
 
 chip_id_t GetPCIeDeviceID(chip_id_t device_id) {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+}
+
+ClusterType GetClusterType() {
+    // Get the cluster type from LLRT and convert to public API type
+    tt::tt_metal::ClusterType llrt_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+
+    // Direct cast since the enum values are identical
+    return static_cast<ClusterType>(llrt_type);
+}
+
+std::string SerializeClusterDescriptor() {
+    std::filesystem::path path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
+    return path.string();
 }
 
 IDevice* CreateDevice(

--- a/ttnn/api/ttnn/cluster.hpp
+++ b/ttnn/api/ttnn/cluster.hpp
@@ -12,8 +12,6 @@ namespace ttnn {
 namespace cluster {
 
 tt::tt_metal::ClusterType get_cluster_type();
-bool is_galaxy_cluster();
-std::size_t number_of_user_devices();
 std::string serialize_cluster_descriptor();
 
 }  // namespace cluster

--- a/ttnn/api/ttnn/cluster.hpp
+++ b/ttnn/api/ttnn/cluster.hpp
@@ -4,12 +4,16 @@
 
 #pragma once
 
-#include <string>
+#include "ttnn/types.hpp"
+#include <tt-metalium/tt_metal.hpp>
 
 namespace ttnn {
 
 namespace cluster {
 
+tt::tt_metal::ClusterType get_cluster_type();
+bool is_galaxy_cluster();
+std::size_t number_of_user_devices();
 std::string serialize_cluster_descriptor();
 
 }  // namespace cluster

--- a/ttnn/core/cluster.cpp
+++ b/ttnn/core/cluster.cpp
@@ -11,10 +11,6 @@ namespace cluster {
 
 tt::tt_metal::ClusterType get_cluster_type() { return tt::tt_metal::GetClusterType(); }
 
-bool is_galaxy_cluster() { return tt::tt_metal::IsGalaxyCluster(); }
-
-std::size_t number_of_user_devices() { return tt::tt_metal::GetNumAvailableDevices(); }
-
 std::string serialize_cluster_descriptor() { return tt::tt_metal::SerializeClusterDescriptor(); }
 
 }  // namespace cluster

--- a/ttnn/core/cluster.cpp
+++ b/ttnn/core/cluster.cpp
@@ -3,18 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cluster.hpp"
-#include <umd/device/cluster.h>
-#include <umd/device/tt_cluster_descriptor.h>
-#include <filesystem>
+#include <tt-metalium/tt_metal.hpp>
 
 namespace ttnn {
 
 namespace cluster {
 
-std::string serialize_cluster_descriptor() {
-    std::filesystem::path path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
-    return path.string();
-};
+tt::tt_metal::ClusterType get_cluster_type() { return tt::tt_metal::GetClusterType(); }
+
+bool is_galaxy_cluster() { return tt::tt_metal::IsGalaxyCluster(); }
+
+std::size_t number_of_user_devices() { return tt::tt_metal::GetNumAvailableDevices(); }
+
+std::string serialize_cluster_descriptor() { return tt::tt_metal::SerializeClusterDescriptor(); }
 
 }  // namespace cluster
 

--- a/ttnn/cpp/ttnn-pybind/__init__.cpp
+++ b/ttnn/cpp/ttnn-pybind/__init__.cpp
@@ -234,6 +234,7 @@ PYBIND11_MODULE(_ttnn, module) {
 
     ttnn::types::py_module_types(m_types);
     ttnn::activation::py_module_types(m_activation);
+    ttnn::cluster::py_cluster_module_types(m_cluster);
     ttnn::core::py_module_types(m_core);
     ttnn::device::py_device_module_types(m_device);
     ttnn::fabric::py_bind_fabric_api(m_fabric);

--- a/ttnn/cpp/ttnn-pybind/cluster.cpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.cpp
@@ -37,41 +37,6 @@ void ttnn_cluster(py::module& module) {
         )doc");
 
     module.def(
-        "is_galaxy_cluster",
-        &ttnn::cluster::is_galaxy_cluster,
-        R"doc(
-            Check if the current cluster is a Galaxy cluster.
-
-            Returns:
-                bool: True if the cluster is a Galaxy cluster, False otherwise.
-
-            Example:
-                >>> import ttnn
-                >>> if ttnn.cluster.is_galaxy_cluster():
-                ...     print("Running on Galaxy cluster")
-                ... else:
-                ...     print("Running on non-Galaxy cluster")
-        )doc");
-
-    module.def(
-        "number_of_user_devices",
-        &ttnn::cluster::number_of_user_devices,
-        R"doc(
-            Get the number of user-accessible devices in the cluster.
-
-            Returns:
-                int: The number of user devices in the cluster.
-
-            Note:
-                For Galaxy systems, this excludes MMIO gateway chips that are only used for dispatch.
-
-            Example:
-                >>> import ttnn
-                >>> num_devices = ttnn.cluster.number_of_user_devices()
-                >>> print(f"Cluster has {num_devices} user devices")
-        )doc");
-
-    module.def(
         "serialize_cluster_descriptor",
         &ttnn::cluster::serialize_cluster_descriptor,
         R"doc(

--- a/ttnn/cpp/ttnn-pybind/cluster.cpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.cpp
@@ -6,71 +6,45 @@
 
 #include <pybind11/pybind11.h>
 
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/impl/context/metal_context.hpp>
-#include <tt-metalium/llrt/tt_cluster.hpp>
-
 #include "ttnn/cluster.hpp"
-
-using namespace tt::tt_metal;
 
 namespace py = pybind11;
 
 namespace {
 
 void ttnn_cluster(py::module& module) {
-    // Bind ClusterType enum
-    py::enum_<tt::ClusterType>(module, "ClusterType", "Enum representing different cluster types")
-        .value("INVALID", tt::ClusterType::INVALID, "Invalid cluster type")
-        .value("N150", tt::ClusterType::N150, "Production N150")
-        .value("N300", tt::ClusterType::N300, "Production N300")
-        .value("T3K", tt::ClusterType::T3K, "Production T3K, built with 4 N300s")
-        .value("GALAXY", tt::ClusterType::GALAXY, "Production Galaxy, all chips with mmio")
-        .value("TG", tt::ClusterType::TG, "Will be deprecated")
-        .value("P100", tt::ClusterType::P100, "Blackhole single card, ethernet disabled")
-        .value("P150", tt::ClusterType::P150, "Blackhole single card, ethernet enabled")
-        .value("P150_X2", tt::ClusterType::P150_X2, "2 Blackhole single card, ethernet connected")
-        .value("P150_X4", tt::ClusterType::P150_X4, "4 Blackhole single card, ethernet connected")
-        .value("SIMULATOR_WORMHOLE_B0", tt::ClusterType::SIMULATOR_WORMHOLE_B0, "Simulator Wormhole B0")
-        .value("SIMULATOR_BLACKHOLE", tt::ClusterType::SIMULATOR_BLACKHOLE, "Simulator Blackhole")
-        .value("N300_2x2", tt::ClusterType::N300_2x2, "2 N300 cards, ethernet connected to form 2x2");
-
     module.def(
         "get_cluster_type",
-        []() -> tt::ClusterType {
-            return tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-        },
+        &ttnn::cluster::get_cluster_type,
         R"doc(
             Get the cluster type of the current cluster.
-            
+
             Returns:
                 ttnn.cluster.ClusterType: The type of the current cluster.
-            
+
             Example:
                 >>> import ttnn
                 >>> cluster_type = ttnn.cluster.get_cluster_type()
                 >>> print(cluster_type)
                 ttnn.cluster.ClusterType.N150  # (example output)
-                >>> 
+                >>>
                 >>> # You can also compare cluster types
                 >>> if cluster_type == ttnn.cluster.ClusterType.T3K:
                 ...     print("Running on T3K cluster")
-                >>> 
+                >>>
                 >>> # Or use in conditional logic
                 >>> is_galaxy = cluster_type in [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
         )doc");
 
     module.def(
         "is_galaxy_cluster",
-        []() -> bool {
-            return tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
-        },
+        &ttnn::cluster::is_galaxy_cluster,
         R"doc(
             Check if the current cluster is a Galaxy cluster.
-            
+
             Returns:
                 bool: True if the cluster is a Galaxy cluster, False otherwise.
-            
+
             Example:
                 >>> import ttnn
                 >>> if ttnn.cluster.is_galaxy_cluster():
@@ -80,19 +54,17 @@ void ttnn_cluster(py::module& module) {
         )doc");
 
     module.def(
-        "number_of_user_devices", 
-        []() -> size_t {
-            return tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
-        },
+        "number_of_user_devices",
+        &ttnn::cluster::number_of_user_devices,
         R"doc(
             Get the number of user-accessible devices in the cluster.
-            
+
             Returns:
                 int: The number of user devices in the cluster.
-            
+
             Note:
                 For Galaxy systems, this excludes MMIO gateway chips that are only used for dispatch.
-            
+
             Example:
                 >>> import ttnn
                 >>> num_devices = ttnn.cluster.number_of_user_devices()
@@ -104,10 +76,10 @@ void ttnn_cluster(py::module& module) {
         &ttnn::cluster::serialize_cluster_descriptor,
         R"doc(
             Serialize cluster descriptor to a file.
-            
+
             Returns:
                 str: Path to the serialized cluster descriptor file.
-            
+
             Example:
                 >>> import ttnn
                 >>> descriptor_path = ttnn.cluster.serialize_cluster_descriptor()
@@ -118,6 +90,23 @@ void ttnn_cluster(py::module& module) {
 }  // namespace
 
 namespace ttnn::cluster {
+void py_cluster_module_types(py::module& module) {
+    // Bind ClusterType enum using the public API
+    py::enum_<tt::tt_metal::ClusterType>(module, "ClusterType", "Enum representing different cluster types")
+        .value("INVALID", tt::tt_metal::ClusterType::INVALID, "Invalid cluster type")
+        .value("N150", tt::tt_metal::ClusterType::N150, "Production N150")
+        .value("N300", tt::tt_metal::ClusterType::N300, "Production N300")
+        .value("T3K", tt::tt_metal::ClusterType::T3K, "Production T3K, built with 4 N300s")
+        .value("GALAXY", tt::tt_metal::ClusterType::GALAXY, "Production Galaxy, all chips with mmio")
+        .value("TG", tt::tt_metal::ClusterType::TG, "Will be deprecated")
+        .value("P100", tt::tt_metal::ClusterType::P100, "Blackhole single card, ethernet disabled")
+        .value("P150", tt::tt_metal::ClusterType::P150, "Blackhole single card, ethernet enabled")
+        .value("P150_X2", tt::tt_metal::ClusterType::P150_X2, "2 Blackhole single card, ethernet connected")
+        .value("P150_X4", tt::tt_metal::ClusterType::P150_X4, "4 Blackhole single card, ethernet connected")
+        .value("SIMULATOR_WORMHOLE_B0", tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "Simulator Wormhole B0")
+        .value("SIMULATOR_BLACKHOLE", tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "Simulator Blackhole")
+        .value("N300_2x2", tt::tt_metal::ClusterType::N300_2x2, "2 N300 cards, ethernet connected to form 2x2");
+}
 
 void py_cluster_module(py::module& module) {
     ttnn_cluster(module);

--- a/ttnn/cpp/ttnn-pybind/cluster.cpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.cpp
@@ -7,6 +7,8 @@
 #include <pybind11/pybind11.h>
 
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/impl/context/metal_context.hpp>
+#include <tt-metalium/llrt/tt_cluster.hpp>
 
 #include "ttnn/cluster.hpp"
 
@@ -14,15 +16,111 @@ using namespace tt::tt_metal;
 
 namespace py = pybind11;
 
-namespace ttnn::cluster {
+namespace {
 
-void py_cluster_module(py::module& module) {
+void ttnn_cluster(py::module& module) {
+    // Bind ClusterType enum
+    py::enum_<tt::ClusterType>(module, "ClusterType", "Enum representing different cluster types")
+        .value("INVALID", tt::ClusterType::INVALID, "Invalid cluster type")
+        .value("N150", tt::ClusterType::N150, "Production N150")
+        .value("N300", tt::ClusterType::N300, "Production N300")
+        .value("T3K", tt::ClusterType::T3K, "Production T3K, built with 4 N300s")
+        .value("GALAXY", tt::ClusterType::GALAXY, "Production Galaxy, all chips with mmio")
+        .value("TG", tt::ClusterType::TG, "Will be deprecated")
+        .value("P100", tt::ClusterType::P100, "Blackhole single card, ethernet disabled")
+        .value("P150", tt::ClusterType::P150, "Blackhole single card, ethernet enabled")
+        .value("P150_X2", tt::ClusterType::P150_X2, "2 Blackhole single card, ethernet connected")
+        .value("P150_X4", tt::ClusterType::P150_X4, "4 Blackhole single card, ethernet connected")
+        .value("SIMULATOR_WORMHOLE_B0", tt::ClusterType::SIMULATOR_WORMHOLE_B0, "Simulator Wormhole B0")
+        .value("SIMULATOR_BLACKHOLE", tt::ClusterType::SIMULATOR_BLACKHOLE, "Simulator Blackhole")
+        .value("N300_2x2", tt::ClusterType::N300_2x2, "2 N300 cards, ethernet connected to form 2x2");
+
+    module.def(
+        "get_cluster_type",
+        []() -> tt::ClusterType {
+            return tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+        },
+        R"doc(
+            Get the cluster type of the current cluster.
+            
+            Returns:
+                ttnn.cluster.ClusterType: The type of the current cluster.
+            
+            Example:
+                >>> import ttnn
+                >>> cluster_type = ttnn.cluster.get_cluster_type()
+                >>> print(cluster_type)
+                ttnn.cluster.ClusterType.N150  # (example output)
+                >>> 
+                >>> # You can also compare cluster types
+                >>> if cluster_type == ttnn.cluster.ClusterType.T3K:
+                ...     print("Running on T3K cluster")
+                >>> 
+                >>> # Or use in conditional logic
+                >>> is_galaxy = cluster_type in [ttnn.cluster.ClusterType.GALAXY, ttnn.cluster.ClusterType.TG]
+        )doc");
+
+    module.def(
+        "is_galaxy_cluster",
+        []() -> bool {
+            return tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
+        },
+        R"doc(
+            Check if the current cluster is a Galaxy cluster.
+            
+            Returns:
+                bool: True if the cluster is a Galaxy cluster, False otherwise.
+            
+            Example:
+                >>> import ttnn
+                >>> if ttnn.cluster.is_galaxy_cluster():
+                ...     print("Running on Galaxy cluster")
+                ... else:
+                ...     print("Running on non-Galaxy cluster")
+        )doc");
+
+    module.def(
+        "number_of_user_devices", 
+        []() -> size_t {
+            return tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
+        },
+        R"doc(
+            Get the number of user-accessible devices in the cluster.
+            
+            Returns:
+                int: The number of user devices in the cluster.
+            
+            Note:
+                For Galaxy systems, this excludes MMIO gateway chips that are only used for dispatch.
+            
+            Example:
+                >>> import ttnn
+                >>> num_devices = ttnn.cluster.number_of_user_devices()
+                >>> print(f"Cluster has {num_devices} user devices")
+        )doc");
+
     module.def(
         "serialize_cluster_descriptor",
         &ttnn::cluster::serialize_cluster_descriptor,
         R"doc(
-               Serialize cluster descriptor to a file.
-             )doc");
+            Serialize cluster descriptor to a file.
+            
+            Returns:
+                str: Path to the serialized cluster descriptor file.
+            
+            Example:
+                >>> import ttnn
+                >>> descriptor_path = ttnn.cluster.serialize_cluster_descriptor()
+                >>> print(f"Cluster descriptor saved to: {descriptor_path}")
+        )doc");
+}
+
+}  // namespace
+
+namespace ttnn::cluster {
+
+void py_cluster_module(py::module& module) {
+    ttnn_cluster(module);
 }
 
 }  // namespace ttnn::cluster

--- a/ttnn/cpp/ttnn-pybind/cluster.hpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.hpp
@@ -6,10 +6,10 @@
 
 #include "ttnn-pybind/pybind_fwd.hpp"
 
+namespace ttnn::cluster {
 namespace py = pybind11;
 
-namespace ttnn::cluster {
-
+void py_cluster_module_types(py::module& module);
 void py_cluster_module(py::module& module);
 
 }  // namespace ttnn::cluster

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -135,6 +135,9 @@ from ttnn._ttnn.global_circular_buffer import (
 
 from ttnn._ttnn.fabric import FabricConfig, FabricReliabilityMode, set_fabric_config
 
+# Import cluster functions and types
+from ttnn._ttnn import cluster
+
 from ttnn._ttnn.global_semaphore import (
     create_global_semaphore,
     get_global_semaphore_address,


### PR DESCRIPTION
### Ticket
Link to Github Issue: #11059 

### Problem description
In order to remove our dependency on the env variable `WH_ARCH_YAML` for setting up eth dispatch (needed for the majority of our LLM models), we need to expose the ability to detect if we're running on an N300 so we can set the default behaviour to be eth dispatch. 

### What's changed
1) Added GetClusterType functionality to the tt_metal public API and rescoped the namespace for the enum `ClusterType` 
2) Updated the namespace for all uses of `ClusterType`. Mostly in `tt_metal/fabric` but also some other references updated. 
3) Added pybindings in ttnn for the cluster module for functions `get_cluster_type`
4) Added some (AI generated) unit tests for for the ttnn cluster module 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16594793852
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes