### PR TITLE
[DM]: Removing arch dependency from write APIs

### DIFF
--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -1138,6 +1138,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  */
 // clang-format on
 template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
     bool update_addr_lo = false,
     bool update_addr_hi = false,
     bool update_val = false,

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -995,3 +995,65 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
     // left-over packet
     ncrisc_noc_write_with_state<noc_mode, non_posted>(noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
 }
+
+template <bool posted = false, bool set_val = false>
+inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
+    uint32_t noc, uint32_t cmd_buf, uint32_t val, uint64_t dest_addr, uint32_t be, uint32_t static_vc) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    if constexpr (set_val) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
+    }
+
+    uint32_t noc_cmd_field = NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(static_vc) | NOC_CMD_CPY | NOC_CMD_WR |
+                             NOC_CMD_WR_INLINE | 0x0 | (posted ? 0x0 : NOC_CMD_RESP_MARKED);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)dest_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(dest_addr >> 32) & NOC_PCIE_MASK);
+    NOC_CMD_BUF_WRITE_REG(
+        noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+
+    // If we're given a misaligned address, don't write to the bytes in the word below the address
+    uint32_t be32 = be << (dest_addr & (NOC_WORD_BYTES - 1));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+}
+
+template <
+    bool update_addr_lo = false,
+    bool update_addr_hi = false,
+    bool update_val = false,
+    bool posted = false,
+    bool update_counter = true>
+inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
+    uint32_t noc, uint32_t cmd_buf, uint32_t val = 0, uint64_t dest_addr = 0) {
+    static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
+    if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
+        }
+    }
+
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    if constexpr (update_addr_lo) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
+    } else if constexpr (update_addr_hi) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
+    }
+    if constexpr (update_val) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+
+    if constexpr (update_counter && noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += 1;
+        }
+    }
+}

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -198,7 +198,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_read_with_transaction_id_f
     return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool update_counter = true>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -212,7 +212,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     bool multicast_path_reserve,
     bool posted = false,
     uint32_t trid = 0) {
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+    if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
         if (posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
         } else {
@@ -239,7 +239,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+    if constexpr (update_counter && noc_mode == DM_DEDICATED_NOC) {
         if (posted) {
             noc_posted_writes_num_issued[noc] += 1;
         } else {
@@ -940,16 +940,18 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
     }
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool non_posted = true, bool one_packet = false>
+template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
+    bool non_posted = true,
+    bool update_counter = true,
+    bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes = 0) {
-    if constexpr (non_posted) {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+    if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (non_posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-        }
-    } else {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        } else {
             inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
         }
     }
@@ -963,13 +965,11 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
     }
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
-    if constexpr (non_posted) {
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
+    if constexpr (update_counter && noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (non_posted) {
             noc_nonposted_writes_num_issued[noc] += 1;
             noc_nonposted_writes_acked[noc] += 1;
-        }
-    } else {
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        } else {
             noc_posted_writes_num_issued[noc] += 1;
         }
     }

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -976,7 +976,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
  * | Argument                            | Description                                              | Data type | Valid range                                              | required |
  * |-------------------------------------|----------------------------------------------------------|-----------|----------------------------------------------------------|----------|
  * | noc                                 | NOC to use for the transaction                           | uint32_t  | 0 or 1                                                   | True     |
- * | cmd_buf                             | Xommand buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
+ * | cmd_buf                             | Command buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
  * | src_local_addr                      | Address in local L1 memory on source core                | uint32_t  | 0..1 MB                                                  | True     |
  * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
  * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | False    |
@@ -1031,7 +1031,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
  * | Argument                            | Description                                              | Data type | Valid range                                              | required |
  * |-------------------------------------|----------------------------------------------------------|-----------|----------------------------------------------------------|----------|
  * | noc                                 | NOC to use for the transaction                           | uint32_t  | 0 or 1                                                   | True     |
- * | cmd_buf                             | Xommand buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
+ * | cmd_buf                             | Command buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
  * | src_local_addr                      | Address in local L1 memory on source core                | uint32_t  | 0..1 MB                                                  | True     |
  * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
  * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | True     |

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -917,3 +917,81 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_any_len_with_state(
     // left-over packet
     ncrisc_noc_read_with_state<noc_mode, inc_num_issued>(noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
 }
+
+template <bool non_posted = true, bool one_packet = false>
+inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
+    uint32_t noc, uint32_t cmd_buf, uint64_t dst_noc_addr, uint32_t len_bytes = 0, const uint32_t vc = 0) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
+                             0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
+                             0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
+                             (non_posted ? NOC_CMD_RESP_MARKED : 0x0);
+
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    // Handles writing to PCIe
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & NOC_PCIE_MASK);
+    NOC_CMD_BUF_WRITE_REG(
+        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+
+    // If one packet, set data size
+    if constexpr (one_packet) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+}
+
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool non_posted = true, bool one_packet = false>
+inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
+    uint32_t noc, uint32_t cmd_buf, uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes = 0) {
+    if constexpr (non_posted) {
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
+        }
+    } else {
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        }
+    }
+
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_local_addr);
+    if constexpr (!one_packet) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+
+    if constexpr (non_posted) {
+        if constexpr (noc_mode == DM_DEDICATED_NOC) {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += 1;
+        }
+    } else {
+        if constexpr (noc_mode == DM_DEDICATED_NOC) {
+            noc_posted_writes_num_issued[noc] += 1;
+        }
+    }
+}
+
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool non_posted = true>
+inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
+    uint32_t noc, uint32_t cmd_buf, uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes) {
+    if (len_bytes > NOC_MAX_BURST_SIZE) {
+        // Set data size for while loop
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, NOC_MAX_BURST_SIZE);
+
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            ncrisc_noc_write_with_state<noc_mode, non_posted, true /* one_packet */>(
+                noc, cmd_buf, src_local_addr, dst_local_addr);
+
+            len_bytes -= NOC_MAX_BURST_SIZE;
+            src_local_addr += NOC_MAX_BURST_SIZE;
+            dst_local_addr += NOC_MAX_BURST_SIZE;
+        }
+    }
+
+    // left-over packet
+    ncrisc_noc_write_with_state<noc_mode, non_posted>(noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
+}

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -861,7 +861,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_local_addr, src_local_l1_addr);
 
     WAYPOINT("NWPW");
-    ncrisc_noc_write_with_state<noc_mode, non_posted, true /* one_packet */>(
+    ncrisc_noc_write_with_state<noc_mode, non_posted, true /* update_counter */, true /* one_packet */>(
         noc, write_cmd_buf, src_local_l1_addr, dst_local_addr);
     WAYPOINT("NWPD");
 }
@@ -1853,123 +1853,65 @@ void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
 
 template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
-    std::uint64_t dst_noc_addr,
+    uint64_t dst_noc_addr,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NAWW");
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, dst_noc_addr, 0, vc);
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
-    WAYPOINT("NAWD");
-    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
-                             0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
-                             0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
-                             (posted ? 0 : NOC_CMD_RESP_MARKED);
 
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
-#ifdef ARCH_BLACKHOLE
-    // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & NOC_PCIE_MASK);
-#endif
-    NOC_CMD_BUF_WRITE_REG(
-        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    ncrisc_noc_write_set_state<!posted, false /* one_packet */>(noc, cmd_buf, dst_noc_addr, 0 /* len_bytes */, vc);
+    WAYPOINT("NAWD");
 }
 
 template <bool update_counter = true, bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
-    std::uint32_t src_local_l1_addr,
-    std::uint32_t dst_noc_addr,
-    std::uint32_t size,
-    std::uint32_t trid,
+    uint32_t src_local_l1_addr,
+    uint32_t dst_local_addr,
+    uint32_t size,
+    uint32_t trid,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index) {
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        if constexpr (update_counter) {
-            if constexpr (posted) {
-                inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
-            } else {
-                inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-                inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-            }
-        }
-    }
-    WAYPOINT("NWPW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_WITH_STATE, 0ull, size, -1);
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
-    WAYPOINT("NWPD");
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc, dst_noc_addr, src_local_l1_addr, size);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        if constexpr (update_counter) {
-            if constexpr (posted) {
-                noc_posted_writes_num_issued[noc] += 1;
-            } else {
-                noc_nonposted_writes_num_issued[noc] += 1;
-                noc_nonposted_writes_acked[noc] += 1;
-            }
-        }
-    }
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc, dst_local_addr, src_local_l1_addr, size);
+
+    WAYPOINT("NWPW");
+    ncrisc_noc_set_transaction_id(noc, cmd_buf, trid);
+    ncrisc_noc_write_with_state<noc_mode, update_counter, !posted>(
+        noc, cmd_buf, src_local_l1_addr, dst_local_addr, size, trid);
+    WAYPOINT("NWPD");
 }
 
 template <bool update_counter = true, bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_with_trid(
-    std::uint32_t src_local_l1_addr,
-    std::uint64_t dst_noc_addr,
-    std::uint32_t size,
-    std::uint32_t trid,
+    uint32_t src_local_l1_addr,
+    uint64_t dst_noc_addr,
+    uint32_t size,
+    uint32_t trid,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        if constexpr (update_counter) {
-            if constexpr (posted) {
-                inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
-            } else {
-                inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-                inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-            }
-        }
-    }
     WAYPOINT("NAWW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size, -1);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    ncrisc_noc_fast_write<noc_mode, true /* use_trid */, update_counter>(
+        noc,
+        cmd_buf,
+        src_local_l1_addr,
+        dst_noc_addr,
+        size,
+        vc,
+        false,  // mcast
+        false,  // linked
+        1,      // num_dests
+        true,   // multicast_path_reserve
+        posted,
+        trid);
     WAYPOINT("NWPD");
