### PR TITLE
[DRAFT][AI][Claude] Port all data movement kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 namespace ttnn::operations::bernoulli {
 
@@ -64,13 +65,13 @@ BernoulliDeviceOperation::ProgramFactory::cached_program_t BernoulliDeviceOperat
     tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
 
     const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/";
-    const uint32_t input_is_dram = input.buffer()->buffer_type() == BufferType::DRAM ? 1 : 0;
-    const std::vector<uint32_t> reader_compile_time_args{in_cb_id, input_is_dram};
+    std::vector<uint32_t> reader_compile_time_args{in_cb_id};
+    TensorAccessorArgs(*input.buffer()).append_args(reader_compile_time_args);
     const std::string reader_file_path = kernels_dir_path + "reader_bernoulli.cpp";
     const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
     const std::string compute_file_path = kernels_dir_path + "compute_bernoulli.cpp";
-    const uint32_t output_is_dram = output.buffer()->buffer_type() == BufferType::DRAM ? 1 : 0;
-    const std::vector<uint32_t> writer_compile_time_args{in_cb_id, intermed_cb_id, intermed1_cb_id, output_is_dram};
+    std::vector<uint32_t> writer_compile_time_args{in_cb_id, intermed_cb_id, intermed1_cb_id};
+    TensorAccessorArgs(*output.buffer()).append_args(writer_compile_time_args);
     const std::string writer_file_path = kernels_dir_path + "writer_bernoulli.cpp";
 
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp
@@ -6,15 +6,14 @@
 
 void kernel_main() {
     constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
-    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
     uint32_t input_addr = get_arg_val<uint32_t>(0);
     uint32_t start_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
     uint32_t end_id = start_id + num_tiles;
 
-    const InterleavedAddrGenFast<input_is_dram> input_addrg = {
-        .bank_base_address = input_addr, .page_size = get_tile_size(in_cb_id), .data_format = get_dataformat(in_cb_id)};
+    const auto input_addrg = TensorAccessor(tensor_args, input_addr, get_tile_size(in_cb_id));
 
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_reserve_back(in_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp
@@ -10,17 +10,14 @@ void kernel_main() {
     constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t intermed1_cb_id = get_compile_time_arg_val(2);
-    constexpr bool output_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<3>();
 
     auto out_addr = get_arg_val<uint32_t>(0);
     auto start_id = get_arg_val<uint32_t>(1);
     auto num_tiles = get_arg_val<uint32_t>(2);
     uint32_t end_id = start_id + num_tiles;
 
-    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
-        .bank_base_address = out_addr,
-        .page_size = get_tile_size(intermed1_cb_id),
-        .data_format = get_dataformat(intermed1_cb_id)};
+    const auto output_addrg = TensorAccessor(tensor_args, out_addr, get_tile_size(intermed1_cb_id));
 
     cb_reserve_back(intermed1_cb_id, 1);
     uint32_t intermed1_cb_write_ptr = get_write_ptr(intermed1_cb_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved.cpp
@@ -16,8 +16,8 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(11);
     uint32_t nc1 = get_arg_val<uint32_t>(12);  // if 1 we expect the bcast tensor to have NC=1
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<0 + src0_tensor_args.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -27,11 +27,8 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = tile_bytes, .data_format = data_format};
-
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, tile_bytes);
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved_input_rows_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved_input_rows_partitioned.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(13);
     uint32_t HtWt = get_arg_val<uint32_t>(14);  // HtWt of input tensor
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<0 + src0_tensor_args.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -31,11 +31,8 @@ void kernel_main() {
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
     const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
-
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, in0_tile_bytes);
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, in1_tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded.cpp
@@ -14,8 +14,8 @@ void kernel_main() {
     uint32_t batch_offset = get_arg_val<uint32_t>(5);  // if weight has multiple batches
 
     // constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr auto src1_tensor_args = TensorAccessorArgs<1>();
 
     // constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -25,8 +25,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in1);
     const DataFormat data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
@@ -15,8 +15,8 @@ void kernel_main() {
     uint32_t batch_b = get_arg_val<uint32_t>(6);
 
     // constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr auto src1_tensor_args = TensorAccessorArgs<1>();
 
     // constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -26,8 +26,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in1);
     const DataFormat data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved.cpp
@@ -17,10 +17,11 @@ void kernel_main() {
     uint32_t nc1 = get_arg_val<uint32_t>(12);  // if 1 we expect the bcast tensor to have NC=1 and wrap around in NC
 
 #ifndef IN0_SHARDED
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<0 + src0_tensor_args.compile_time_args_skip()>();
+#else
+    constexpr auto src1_tensor_args = TensorAccessorArgs<0>();
 #endif
-
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -40,15 +41,13 @@ void kernel_main() {
 
 #ifndef IN0_SHARDED
     uint32_t i = 0;
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, in0_tile_bytes);
 #else
     cb_reserve_back(cb_id_in0, num_tiles);
     cb_push_back(cb_id_in0, num_tiles);
 #endif
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, in1_tile_bytes);
 
 #ifdef BCAST_SCALAR
     cb_reserve_back(cb_id_in1, onetile);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
@@ -16,7 +16,7 @@ void kernel_main() {
     auto bcast_id = get_arg_val<uint32_t>(6);
 
 #ifndef IN0_SHARDED
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 #endif
 
     constexpr uint32_t cb_id_in0 = 0;
@@ -32,8 +32,7 @@ void kernel_main() {
     uint32_t l1_write_addr_in1;
 
 #ifndef IN0_SHARDED
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    const auto s0 = TensorAccessor(tensor_args, src0_addr, in0_tile_bytes);
 #else
     cb_reserve_back(cb_id_in0, num_tiles);
     cb_push_back(cb_id_in0, num_tiles);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved.cpp
@@ -16,8 +16,8 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(11);
     uint32_t nc1 = get_arg_val<uint32_t>(12);  // if 1 we expect the bcast tensor to have NC=1
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<0 + src0_tensor_args.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -36,11 +36,8 @@ void kernel_main() {
     uint32_t i = 0;
     uint32_t i_bcast = 0;
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
-
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, in0_tile_bytes);
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, in1_tile_bytes);
 
     for (uint32_t nc = 0; nc < NC; nc++) {
         for (uint32_t ht = 0; ht < Ht; ht++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved_input_cols_partitioned.cpp
@@ -19,8 +19,8 @@ void kernel_main() {
     uint32_t HtWt = get_arg_val<uint32_t>(14);  // HtWt of input tensor
     uint32_t Wt_skip = get_arg_val<uint32_t>(15);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<0 + src0_tensor_args.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -39,11 +39,8 @@ void kernel_main() {
     uint32_t i = 0;
     uint32_t i_bcast = 0;
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
-
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, in0_tile_bytes);
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, in1_tile_bytes);
 
     uint32_t i_nc = 0;
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/writer_unary_interleaved_input_cols_batched.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/writer_unary_interleaved_input_cols_batched.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     uint32_t NC = get_arg_val<uint32_t>(7);
     uint32_t HtWt = get_arg_val<uint32_t>(8);  // HtWt of input tensor
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t cb_id_out0 = 16;
 
@@ -22,8 +22,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     uint32_t tile_id = 0;
     uint32_t i_nc = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -84,12 +85,12 @@ operation::ProgramWithCallbacks bcast_multi_core_w(
             .set_page_size(output_cb_index, dst_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
 
     KernelHandle binary_reader_kernel_id = tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
@@ -7,6 +7,7 @@
 #include "clone_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/math.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 namespace ttnn::operations::data_movement::clone {
 CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory::create(
@@ -61,14 +62,10 @@ CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory:
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        reader_compile_time_args = {
-            (uint32_t)src_cb_id,
-            (uint32_t)input_is_dram,
-        };
-        writer_compile_time_args = {
-            (uint32_t)dst_cb_id,
-            (uint32_t)output_is_dram,
-        };
+        reader_compile_time_args = {(uint32_t)src_cb_id};
+        TensorAccessorArgs(*input_buffer).append_args(reader_compile_time_args);
+        writer_compile_time_args = {(uint32_t)dst_cb_id};
+        TensorAccessorArgs(*output_buffer).append_args(writer_compile_time_args);
     } else {
         bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_unit_size);
         uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (uint32_t)log2(input_unit_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
@@ -10,13 +10,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGenFast<input_is_dram> s = {
-        .bank_base_address = input_buffer_address,
-        .page_size = get_tile_size(src_cb_id),
-        .data_format = get_dataformat(src_cb_id),
-    };
+    const auto s = TensorAccessor(tensor_args, input_buffer_address, get_tile_size(src_cb_id));
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
@@ -10,13 +10,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGenFast<output_is_dram> s = {
-        .bank_base_address = output_buffer_address,
-        .page_size = get_tile_size(dst_cb_id),
-        .data_format = get_dataformat(dst_cb_id),
-    };
+    const auto s = TensorAccessor(tensor_args, output_buffer_address, get_tile_size(dst_cb_id));
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_s2i_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_s2i_width.cpp
@@ -7,7 +7,7 @@
 
 void kernel_main() {
     constexpr uint32_t num_tensors = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
@@ -18,10 +18,7 @@ void kernel_main() {
 
     uint32_t arg_index = 6;
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr,
-        .page_size = stick_size,
-    };
+    const auto s = TensorAccessor(tensor_args, dst_addr, stick_size);
 
     for (uint32_t tensor_id = 0; tensor_id < num_tensors; tensor_id++) {
         const uint32_t input_shard_cb = get_arg_val<uint32_t>(arg_index++);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/util.hpp>
 #include "copy_device_operation.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 #include "ttnn/operations/math.hpp"
 
 #include <tt-metalium/constants.hpp>
@@ -80,8 +81,10 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        reader_compile_time_args = {(uint32_t)src_is_dram};
-        writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+        reader_compile_time_args = {};
+        TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+        writer_compile_time_args = {(std::uint32_t)output_cb_index};
+        TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
     } else {
         bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_unit_size);
         uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (std::uint32_t)log2(input_unit_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
@@ -12,7 +12,6 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
 #ifdef OUT_SHARDED
     cb_wait_front(cb_id_out, num_tiles);
@@ -24,6 +23,7 @@ void kernel_main() {
     const DataFormat data_format = get_dataformat(cb_id_out);
 
 #ifdef SHARDED
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
     typedef ShardedInfo<
         get_compile_time_arg_val(2),
         get_compile_time_arg_val(3),
@@ -38,8 +38,8 @@ void kernel_main() {
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(3));
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 #else
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 #endif
 
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 
 #include "fill_pad_program_factory.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 bool is_power_of_two_at_least_32(uint32_t value) { return value >= 32 && (value & (value - 1)) == 0; }
 
@@ -78,19 +79,18 @@ tt::tt_metal::operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& 
 
     // create kernel
     // reader compile time args
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)src_is_dram,
-        (std::uint32_t)packed_fill_value,
-        (std::uint32_t)input_element_size_bytes,
-        (std::uint32_t)height,
-        (std::uint32_t)width,
-        (std::uint32_t)padded_height,
-        (std::uint32_t)padded_width,
-        (std::uint32_t)tiles_per_2d_tensor,
-        (std::uint32_t)tiles_per_tile_row,
-        (std::uint32_t)tt::constants::TILE_HEIGHT,
-        (std::uint32_t)tt::constants::FACE_HEIGHT};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index};
+    TensorAccessorArgs(*tens_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.push_back((std::uint32_t)packed_fill_value);
+    writer_compile_time_args.push_back((std::uint32_t)input_element_size_bytes);
+    writer_compile_time_args.push_back((std::uint32_t)height);
+    writer_compile_time_args.push_back((std::uint32_t)width);
+    writer_compile_time_args.push_back((std::uint32_t)padded_height);
+    writer_compile_time_args.push_back((std::uint32_t)padded_width);
+    writer_compile_time_args.push_back((std::uint32_t)tiles_per_2d_tensor);
+    writer_compile_time_args.push_back((std::uint32_t)tiles_per_tile_row);
+    writer_compile_time_args.push_back((std::uint32_t)tt::constants::TILE_HEIGHT);
+    writer_compile_time_args.push_back((std::uint32_t)tt::constants::FACE_HEIGHT);
 
     std::map<std::string, std::string> compute_defines;
     if (sharded) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/util.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt::tt_metal;
 
@@ -48,8 +49,8 @@ operation::ProgramWithCallbacks fill_rm_single_core(
             .set_page_size(1, single_tile_size);
     auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)dst_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*dst_buffer).append_args(reader_compile_time_args);
 
     tt::tt_metal::KernelHandle binary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
@@ -22,8 +22,8 @@ void kernel_main() {
     uint32_t val_hi = get_arg_val<uint32_t>(6);
     uint32_t val_lo = get_arg_val<uint32_t>(7);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = W << 1};
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, W << 1);
 
     // DPRINT << "fill_rm_8bank: NC=" << NC << " H=" << H << " W=" << W << " fillH=" << fillH << " fillW=" << fillW <<
     // ENDL();

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -93,7 +93,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
 
     // Configure compile-time arguments for reader kernel
     std::vector<uint32_t> reader_compile_time_args = {ntiles_per_row, src0_cb_index};
-    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
 
     // Configure compile-time arguments for writer kernel
     std::vector<uint32_t> writer_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -18,6 +18,7 @@
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include "fold_device_op.hpp"
 namespace ttnn::operations::data_movement {
@@ -91,10 +92,8 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     // Configure compile-time arguments for reader kernel
-    std::vector<uint32_t> reader_compile_time_args = {
-        ntiles_per_row,
-        src0_cb_index,
-    };
+    std::vector<uint32_t> reader_compile_time_args = {ntiles_per_row, src0_cb_index};
+    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
 
     // Configure compile-time arguments for writer kernel
     std::vector<uint32_t> writer_compile_time_args = {
@@ -106,8 +105,8 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         stick_nbytes,
         ntiles_per_row,
         datum_size(cb_data_format),
-        src1_cb_index,
-    };
+        src1_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
 
     // Create reader kernel for DRAM to circular buffer data movement
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -19,8 +19,8 @@ void kernel_main() {
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
     // Initialize interleaved address generator for DRAM access
-    const InterleavedAddrGenFast<true> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto tensor_args = TensorAccessorArgs<2>();
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // Process each block of data
     uint32_t end_block_id = start_block_id + num_blocks;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -30,7 +30,8 @@ void kernel_main() {
     // dump(stick_nbytes);
 
     // Initialize DRAM address generator
-    const InterleavedAddrGen<true> d = {.bank_base_address = dst_addr, .page_size = stick_nbytes};
+    constexpr auto tensor_args = TensorAccessorArgs<9>();
+    const auto d = TensorAccessor(tensor_args, dst_addr, stick_nbytes);
 
     // Pre-calculate output dimensions and patch size - moved outside loops
     const uint32_t OH = input_height / stride_height;                   // Output height

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 namespace ttnn::operations::data_movement::gather::program {
 // Single row - single core
@@ -360,17 +361,15 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
     tt::tt_metal::CreateCircularBuffer(program, core_range, output_tensor_cb_config);
 
     // Kernels
-    const std::vector<uint32_t> reader_compile_time_args = {
-        input_tensor_cb_index,
-        input_index_tensor_cb_index,
-        output_tensor_cb_index,
-        static_cast<uint32_t>(input_index_tensor_is_dram),
-        Ht,
-        Wt_input,
-        Wt_index,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+    std::vector<uint32_t> reader_compile_time_args = {
+        input_tensor_cb_index, input_index_tensor_cb_index, output_tensor_cb_index};
+    TensorAccessorArgs(*input_index_tensor_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.push_back(Ht);
+    reader_compile_time_args.push_back(Wt_input);
+    reader_compile_time_args.push_back(Wt_index);
+    reader_compile_time_args.push_back(total_number_of_cores);
+    reader_compile_time_args.push_back(compute_with_storage_grid_size.x);
+    reader_compile_time_args.push_back(compute_with_storage_grid_size.y);
     const std::string gather_reader_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp";
     tt::tt_metal::KernelHandle gather_reader_kernel_id = tt::tt_metal::CreateKernel(
@@ -387,17 +386,15 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
          tile_width,
          tile_height});
 
-    const std::vector<uint32_t> writer_compile_time_args = {
-        input_tensor_cb_index,
-        output_tensor_cb_index,
-        static_cast<uint32_t>(input_tensor_is_dram),
-        static_cast<uint32_t>(output_tensor_is_dram),
-        Ht,
-        Wt_input,
-        Wt_index,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+    std::vector<uint32_t> writer_compile_time_args = {input_tensor_cb_index, output_tensor_cb_index};
+    TensorAccessorArgs(*input_tensor_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*output_tensor_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.push_back(Ht);
+    writer_compile_time_args.push_back(Wt_input);
+    writer_compile_time_args.push_back(Wt_index);
+    writer_compile_time_args.push_back(total_number_of_cores);
+    writer_compile_time_args.push_back(compute_with_storage_grid_size.x);
+    writer_compile_time_args.push_back(compute_with_storage_grid_size.y);
     const std::string gather_writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp";
     tt::tt_metal::KernelHandle gather_writer_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -56,24 +56,24 @@ void kernel_main() {
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t input_index_tensor_cb_index = get_compile_time_arg_val(1);
     constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(2);
-    constexpr bool input_index_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto input_index_tensor_args = TensorAccessorArgs<3>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(3 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(4 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(5 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores =
+        get_compile_time_arg_val(6 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(7 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(8 + input_index_tensor_args.compile_time_args_skip());
 
     constexpr uint32_t one_tile = 1;
     const uint32_t TILE_WIDTH_MASK = tile_width - 1;
 
     // Index tensor config
     constexpr uint32_t input_index_tensor_tile_size_bytes = get_tile_size(input_index_tensor_cb_index);
-    constexpr DataFormat input_index_tensor_data_format = get_dataformat(input_index_tensor_cb_index);
-    const InterleavedAddrGenFast<input_index_tensor_is_dram> input_index_tensor_dram = {
-        .bank_base_address = input_index_tensor_buffer_addr,
-        .page_size = input_index_tensor_tile_size_bytes,
-        .data_format = input_index_tensor_data_format};
+    const auto input_index_tensor_dram =
+        TensorAccessor(input_index_tensor_args, input_index_tensor_buffer_addr, input_index_tensor_tile_size_bytes);
 
     // Dataformats size
     constexpr uint32_t input_tensor_data_format_size =

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
@@ -118,13 +118,16 @@ void kernel_main() {
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t input_index_tensor_cb_index = get_compile_time_arg_val(1);
     constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(2);
-    constexpr bool input_index_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto input_index_tensor_args = TensorAccessorArgs<3>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(3 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(4 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(5 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores =
+        get_compile_time_arg_val(6 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(7 + input_index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(8 + input_index_tensor_args.compile_time_args_skip());
 
     constexpr uint32_t one_tile = 1;
     const uint32_t tile_width_mask = tile_width - 1;
@@ -132,10 +135,8 @@ void kernel_main() {
     // Index tensor config
     constexpr uint32_t input_index_tensor_tile_size_bytes = get_tile_size(input_index_tensor_cb_index);
     constexpr DataFormat input_index_tensor_data_format = get_dataformat(input_index_tensor_cb_index);
-    const InterleavedAddrGenFast<input_index_tensor_is_dram> input_index_tensor_dram = {
-        .bank_base_address = input_index_tensor_buffer_addr,
-        .page_size = input_index_tensor_tile_size_bytes,
-        .data_format = input_index_tensor_data_format};
+    const auto input_index_tensor_dram =
+        TensorAccessor(input_index_tensor_args, input_index_tensor_buffer_addr, input_index_tensor_tile_size_bytes);
 
     // Dataformats size
     constexpr uint32_t input_tensor_data_format_size =

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -22,32 +22,32 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr bool output_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto input_tensor_args = TensorAccessorArgs<2>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<2 + input_tensor_args.compile_time_args_skip()>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        2 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(
+        3 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(
+        4 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(
+        5 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(
+        6 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(
+        7 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
-    constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_dram = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_dram =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Output tensor config
     constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
-    constexpr DataFormat output_tensor_data_format = get_dataformat(output_tensor_cb_index);
-    const InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_dram = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = output_tensor_tile_size_bytes,
-        .data_format = output_tensor_data_format};
+    const auto output_tensor_dram =
+        TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
     const auto start_tile_id = get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
     uint32_t current_index_tile_id = start_tile_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
@@ -30,32 +30,34 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr bool output_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto input_tensor_args = TensorAccessorArgs<2>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<2 + input_tensor_args.compile_time_args_skip()>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        2 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(
+        3 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(
+        4 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(
+        5 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(
+        6 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(
+        7 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_dram = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_dram =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Output tensor config
     constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
     constexpr DataFormat output_tensor_data_format = get_dataformat(output_tensor_cb_index);
-    const InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_dram = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = output_tensor_tile_size_bytes,
-        .data_format = output_tensor_data_format};
+    const auto output_tensor_dram =
+        TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/util.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt::tt_metal;
 
@@ -63,14 +64,12 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(
 
     // Create Kernels
     // reader
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)cb_index,
-        (std::uint32_t)batch_cb_index,
-        (std::uint32_t)batch_ids_is_dram,
-        (std::uint32_t)in0_is_dram,
-        (std::uint32_t)in1_is_dram,
-        (std::uint32_t)stick_size_is_power_of_two,
-        (std::uint32_t)log2_stick_size};
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)cb_index, (std::uint32_t)batch_cb_index};
+    TensorAccessorArgs(*batch_ids.buffer()).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*input_a.buffer()).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*input_b.buffer()).append_args(reader_compile_time_args);
+    reader_compile_time_args.push_back((std::uint32_t)stick_size_is_power_of_two);
+    reader_compile_time_args.push_back((std::uint32_t)log2_stick_size);
 
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -33,8 +33,8 @@ void kernel_main() {
     bool do_third_multicast = get_arg_val<uint32_t>(24) == 1;
 
     constexpr uint32_t cb_id = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<1>();
+    constexpr auto dst_tensor_args = TensorAccessorArgs<1 + src_tensor_args.compile_time_args_skip()>();
 
     const DataFormat data_format = get_dataformat(cb_id);
 
@@ -47,11 +47,8 @@ void kernel_main() {
     constexpr uint32_t ublock_size_tiles = 1;
     uint32_t tile_bytes = get_tile_size(cb_id);
 
-    const InterleavedAddrGenFast<src_is_dram> src_addrgen = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
-
-    const InterleavedAddrGenFast<dst_is_dram> dst_addrgen = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto src_addrgen = TensorAccessor(src_tensor_args, src_addr, tile_bytes);
+    const auto dst_addrgen = TensorAccessor(dst_tensor_args, dst_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB
     cb_reserve_back(cb_id, num_tiles);

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 
 #include <tt-metalium/hal.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -103,7 +104,9 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor& input
     bool dst_is_dram = dst_buffer->buffer_type() == BufferType::DRAM;
 
     uint32_t log2_page_size = 0;
-    std::vector<uint32_t> compile_time_args = {cb_index, (uint32_t)src_is_dram, (uint32_t)dst_is_dram};
+    std::vector<uint32_t> compile_time_args = {cb_index};
+    TensorAccessorArgs(*src_buffer).append_args(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_args(compile_time_args);
     if (!tilized) {
         bool page_size_is_power_of_two = is_power_of_two_at_least_32(page_size);
         log2_page_size = page_size_is_power_of_two ? (std::uint32_t)log2(page_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/kernels/dataflow/non_zero_indices_sc_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/kernels/dataflow/non_zero_indices_sc_reader.cpp
@@ -18,17 +18,14 @@ void kernel_main() {
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t output_cb_index_0 = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb_index_1 = get_compile_time_arg_val(2);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(4) == 1;
-    constexpr bool dst1_is_dram = get_compile_time_arg_val(5) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<3>();
+    constexpr auto dst0_tensor_args = TensorAccessorArgs<3 + src_tensor_args.compile_time_args_skip()>();
+    constexpr auto dst1_tensor_args =
+        TensorAccessorArgs<3 + src_tensor_args.compile_time_args_skip() + dst0_tensor_args.compile_time_args_skip()>();
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {
-        .bank_base_address = input_addr, .page_size = aligned_elements * element_size};
-
-    const InterleavedAddrGen<dst0_is_dram> out0 = {.bank_base_address = output_addr_0, .page_size = 32};
-
-    const InterleavedAddrGen<dst1_is_dram> out1 = {
-        .bank_base_address = output_addr_1, .page_size = aligned_elements * element_size};
+    const auto s0 = TensorAccessor(src_tensor_args, input_addr, aligned_elements * element_size);
+    const auto out0 = TensorAccessor(dst0_tensor_args, output_addr_0, 32);
+    const auto out1 = TensorAccessor(dst1_tensor_args, output_addr_1, aligned_elements * element_size);
 
     uint64_t src_noc_addr = get_noc_addr(0, s0);
     uint32_t input_l1_addr = get_write_ptr(input_cb_index);

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -66,13 +67,10 @@ operation::ProgramWithCallbacks non_zero_indices_single_core(
 
     // Create Kernel
     std::vector<uint32_t> compile_time_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)output_cb_index_0,
-        (std::uint32_t)output_cb_index_1,
-        (std::uint32_t)src_is_dram,
-        (std::uint32_t)out_is_dram_0,
-        (std::uint32_t)out_is_dram_1,
-    };
+        (std::uint32_t)input_cb_index, (std::uint32_t)output_cb_index_0, (std::uint32_t)output_cb_index_1};
+    TensorAccessorArgs(*input.buffer()).append_args(compile_time_args);
+    TensorAccessorArgs(*out_num_indices.buffer()).append_args(compile_time_args);
+    TensorAccessorArgs(*out_indices.buffer()).append_args(compile_time_args);
 
     const std::array run_time_args = {
         (std::uint32_t)input.buffer()->address(),

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
@@ -51,8 +51,9 @@ void kernel_main() {
     const uint32_t full_unpadded_X_nbytes = get_arg_val<uint32_t>(23);
     const uint32_t num_local_W = get_arg_val<uint32_t>(26);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<0>();
+    constexpr bool src_stick_size_is_pow2 =
+        get_compile_time_arg_val(0 + src_tensor_args.compile_time_args_skip() + 1) == 1;
 
     constexpr uint32_t cb_id = tt::CBIndex::c_0;
 
@@ -61,20 +62,10 @@ void kernel_main() {
     const uint32_t l1_addr_align_offset =
         32 - l1_addr_partial % 32;  // NOTE: this is fine with double buffering since offset will be same for each page
 
-    // #if (src_stick_size_is_pow2)
-    //     constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
-    //     const InterleavedPow2AddrGen<src0_is_dram> s0 = {
-    //         .bank_base_address = src_addr,
-    //         .log_base_2_of_page_size = src_log_base_2_of_page_size
-    //     };
-    // #else
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = full_unpadded_X_nbytes};
-    // #endif
+    const auto s0 = TensorAccessor(src_tensor_args, src_addr, full_unpadded_X_nbytes);
 
-    const InterleavedPow2AddrGen<false> s_const = {
-        .bank_base_address = pad_value_const_buffer_addr,
-        .log_base_2_of_page_size = 6  // TODO: generalize. Currently hardcoded for 32 16b values (2^6 = 64)
-    };
+    constexpr auto const_tensor_args = TensorAccessorArgs<false, false, false>();
+    const auto s_const = TensorAccessor(const_tensor_args, pad_value_const_buffer_addr, 64);
     const uint64_t const_buffer_noc_addr = get_noc_addr(0, s_const);
 
     uint16_t pad_value = pad_value_packed >> 16;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
@@ -20,20 +20,14 @@ void kernel_main() {
     const uint32_t dst_stick_offset = get_arg_val<uint32_t>(25);  // == start_src_stick_wi * elem_size
     const uint32_t num_local_W = get_arg_val<uint32_t>(26);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(4) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<0>();
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0 + src_tensor_args.compile_time_args_skip()) == 1;
+    constexpr bool dst_stick_size_is_pow2 =
+        get_compile_time_arg_val(0 + src_tensor_args.compile_time_args_skip() + 3) == 1;
 
     constexpr uint32_t cb_id = tt::CBIndex::c_0;
 
-    // #if (dst_stick_size_is_pow2)
-    //     constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(5);
-    //     const InterleavedPow2AddrGen<dst_is_dram> s1 = {
-    //         .bank_base_address = dst_addr,
-    //         .log_base_2_of_page_size = dst_log_base_2_of_page_size
-    //     };
-    // #else
-    const InterleavedAddrGen<dst_is_dram> s1 = {.bank_base_address = dst_addr, .page_size = full_padded_X_nbytes};
-    // #endif
+    const auto s1 = TensorAccessor(src_tensor_args, dst_addr, full_padded_X_nbytes);
 
     uint32_t dst_stick_id = start_dst_stick_id;
     uint32_t dst_stick_wi = start_dst_stick_wi;
@@ -43,7 +37,7 @@ void kernel_main() {
                 // DPRINT << "WR: " << w << ", " << z << ", " << y << ENDL();
                 cb_wait_front(cb_id, 1);
                 uint32_t l1_addr = get_read_ptr(cb_id);
-                uint64_t dst_noc_addr = get_noc_addr<dst_is_dram>(dst_stick_id, s1, dst_stick_offset);
+                uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s1, dst_stick_offset);
                 noc_async_write(l1_addr, dst_noc_addr, padded_X_nbytes);
                 noc_async_write_barrier();
                 ++dst_stick_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -19,13 +19,12 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_out1 = get_compile_time_arg_val(1);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<2>();
 
     const uint32_t tile_size = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram> s1 = {
-        .bank_base_address = dst_addr, .page_size = tile_size, .data_format = data_format};
+    const auto s1 = TensorAccessor(tensor_args, dst_addr, tile_size);
 
     cb_reserve_back(cb_id_out1, 1);  // in this kernel we are not pushing anything into CBs, just using the space
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/tt_align.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 static const uint32_t max_read_size = 2048;  // max read size in bytes for reader and writer kernels
 using namespace tt::constants;
@@ -72,13 +73,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
     bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(padded_row_size_nbytes);
     uint32_t dst_log2_stick_size =
         dst_stick_size_is_power_of_two ? (std::uint32_t)std::log2(padded_row_size_nbytes) : 0;
-    std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)src0_is_dram,
-        (std::uint32_t)dst_is_dram,
-        (std::uint32_t)src_stick_size_is_power_of_two,
-        (std::uint32_t)src_log2_stick_size,
-        (std::uint32_t)dst_stick_size_is_power_of_two,
-        (std::uint32_t)dst_log2_stick_size};
+    std::vector<uint32_t> reader_ct_args;
+    TensorAccessorArgs(*input.buffer()).append_args(reader_ct_args);
+    reader_ct_args.push_back((std::uint32_t)dst_is_dram);
+    reader_ct_args.push_back((std::uint32_t)src_stick_size_is_power_of_two);
+    reader_ct_args.push_back((std::uint32_t)src_log2_stick_size);
+    reader_ct_args.push_back((std::uint32_t)dst_stick_size_is_power_of_two);
+    reader_ct_args.push_back((std::uint32_t)dst_log2_stick_size);
     const std::vector<uint32_t>& writer_ct_args = reader_ct_args;
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
@@ -524,13 +525,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
     bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(padded_row_size_nbytes);
     uint32_t dst_log2_stick_size =
         dst_stick_size_is_power_of_two ? (std::uint32_t)std::log2(padded_row_size_nbytes) : 0;
-    std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)src0_is_dram,
-        (std::uint32_t)dst_is_dram,
-        (std::uint32_t)src_stick_size_is_power_of_two,
-        (std::uint32_t)src_log2_stick_size,
-        (std::uint32_t)dst_stick_size_is_power_of_two,
-        (std::uint32_t)dst_log2_stick_size};
+    std::vector<uint32_t> reader_ct_args;
+    TensorAccessorArgs(*src0_buffer).append_args(reader_ct_args);
+    reader_ct_args.push_back((std::uint32_t)dst_is_dram);
+    reader_ct_args.push_back((std::uint32_t)src_stick_size_is_power_of_two);
+    reader_ct_args.push_back((std::uint32_t)src_log2_stick_size);
+    reader_ct_args.push_back((std::uint32_t)dst_stick_size_is_power_of_two);
+    reader_ct_args.push_back((std::uint32_t)dst_log2_stick_size);
     std::vector<uint32_t> writer_ct_args = reader_ct_args;
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -74,7 +74,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
     uint32_t dst_log2_stick_size =
         dst_stick_size_is_power_of_two ? (std::uint32_t)std::log2(padded_row_size_nbytes) : 0;
     std::vector<uint32_t> reader_ct_args;
-    TensorAccessorArgs(*input.buffer()).append_args(reader_ct_args);
+    TensorAccessorArgs(*a.buffer()).append_args(reader_ct_args);
     reader_ct_args.push_back((std::uint32_t)dst_is_dram);
     reader_ct_args.push_back((std::uint32_t)src_stick_size_is_power_of_two);
     reader_ct_args.push_back((std::uint32_t)src_log2_stick_size);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -7,18 +7,18 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
-    constexpr uint32_t x_dim = get_compile_time_arg_val(4);
-    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(5);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(6);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(7);
-    constexpr uint32_t x_block_size = get_compile_time_arg_val(8);
-    constexpr uint32_t w_block_size = get_compile_time_arg_val(9);
-    constexpr uint32_t element_size = get_compile_time_arg_val(10);
-    constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(11);
+    constexpr auto src_tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(0 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(1 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_rows = get_compile_time_arg_val(2 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_dim = get_compile_time_arg_val(3 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(4 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(5 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(6 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_block_size = get_compile_time_arg_val(7 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t w_block_size = get_compile_time_arg_val(8 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t element_size = get_compile_time_arg_val(9 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(10 + src_tensor_args.compile_time_args_skip());
 
     // Precomputed constants: size of a 32 element block along the W dimension (measured in bytes)
     constexpr uint32_t w_block_size_bytes = w_block_size * element_size;
@@ -50,7 +50,7 @@ void kernel_main() {
     uint32_t X = input_shape[x_dim];
     uint32_t X_stride = src_strides[x_dim];
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = input_tensor_page_size};
+    const auto s0 = TensorAccessor(src_tensor_args, src_addr, input_tensor_page_size);
 
     uint32_t idxs[N];
     idxs[N - 1] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
@@ -6,16 +6,16 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
+    constexpr auto src_tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(0 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t page_size = get_compile_time_arg_val(1 + src_tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_rows = get_compile_time_arg_val(2 + src_tensor_args.compile_time_args_skip());
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_row = get_arg_val<uint32_t>(1);
     const uint32_t end_row = get_arg_val<uint32_t>(2);
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(src_tensor_args, src_addr, page_size);
 
     uint32_t curr_addr = src_addr;
     for (uint32_t row = start_row; row < end_row; ++row) {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
@@ -25,35 +25,37 @@ void kernel_main() {
     // 1) Compile-time arguments
     // ------------------------------------------------------------------------
 
-    constexpr bool src0_is_dram = static_cast<bool>(get_compile_time_arg_val(0));
-    constexpr uint32_t RANK = get_compile_time_arg_val(1);
-    // constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t element_size = get_compile_time_arg_val(3);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(4);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(5);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t x_dim_index_in_input = get_compile_time_arg_val(8);
-    constexpr uint32_t X = get_compile_time_arg_val(9);
-    constexpr uint32_t W = get_compile_time_arg_val(10);
-    constexpr uint32_t H = get_compile_time_arg_val(11);
-    constexpr uint32_t X_p = get_compile_time_arg_val(12);
-    constexpr uint32_t W_p = get_compile_time_arg_val(13);
-    constexpr uint32_t H_p = get_compile_time_arg_val(14);
-    constexpr uint32_t H_t = get_compile_time_arg_val(15);
-    constexpr uint32_t W_t = get_compile_time_arg_val(16);
-    constexpr uint32_t final_tile_real_w = get_compile_time_arg_val(17);
-    constexpr uint32_t final_tile_real_faces_w = get_compile_time_arg_val(18);
-    constexpr uint32_t xw_blocks = get_compile_time_arg_val(19);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(20);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(21);
-    constexpr uint32_t num_writes = get_compile_time_arg_val(22);
-    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(23);
-    constexpr bool needs_x_padding = static_cast<bool>(get_compile_time_arg_val(24));
-    constexpr bool needs_y_padding = static_cast<bool>(get_compile_time_arg_val(25));
-    constexpr uint32_t rows_per_x = get_compile_time_arg_val(26);
-    constexpr uint32_t misalignment = get_compile_time_arg_val(27);
-    constexpr uint32_t read_alignment = get_compile_time_arg_val(28);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t RANK = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    // constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t element_size = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_dim_index_in_input = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t X = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H = get_compile_time_arg_val(10 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t X_p = get_compile_time_arg_val(11 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_p = get_compile_time_arg_val(12 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H_p = get_compile_time_arg_val(13 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H_t = get_compile_time_arg_val(14 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_t = get_compile_time_arg_val(15 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t final_tile_real_w = get_compile_time_arg_val(16 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t final_tile_real_faces_w = get_compile_time_arg_val(17 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t xw_blocks = get_compile_time_arg_val(18 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(19 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(20 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_writes = get_compile_time_arg_val(21 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(22 + tensor_args.compile_time_args_skip());
+    constexpr bool needs_x_padding =
+        static_cast<bool>(get_compile_time_arg_val(23 + tensor_args.compile_time_args_skip()));
+    constexpr bool needs_y_padding =
+        static_cast<bool>(get_compile_time_arg_val(24 + tensor_args.compile_time_args_skip()));
+    constexpr uint32_t rows_per_x = get_compile_time_arg_val(25 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t misalignment = get_compile_time_arg_val(26 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t read_alignment = get_compile_time_arg_val(27 + tensor_args.compile_time_args_skip());
 
     // ------------------------------------------------------------------------
     // 2) Derived Constants (kept as constexpr)
@@ -111,8 +113,7 @@ void kernel_main() {
         src_tiled_strides[i] = src_tiled_strides[i + 1] * input_tiled_shape[i + 1];
     }
     constexpr auto data_format = get_dataformat(tt::CBIndex::c_0);
-    const InterleavedAddrGenFast<src0_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // Stride for stepping along x_dim_index_in_input
     const uint32_t X_stride_tile = src_tiled_strides[x_dim_index_in_input];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
@@ -6,10 +6,10 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_tiles = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t page_size = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_tile = get_arg_val<uint32_t>(1);
@@ -21,8 +21,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
     uint32_t output_tiled_shape[N], inv_perm[N], src_strides[N];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -9,26 +9,26 @@
 
 void kernel_main() {
     // Compile-time constants
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t output_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t output_cb_page_size = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_rows = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
 
-    constexpr uint32_t X = get_compile_time_arg_val(4);
-    constexpr uint32_t X_stride = get_compile_time_arg_val(5);
-    constexpr uint32_t x_dim = get_compile_time_arg_val(6);
+    constexpr uint32_t X = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t X_stride = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_dim = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
 
-    constexpr uint32_t W_stride = get_compile_time_arg_val(7);
-    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(8);
-    constexpr uint32_t element_size = get_compile_time_arg_val(9);
+    constexpr uint32_t W_stride = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t element_size = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
 
-    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(10);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(11);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(12);
-    constexpr uint32_t x_block_size = get_compile_time_arg_val(13);
-    constexpr uint32_t w_block_size = get_compile_time_arg_val(14);
-    constexpr uint32_t W = get_compile_time_arg_val(15);
-    constexpr uint32_t output_tensor_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(10 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(11 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_block_size = get_compile_time_arg_val(12 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t w_block_size = get_compile_time_arg_val(13 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(14 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t output_tensor_page_size = get_compile_time_arg_val(15 + tensor_args.compile_time_args_skip());
 
     constexpr uint32_t cb_id_in = tt::CBIndex::c_2;
 
@@ -47,7 +47,7 @@ void kernel_main() {
     const uint32_t end_block = get_arg_val<uint32_t>(2);
 
     // Interleaved address configuration for the destination
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = output_tensor_page_size};
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, output_tensor_page_size);
 
     // Input shape, permutation, and destination strides
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -6,16 +6,16 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
+    constexpr auto dst_tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(0 + dst_tensor_args.compile_time_args_skip());
+    constexpr uint32_t page_size = get_compile_time_arg_val(1 + dst_tensor_args.compile_time_args_skip());
+    constexpr uint32_t num_rows = get_compile_time_arg_val(2 + dst_tensor_args.compile_time_args_skip());
 
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_row = get_arg_val<uint32_t>(1);
     const uint32_t end_row = get_arg_val<uint32_t>(2);
 
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(dst_tensor_args, dst_addr, page_size);
 
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
     uint32_t input_shape[N], perm[N], dest_strides[N];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
@@ -25,30 +25,30 @@ void kernel_main() {
     // 1) Compile-time Arguments
     //--------------------------------------------------------------------------
 
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t RANK = get_compile_time_arg_val(1);
-    // constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t element_size = get_compile_time_arg_val(3);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(4);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(5);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t x_dim_in_input = get_compile_time_arg_val(8);
-    constexpr uint32_t X = get_compile_time_arg_val(9);
-    constexpr uint32_t W = get_compile_time_arg_val(10);
-    constexpr uint32_t Y = get_compile_time_arg_val(11);
-    constexpr uint32_t X_p = get_compile_time_arg_val(12);
-    constexpr uint32_t W_p = get_compile_time_arg_val(13);
-    constexpr uint32_t rows_per_x = get_compile_time_arg_val(14);
-    // 15 is Y_t, see below
-    constexpr uint32_t W_t = get_compile_time_arg_val(16);
-    constexpr uint32_t final_tile_real_x = get_compile_time_arg_val(17);
-    constexpr uint32_t final_tile_real_faces_x = get_compile_time_arg_val(18);
-    constexpr uint32_t xw_blocks = get_compile_time_arg_val(19);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(20);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(21);
-    constexpr bool needs_y_padding = (bool)get_compile_time_arg_val(22);
-    constexpr uint32_t permuted_w_dim = get_compile_time_arg_val(23);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t RANK = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    // constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t element_size = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_dim_in_input = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t X = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t Y = get_compile_time_arg_val(10 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t X_p = get_compile_time_arg_val(11 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_p = get_compile_time_arg_val(12 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t rows_per_x = get_compile_time_arg_val(13 + tensor_args.compile_time_args_skip());
+    // 14 is Y_t, see below
+    constexpr uint32_t W_t = get_compile_time_arg_val(15 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t final_tile_real_x = get_compile_time_arg_val(16 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t final_tile_real_faces_x = get_compile_time_arg_val(17 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t xw_blocks = get_compile_time_arg_val(18 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(19 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(20 + tensor_args.compile_time_args_skip());
+    constexpr bool needs_y_padding = (bool)get_compile_time_arg_val(21 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t permuted_w_dim = get_compile_time_arg_val(22 + tensor_args.compile_time_args_skip());
 
     //--------------------------------------------------------------------------
     // 2) Derived Constants (all constexpr)
@@ -124,8 +124,7 @@ void kernel_main() {
     uint32_t W_stride_tile = dest_tiled_strides[permuted_w_dim];
 
     constexpr auto data_format = get_dataformat(tt::CBIndex::c_0);
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     uint32_t idxs[RANK];
     idxs[RANK - 1] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -51,19 +51,19 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     // 0) Read compile-time constants
     // ------------------------------------------------------------------------
-    constexpr bool dst_is_dram = (get_compile_time_arg_val(0) == 1);
-    constexpr uint32_t element_size = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(2);
-    constexpr uint32_t output_H = get_compile_time_arg_val(3);
-    constexpr uint32_t H = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
-    constexpr bool needs_padding = (get_compile_time_arg_val(10) == 1);
-    constexpr uint32_t RANK = get_compile_time_arg_val(11);
-    constexpr uint32_t permuted_input_h_index = get_compile_time_arg_val(12);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t element_size = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t output_H = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
+    constexpr bool needs_padding = (get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip()) == 1);
+    constexpr uint32_t RANK = get_compile_time_arg_val(10 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t permuted_input_h_index = get_compile_time_arg_val(11 + tensor_args.compile_time_args_skip());
 
     // ------------------------------------------------------------------------
     // 1) Read runtime arguments
@@ -109,8 +109,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const auto input_data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram, TILE_HW> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = input_data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     // ------------------------------------------------------------------------
     // 3) Height dimension remainder logic

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_interleaved.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     uint32_t output_Ht = get_arg_val<uint32_t>(4);
     uint32_t output_Wt = get_arg_val<uint32_t>(5);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
 
     uint32_t num_sticks_per_input_tile_row = input_Wt << 5;  // Tile height is 32
     uint32_t num_sticks_per_output_tile_row = output_Wt << 5;
@@ -35,8 +35,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, src0_addr, tile_bytes);
 
     // Sticks are a row of elements in a single tile (32 elements)
     // Stick id increments row-wise

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_stick_layout_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_stick_layout_interleaved.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     const uint32_t num_sticks = get_arg_val<uint32_t>(1);
     const uint32_t stick_size = get_arg_val<uint32_t>(2);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 
     // TODO(agrebenisan): This isn't good... here we are assuming
     // that the stick size dictates tiles c, but stick size
@@ -22,19 +22,13 @@ void kernel_main() {
     const uint32_t num_tiles_c = stick_size / 64;  // Assuming 2 bytes per datum, there are 64 bytes per tile row
     uint32_t stick_id = 0;
 
-    constexpr bool stick_size_is_power_of_two = (get_compile_time_arg_val(1) == 1);
+    constexpr bool stick_size_is_power_of_two =
+        (get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip()) == 1);
 #if (stick_size_is_power_of_two)
     const uint32_t log_base_2_of_page_size = get_arg_val<uint32_t>(3);
-    const InterleavedPow2AddrGen<src0_is_dram> s = {
-        .bank_base_address = src_addr,
-
-        .log_base_2_of_page_size = log_base_2_of_page_size  // TODO(AP): refactor
-    };
+    const auto s = TensorAccessor(tensor_args, src_addr, log_base_2_of_page_size, true);
 #else
-    const InterleavedAddrGen<src0_is_dram> s = {
-        .bank_base_address = src_addr,
-
-        .page_size = stick_size};
+    const auto s = TensorAccessor(tensor_args, src_addr, stick_size);
 #endif
 
     for (uint32_t i = 0; i < num_sticks / 32; i++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -16,21 +16,21 @@ void kernel_main() {
     const uint32_t start_output_page = get_arg_val<uint32_t>(1);
     const uint32_t end_output_page = get_arg_val<uint32_t>(2);
 
-    constexpr bool output_is_dram = get_compile_time_arg_val(0);
-    constexpr uint32_t Tile_size_bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t Max_Map_Entries = get_compile_time_arg_val(2);
+    constexpr auto output_tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t Tile_size_bytes = get_compile_time_arg_val(0 + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Max_Map_Entries = get_compile_time_arg_val(1 + output_tensor_args.compile_time_args_skip());
 
-    constexpr uint8_t element_sz_bytes = get_compile_time_arg_val(3);
+    constexpr uint8_t element_sz_bytes = get_compile_time_arg_val(2 + output_tensor_args.compile_time_args_skip());
 
-    constexpr uint32_t cb_id_mapping = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_id_input = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_id_working = get_compile_time_arg_val(6);  // scratch
+    constexpr uint32_t cb_id_mapping = get_compile_time_arg_val(3 + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_input = get_compile_time_arg_val(4 + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_working =
+        get_compile_time_arg_val(5 + output_tensor_args.compile_time_args_skip());  // scratch
 
     const DataFormat input_data_format = get_dataformat(cb_id_input);
 
     //  TODO sharded
-    const InterleavedAddrGenFast<output_is_dram> output_addrgen = {
-        .bank_base_address = output_base_addr, .page_size = Tile_size_bytes, .data_format = input_data_format};
+    const auto output_addrgen = TensorAccessor(output_tensor_args, output_base_addr, Tile_size_bytes);
 
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -27,14 +27,13 @@ void kernel_main() {
     const uint32_t start_id = start_id_base + start_id_offset;
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t num_readers = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t num_readers = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_readers>();
     uint32_t barrier_count = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -21,12 +21,12 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
 
-    constexpr bool src0_is_dram          = get_compile_time_arg_val(2) == 1;
-    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(4);
+    constexpr auto tensor_args = TensorAccessorArgs<2>();
+    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip()) == 1;
+    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
 
-    const auto s0 = get_interleaved_addr_gen<src0_is_dram, src_stick_size_is_pow2>(
-        src_addr + aligned_input_width_offset_bytes, stick_size, src_log_base_2_of_page_size);
+    const auto s0 = TensorAccessor(tensor_args, src_addr + aligned_input_width_offset_bytes,
+                                  src_stick_size_is_pow2 ? (1 << src_log_base_2_of_page_size) : stick_size);
 
     uint32_t stick_id = start_id;
     cb_reserve_back(cb_id_in0, block_height);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
@@ -17,14 +17,13 @@ void kernel_main() {
     const uint32_t start_id = start_id_base + start_id_offset;
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
     // single-tile ublocks
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
     const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     const uint32_t padded_width_diff = (block_width_tiles - unpadded_block_width_tiles) * tile_bytes;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -16,12 +16,14 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
 
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip()) == 1;
+    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
 
-    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_stick_size_is_pow2>(
-        dst_addr + input_width_offset_bytes, stick_size, dst_log_base_2_of_page_size);
+    const auto s0 = TensorAccessor(
+        tensor_args,
+        dst_addr + input_width_offset_bytes,
+        dst_stick_size_is_pow2 ? (1 << dst_log_base_2_of_page_size) : stick_size);
 
     uint32_t stick_id = start_id;
     cb_wait_front(cb_id_out0, block_height);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
@@ -21,10 +21,9 @@ void kernel_main() {
     constexpr uint32_t tile_size = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<2>();
     // In and out are assumed to be same dataformat
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src_addr, .page_size = tile_size, .data_format = data_format};
+    const auto s0 = TensorAccessor(src_tensor_args, src_addr, tile_size);
 
     uint32_t src_tile_id = start_id;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -22,10 +22,10 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, padded_stick_size);
 
     constexpr uint32_t cb_id_in0 = 0;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -15,9 +15,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = stick_size};
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, stick_size);
 
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
@@ -6,9 +6,9 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t dims = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t page_size = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t dims = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
 
@@ -31,7 +31,7 @@ void kernel_main() {
     }
     prod[dims - 1] = 1;  // Not used, but set to 1 for completeness
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, page_size);
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_out0 = 24;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp
@@ -6,13 +6,13 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool dst0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t page_size = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
 
-    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, page_size);
 
     constexpr uint32_t cb_id_out0 = 24;
     const uint32_t start_id = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/host_api.hpp>
 
 #include "slice_op.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
@@ -907,13 +908,10 @@ operation::ProgramWithCallbacks slice_tile_multi_core(
 
     // Reader compile-time args
     // Data is 32 byte aligned
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index),
-        static_cast<uint32_t>(num_dims),
-        static_cast<uint32_t>(src0_is_dram),
-    };
+        static_cast<uint32_t>(src0_cb_index), static_cast<uint32_t>(num_dims)};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {
         static_cast<uint32_t>(src0_cb_index), static_cast<uint32_t>(dst_is_dram)};
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -29,34 +29,30 @@ void kernel_main() {
     constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(4);
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(5);
     constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(6);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(7) == 1;
-    constexpr bool output_tensor_is_dram = get_compile_time_arg_val(8) == 1;
-    constexpr bool output_index_tensor_is_dram = get_compile_time_arg_val(9) == 1;
-    constexpr bool is_32_bit_data = get_compile_time_arg_val(10) == 1;
+    constexpr auto input_tensor_args = TensorAccessorArgs<7>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<7 + input_tensor_args.compile_time_args_skip()>();
+    constexpr auto output_index_tensor_args = TensorAccessorArgs<
+        7 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip()>();
+    constexpr bool is_32_bit_data =
+        get_compile_time_arg_val(
+            7 + input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() +
+            output_index_tensor_args.compile_time_args_skip()) == 1;
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
-    constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_addr_ger = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_addr_ger =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Output tensor config
-    const InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_addr_gen = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto output_tensor_addr_gen =
+        TensorAccessor(output_tensor_args, output_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Output index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_cb_index);
-    const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_cb_index);
-    const InterleavedAddrGenFast<output_index_tensor_is_dram> output_index_tensor_addr_gen = {
-        .bank_base_address = output_index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto output_index_tensor_addr_gen =
+        TensorAccessor(output_index_tensor_args, output_index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     // Semaphore setup
     volatile tt_l1_ptr uint32_t* semaphore_ptr =

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_cross_core_data_exchange.cpp
@@ -26,17 +26,33 @@ void kernel_main() {
     constexpr uint32_t index_tensor_peer_cb_index = get_compile_time_arg_val(7);
     constexpr uint32_t physical_core_lookup_table_cb_index = get_compile_time_arg_val(8);
 
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(9) == 1;
-    constexpr bool index_tensor_output_is_dram = get_compile_time_arg_val(10) == 1;
-    constexpr bool physical_core_lookup_table_is_dram = get_compile_time_arg_val(11) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(12);
-    constexpr uint32_t Wt = get_compile_time_arg_val(13);
-    constexpr uint32_t number_of_tiles_per_core = get_compile_time_arg_val(14);
-    constexpr uint32_t number_of_cores_used = get_compile_time_arg_val(15);
-    constexpr bool ascending = get_compile_time_arg_val(16) == 1;
+    constexpr auto input_tensor_args = TensorAccessorArgs<9>();
+    constexpr auto index_tensor_args = TensorAccessorArgs<9 + input_tensor_args.compile_time_args_skip()>();
+    constexpr auto physical_core_lookup_tensor_args = TensorAccessorArgs<
+        9 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip()>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        9 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+        physical_core_lookup_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt = get_compile_time_arg_val(
+        10 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+        physical_core_lookup_tensor_args.compile_time_args_skip());
+    constexpr uint32_t number_of_tiles_per_core = get_compile_time_arg_val(
+        11 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+        physical_core_lookup_tensor_args.compile_time_args_skip());
+    constexpr uint32_t number_of_cores_used = get_compile_time_arg_val(
+        12 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+        physical_core_lookup_tensor_args.compile_time_args_skip());
+    constexpr bool ascending =
+        get_compile_time_arg_val(
+            13 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+            physical_core_lookup_tensor_args.compile_time_args_skip()) == 1;
 
-    const uint32_t sem_exchange_addr = get_semaphore(get_compile_time_arg_val(17));
-    const uint32_t sem_barrier_addr = get_semaphore(get_compile_time_arg_val(18));
+    const uint32_t sem_exchange_addr = get_semaphore(get_compile_time_arg_val(
+        14 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+        physical_core_lookup_tensor_args.compile_time_args_skip()));
+    const uint32_t sem_barrier_addr = get_semaphore(get_compile_time_arg_val(
+        15 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip() +
+        physical_core_lookup_tensor_args.compile_time_args_skip()));
 
     // Constants
     constexpr uint32_t one_tile = 1;
@@ -49,26 +65,22 @@ void kernel_main() {
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_accessor = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_accessor =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
-    const InterleavedAddrGenFast<index_tensor_output_is_dram> index_tensor_output_accessor = {
-        .bank_base_address = index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto index_tensor_output_accessor =
+        TensorAccessor(index_tensor_args, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     // Physical core lookup table config
     constexpr uint32_t physical_core_lookup_table_tile_size_bytes = get_tile_size(physical_core_lookup_table_cb_index);
     constexpr DataFormat physical_core_lookup_table_data_format = get_dataformat(physical_core_lookup_table_cb_index);
-    const InterleavedAddrGenFast<physical_core_lookup_table_is_dram> physical_core_lookup_table_accessor = {
-        .bank_base_address = physical_core_lookup_table_buffer_addr,
-        .page_size = physical_core_lookup_table_tile_size_bytes,
-        .data_format = physical_core_lookup_table_data_format};
+    const auto physical_core_lookup_table_accessor = TensorAccessor(
+        physical_core_lookup_tensor_args,
+        physical_core_lookup_table_buffer_addr,
+        physical_core_lookup_table_tile_size_bytes);
 
     // Read lookup table for physical core IDs
     cb_reserve_back(physical_core_lookup_table_cb_index, one_tile);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
@@ -18,32 +18,33 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t Ht = get_compile_time_arg_val(5);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(8);
-    constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(9);
+    constexpr auto input_tensor_args = TensorAccessorArgs<2>();
+    constexpr auto index_tensor_args = TensorAccessorArgs<2 + input_tensor_args.compile_time_args_skip()>();
+    constexpr uint32_t Wt = get_compile_time_arg_val(
+        2 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        3 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(
+        4 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(
+        5 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(
+        6 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(
+        7 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_addr_gen = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_addr_gen = TensorAccessor(input_tensor_args, input_tensor_buffer_addr, tile_size_bytes);
 
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_cb_index);
-    const InterleavedAddrGenFast<index_tensor_is_dram> index_tensor_addr_gen = {
-        .bank_base_address = index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto index_tensor_addr_gen =
+        TensorAccessor(index_tensor_args, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     // Sempahore setup
     volatile tt_l1_ptr uint32_t* semaphore_ptr =

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp
@@ -26,30 +26,28 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t Ht = get_compile_time_arg_val(5);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(8);
+    constexpr auto input_tensor_args = TensorAccessorArgs<2>();
+    constexpr auto index_tensor_args = TensorAccessorArgs<2 + input_tensor_args.compile_time_args_skip()>();
+    constexpr uint32_t Wt = get_compile_time_arg_val(
+        2 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        3 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(
+        4 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(
+        5 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(
+        6 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
 
     // Input tensor config
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t tile_size_bytes = get_tile_size(input_tensor_cb_index);
-    constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> interleaved_accessor0 = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto interleaved_accessor0 = TensorAccessor(input_tensor_args, input_tensor_buffer_addr, tile_size_bytes);
 
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
-    const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
-    const InterleavedAddrGenFast<index_tensor_is_dram> interleaved_accessor1 = {
-        .bank_base_address = index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto interleaved_accessor1 =
+        TensorAccessor(index_tensor_args, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp
@@ -21,13 +21,16 @@ void kernel_main() {
     constexpr uint32_t value_tensor_peer_cb_index = get_compile_time_arg_val(4);
     constexpr uint32_t physical_core_lookup_table_cb_index =
         get_compile_time_arg_val(5);  // unused - for future improvements
-    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(6) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(7);
-    constexpr uint32_t Ht = get_compile_time_arg_val(8);
-    constexpr uint32_t number_of_tiles_per_core = get_compile_time_arg_val(9);
-    constexpr uint32_t number_of_cores_used = get_compile_time_arg_val(10);          // unused - for future improvements
-    const uint32_t sem_exchange_addr = get_semaphore(get_compile_time_arg_val(11));  // unused - for future improvements
-    constexpr bool is_32_bit_data = get_compile_time_arg_val(12) == 1;
+    constexpr auto value_tensor_args = TensorAccessorArgs<6>();
+    constexpr uint32_t Wt = get_compile_time_arg_val(6 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Ht = get_compile_time_arg_val(7 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t number_of_tiles_per_core =
+        get_compile_time_arg_val(8 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t number_of_cores_used =
+        get_compile_time_arg_val(9 + value_tensor_args.compile_time_args_skip());  // unused - for future improvements
+    const uint32_t sem_exchange_addr = get_semaphore(
+        get_compile_time_arg_val(10 + value_tensor_args.compile_time_args_skip()));  // unused - for future improvements
+    constexpr bool is_32_bit_data = get_compile_time_arg_val(11 + value_tensor_args.compile_time_args_skip()) == 1;
 
     // Constants
     constexpr uint32_t one_tile = 1;
@@ -41,11 +44,8 @@ void kernel_main() {
 
     // Output tensor config
     const uint32_t value_tensor_tile_size_bytes = get_tile_size(value_tensor_cb_index);
-    const DataFormat value_tensor_data_format = get_dataformat(value_tensor_cb_index);
-    const InterleavedAddrGenFast<value_tensor_is_dram> output_tensor_accessor = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = value_tensor_tile_size_bytes,
-        .data_format = value_tensor_data_format};
+    const auto output_tensor_accessor =
+        TensorAccessor(value_tensor_args, output_tensor_buffer_addr, value_tensor_tile_size_bytes);
 
     for (uint32_t h = 0; h < Ht; h++) {
         // Generate input index tiles

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
@@ -16,32 +16,32 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t input_tensor_output_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t Ht = get_compile_time_arg_val(5);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(8);
-    constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(9);
+    constexpr auto input_tensor_args = TensorAccessorArgs<2>();
+    constexpr auto index_tensor_args = TensorAccessorArgs<2 + input_tensor_args.compile_time_args_skip()>();
+    constexpr uint32_t Wt = get_compile_time_arg_val(
+        2 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        3 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(
+        4 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(
+        5 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(
+        6 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
+    constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(
+        7 + input_tensor_args.compile_time_args_skip() + index_tensor_args.compile_time_args_skip());
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_output_cb_index);
-    constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_output_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_addr_gen = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_addr_gen =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
-    const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
-    const InterleavedAddrGenFast<index_tensor_is_dram> index_tensor_addr_gen = {
-        .bank_base_address = index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto index_tensor_addr_gen =
+        TensorAccessor(index_tensor_args, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     // Semaphore setup
     const uint64_t coordinator_core_addr = get_noc_addr(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp
@@ -26,22 +26,22 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(5);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(7);
-    constexpr bool is_32_bit_data = get_compile_time_arg_val(8) == 1;
+    constexpr auto value_tensor_args = TensorAccessorArgs<2>();
+    constexpr uint32_t Wt = get_compile_time_arg_val(2 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t Ht = get_compile_time_arg_val(3 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(4 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(5 + value_tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(6 + value_tensor_args.compile_time_args_skip());
+    constexpr bool is_32_bit_data = get_compile_time_arg_val(7 + value_tensor_args.compile_time_args_skip()) == 1;
 
     // Output tensor config
     constexpr uint32_t one_tile = 1;
     const uint32_t value_tensor_tile_size_bytes = get_tile_size(value_tensor_cb_index);
     const DataFormat value_tensor_data_format = get_dataformat(value_tensor_cb_index);
-    const InterleavedAddrGenFast<value_tensor_is_dram> interleaved_accessor0 = {
-        .bank_base_address = value_tensor_buffer_addr,
-        .page_size = value_tensor_tile_size_bytes,
-        .data_format = value_tensor_data_format};
+    const auto interleaved_accessor0 =
+        TensorAccessor(value_tensor_args, value_tensor_buffer_addr, value_tensor_tile_size_bytes);
 
     // Move data from L1 to DRAMs
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 #include <cmath>
 #include <cstdint>
@@ -159,16 +160,14 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     auto cb_synchronization = tt::tt_metal::CreateCircularBuffer(program, core_range, synchronization_cb_config);
 
     // Kernels
-    const std::vector<uint32_t> reader_compile_time_args = {
-        input_tensor_cb_index,
-        index_tensor_output_cb_index,
-        static_cast<uint32_t>(input_tensor_is_dram),
-        static_cast<uint32_t>(index_tensor_is_dram),
-        Wt,
-        Ht,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+    std::vector<uint32_t> reader_compile_time_args = {input_tensor_cb_index, index_tensor_output_cb_index};
+    TensorAccessorArgs(*input_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*index_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.push_back(Wt);
+    reader_compile_time_args.push_back(Ht);
+    reader_compile_time_args.push_back(total_number_of_cores);
+    reader_compile_time_args.push_back(compute_with_storage_grid_size.x);
+    reader_compile_time_args.push_back(compute_with_storage_grid_size.y);
     const std::string reader_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp";
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
@@ -181,16 +180,14 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
          index_buffer->address(),
          all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
-    const std::vector<uint32_t> writer_compile_time_args = {
-        value_tensor_cb_index,
-        index_tensor_cb_index,
-        static_cast<uint32_t>(value_tensor_is_dram),
-        Wt,
-        Ht,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y,
-        static_cast<uint32_t>(is_32_bit_data)};
+    std::vector<uint32_t> writer_compile_time_args = {value_tensor_cb_index, index_tensor_cb_index};
+    TensorAccessorArgs(*value_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.push_back(Wt);
+    writer_compile_time_args.push_back(Ht);
+    writer_compile_time_args.push_back(total_number_of_cores);
+    writer_compile_time_args.push_back(compute_with_storage_grid_size.x);
+    writer_compile_time_args.push_back(compute_with_storage_grid_size.y);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(is_32_bit_data));
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp";
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
@@ -583,20 +580,20 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         core_range,
         {input_buffer->address(), index_buffer->address(), physical_core_lookup_table_tensor_buffer->address()});
 
-    const std::vector<uint32_t> writer_compile_time_args = {
+    std::vector<uint32_t> writer_compile_time_args = {
         compute_with_storage_grid_size.x,
         compute_with_storage_grid_size.y,
         index_tensor_cb_index,
         value_tensor_cb_index,
         value_tensor_peer_cb_index,
-        physical_core_lookup_table_cb_index,
-        value_tensor_is_dram,
-        Wt,
-        Ht,
-        number_of_tiles_per_core,
-        total_number_of_cores_virtual,
-        semaphore_exchange_readers,
-        static_cast<uint32_t>(is_32_bit_data)};
+        physical_core_lookup_table_cb_index};
+    TensorAccessorArgs(*value_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.push_back(Wt);
+    writer_compile_time_args.push_back(Ht);
+    writer_compile_time_args.push_back(number_of_tiles_per_core);
+    writer_compile_time_args.push_back(total_number_of_cores_virtual);
+    writer_compile_time_args.push_back(semaphore_exchange_readers);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(is_32_bit_data));
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp";
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
@@ -872,18 +869,18 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     const auto end_core_physical_coord = device->worker_core_from_logical_core(coordinator_core);
 
     // Kernels
-    const std::vector<uint32_t> coordinator_compile_time_args = {
+    std::vector<uint32_t> coordinator_compile_time_args = {
         total_work_units,
         Wt,
         Ht,
         total_number_of_cores,
         number_of_available_cores,
         input_tensor_cb_index,
-        index_tensor_cb_index,
-        static_cast<uint32_t>(input_tensor_is_dram),
-        static_cast<uint32_t>(value_tensor_is_dram),
-        static_cast<uint32_t>(index_tensor_is_dram),
-        static_cast<uint32_t>(is_32_bit_data)};
+        index_tensor_cb_index};
+    TensorAccessorArgs(*input_buffer).append_args(coordinator_compile_time_args);
+    TensorAccessorArgs(*value_buffer).append_args(coordinator_compile_time_args);
+    TensorAccessorArgs(*index_buffer).append_args(coordinator_compile_time_args);
+    coordinator_compile_time_args.push_back(static_cast<uint32_t>(is_32_bit_data));
     const std::string coordinator_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp";
     tt::tt_metal::KernelHandle coordinator_kernel_id = tt::tt_metal::CreateKernel(
@@ -932,17 +929,15 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
          coordinator_to_cores_semaphore_id,
          cores_to_coordinator_semaphore_id});
 
-    const std::vector<uint32_t> writer_compile_time_args = {
-        input_tensor_output_cb_index,
-        index_tensor_output_cb_index,
-        static_cast<uint32_t>(value_tensor_is_dram),
-        static_cast<uint32_t>(index_tensor_is_dram),
-        Wt,
-        Ht,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y,
-        number_of_available_cores};
+    std::vector<uint32_t> writer_compile_time_args = {input_tensor_output_cb_index, index_tensor_output_cb_index};
+    TensorAccessorArgs(*value_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*index_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.push_back(Wt);
+    writer_compile_time_args.push_back(Ht);
+    writer_compile_time_args.push_back(total_number_of_cores);
+    writer_compile_time_args.push_back(compute_with_storage_grid_size.x);
+    writer_compile_time_args.push_back(compute_with_storage_grid_size.y);
+    writer_compile_time_args.push_back(number_of_available_cores);
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp";
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp
@@ -20,25 +20,22 @@ void kernel_main() {
 
     // COMPILE TIME ARGS
     // interleaved accessor args
-    constexpr uint32_t in0_is_dram = get_compile_time_arg_val(1);
-    constexpr uint32_t z = get_compile_time_arg_val(2);
-    constexpr uint32_t out_num_tiles_per_tensor_y = get_compile_time_arg_val(3);
-    constexpr uint32_t out_num_tiles_per_tensor_x = get_compile_time_arg_val(4);
-    constexpr uint32_t z_stride = get_compile_time_arg_val(5);
-    constexpr uint32_t y_stride = get_compile_time_arg_val(6);
+    constexpr bool tile_dtype_is_bfloat16 = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t z = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t out_num_tiles_per_tensor_y = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t out_num_tiles_per_tensor_x = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t z_stride = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t y_stride = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
 
     constexpr uint32_t out_num_tensors = 1;
     constexpr uint32_t cb_id_in0 = 0;
     uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
 
-    constexpr bool in0_is_dram_bool = in0_is_dram == 1;
-
     constexpr uint32_t onetile = 1;
-    constexpr bool tile_dtype_is_bfloat16 = get_compile_time_arg_val(0) == 1;
     constexpr DataFormat data_format = (tile_dtype_is_bfloat16) ? DataFormat::Float16 : DataFormat::Bfp8_b;
 
-    const InterleavedAddrGenFast<in0_is_dram_bool> s0 = {
-        .bank_base_address = in0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, in0_tensor_addr, single_tile_size_bytes);
 
     uint32_t tensor_stride = out_num_tiles_per_tensor_x;
     uint32_t tensor_stride_cum = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows.cpp
@@ -37,16 +37,13 @@ void kernel_main() {
     const uint32_t num_tiles_block_c =
         block_row_size / bytes_per_tile_row;  // Assuming 2 bytes per datum, there are 64 bytes per tile row
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip()) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(2);
-    const InterleavedPow2AddrGen<src0_is_dram> s = {
-        .bank_base_address = src_addr,
-        .log_base_2_of_page_size = log_base_2_of_page_size  // TODO(AP): refactor
-    };
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, src_addr, log_base_2_of_page_size, true);
 #else
-    const InterleavedAddrGen<src0_is_dram> s = {.bank_base_address = src_addr, .page_size = unpadded_X_size};
+    const auto s = TensorAccessor(tensor_args, src_addr, unpadded_X_size);
 #endif
 
     uint32_t stick_id = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -29,14 +29,13 @@ void kernel_main() {
     const uint32_t num_tiles_per_row =
         padded_X_size >> tile_row_shift_bits;  // means / 64, assuming bfloat16, there are 64 bytes per tile row
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip()) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(2);
-    const InterleavedPow2AddrGen<src0_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, src_addr, 1 << log_base_2_of_page_size);
 #else
-    const InterleavedAddrGen<src0_is_dram> s = {.bank_base_address = src_addr, .page_size = unpadded_X_size};
+    const auto s = TensorAccessor(tensor_args, src_addr, unpadded_X_size);
 #endif
 
     auto pad_blocks = [&](uint32_t num_blocks) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     uint32_t batch_step = get_arg_val<uint32_t>(4);    // CHtWt - HtWt
     uint32_t channel_step = get_arg_val<uint32_t>(5);  // NCHtWt - HtWt
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -22,8 +22,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t i = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -18,15 +18,14 @@ void kernel_main() {
     uint32_t n = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t tile_idx = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
@@ -27,10 +27,10 @@ void kernel_main() {
     uint32_t ctoffs = get_arg_val<uint32_t>(12);
     uint32_t wt = get_arg_val<uint32_t>(13);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
-    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(2);
-    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
     constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
 
     constexpr uint32_t onetile = 1;
@@ -43,8 +43,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, src0_addr, tile_bytes);
     uint32_t intermed_l1_scratch = MISALIGNED ? get_write_ptr(1) : 0;
     volatile tt_l1_ptr uint8_t* intermed_l1_scratch_ptr = (volatile uint8_t*)intermed_l1_scratch;
     for (uint32_t t = 0; t < num_tiles; t++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -14,11 +14,11 @@ void kernel_main() {
     uint32_t curr_h = get_arg_val<uint32_t>(5);
     uint32_t curr_n = get_arg_val<uint32_t>(6);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t H = get_compile_time_arg_val(2);
-    constexpr uint32_t C = get_compile_time_arg_val(3);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(4);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t C = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
 
     constexpr uint32_t CH = C * H;
 
@@ -26,17 +26,13 @@ void kernel_main() {
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(5) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip()) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(6);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, src_addr, log_base_2_of_page_size, true);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(6);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<src_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, src_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -11,16 +11,16 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t num_writes = get_compile_time_arg_val(1);
-    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(2);
-    constexpr uint32_t needs_padding = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t swap_hw = get_compile_time_arg_val(4) == 1;
-    constexpr uint32_t H = get_compile_time_arg_val(5);
-    constexpr uint32_t W = get_compile_time_arg_val(6);
-    constexpr uint32_t accumulated_outer_dims = get_compile_time_arg_val(7);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(8);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(9);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t num_writes = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t needs_padding = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip()) == 1;
+    constexpr uint32_t swap_hw = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip()) == 1;
+    constexpr uint32_t H = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t accumulated_outer_dims = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
 
     constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
     constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
@@ -37,8 +37,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -12,7 +12,7 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(3);
     uint32_t HtWt = get_arg_val<uint32_t>(4);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
     constexpr uint32_t cb_id_in0 = 0;
 
     // ublocks size defined in tiles
@@ -22,7 +22,7 @@ void kernel_main() {
 
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_in_2 = 2;
-    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+    constexpr uint32_t scaler = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
     cb_reserve_back(cb_in_2, 1);
     if (scaler != 0) {
         uint16_t u = uint16_t(scaler >> 16);
@@ -43,8 +43,7 @@ void kernel_main() {
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // this reader will read a NHW tensor in NWH order
     for (uint32_t n = 0; n < N; n++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -16,7 +16,7 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(6);
     uint32_t HtWt = get_arg_val<uint32_t>(7);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
     // uint32_t Ht  = (uint32_t)get_compile_time_arg_val(1);
     // uint32_t Wt  = (uint32_t)get_compile_time_arg_val(2);
     // uint32_t HtWt  = (uint32_t)get_compile_time_arg_val(3);
@@ -28,8 +28,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     uint32_t ht = start_ht;
     uint32_t wt = start_wt;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -10,31 +10,27 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(1);
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t H_per_tile = get_compile_time_arg_val(2);
-    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(6);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(8);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H_per_tile = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t HtWt = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(9) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip()) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, src_addr, log_base_2_of_page_size, true);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(10);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<src_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, src_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -11,22 +11,18 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(3) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip()) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(4);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, dst_addr, log_base_2_of_page_size, true);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(4);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<dst_is_dram> s = {.bank_base_address = dst_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, dst_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -14,17 +14,17 @@ void kernel_main() {
     uint32_t end_padding_tile_idx = get_arg_val<uint32_t>(4);
 
     // Compile-time constants
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t element_size = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(2);
-    constexpr uint32_t C = get_compile_time_arg_val(3);
-    constexpr uint32_t H = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
-    constexpr bool needs_padding = get_compile_time_arg_val(10) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t element_size = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t C = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
+    constexpr bool needs_padding = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip()) == 1;
 
     // Derived compile-time constants
     constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
@@ -45,8 +45,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const auto input_data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram, TILE_HW> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = input_data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     // Calculate actual data height in the last tile
     constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -10,30 +10,26 @@ void kernel_main() {
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(2);
-    constexpr uint32_t H = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t W_per_tile = get_compile_time_arg_val(5);
-    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(6);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(7);
-    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(8);
-    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(9);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H = get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t Wt = get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_per_tile = get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t HtWt = get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(8 + tensor_args.compile_time_args_skip());
 
     // single-tile ublocks
     const uint32_t stick_size_bytes = H_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(10) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(9 + tensor_args.compile_time_args_skip()) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(10 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, dst_addr, log_base_2_of_page_size, true);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(11);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<dst_is_dram> s = {.bank_base_address = dst_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(10 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, dst_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include "ttnn/operation.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 #include <cstdint>
 #include <math.h>
@@ -140,10 +141,10 @@ operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor& a, Tensor&
             .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)src0_is_dram};
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
 
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -580,19 +581,18 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
     // create writer kernel with compile time and runtime args
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)dst_is_dram,
-        a.element_size(),
-        tt::CBIndex::c_0,
-        C,
-        H,
-        W,
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1],
-        (uint32_t)needs_padding};
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.push_back(a.element_size());
+    writer_compile_time_args.push_back(tt::CBIndex::c_0);
+    writer_compile_time_args.push_back(C);
+    writer_compile_time_args.push_back(H);
+    writer_compile_time_args.push_back(W);
+    writer_compile_time_args.push_back(tile_shape[0]);
+    writer_compile_time_args.push_back(tile_shape[1]);
+    writer_compile_time_args.push_back(face_shape[0]);
+    face_shape[1], (uint32_t)needs_padding
+};
 
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -701,8 +701,8 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(
     }
 
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
     if (row_major) {
         reader_compile_time_args.push_back((std::uint32_t)N);
         reader_compile_time_args.push_back((std::uint32_t)H);
@@ -723,8 +723,8 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(
         reader_compile_time_args.push_back((std::uint32_t)(cb_data_format == tt::DataFormat::Float32));
         reader_compile_time_args.push_back((std::uint32_t)alignment);
     }
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
     if (row_major) {
         writer_compile_time_args.push_back((std::uint32_t)W * a.element_size());
 
@@ -1579,10 +1579,8 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor&
         auto cb_im2 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_im2_config);
     }
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)src0_is_dram,
-    };
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
     if (row_major) {
         reader_compile_time_args.push_back(ht);
         reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
@@ -1604,8 +1602,8 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor&
         }
     }
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
     if (row_major) {
         writer_compile_time_args.push_back(ht);
         writer_compile_time_args.push_back(H);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -591,8 +591,8 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
     writer_compile_time_args.push_back(tile_shape[0]);
     writer_compile_time_args.push_back(tile_shape[1]);
     writer_compile_time_args.push_back(face_shape[0]);
-    face_shape[1], (uint32_t)needs_padding
-};
+    writer_compile_time_args.push_back(face_shape[1]);
+    writer_compile_time_args.push_back((uint32_t)needs_padding);
 
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -607,7 +607,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
     auto override_runtime_args_callback =
         [unary_reader_kernel_id, unary_writer_kernel_id, compute_with_storage_grid_size](
             const void* operation,
-            const Program& program,
+            Program& program,
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>&,
             const std::vector<Tensor>& output_tensors) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/reader_unary_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/reader_unary_start_id.cpp
@@ -13,28 +13,29 @@ void kernel_main() {
     const uint32_t start_page_id = get_arg_val<uint32_t>(2);
 
     // compile-time args
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
 
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
 #ifdef SHARDED
     using tensor_shard_info = ShardedInfo<
-        get_compile_time_arg_val(2),   // Memory layout
-        get_compile_time_arg_val(3),   // The number of sharding cores
-        get_compile_time_arg_val(4),   // The page size we offset each write to
-        get_compile_time_arg_val(5),   // The number of pages in each sharding row not including padding pages
-        get_compile_time_arg_val(6),   // This defines times when contiguous pages can't be calculated
-        get_compile_time_arg_val(7),   // pages_per_shard_x
-        get_compile_time_arg_val(8)>;  // pages_per_shard_y
+        get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip()),  // Memory layout
+        get_compile_time_arg_val(2 + tensor_args.compile_time_args_skip()),  // The number of sharding cores
+        get_compile_time_arg_val(3 + tensor_args.compile_time_args_skip()),  // The page size we offset each write to
+        get_compile_time_arg_val(4 + tensor_args.compile_time_args_skip()),  // The number of pages in each sharding row
+                                                                             // not including padding pages
+        get_compile_time_arg_val(5 + tensor_args.compile_time_args_skip()),  // This defines times when contiguous pages
+                                                                             // can't be calculated
+        get_compile_time_arg_val(6 + tensor_args.compile_time_args_skip()),  // pages_per_shard_x
+        get_compile_time_arg_val(7 + tensor_args.compile_time_args_skip())>;  // pages_per_shard_y
 
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(3));
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = src_addr, .shard_array = mapping_table};
 #else
     const DataFormat data_format = get_dataformat(cb_id_in0);
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 #endif
 
     uint32_t end_page_id = start_page_id + num_tiles;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
@@ -16,14 +16,13 @@ void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t unpadded_X_size = get_arg_val<uint32_t>(1);
 
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 
 #if (STICK_SIZE_IS_POW2 == 1)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(1);
-    const InterleavedPow2AddrGen<dst0_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(0 + tensor_args.compile_time_args_skip());
+    const auto s = TensorAccessor(tensor_args, dst_addr, log_base_2_of_page_size, true);
 #else
-    const InterleavedAddrGen<dst0_is_dram> s = {.bank_base_address = dst_addr, .page_size = unpadded_X_size};
+    const auto s = TensorAccessor(tensor_args, dst_addr, unpadded_X_size);
 #endif
     auto write_block = [&](uint32_t num_rows,
                            uint32_t start_row_id,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes