### PR TITLE
Different RoPE scaling types

### DIFF
--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
@@ -242,8 +242,7 @@ def test_cross_attention_transformer_text_inference(
                     mesh_device,
                     seq_len,
                     model_args.rope_theta,
-                    model_args.rope_scaling_factor,
-                    model_args.orig_context_len,
+                    model_args.rope_scaling,
                 )
                 tt_out = tt_model(
                     tt_h,
@@ -287,8 +286,7 @@ def test_cross_attention_transformer_text_inference(
                 model_args.num_devices,
                 start_pos=cur_pos - 1,
                 theta=model_args.rope_theta,
-                scale_factor=model_args.rope_scaling_factor,
-                orig_context_len=model_args.orig_context_len,
+                rope_scaling=model_args.rope_scaling,
             )
             tt_rope_id = tt_model.rope_setup.get_rot_idxs(position_ids)
             rot_mats = tt_model.rope_setup.get_rot_mats(tt_rope_id)

--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -240,8 +240,7 @@ def test_tt_model_acc(
             mesh_device,
             prefill_lens[0],
             model_args.rope_theta,
-            model_args.rope_scaling_factor,
-            model_args.orig_context_len,
+            model_args.rope_scaling,
         )
 
         prefill_input = model_args.prepare_residual_tensor_prefill(

--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -88,8 +88,7 @@ def test_attention_inference(
         model_args.head_dim,
         model_args.max_seq_len,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
-        model_args.orig_context_len,
+        model_args.rope_scaling,
     )
 
     transformation_mats = rope_setup.get_both_trans_mats()
@@ -137,8 +136,7 @@ def test_attention_inference(
         model_args.head_dim,
         model_args.max_seq_len * 2,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
-        model_args.orig_context_len,
+        model_args.rope_scaling,
     )
     freqs_cis = torch.complex(cos, sin)
 

--- a/models/tt_transformers/tests/test_attention_prefill.py
+++ b/models/tt_transformers/tests/test_attention_prefill.py
@@ -80,8 +80,7 @@ def test_attention_inference(
         mesh_device,
         max_seq_len,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
-        model_args.orig_context_len,
+        model_args.rope_scaling,
     )
     transformation_mat_torch = get_rot_transformation_mat(model_args.head_dim)
 
@@ -158,7 +157,7 @@ def test_attention_inference(
         model_args.head_dim,
         model_args.max_seq_len * 2,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
+        model_args.rope_scaling["factor"],
     )[positions]
     attn_mask = torch.full((max_seq_len, max_seq_len), torch.finfo(torch.float32).min)
     attn_mask_torch = torch.triu(attn_mask, diagonal=1)

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -84,8 +84,7 @@ def test_decoder_inference(
         model_args.head_dim,
         model_args.max_seq_len,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
-        model_args.orig_context_len,
+        model_args.rope_scaling,
     )
     transformation_mats = rope_setup.get_both_trans_mats()
 
@@ -135,8 +134,7 @@ def test_decoder_inference(
         model_args.head_dim,
         model_args.max_seq_len * 2,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
-        model_args.orig_context_len,
+        model_args.rope_scaling,
     )
     freqs_cis = torch.complex(cos, sin)
 

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -89,8 +89,7 @@ def test_decoder_inference(
         mesh_device,
         max_seq_len,
         model_args.rope_theta,
-        model_args.rope_scaling_factor,
-        model_args.orig_context_len,
+        model_args.rope_scaling,
     )
     transformation_mat_torch = get_rot_transformation_mat(model_args.head_dim)
     transformation_mats_prefill = ttnn.as_tensor(
@@ -151,7 +150,7 @@ def test_decoder_inference(
             model_args.head_dim,
             model_args.max_seq_len * 2,
             model_args.rope_theta,
-            model_args.rope_scaling_factor,
+            model_args.rope_scaling["factor"],
         )[positions]
 
         # Reference model

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -53,9 +53,9 @@ class Transformer(LightweightModule):
             args.head_dim,
             args.max_seq_len,
             args.rope_theta,
-            args.rope_scaling_factor,
-            args.orig_context_len,
+            args.rope_scaling,
         )
+
         self.trans_mats_dict = self.rope_setup.get_both_trans_mats()
 
         self.layers = [

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1455,16 +1455,25 @@ class ModelArgs:
 
         # RoPE params
         self.rope_theta = text_config.get("rope_theta")
+        self.rope_theta_local = text_config.get("rope_local_base_freq", None)
         # If use_scaled_rope is not present, assume setting rope_scaling means use scaled rope
         # If it is present and is set to false, do not use scaled rope
-        # Setting self.rope_scaling_factor to None is our way of saying do not use scaled rope
+
+        # Default rope scaling parameters
+        self.rope_scaling = {
+            "factor": None,  # Setting self.rope_scaling["factor"] to None is our way of saying do not use scaled rope
+            "orig_context_len": self.max_context_len,
+            "type": "llama3",  # Default to llama3 scaling type
+        }
+
+        # Override default rope scaling parameters with any specified in config
         rope_scaling_params = text_config.get("rope_scaling", None)
         if rope_scaling_params:
-            self.rope_scaling_factor = rope_scaling_params.get("factor", None)
-            self.orig_context_len = rope_scaling_params.get("original_max_position_embeddings", self.max_context_len)
-        else:
-            self.rope_scaling_factor = None
-            self.orig_context_len = None
+            self.rope_scaling["factor"] = rope_scaling_params.get("factor", None)
+            self.rope_scaling["type"] = rope_scaling_params.get("type", rope_scaling_params.get("rope_type", "llama3"))
+            self.rope_scaling["orig_context_len"] = rope_scaling_params.get(
+                "original_max_position_embeddings", self.max_context_len
+            )
 
         self.query_pre_attn_scalar = text_config.get("query_pre_attn_scalar", None)
 
@@ -1496,7 +1505,7 @@ class ModelArgs:
 
     @property
     def use_scaled_rope(self):
-        return self.rope_scaling_factor is not None
+        return self.rope_scaling["factor"] is not None
 
     @property
     def base_model_name(self):
@@ -1524,31 +1533,31 @@ class ModelArgs:
             params = json.load(f)
         self._set_params_from_dict(params)
 
-        # Meta-style config dicts don't specity model name or rope_scaling_factor so hard-code these
+        # Meta-style config dicts don't specity model name or rope scaling factor so hard-code these
         # Set the model name based on the checkpoint directory being loaded
         if "3.2-1B" in checkpoint_dir:
             self.model_name = "Llama-3.2-1B" + ("-Instruct" if self.instruct else "")
-            self.rope_scaling_factor = 32
+            self.rope_scaling["factor"] = 32
         elif "3.2-3B" in checkpoint_dir:
             self.model_name = "Llama-3.2-3B" + ("-Instruct" if self.instruct else "")
-            self.rope_scaling_factor = 32
+            self.rope_scaling["factor"] = 32
         elif "3.1-8B" in checkpoint_dir:
             self.model_name = "Llama-3.1-8B" + ("-Instruct" if self.instruct else "")
-            self.rope_scaling_factor = 8
+            self.rope_scaling["factor"] = 8
         elif "3.2-11B" in checkpoint_dir:
             self.model_name = "Llama-3.2-11B" + ("-Instruct" if self.instruct else "")
-            self.rope_scaling_factor = 8  # shared with 3.1-8B
+            self.rope_scaling["factor"] = 8  # shared with 3.1-8B
         elif "3.1-70B" in checkpoint_dir:
             self.model_name = "Llama-3.1-70B" + ("-Instruct" if self.instruct else "")
-            self.rope_scaling_factor = 8
+            self.rope_scaling["factor"] = 8
             self.is_70b = True  # self.dim == 8192 and self.n_layers == 80
         elif "3.2-90B" in checkpoint_dir:
             self.model_name = "Llama-3.2-90B" + ("-Instruct" if self.instruct else "")
-            self.rope_scaling_factor = 8
+            self.rope_scaling["factor"] = 8
             self.is_90b = True
         else:
             logger.warning(f"Unknown Meta-style model: {checkpoint_dir}")
-        self.orig_context_len = 8192
+        self.rope_scaling["orig_context_len"] = 8192
 
     def _set_hf_params(self, checkpoint_dir):
         if self.from_hf_url:
@@ -1580,7 +1589,7 @@ class ModelArgs:
     ffn_dim_multiplier={self.ffn_dim_multiplier},
     norm_eps={self.norm_eps},
     rope_theta={self.rope_theta},
-    rope_scaling_factor={self.rope_scaling_factor},
+    rope_scaling_factor={self.rope_scaling["factor"]},
     max_batch_size={self.max_batch_size},
     max_seq_len={self.max_seq_len},
     vision_chunk_size={self.vision_chunk_size},

--- a/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -123,8 +123,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
             configuration.head_dim,
             configuration.max_seq_len,
             configuration.rope_theta,
-            configuration.rope_scaling_factor,
-            configuration.orig_context_len,
+            configuration.rope_scaling,
         )
         self.trans_mats_dict = self.rope_setup.get_both_trans_mats()
 

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -352,8 +352,7 @@ class CrossAttentionTransformer(torch.nn.Module):
             self.mesh_device,
             seq_len=S,
             theta=self.configuration.rope_theta,
-            scale_factor=self.configuration.rope_scaling_factor,
-            orig_context_len=self.configuration.orig_context_len,
+            rope_scaling=self.configuration.rope_scaling,
         )
 
         if isinstance(page_table, torch.Tensor):

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any, Dict
+
 import torch
 
 import ttnn
@@ -11,8 +13,8 @@ from models.utility_functions import nearest_32
 from ttnn import ReplicateTensorToMesh, ShardTensor2dMesh
 
 
-def compute_gather_cos_sin(dhead, end, theta, scale_factor, orig_context_len, position_ids):
-    cos, sin = precompute_freqs(dhead, end, theta, scale_factor, orig_context_len)
+def compute_gather_cos_sin(dhead, end, theta, rope_scaling, position_ids):
+    cos, sin = precompute_freqs(dhead, end, theta, rope_scaling)
     return gather_cos_sin(position_ids, cos, sin)
 
 
@@ -24,8 +26,7 @@ class RotarySetup(LightweightModule):
         head_dim: int,
         max_seq_len: int,
         rope_theta: float,
-        scale_factor: float,  # use None to disable rope scaling
-        orig_context_len: int,  # only used if scaling enabled
+        rope_scaling: Dict[str, Any],
         datatype=ttnn.bfloat16,
     ):
         super().__init__()
@@ -46,8 +47,7 @@ class RotarySetup(LightweightModule):
             dhead=head_dim,
             end=max_seq_len * 2,
             theta=rope_theta,
-            scale_factor=scale_factor,
-            orig_context_len=orig_context_len,
+            rope_scaling=rope_scaling,
             position_ids=torch.arange(max_seq_len),
         )
 


### PR DESCRIPTION
### Ticket
[22809](https://github.com/tenstorrent/tt-metal/issues/22809)

### Problem description
Gemma3 embeddings use linear and default scaling for global and local

### What's changed
Add support for various RoPE scalings
Cover default (none) and linear

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16442898704)
- [ ] [T3K Unit and Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16420265624)