### PR TITLE
#11406: Query SystemMesh global and local shape in python

### DIFF
--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -35,13 +35,16 @@ namespace ttnn::distributed {
 
 struct SystemMeshDescriptor {
 private:
-    tt::tt_metal::distributed::SystemMesh& system_mesh_;
+    const MeshShape& global_shape_;
+    const MeshShape& local_shape_;
 
 public:
-    SystemMeshDescriptor() : system_mesh_(tt::tt_metal::distributed::SystemMesh::instance()) {}
+    SystemMeshDescriptor() :
+        global_shape_(tt::tt_metal::distributed::SystemMesh::instance().shape()),
+        local_shape_(tt::tt_metal::distributed::SystemMesh::instance().local_shape()) {}
 
-    const MeshShape& shape() const { return system_mesh_.shape(); }
-    const MeshShape& local_shape() const { return system_mesh_.local_shape(); }
+    const MeshShape& shape() const { return global_shape_; }
+    const MeshShape& local_shape() const { return local_shape_; }
 };
 
 namespace py = pybind11;
@@ -215,6 +218,7 @@ void py_module(py::module& module) {
         .def(
             "create_submeshes",
             &MeshDevice::create_submeshes,
+            py::arg("submesh_shape"),
             py::keep_alive<1, 0>())  // Keep MeshDevice alive as long as SubmeshDevices are alive
         .def(
             "get_submeshes",

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -33,10 +33,10 @@ using namespace tt::tt_metal;
 
 namespace ttnn::distributed {
 
-struct SystemMeshDescriptor {
+class SystemMeshDescriptor {
 private:
-    const MeshShape& global_shape_;
-    const MeshShape& local_shape_;
+    MeshShape global_shape_;
+    MeshShape local_shape_;
 
 public:
     SystemMeshDescriptor() :

--- a/ttnn/ttnn/distributed/__init__.py
+++ b/ttnn/ttnn/distributed/__init__.py
@@ -22,6 +22,6 @@ from .distributed import (
     get_device_ids,
     create_mesh_device,
     visualize_mesh_device,
-    print_system_mesh_shape,
+    visualize_system_mesh,
     distribute,
 )

--- a/ttnn/ttnn/distributed/__init__.py
+++ b/ttnn/ttnn/distributed/__init__.py
@@ -22,5 +22,6 @@ from .distributed import (
     get_device_ids,
     create_mesh_device,
     visualize_mesh_device,
+    print_system_mesh_shape,
     distribute,
 )

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -114,6 +114,34 @@ def visualize_mesh_device(mesh_device: "ttnn.MeshDevice", tensor: "ttnn.Tensor" 
     Console().print(mesh_table)
 
 
+def print_system_mesh_shape(show_global: bool = True, show_local: bool = True):
+    """
+    Print SystemMesh global and/or local shapes.
+
+    Args:
+        show_global (bool): Whether to show SystemMesh global shape. Defaults to True.
+        show_local (bool): Whether to show SystemMesh local shape. Defaults to True.
+    """
+    from rich.console import Console
+    from loguru import logger
+
+    try:
+        system_mesh_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()
+        global_shape = system_mesh_desc.shape()
+        local_shape = system_mesh_desc.local_shape()
+    except Exception as e:
+        logger.error(f"Error accessing SystemMesh: {e}")
+        return
+
+    console = Console()
+
+    if show_global:
+        console.print(f"\n[bold blue]SystemMesh Global Shape: {global_shape}[/bold blue]")
+
+    if show_local:
+        console.print(f"\n[bold green]SystemMesh Local Shape: {local_shape}[/bold green]")
+
+
 def get_num_devices() -> List[int]:
     return ttnn._ttnn.device.GetNumAvailableDevices()
 
@@ -288,4 +316,7 @@ def distribute(default: Union[ttnn.CppTensorToMesh, ReplicateTensorToMeshWrapper
         ttnn.to_torch = _original_to_torch
 
 
-__all__ = []
+__all__ = [
+    "get_system_mesh_descriptor",
+    "visualize_system_mesh",
+]

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -114,13 +114,9 @@ def visualize_mesh_device(mesh_device: "ttnn.MeshDevice", tensor: "ttnn.Tensor" 
     Console().print(mesh_table)
 
 
-def print_system_mesh_shape(show_global: bool = True, show_local: bool = True):
+def visualize_system_mesh():
     """
-    Print SystemMesh global and/or local shapes.
-
-    Args:
-        show_global (bool): Whether to show SystemMesh global shape. Defaults to True.
-        show_local (bool): Whether to show SystemMesh local shape. Defaults to True.
+    Print SystemMesh global and local shapes.
     """
     from rich.console import Console
     from loguru import logger
@@ -134,12 +130,8 @@ def print_system_mesh_shape(show_global: bool = True, show_local: bool = True):
         return
 
     console = Console()
-
-    if show_global:
-        console.print(f"\n[bold blue]SystemMesh Global Shape: {global_shape}[/bold blue]")
-
-    if show_local:
-        console.print(f"\n[bold green]SystemMesh Local Shape: {local_shape}[/bold green]")
+    console.print(f"\n[bold blue]SystemMesh Global Shape: {global_shape}[/bold blue]")
+    console.print(f"\n[bold green]SystemMesh Local Shape: {local_shape}[/bold green]")
 
 
 def get_num_devices() -> List[int]:
@@ -316,7 +308,4 @@ def distribute(default: Union[ttnn.CppTensorToMesh, ReplicateTensorToMeshWrapper
         ttnn.to_torch = _original_to_torch
 
 
-__all__ = [
-    "get_system_mesh_descriptor",
-    "visualize_system_mesh",
-]
+__all__ = []


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11406)

### Problem description
At this time, there is no support to query/visualize SystemMesh details in python.

### What's changed
Now SystemMesh global and local shapes are exposed and can be queried in python from the ttnn module. Visualization perhaps coming soon.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (Link to run: https://github.com/tenstorrent/tt-metal/actions/runs/16451491575/job/46568076277)