### PR TITLE
enable int32 on reshape

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -19,7 +19,7 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::UINT32 or
-            input_tensor_a.dtype() == DataType::FLOAT32,
+            input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::INT32,
         "Can only work with bfloat16/float32 or uint32 tensors");
     TT_FATAL(
         this->output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -20,7 +20,7 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
     TT_FATAL(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::UINT32 or
             input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::INT32,
-        "Can only work with bfloat16/float32 or uint32 tensors");
+        "Can only work with bfloat16/float32 or int32/uint32 tensors");
     TT_FATAL(
         this->output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),
         "Output tensor must have the same memory layout as input tensor");


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25583)

### Problem description
Reshape needs to support int32

### What's changed
Reshape already does support int32, just needed to enable it through removing fatal condition in reshape_device_op

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16630255780) CI passes
- [ ] [All post commit (rebased)](https://github.com/tenstorrent/tt-metal/actions/runs/16660929414) CI passes
- [ ] [single-card device perf](https://github.com/tenstorrent/tt-metal/actions/runs/16456263797)
- [ ] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16456279957)