### PR TITLE
Activate multicore `argmax` for `batch=32` in `tt_transformers`

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -736,10 +736,8 @@ def test_demo_text(
 
         user_done = [False] * global_batch_size  # Keeps track when a user reaches EoD token
 
-        # TODO Argmax on device is only supported for batch_size=1 (per submesh)
-        argmax_on_device = (
-            False if (global_batch_size // data_parallel > 1 or sampling_params["temperature"] != 0) else True
-        )
+        # Currently only supporting greedy decoding (temperature=0) on device
+        argmax_on_device = sampling_params["temperature"] == 0
         if argmax_on_device:
             device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
         else:

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -333,12 +333,7 @@ class Transformer(LightweightModule):
         tt_logits = ttnn.untilize(tt_logits, use_multicore=True)
 
         if argmax_on_device:
-            tt_logits = ttnn.argmax(
-                tt_logits,
-                dim=3,
-                keepdim=True,
-                use_multicore=True,
-            )
+            tt_logits = ttnn.argmax(tt_logits, dim=3, keepdim=True, use_multicore=True)
         else:
             # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations
             if not self.args.is_galaxy:

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -257,7 +257,7 @@ class Transformer(LightweightModule):
                     dims=(3, 1) if self.args.is_galaxy else (1, -1),
                     mesh_shape=self.args.cluster_shape,
                 ),
-            )[0, 0, 0, :B]
+            )[0, 0, :B, 0]
             return tt_out
 
         if self.args.num_devices > 1:
@@ -333,11 +333,11 @@ class Transformer(LightweightModule):
         tt_logits = ttnn.untilize(tt_logits, use_multicore=True)
 
         if argmax_on_device:
-            tt_logits = ttnn.argmax(  # TODO Add multicore support to batch > 1
+            tt_logits = ttnn.argmax(
                 tt_logits,
                 dim=3,
                 keepdim=True,
-                use_multicore=False if self.args.max_batch_size > 1 else True,  # ,output_tensor=tokens
+                use_multicore=True,
             )
         else:
             # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24326

### Problem description
Recent op improvements now allow this. This also became a requirement to achieve desired perf for llama 8b DP=4 through inference server.
Before this change, with sampling on host we were seeing significant perf drop with `batch=32`

|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |     246.2 |      30.1 |           33.26 |              33.3 |              519.9 |    4065.0 |          0.246 |
|   128 | 1024 |           1 |     4 |     242.4 |      31.1 |           32.19 |              32.2 |              528.1 |   32024.8 |          0.031 |
|  1024 |  128 |           1 |     4 |     277.9 |      31.1 |           32.11 |              32.1 |             3684.9 |    4232.5 |          0.236 |
|  2048 |  128 |           1 |     4 |     398.6 |      31.7 |           31.58 |              31.6 |             5138.4 |    4419.8 |          0.226 |
|  3072 |  128 |           1 |     4 |     627.6 |      32.2 |           31.02 |              31.0 |             4894.6 |    4722.1 |          0.212 |
|  4096 |  128 |           1 |     2 |     636.3 |      32.6 |           30.71 |              30.7 |             6437.4 |    4772.0 |          0.209 |
|  8192 |  128 |           1 |     2 |    1087.5 |      35.1 |           28.49 |              28.5 |             7532.9 |    5545.5 |          0.18  |
| 16384 |  128 |           1 |     2 |    2158.3 |      42.2 |           23.68 |              23.7 |             7591.2 |    7521.0 |          0.133 |
| 32000 |  128 |           1 |     2 |    4735.1 |      54.2 |           18.47 |              18.5 |             6758.0 |   11612.7 |          0.086 |
|   128 |  128 |         128 |  1024 |   27773.1 |     128.8 |            7.76 |             993.9 |              589.9 |   44129.2 |          2.897 |
|   128 | 1024 |         128 |   512 |   26807.0 |     135.5 |            7.38 |             944.5 |              611.2 |  165449.8 |          0.76  |
|  2048 |  128 |         128 |   512 |   53956.7 |     100.6 |            9.94 |            1271.9 |             4858.4 |   66737.5 |          1.794 |
|  2048 | 2048 |         128 |   256 |  216823.0 |      89.2 |           11.21 |            1434.5 |             1209.0 |  399481.1 |          0.266 |
|  3000 |   64 |         128 |   512 |   73355.5 |      81.1 |           12.33 |            1578.2 |             5234.8 |   78465.2 |          1.484 |
|  4000 |   64 |         128 |   512 |   76743.8 |      72.7 |           13.75 |            1759.8 |             6671.5 |   81326.2 |          1.419 |
|  4500 |   64 |         128 |   256 |   94234.5 |      49.9 |           20.06 |            2567.4 |             6112.4 |   97375.4 |          1.052 |
|  8000 |   64 |         128 |   256 |  114586.3 |      46.4 |           21.54 |            2757.3 |             8936.5 |  117510.9 |          0.846 |
| 16000 |   64 |         128 |   256 |  233739.8 |      43.4 |           23.02 |            2946.6 |             8761.9 |  236476.5 |          0.415 |

With argmax active we now see overall perf improvement and particularly for 128 users
|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |     247.6 |      23.8 |           42.02 |              42.0 |              517.1 |    3269.8 |          0.306 |
|   128 | 1024 |           1 |     4 |     239.4 |      24.3 |           41.2  |              41.2 |              534.8 |   25067.2 |          0.04  |
|  1024 |  128 |           1 |     4 |     275.3 |      24.5 |           40.9  |              40.9 |             3719.8 |    3380.5 |          0.296 |
|  2048 |  128 |           1 |     4 |     387.1 |      25.2 |           39.69 |              39.7 |             5290.2 |    3587.1 |          0.279 |
|  3072 |  128 |           1 |     4 |     611.0 |      26.1 |           38.34 |              38.3 |             5028.2 |    3923.6 |          0.255 |
|  4096 |  128 |           1 |     2 |     608.5 |      26.7 |           37.47 |              37.5 |             6731.0 |    3997.7 |          0.25  |
|  8192 |  128 |           1 |     2 |    1066.5 |      29.4 |           33.96 |              34.0 |             7681.4 |    4806.4 |          0.208 |
| 16384 |  128 |           1 |     2 |    2125.5 |      34.8 |           28.7  |              28.7 |             7708.2 |    6550.9 |          0.153 |
| 32000 |  128 |           1 |     2 |    4668.9 |      45.5 |           22.0  |              22.0 |             6853.8 |   10441.7 |          0.096 |
|   128 |  128 |         128 |  1024 |   28486.2 |      28.7 |           34.85 |            4460.9 |              575.2 |   32130.3 |          3.976 |
|   128 | 1024 |         128 |   512 |   27407.2 |      34.2 |           29.22 |            3740.4 |              597.8 |   62415.0 |          1.971 |
|  2048 |  128 |         128 |   512 |   47395.2 |      45.8 |           21.82 |            2793.6 |             5531.0 |   53214.3 |          2.244 |
|  2048 | 2048 |         128 |   256 |  132737.2 |      48.7 |           20.53 |            2628.3 |             1974.9 |  232427.1 |          0.453 |
|  3000 |   64 |         128 |   512 |   69335.0 |      48.8 |           20.49 |            2623.0 |             5538.3 |   72409.3 |          1.609 |
|  4000 |   64 |         128 |   512 |   71205.1 |      41.9 |           23.87 |            3054.9 |             7190.5 |   73844.9 |          1.563 |
|  4500 |   64 |         128 |   256 |   92364.3 |      44.3 |           22.57 |            2889.3 |             6236.2 |   95155.3 |          1.077 |
|  8000 |   64 |         128 |   256 |  111378.5 |      40.0 |           25.02 |            3203.0 |             9193.9 |  113896.2 |          0.874 |
| 16000 |   64 |         128 |   256 |  225871.2 |      35.9 |           27.87 |            3566.9 |             9067.1 |  228131.9 |          0.43  |

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16444495275) CI passes
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/runs/16440532443) CI passes
- [ ] [T3K demo+frequent+perplexity+model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/16450621504) (same failures as on main)
- [x] [llama 8b DP=4](https://github.com/tenstorrent/tt-shield/actions/runs/16441505277)
- [ ] [Single card demo+perf+frequent](https://github.com/tenstorrent/tt-metal/actions/runs/16450637245) (same failures as on main)