### PR TITLE
Use read only boundary check

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -130,6 +130,8 @@
 #error "Tensix fabric connections base and size must be 16-byte aligned"
 #endif
 
+// Read-only reserved memory boundary for watcher checks
+#define MEM_MAP_READ_ONLY_END MEM_TENSIX_FABRIC_CONNECTIONS_BASE
 #define MEM_MAP_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_CONNECTIONS_SIZE)
 
 // Every address after MEM_MAP_END is a "scratch" address

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -166,7 +166,7 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
     }
 
 #if !defined(DISPATCH_KERNEL) || (DISPATCH_KERNEL == 0)
-    if (write && (addr < MEM_MAP_END)) {
+    if (write && (addr < MEM_MAP_READ_ONLY_END)) {
         return DebugSanitizeNocAddrMailbox;
     }
 #endif

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -112,6 +112,8 @@
 #error "Tensix fabric connections base and size must be 16-byte aligned"
 #endif
 
+// Read-only reserved memory boundary for watcher checks
+#define MEM_MAP_READ_ONLY_END MEM_TENSIX_FABRIC_CONNECTIONS_BASE
 #define MEM_MAP_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_CONNECTIONS_SIZE)
 
 // Every address after MEM_MAP_END is a "scratch" address


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23384

### Problem description
[This PR](https://github.com/tenstorrent/tt-metal/pull/24673) moved flow control semaphore to fixed L1 region, which makes watcher to detect as invalid write.

### What's changed
Newly added read only region. in dev_mem_map.h

TG
https://github.com/tenstorrent/tt-metal/actions/runs/16430355426
benchmark
https://github.com/tenstorrent/tt-metal/actions/runs/16430351237
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16430357216
Blackhole
https://github.com/tenstorrent/tt-metal/actions/runs/16430358233
T3K (known issue?? locally works or simply unstable on main)
https://github.com/tenstorrent/tt-metal/actions/runs/16430353293

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes