### PR TITLE
Shrink tensix connection info region

### DIFF
--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -99,40 +99,38 @@ static_assert(sizeof(tensix_routing_l1_info_t) == 2064, "Struct size mismatch!")
 constexpr std::uint8_t USE_DYNAMIC_CREDIT_ADDR = 255;
 
 struct fabric_connection_info_t {
-    uint32_t edm_direction;
+    uint8_t edm_direction;
     uint32_t edm_noc_xy;  // packed x,y coordinates
     uint32_t edm_buffer_base_addr;
-    uint32_t num_buffers_per_channel;
+    uint8_t num_buffers_per_channel;
     uint32_t edm_l1_sem_addr;
     uint32_t edm_connection_handshake_addr;
     uint32_t edm_worker_location_info_addr;
-    uint32_t buffer_size_bytes;
+    uint16_t buffer_size_bytes;
     uint32_t buffer_index_semaphore_id;
-    uint32_t padding[3];
+} __attribute__((packed));
+
+static_assert(sizeof(fabric_connection_info_t) == 28, "Struct size mismatch!");
+
+struct fabric_aligned_connection_info_t {
     // 16-byte aligned semaphore address for flow control
     uint32_t worker_flow_control_semaphore;
-} __attribute__((aligned(16)));
-
-// Ensure worker_flow_control_semaphore is properly aligned for pointer access in all array elements
-static_assert(
-    offsetof(fabric_connection_info_t, worker_flow_control_semaphore) % 16 == 0,
-    "worker_flow_control_semaphore must be 16-byte aligned for safe pointer access");
-
-// Ensure the struct itself is 16-byte aligned so that worker_flow_control_semaphore
-// remains aligned in connections array
-static_assert(
-    sizeof(fabric_connection_info_t) % 16 == 0,
-    "fabric_connection_info_t size must be a multiple of 16 bytes to maintain worker_flow_control_semaphore alignment "
-    "in arrays");
+    uint32_t padding_0[3];
+} __attribute__((packed));
 
 struct tensix_fabric_connections_l1_info_t {
     static constexpr uint8_t MAX_FABRIC_ENDPOINTS = 16;
     // Each index corresponds to ethernet channel index
     fabric_connection_info_t connections[MAX_FABRIC_ENDPOINTS];
     uint32_t valid_connections_mask;  // bit mask indicating which connections are valid
-    uint8_t padding[12];              // pad to cache line alignment
+    uint32_t padding_0[3];            // pad to 16-byte alignment
+    fabric_aligned_connection_info_t aligned_connections[MAX_FABRIC_ENDPOINTS];
 };
 
-static_assert(sizeof(tensix_fabric_connections_l1_info_t) == 1040, "Struct size mismatch!");
+static_assert(sizeof(tensix_fabric_connections_l1_info_t) == 720, "Struct size mismatch!");
+static_assert(
+    offsetof(tensix_fabric_connections_l1_info_t, aligned_connections) == 464,
+    "Aligned connections offset must be 672 bytes!");
+static_assert(sizeof(tensix_fabric_connections_l1_info_t) % 16 == 0, "Struct size must be 16-byte aligned!");
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -117,7 +117,7 @@ struct fabric_aligned_connection_info_t {
     // 16-byte aligned semaphore address for flow control
     uint32_t worker_flow_control_semaphore;
     uint32_t padding_0[3];
-} __attribute__((packed));
+};
 
 struct tensix_fabric_connections_l1_info_t {
     static constexpr uint8_t MAX_FABRIC_ENDPOINTS = 16;

--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -100,7 +100,8 @@ constexpr std::uint8_t USE_DYNAMIC_CREDIT_ADDR = 255;
 
 struct fabric_connection_info_t {
     uint8_t edm_direction;
-    uint32_t edm_noc_xy;  // packed x,y coordinates
+    uint8_t edm_noc_x;
+    uint8_t edm_noc_y;
     uint32_t edm_buffer_base_addr;
     uint8_t num_buffers_per_channel;
     uint32_t edm_l1_sem_addr;
@@ -110,7 +111,7 @@ struct fabric_connection_info_t {
     uint32_t buffer_index_semaphore_id;
 } __attribute__((packed));
 
-static_assert(sizeof(fabric_connection_info_t) == 28, "Struct size mismatch!");
+static_assert(sizeof(fabric_connection_info_t) == 26, "Struct size mismatch!");
 
 struct fabric_aligned_connection_info_t {
     // 16-byte aligned semaphore address for flow control
@@ -127,9 +128,9 @@ struct tensix_fabric_connections_l1_info_t {
     fabric_aligned_connection_info_t aligned_connections[MAX_FABRIC_ENDPOINTS];
 };
 
-static_assert(sizeof(tensix_fabric_connections_l1_info_t) == 720, "Struct size mismatch!");
+static_assert(sizeof(tensix_fabric_connections_l1_info_t) == 688, "Struct size mismatch!");
 static_assert(
-    offsetof(tensix_fabric_connections_l1_info_t, aligned_connections) == 464,
+    offsetof(tensix_fabric_connections_l1_info_t, aligned_connections) == 432,
     "Aligned connections offset must be 672 bytes!");
 static_assert(sizeof(tensix_fabric_connections_l1_info_t) % 16 == 0, "Struct size must be 16-byte aligned!");
 

--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -93,9 +93,6 @@ struct tensix_routing_l1_info_t {
     std::uint8_t padding[8];  // pad to 16-byte alignment
 } __attribute__((packed));
 
-// MEM_TENSIX_ROUTING_TABLE_SIZE
-static_assert(sizeof(tensix_routing_l1_info_t) == 2064, "Struct size mismatch!");
-
 constexpr std::uint8_t USE_DYNAMIC_CREDIT_ADDR = 255;
 
 struct fabric_connection_info_t {
@@ -122,16 +119,10 @@ struct fabric_aligned_connection_info_t {
 struct tensix_fabric_connections_l1_info_t {
     static constexpr uint8_t MAX_FABRIC_ENDPOINTS = 16;
     // Each index corresponds to ethernet channel index
-    fabric_connection_info_t connections[MAX_FABRIC_ENDPOINTS];
+    fabric_connection_info_t read_only[MAX_FABRIC_ENDPOINTS];
     uint32_t valid_connections_mask;  // bit mask indicating which connections are valid
     uint32_t padding_0[3];            // pad to 16-byte alignment
-    fabric_aligned_connection_info_t aligned_connections[MAX_FABRIC_ENDPOINTS];
+    fabric_aligned_connection_info_t read_write[MAX_FABRIC_ENDPOINTS];
 };
-
-static_assert(sizeof(tensix_fabric_connections_l1_info_t) == 688, "Struct size mismatch!");
-static_assert(
-    offsetof(tensix_fabric_connections_l1_info_t, aligned_connections) == 432,
-    "Aligned connections offset must be 672 bytes!");
-static_assert(sizeof(tensix_fabric_connections_l1_info_t) % 16 == 0, "Struct size must be 16-byte aligned!");
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1453,8 +1453,8 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip
             const auto sender_channel = is_2d_fabric ? router_direction : 0;
             auto& connection_info = fabric_connections.connections[eth_channel_id];
             connection_info.edm_direction = router_direction;
-            connection_info.edm_noc_xy =
-                tt::tt_fabric::WorkerXY(fabric_router_virtual_core.x, fabric_router_virtual_core.y).to_uint32();
+            connection_info.edm_noc_x = static_cast<uint8_t>(fabric_router_virtual_core.x);
+            connection_info.edm_noc_y = static_cast<uint8_t>(fabric_router_virtual_core.y);
             connection_info.edm_buffer_base_addr = edm_config.sender_channels_base_address[sender_channel];
             connection_info.num_buffers_per_channel = edm_config.sender_channels_num_buffers[sender_channel];
             connection_info.edm_l1_sem_addr =

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1451,7 +1451,7 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip
 
             // Populate connection info for fabric-routed channels
             const auto sender_channel = is_2d_fabric ? router_direction : 0;
-            auto& connection_info = fabric_connections.connections[eth_channel_id];
+            auto& connection_info = fabric_connections.read_only[eth_channel_id];
             connection_info.edm_direction = router_direction;
             connection_info.edm_noc_x = static_cast<uint8_t>(fabric_router_virtual_core.x);
             connection_info.edm_noc_y = static_cast<uint8_t>(fabric_router_virtual_core.y);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -809,7 +809,8 @@ void append_worker_to_fabric_edm_sender_rt_args(
     tt::tt_fabric::tensix_fabric_connections_l1_info_t fabric_connections = {};
     auto& connection_info = fabric_connections.connections[eth_channel];
     connection_info.edm_direction = connection.edm_direction;
-    connection_info.edm_noc_xy = tt::tt_fabric::WorkerXY(connection.edm_noc_x, connection.edm_noc_y).to_uint32();
+    connection_info.edm_noc_x = connection.edm_noc_x;
+    connection_info.edm_noc_y = connection.edm_noc_y;
     connection_info.edm_buffer_base_addr = connection.edm_buffer_base_addr;
     connection_info.num_buffers_per_channel = connection.num_buffers_per_channel;
     connection_info.edm_l1_sem_addr = connection.edm_l1_sem_addr;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -807,7 +807,7 @@ void append_worker_to_fabric_edm_sender_rt_args(
     // copy "only" connections[eth_channel] to L1, not the whole tensix_fabric_connections_l1_info_t
     // because this function is called several times for same device which overwrites info written by previous calls
     tt::tt_fabric::tensix_fabric_connections_l1_info_t fabric_connections = {};
-    auto& connection_info = fabric_connections.connections[eth_channel];
+    auto& connection_info = fabric_connections.read_only[eth_channel];
     connection_info.edm_direction = connection.edm_direction;
     connection_info.edm_noc_x = connection.edm_noc_x;
     connection_info.edm_noc_y = connection.edm_noc_y;
@@ -823,7 +823,7 @@ void append_worker_to_fabric_edm_sender_rt_args(
     //       we want to reduce the number of write_core calls
     fabric_connections.valid_connections_mask |= (1u << eth_channel);
 
-    size_t connection_offset = offsetof(tt::tt_fabric::tensix_fabric_connections_l1_info_t, connections) +
+    size_t connection_offset = offsetof(tt::tt_fabric::tensix_fabric_connections_l1_info_t, read_only) +
                                eth_channel * sizeof(tt::tt_fabric::fabric_connection_info_t);
     // Write to Tensix cores
     std::vector<CoreCoord> worker_core_coords = corerange_to_cores(worker_cores, std::nullopt, true);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -70,7 +70,8 @@ struct WorkerToFabricEdmSenderImpl {
     static WorkerToFabricEdmSenderImpl build_from_args(std::size_t& arg_idx) {
         constexpr bool is_persistent_fabric = true;
         uint8_t direction;
-        WorkerXY edm_worker_xy(0, 0);
+        uint8_t edm_worker_x;
+        uint8_t edm_worker_y;
         uint32_t edm_buffer_base_addr;
         uint8_t num_buffers_per_channel;
         uint32_t edm_l1_sem_id;
@@ -93,7 +94,8 @@ struct WorkerToFabricEdmSenderImpl {
             const auto conn = &connection_info->connections[eth_channel];
             const auto aligned_conn = &aligned_info[eth_channel];
             direction = conn->edm_direction;
-            edm_worker_xy = WorkerXY::from_uint32(conn->edm_noc_xy);
+            edm_worker_x = conn->edm_noc_x;
+            edm_worker_y = conn->edm_noc_y;
             edm_buffer_base_addr = conn->edm_buffer_base_addr;
             num_buffers_per_channel = conn->num_buffers_per_channel;
             edm_l1_sem_id = conn->edm_l1_sem_addr;
@@ -107,7 +109,9 @@ struct WorkerToFabricEdmSenderImpl {
             // TODO: will be deprecated. currently for ethernet dispatch case
             //       ethernet core need to have same memory mapping as worker
             direction = static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++));
-            edm_worker_xy = WorkerXY::from_uint32(get_arg_val<uint32_t>(arg_idx++));
+            auto edm_worker_xy = WorkerXY::from_uint32(get_arg_val<uint32_t>(arg_idx++));
+            edm_worker_x = edm_worker_xy.x;
+            edm_worker_y = edm_worker_xy.y;
             edm_buffer_base_addr = get_arg_val<uint32_t>(arg_idx++);
             num_buffers_per_channel = static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++));
             edm_l1_sem_id = get_arg_val<uint32_t>(arg_idx++);
@@ -131,8 +135,8 @@ struct WorkerToFabricEdmSenderImpl {
         return WorkerToFabricEdmSenderImpl(
             is_persistent_fabric,
             direction,
-            edm_worker_xy.x,
-            edm_worker_xy.y,
+            edm_worker_x,
+            edm_worker_y,
             edm_buffer_base_addr,
             num_buffers_per_channel,
             edm_l1_sem_id,

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -86,8 +86,8 @@ struct WorkerToFabricEdmSenderImpl {
         if constexpr (my_core_type == ProgrammableCoreType::TENSIX) {
             tt_l1_ptr tensix_fabric_connections_l1_info_t* connection_info =
                 reinterpret_cast<tt_l1_ptr tensix_fabric_connections_l1_info_t*>(MEM_TENSIX_FABRIC_CONNECTIONS_BASE);
-            tt_l1_ptr tensix_fabric_aligned_connections_l1_info_t* aligned_info =
-                reinterpret_cast<tt_l1_ptr tensix_fabric_aligned_connections_l1_info_t*>(
+            tt_l1_ptr fabric_aligned_connection_info_t* aligned_info =
+                reinterpret_cast<tt_l1_ptr fabric_aligned_connection_info_t*>(
                     MEM_TENSIX_FABRIC_CONNECTIONS_BASE +
                     offsetof(tensix_fabric_connections_l1_info_t, aligned_connections));
             uint32_t eth_channel = get_arg_val<uint32_t>(arg_idx++);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -86,13 +86,9 @@ struct WorkerToFabricEdmSenderImpl {
         if constexpr (my_core_type == ProgrammableCoreType::TENSIX) {
             tt_l1_ptr tensix_fabric_connections_l1_info_t* connection_info =
                 reinterpret_cast<tt_l1_ptr tensix_fabric_connections_l1_info_t*>(MEM_TENSIX_FABRIC_CONNECTIONS_BASE);
-            tt_l1_ptr fabric_aligned_connection_info_t* aligned_info =
-                reinterpret_cast<tt_l1_ptr fabric_aligned_connection_info_t*>(
-                    MEM_TENSIX_FABRIC_CONNECTIONS_BASE +
-                    offsetof(tensix_fabric_connections_l1_info_t, aligned_connections));
             uint32_t eth_channel = get_arg_val<uint32_t>(arg_idx++);
-            const auto conn = &connection_info->connections[eth_channel];
-            const auto aligned_conn = &aligned_info[eth_channel];
+            const auto conn = &connection_info->read_only[eth_channel];
+            const auto aligned_conn = &connection_info->read_write[eth_channel];
             direction = conn->edm_direction;
             edm_worker_x = conn->edm_noc_x;
             edm_worker_y = conn->edm_noc_y;

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -113,13 +113,15 @@
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
-#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 1040  // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 720  // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO \
+    464  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
 #if (MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 != 0) || (MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 != 0)
 #error "Tensix fabric connections base and size must be 16-byte aligned"
 #endif
 
 // Read-only reserved memory boundary for watcher checks
-#define MEM_MAP_READ_ONLY_END MEM_TENSIX_FABRIC_CONNECTIONS_BASE
+#define MEM_MAP_READ_ONLY_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO)
 #define MEM_MAP_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_CONNECTIONS_SIZE)
 
 // Every address after MEM_MAP_END is a "scratch" address

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -113,9 +113,9 @@
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
-#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 720  // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 688  // sizeof(tensix_fabric_connections_l1_info_t)
 #define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO \
-    464  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
+    432  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
 #if (MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 != 0) || (MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 != 0)
 #error "Tensix fabric connections base and size must be 16-byte aligned"
 #endif

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -107,18 +107,11 @@
 // Tensix routing table for fabric networking
 #define MEM_TENSIX_ROUTING_TABLE_BASE (MEM_NOC_COUNTER_BASE + MEM_NOC_COUNTER_L1_SIZE)
 #define MEM_TENSIX_ROUTING_TABLE_SIZE 2064
-#if (MEM_TENSIX_ROUTING_TABLE_BASE % 16 != 0) || (MEM_TENSIX_ROUTING_TABLE_SIZE % 16 != 0)
-#error "Tensix routing table base and size must be 16-byte aligned"
-#endif
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
 #define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 688  // sizeof(tensix_fabric_connections_l1_info_t)
-#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO \
-    432  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
-#if (MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 != 0) || (MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 != 0)
-#error "Tensix fabric connections base and size must be 16-byte aligned"
-#endif
+#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO 432  // offsetof(tensix_fabric_connections_l1_info_t, read_write)
 
 // Read-only reserved memory boundary for watcher checks
 #define MEM_MAP_READ_ONLY_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO)

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -107,9 +107,9 @@
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
-#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 720  // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 688  // sizeof(tensix_fabric_connections_l1_info_t)
 #define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO \
-    464  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
+    432  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
 #if (MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 != 0) || (MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 != 0)
 #error "Tensix fabric connections base and size must be 16-byte aligned"
 #endif

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -107,13 +107,15 @@
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
-#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 1040  // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 720  // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO \
+    464  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
 #if (MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 != 0) || (MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 != 0)
 #error "Tensix fabric connections base and size must be 16-byte aligned"
 #endif
 
 // Read-only reserved memory boundary for watcher checks
-#define MEM_MAP_READ_ONLY_END MEM_TENSIX_FABRIC_CONNECTIONS_BASE
+#define MEM_MAP_READ_ONLY_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO)
 #define MEM_MAP_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_CONNECTIONS_SIZE)
 
 // Every address after MEM_MAP_END is a "scratch" address

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -101,18 +101,11 @@
 // Tensix routing table for fabric networking
 #define MEM_TENSIX_ROUTING_TABLE_BASE (MEM_NOC_COUNTER_BASE + MEM_NOC_COUNTER_L1_SIZE)
 #define MEM_TENSIX_ROUTING_TABLE_SIZE 2064
-#if (MEM_TENSIX_ROUTING_TABLE_BASE % 16 != 0) || (MEM_TENSIX_ROUTING_TABLE_SIZE % 16 != 0)
-#error "Tensix routing table base and size must be 16-byte aligned"
-#endif
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
 #define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 688  // sizeof(tensix_fabric_connections_l1_info_t)
-#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO \
-    432  // offsetof(tensix_fabric_connections_l1_info_t, aligned_connections)
-#if (MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 != 0) || (MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 != 0)
-#error "Tensix fabric connections base and size must be 16-byte aligned"
-#endif
+#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO 432  // offsetof(tensix_fabric_connections_l1_info_t, read_write)
 
 // Read-only reserved memory boundary for watcher checks
 #define MEM_MAP_READ_ONLY_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO)

--- a/tt_metal/llrt/blackhole/bh_hal_tensix_asserts.hpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix_asserts.hpp
@@ -10,6 +10,7 @@
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"
+#include "tt-metalium/fabric_host_interface.h"
 
 // Validate assumptions on mailbox layout on host compile
 // Constexpr definitions allow for printing of breaking values at compile time
@@ -21,3 +22,19 @@ static constexpr uint32_t TENSIX_PROFILER_CHECK =
 static_assert(TENSIX_LAUNCH_CHECK == 0);
 static_assert(TENSIX_PROFILER_CHECK == 0);
 static_assert(sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+
+static_assert(
+    sizeof(tt::tt_fabric::tensix_routing_l1_info_t) == MEM_TENSIX_ROUTING_TABLE_SIZE, "Struct size mismatch!");
+static_assert(
+    sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t) == MEM_TENSIX_FABRIC_CONNECTIONS_SIZE,
+    "Struct size mismatch!");
+static_assert(
+    offsetof(tt::tt_fabric::tensix_fabric_connections_l1_info_t, read_write) ==
+        MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO,
+    "Read-write connections offset must be 432 bytes!");
+static_assert(
+    sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t) % 16 == 0, "Struct size must be 16-byte aligned!");
+static_assert(MEM_TENSIX_ROUTING_TABLE_BASE % 16 == 0, "Tensix routing table base must be 16-byte aligned");
+static_assert(MEM_TENSIX_ROUTING_TABLE_SIZE % 16 == 0, "Tensix routing table size must be 16-byte aligned");
+static_assert(MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 == 0, "Tensix fabric connections base must be 16-byte aligned");
+static_assert(MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 == 0, "Tensix fabric connections size must be 16-byte aligned");

--- a/tt_metal/llrt/wormhole/wh_hal_tensix_asserts.hpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix_asserts.hpp
@@ -11,6 +11,7 @@
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"
 #include "eth_l1_address_map.h"
+#include "tt-metalium/fabric_host_interface.h"
 
 // Validate assumptions on mailbox layout on host compile
 // Constexpr definitions allow for printing of breaking values at compile time
@@ -28,3 +29,19 @@ static constexpr uint32_t TENSIX_PROFILER_CHECK =
 static_assert(TENSIX_LAUNCH_CHECK == 0);
 static_assert(TENSIX_PROFILER_CHECK == 0);
 static_assert(sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+
+static_assert(
+    sizeof(tt::tt_fabric::tensix_routing_l1_info_t) == MEM_TENSIX_ROUTING_TABLE_SIZE, "Struct size mismatch!");
+static_assert(
+    sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t) == MEM_TENSIX_FABRIC_CONNECTIONS_SIZE,
+    "Struct size mismatch!");
+static_assert(
+    offsetof(tt::tt_fabric::tensix_fabric_connections_l1_info_t, read_write) ==
+        MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO,
+    "Read-write connections offset must be 432 bytes!");
+static_assert(
+    sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t) % 16 == 0, "Struct size must be 16-byte aligned!");
+static_assert(MEM_TENSIX_ROUTING_TABLE_BASE % 16 == 0, "Tensix routing table base must be 16-byte aligned");
+static_assert(MEM_TENSIX_ROUTING_TABLE_SIZE % 16 == 0, "Tensix routing table size must be 16-byte aligned");
+static_assert(MEM_TENSIX_FABRIC_CONNECTIONS_BASE % 16 == 0, "Tensix fabric connections base must be 16-byte aligned");
+static_assert(MEM_TENSIX_FABRIC_CONNECTIONS_SIZE % 16 == 0, "Tensix fabric connections size must be 16-byte aligned");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23384

### Problem description
There are OoM happening by recent Tensix's L1 static reservation.
ttnn nightly conv test has the one (because this pipeline is not mandatory, we could not find)
https://github.com/tenstorrent/tt-metal/actions/runs/16428889952/job/46426514605
```
Statically allocated circular buffers in program 17259 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 310272 and static circular buffer region ends at 310336
```

### What's changed
1040 -> 688 bytes (-352 bytes)
- Use smaller type by following WorkerToFabricEdmSenderImpl member variables.
- Rearrange worker side send credit region to efficiently pack and make fabric_connection_info_t to be read-only region

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes