### PR TITLE
Implement multi-device buffer throughput benchmark using DevicePool

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <chrono>
 #include <fmt/base.h>
 #include <fmt/format.h>
@@ -12,7 +13,6 @@
 #include <cmath>
 #include <cstring>
 #include <memory>
-#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -23,8 +23,9 @@
 #include <tt-metalium/device.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <benchmark/benchmark.h>
-#include "command_queue.hpp"
-#include "test_common.hpp"
+#include "device_pool.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "hostdevcommon/common_values.hpp"
 #include "impl/context/metal_context.hpp"
 
 using namespace tt;
@@ -42,17 +43,18 @@ using std::chrono::microseconds;
 // Page Size: 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
 // Transfer Size: 32k, 512M
 // Read & Write
-// Device: 0 (local), 1 (remote)
+// Device: 0 (local), 1 (remote) (when possible)
 //
 ////////////////////////////////////////////////////////////////////////////////
 
 static const auto PAGE_SIZE_ARGS = benchmark::CreateRange(32, 32768, 2);
 static const std::vector<int64_t> TRANSFER_SIZE_ARGS{32 * 1024, 512 * 1024 * 1024};
-static const auto BENCHMARK_ARGS = {PAGE_SIZE_ARGS, TRANSFER_SIZE_ARGS};
 
-static void BM_write(benchmark::State& state, tt_metal::IDevice* device) {
+static void BM_write(benchmark::State& state) {
     auto page_size = state.range(0);
     auto transfer_size = state.range(1);
+    auto device = DevicePool::instance().get_active_device(state.range(2));
+
     auto random_buffer_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
     auto device_buffer = Buffer::create(device, transfer_size, page_size, BufferType::DRAM);
@@ -66,9 +68,10 @@ static void BM_write(benchmark::State& state, tt_metal::IDevice* device) {
     state.SetBytesProcessed(transfer_size * state.iterations());
 }
 
-static void BM_read(benchmark::State& state, tt_metal::IDevice* device) {
+static void BM_read(benchmark::State& state) {
     auto page_size = state.range(0);
     auto transfer_size = state.range(1);
+    auto device = DevicePool::instance().get_active_device(state.range(2));
 
     auto device_buffer = Buffer::create(device, transfer_size, page_size, BufferType::DRAM);
     std::vector<uint32_t> host_buffer;
@@ -80,33 +83,34 @@ static void BM_read(benchmark::State& state, tt_metal::IDevice* device) {
     state.SetBytesProcessed(transfer_size * state.iterations());
 }
 
+std::vector<chip_id_t> setup_device_pool() {
+    auto available_device_ids = MetalContext::instance().get_cluster().all_chip_ids();
+    TT_ASSERT(available_device_ids.contains(0));
+
+    std::vector<chip_id_t> device_ids = {0};
+    log_info(tt::LogTest, "Device 1 available, enable testing on device 1 assuming it's a remote device");
+    if (available_device_ids.contains(1)) {
+        device_ids.push_back(1);
+    }
+
+    DevicePool::initialize(device_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{});
+
+    return device_ids;
+}
+
 int main(int argc, char** argv) {
     benchmark::Initialize(&argc, argv);
 
-    // TODO: Test Across Multiple devices.
-    auto device_id = 0;
-    if (device_id >= MetalContext::instance().get_cluster().number_of_devices()) {
-        log_info(LogTest, "Skip! Device id {} is not applicable on this system", device_id);
-        return 1;
-    }
+    auto device_args = setup_device_pool();
+    auto benchmark_args = {PAGE_SIZE_ARGS, TRANSFER_SIZE_ARGS, {device_args.begin(), device_args.end()}};
 
-    tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
-
-    if (!device->using_fast_dispatch()) {
-        log_info(LogTest, "Skip! This test needs to be run with fast dispatch enabled");
-        return 1;
-    }
-
-    benchmark::RegisterBenchmark("EnqueueWriteBuffer", BM_write, device)
-        ->ArgsProduct(BENCHMARK_ARGS)
-        // Google Benchmark uses CPU time to calculate throughput by default, which is not suitable for this
-        // benchmark
-        ->UseRealTime();
-
-    benchmark::RegisterBenchmark("EnqueueReadBuffer", BM_read, device)->ArgsProduct(BENCHMARK_ARGS)->UseRealTime();
+    // Google Benchmark uses CPU time to calculate throughput by default, which is not suitable for this
+    // benchmark
+    benchmark::RegisterBenchmark("EnqueueWriteBuffer", BM_write)->ArgsProduct(benchmark_args)->UseRealTime();
+    benchmark::RegisterBenchmark("EnqueueReadBuffer", BM_read)->ArgsProduct(benchmark_args)->UseRealTime();
 
     benchmark::RunSpecifiedBenchmarks();
-    tt_metal::CloseDevice(device);
+    DevicePool::instance().close_devices(DevicePool::instance().get_all_active_devices());
     benchmark::Shutdown();
 
     return 0;


### PR DESCRIPTION
### Ticket
#25132 

### Problem description
benchmark for buffer operations currently only test for local device (0).

### What's changed
Allow multiple device (0 and 1 (assumed to be connected by fabric))'s throughput to be tested.


### Benchmark Result
Note: This is tested on `aus-wh-01`, so it might be noisy.

Reads (measured mid day):

| Transfer Size | Page Size | Read throughput device 0 | Read throughput device 1 |
|--------------|-----------|--------------------------|--------------------------|
| 32768        | 32        | 336.823Mi/s             | 243.806Mi/s             |
| 32768        | 64        | 466.116Mi/s             | 351.234Mi/s             |
| 32768        | 128       | 570.844Mi/s             | 441.14Mi/s              |
| 32768        | 256       | 629.425Mi/s             | 447.78Mi/s              |
| 32768        | 512       | 617.321Mi/s             | 512.853Mi/s             |
| 32768        | 1024      | 657.089Mi/s             | 536.134Mi/s             |
| 32768        | 2048      | 640.884Mi/s             | 552.781Mi/s             |
| 32768        | 4096      | 639.27Mi/s              | 541.126Mi/s             |
| 32768        | 8192      | 641.054Mi/s             | 531.108Mi/s             |
| 32768        | 16384     | 643.625Mi/s             | 401.698Mi/s             |
| 32768        | 32768     | 686.491Mi/s             | 445.31Mi/s              |
| 536870912    | 32        | 473.908Mi/s             | 436.24Mi/s              |
| 536870912    | 64        | 740.972Mi/s             | 696.188Mi/s             |
| 536870912    | 128       | 1.39558Gi/s             | 989.123Mi/s             |
| 536870912    | 256       | 1.92272Gi/s             | 1.82436Gi/s             |
| 536870912    | 512       | 3.47778Gi/s             | 2.45531Gi/s             |
| 536870912    | 1024      | 5.10288Gi/s             | 2.42998Gi/s             |
| 536870912    | 2048      | 4.16059Gi/s             | 2.45295Gi/s             |
| 536870912    | 4096      | 6.55767Gi/s             | 1.96305Gi/s             |
| 536870912    | 8192      | 6.71842Gi/s             | 1.99789Gi/s             |
| 536870912    | 16384     | 6.74259Gi/s             | 2.45704Gi/s             |
| 536870912    | 32768     | 6.79246Gi/s             | 2.38757Gi/s             |

Writes:

| Transfer Size | Page Size | Write throughput device 0 | Write throughput device 1 |
|--------------|-----------|---------------------------|---------------------------|
| 32768        | 32        | 386.633Mi/s              | 328.929Mi/s              |
| 32768        | 64        | 629.42Mi/s               | 492.151Mi/s              |
| 32768        | 128       | 927.097Mi/s              | 678.479Mi/s              |
| 32768        | 256       | 1.24766Gi/s              | 824.826Mi/s              |
| 32768        | 512       | 1.52018Gi/s              | 951.986Mi/s              |
| 32768        | 1024      | 1.67216Gi/s              | 996.994Mi/s              |
| 32768        | 2048      | 1.72371Gi/s              | 1.04601Gi/s              |
| 32768        | 4096      | 1.71601Gi/s              | 1.03483Gi/s              |
| 32768        | 8192      | 1.73227Gi/s              | 1.04787Gi/s              |
| 32768        | 16384     | 1.71632Gi/s              | 1.14959Gi/s              |
| 32768        | 32768     | 1.72143Gi/s              | 1.04622Gi/s              |
| 536870912    | 32        | 500.502Mi/s              | 524.346Mi/s              |
| 536870912    | 64        | 999.378Mi/s              | 1.01943Gi/s              |
| 536870912    | 128       | 1.94352Gi/s              | 2.04726Gi/s              |
| 536870912    | 256       | 3.85913Gi/s              | 3.89082Gi/s              |
| 536870912    | 512       | 7.36238Gi/s              | 7.43393Gi/s              |
| 536870912    | 1024      | 11.9683Gi/s              | 7.93086Gi/s              |
| 536870912    | 2048      | 12.9536Gi/s              | 8.19996Gi/s              |
| 536870912    | 4096      | 12.9167Gi/s              | 7.71419Gi/s              |
| 536870912    | 8192      | 12.8837Gi/s              | 8.12882Gi/s              |
| 536870912    | 16384     | 12.8347Gi/s              | 8.18394Gi/s              |
| 536870912    | 32768     | 12.7286Gi/s              | 8.36251Gi/s              |

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([Link](https://github.com/tenstorrent/tt-metal/actions/runs/16479901286))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes