### PR TITLE
#25496: Ensure that device frequency (AICLK) goes to idle after the process exists, optimizing idle power consumption

### DIFF
--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -90,7 +90,8 @@ public:
 private:
     friend class tt::stl::Indestructible<MetalContext>;
     MetalContext();
-    ~MetalContext();
+
+    static Cluster& cluster_instance(llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal);
 
     void clear_l1_state(chip_id_t device_id);
     void clear_dram_state(chip_id_t device_id);
@@ -135,7 +136,7 @@ private:
     std::unordered_map<chip_id_t, std::vector<uint16_t>> l1_bank_to_noc_xy_;
 
     llrt::RunTimeOptions rtoptions_;
-    std::unique_ptr<Cluster> cluster_;
+    Cluster* cluster_ = nullptr;
     std::unique_ptr<Hal> hal_;
     std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25496

### Problem description
Currently, after any usage of tt-metal device frequency (AICLK) goes to maximum and never reduces until PC reboot. This causes unnecessary power consumption when the device is completely idle.
This issue is caused by MetalContext being wrapped in Indestructible, which in turn skips the destructor of Cluster, which was supposed to lower the device frequency.

This change gives major improvements to the idle power consumption of the cards, however has some drawbacks, which would be nice to investigate/address going forward:
1. The current flow increases AICLK of all devices present on the system upon the first usage. Ideally, we should only activate the devices which are explicitly open and deactivate them when they are closed. This may have implications on fabric functionality and not directly connected chips (like in N300 card)
2. If the process crashes, the AICLK would not go to idle until the next "run" of software which uses tt-metal in some way. This could be fixed by changes to tt-kmd making it monitor the list of processes currently using any of the devices, and manually putting all devices to idle if there are no processes using them.
Both of those directions for improvement are outside of the scope of this change.

### What's changed
Make Cluster object destructible on process exit, by storing it as a separate static outside of Indestructible<MetalContext>

### Checklist
- [ ] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16432018561)
- [x] Manually verified with tt-smi that during running tests AICLK increases to maximum value and then decreases to idle after the tests are completed
- [x] New/Existing tests provide coverage for changes