### PR TITLE
assert_with_ulp(): improve documentation and fix bfloat8_b results

### DIFF
--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -150,12 +150,17 @@ def assert_with_ulp(
         ULP should be preferred when errors between `calculated` and `golden` outputs are known to be small (difference < 10s of ULPs).
         This is typically the case for element-wise operations that approximate common numerical functions (e.g. exp, pow, log, ...).
 
-        For more significant differences, where `calculated` and `golden` differs by orders of magnitude, ULPs may be harder to compare
+        For more significant differences, where `calculated` and `golden` differ by orders of magnitude, ULPs may be harder to compare
         Indeed, with current definition, on bfloat16:
         - ULP-Delta(4, 0) = 128
         - ULP-Delta(0, 4) = 4.36e+40
 
-        Generally, if the ULP errors exceeds the 2**(#mantissa bits) (128-ULP for bfloat16, 8388608 for float32), then it means that both outputs are different by more than an order of magnitude.
+        To measure the accuracy in ULP of operations on bfloat8_b data type, make sure to either pass the ttnn bfloat8_b tensor directly to the
+        function, or convert torch tensor to bfloat16 beforehand (bfloat16 has the 'same' resolution as bfloat8_b).
+        Indeed, ttnn.to_torch() converts bfloat8_b to float32 by default, which would lead to assert_with_ulp() measuring ULP error as if
+        data type was computed as float32.
+
+        Generally, if the ULP error exceeds the 2**(#mantissa bits) (128-ULP for bfloat16, 8388608 for float32), then it means that both outputs are different by more than an order of magnitude.
         For these cases, functions such as `assert_allclose(golden, calculated, rtol, atol)` should be used instead.
     Returns:
         tuple: A tuple containing:

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -155,8 +155,8 @@ def assert_with_ulp(
         - ULP-Delta(4, 0) = 128
         - ULP-Delta(0, 4) = 4.36e+40
 
-        To measure the accuracy in ULP of operations on bfloat8_b data type, make sure to either pass the ttnn bfloat8_b tensor directly to the
-        function, or convert torch tensor to bfloat16 beforehand (bfloat16 has the 'same' resolution as bfloat8_b).
+        To measure the accuracy in ULP of operations on bfloat8_b data type, the ttnn bfloat8_b tensor should be either passed directly to the
+        function, or converted to bfloat16 beforehand (bfloat16 has the 'same' resolution as bfloat8_b).
         Indeed, ttnn.to_torch() converts bfloat8_b to float32 by default, which would lead to assert_with_ulp() measuring ULP error as if
         data type was computed as float32.
 

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -192,6 +192,23 @@ def assert_with_ulp(
         actual_result.shape
     ), f"list(expected_result.shape)={list(expected_result.shape)} vs list(actual_result.shape)={list(actual_result.shape)}"
 
+    maximum_meaningful_ulp_thresholds = {
+        torch.float64: 2**52,
+        torch.float32: 2**23,
+        torch.float16: 2**10,
+        torch.bfloat16: 2**7,
+    }
+    maximum_meaningful_ulp_threshold = (
+        maximum_meaningful_ulp_thresholds[torch.float32]
+        if expected_result.dtype in maximum_meaningful_ulp_thresholds
+        else maximum_meaningful_ulp_thresholds[expected_result.dtype]
+    )
+
+    if ulp_threshold > maximum_meaningful_ulp_threshold:
+        logger.warning(
+            f"ULP threshold {ulp_threshold} is greater than the maximum meaningful ULP threshold of {maximum_meaningful_ulp_threshold} for dtype {expected_result.dtype}"
+        )
+
     ulp_passed, ulp_message = comp_ulp(expected_result, actual_result, ulp_threshold, allow_nonfinite)
     assert ulp_passed, ulp_message
     return ulp_passed, ulp_message

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -155,13 +155,14 @@ def assert_with_ulp(
         - ULP-Delta(4, 0) = 128
         - ULP-Delta(0, 4) = 4.36e+40
 
+        Generally, if the ULP error exceeds the 2**(#mantissa bits) (128-ULP for bfloat16, 8388608 for float32), then it means that both outputs are different by more than an order of magnitude.
+        For these cases, functions such as `assert_allclose(golden, calculated, rtol, atol)` should be used instead.
+
         To measure the accuracy in ULP of operations on bfloat8_b data type, the ttnn bfloat8_b tensor should be either passed directly to the
         function, or converted to bfloat16 beforehand (bfloat16 has the 'same' resolution as bfloat8_b).
         Indeed, ttnn.to_torch() converts bfloat8_b to float32 by default, which would lead to assert_with_ulp() measuring ULP error as if
         data type was computed as float32.
 
-        Generally, if the ULP error exceeds the 2**(#mantissa bits) (128-ULP for bfloat16, 8388608 for float32), then it means that both outputs are different by more than an order of magnitude.
-        For these cases, functions such as `assert_allclose(golden, calculated, rtol, atol)` should be used instead.
     Returns:
         tuple: A tuple containing:
             - ulp_passed (bool): True if ulp check passed, False otherwise


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

`assert_with_ulp()`, and other ULP-related functions are meant to be used when error between golden outputs and calculated outputs is known to be small (a few dozens ULPs in difference). However, this is not stated in the documentation.

Moreover, `assert_with_ulp()` returns wrong results when comparing `bfloat8_b` tensors. That's because `to_torch()` converts these tensors to `torch.float32` rather than `torch.bfloat16`. 

### What's changed

This improves documentation for `assert_with_ulp()`.
Also, when provided with bfloat8_b ttnn tensors, `assert_with_ulp()` will properly return expected ULP error. This is achieved by explicitly converting tensor to bfloat16 rather than the default of float32.

Note: If bfloat8_b tensor was converted to torch before calling `assert_with_ulp()` then it will be float32 and `assert_with_ulp()` will treat it as such. 
To evaluate `bfloat8_b` results, either pass ttnn tensor to `assert_with_ulp()` or convert it to bfloat16 before calling `assert_with_ulp` function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes  : https://github.com/tenstorrent/tt-metal/actions/runs/16466743383
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes