### PR TITLE
Llama70b TG - Fix tag for 6U uploading perf numbers

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -59,7 +59,7 @@ def test_llama_tg_ops_perf_device(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-min", measured_min)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
     expected_results = check_device_perf(post_processed_results, perf_margin, expected_perf_cols, assert_on_fail=True)

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ring_matmul_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ring_matmul_perf_TG_llama.py
@@ -25,6 +25,7 @@ THRESHOLD = 1.0
 def test_ring_mm_tg_llama_perf(
     mm_type,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
@@ -57,7 +58,7 @@ def test_ring_mm_tg_llama_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 


### PR DESCRIPTION
### Problem description
Not all perf unit test distinguish between 6U and 4U. So when uploaded, numbers are mixed in the same dataset and it's hard to monitor 6U vs 4U numbers.
### What's changed
Added extra string "6U" to separate perf unit tests executed on 6U and 4U so it's properly visualized in superset.