### PR TITLE
[DRAFT][AI][Cursor] Port all data movement kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved.cpp
@@ -16,8 +16,8 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(11);
     uint32_t nc1 = get_arg_val<uint32_t>(12);  // if 1 we expect the bcast tensor to have NC=1
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<src0_tensor_args.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -27,11 +27,9 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, tile_bytes);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved_input_rows_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved_input_rows_partitioned.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(13);
     uint32_t HtWt = get_arg_val<uint32_t>(14);  // HtWt of input tensor
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args_src0 = TensorAccessorArgs<0>();
+    constexpr auto tensor_args_src1 = TensorAccessorArgs<tensor_args_src0.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -31,11 +31,8 @@ void kernel_main() {
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
     const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
-
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s0 = TensorAccessor(tensor_args_src0, src0_addr, in0_tile_bytes);
+    const auto s1 = TensorAccessor(tensor_args_src1, src1_addr, in1_tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded.cpp
@@ -14,8 +14,8 @@ void kernel_main() {
     uint32_t batch_offset = get_arg_val<uint32_t>(5);  // if weight has multiple batches
 
     // constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
 
     // constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -25,8 +25,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in1);
     const DataFormat data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s1 = TensorAccessor(tensor_args, src1_addr, tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
@@ -15,8 +15,8 @@ void kernel_main() {
     uint32_t batch_b = get_arg_val<uint32_t>(6);
 
     // constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
 
     // constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -26,8 +26,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in1);
     const DataFormat data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s1 = TensorAccessor(tensor_args, src1_addr, tile_bytes);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved_partitioned.cpp
@@ -15,10 +15,16 @@ void kernel_main() {
     uint32_t bcast_id = get_arg_val<uint32_t>(6);
 
 #ifndef IN0_SHARDED
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args_src0 = TensorAccessorArgs<0>();
 #endif
 
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args_src1 = TensorAccessorArgs<
+#ifndef IN0_SHARDED
+        tensor_args_src0.compile_time_args_skip()
+#else
+        0
+#endif
+        >();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -34,15 +40,13 @@ void kernel_main() {
     uint32_t l1_write_addr_in1;
 
 #ifndef IN0_SHARDED
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    const auto s0 = TensorAccessor(tensor_args_src0, src0_addr, in0_tile_bytes);
 #else
     cb_reserve_back(cb_id_in0, num_tiles);
     cb_push_back(cb_id_in0, num_tiles);
 #endif
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s1 = TensorAccessor(tensor_args_src1, src1_addr, in1_tile_bytes);
 
 #ifdef BCAST_SCALAR
     cb_reserve_back(cb_id_in1, onetile);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
@@ -16,7 +16,7 @@ void kernel_main() {
     auto bcast_id = get_arg_val<uint32_t>(6);
 
 #ifndef IN0_SHARDED
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 #endif
 
     constexpr uint32_t cb_id_in0 = 0;
@@ -32,8 +32,7 @@ void kernel_main() {
     uint32_t l1_write_addr_in1;
 
 #ifndef IN0_SHARDED
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    const auto s0 = TensorAccessor(tensor_args, src0_addr, in0_tile_bytes);
 #else
     cb_reserve_back(cb_id_in0, num_tiles);
     cb_push_back(cb_id_in0, num_tiles);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved.cpp
@@ -16,8 +16,8 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(11);
     uint32_t nc1 = get_arg_val<uint32_t>(12);  // if 1 we expect the bcast tensor to have NC=1
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto src1_tensor_args = TensorAccessorArgs<src0_tensor_args.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -36,11 +36,9 @@ void kernel_main() {
     uint32_t i = 0;
     uint32_t i_bcast = 0;
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    const auto s0 = TensorAccessor(src0_tensor_args, src0_addr, in0_tile_bytes);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s1 = TensorAccessor(src1_tensor_args, src1_addr, in1_tile_bytes);
 
     for (uint32_t nc = 0; nc < NC; nc++) {
         for (uint32_t ht = 0; ht < Ht; ht++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved_input_cols_partitioned.cpp
@@ -19,8 +19,8 @@ void kernel_main() {
     uint32_t HtWt = get_arg_val<uint32_t>(14);  // HtWt of input tensor
     uint32_t Wt_skip = get_arg_val<uint32_t>(15);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args_src0 = TensorAccessorArgs<0>();
+    constexpr auto tensor_args_src1 = TensorAccessorArgs<tensor_args_src0.compile_time_args_skip()>();
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
@@ -39,11 +39,9 @@ void kernel_main() {
     uint32_t i = 0;
     uint32_t i_bcast = 0;
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    const auto s0 = TensorAccessor(tensor_args_src0, src0_addr, in0_tile_bytes);
 
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    const auto s1 = TensorAccessor(tensor_args_src1, src1_addr, in1_tile_bytes);
 
     uint32_t i_nc = 0;
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/writer_unary_interleaved_input_cols_batched.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/writer_unary_interleaved_input_cols_batched.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     uint32_t NC = get_arg_val<uint32_t>(7);
     uint32_t HtWt = get_arg_val<uint32_t>(8);  // HtWt of input tensor
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t cb_id_out0 = 16;
 
@@ -22,8 +22,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     uint32_t tile_id = 0;
     uint32_t i_nc = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
@@ -85,12 +85,12 @@ operation::ProgramWithCallbacks bcast_multi_core_h(
             .set_page_size(output_cb_index, dst_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
 
     KernelHandle binary_reader_kernel_id = tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
@@ -104,8 +104,9 @@ operation::ProgramWithCallbacks bcast_sharded_h(
     auto src0_buffer = a.buffer();
     auto src1_buffer = b.buffer();
     auto dst_buffer = output.buffer();
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(reader_compile_time_args.end(), {(uint32_t)src0_cb_index});
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -107,8 +107,9 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(
     auto src0_buffer = a.buffer();
     auto src1_buffer = b.buffer();
     auto dst_buffer = output.buffer();
-    bool src1_is_dram = src1_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(reader_compile_time_args.end(), {(uint32_t)src0_cb_index});
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -113,9 +113,11 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    if (!src0_sharded) {
+        TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    }
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "bcast_op_multi_core_w.hpp"
+
 #include "ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/host_api.hpp>
@@ -84,9 +87,9 @@ operation::ProgramWithCallbacks bcast_multi_core_w(
             .set_page_size(output_cb_index, dst_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
@@ -4,9 +4,12 @@
 
 #include <math.h>
 
+#include <math.h>
+
 #include "clone_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/math.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 namespace ttnn::operations::data_movement::clone {
 CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory::create(
@@ -61,14 +64,11 @@ CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory:
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        reader_compile_time_args = {
-            (uint32_t)src_cb_id,
-            (uint32_t)input_is_dram,
-        };
-        writer_compile_time_args = {
-            (uint32_t)dst_cb_id,
-            (uint32_t)output_is_dram,
-        };
+        reader_compile_time_args = {(uint32_t)src_cb_id};
+        TensorAccessorArgs(*input_buffer).append_args(reader_compile_time_args);
+
+        writer_compile_time_args = {(uint32_t)dst_cb_id};
+        TensorAccessorArgs(*output_buffer).append_args(writer_compile_time_args);
     } else {
         bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_unit_size);
         uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (uint32_t)log2(input_unit_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
@@ -10,13 +10,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGenFast<input_is_dram> s = {
-        .bank_base_address = input_buffer_address,
-        .page_size = get_tile_size(src_cb_id),
-        .data_format = get_dataformat(src_cb_id),
-    };
+    const auto s = TensorAccessor(tensor_args, input_buffer_address, get_tile_size(src_cb_id));
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
@@ -10,13 +10,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGenFast<output_is_dram> s = {
-        .bank_base_address = output_buffer_address,
-        .page_size = get_tile_size(dst_cb_id),
-        .data_format = get_dataformat(dst_cb_id),
-    };
+    const auto s = TensorAccessor(tensor_args, output_buffer_address, get_tile_size(dst_cb_id));
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
@@ -13,39 +13,44 @@ void kernel_main() {
     const uint32_t start_tensor = get_arg_val<uint32_t>(1);
     const uint32_t start_tensor_id = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t num_tensors = get_compile_time_arg_val(1);
+    constexpr auto tensor_args_0 = TensorAccessorArgs<0>();
+    constexpr auto tensor_args_1 = TensorAccessorArgs<tensor_args_0.compile_time_args_skip()>();
+    constexpr auto tensor_args_2 = TensorAccessorArgs<tensor_args_1.compile_time_args_skip()>();
+    constexpr auto tensor_args_3 = TensorAccessorArgs<tensor_args_2.compile_time_args_skip()>();
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(tensor_args_3.compile_time_args_skip());
+    constexpr uint32_t num_tensors = get_compile_time_arg_val(tensor_args_3.compile_time_args_skip() + 1);
 
     // ublocks size defined in pages
     constexpr uint32_t ublock_size_pages = 1;
 
-    uint8_t l1_src_addr_gens_memblk[sizeof(InterleavedAddrGen<false>) * num_tensors];
-    uint8_t dram_src_addr_gens_memblk[sizeof(InterleavedAddrGen<true>) * num_tensors];
+    uint8_t tensor_accessor_memblk_0[sizeof(TensorAccessor)];
+    uint8_t tensor_accessor_memblk_1[sizeof(TensorAccessor)];
+    uint8_t tensor_accessor_memblk_2[sizeof(TensorAccessor)];
+    uint8_t tensor_accessor_memblk_3[sizeof(TensorAccessor)];
 
-    InterleavedAddrGen<false>* l1_src_addr_gens = reinterpret_cast<InterleavedAddrGen<false>*>(l1_src_addr_gens_memblk);
-    InterleavedAddrGen<true>* dram_src_addr_gens =
-        reinterpret_cast<InterleavedAddrGen<true>*>(dram_src_addr_gens_memblk);
+    TensorAccessor* tensor_accessors[num_tensors];
 
-    bool is_dram[num_tensors];
     uint32_t num_pages_per_block[num_tensors];
     uint32_t page_id_per_tensor[num_tensors];
     constexpr uint32_t src_addr_base_idx = 3;
-    constexpr uint32_t is_dram_base_offset = num_tensors;
-    constexpr uint32_t num_pages_per_block_base_offset = is_dram_base_offset + num_tensors;
+    constexpr uint32_t num_pages_per_block_base_offset = num_tensors;
     constexpr uint32_t page_size_per_tensor_offset = num_pages_per_block_base_offset + num_tensors;
     constexpr uint32_t page_id_per_tensor_offset = page_size_per_tensor_offset + num_tensors;
     tt_l1_ptr uint32_t* arg_ptr = (tt_l1_ptr uint32_t*)get_arg_addr(src_addr_base_idx);
     for (uint32_t i = 0; i < num_tensors; ++i) {
         uint32_t src_addr = arg_ptr[i];
-        is_dram[i] = (bool)arg_ptr[is_dram_base_offset + i];
         num_pages_per_block[i] = arg_ptr[num_pages_per_block_base_offset + i];
         page_id_per_tensor[i] = arg_ptr[page_id_per_tensor_offset + i];
-        if (is_dram[i]) {
-            new (&dram_src_addr_gens[i]) InterleavedAddrGen<true>{
-                .bank_base_address = src_addr, .page_size = arg_ptr[page_size_per_tensor_offset + i]};
-        } else {
-            new (&l1_src_addr_gens[i]) InterleavedAddrGen<false>{
-                .bank_base_address = src_addr, .page_size = arg_ptr[page_size_per_tensor_offset + i]};
+        uint32_t page_size = arg_ptr[page_size_per_tensor_offset + i];
+
+        if (i == 0) {
+            tensor_accessors[i] = new (tensor_accessor_memblk_0) TensorAccessor(tensor_args_0, src_addr, page_size);
+        } else if (i == 1) {
+            tensor_accessors[i] = new (tensor_accessor_memblk_1) TensorAccessor(tensor_args_1, src_addr, page_size);
+        } else if (i == 2) {
+            tensor_accessors[i] = new (tensor_accessor_memblk_2) TensorAccessor(tensor_args_2, src_addr, page_size);
+        } else if (i == 3) {
+            tensor_accessors[i] = new (tensor_accessor_memblk_3) TensorAccessor(tensor_args_3, src_addr, page_size);
         }
     }
 
@@ -59,23 +64,14 @@ void kernel_main() {
         // For width concat we know we start at curr_tensor=0
         // num_pages_per_block[curr_tensor] is always one for width concat
         for (uint32_t j = 0; j < num_tensors; ++j) {
-            if (is_dram[curr_tensor]) {
-                noc_async_read_page(page_id_per_tensor[curr_tensor], dram_src_addr_gens[curr_tensor], l1_write_addr);
-                l1_write_addr += dram_src_addr_gens[curr_tensor].page_size;
-            } else {
-                noc_async_read_page(page_id_per_tensor[curr_tensor], l1_src_addr_gens[curr_tensor], l1_write_addr);
-                l1_write_addr += l1_src_addr_gens[curr_tensor].page_size;
-            }
+            noc_async_read_page(page_id_per_tensor[curr_tensor], *tensor_accessors[curr_tensor], l1_write_addr);
+            l1_write_addr += tensor_accessors[curr_tensor]->page_size;
             page_id_per_tensor[curr_tensor]++;
             curr_tensor++;
         }
         curr_tensor = 0;
 #else
-        if (is_dram[curr_tensor]) {
-            noc_async_read_page(page_id_per_tensor[curr_tensor], dram_src_addr_gens[curr_tensor], l1_write_addr);
-        } else {
-            noc_async_read_page(page_id_per_tensor[curr_tensor], l1_src_addr_gens[curr_tensor], l1_write_addr);
-        }
+        noc_async_read_page(page_id_per_tensor[curr_tensor], *tensor_accessors[curr_tensor], l1_write_addr);
 
         page_id_per_tensor[curr_tensor]++;
         curr_tensor_id++;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_s2i_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_s2i_width.cpp
@@ -6,8 +6,8 @@
 #include "debug/dprint.h"
 
 void kernel_main() {
-    constexpr uint32_t num_tensors = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t num_tensors = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
 
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
@@ -18,10 +18,7 @@ void kernel_main() {
 
     uint32_t arg_index = 6;
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr,
-        .page_size = stick_size,
-    };
+    const auto s = TensorAccessor(tensor_args, dst_addr, stick_size);
 
     for (uint32_t tensor_id = 0; tensor_id < num_tensors; tensor_id++) {
         const uint32_t input_shard_cb = get_arg_val<uint32_t>(arg_index++);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -80,8 +81,11 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        reader_compile_time_args = {(uint32_t)src_is_dram};
-        writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+        reader_compile_time_args = {};
+        TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+
+        writer_compile_time_args = {(std::uint32_t)output_cb_index};
+        TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
     } else {
         bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_unit_size);
         uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (std::uint32_t)log2(input_unit_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
@@ -12,7 +12,11 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+#ifndef SHARDED
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+#else
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+#endif
 
 #ifdef OUT_SHARDED
     cb_wait_front(cb_id_out, num_tiles);
@@ -38,8 +42,7 @@ void kernel_main() {
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(3));
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 #else
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 #endif
 
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -8,19 +8,19 @@
 
 void kernel_main() {
     constexpr uint32_t cb_id_0 = get_compile_time_arg_val(0);
-    constexpr bool tensor_in_dram = get_compile_time_arg_val(1) == 1;
-    const uint32_t fill_value = get_compile_time_arg_val(2);
-    const uint32_t element_size_bytes = get_compile_time_arg_val(3);
-    uint32_t logical_height = get_compile_time_arg_val(4);
-    uint32_t logical_width = get_compile_time_arg_val(5);
-    uint32_t padded_height = get_compile_time_arg_val(6);
-    uint32_t padded_width = get_compile_time_arg_val(7);
-    uint32_t tiles_per_2d_tensor = get_compile_time_arg_val(8);
-    uint32_t tiles_per_tile_row = get_compile_time_arg_val(9);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    const uint32_t fill_value = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    const uint32_t element_size_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    uint32_t logical_height = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    uint32_t logical_width = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    uint32_t padded_height = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    uint32_t padded_width = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    uint32_t tiles_per_2d_tensor = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    uint32_t tiles_per_tile_row = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
     // hardware constraints
-    constexpr uint32_t tile_size = get_compile_time_arg_val(10);
+    constexpr uint32_t tile_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
     constexpr uint32_t tile_hw = tile_size * tile_size;
-    constexpr uint32_t face_size = get_compile_time_arg_val(11);
+    constexpr uint32_t face_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
     constexpr uint32_t face_hw = face_size * face_size;
     constexpr uint32_t alignment_adjustor = 16;
 
@@ -32,24 +32,22 @@ void kernel_main() {
 
 #ifdef SHARDED
     using tensor_shard_info = ShardedInfo<
-        get_compile_time_arg_val(12),   // Memory layout
-        get_compile_time_arg_val(13),   // The number of sharding cores
-        get_compile_time_arg_val(14),   // The page size we offset each write to
-        get_compile_time_arg_val(15),   // The number of pages in each sharding row not including padding pages
-        get_compile_time_arg_val(16),   // This defines times when contiguous pages can't be calculated
-        get_compile_time_arg_val(17),   // pages_per_shard_x
-        get_compile_time_arg_val(18)>;  // pages_per_shard_y
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 11),   // Memory layout
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 12),   // The number of sharding cores
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 13),   // The page size we offset each write to
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 14),   // The number of pages in each sharding
+                                                                               // row not including padding pages
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 15),   // This defines times when contiguous
+                                                                               // pages can't be calculated
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 16),   // pages_per_shard_x
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 17)>;  // pages_per_shard_y
 
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(rt_arg_ind));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 #else
     const DataFormat data_format = get_dataformat(cb_id_0);
-    const InterleavedAddrGenFast<tensor_in_dram> s0 = {
-        .bank_base_address = dst_addr,
-        .page_size = tile_hw * element_size_bytes,
-        .data_format = data_format  // page_size needs to be tile_size_bytes
-    };
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, tile_hw * element_size_bytes);
 #endif
 
     // Reserve and push the fill value into the circular buffer
@@ -76,7 +74,7 @@ void kernel_main() {
 
             for (uint32_t col = start_col; col < padded_width;) {
                 // so for each iteration of col, we will be writing at most 2 faces
-                uint64_t start_tile_noc_addr = get_noc_addr(curr_tile, s0);
+                uint64_t start_tile_noc_addr = s0.get_noc_addr(curr_tile);
                 uint32_t face = face_offset / (face_hw);
 
                 uint64_t dst_noc_addr = start_tile_noc_addr + face_offset * element_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -48,8 +48,8 @@ operation::ProgramWithCallbacks fill_rm_single_core(
             .set_page_size(1, single_tile_size);
     auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)dst_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_args(reader_compile_time_args);
 
     tt::tt_metal::KernelHandle binary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
@@ -22,8 +22,8 @@ void kernel_main() {
     uint32_t val_hi = get_arg_val<uint32_t>(6);
     uint32_t val_lo = get_arg_val<uint32_t>(7);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = W << 1};
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, W << 1);
 
     // DPRINT << "fill_rm_8bank: NC=" << NC << " H=" << H << " W=" << W << " fillH=" << fillH << " fillW=" << fillW <<
     // ENDL();
@@ -57,7 +57,7 @@ void kernel_main() {
     // input is NCH(Wt*32) unpadded RM
     for (uint32_t nc = 0; nc < NC; nc++) {
         for (uint32_t h = 0; h < H; h++) {
-            uint64_t dst_noc_addr = get_noc_addr(nch_dst, s0);
+            uint64_t dst_noc_addr = s0.get_noc_addr(nch_dst);
             if (h < fillH) {
                 noc_async_write(l1_w_addr, dst_noc_addr, (W << 1));  // TODO(AP): segment this write
             } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -91,10 +91,14 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     // Configure compile-time arguments for reader kernel
-    std::vector<uint32_t> reader_compile_time_args = {
-        ntiles_per_row,
-        src0_cb_index,
-    };
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(
+        reader_compile_time_args.end(),
+        {
+            ntiles_per_row,
+            src0_cb_index,
+        });
 
     // Configure compile-time arguments for writer kernel
     std::vector<uint32_t> writer_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -8,8 +8,9 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
-    constexpr uint32_t ntiles_per_row = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t ntiles_per_row = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t start_block_id = get_arg_val<uint32_t>(1);
@@ -18,9 +19,8 @@ void kernel_main() {
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
-    // Initialize interleaved address generator for DRAM access
-    const InterleavedAddrGenFast<true> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    // Initialize TensorAccessor for tensor access
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // Process each block of data
     uint32_t end_block_id = start_block_id + num_blocks;

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -119,17 +119,19 @@ GatherProgramFactorySingleRowSingleCore::cached_program_t GatherProgramFactorySi
     tt::tt_metal::CreateCircularBuffer(program, core_range, output_tensor_cb_config);
 
     // Kernels
-    const std::vector<uint32_t> reader_compile_time_args = {
-        input_tensor_cb_index,
-        input_index_tensor_cb_index,
-        output_tensor_cb_index,
-        static_cast<uint32_t>(input_index_tensor_is_dram),
-        Ht,
-        Wt_input,
-        Wt_index,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*input_index_tensor_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(
+        reader_compile_time_args.end(),
+        {input_tensor_cb_index,
+         input_index_tensor_cb_index,
+         output_tensor_cb_index,
+         Ht,
+         Wt_input,
+         Wt_index,
+         total_number_of_cores,
+         compute_with_storage_grid_size.x,
+         compute_with_storage_grid_size.y});
     const std::string gather_reader_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/"
         "gather_reader_single_row_single_core.cpp";
@@ -360,17 +362,19 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
     tt::tt_metal::CreateCircularBuffer(program, core_range, output_tensor_cb_config);
 
     // Kernels
-    const std::vector<uint32_t> reader_compile_time_args = {
-        input_tensor_cb_index,
-        input_index_tensor_cb_index,
-        output_tensor_cb_index,
-        static_cast<uint32_t>(input_index_tensor_is_dram),
-        Ht,
-        Wt_input,
-        Wt_index,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*input_index_tensor_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(
+        reader_compile_time_args.end(),
+        {input_tensor_cb_index,
+         input_index_tensor_cb_index,
+         output_tensor_cb_index,
+         Ht,
+         Wt_input,
+         Wt_index,
+         total_number_of_cores,
+         compute_with_storage_grid_size.x,
+         compute_with_storage_grid_size.y});
     const std::string gather_reader_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp";
     tt::tt_metal::KernelHandle gather_reader_kernel_id = tt::tt_metal::CreateKernel(
@@ -387,17 +391,19 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
          tile_width,
          tile_height});
 
-    const std::vector<uint32_t> writer_compile_time_args = {
-        input_tensor_cb_index,
-        output_tensor_cb_index,
-        static_cast<uint32_t>(input_tensor_is_dram),
-        static_cast<uint32_t>(output_tensor_is_dram),
-        Ht,
-        Wt_input,
-        Wt_index,
-        total_number_of_cores,
-        compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*input_tensor_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*output_tensor_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.insert(
+        writer_compile_time_args.end(),
+        {input_tensor_cb_index,
+         output_tensor_cb_index,
+         Ht,
+         Wt_input,
+         Wt_index,
+         total_number_of_cores,
+         compute_with_storage_grid_size.x,
+         compute_with_storage_grid_size.y});
     const std::string gather_writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp";
     tt::tt_metal::KernelHandle gather_writer_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -53,16 +53,18 @@ void kernel_main() {
     const uint32_t tile_height = get_arg_val<uint32_t>(3);
 
     // Compile time args
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t input_index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(2);
-    constexpr bool input_index_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t input_index_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
 
     constexpr uint32_t one_tile = 1;
     const uint32_t TILE_WIDTH_MASK = tile_width - 1;
@@ -70,10 +72,8 @@ void kernel_main() {
     // Index tensor config
     constexpr uint32_t input_index_tensor_tile_size_bytes = get_tile_size(input_index_tensor_cb_index);
     constexpr DataFormat input_index_tensor_data_format = get_dataformat(input_index_tensor_cb_index);
-    const InterleavedAddrGenFast<input_index_tensor_is_dram> input_index_tensor_dram = {
-        .bank_base_address = input_index_tensor_buffer_addr,
-        .page_size = input_index_tensor_tile_size_bytes,
-        .data_format = input_index_tensor_data_format};
+    const auto input_index_tensor_dram =
+        TensorAccessor(tensor_args, input_index_tensor_buffer_addr, input_index_tensor_tile_size_bytes);
 
     // Dataformats size
     constexpr uint32_t input_tensor_data_format_size =

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -20,34 +20,38 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
 
     // Compile time args
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr bool output_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto input_tensor_args = TensorAccessorArgs<0>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip());
+    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t Ht = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(
+        input_tensor_args.compile_time_args_skip() + output_tensor_args.compile_time_args_skip() + 7);
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_dram = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_dram =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Output tensor config
     constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
     constexpr DataFormat output_tensor_data_format = get_dataformat(output_tensor_cb_index);
-    const InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_dram = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = output_tensor_tile_size_bytes,
-        .data_format = output_tensor_data_format};
+    const auto output_tensor_dram =
+        TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
     const auto start_tile_id = get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
     uint32_t current_index_tile_id = start_tile_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
@@ -28,34 +28,34 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
 
     // Compile time args
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr bool output_tensor_is_dram = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt_input = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt_index = get_compile_time_arg_val(6);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(8);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(9);
+    constexpr auto tensor_args_input = TensorAccessorArgs<0>();
+    constexpr auto tensor_args_output = TensorAccessorArgs<tensor_args_input.compile_time_args_skip()>();
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(tensor_args_output.compile_time_args_skip());
+    constexpr uint32_t output_tensor_cb_index =
+        get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 1);
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 2);
+    constexpr uint32_t Wt_input = get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 3);
+    constexpr uint32_t Wt_index = get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 4);
+    constexpr uint32_t total_number_of_cores =
+        get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 5);
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 6);
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(tensor_args_output.compile_time_args_skip() + 7);
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_dram = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_dram =
+        TensorAccessor(tensor_args_input, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Output tensor config
     constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
     constexpr DataFormat output_tensor_data_format = get_dataformat(output_tensor_cb_index);
-    const InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_dram = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = output_tensor_tile_size_bytes,
-        .data_format = output_tensor_data_format};
+    const auto output_tensor_dram =
+        TensorAccessor(tensor_args_output, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
@@ -18,19 +18,20 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t batch_cb_id = get_compile_time_arg_val(1);
-    constexpr bool batch_ids_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool src0_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(4) == 1;
-    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(5) == 1;
-    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(6);
+    constexpr auto batch_tensor_args = TensorAccessorArgs<2>();
+    constexpr bool src0_is_dram = get_compile_time_arg_val(batch_tensor_args.compile_time_args_skip()) == 1;
+    constexpr bool src1_is_dram = get_compile_time_arg_val(batch_tensor_args.compile_time_args_skip() + 1) == 1;
+    constexpr bool src_stick_size_is_pow2 =
+        get_compile_time_arg_val(batch_tensor_args.compile_time_args_skip() + 2) == 1;
+    constexpr uint32_t src_log_base_2_of_page_size =
+        get_compile_time_arg_val(batch_tensor_args.compile_time_args_skip() + 3);
 
     const auto s0 = get_interleaved_addr_gen<src0_is_dram, src_stick_size_is_pow2>(
         input_addr_a, stick_size, src_log_base_2_of_page_size);
     const auto s1 = get_interleaved_addr_gen<src1_is_dram, src_stick_size_is_pow2>(
         input_addr_b, stick_size, src_log_base_2_of_page_size);
 
-    const InterleavedAddrGen<batch_ids_is_dram> batchAddr = {
-        .bank_base_address = batch_ids_addr, .page_size = batch_id_size << 2};
+    const auto batchAddr = TensorAccessor(batch_tensor_args, batch_ids_addr, batch_id_size << 2);
 
     bool replace_batch = false;
     uint32_t batch_to_replace_id = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -33,8 +33,8 @@ void kernel_main() {
     bool do_third_multicast = get_arg_val<uint32_t>(24) == 1;
 
     constexpr uint32_t cb_id = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<1>();
+    constexpr auto dst_tensor_args = TensorAccessorArgs<1 + src_tensor_args.compile_time_args_skip()>();
 
     const DataFormat data_format = get_dataformat(cb_id);
 
@@ -47,11 +47,9 @@ void kernel_main() {
     constexpr uint32_t ublock_size_tiles = 1;
     uint32_t tile_bytes = get_tile_size(cb_id);
 
-    const InterleavedAddrGenFast<src_is_dram> src_addrgen = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto src_addrgen = TensorAccessor(src_tensor_args, src_addr, tile_bytes);
 
-    const InterleavedAddrGenFast<dst_is_dram> dst_addrgen = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto dst_addrgen = TensorAccessor(dst_tensor_args, dst_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB
     cb_reserve_back(cb_id, num_tiles);

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/data_movement/move/device/move_device_operation.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/data_movement/copy/device/copy_device_operation.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
@@ -99,11 +100,11 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor& input
 
     auto src_buffer = input.buffer();
     auto dst_buffer = output.buffer();
-    bool src_is_dram = src_buffer->buffer_type() == BufferType::DRAM;
-    bool dst_is_dram = dst_buffer->buffer_type() == BufferType::DRAM;
 
     uint32_t log2_page_size = 0;
-    std::vector<uint32_t> compile_time_args = {cb_index, (uint32_t)src_is_dram, (uint32_t)dst_is_dram};
+    std::vector<uint32_t> compile_time_args = {cb_index};
+    TensorAccessorArgs(*src_buffer).append_args(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_args(compile_time_args);
     if (!tilized) {
         bool page_size_is_power_of_two = is_power_of_two_at_least_32(page_size);
         log2_page_size = page_size_is_power_of_two ? (std::uint32_t)log2(page_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/kernels/dataflow/non_zero_indices_sc_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/kernels/dataflow/non_zero_indices_sc_reader.cpp
@@ -18,17 +18,15 @@ void kernel_main() {
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t output_cb_index_0 = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb_index_1 = get_compile_time_arg_val(2);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(4) == 1;
-    constexpr bool dst1_is_dram = get_compile_time_arg_val(5) == 1;
+    constexpr auto src_tensor_args = TensorAccessorArgs<3>();
+    constexpr auto dst0_tensor_args = TensorAccessorArgs<src_tensor_args.compile_time_args_skip()>();
+    constexpr auto dst1_tensor_args = TensorAccessorArgs<dst0_tensor_args.compile_time_args_skip()>();
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {
-        .bank_base_address = input_addr, .page_size = aligned_elements * element_size};
+    const auto s0 = TensorAccessor(src_tensor_args, input_addr, aligned_elements * element_size);
 
-    const InterleavedAddrGen<dst0_is_dram> out0 = {.bank_base_address = output_addr_0, .page_size = 32};
+    const auto out0 = TensorAccessor(dst0_tensor_args, output_addr_0, 32);
 
-    const InterleavedAddrGen<dst1_is_dram> out1 = {
-        .bank_base_address = output_addr_1, .page_size = aligned_elements * element_size};
+    const auto out1 = TensorAccessor(dst1_tensor_args, output_addr_1, aligned_elements * element_size);
 
     uint64_t src_noc_addr = get_noc_addr(0, s0);
     uint32_t input_l1_addr = get_write_ptr(input_cb_index);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -17,15 +17,14 @@ void kernel_main() {
     const uint32_t num_padded_Xt = get_arg_val<uint32_t>(8);
     const uint32_t pad_value = get_arg_val<uint32_t>(9);
 
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out1 = get_compile_time_arg_val(1);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_out1 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
 
     const uint32_t tile_size = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram> s1 = {
-        .bank_base_address = dst_addr, .page_size = tile_size, .data_format = data_format};
+    const auto s1 = TensorAccessor(tensor_args, dst_addr, tile_size);
 
     cb_reserve_back(cb_id_out1, 1);  // in this kernel we are not pushing anything into CBs, just using the space
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -7,18 +7,18 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
-    constexpr uint32_t x_dim = get_compile_time_arg_val(4);
-    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(5);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(6);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(7);
-    constexpr uint32_t x_block_size = get_compile_time_arg_val(8);
-    constexpr uint32_t w_block_size = get_compile_time_arg_val(9);
-    constexpr uint32_t element_size = get_compile_time_arg_val(10);
-    constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(11);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t x_dim = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t x_block_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t w_block_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
+    constexpr uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
+    constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
 
     // Precomputed constants: size of a 32 element block along the W dimension (measured in bytes)
     constexpr uint32_t w_block_size_bytes = w_block_size * element_size;
@@ -50,7 +50,7 @@ void kernel_main() {
     uint32_t X = input_shape[x_dim];
     uint32_t X_stride = src_strides[x_dim];
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = input_tensor_page_size};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, input_tensor_page_size);
 
     uint32_t idxs[N];
     idxs[N - 1] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
@@ -6,16 +6,16 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_row = get_arg_val<uint32_t>(1);
     const uint32_t end_row = get_arg_val<uint32_t>(2);
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, page_size);
 
     uint32_t curr_addr = src_addr;
     for (uint32_t row = start_row; row < end_row; ++row) {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
@@ -25,35 +25,37 @@ void kernel_main() {
     // 1) Compile-time arguments
     // ------------------------------------------------------------------------
 
-    constexpr bool src0_is_dram = static_cast<bool>(get_compile_time_arg_val(0));
-    constexpr uint32_t RANK = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t RANK = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
     // constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t element_size = get_compile_time_arg_val(3);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(4);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(5);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t x_dim_index_in_input = get_compile_time_arg_val(8);
-    constexpr uint32_t X = get_compile_time_arg_val(9);
-    constexpr uint32_t W = get_compile_time_arg_val(10);
-    constexpr uint32_t H = get_compile_time_arg_val(11);
-    constexpr uint32_t X_p = get_compile_time_arg_val(12);
-    constexpr uint32_t W_p = get_compile_time_arg_val(13);
-    constexpr uint32_t H_p = get_compile_time_arg_val(14);
-    constexpr uint32_t H_t = get_compile_time_arg_val(15);
-    constexpr uint32_t W_t = get_compile_time_arg_val(16);
-    constexpr uint32_t final_tile_real_w = get_compile_time_arg_val(17);
-    constexpr uint32_t final_tile_real_faces_w = get_compile_time_arg_val(18);
-    constexpr uint32_t xw_blocks = get_compile_time_arg_val(19);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(20);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(21);
-    constexpr uint32_t num_writes = get_compile_time_arg_val(22);
-    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(23);
-    constexpr bool needs_x_padding = static_cast<bool>(get_compile_time_arg_val(24));
-    constexpr bool needs_y_padding = static_cast<bool>(get_compile_time_arg_val(25));
-    constexpr uint32_t rows_per_x = get_compile_time_arg_val(26);
-    constexpr uint32_t misalignment = get_compile_time_arg_val(27);
-    constexpr uint32_t read_alignment = get_compile_time_arg_val(28);
+    constexpr uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t x_dim_index_in_input = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t X = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
+    constexpr uint32_t H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
+    constexpr uint32_t X_p = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 11);
+    constexpr uint32_t W_p = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 12);
+    constexpr uint32_t H_p = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 13);
+    constexpr uint32_t H_t = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 14);
+    constexpr uint32_t W_t = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 15);
+    constexpr uint32_t final_tile_real_w = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 16);
+    constexpr uint32_t final_tile_real_faces_w = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 17);
+    constexpr uint32_t xw_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 18);
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 19);
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 20);
+    constexpr uint32_t num_writes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 21);
+    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 22);
+    constexpr bool needs_x_padding =
+        static_cast<bool>(get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 23));
+    constexpr bool needs_y_padding =
+        static_cast<bool>(get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 24));
+    constexpr uint32_t rows_per_x = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 25);
+    constexpr uint32_t misalignment = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 26);
+    constexpr uint32_t read_alignment = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 27);
 
     // ------------------------------------------------------------------------
     // 2) Derived Constants (kept as constexpr)
@@ -111,8 +113,7 @@ void kernel_main() {
         src_tiled_strides[i] = src_tiled_strides[i + 1] * input_tiled_shape[i + 1];
     }
     constexpr auto data_format = get_dataformat(tt::CBIndex::c_0);
-    const InterleavedAddrGenFast<src0_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // Stride for stepping along x_dim_index_in_input
     const uint32_t X_stride_tile = src_tiled_strides[x_dim_index_in_input];
@@ -193,7 +194,7 @@ void kernel_main() {
 
             for (uint32_t x = x_start; x < x_end; ++x) {
                 uint32_t l1_col_base = src_buffer_l1_addr + page_offset;
-                uint64_t src_noc_addr = get_noc_addr(tile, s, base_face_line_offset_bytes);
+                uint64_t src_noc_addr = s.get_noc_addr(tile) + base_face_line_offset_bytes;
 
                 // Read each face in [0..real_faces_w)
                 uint16_t w_offset = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
@@ -6,10 +6,10 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_tiles = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_tile = get_arg_val<uint32_t>(1);
@@ -21,8 +21,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
     uint32_t output_tiled_shape[N], inv_perm[N], src_strides[N];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -9,26 +9,26 @@
 
 void kernel_main() {
     // Compile-time constants
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t output_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t output_cb_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
 
-    constexpr uint32_t X = get_compile_time_arg_val(4);
-    constexpr uint32_t X_stride = get_compile_time_arg_val(5);
-    constexpr uint32_t x_dim = get_compile_time_arg_val(6);
+    constexpr uint32_t X = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t X_stride = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t x_dim = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
 
-    constexpr uint32_t W_stride = get_compile_time_arg_val(7);
-    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(8);
-    constexpr uint32_t element_size = get_compile_time_arg_val(9);
+    constexpr uint32_t W_stride = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
 
-    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(10);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(11);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(12);
-    constexpr uint32_t x_block_size = get_compile_time_arg_val(13);
-    constexpr uint32_t w_block_size = get_compile_time_arg_val(14);
-    constexpr uint32_t W = get_compile_time_arg_val(15);
-    constexpr uint32_t output_tensor_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t num_blocks_total = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 11);
+    constexpr uint32_t x_block_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 12);
+    constexpr uint32_t w_block_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 13);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 14);
+    constexpr uint32_t output_tensor_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 15);
 
     constexpr uint32_t cb_id_in = tt::CBIndex::c_2;
 
@@ -47,7 +47,7 @@ void kernel_main() {
     const uint32_t end_block = get_arg_val<uint32_t>(2);
 
     // Interleaved address configuration for the destination
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = output_tensor_page_size};
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, output_tensor_page_size);
 
     // Input shape, permutation, and destination strides
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -6,16 +6,16 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
 
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_row = get_arg_val<uint32_t>(1);
     const uint32_t end_row = get_arg_val<uint32_t>(2);
 
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, page_size);
 
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
     uint32_t input_shape[N], perm[N], dest_strides[N];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
@@ -25,30 +25,30 @@ void kernel_main() {
     // 1) Compile-time Arguments
     //--------------------------------------------------------------------------
 
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t RANK = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t RANK = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
     // constexpr uint32_t input_cb_page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t element_size = get_compile_time_arg_val(3);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(4);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(5);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t x_dim_in_input = get_compile_time_arg_val(8);
-    constexpr uint32_t X = get_compile_time_arg_val(9);
-    constexpr uint32_t W = get_compile_time_arg_val(10);
-    constexpr uint32_t Y = get_compile_time_arg_val(11);
-    constexpr uint32_t X_p = get_compile_time_arg_val(12);
-    constexpr uint32_t W_p = get_compile_time_arg_val(13);
-    constexpr uint32_t rows_per_x = get_compile_time_arg_val(14);
+    constexpr uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t x_dim_in_input = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t X = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
+    constexpr uint32_t Y = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
+    constexpr uint32_t X_p = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 11);
+    constexpr uint32_t W_p = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 12);
+    constexpr uint32_t rows_per_x = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 13);
     // 15 is Y_t, see below
-    constexpr uint32_t W_t = get_compile_time_arg_val(16);
-    constexpr uint32_t final_tile_real_x = get_compile_time_arg_val(17);
-    constexpr uint32_t final_tile_real_faces_x = get_compile_time_arg_val(18);
-    constexpr uint32_t xw_blocks = get_compile_time_arg_val(19);
-    constexpr uint32_t x_blocks = get_compile_time_arg_val(20);
-    constexpr uint32_t w_blocks = get_compile_time_arg_val(21);
-    constexpr bool needs_y_padding = (bool)get_compile_time_arg_val(22);
-    constexpr uint32_t permuted_w_dim = get_compile_time_arg_val(23);
+    constexpr uint32_t W_t = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 15);
+    constexpr uint32_t final_tile_real_x = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 16);
+    constexpr uint32_t final_tile_real_faces_x = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 17);
+    constexpr uint32_t xw_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 18);
+    constexpr uint32_t x_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 19);
+    constexpr uint32_t w_blocks = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 20);
+    constexpr bool needs_y_padding = (bool)get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 21);
+    constexpr uint32_t permuted_w_dim = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 22);
 
     //--------------------------------------------------------------------------
     // 2) Derived Constants (all constexpr)
@@ -124,8 +124,7 @@ void kernel_main() {
     uint32_t W_stride_tile = dest_tiled_strides[permuted_w_dim];
 
     constexpr auto data_format = get_dataformat(tt::CBIndex::c_0);
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     uint32_t idxs[RANK];
     idxs[RANK - 1] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -51,19 +51,19 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     // 0) Read compile-time constants
     // ------------------------------------------------------------------------
-    constexpr bool dst_is_dram = (get_compile_time_arg_val(0) == 1);
-    constexpr uint32_t element_size = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(2);
-    constexpr uint32_t output_H = get_compile_time_arg_val(3);
-    constexpr uint32_t H = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
-    constexpr bool needs_padding = (get_compile_time_arg_val(10) == 1);
-    constexpr uint32_t RANK = get_compile_time_arg_val(11);
-    constexpr uint32_t permuted_input_h_index = get_compile_time_arg_val(12);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t output_H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
+    constexpr bool needs_padding = (get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9) == 1);
+    constexpr uint32_t RANK = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
+    constexpr uint32_t permuted_input_h_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 11);
 
     // ------------------------------------------------------------------------
     // 1) Read runtime arguments
@@ -109,8 +109,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const auto input_data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram, TILE_HW> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = input_data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     // ------------------------------------------------------------------------
     // 3) Height dimension remainder logic

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -2,7 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "permute_rm_program_factory.hpp"
+
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
+#include "ttnn/operations/data_movement/permute/device/permute_op.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/util.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/hal.hpp>
 
@@ -76,8 +85,9 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
 
     uint32_t N = operation_attributes.dims.size();
 
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, N, input_rm_page_size, num_rows};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(reader_compile_time_args.end(), {N, input_rm_page_size, num_rows});
 
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -86,8 +96,9 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)dst_is_dram, N, output_rm_page_size, num_rows};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.insert(writer_compile_time_args.end(), {N, output_rm_page_size, num_rows});
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
@@ -239,20 +250,21 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
             .set_page_size(src2_cb_index, x_block_size * w_block_size * input_tensor.element_size());
     auto cb_src2 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
 
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {
-        (uint32_t)src_is_dram,
-        N,
-        input_cb_page_size,
-        num_rows,
-        x_dim,
-        num_blocks_total,
-        x_blocks,
-        w_blocks,
-        x_block_size,
-        w_block_size,
-        input_tensor.element_size(),
-        input_tensor.logical_shape()[-1] * input_tensor.element_size()};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(
+        reader_compile_time_args.end(),
+        {N,
+         input_cb_page_size,
+         num_rows,
+         x_dim,
+         num_blocks_total,
+         x_blocks,
+         w_blocks,
+         x_block_size,
+         w_block_size,
+         input_tensor.element_size(),
+         input_tensor.logical_shape()[-1] * input_tensor.element_size()});
 
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -261,29 +273,30 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)dst_is_dram,
-        N,
-        output_cb_page_size,
-        num_rows,
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.insert(
+        writer_compile_time_args.end(),
+        {N,
+         output_cb_page_size,
+         num_rows,
 
-        X,
-        X_stride,
-        x_dim,
+         X,
+         X_stride,
+         x_dim,
 
-        W_stride,
-        input_cb_page_size,
-        input_tensor.element_size(),
+         W_stride,
+         input_cb_page_size,
+         input_tensor.element_size(),
 
-        num_blocks_total,
-        x_blocks,
-        w_blocks,
-        x_block_size,
-        w_block_size,
+         num_blocks_total,
+         x_blocks,
+         w_blocks,
+         x_block_size,
+         w_block_size,
 
-        W,
-        output_tensor.logical_shape()[-1] * output_tensor.element_size()};
+         W,
+         output_tensor.logical_shape()[-1] * output_tensor.element_size()});
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_interleaved.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     uint32_t output_Ht = get_arg_val<uint32_t>(4);
     uint32_t output_Wt = get_arg_val<uint32_t>(5);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
 
     uint32_t num_sticks_per_input_tile_row = input_Wt << 5;  // Tile height is 32
     uint32_t num_sticks_per_output_tile_row = output_Wt << 5;
@@ -35,8 +35,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, src0_addr, tile_bytes);
 
     // Sticks are a row of elements in a single tile (32 elements)
     // Stick id increments row-wise

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_stick_layout_interleaved_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_stick_layout_interleaved_multi_core.cpp
@@ -12,15 +12,15 @@ void kernel_main() {
     uint32_t num_sticks_per_cb_push = get_arg_val<uint32_t>(3);
     uint32_t start_id = get_arg_val<uint32_t>(4);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t old_stick_size = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t old_stick_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t size = get_compile_time_arg_val(3);
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1) == 1;
+    constexpr uint32_t size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
 
-    const auto s = get_interleaved_addr_gen<src_is_dram, stick_size_is_pow2>(src_addr, size);
+    const auto s = TensorAccessor(tensor_args, src_addr, size);
 
     uint32_t i_stick = start_id;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/writer_unary_reshape_stick_layout_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/writer_unary_reshape_stick_layout_interleaved.cpp
@@ -13,7 +13,8 @@ void kernel_main() {
     uint32_t num_sticks = get_arg_val<uint32_t>(1);
     uint32_t stick_size = get_arg_val<uint32_t>(2);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr bool stick_size_is_power_of_two = get_compile_time_arg_val(tensor_args.compile_time_args_skip()) == 1;
 
     // TODO(agrebenisan): This isn't good... here we are assuming
     // that the stick size dictates tiles c, but stick size
@@ -22,19 +23,11 @@ void kernel_main() {
     const uint32_t num_tiles_c = stick_size / 64;  // Assuming 2 bytes per datum, there are 64 bytes per tile row
     uint32_t stick_id = 0;
 
-    constexpr bool stick_size_is_power_of_two = (get_compile_time_arg_val(1) == 1);
 #if (stick_size_is_power_of_two)
-    const uint32_t log_base_2_of_page_size = get_arg_val<uint32_t>(3);
-    const InterleavedPow2AddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr,
-
-        .log_base_2_of_page_size = log_base_2_of_page_size  // TODO(AP): refactor
-    };
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    const auto s = TensorAccessor(tensor_args, dst_addr, 1 << log_base_2_of_page_size);
 #else
-    const InterleavedAddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr,
-
-        .page_size = stick_size};
+    const auto s = TensorAccessor(tensor_args, dst_addr, stick_size);
 #endif
 
     for (uint32_t i = 0; i < num_sticks / 32; i++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp
@@ -19,12 +19,12 @@ void kernel_main() {
     uint32_t start_output_page_idx = get_arg_val<uint32_t>(2);
     uint32_t end_output_page_idx = get_arg_val<uint32_t>(3);
 
-    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t Max_Map_Size_Bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t Tile_Size_Bytes = get_compile_time_arg_val(2);
+    constexpr auto tensor_args_input = TensorAccessorArgs<0>();
+    constexpr uint32_t Max_Map_Size_Bytes = get_compile_time_arg_val(tensor_args_input.compile_time_args_skip());
+    constexpr uint32_t Tile_Size_Bytes = get_compile_time_arg_val(tensor_args_input.compile_time_args_skip() + 1);
 
-    constexpr uint32_t mapping_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t input_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t mapping_cb_id = get_compile_time_arg_val(tensor_args_input.compile_time_args_skip() + 2);
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(tensor_args_input.compile_time_args_skip() + 3);
 
     constexpr uint32_t Max_Map_Entries = Max_Map_Size_Bytes / sizeof(SegmentMapData);
     constexpr uint32_t Max_Map_Elements = Max_Map_Entries * SegmentMapData::size;
@@ -32,10 +32,11 @@ void kernel_main() {
     const DataFormat input_data_format = get_dataformat(input_cb_id);
     const DataFormat map_data_format = get_dataformat(mapping_cb_id);
 
-    const InterleavedAddrGenFast<input_is_dram> input_addr_gen = {
-        .bank_base_address = input_addr, .page_size = Tile_Size_Bytes, .data_format = input_data_format};
+    const auto input_addr_gen = TensorAccessor(tensor_args_input, input_addr, Tile_Size_Bytes);
 
-    const InterleavedAddrGen<true> map_addr_gen = {.bank_base_address = map_addr, .page_size = Max_Map_Size_Bytes};
+    // Create a separate TensorAccessor for map (hardcoded DRAM access pattern)
+    constexpr auto tensor_args_map = TensorAccessorArgs<tensor_args_input.compile_time_args_skip()>();
+    const auto map_addr_gen = TensorAccessor(tensor_args_map, map_addr, Max_Map_Size_Bytes);
 
     bool first = true;
     for (uint32_t out_page_idx = start_output_page_idx; out_page_idx < end_output_page_idx; ++out_page_idx) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -16,21 +16,20 @@ void kernel_main() {
     const uint32_t start_output_page = get_arg_val<uint32_t>(1);
     const uint32_t end_output_page = get_arg_val<uint32_t>(2);
 
-    constexpr bool output_is_dram = get_compile_time_arg_val(0);
-    constexpr uint32_t Tile_size_bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t Max_Map_Entries = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t Tile_size_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t Max_Map_Entries = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
 
-    constexpr uint8_t element_sz_bytes = get_compile_time_arg_val(3);
+    constexpr uint8_t element_sz_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
 
-    constexpr uint32_t cb_id_mapping = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_id_input = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_id_working = get_compile_time_arg_val(6);  // scratch
+    constexpr uint32_t cb_id_mapping = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t cb_id_input = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t cb_id_working = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);  // scratch
 
     const DataFormat input_data_format = get_dataformat(cb_id_input);
 
     //  TODO sharded
-    const InterleavedAddrGenFast<output_is_dram> output_addrgen = {
-        .bank_base_address = output_base_addr, .page_size = Tile_size_bytes, .data_format = input_data_format};
+    const auto output_addrgen = TensorAccessor(tensor_args, output_base_addr, Tile_size_bytes);
 
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
@@ -366,22 +366,29 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
 
     TT_ASSERT(num_cores <= num_output_pages);
 
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*input_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*mapping_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(
+        reader_compile_time_args.end(), {mapping_page_size_bytes, input_tile_size_bytes, mapping_cb_idx, input_cb_idx});
+
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp",
         total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            {input_is_dram, mapping_page_size_bytes, input_tile_size_bytes, mapping_cb_idx, input_cb_idx}));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
     const uint32_t max_map_entries = mapping_page_size / detail::SegmentMapData::size;
-    std::vector<uint32_t> writer_compile_time_args = {
-        output_is_dram,
-        input_tile_size_bytes,
-        max_map_entries,
-        tt::datum_size(output_cb_data_format),
-        mapping_cb_idx,
-        input_cb_idx,
-        output_cb_idx};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*output_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.insert(
+        writer_compile_time_args.end(),
+        {input_tile_size_bytes,
+         max_map_entries,
+         tt::datum_size(output_cb_data_format),
+         mapping_cb_idx,
+         input_cb_idx,
+         output_cb_idx});
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -27,14 +27,13 @@ void kernel_main() {
     const uint32_t start_id = start_id_base + start_id_offset;
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t num_readers = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t num_readers = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_readers>();
     uint32_t barrier_count = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
@@ -16,15 +16,14 @@ void kernel_main() {
     const uint32_t start_id_base = get_arg_val<uint32_t>(8);
     const uint32_t start_id = start_id_base + start_id_offset;
 
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
 
     // single-tile ublocks
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
     const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     const uint32_t padded_width_diff = (block_width_tiles - unpadded_block_width_tiles) * tile_bytes;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/hal.hpp>
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -130,8 +131,9 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
 
     tt::tt_metal::KernelHandle unary_reader_kernel_id;
     if (input.layout() == Layout::TILE) {
-        std::vector<uint32_t> reader_compile_time_args = {
-            (std::uint32_t)input_cb_index, (std::uint32_t)src_is_dram, all_cores.num_cores()};
+        std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index};
+        TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+        reader_compile_time_args.push_back(all_cores.num_cores());
 
         unary_reader_kernel_id = tt::tt_metal::CreateKernel(
             program,
@@ -143,10 +145,10 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
         uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (std::uint32_t)log2(num_units_per_row) : 0;
         std::vector<uint32_t> reader_compile_time_args = {
             (std::uint32_t)input_cb_index,
-            (std::uint32_t)scratch_cb_index,
-            (std::uint32_t)src_is_dram,
-            (std::uint32_t)src_stick_size_is_power_of_two,
-            (std::uint32_t)src_log2_stick_size};
+            (std::uint32_t)scratch_cb_index};
+        TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+        reader_compile_time_args.push_back((std::uint32_t)src_stick_size_is_power_of_two);
+        reader_compile_time_args.push_back((std::uint32_t)src_log2_stick_size);
 
         unary_reader_kernel_id = tt::tt_metal::CreateKernel(
             program,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -113,12 +113,13 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
         all_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
 
     tt_metal::KernelHandle unary_writer_kernel_id;
     if (input.layout() == Layout::TILE) {
-        std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)out_cb_index, (std::uint32_t)dst_is_dram};
+        std::vector<uint32_t> writer_compile_time_args = {};
+        TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+        writer_compile_time_args.push_back((std::uint32_t)out_cb_index);
 
         unary_writer_kernel_id = tt_metal::CreateKernel(
             program,
@@ -128,11 +129,12 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
     } else {
         bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(num_units_per_row);
         uint32_t dst_log2_stick_size = dst_stick_size_is_power_of_two ? (std::uint32_t)log2(num_units_per_row) : 0;
-        std::vector<uint32_t> writer_compile_time_args = {
+        std::vector<uint32_t> writer_compile_time_args = {};
+        TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+        writer_compile_time_args.insert(writer_compile_time_args.end(), {
             (std::uint32_t)out_cb_index,
-            (std::uint32_t)dst_is_dram,
             (std::uint32_t)dst_stick_size_is_power_of_two,
-            (std::uint32_t)dst_log2_stick_size};
+            (std::uint32_t)dst_log2_stick_size});
 
         unary_writer_kernel_id = tt_metal::CreateKernel(
             program,
@@ -235,6 +237,7 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
             uint32_t dram_alignment = hal::get_dram_alignment();
             uint32_t l1_alignment = hal::get_l1_alignment();
             uint32_t padded_shard_width = align(output_unit_size, dst_buffer->alignment());
+            bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
             if(is_blackhole or is_l1_aligned) {
                 if(!dst_is_dram or is_l1_aligned)
                     padded_shard_width = align(output_unit_size, l1_alignment);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
@@ -8,6 +8,7 @@
 void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t num_dims = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<2>();
     const uint32_t src_addr = get_common_arg_val<uint32_t>(0);
 
     volatile tt_l1_ptr uint32_t* num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(1));
@@ -21,10 +22,8 @@ void kernel_main() {
     constexpr uint32_t tile_size = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(2) == 1;
     // In and out are assumed to be same dataformat
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src_addr, .page_size = tile_size, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, tile_size);
 
     uint32_t src_tile_id = start_id;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -4,28 +4,29 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
-#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
-    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
-    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
-    const uint32_t num_dims = get_arg_val<uint32_t>(4);
-    const uint32_t misalignment = get_arg_val<uint32_t>(5);
-    const uint32_t start_id = get_arg_val<uint32_t>(6);
-    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
-    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
-    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(3);
+    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(4);
+    uint32_t padded_stick_size = get_arg_val<uint32_t>(5);
+    uint32_t unpadded_stick_size = get_arg_val<uint32_t>(6);
+    uint32_t num_dims = get_arg_val<uint32_t>(7);
+    uint32_t misalignment = get_arg_val<uint32_t>(8);
+
+    // Get addresses for arrays stored in common args
+    volatile tt_l1_ptr uint32_t* num_unpadded_sticks = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(9));
 
     tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(10));
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, padded_stick_size);
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -33,28 +34,13 @@ void kernel_main() {
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
         cb_reserve_back(cb_id_in0, num_read_per_barrier);
-        uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
-
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0, misalignment);
+            noc_async_read(src_noc_addr, l1_write_addr, read_size);
+            l1_write_addr += padded_stick_size;
+            src_stick_id = update_stick_id(src_stick_id, num_dims, num_unpadded_sticks, num_padded_sticks, id_per_dim);
             sticks_read++;
-            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-            noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
-            if (misalignment != 0) {
-                noc_async_read_barrier();
-                tt::data_movement::common::tt_memmove<false, false, false, 0>(
-                    src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
-            }
-            src_buffer_l1_addr += stick_size_offset;
-            src_stick_id++;
-            for (uint32_t j = 0; j < num_dims; j++) {
-                id_per_dim[j]++;
-                if (id_per_dim[j] == num_unpadded_sticks[j]) {
-                    id_per_dim[j] = 0;
-                    src_stick_id += num_padded_sticks[j];
-                } else {
-                    break;
-                }
-            }
         }
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, num_read_per_barrier);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -15,9 +15,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = stick_size};
+    const auto s0 = TensorAccessor(tensor_args, dst_addr, stick_size);
 
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;
@@ -27,7 +27,7 @@ void kernel_main() {
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            uint64_t dst_noc_addr = get_noc_addr(i_stick, s0);
+            uint64_t dst_noc_addr = s0.get_noc_addr(i_stick);
             noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
             l1_read_addr += stick_size_offset;
             i_stick += 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
@@ -6,9 +6,9 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t dims = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t dims = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
 
@@ -31,7 +31,7 @@ void kernel_main() {
     }
     prod[dims - 1] = 1;  // Not used, but set to 1 for completeness
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = page_size};
+    const auto s0 = TensorAccessor(tensor_args, src_addr, page_size);
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_out0 = 24;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp
@@ -24,32 +24,30 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
 
     // Compile time args
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t Ht = get_compile_time_arg_val(5);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(8);
+    constexpr auto tensor_args_input = TensorAccessorArgs<0>();
+    constexpr auto tensor_args_index = TensorAccessorArgs<tensor_args_input.compile_time_args_skip()>();
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip());
+    constexpr uint32_t index_tensor_output_cb_index =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 1);
+    constexpr uint32_t Wt = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 2);
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 3);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 4);
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 5);
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 6);
 
     // Input tensor config
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> interleaved_accessor0 = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto interleaved_accessor0 = TensorAccessor(tensor_args_input, input_tensor_buffer_addr, tile_size_bytes);
 
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
-    const InterleavedAddrGenFast<index_tensor_is_dram> interleaved_accessor1 = {
-        .bank_base_address = index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto interleaved_accessor1 =
+        TensorAccessor(tensor_args_index, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp
@@ -14,20 +14,24 @@ void kernel_main() {
     const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(0);
 
     // Compile time args
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(0);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(1);
-    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(2);
-    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(3);
-    constexpr uint32_t value_tensor_peer_cb_index = get_compile_time_arg_val(4);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t value_tensor_peer_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
     constexpr uint32_t physical_core_lookup_table_cb_index =
-        get_compile_time_arg_val(5);  // unused - for future improvements
-    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(6) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(7);
-    constexpr uint32_t Ht = get_compile_time_arg_val(8);
-    constexpr uint32_t number_of_tiles_per_core = get_compile_time_arg_val(9);
-    constexpr uint32_t number_of_cores_used = get_compile_time_arg_val(10);          // unused - for future improvements
-    const uint32_t sem_exchange_addr = get_semaphore(get_compile_time_arg_val(11));  // unused - for future improvements
-    constexpr bool is_32_bit_data = get_compile_time_arg_val(12) == 1;
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);  // unused - for future improvements
+    constexpr uint32_t Wt = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t number_of_tiles_per_core = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
+    constexpr uint32_t number_of_cores_used =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);  // unused - for future improvements
+    const uint32_t sem_exchange_addr = get_semaphore(
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10));  // unused - for future improvements
+    constexpr bool is_32_bit_data = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 11) == 1;
 
     // Constants
     constexpr uint32_t one_tile = 1;
@@ -42,10 +46,8 @@ void kernel_main() {
     // Output tensor config
     const uint32_t value_tensor_tile_size_bytes = get_tile_size(value_tensor_cb_index);
     const DataFormat value_tensor_data_format = get_dataformat(value_tensor_cb_index);
-    const InterleavedAddrGenFast<value_tensor_is_dram> output_tensor_accessor = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = value_tensor_tile_size_bytes,
-        .data_format = value_tensor_data_format};
+    const auto output_tensor_accessor =
+        TensorAccessor(tensor_args, output_tensor_buffer_addr, value_tensor_tile_size_bytes);
 
     for (uint32_t h = 0; h < Ht; h++) {
         // Generate input index tiles

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
@@ -14,34 +14,35 @@ void kernel_main() {
     const uint32_t cores_to_coordinator_semaphore_id = get_semaphore(get_arg_val<uint32_t>(5));
 
     // Compile time args
-    constexpr uint32_t input_tensor_output_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
-    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t Ht = get_compile_time_arg_val(5);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(7);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(8);
-    constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(9);
+    constexpr auto tensor_args_input = TensorAccessorArgs<0>();
+    constexpr auto tensor_args_index = TensorAccessorArgs<tensor_args_input.compile_time_args_skip()>();
+    constexpr uint32_t input_tensor_output_cb_index =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip());
+    constexpr uint32_t index_tensor_output_cb_index =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 1);
+    constexpr uint32_t Wt = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 2);
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 3);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 4);
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 5);
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 6);
+    constexpr uint32_t number_of_available_cores =
+        get_compile_time_arg_val(tensor_args_index.compile_time_args_skip() + 7);
 
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
     constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_output_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_output_cb_index);
-    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_addr_gen = {
-        .bank_base_address = input_tensor_buffer_addr,
-        .page_size = input_tensor_tile_size_bytes,
-        .data_format = input_tensor_data_format};
+    const auto input_tensor_addr_gen =
+        TensorAccessor(tensor_args_input, input_tensor_buffer_addr, input_tensor_tile_size_bytes);
 
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
-    const InterleavedAddrGenFast<index_tensor_is_dram> index_tensor_addr_gen = {
-        .bank_base_address = index_tensor_buffer_addr,
-        .page_size = index_tensor_output_tile_size_bytes,
-        .data_format = index_tensor_output_data_format};
+    const auto index_tensor_addr_gen =
+        TensorAccessor(tensor_args_index, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
     // Semaphore setup
     const uint64_t coordinator_core_addr = get_noc_addr(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp
@@ -24,24 +24,24 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(1);
 
     // Compile time args
-    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(5);
-    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(6);
-    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(7);
-    constexpr bool is_32_bit_data = get_compile_time_arg_val(8) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t Wt = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t compute_with_storage_grid_size_x =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t compute_with_storage_grid_size_y =
+        get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr bool is_32_bit_data = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7) == 1;
 
     // Output tensor config
     constexpr uint32_t one_tile = 1;
     const uint32_t value_tensor_tile_size_bytes = get_tile_size(value_tensor_cb_index);
     const DataFormat value_tensor_data_format = get_dataformat(value_tensor_cb_index);
-    const InterleavedAddrGenFast<value_tensor_is_dram> interleaved_accessor0 = {
-        .bank_base_address = value_tensor_buffer_addr,
-        .page_size = value_tensor_tile_size_bytes,
-        .data_format = value_tensor_data_format};
+    const auto interleaved_accessor0 =
+        TensorAccessor(tensor_args, value_tensor_buffer_addr, value_tensor_tile_size_bytes);
 
     // Move data from L1 to DRAMs
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp
@@ -20,25 +20,24 @@ void kernel_main() {
 
     // COMPILE TIME ARGS
     // interleaved accessor args
-    constexpr uint32_t in0_is_dram = get_compile_time_arg_val(1);
-    constexpr uint32_t z = get_compile_time_arg_val(2);
-    constexpr uint32_t out_num_tiles_per_tensor_y = get_compile_time_arg_val(3);
-    constexpr uint32_t out_num_tiles_per_tensor_x = get_compile_time_arg_val(4);
-    constexpr uint32_t z_stride = get_compile_time_arg_val(5);
-    constexpr uint32_t y_stride = get_compile_time_arg_val(6);
+    constexpr bool tile_dtype_is_bfloat16 = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t z = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t out_num_tiles_per_tensor_y =
+        get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t out_num_tiles_per_tensor_x =
+        get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t z_stride = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t y_stride = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 4);
 
     constexpr uint32_t out_num_tensors = 1;
     constexpr uint32_t cb_id_in0 = 0;
     uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
 
-    constexpr bool in0_is_dram_bool = in0_is_dram == 1;
-
     constexpr uint32_t onetile = 1;
-    constexpr bool tile_dtype_is_bfloat16 = get_compile_time_arg_val(0) == 1;
     constexpr DataFormat data_format = (tile_dtype_is_bfloat16) ? DataFormat::Float16 : DataFormat::Bfp8_b;
 
-    const InterleavedAddrGenFast<in0_is_dram_bool> s0 = {
-        .bank_base_address = in0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, in0_tensor_addr, single_tile_size_bytes);
 
     uint32_t tensor_stride = out_num_tiles_per_tensor_x;
     uint32_t tensor_stride_cum = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_two_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_two_chunks.cpp
@@ -21,30 +21,27 @@ void kernel_main() {
 
     // COMPILE TIME ARGS
     // interleaved accessor args
-    constexpr uint32_t out_is_dram = get_compile_time_arg_val(1);
+    constexpr bool tile_dtype_is_bfloat16 = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
     // WRITER COMPILE TIME ARGS
     // constexpr uint32_t out_num_tiles_per_tensor = get_compile_time_arg_val(2);
-    constexpr uint32_t out_num_tiles_per_tensor_y = get_compile_time_arg_val(2);
-    constexpr uint32_t out_num_tiles_per_tensor_x = get_compile_time_arg_val(3);
-    constexpr uint32_t z = get_compile_time_arg_val(4);
-    constexpr uint32_t z_stride = get_compile_time_arg_val(5);
-    constexpr uint32_t y_stride = get_compile_time_arg_val(6);
+    constexpr uint32_t out_num_tiles_per_tensor_y = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip());
+    constexpr uint32_t out_num_tiles_per_tensor_x =
+        get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t z = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t z_stride = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t y_stride = get_compile_time_arg_val(1 + tensor_args.compile_time_args_skip() + 4);
 
     constexpr uint32_t cb_id_out0 = 0;  // same as cb_id_in0
     uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
 
-    constexpr bool out_is_dram_bool = out_is_dram == 1;
     constexpr uint32_t onetile = 1;
-
-    constexpr bool tile_dtype_is_bfloat16 = get_compile_time_arg_val(0) == 1;
     constexpr DataFormat data_format = (tile_dtype_is_bfloat16) ? DataFormat::Float16 : DataFormat::Bfp8_b;
 
-    const InterleavedAddrGenFast<out_is_dram_bool> s0 = {
-        .bank_base_address = out0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
-    const InterleavedAddrGenFast<out_is_dram_bool> s1 = {
-        .bank_base_address = out1_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, out0_tensor_addr, single_tile_size_bytes);
+    const auto s1 = TensorAccessor(tensor_args, out1_tensor_addr, single_tile_size_bytes);
 
-    std::array<InterleavedAddrGenFast<out_is_dram_bool>, 2> output_banks{s0, s1};
+    std::array<decltype(s0), 2> output_banks{s0, s1};
     uint32_t out_split_tensor_tile_id;
     //    uint32_t out_num_tiles_read = out_num_tiles_per_tensor;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
@@ -16,23 +16,29 @@ FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, uint32_t val) {
 void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
 
-    const uint32_t total_num_rows = get_compile_time_arg_val(2);
-    const uint32_t third_dim = get_compile_time_arg_val(3);
-    const uint32_t tile_height = get_compile_time_arg_val(4);
-    const uint32_t element_size = get_compile_time_arg_val(5);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+
+#if (STICK_SIZE_IS_POW2 == 1)
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    const uint32_t total_num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    const uint32_t third_dim = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    const uint32_t tile_height = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    const uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+#else
+    const uint32_t total_num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    const uint32_t third_dim = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    const uint32_t tile_height = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    const uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+#endif
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t unpadded_X_size = get_arg_val<uint32_t>(1);
     const uint32_t pad_value = get_arg_val<uint32_t>(2);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-
 #if (STICK_SIZE_IS_POW2 == 1)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(1);
-    const InterleavedPow2AddrGen<src0_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
+    const auto s = TensorAccessor(tensor_args, src_addr, 1U << log_base_2_of_page_size);
 #else
-    const InterleavedAddrGen<src0_is_dram> s = {.bank_base_address = src_addr, .page_size = unpadded_X_size};
+    const auto s = TensorAccessor(tensor_args, src_addr, unpadded_X_size);
 #endif
 
     auto read_block = [&](uint32_t num_rows,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     uint32_t batch_step = get_arg_val<uint32_t>(4);    // CHtWt - HtWt
     uint32_t channel_step = get_arg_val<uint32_t>(5);  // NCHtWt - HtWt
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -22,8 +22,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t i = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -18,15 +18,14 @@ void kernel_main() {
     uint32_t n = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t tile_idx = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
@@ -27,10 +27,10 @@ void kernel_main() {
     uint32_t ctoffs = get_arg_val<uint32_t>(12);
     uint32_t wt = get_arg_val<uint32_t>(13);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
-    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(2);
-    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(3);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
     constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
 
     constexpr uint32_t onetile = 1;
@@ -43,8 +43,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s0 = TensorAccessor(tensor_args, src0_addr, tile_bytes);
     uint32_t intermed_l1_scratch = MISALIGNED ? get_write_ptr(1) : 0;
     volatile tt_l1_ptr uint8_t* intermed_l1_scratch_ptr = (volatile uint8_t*)intermed_l1_scratch;
     for (uint32_t t = 0; t < num_tiles; t++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -14,11 +14,11 @@ void kernel_main() {
     uint32_t curr_h = get_arg_val<uint32_t>(5);
     uint32_t curr_n = get_arg_val<uint32_t>(6);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t N = get_compile_time_arg_val(1);
-    constexpr uint32_t H = get_compile_time_arg_val(2);
-    constexpr uint32_t C = get_compile_time_arg_val(3);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(4);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t N = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t C = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
 
     constexpr uint32_t CH = C * H;
 
@@ -26,17 +26,13 @@ void kernel_main() {
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(5) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(6);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    const auto s = TensorAccessor(tensor_args, src_addr, 1 << log_base_2_of_page_size);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(6);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<src_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    const auto s = TensorAccessor(tensor_args, src_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -11,16 +11,16 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t num_writes = get_compile_time_arg_val(1);
-    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(2);
-    constexpr uint32_t needs_padding = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t swap_hw = get_compile_time_arg_val(4) == 1;
-    constexpr uint32_t H = get_compile_time_arg_val(5);
-    constexpr uint32_t W = get_compile_time_arg_val(6);
-    constexpr uint32_t accumulated_outer_dims = get_compile_time_arg_val(7);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(8);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(9);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t num_writes = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t padding_val_packed = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t needs_padding = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2) == 1;
+    constexpr uint32_t swap_hw = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3) == 1;
+    constexpr uint32_t H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t accumulated_outer_dims = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
 
     constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
     constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
@@ -37,8 +37,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -12,7 +12,7 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(3);
     uint32_t HtWt = get_arg_val<uint32_t>(4);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
     constexpr uint32_t cb_id_in0 = 0;
 
     // ublocks size defined in tiles
@@ -22,7 +22,7 @@ void kernel_main() {
 
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_in_2 = 2;
-    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+    constexpr uint32_t scaler = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
     cb_reserve_back(cb_in_2, 1);
     if (scaler != 0) {
         uint16_t u = uint16_t(scaler >> 16);
@@ -43,8 +43,7 @@ void kernel_main() {
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     // this reader will read a NHW tensor in NWH order
     for (uint32_t n = 0; n < N; n++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -16,7 +16,7 @@ void kernel_main() {
     uint32_t Wt = get_arg_val<uint32_t>(6);
     uint32_t HtWt = get_arg_val<uint32_t>(7);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
     // uint32_t Ht  = (uint32_t)get_compile_time_arg_val(1);
     // uint32_t Wt  = (uint32_t)get_compile_time_arg_val(2);
     // uint32_t HtWt  = (uint32_t)get_compile_time_arg_val(3);
@@ -28,8 +28,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     uint32_t ht = start_ht;
     uint32_t wt = start_wt;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -10,31 +10,27 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(1);
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t H_per_tile = get_compile_time_arg_val(2);
-    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(6);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(8);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t H_per_tile = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t Wt = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(9) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
+    const auto s = TensorAccessor(tensor_args, src_addr, 1 << log_base_2_of_page_size);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(10);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<src_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9);
+    const auto s = TensorAccessor(tensor_args, src_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -10,23 +10,19 @@ void kernel_main() {
     uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(2);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(3) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(4);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    const auto s = TensorAccessor(tensor_args, dst_addr, 1 << log_base_2_of_page_size);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(4);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<dst_is_dram> s = {.bank_base_address = dst_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    const auto s = TensorAccessor(tensor_args, dst_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -14,17 +14,17 @@ void kernel_main() {
     uint32_t end_padding_tile_idx = get_arg_val<uint32_t>(4);
 
     // Compile-time constants
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t element_size = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(2);
-    constexpr uint32_t C = get_compile_time_arg_val(3);
-    constexpr uint32_t H = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(6);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
-    constexpr bool needs_padding = get_compile_time_arg_val(10) == 1;
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t element_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t C = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t W = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
+    constexpr bool needs_padding = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9) == 1;
 
     // Derived compile-time constants
     constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
@@ -45,8 +45,7 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const auto input_data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<dst_is_dram, TILE_HW> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = input_data_format};
+    const auto s = TensorAccessor(tensor_args, dst_addr, tile_bytes);
 
     // Calculate actual data height in the last tile
     constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -9,31 +9,27 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(1);
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(2);
-    constexpr uint32_t H = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t W_per_tile = get_compile_time_arg_val(5);
-    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(6);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(7);
-    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(8);
-    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(9);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t Ht = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t H = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t Wt = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
+    constexpr uint32_t W_per_tile = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 4);
+    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 5);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 6);
+    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 7);
+    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 8);
 
     // single-tile ublocks
     const uint32_t stick_size_bytes = H_size_bytes;
 
-    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(10) == 1;
+    constexpr bool stick_size_is_pow2 = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 9) == 1;
 #if (stick_size_is_pow2)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
+    const auto s = TensorAccessor(tensor_args, dst_addr, 1 << log_base_2_of_page_size);
 #else
-    constexpr uint32_t page_size = get_compile_time_arg_val(11);
-#endif
-#if (stick_size_is_pow2)
-    const InterleavedPow2AddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<dst_is_dram> s = {.bank_base_address = dst_addr, .page_size = page_size};
+    constexpr uint32_t page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 10);
+    const auto s = TensorAccessor(tensor_args, dst_addr, page_size);
 #endif
 
     uint32_t i_stick = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -2,14 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/work_split.hpp>
-#include "ttnn/tensor/host_buffer/functions.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal.hpp>
+#include "transpose_program_factory.hpp"
+
+#include <algorithm>
+
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp"
 #include "ttnn/operations/math.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/util.hpp>
-#include "ttnn/operation.hpp"
+#include <tt-metalium/work_split.hpp>
 
 #include <cstdint>
 #include <math.h>
@@ -140,8 +145,8 @@ operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor& a, Tensor&
             .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)src0_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
 
@@ -580,19 +585,20 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
     // create writer kernel with compile time and runtime args
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)dst_is_dram,
-        a.element_size(),
-        tt::CBIndex::c_0,
-        C,
-        H,
-        W,
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1],
-        (uint32_t)needs_padding};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    writer_compile_time_args.insert(
+        writer_compile_time_args.end(),
+        {a.element_size(),
+         tt::CBIndex::c_0,
+         C,
+         H,
+         W,
+         tile_shape[0],
+         tile_shape[1],
+         face_shape[0],
+         face_shape[1],
+         (uint32_t)needs_padding});
 
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -701,13 +707,12 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(
     }
 
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
     if (row_major) {
-        reader_compile_time_args.push_back((std::uint32_t)N);
-        reader_compile_time_args.push_back((std::uint32_t)H);
-        reader_compile_time_args.push_back((std::uint32_t)C);
-        reader_compile_time_args.push_back((std::uint32_t)W * a.element_size());
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(),
+            {(std::uint32_t)N, (std::uint32_t)H, (std::uint32_t)C, (std::uint32_t)W * a.element_size()});
 
         auto stick_size = W * a.element_size();
         bool stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
@@ -718,11 +723,8 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(
         } else {
             reader_compile_time_args.push_back(stick_size);
         }
-    } else {
-        reader_compile_time_args.push_back((std::uint32_t)sub_tile_line_bytes);
-        reader_compile_time_args.push_back((std::uint32_t)(cb_data_format == tt::DataFormat::Float32));
-        reader_compile_time_args.push_back((std::uint32_t)alignment);
     }
+
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
     if (row_major) {
@@ -1579,60 +1581,16 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor&
         auto cb_im2 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_im2_config);
     }
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)src0_is_dram,
-    };
-    if (row_major) {
-        reader_compile_time_args.push_back(ht);
-        reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
-        reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
-        reader_compile_time_args.push_back(wt);
-        reader_compile_time_args.push_back(W);
-        reader_compile_time_args.push_back(ht * wt);
-        reader_compile_time_args.push_back(W * a.element_size());
-        reader_compile_time_args.push_back(wt * a.element_size() * TILE_WIDTH);
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(
+        reader_compile_time_args.end(),
+        {num_writes, padding_val_packed, (uint32_t)needs_padding, (uint32_t)0, 1, 1, 1, 1, 1});
 
-        auto stick_size = W * a.element_size();
-        bool stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
-        reader_compile_time_args.push_back((std::uint32_t)stick_size_is_power_of_two);
-        if (stick_size_is_power_of_two) {
-            uint32_t log2_stick_size = (std::uint32_t)std::log2(stick_size);
-            reader_compile_time_args.push_back((std::uint32_t)log2_stick_size);
-        } else {
-            reader_compile_time_args.push_back(stick_size);
-        }
-    }
-
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
-    if (row_major) {
-        writer_compile_time_args.push_back(ht);
-        writer_compile_time_args.push_back(H);
-        writer_compile_time_args.push_back(wt);
-        writer_compile_time_args.push_back(W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH);
-        writer_compile_time_args.push_back(W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH);
-        writer_compile_time_args.push_back(ht * wt);
-        writer_compile_time_args.push_back(H * output.element_size());
-        writer_compile_time_args.push_back(ht * output.element_size() * TILE_HEIGHT);
-
-        auto stick_size = H * output.element_size();
-        bool stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
-        writer_compile_time_args.push_back((std::uint32_t)stick_size_is_power_of_two);
-        if (stick_size_is_power_of_two) {
-            uint32_t log2_stick_size = (std::uint32_t)std::log2(stick_size);
-            writer_compile_time_args.push_back((std::uint32_t)log2_stick_size);
-        } else {
-            writer_compile_time_args.push_back(stick_size);
-        }
-    }
-
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
-        row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                    "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"
-                  : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                    "reader_unary_transpose_wh_interleaved_start_id.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+        "reader_unary_transpose_wh_interleaved_start_id_rm.cpp",
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
@@ -1664,7 +1622,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor&
     if (row_major) {
         override_runtime_args_wh_rm<true>(
             program,
-            reader_kernel_id,
+            unary_reader_kernel_id,
             compute_kernel_id,
             writer_kernel_id,
             a,
@@ -1679,7 +1637,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor&
     } else {
         override_runtime_args_wh<true>(
             program,
-            reader_kernel_id,
+            unary_reader_kernel_id,
             compute_kernel_id,
             writer_kernel_id,
             a,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "untilize_program_factory.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 #include <math.h>
 
@@ -1033,11 +1033,9 @@ operation::ProgramWithCallbacks untilize_multi_core(
             tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
     } else {
         // Interleaved input
-        bool src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM;
-        std::vector<uint32_t> reader_compile_time_args = {
-            (uint32_t)src0_is_dram,
-            (uint32_t)src0_cb_index,
-        };
+        std::vector<uint32_t> reader_compile_time_args = {};
+        TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+        reader_compile_time_args.push_back((uint32_t)src0_cb_index);
         unary_reader_kernel_id = CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
@@ -9,22 +9,17 @@
 void kernel_main() {
     constexpr uint32_t cb_id_out0 = 16;
 
-    const uint32_t total_num_rows = get_compile_time_arg_val(2);
-    const uint32_t third_dim = get_compile_time_arg_val(3);
-    const uint32_t tile_height = get_compile_time_arg_val(4);
+    constexpr auto tensor_args = TensorAccessorArgs<0>();
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(tensor_args.compile_time_args_skip());
+    constexpr uint32_t total_num_rows = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 1);
+    constexpr uint32_t third_dim = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 2);
+    constexpr uint32_t tile_height = get_compile_time_arg_val(tensor_args.compile_time_args_skip() + 3);
 
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t unpadded_X_size = get_arg_val<uint32_t>(1);
 
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(0) == 1;
+    const auto s = TensorAccessor(tensor_args, dst_addr, unpadded_X_size);
 
-#if (STICK_SIZE_IS_POW2 == 1)
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(1);
-    const InterleavedPow2AddrGen<dst0_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
-#else
-    const InterleavedAddrGen<dst0_is_dram> s = {.bank_base_address = dst_addr, .page_size = unpadded_X_size};
-#endif
     auto write_block = [&](uint32_t num_rows,
                            uint32_t start_row_id,
                            uint32_t start_column_id,
@@ -37,7 +32,7 @@ void kernel_main() {
         uint32_t l1_read_addr = get_write_ptr(cb_id_out0);
 
         for (uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
-            uint64_t dst_noc_addr = get_noc_addr(size_2d + k, s);
+            uint64_t dst_noc_addr = s.get_noc_addr(size_2d + k);
             uint32_t total_size = start_column_id + width_size;
             uint32_t write_size = width_size;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -2,14 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "binary_device_operation.hpp"
-#include "ttnn/tensor/tensor.hpp"
-#include "ttnn/operations/data_movement/bcast/bcast.hpp"
-#include <tt-metalium/work_split.hpp>
+#include "broadcast_height_multi_core_program_factory.hpp"
+
+#include <cstdint>
+
+#include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
+#include "ttnn/operations/eltwise/binary/device/binary_device_operation.hpp"
+#include "ttnn/tensor/tensor_accessor_args.hpp"
+
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::binary {
 
@@ -112,9 +116,9 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
             .set_page_size(output_cb_index, dst_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -147,8 +147,9 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreShardedOptimized::create(
     auto src0_buffer = a.buffer();
     auto src1_buffer = b->buffer();
     auto dst_buffer = output.buffer();
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(reader_compile_time_args.end(), {(uint32_t)src0_cb_index});
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
@@ -137,8 +137,9 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreSharded::create(
     auto src0_buffer = a.buffer();
     auto src1_buffer = b->buffer();
     auto dst_buffer = output.buffer();
-    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*src1_buffer).append_args(reader_compile_time_args);
+    reader_compile_time_args.insert(reader_compile_time_args.end(), {(uint32_t)src0_cb_index});
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes