### PR TITLE
Mark last fast dispatch dump for each device

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -292,7 +292,7 @@ def test_dispatch_cores():
 @skip_for_blackhole()
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
-    REF_COUNT_DICT = {"Ethernet CQ Dispatch": [590, 1220, 1430, 1660, 2320], "Ethernet CQ Prefetch": [1180, 4630]}
+    REF_COUNT_DICT = {"Ethernet CQ Dispatch": [590, 840, 1430, 1660, 2320], "Ethernet CQ Prefetch": [572, 4030]}
     devicesData = run_device_profiler_test(
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
         setupAutoExtract=True,

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -6,7 +6,7 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerDumpState { NORMAL, FORCE_UMD_READ, ONLY_DISPATCH_CORES };
+enum class ProfilerDumpState { NORMAL, FORCE_UMD_READ, ONLY_DISPATCH_CORES, LAST_FD_DUMP };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
 enum class ProfilerDataBufferSource { L1, DRAM };
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -523,11 +523,7 @@ bool MeshDevice::close() {
     ZoneScoped;
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
-    // We only dump profile results for mesh devices that don't have any submeshes as they have active mesh command
-    // queues, whereas mesh devices with submeshes don't.
-    if (this->submeshes_.empty()) {
-        DumpMeshDeviceProfileResults(*this);
-    }
+    DumpMeshDeviceProfileResults(*this, ProfilerDumpState::LAST_FD_DUMP);
 
     // TODO #20966: Remove these calls
     for (auto device : view_->get_devices()) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -814,9 +814,10 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
         }
     }
 
+    // TODO(MO): Remove when legacy non-mesh device is removed
     for (const chip_id_t device_id : devices_to_close) {
         IDevice* device = tt::DevicePool::instance().get_active_device(device_id);
-        detail::DumpDeviceProfileResults(device);
+        detail::DumpDeviceProfileResults(device, ProfilerDumpState::LAST_FD_DUMP);
     }
 
     dispatch_firmware_active_ = false;

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1330,6 +1330,12 @@ CoreCoord DeviceProfiler::getPhysicalAddressFromVirtual(chip_id_t device_id, con
     return c;
 }
 
+void DeviceProfiler::setLastFDDumpAsNotDone() { this->is_last_fd_dump_done = false; }
+
+void DeviceProfiler::setLastFDDumpAsDone() { this->is_last_fd_dump_done = true; }
+
+bool DeviceProfiler::isLastFDDumpDone() const { return this->is_last_fd_dump_done; }
+
 DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
 #if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
@@ -1341,6 +1347,7 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
         std::filesystem::remove(log_path);
     }
 
+    this->is_last_fd_dump_done = false;
     this->current_zone_it = device_events.begin();
     device_events.reserve(
         (MAX_RISCV_PER_CORE * PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC * device->compute_with_storage_grid_size().x *

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -124,6 +124,9 @@ private:
     // Device frequency
     int device_core_frequency;
 
+    // Last fast dispatch dump performed flag
+    bool is_last_fd_dump_done;
+
     // Smallest timestamp
     uint64_t smallest_timestamp = (1lu << 63);
 
@@ -345,6 +348,13 @@ public:
 
     // Get zone details for the zone corresponding to the given timer id
     ZoneDetails getZoneDetails(uint16_t timer_id) const;
+
+    // setter and getter on last fast dispatch dump
+    void setLastFDDumpAsDone();
+
+    void setLastFDDumpAsNotDone();
+
+    bool isLastFDDumpDone() const;
 };
 
 bool useFastDispatchForControlBuffers(const IDevice* device, ProfilerDumpState state);


### PR DESCRIPTION
### Ticket
#25432 

### Problem description
Dump device profiler in device close is hanging in some mesh device setups

### What's changed
Dump device profiler as the first call in close mesh device

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16456282326/job/46563203249) 
- [x] [Post commit follow up profiler regression](https://github.com/tenstorrent/tt-metal/actions/runs/16475253567) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16454111657)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/16475238428/job/46575899680) 
- [x] [uBenchmark](https://github.com/tenstorrent/tt-metal/actions/runs/16454135816/job/46508314569)