-
-    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
-                             0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
-                             0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
-                             (posted ? 0 : NOC_CMD_RESP_MARKED);
-
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
-#ifdef ARCH_BLACKHOLE
-    // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & NOC_PCIE_MASK);
-#endif
-    NOC_CMD_BUF_WRITE_REG(
-        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        if constexpr (update_counter) {
-            if constexpr (posted) {
-                noc_posted_writes_num_issued[noc] += 1;
-            } else {
-                noc_nonposted_writes_num_issued[noc] += 1;
-                noc_nonposted_writes_acked[noc] += 1;
-            }
-        }
-    }
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2010,8 +2010,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
 
     WAYPOINT("NWPW");
     ncrisc_noc_set_transaction_id(noc, cmd_buf, trid);
-    ncrisc_noc_write_with_state<noc_mode, update_counter, !posted>(
-        noc, cmd_buf, src_local_l1_addr, dst_local_l1_addr, size, trid);
+    ncrisc_noc_write_with_state<noc_mode, !posted, update_counter>(
+        noc, cmd_buf, src_local_l1_addr, dst_local_l1_addr, size);
     WAYPOINT("NWPD");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1919,6 +1919,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     WAYPOINT("NAWW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size, -1);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
 
     ncrisc_noc_fast_write<noc_mode, true /* use_trid */, update_counter>(
         noc,

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1740,7 +1740,7 @@ template <
 FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
     WAYPOINT("NWIW");
-    noc_fast_write_dw_inline_with_state<update_addr_lo, update_addr_hi, update_val, posted, update_counter>(
+    noc_fast_write_dw_inline_with_state<noc_mode, update_addr_lo, update_addr_hi, update_val, posted, update_counter>(
         noc, cmd_buf, val, addr);
     WAYPOINT("NWID");
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -841,70 +841,29 @@ inline void noc_async_write_multicast(
 // this sets the state for issuing a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
-    std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    uint64_t dst_noc_addr, uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc);
 
     WAYPOINT("NWPW");
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    ncrisc_noc_write_set_state<non_posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
     WAYPOINT("NWPD");
-
-    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
-                             0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
-                             0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
-                             (non_posted ? NOC_CMD_RESP_MARKED : 0x0);
-
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
-#ifdef ARCH_BLACKHOLE
-    // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & NOC_PCIE_MASK);
-#endif
-    NOC_CMD_BUF_WRITE_REG(
-        noc,
-        write_cmd_buf,
-        NOC_RET_ADDR_COORDINATE,
-        (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
 }
 
 // TODO: write docs
 // this issues only a single packet with cmd buf state with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
-    std::uint32_t src_local_l1_addr, std::uint32_t dst_noc_addr, uint8_t noc = noc_index) {
+    uint32_t src_local_l1_addr, uint32_t dst_local_addr, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
 
-    if constexpr (non_posted) {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-        }
-    } else {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
-        }
-    }
-    WAYPOINT("NWPW");
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
-    WAYPOINT("NWPD");
-
     // In order to sanitize, need to grab full noc addr + xfer size from state.
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_noc_addr, src_local_l1_addr);
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_local_addr, src_local_l1_addr);
 
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-
-    if constexpr (non_posted) {
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_nonposted_writes_num_issued[noc] += 1;
-            noc_nonposted_writes_acked[noc] += 1;  // num_dests
-        }
-    } else {
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_posted_writes_num_issued[noc] += 1;
-        }
-    }
+    WAYPOINT("NWPW");
+    ncrisc_noc_write_with_state<noc_mode, non_posted, true /* one_packet */>(
+        noc, write_cmd_buf, src_local_l1_addr, dst_local_addr);
+    WAYPOINT("NWPD");
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -1035,6 +1035,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  */
 // clang-format on
 template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
     bool update_addr_lo = false,
     bool update_addr_hi = false,
     bool update_val = false,

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -818,6 +818,29 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_any_len_with_state(
     ncrisc_noc_read_with_state<noc_mode, inc_num_issued>(noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
 }
 
+// clang-format off
+/**
+ * Sets the stateful registers for an asynchronous write to a specified destination node located at
+ * NOC coordinates (x,y) at a local address (encoded as a uint64_t using \a
+ * get_noc_addr function). This function is used to set up the state for
+ * \a ncrisc_noc_write_with_state, which will issue the actual
+ * write request.
+ *
+ * The destination node can be either a DRAM bank, a Tensix core or a PCIe controller.
+ *
+ * Return value: None
+ *
+ * | Argument                        | Description                                              | Data type | Valid range                      | required |
+ * |---------------------------------|----------------------------------------------------------|-----------|----------------------------------|----------|
+ * | noc                             | NOC to use for the transaction                           | uint32_t  | 0 or 1                           | True     |
+ * | cmd_buf                         | Command buffer to use for the transaction                | uint32_t  | 0 - 3                            | True     |
+ * | dst_noc_addr                    | Encoding of the destination NOC location (x,y)+address   | uint64_t  | Results of \a get_noc_addr calls | True     |
+ * | len_bytes                       | Size of the transaction in bytes.                        | uint32_t  | 0..1 MB                          | False    |
+ * | vc                              | Which VC to use for the transaction                      | uint32_t  | 0 - 3                            | False    |
+ * | non_posted (template parameter) | Whether the transaction is nonposted (i.e. requires ack) | bool      | true or false                    | False    |
+ * | one_packet (template parameter) | Whether transaction size is <= NOC_MAX_BURST_SIZE        | bool      | true or false                    | False    |
+ */
+// clang-format on
 template <bool non_posted = true, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
     uint32_t noc, uint32_t cmd_buf, uint64_t dst_noc_addr, uint32_t len_bytes = 0, const uint32_t vc = 0) {
@@ -838,6 +861,29 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
     }
 }
 
+// clang-format off
+/**
+ * Initiates an asynchronous write to a specified destination node located at
+ * NOC coordinates (x,y) at a local address (encoded as a uint64_t using \a
+ * get_noc_addr function). This function must be preceded by a call to
+ * \a ncrisc_noc_write_set_state. This function is used to issue the actual
+ * write request after the state has been set up.
+ *
+ * Return value: None
+ *
+ * | Argument                            | Description                                              | Data type | Valid range                                              | required |
+ * |-------------------------------------|----------------------------------------------------------|-----------|----------------------------------------------------------|----------|
+ * | noc                                 | NOC to use for the transaction                           | uint32_t  | 0 or 1                                                   | True     |
+ * | cmd_buf                             | Xommand buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
+ * | src_local_addr                      | Address in local L1 memory on source core                | uint32_t  | 0..1 MB                                                  | True     |
+ * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
+ * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | False    |
+ * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
+ * | non_posted (template parameter)     | Whether the transaction is nonposted (i.e. requires ack) | bool      | true or false                                            | False    |
+ * | update_counter (template parameter) | Whether to increment write counters                      | bool      | true or false                                            | False    |
+ * | one_packet (template parameter)     | Whether transaction size is <= NOC_MAX_BURST_SIZE        | bool      | true or false                                            | False    |
+ */
+// clang-format on
 template <
     uint8_t noc_mode = DM_DEDICATED_NOC,
     bool non_posted = true,
@@ -873,7 +919,26 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
     }
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool non_posted = true>
+// clang-format off
+/**
+ * Initiates an asynchronous write for all transaction sizes.
+ * Refer to \a ncrisc_noc_write_with_state for more details.
+ *
+ * Return value: None
+ *
+ * | Argument                            | Description                                              | Data type | Valid range                                              | required |
+ * |-------------------------------------|----------------------------------------------------------|-----------|----------------------------------------------------------|----------|
+ * | noc                                 | NOC to use for the transaction                           | uint32_t  | 0 or 1                                                   | True     |
+ * | cmd_buf                             | Xommand buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
+ * | src_local_addr                      | Address in local L1 memory on source core                | uint32_t  | 0..1 MB                                                  | True     |
+ * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
+ * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | True     |
+ * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
+ * | non_posted (template parameter)     | Whether the transaction is nonposted (i.e. requires ack) | bool      | true or false                                            | False    |
+ * | update_counter (template parameter) | Whether to increment write counters                      | bool      | true or false                                            | False    |
+ */
+// clang-format on
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool non_posted = true, bool update_counter = true>
 inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes) {
     if (len_bytes > NOC_MAX_BURST_SIZE) {
@@ -881,7 +946,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, NOC_MAX_BURST_SIZE);
 
         while (len_bytes > NOC_MAX_BURST_SIZE) {
-            ncrisc_noc_write_with_state<noc_mode, non_posted, true /* one_packet */>(
+            ncrisc_noc_write_with_state<noc_mode, non_posted, update_counter, true /* one_packet */>(
                 noc, cmd_buf, src_local_addr, dst_local_addr);
 
             len_bytes -= NOC_MAX_BURST_SIZE;
@@ -891,9 +956,35 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
     }
 
     // left-over packet
-    ncrisc_noc_write_with_state<noc_mode, non_posted>(noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
+    ncrisc_noc_write_with_state<noc_mode, non_posted, update_counter>(
+        noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
 }
 
+// clang-format off
+/**
+ * Sets the stateful registers for an inline write of a 32-bit value to a NOC destination.
+ * This function is used to set up the state for \a noc_fast_write_dw_inline_with_state, which will issue the actual
+ * write request. The 32-bit value and part of the destination address can be set later in \a noc_fast_write_dw_inline_with_state.
+ *
+ * The destination node can be either a Tensix core+L1 memory
+ * address or a PCIe controller; This API does not support DRAM addresses.
+ *
+ * Note: On Blackhole, this API can only write to stream registers, writing to L1 will cause hangs!
+ *
+ * Return value: None
+ *
+ * | Argument                     | Description                                            | Type     | Valid Range                      | Required |
+ * |------------------------------|--------------------------------------------------------|----------|----------------------------------|----------|
+ * | noc                          | NOC to use for the transaction                         | uint32_t | 0 or 1                           | True     |
+ * | cmd_buf                      | Command buffer to use for the transaction              | uint32_t | 0 - 3                            | True     |
+ * | dest_addr                    | Encoding of the destination NOC location (x,y)+address | uint64_t | Results of \a get_noc_addr calls | True     |
+ * | be                           | Byte-enable                                            | uint32_t | 0x1-0xF                          | True     |
+ * | static_vc                    | VC to use for the transaction                          | uint32_t | 0 - 3 (Unicast VCs)              | True     |
+ * | val                          | The value to be written                                | uint32_t | Any uint32_t value               | False    |
+ * | posted (template parameter)  | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
+ * | set_val (template parameter) | Whether to set the value for the write here            | bool     | true or false                    | False    |
+ */
+// clang-format on
 template <bool posted = false, bool set_val = false>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t be, uint32_t static_vc, uint32_t val = 0) {
@@ -915,6 +1006,34 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
 }
 
+// clang-format off
+/**
+ * Initiates an inline write of a 32-bit value to a NOC destination.
+ * This function must be preceded by a call to \a noc_fast_write_dw_inline_set_state.
+ * This function is used to issue the actual write request after the state has been set up.
+ * The 32-bit value and part of the destination address can also be set in this API
+ * (Either hi or lo address should be getting updated).
+ *
+ * The destination node can be either a Tensix core+L1 memory
+ * address or a PCIe controller; This API does not support DRAM addresses.
+ *
+ * Note: On Blackhole, this API can only write to stream registers, writing to L1 will cause hangs!
+ *
+ * Return value: None
+ *
+ * | Argument                            | Description                                            | Type     | Valid Range                      | Required |
+ * |-------------------------------------|--------------------------------------------------------|----------|----------------------------------|----------|
+ * | noc                                 | NOC to use for the transaction                         | uint32_t | 0 or 1                           | True     |
+ * | cmd_buf                             | Command buffer to use for the transaction              | uint32_t | 0 - 3                            | True     |
+ * | val                                 | The value to be written                                | uint32_t | Any uint32_t value               | False    |
+ * | dest_addr                           | Encoding of the destination NOC location (x,y)+address | uint64_t | Results of \a get_noc_addr calls | False    |
+ * | update_addr_lo (template parameter) | Whether to update the lower 32 bits of the address     | bool     | true or false                    | False    |
+ * | update_addr_hi (template parameter) | Whether to update the upper 32 bits of the address     | bool     | true or false                    | False    |
+ * | update_val (template parameter)     | Whether to set the value to be written                 | bool     | true or false                    | False    |
+ * | posted (template parameter)         | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
+ * | update_counter (template parameter) | Whether to update the write counters                   | bool     | true or false                    | False    |
+ */
+// clang-format on
 template <
     bool update_addr_lo = false,
     bool update_addr_hi = false,

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -874,7 +874,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
  * | Argument                            | Description                                              | Data type | Valid range                                              | required |
  * |-------------------------------------|----------------------------------------------------------|-----------|----------------------------------------------------------|----------|
  * | noc                                 | NOC to use for the transaction                           | uint32_t  | 0 or 1                                                   | True     |
- * | cmd_buf                             | Xommand buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
+ * | cmd_buf                             | Command buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
  * | src_local_addr                      | Address in local L1 memory on source core                | uint32_t  | 0..1 MB                                                  | True     |
  * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
  * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | False    |
@@ -929,7 +929,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
  * | Argument                            | Description                                              | Data type | Valid range                                              | required |
  * |-------------------------------------|----------------------------------------------------------|-----------|----------------------------------------------------------|----------|
  * | noc                                 | NOC to use for the transaction                           | uint32_t  | 0 or 1                                                   | True     |
- * | cmd_buf                             | Xommand buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
+ * | cmd_buf                             | Command buffer to use for the transaction                | uint32_t  | 0 - 3                                                    | True     |
  * | src_local_addr                      | Address in local L1 memory on source core                | uint32_t  | 0..1 MB                                                  | True     |
  * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
  * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | True     |


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23801)

### Problem description
`dataflow_api.h` contains functions that contain NOC commands which are arch dependent. All of these functions need to be arch agnostic in dataflow api, and should be lowered to `noc_nonblocking` instead.

### What's changed
Lowered all arch dependent functions in write APIs into `noc_nonblocking_api` and adjusted these dataflow APIs to call them accordingly, with the exception of `noc_inline_dw_write`. This API will be investigated in another PR. Also added docstrings for any modified APIs in dataflow and noc_nonblocking.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16580993387) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16580995961) CI passes
- [x] [Single card perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/16581002687)
- [x] [T3K perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/16581000725)
- [x] [TG perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/16580998011)
- [ ] [metal - Run microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/workflows/metal-run-microbenchmarks.yaml)