### PR TITLE
Remove unused (& broken) accessors.

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -96,14 +96,6 @@ public:
     }
 #endif
 
-    FORCE_INLINE bool needs_to_send_channel_sync() const { return this->need_to_send_channel_sync; }
-
-    FORCE_INLINE void set_need_to_send_channel_sync(bool need_to_send_channel_sync) {
-        this->need_to_send_channel_sync = need_to_send_channel_sync;
-    }
-
-    FORCE_INLINE void clear_need_to_send_channel_sync() { this->need_to_send_channel_sync = false; }
-
     FORCE_INLINE size_t get_cached_next_buffer_slot_addr() const { return this->cached_next_buffer_slot_addr; }
 
     FORCE_INLINE void set_cached_next_buffer_slot_addr(size_t next_buffer_slot_addr) {


### PR DESCRIPTION
### Ticket
NA

### Problem description
In testing an sfpi update to gcc-15, I fell over this bug -- there's no such member variable.  As it's a template and we're using 'this->member' to access it, the compiler used to defer checking until instantiation time.  And apparently this is never being instantiated.  Anyway, GCC 15 spots that there are no dependent bases, so the lookup must resolve at parse time, and it complains. (grepping the source base for uses of these accessors leads to zero hits)

### What's changed
1) added a default initialized member
2) rename getter from `needs_to_send_channel_sync` to `get_need_to_send_channel_sync`, which matches the setter and clearer names.

Testing this with an updated gcc-15 right now.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes