### PR TITLE
Adapt testing kernel for pack_untilize_dest to accept more than 8 tiles

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -462,7 +462,7 @@ TEST_F(DeviceFixture, TensixComputePackUntilize) {
 }
 
 TEST_F(DeviceFixture, TensixComputePackUntilizeDst) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
+    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}, {10, 10}, {2, 40}};
     for (auto num_tile : num_tiles) {
         for (bool dst_full_sync_en : {true, false}) {
             unit_tests::compute::tilize::TestConfig test_config = {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
@@ -10,32 +10,50 @@
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
 namespace NAMESPACE {
+
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
+
 void MAIN {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     constexpr uint32_t num_faces = get_compile_time_arg_val(2);
     constexpr uint32_t num_rows_per_face = get_compile_time_arg_val(3);
 
+    // Compute optimal num_blocks_per_col and block_ct_dim
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(per_core_block_tile_cnt);
+    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
+
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_tile_to_dst_init_short(tt::CBIndex::c_0);
-    pack_untilize_dest_init<per_core_block_tile_cnt>(tt::CBIndex::c_16, num_rows_per_face, num_faces);
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_16, num_rows_per_face, num_faces);
 
-    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
-        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
-
-        tile_regs_acquire();
-        for (uint32_t i = 0; i < per_core_block_tile_cnt; ++i) {
-            copy_tile(tt::CBIndex::c_0, i, i);
+    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
+        cb_reserve_back(tt::CBIndex::c_16, full_ct_dim);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            cb_wait_front(tt::CBIndex::c_0, block_ct_dim);
+            tile_regs_acquire();
+            for (uint32_t i = 0; i < block_ct_dim; ++i) {
+                copy_tile(tt::CBIndex::c_0, i, i);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<block_ct_dim, full_ct_dim>(tt::CBIndex::c_16, 1, b, num_rows_per_face, num_faces);
+            tile_regs_release();
+            cb_pop_front(tt::CBIndex::c_0, block_ct_dim);
         }
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_untilize_dest<per_core_block_tile_cnt>(tt::CBIndex::c_16, 1, 0, num_rows_per_face, num_faces);
-        tile_regs_release();
-
-        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
-        cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
+        cb_push_back(tt::CBIndex::c_16, full_ct_dim);
     }
 
     pack_untilize_uninit(tt::CBIndex::c_16);


### PR DESCRIPTION
### Ticket
#11716 

### Problem description
There was a cpp test missing for pack_untilize_dest for cases where the number of input blocks is greater than 8. 

### What's changed
Added tests to TensixComputePackUntilizeDst for 10x10 and 2x40 tiles. 
Adapted testing kernel `tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp` to work in the similar fashion to `tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp`, accepting more than 8 tiles. 

The test is passing for all input shapes:
```
2025-07-22 12:12:22.835 | info     |            Test | Done running test with: num_tiles_r = 10, num_tiles_c = 10, FP32_DestAcc = false, DstSyncFull = true, FastTilize = false, pass = true (test_untilize_tilize.cpp:332)
2025-07-22 12:12:23.556 | info     |            Test | Done running test with: num_tiles_r = 10, num_tiles_c = 10, FP32_DestAcc = false, DstSyncFull = false, FastTilize = false, pass = true (test_untilize_tilize.cpp:332)
2025-07-22 12:12:24.275 | info     |            Test | Done running test with: num_tiles_r = 2, num_tiles_c = 40, FP32_DestAcc = false, DstSyncFull = true, FastTilize = false, pass = true (test_untilize_tilize.cpp:332)
2025-07-22 12:12:24.985 | info     |            Test | Done running test with: num_tiles_r = 2, num_tiles_c = 40, FP32_DestAcc = false, DstSyncFull = false, FastTilize = false, pass = true (test_untilize_tilize.cpp:332)

```
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16619665448)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) [Same](https://github.com/tenstorrent/tt-metal/actions/runs/16619669213/job/47021243162) as [main](https://github.com/tenstorrent/tt-metal/actions/runs/16617062217)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes