### PR TITLE
Ttnn bringup for UniAd model - WIP

### DIFF
--- a/models/experimental/uniad/reference/detr_transformer_decoder.py
+++ b/models/experimental/uniad/reference/detr_transformer_decoder.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+import warnings
+import copy
+
+from models.experimental.uniad.reference.detr_transformer_encoder import MultiScaleDeformableAttention
+from models.experimental.uniad.reference.ffn import FFN
+
+
+def inverse_sigmoid(x, eps=1e-5):
+    x = x.clamp(min=0, max=1)
+    x1 = x.clamp(min=eps)
+    x2 = (1 - x).clamp(min=eps)
+    return torch.log(x1 / x2)
+
+
+class MultiheadAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        dropout_layer=dict(type="Dropout", drop_prob=0.0),
+        init_cfg=None,
+        batch_first=False,
+        **kwargs,
+    ):
+        super(MultiheadAttention, self).__init__()
+        if "dropout" in kwargs:
+            warnings.warn(
+                "The arguments `dropout` in MultiheadAttention "
+                "has been deprecated, now you can separately "
+                "set `attn_drop`(float), proj_drop(float), "
+                "and `dropout_layer`(dict) "
+            )
+            attn_drop = kwargs["dropout"]
+            dropout_layer["drop_prob"] = kwargs.pop("dropout")
+
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+        self.batch_first = batch_first
+
+        self.attn = nn.MultiheadAttention(embed_dims, num_heads, attn_drop, **kwargs)
+
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.dropout_layer = nn.Dropout(p=0.1)
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_pos=None,
+        attn_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """
+        Returns:
+            Tensor: forwarded results with shape
+                [num_queries, bs, embed_dims]
+                if self.batch_first is False, else
+                [bs, num_queries embed_dims].
+        """
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+        if identity is None:
+            identity = query
+        if key_pos is None:
+            if query_pos is not None:
+                # use query_pos if key_pos is not available
+                if query_pos.shape == key.shape:
+                    key_pos = query_pos
+                else:
+                    warnings.warn(f"position encoding of key is" f"missing in {self.__class__.__name__}.")
+        if query_pos is not None:
+            query = query + query_pos
+        if key_pos is not None:
+            key = key + key_pos
+
+        # Because the dataflow('key', 'query', 'value') of
+        # ``torch.nn.MultiheadAttention`` is (num_query, batch,
+        # embed_dims), We should adjust the shape of dataflow from
+        # batch_first (batch, num_query, embed_dims) to num_query_first
+        # (num_query ,batch, embed_dims), and recover ``attn_output``
+        # from num_query_first to batch_first.
+        if self.batch_first:
+            query = query.transpose(0, 1)
+            key = key.transpose(0, 1)
+            value = value.transpose(0, 1)
+
+        out = self.attn(query=query, key=key, value=value, attn_mask=attn_mask, key_padding_mask=key_padding_mask)[0]
+
+        if self.batch_first:
+            out = out.transpose(0, 1)
+        return identity + self.dropout_layer(self.proj_drop(out))
+
+
+class DetrTransformerDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=1024,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=None,
+        norm_cfg=dict(type="LN"),
+        init_cfg=None,
+        batch_first=False,
+        **kwargs,
+    ):
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels", ffn_dropout="ffn_drop", ffn_num_fcs="num_fcs"
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                warnings.warn(
+                    f"The arguments `{ori_name}` in BaseTransformerLayer "
+                    f"has been deprecated, now you should set `{new_name}` "
+                    f"and other FFN related arguments "
+                    f"to a dict named `ffn_cfgs`. "
+                )
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super(DetrTransformerDecoderLayer, self).__init__()
+
+        self.batch_first = batch_first
+
+        assert set(operation_order) & set(["self_attn", "norm", "ffn", "cross_attn"]) == set(operation_order), (
+            f"The operation_order of"
+            f" {self.__class__.__name__} should "
+            f"contains all four operation type "
+            f"{['self_attn', 'norm', 'ffn', 'cross_attn']}"
+        )
+
+        num_attn = operation_order.count("self_attn") + operation_order.count("cross_attn")
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+        self.attentions = nn.ModuleList()
+
+        index = 0
+        for operation_name in operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                if "batch_first" in attn_cfgs[index]:
+                    assert self.batch_first == attn_cfgs[index]["batch_first"]
+                else:
+                    attn_cfgs[index]["batch_first"] = self.batch_first
+                if attn_cfgs[index]["type"] == "MultiheadAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = MultiheadAttention(**attn_cfgs[index])
+                    attn_cfgs[index]["type"] = "MultiheadAttention"
+                elif attn_cfgs[index]["type"] == "MultiScaleDeformableAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = MultiScaleDeformableAttention(**attn_cfgs[index])
+                    attn_cfgs[index]["type"] = "MultiScaleDeformableAttention"
+
+                self.attentions.append(attention)
+                index += 1
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.pre_norm = operation_order[0] == "norm"
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        num_attn = operation_order.count("self_attn") + operation_order.count("cross_attn")
+
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.ffns = nn.ModuleList()
+        num_ffns = operation_order.count("ffn")
+
+        for ffn_index in range(num_ffns):
+            self.ffns.append(FFN(self.embed_dims))
+
+        self.norms = nn.ModuleList()
+        num_norms = operation_order.count("norm")
+        for _ in range(num_norms):
+            self.norms.append(nn.LayerNorm(self.embed_dims))
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        elif isinstance(attn_masks, torch.Tensor):
+            attn_masks = [copy.deepcopy(attn_masks) for _ in range(self.num_attn)]
+            warnings.warn(f"Use same attn_mask in all attentions in " f"{self.__class__.__name__} ")
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                temp_key = temp_value = query
+                query = self.attentions[attn_index](
+                    query,
+                    temp_key,
+                    temp_value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=query_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+class DeformableDetrTransformerDecoder(nn.Module):
+    """Implements the decoder in DETR3D transformer.
+    Args:
+        return_intermediate (bool): Whether to return intermediate outputs.
+        coder_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`.
+    """
+
+    def __init__(self, num_layers, embed_dim, num_heads, return_intermediate=True):
+        super(DeformableDetrTransformerDecoder, self).__init__()
+        self.return_intermediate = True
+        self.layers = nn.ModuleList(
+            [
+                DetrTransformerDecoderLayer(
+                    attn_cfgs=[
+                        {"type": "MultiheadAttention", "embed_dims": embed_dim, "num_heads": num_heads, "dropout": 0.1},
+                        {"type": "MultiScaleDeformableAttention", "embed_dims": embed_dim, "num_levels": 4},
+                    ],
+                    ffn_cfgs=dict(
+                        type="FFN",
+                        embed_dims=embed_dim,
+                        feedforward_channels=1024,
+                        num_fcs=2,
+                        ffn_drop=0.0,
+                        act_cfg=dict(type="ReLU", inplace=True),
+                    ),
+                    operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+                    norm_cfg=dict(type="LN"),
+                    init_cfg=None,
+                    batch_first=False,
+                    kwargs={
+                        "feedforward_channels": 512,
+                        "ffn_dropout": 0.1,
+                        "act_cfg": {"type": "ReLU", "inplace": True},
+                        "ffn_num_fcs": 2,
+                    },
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        reg_branches=None,
+        cls_branches=None,
+        valid_ratios=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        output = query
+        intermediate = []
+        intermediate_reference_points = []
+        for lid, layer in enumerate(self.layers):
+            if reference_points.shape[-1] == 4:
+                reference_points_input = (
+                    reference_points[:, :, None] * torch.cat([valid_ratios, valid_ratios], -1)[:, None]
+                )
+            else:
+                assert reference_points.shape[-1] == 2
+                reference_points_input = reference_points[:, :, None] * valid_ratios[:, None]
+
+            output = layer(
+                output,
+                key=key,
+                value=value,
+                query_pos=query_pos,
+                reference_points=reference_points_input,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+            )
+            output = output.permute(1, 0, 2)
+
+            if reg_branches is not None:
+                tmp = reg_branches[lid](output)
+                if reference_points.shape[-1] == 4:
+                    new_reference_points = tmp + inverse_sigmoid(reference_points)
+                    new_reference_points = new_reference_points.sigmoid()
+                else:
+                    assert reference_points.shape[-1] == 2
+                    new_reference_points = tmp
+                    new_reference_points[..., :2] = tmp[..., :2] + inverse_sigmoid(reference_points)
+                    new_reference_points = new_reference_points.sigmoid()
+                reference_points = new_reference_points.detach()
+
+            output = output.permute(1, 0, 2)
+            if self.return_intermediate:
+                intermediate.append(output)
+                intermediate_reference_points.append(reference_points)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate), torch.stack(intermediate_reference_points)
+
+        return output, reference_points

--- a/models/experimental/uniad/reference/detr_transformer_encoder.py
+++ b/models/experimental/uniad/reference/detr_transformer_encoder.py
@@ -1,0 +1,194 @@
+import torch
+from torch import nn
+from models.experimental.uniad.reference.utils import multi_scale_deformable_attn_pytorch
+from models.experimental.uniad.reference.ffn import FFN
+
+from typing import Optional
+
+
+class MultiScaleDeformableAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dims: int = 256,
+        num_heads: int = 8,
+        num_levels: int = 4,
+        num_points: int = 4,
+        im2col_step: int = 64,
+        dropout: float = 0.1,
+        batch_first: bool = False,
+        norm_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, " f"but got {embed_dims} and {num_heads}")
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+
+        # you'd better set dim_per_head to a power of 2
+        # which is more efficient in the CUDA implementation
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError("invalid input for _is_power_of_2: {} (type: {})".format(n, type(n)))
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.sampling_offsets = nn.Linear(embed_dims, num_heads * num_levels * num_points * 2)
+        self.attention_weights = nn.Linear(embed_dims, num_heads * num_levels * num_points)
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor] = None,
+        value: Optional[torch.Tensor] = None,
+        identity: Optional[torch.Tensor] = None,
+        query_pos: Optional[torch.Tensor] = None,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        reference_points: Optional[torch.Tensor] = None,
+        spatial_shapes: Optional[torch.Tensor] = None,
+        level_start_index: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if value is None:
+            value = query
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(bs, num_query, self.num_heads, self.num_levels, self.num_points)
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :]
+                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+        elif reference_points.shape[-1] == 4:
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :2]
+                + sampling_offsets / self.num_points * reference_points[:, :, None, :, None, 2:] * 0.5
+            )
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be" f" 2 or 4, but get {reference_points.shape[-1]} instead."
+            )
+        if torch.cuda.is_available() and value.is_cuda:
+            output = MultiScaleDeformableAttnFunction.apply(
+                value, spatial_shapes, level_start_index, sampling_locations, attention_weights, self.im2col_step
+            )
+        else:
+            output = multi_scale_deformable_attn_pytorch(
+                value, spatial_shapes, level_start_index, sampling_locations, attention_weights, self.im2col_step
+            )
+
+        output = self.output_proj(output)
+
+        if not self.batch_first:
+            # (num_query, bs ,embed_dims)
+            output = output.permute(1, 0, 2)
+
+        return self.dropout(output) + identity
+
+
+class DetrTransformerEncoder(nn.Module):
+    def __init__(
+        self,
+        num_layers=6,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        im2col_step=64,
+        dropout=0.1,
+        post_norm=False,
+        feedforward_channels=512,
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList()
+
+        for _ in range(num_layers):
+            attentions = nn.ModuleList(
+                [MultiScaleDeformableAttention(embed_dims, num_heads, num_levels, num_points, dropout)]
+            )
+            ffns = nn.ModuleList([FFN(embed_dims)])
+            norms = nn.ModuleList([nn.LayerNorm(embed_dims), nn.LayerNorm(embed_dims)])
+            layer = nn.ModuleDict({"attentions": attentions, "ffns": ffns, "norms": norms})
+            self.layers.append(layer)
+
+        self.post_norm = False
+        self.embed_dims = embed_dims
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_padding_mask=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        for i, layer in enumerate(self.layers):
+            temp_key = temp_value = query
+            query = layer["attentions"][0](
+                query,
+                temp_key,
+                temp_value,
+                identity=None,
+                query_pos=query_pos,
+                key_pos=query_pos,
+                attn_mask=None,
+                spatial_shapes=spatial_shapes,
+                reference_points=reference_points,
+                key_padding_mask=query_key_padding_mask,
+                **kwargs,
+            )
+            identity = query
+
+            query = layer["norms"][0](query)
+
+            query = layer["ffns"][0](query)
+
+            query = layer["norms"][1](query)
+
+        return query

--- a/models/experimental/uniad/reference/encoder.py
+++ b/models/experimental/uniad/reference/encoder.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import numpy as np
+import torch.nn as nn
+import copy
+import warnings
+
+from models.experimental.uniad.reference.ffn import FFN
+from models.experimental.uniad.reference.spatial_cross_attention import SpatialCrossAttention
+from models.experimental.uniad.reference.temporal_self_attention import TemporalSelfAttention
+
+
+class BEVFormerEncoder(nn.Module):
+    def __init__(
+        self,
+        num_layers=6,
+        pc_range=None,
+        num_points_in_pillar=4,
+        return_intermediate=False,
+        embed_dims=256,
+        num_heads=8,
+        dilation=1,
+        kernel_size=(3, 5),
+        im2col_step=192,
+        feedforward_channels=512,
+        ffn_dropout=0.1,
+        operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+    ):
+        super(BEVFormerEncoder, self).__init__()
+        self.return_intermediate = return_intermediate
+        self.num_points_in_pillar = num_points_in_pillar
+        self.pc_range = pc_range
+        self.num_layers = num_layers
+        self.fp16_enabled = False
+
+        transformer_layers = dict(
+            attn_cfgs=[
+                dict(type="TemporalSelfAttention", embed_dims=embed_dims, num_levels=1),
+                dict(
+                    type="SpatialCrossAttention",
+                    pc_range=pc_range,
+                    attention=dict(
+                        embed_dims=embed_dims,
+                        num_heads=num_heads,
+                        dilation=dilation,
+                        num_levels=1,
+                    ),
+                    embed_dims=embed_dims,
+                ),
+            ],
+            feedforward_channels=feedforward_channels,
+            ffn_dropout=ffn_dropout,
+            operation_order=operation_order,
+        )
+
+        self.layers = nn.ModuleList()
+        for _ in range(self.num_layers):
+            self.layers.append(BEVFormerLayer(**transformer_layers))
+
+    @staticmethod
+    def get_reference_points(H, W, Z=8, num_points_in_pillar=4, dim="3d", bs=1, device="cuda", dtype=torch.float):
+        # reference points in 3D space, used in spatial cross-attention (SCA)
+        if dim == "3d":
+            zs = (
+                torch.linspace(0.5, Z - 0.5, num_points_in_pillar, dtype=dtype, device=device)
+                .view(-1, 1, 1)
+                .expand(num_points_in_pillar, H, W)
+                / Z
+            )
+            xs = (
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device)
+                .view(1, 1, W)
+                .expand(num_points_in_pillar, H, W)
+                / W
+            )
+            ys = (
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device)
+                .view(1, H, 1)
+                .expand(num_points_in_pillar, H, W)
+                / H
+            )
+            ref_3d = torch.stack((xs, ys, zs), -1)
+            ref_3d = ref_3d.permute(0, 3, 1, 2).flatten(2).permute(0, 2, 1)
+            ref_3d = ref_3d[None].repeat(bs, 1, 1, 1)
+            return ref_3d
+
+        # reference points on 2D bev plane, used in temporal self-attention (TSA).
+        elif dim == "2d":
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device),
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device),
+            )
+            ref_y = ref_y.reshape(-1)[None] / H
+            ref_x = ref_x.reshape(-1)[None] / W
+            ref_2d = torch.stack((ref_x, ref_y), -1)
+            ref_2d = ref_2d.repeat(bs, 1, 1).unsqueeze(2)
+        return ref_2d
+
+    def point_sampling(self, reference_points, pc_range, img_metas):  # TODO Handle fp32
+        lidar2img = []
+        for img_meta in img_metas:
+            lidar2img.append(img_meta["lidar2img"])
+        lidar2img = np.asarray(lidar2img)
+        lidar2img = reference_points.new_tensor(lidar2img)  # (B, N, 4, 4)
+        reference_points = reference_points.clone()
+
+        reference_points[..., 0:1] = reference_points[..., 0:1] * (pc_range[3] - pc_range[0]) + pc_range[0]
+        reference_points[..., 1:2] = reference_points[..., 1:2] * (pc_range[4] - pc_range[1]) + pc_range[1]
+        reference_points[..., 2:3] = reference_points[..., 2:3] * (pc_range[5] - pc_range[2]) + pc_range[2]
+
+        reference_points = torch.cat((reference_points, torch.ones_like(reference_points[..., :1])), -1)
+
+        reference_points = reference_points.permute(1, 0, 2, 3)
+        D, B, num_query = reference_points.size()[:3]
+        num_cam = lidar2img.size(1)
+
+        reference_points = reference_points.view(D, B, 1, num_query, 4).repeat(1, 1, num_cam, 1, 1).unsqueeze(-1)
+        lidar2img = lidar2img.view(1, B, num_cam, 1, 4, 4).repeat(D, 1, 1, num_query, 1, 1)
+
+        reference_points_cam = torch.matmul(lidar2img.to(torch.float32), reference_points.to(torch.float32)).squeeze(-1)
+        eps = 1e-5
+
+        bev_mask = reference_points_cam[..., 2:3] > eps
+        reference_points_cam = reference_points_cam[..., 0:2] / torch.maximum(
+            reference_points_cam[..., 2:3], torch.ones_like(reference_points_cam[..., 2:3]) * eps
+        )
+
+        reference_points_cam[..., 0] /= img_metas[0]["img_shape"][0][1]
+        reference_points_cam[..., 1] /= img_metas[0]["img_shape"][0][0]
+
+        bev_mask = (
+            bev_mask
+            & (reference_points_cam[..., 1:2] > 0.0)
+            & (reference_points_cam[..., 1:2] < 1.0)
+            & (reference_points_cam[..., 0:1] < 1.0)
+            & (reference_points_cam[..., 0:1] > 0.0)
+        )
+        # TODO handle
+        bev_mask = torch.nan_to_num(bev_mask)
+        reference_points_cam = reference_points_cam.permute(2, 1, 3, 0, 4)
+        bev_mask = bev_mask.permute(2, 1, 3, 0, 4).squeeze(-1)
+
+        return reference_points_cam, bev_mask
+
+    # TODO Handle fp16
+    def forward(
+        self,
+        bev_query,
+        key,
+        value,
+        *args,
+        bev_h=None,
+        bev_w=None,
+        bev_pos=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        valid_ratios=None,
+        prev_bev=None,
+        shift=0.0,
+        **kwargs,
+    ):
+        """Forward function for `TransformerDecoder`.
+        Args:
+            bev_query (Tensor): Input BEV query with shape
+                `(num_query, bs, embed_dims)`.
+            key & value (Tensor): Input multi-cameta features with shape
+                (num_cam, num_value, bs, embed_dims)
+            reference_points (Tensor): The reference
+                points of offset. has shape
+                (bs, num_query, 4) when as_two_stage,
+                otherwise has shape ((bs, num_query, 2).
+            valid_ratios (Tensor): The radios of valid
+                points on the feature map, has shape
+                (bs, num_levels, 2)
+        Returns:
+            Tensor: Results with shape [1, num_query, bs, embed_dims] when
+                return_intermediate is `False`, otherwise it has shape
+                [num_layers, num_query, bs, embed_dims].
+        """
+        output = bev_query
+        intermediate = []
+
+        ref_3d = self.get_reference_points(
+            bev_h,
+            bev_w,
+            self.pc_range[5] - self.pc_range[2],
+            self.num_points_in_pillar,
+            dim="3d",
+            bs=bev_query.size(1),
+            device=bev_query.device,
+            dtype=bev_query.dtype,
+        )
+        ref_2d = self.get_reference_points(
+            bev_h, bev_w, dim="2d", bs=bev_query.size(1), device=bev_query.device, dtype=bev_query.dtype
+        )
+
+        reference_points_cam, bev_mask = self.point_sampling(ref_3d, self.pc_range, kwargs["img_metas"])
+
+        # bug: this code should be 'shift_ref_2d = ref_2d.clone()', we keep this bug for reproducing our results in paper.
+        # shift_ref_2d = ref_2d  # .clone()
+        shift_ref_2d = ref_2d.clone()
+        shift_ref_2d += shift[:, None, None, :]
+
+        # (num_query, bs, embed_dims) -> (bs, num_query, embed_dims)
+        bev_query = bev_query.permute(1, 0, 2)
+        bev_pos = bev_pos.permute(1, 0, 2)
+        bs, len_bev, num_bev_level, _ = ref_2d.shape
+        if prev_bev is not None:
+            prev_bev = prev_bev.permute(1, 0, 2)
+            prev_bev = torch.stack([prev_bev, bev_query], 1).reshape(bs * 2, len_bev, -1)
+            hybird_ref_2d = torch.stack([shift_ref_2d, ref_2d], 1).reshape(bs * 2, len_bev, num_bev_level, 2)
+        else:
+            hybird_ref_2d = torch.stack([ref_2d, ref_2d], 1).reshape(bs * 2, len_bev, num_bev_level, 2)
+        for lid, layer in enumerate(self.layers):
+            output = layer(
+                bev_query,
+                key,
+                value,
+                *args,
+                bev_pos=bev_pos,
+                ref_2d=hybird_ref_2d,
+                ref_3d=ref_3d,
+                bev_h=bev_h,
+                bev_w=bev_w,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+                reference_points_cam=reference_points_cam,
+                bev_mask=bev_mask,
+                prev_bev=prev_bev,
+                **kwargs,
+            )
+
+            bev_query = output
+            if self.return_intermediate:
+                intermediate.append(output)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate)
+
+        return output
+
+
+class BEVFormerLayer(nn.Module):
+    def __init__(self, attn_cfgs, feedforward_channels, ffn_dropout=0.0, operation_order=None, ffn_num_fcs=2, **kwargs):
+        attn_cfgs = [
+            {"type": "TemporalSelfAttention", "embed_dims": 256, "num_levels": 1},
+            {
+                "type": "SpatialCrossAttention",
+                "pc_range": [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+                "deformable_attention": {
+                    "type": "MSDeformableAttention3D",
+                    "embed_dims": 256,
+                    "num_points": 8,
+                    "num_levels": 4,
+                },
+                "embed_dims": 256,
+            },
+        ]
+        super(BEVFormerLayer, self).__init__()
+
+        self.attn_cfgs = attn_cfgs
+        self.feedforward_channels = feedforward_channels
+        self.ffn_dropout = ffn_dropout
+        self.operation_order = operation_order
+        self.ffn_num_fcs = ffn_num_fcs
+        self.fp16_enabled = False
+        self.batch_first = True
+        self.attentions = nn.ModuleList()
+        index = 0
+        for operation_name in self.operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                if "batch_first" in attn_cfgs[index]:
+                    assert self.batch_first == attn_cfgs[index]["batch_first"]
+                else:
+                    attn_cfgs[index]["batch_first"] = self.batch_first
+                if attn_cfgs[index]["type"] == "TemporalSelfAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = TemporalSelfAttention(**attn_cfgs[index])
+                    attn_cfgs[index]["type"] = "TemporalSelfAttention"
+                elif attn_cfgs[index]["type"] == "SpatialCrossAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = SpatialCrossAttention(**attn_cfgs[index])
+                    attn_cfgs[index]["type"] = "SpatialCrossAttention"
+
+                self.attentions.append(attention)
+                index += 1
+
+        self.pre_norm = operation_order[0] == "norm"
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        num_attn = operation_order.count("self_attn") + operation_order.count("cross_attn")
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.ffns = nn.ModuleList()
+        num_ffns = operation_order.count("ffn")
+
+        for ffn_index in range(num_ffns):
+            self.ffns.append(FFN(self.embed_dims))
+
+        self.norms = nn.ModuleList()
+        num_norms = operation_order.count("norm")
+        for _ in range(num_norms):
+            self.norms.append(nn.LayerNorm(self.embed_dims))
+
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])
+
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        bev_pos=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        ref_2d=None,
+        ref_3d=None,
+        bev_h=None,
+        bev_w=None,
+        reference_points_cam=None,
+        mask=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        elif isinstance(attn_masks, torch.Tensor):
+            attn_masks = [copy.deepcopy(attn_masks) for _ in range(self.num_attn)]
+            warnings.warn(f"Use same attn_mask in all attentions in " f"{self.__class__.__name__} ")
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    prev_bev,
+                    prev_bev,
+                    identity if self.pre_norm else None,
+                    query_pos=bev_pos,
+                    key_pos=bev_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    reference_points=ref_2d,
+                    spatial_shapes=torch.tensor([[bev_h, bev_w]], device=query.device),
+                    level_start_index=torch.tensor([0], device=query.device),
+                    **kwargs,
+                )
+                attn_index += 1
+
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            # spaital cross attention
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    reference_points=ref_3d,
+                    reference_points_cam=reference_points_cam,
+                    mask=mask,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    spatial_shapes=spatial_shapes,
+                    level_start_index=level_start_index,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+
+                ffn_index += 1
+
+        return query

--- a/models/experimental/uniad/reference/ffn.py
+++ b/models/experimental/uniad/reference/ffn.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+
+
+class FFN(nn.Module):
+    def __init__(self, embed_dims=256):
+        super(FFN, self).__init__()
+        self.embed_dims = embed_dims
+        self.activate = nn.ReLU(inplace=True)
+
+        self.layers = nn.Sequential(
+            nn.Sequential(nn.Linear(self.embed_dims, 512), nn.ReLU(inplace=True), nn.Dropout(p=0.1)),
+            nn.Linear(512, self.embed_dims),
+            nn.Dropout(p=0.1),
+        )
+
+    def forward(self, x, identity=None):
+        if identity is None:
+            identity = x
+        return identity + self.layers(x)

--- a/models/experimental/uniad/reference/fpn.py
+++ b/models/experimental/uniad/reference/fpn.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ConvModule(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=1,
+        stride=1,
+        padding=0,
+    ):
+        super(ConvModule, self).__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, stride, padding)
+
+    def forward(self, x):
+        x = self.conv(x)
+        return x
+
+
+class FPN(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        num_outs,
+        start_level=0,
+        end_level=-1,
+        add_extra_convs=False,
+        relu_before_extra_convs=False,
+        no_norm_on_lateral=False,
+        conv_cfg=None,
+        norm_cfg=None,
+        act_cfg=None,
+        upsample_cfg=dict(mode="nearest"),
+        init_cfg=dict(type="Xavier", layer="Conv2d", distribution="uniform"),
+    ):
+        super(FPN, self).__init__()
+        assert isinstance(in_channels, list)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.num_ins = len(in_channels)
+        self.num_outs = num_outs
+        self.relu_before_extra_convs = relu_before_extra_convs
+        self.no_norm_on_lateral = no_norm_on_lateral
+        self.fp16_enabled = False
+        self.upsample_cfg = upsample_cfg.copy()
+
+        if end_level == -1 or end_level == self.num_ins - 1:
+            self.backbone_end_level = self.num_ins
+            assert num_outs >= self.num_ins - start_level
+        else:
+            # if end_level is not the last level, no extra level is allowed
+            self.backbone_end_level = end_level + 1
+            assert end_level < self.num_ins
+            assert num_outs == end_level - start_level + 1
+        self.start_level = start_level
+        self.end_level = end_level
+        self.add_extra_convs = add_extra_convs
+        assert isinstance(add_extra_convs, (str, bool))
+        if isinstance(add_extra_convs, str):
+            # Extra_convs_source choices: 'on_input', 'on_lateral', 'on_output'
+            assert add_extra_convs in ("on_input", "on_lateral", "on_output")
+        elif add_extra_convs:  # True
+            self.add_extra_convs = "on_input"
+
+        self.lateral_convs = nn.ModuleList()
+        self.fpn_convs = nn.ModuleList()
+
+        for i in range(self.start_level, self.backbone_end_level):
+            l_conv = ConvModule(
+                in_channels[i],
+                out_channels,
+                1,
+            )
+            fpn_conv = ConvModule(
+                out_channels,
+                out_channels,
+                3,
+                padding=1,
+            )
+
+            self.lateral_convs.append(l_conv)
+            self.fpn_convs.append(fpn_conv)
+
+    def forward(self, inputs):
+        """Forward function."""
+        assert len(inputs) == len(self.in_channels)
+
+        # build laterals
+        laterals = []
+        for i, lateral_conv in enumerate(self.lateral_convs):
+            inp = inputs[i + self.start_level]
+            output = lateral_conv(inp)
+            laterals.append(output)
+
+        # build top-down path
+        used_backbone_levels = len(laterals)
+        for i in range(used_backbone_levels - 1, 0, -1):
+            prev_shape = laterals[i - 1].shape[2:]
+            laterals[i] = F.interpolate(laterals[i], size=prev_shape, **self.upsample_cfg)
+            laterals[i - 1] = laterals[i - 1] + laterals[i]
+
+        # build outputs
+        # part 1: from original levels
+        outs = [self.fpn_convs[i](laterals[i]) for i in range(used_backbone_levels)]
+
+        return tuple(outs)

--- a/models/experimental/uniad/reference/memory_bank.py
+++ b/models/experimental/uniad/reference/memory_bank.py
@@ -82,7 +82,6 @@ class MemoryBank(nn.Module):
             )[0][0]
 
             out = embed + embed2
-            torch.save(embed2, "torch_embed.pt")
             embed = self.temporal_norm1(out)
             embed2 = self.temporal_fc2(F.relu(self.temporal_fc1(embed)))  ##
             embed = self.temporal_norm2(embed + embed2)

--- a/models/experimental/uniad/reference/memory_bank.py
+++ b/models/experimental/uniad/reference/memory_bank.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from models.experimental.uniad.reference.utils import Instances
+
+
+class MemoryBank(nn.Module):
+    def __init__(
+        self,
+        dim_in=256,
+        hidden_dim=256,
+        dim_out=256,
+        memory_bank_score_thresh=0,
+        memory_bank_len=4,
+    ):
+        super().__init__()
+        self._build_layers(memory_bank_score_thresh, memory_bank_len, dim_in, hidden_dim, dim_out)
+
+    def _build_layers(self, memory_bank_score_thresh, memory_bank_len, dim_in, hidden_dim, dim_out):
+        self.save_thresh = memory_bank_score_thresh
+        self.save_period = 3
+        self.max_his_length = memory_bank_len
+
+        self.save_proj = nn.Linear(dim_in, dim_in)
+
+        self.temporal_attn = nn.MultiheadAttention(dim_in, 8)
+        self.temporal_fc1 = nn.Linear(dim_in, hidden_dim)
+        self.temporal_fc2 = nn.Linear(hidden_dim, dim_in)
+        self.temporal_norm1 = nn.LayerNorm(dim_in)
+        self.temporal_norm2 = nn.LayerNorm(dim_in)
+
+    def update(self, track_instances):
+        embed = track_instances.output_embedding[:, None]  # ( N, 1, 256)
+        scores = track_instances.scores
+        mem_padding_mask = track_instances.mem_padding_mask
+        device = embed.device
+
+        save_period = track_instances.save_period
+        if self.training:
+            saved_idxes = scores > 0
+        else:
+            saved_idxes = (save_period == 0) & (scores > self.save_thresh)
+            # saved_idxes = (save_period == 0)
+            save_period[save_period > 0] -= 1
+            save_period[saved_idxes] = self.save_period
+
+        saved_embed = embed[saved_idxes]
+        if len(saved_embed) > 0:
+            prev_embed = track_instances.mem_bank[saved_idxes]
+            save_embed = self.save_proj(saved_embed)
+            mem_padding_mask[saved_idxes] = torch.cat(
+                [
+                    mem_padding_mask[saved_idxes, 1:],
+                    torch.zeros((len(saved_embed), 1), dtype=torch.bool, device=device),
+                ],
+                dim=1,
+            )
+            track_instances.mem_bank = track_instances.mem_bank.clone()
+            track_instances.mem_bank[saved_idxes] = torch.cat([prev_embed[:, 1:], save_embed], dim=1)
+
+    def _forward_temporal_attn(self, track_instances):
+        key_padding_mask = track_instances.mem_padding_mask  # [n_, memory_bank_len]
+
+        valid_idxes = key_padding_mask[:, -1] == 0
+
+        valid_indices = valid_idxes.nonzero(as_tuple=False).squeeze(-1)
+        embed = torch.index_select(track_instances.output_embedding, dim=0, index=valid_indices)
+
+        if len(embed) > 0:
+            prev_embed = track_instances.mem_bank[valid_idxes]
+            key_padding_mask = key_padding_mask[valid_idxes]
+            embed2 = self.temporal_attn(
+                embed[None],  # (num_track, dim) to (1, num_track, dim)
+                prev_embed.transpose(0, 1),  # (num_track, mem_len, dim) to (mem_len, num_track, dim)
+                prev_embed.transpose(0, 1),
+                key_padding_mask=key_padding_mask,
+            )[0][0]
+
+            out = embed + embed2
+            torch.save(embed2, "torch_embed.pt")
+            embed = self.temporal_norm1(out)
+            embed2 = self.temporal_fc2(F.relu(self.temporal_fc1(embed)))  ##
+            embed = self.temporal_norm2(embed + embed2)
+            track_instances.output_embedding = track_instances.output_embedding.clone()
+            track_instances.output_embedding[valid_idxes] = embed
+
+        return track_instances
+
+    def forward_temporal_attn(self, track_instances):
+        return self._forward_temporal_attn(track_instances)
+
+    def forward(self, track_instances: Instances, update_bank=True) -> Instances:
+        track_instances = self._forward_temporal_attn(track_instances)
+        if update_bank:
+            self.update(track_instances)
+        return track_instances

--- a/models/experimental/uniad/reference/pan_segformer_head.py
+++ b/models/experimental/uniad/reference/pan_segformer_head.py
@@ -1,0 +1,572 @@
+import copy
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import math
+from models.experimental.uniad.reference.seg_deformable_transformer import SegDeformableTransformer
+from models.experimental.uniad.reference.seg_mask_head import SegMaskHead
+
+
+def inverse_sigmoid(x, eps=1e-5):
+    x = x.clamp(min=0, max=1)
+    x1 = x.clamp(min=eps)
+    x2 = (1 - x).clamp(min=eps)
+    return torch.log(x1 / x2)
+
+
+def bbox_cxcywh_to_xyxy(bbox):
+    cx, cy, w, h = bbox.split((1, 1, 1, 1), dim=-1)
+    bbox_new = [(cx - 0.5 * w), (cy - 0.5 * h), (cx + 0.5 * w), (cy + 0.5 * h)]
+    return torch.cat(bbox_new, dim=-1)
+
+
+def IOU(intputs, targets):
+    numerator = (intputs * targets).sum(dim=1)
+    denominator = intputs.sum(dim=1) + targets.sum(dim=1) - numerator
+    loss = numerator / (denominator + 0.0000000000001)
+    return loss.cpu(), numerator.cpu(), denominator.cpu()
+
+
+class SinePositionalEncoding(nn.Module):
+    def __init__(
+        self, num_feats, temperature=10000, normalize=False, scale=2 * math.pi, eps=1e-6, offset=0.0, init_cfg=None
+    ):
+        super(SinePositionalEncoding, self).__init__()
+        if normalize:
+            assert isinstance(scale, (float, int)), (
+                "when normalize is set," "scale should be provided and in float or int type, " f"found {type(scale)}"
+            )
+        self.num_feats = num_feats
+        self.temperature = temperature
+        self.normalize = normalize
+        self.scale = scale
+        self.eps = eps
+        self.offset = offset
+
+    def forward(self, mask):
+        # For convenience of exporting to ONNX, it's required to convert
+        # `masks` from bool to int.
+        mask = mask.to(torch.int)
+        not_mask = 1 - mask  # logical_not
+        y_embed = not_mask.cumsum(1, dtype=torch.float32)
+        x_embed = not_mask.cumsum(2, dtype=torch.float32)
+        if self.normalize:
+            y_embed = (y_embed + self.offset) / (y_embed[:, -1:, :] + self.eps) * self.scale
+            x_embed = (x_embed + self.offset) / (x_embed[:, :, -1:] + self.eps) * self.scale
+        dim_t = torch.arange(self.num_feats, dtype=torch.float32, device=mask.device)
+        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_feats)
+        pos_x = x_embed[:, :, :, None] / dim_t
+        pos_y = y_embed[:, :, :, None] / dim_t
+        # use `view` instead of `flatten` for dynamically exporting to ONNX
+        B, H, W = mask.size()
+        pos_x = torch.stack((pos_x[:, :, :, 0::2].sin(), pos_x[:, :, :, 1::2].cos()), dim=4).view(B, H, W, -1)
+        pos_y = torch.stack((pos_y[:, :, :, 0::2].sin(), pos_y[:, :, :, 1::2].cos()), dim=4).view(B, H, W, -1)
+        pos = torch.cat((pos_y, pos_x), dim=3).permute(0, 3, 1, 2)
+        return pos
+
+
+class PansegformerHead(nn.Module):
+    def __init__(
+        self,
+        *args,
+        bev_h,
+        bev_w,
+        canvas_size,
+        pc_range,
+        num_reg_fcs=2,
+        with_box_refine=False,
+        as_two_stage=False,
+        transformer=None,
+        quality_threshold_things=0.25,
+        quality_threshold_stuff=0.25,
+        overlap_threshold_things=0.4,
+        overlap_threshold_stuff=0.2,
+        thing_transformer_head=dict(
+            type="TransformerHead", d_model=256, nhead=8, num_decoder_layers=6  # mask decoder for things
+        ),
+        stuff_transformer_head=dict(
+            type="TransformerHead", d_model=256, nhead=8, num_decoder_layers=6  # mask decoder for stuff
+        ),
+        loss_mask=dict(type="DiceLoss", weight=2.0),
+        train_cfg=dict(
+            assigner=dict(
+                type="HungarianAssigner",
+                cls_cost=dict(type="ClassificationCost", weight=1.0),
+                reg_cost=dict(type="BBoxL1Cost", weight=5.0),
+                iou_cost=dict(type="IoUCost", iou_mode="giou", weight=2.0),
+            ),
+            sampler=dict(type="PseudoSampler"),
+        ),
+        **kwargs,
+    ):
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.canvas_size = canvas_size
+        self.pc_range = pc_range
+        self.real_w = self.pc_range[3] - self.pc_range[0]
+        self.real_h = self.pc_range[4] - self.pc_range[1]
+
+        self.with_box_refine = with_box_refine
+        self.as_two_stage = as_two_stage
+        self.quality_threshold_things = 0.1
+        self.quality_threshold_stuff = quality_threshold_stuff
+        self.overlap_threshold_things = overlap_threshold_things
+        self.overlap_threshold_stuff = overlap_threshold_stuff
+        if self.as_two_stage:
+            transformer["as_two_stage"] = self.as_two_stage
+        self.num_dec_things = 4
+        self.num_dec_stuff = 6
+        super(PansegformerHead, self).__init__()
+
+        # self.loss_mask = build_loss(loss_mask)
+        self.positional_encoding = SinePositionalEncoding(num_feats=128, normalize=True, scale=6.283185307179586)
+        self.transformer = SegDeformableTransformer()
+        self.as_two_stag = False
+        self.embed_dims = 256
+        self.cls_out_channels = 3
+        self.num_reg_fcs = num_reg_fcs
+        self.num_query = 300
+        self.num_stuff_classes = 1
+        self._init_layers()
+        self.num_things_classes = 3
+        self.things_mask_head = SegMaskHead(
+            cfg=None,
+            d_model=256,
+            nhead=8,
+            num_encoder_layers=6,
+            num_decoder_layers=4,
+            dim_feedforward=64,
+            activation="relu",
+            normalize_before=False,
+            return_intermediate_dec=False,
+            self_attn=False,
+        )
+        self.stuff_mask_head = SegMaskHead(
+            cfg=None,
+            d_model=256,
+            nhead=8,
+            num_encoder_layers=6,
+            num_decoder_layers=6,
+            dim_feedforward=64,
+            activation="relu",
+            normalize_before=False,
+            return_intermediate_dec=False,
+            self_attn=True,
+        )
+        # self.count = 0
+
+    def _init_layers(self):
+        """Initialize classification branch and regression branch of head."""
+        if not self.as_two_stag:
+            self.bev_embedding = nn.Embedding(200 * 200, self.embed_dims)
+            # self.bev_embedding = nn.Embedding(self.bev_h * self.bev_w, self.embed_dims)
+
+        fc_cls = nn.Linear(self.embed_dims, self.cls_out_channels)
+        fc_cls_stuff = nn.Linear(self.embed_dims, 1)
+        reg_branch = []
+        for _ in range(self.num_reg_fcs):
+            reg_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            reg_branch.append(nn.ReLU())
+        reg_branch.append(nn.Linear(self.embed_dims, 4))
+        reg_branch = nn.Sequential(*reg_branch)
+
+        def _get_clones(module, N):
+            return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+        self.transformer.decoder.num_layers = 6
+        # last reg_branch is used to generate proposal from
+        # encode feature map when as_two_stage is True.
+        num_pred = (
+            (self.transformer.decoder.num_layers + 1) if self.as_two_stage else self.transformer.decoder.num_layers
+        )
+
+        if self.with_box_refine:
+            self.cls_branches = _get_clones(fc_cls, num_pred)
+            self.reg_branches = _get_clones(reg_branch, num_pred)
+        else:
+            self.cls_branches = nn.ModuleList([fc_cls for _ in range(num_pred)])
+            self.reg_branches = nn.ModuleList([reg_branch for _ in range(num_pred)])
+        if not self.as_two_stage:
+            self.query_embedding = nn.Embedding(self.num_query, self.embed_dims * 2)
+        self.stuff_query = nn.Embedding(self.num_stuff_classes, self.embed_dims * 2)
+        self.reg_branches2 = _get_clones(reg_branch, self.num_dec_things)  # used in mask decoder
+        self.cls_thing_branches = _get_clones(fc_cls, self.num_dec_things)  # used in mask decoder
+        self.cls_stuff_branches = _get_clones(fc_cls_stuff, self.num_dec_stuff)  # used in mask deocder
+
+    def init_weights(self):
+        """Initialize weights of the DeformDETR head."""
+        self.transformer.init_weights()
+        if self.loss_cls.use_sigmoid:
+            bias_init = float(-np.log((1 - 0.01) / 0.01))
+            for m in self.cls_branches:
+                nn.init.constant_(m.bias, bias_init)
+            for m in self.cls_thing_branches:
+                nn.init.constant_(m.bias, bias_init)
+            for m in self.cls_stuff_branches:
+                nn.init.constant_(m.bias, bias_init)
+        for m in self.reg_branches:
+            constant_init(m[-1], 0, bias=0)
+        for m in self.reg_branches2:
+            constant_init(m[-1], 0, bias=0)
+        nn.init.constant_(self.reg_branches[0][-1].bias.data[2:], -2.0)
+
+        if self.as_two_stage:
+            for m in self.reg_branches:
+                nn.init.constant_(m[-1].bias.data[2:], 0.0)
+
+    def forward(self, bev_embed, level_embeds=None):
+        _, bs, _ = bev_embed.shape
+
+        mlvl_feats = [torch.reshape(bev_embed, (bs, self.bev_h, self.bev_w, -1)).permute(0, 3, 1, 2)]
+        img_masks = mlvl_feats[0].new_zeros((bs, self.bev_h, self.bev_w))
+
+        hw_lvl = [feat_lvl.shape[-2:] for feat_lvl in mlvl_feats]
+        mlvl_masks = []
+        mlvl_positional_encodings = []
+        for feat in mlvl_feats:
+            img_masks_batched = img_masks[None]
+            target_size = feat.shape[-2:]
+            interpolated = F.interpolate(img_masks_batched, size=target_size)
+            interpolated = interpolated.to(torch.bool)
+            interpolated = interpolated.squeeze(0)
+            mlvl_masks.append(interpolated)
+
+            mlvl_positional_encodings.append(self.positional_encoding(mlvl_masks[-1]))
+
+        query_embeds = None
+        if not self.as_two_stage:
+            query_embeds = self.query_embedding.weight
+
+        out = self.transformer(
+            mlvl_feats,
+            mlvl_masks,
+            query_embeds,
+            mlvl_positional_encodings,
+            level_embeds=level_embeds,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+        )
+
+        (
+            (memory, memory_pos, memory_mask, query_pos),
+            hs,
+            init_reference,
+            inter_references,
+            enc_outputs_class,
+            enc_outputs_coord,
+        ) = self.transformer(
+            mlvl_feats,
+            mlvl_masks,
+            query_embeds,
+            mlvl_positional_encodings,
+            level_embeds=level_embeds,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+        )
+
+        memory = memory.permute(1, 0, 2)
+        query = hs[-1].permute(1, 0, 2)
+        query_pos = query_pos.permute(1, 0, 2)
+        memory_pos = memory_pos.permute(1, 0, 2)
+
+        # we should feed these to mask deocder.
+        args_tuple = [memory, memory_mask, memory_pos, query, None, query_pos, hw_lvl]
+
+        hs = hs.permute(0, 2, 1, 3)
+        outputs_classes = []
+        outputs_coords = []
+
+        for lvl in range(hs.shape[0]):
+            if lvl == 0:
+                reference = init_reference
+            else:
+                reference = inter_references[lvl - 1]
+
+            reference = inverse_sigmoid(reference)
+
+            outputs_class = self.cls_branches[lvl](hs[lvl])
+
+            tmp = self.reg_branches[lvl](hs[lvl])
+
+            if reference.shape[-1] == 4:
+                tmp += reference
+            else:
+                assert reference.shape[-1] == 2
+                tmp[..., :2] += reference
+            outputs_coord = tmp.sigmoid()
+            outputs_classes.append(outputs_class)
+            outputs_coords.append(outputs_coord)
+
+        outputs_classes = torch.stack(outputs_classes)
+
+        outputs_coords = torch.stack(outputs_coords)
+
+        outs = {
+            "bev_embed": None if self.as_two_stage else bev_embed,
+            "outputs_classes": outputs_classes,
+            "outputs_coords": outputs_coords,
+            "enc_outputs_class": enc_outputs_class if self.as_two_stage else None,
+            "enc_outputs_coord": enc_outputs_coord.sigmoid() if self.as_two_stage else None,
+            "args_tuple": args_tuple,
+            "reference": reference,
+        }
+
+        return outs
+
+    def forward_test(
+        self,
+        pts_feats=None,
+        gt_lane_labels=None,
+        gt_lane_masks=None,
+        img_metas=None,
+        rescale=False,
+        level_embeds=None,
+    ):
+        bbox_list = [dict() for i in range(len(img_metas))]
+
+        pred_seg_dict = self(pts_feats, level_embeds=level_embeds)
+        results = self.get_bboxes(
+            pred_seg_dict["outputs_classes"],
+            pred_seg_dict["outputs_coords"],
+            pred_seg_dict["enc_outputs_class"],
+            pred_seg_dict["enc_outputs_coord"],
+            pred_seg_dict["args_tuple"],
+            pred_seg_dict["reference"],
+            img_metas,
+            rescale=rescale,
+        )
+
+        with torch.no_grad():
+            drivable_pred = results[0]["drivable"]
+            drivable_gt = gt_lane_masks[0][0, -1]
+            drivable_iou, drivable_intersection, drivable_union = IOU(
+                drivable_pred.view(1, -1), drivable_gt.view(1, -1)
+            )
+
+            lane_pred = results[0]["lane"]
+            lanes_pred = (results[0]["lane"].sum(0) > 0).int()
+            lanes_gt = (gt_lane_masks[0][0][:-1].sum(0) > 0).int()
+            lanes_iou, lanes_intersection, lanes_union = IOU(lanes_pred.view(1, -1), lanes_gt.view(1, -1))
+
+            divider_gt = (gt_lane_masks[0][0][gt_lane_labels[0][0] == 0].sum(0) > 0).int()
+            crossing_gt = (gt_lane_masks[0][0][gt_lane_labels[0][0] == 1].sum(0) > 0).int()
+            contour_gt = (gt_lane_masks[0][0][gt_lane_labels[0][0] == 2].sum(0) > 0).int()
+            divider_iou, divider_intersection, divider_union = IOU(lane_pred[0].view(1, -1), divider_gt.view(1, -1))
+            crossing_iou, crossing_intersection, crossing_union = IOU(lane_pred[1].view(1, -1), crossing_gt.view(1, -1))
+            contour_iou, contour_intersection, contour_union = IOU(lane_pred[2].view(1, -1), contour_gt.view(1, -1))
+
+            ret_iou = {
+                "drivable_intersection": drivable_intersection,
+                "drivable_union": drivable_union,
+                "lanes_intersection": lanes_intersection,
+                "lanes_union": lanes_union,
+                "divider_intersection": divider_intersection,
+                "divider_union": divider_union,
+                "crossing_intersection": crossing_intersection,
+                "crossing_union": crossing_union,
+                "contour_intersection": contour_intersection,
+                "contour_union": contour_union,
+                "drivable_iou": drivable_iou,
+                "lanes_iou": lanes_iou,
+                "divider_iou": divider_iou,
+                "crossing_iou": crossing_iou,
+                "contour_iou": contour_iou,
+            }
+        for result_dict, pts_bbox in zip(bbox_list, results):
+            result_dict["pts_bbox"] = pts_bbox
+            result_dict["ret_iou"] = ret_iou
+            result_dict["args_tuple"] = pred_seg_dict["args_tuple"]
+        return bbox_list
+
+    def _get_bboxes_single(self, cls_score, bbox_pred, img_shape, scale_factor, rescale=False):
+        """ """
+        assert len(cls_score) == len(bbox_pred)
+        max_per_img = 100
+        # exclude background
+        self.loss_cls = True
+        if self.loss_cls:
+            cls_score = cls_score.sigmoid()
+            scores, indexes = cls_score.view(-1).topk(max_per_img)
+            det_labels = indexes % self.num_things_classes
+
+            bbox_index = indexes // self.num_things_classes
+            bbox_pred = bbox_pred[bbox_index]
+        else:
+            scores, det_labels = F.softmax(cls_score, dim=-1)[..., :-1].max(-1)
+            scores, bbox_index = scores.topk(max_per_img)
+            bbox_pred = bbox_pred[bbox_index]
+            det_labels = det_labels[bbox_index]
+
+        det_bboxes = bbox_cxcywh_to_xyxy(bbox_pred)
+        det_bboxes[:, 0::2] = det_bboxes[:, 0::2] * img_shape[1]
+        det_bboxes[:, 1::2] = det_bboxes[:, 1::2] * img_shape[0]
+        det_bboxes[:, 0::2].clamp_(min=0, max=img_shape[1])
+        det_bboxes[:, 1::2].clamp_(min=0, max=img_shape[0])
+        if rescale:
+            det_bboxes /= det_bboxes.new_tensor(scale_factor)
+        det_bboxes = torch.cat((det_bboxes, scores.unsqueeze(1)), -1)
+        return bbox_index, det_bboxes, det_labels
+
+    def get_bboxes(
+        self,
+        all_cls_scores,
+        all_bbox_preds,
+        enc_cls_scores,
+        enc_bbox_preds,
+        args_tuple,
+        reference,
+        img_metas,
+        rescale=False,
+    ):
+        """ """
+        cls_scores = all_cls_scores[-1]
+        bbox_preds = all_bbox_preds[-1]
+        memory, memory_mask, memory_pos, query, _, query_pos, hw_lvl = args_tuple
+
+        seg_list = []
+        stuff_score_list = []
+        panoptic_list = []
+        bbox_list = []
+        labels_list = []
+        drivable_list = []
+        lane_list = []
+        lane_score_list = []
+        score_list = []
+        for img_id in range(len(img_metas)):
+            cls_score = cls_scores[img_id]
+            bbox_pred = bbox_preds[img_id]
+            img_shape = (self.canvas_size[0], self.canvas_size[1], 3)
+            ori_shape = (self.canvas_size[0], self.canvas_size[1], 3)
+            scale_factor = 1
+
+            index, bbox, labels = self._get_bboxes_single(cls_score, bbox_pred, img_shape, scale_factor, rescale)
+
+            i = img_id
+            thing_query = query[i : i + 1, index, :]
+            thing_query_pos = query_pos[i : i + 1, index, :]
+            joint_query = torch.cat([thing_query, self.stuff_query.weight[None, :, : self.embed_dims]], 1)
+
+            stuff_query_pos = self.stuff_query.weight[None, :, self.embed_dims :]
+
+            mask_things, mask_inter_things, query_inter_things = self.things_mask_head(
+                memory[i : i + 1],
+                memory_mask[i : i + 1],
+                None,
+                joint_query[:, : -self.num_stuff_classes],
+                None,
+                None,
+                hw_lvl=hw_lvl,
+            )
+            mask_stuff, mask_inter_stuff, query_inter_stuff = self.stuff_mask_head(
+                memory[i : i + 1],
+                memory_mask[i : i + 1],
+                None,
+                joint_query[:, -self.num_stuff_classes :],
+                None,
+                stuff_query_pos,
+                hw_lvl=hw_lvl,
+            )
+
+            attn_map = torch.cat([mask_things, mask_stuff], 1)
+            attn_map = attn_map.squeeze(-1)  # BS, NQ, N_head,LEN
+
+            stuff_query = query_inter_stuff[-1]
+            scores_stuff = self.cls_stuff_branches[-1](stuff_query).sigmoid().reshape(-1)
+
+            mask_pred = attn_map.reshape(-1, *hw_lvl[0])
+
+            mask_pred = F.interpolate(mask_pred.unsqueeze(0), size=ori_shape[:2], mode="bilinear").squeeze(0)
+
+            masks_all = mask_pred
+            score_list.append(masks_all)
+            drivable_list.append(masks_all[-1] > 0.5)
+            masks_all = masks_all[: -self.num_stuff_classes]
+            seg_all = masks_all > 0.5
+            sum_seg_all = seg_all.sum((1, 2)).float() + 1
+
+            scores_all = bbox[:, -1]
+            bboxes_all = bbox
+            labels_all = labels
+
+            ## mask wise merging
+            seg_scores = (masks_all * seg_all.float()).sum((1, 2)) / sum_seg_all
+            seg_scores = seg_scores**2
+            scores_all *= seg_scores
+
+            scores_all, index = torch.sort(scores_all, descending=True)
+
+            masks_all = masks_all[index]
+            labels_all = labels_all[index]
+            bboxes_all = bboxes_all[index]
+            seg_all = seg_all[index]
+
+            bboxes_all[:, -1] = scores_all
+
+            # MDS: select things for instance segmeantion
+            things_selected = labels_all < self.num_things_classes
+            stuff_selected = labels_all >= self.num_things_classes
+            bbox_th = bboxes_all[things_selected][:100]
+
+            labels_th = labels_all[things_selected][:100]
+            seg_th = seg_all[things_selected][:100]
+            labels_st = labels_all[stuff_selected]
+            scores_st = scores_all[stuff_selected]
+            masks_st = masks_all[stuff_selected]
+
+            stuff_score_list.append(scores_st)
+
+            results = torch.zeros((2, *mask_pred.shape[-2:]), device=mask_pred.device).to(torch.long)
+            id_unique = 1
+            lane = torch.zeros((self.num_things_classes, *mask_pred.shape[-2:]), device=mask_pred.device).to(torch.long)
+            lane_score = torch.zeros((self.num_things_classes, *mask_pred.shape[-2:]), device=mask_pred.device).to(
+                mask_pred.dtype
+            )
+            for i, scores in enumerate(scores_all):
+                # MDS: things and sutff have different threholds may perform a little bit better
+                if labels_all[i] < self.num_things_classes and scores < self.quality_threshold_things:
+                    continue
+                elif labels_all[i] >= self.num_things_classes and scores < self.quality_threshold_stuff:
+                    continue
+                _mask = masks_all[i] > 0.5
+                mask_area = _mask.sum().item()
+                intersect = _mask & (results[0] > 0)
+                intersect_area = intersect.sum().item()
+                if labels_all[i] < self.num_things_classes:
+                    if mask_area == 0 or (intersect_area * 1.0 / mask_area) > self.overlap_threshold_things:
+                        continue
+                else:
+                    if mask_area == 0 or (intersect_area * 1.0 / mask_area) > self.overlap_threshold_stuff:
+                        continue
+                if intersect_area > 0:
+                    _mask = _mask & (results[0] == 0)
+                results[0, _mask] = labels_all[i]
+                if labels_all[i] < self.num_things_classes:
+                    lane[labels_all[i], _mask] = 1
+                    lane_score[labels_all[i], _mask] = masks_all[i][_mask]
+                    results[1, _mask] = id_unique
+                    id_unique += 1
+
+            file_name = img_metas[img_id]["pts_filename"].split("/")[-1].split(".")[0]
+            panoptic_list.append((results.permute(1, 2, 0).cpu().numpy(), file_name, ori_shape))
+
+            bbox_list.append(bbox_th)
+            labels_list.append(labels_th)
+            seg_list.append(seg_th)
+            lane_list.append(lane)
+            lane_score_list.append(lane_score)
+        results = []
+        for i in range(len(img_metas)):
+            results.append(
+                {
+                    "bbox": bbox_list[i],
+                    "segm": seg_list[i],
+                    "labels": labels_list[i],
+                    "panoptic": panoptic_list[i],
+                    "drivable": drivable_list[i],
+                    "score_list": score_list[i],
+                    "lane": lane_list[i],
+                    "lane_score": lane_score_list[i],
+                    "stuff_score_list": stuff_score_list[i],
+                }
+            )
+        return results

--- a/models/experimental/uniad/reference/planning_head.py
+++ b/models/experimental/uniad/reference/planning_head.py
@@ -1,0 +1,200 @@
+import torch
+import torch.nn as nn
+
+from einops import rearrange
+from models.experimental.uniad.reference.utils import bivariate_gaussian_activation
+from models.experimental.uniad.reference.utils import CollisionNonlinearOptimizer
+import numpy as np
+import copy
+
+
+class PlanningHeadSingleMode(nn.Module):
+    def __init__(
+        self,
+        bev_h=200,
+        bev_w=200,
+        embed_dims=256,
+        planning_steps=6,
+        loss_planning=None,
+        loss_collision=None,
+        planning_eval=True,
+        use_col_optim=True,
+        col_optim_args=dict(
+            occ_filter_range=5.0,
+            sigma=1.0,
+            alpha_collision=5.0,
+        ),
+        with_adapter=True,
+    ):
+        super(PlanningHeadSingleMode, self).__init__()
+
+        # Nuscenes
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.navi_embed = nn.Embedding(3, embed_dims)
+        self.reg_branch = nn.Sequential(
+            nn.Linear(embed_dims, embed_dims),
+            nn.ReLU(),
+            nn.Linear(embed_dims, planning_steps * 2),
+        )
+        # self.loss_planning = build_loss(loss_planning)
+        self.planning_steps = planning_steps
+        self.planning_eval = planning_eval
+
+        #### planning head
+        fuser_dim = 3
+        attn_module_layer = nn.TransformerDecoderLayer(
+            embed_dims, 8, dim_feedforward=embed_dims * 2, dropout=0.1, batch_first=False
+        )
+        self.attn_module = nn.TransformerDecoder(attn_module_layer, 3)
+
+        self.mlp_fuser = nn.Sequential(
+            nn.Linear(embed_dims * fuser_dim, embed_dims),
+            nn.LayerNorm(embed_dims),
+            nn.ReLU(inplace=True),
+        )
+
+        self.pos_embed = nn.Embedding(1, embed_dims)
+
+        # self.loss_collision = []
+        # for cfg in loss_collision:
+        #     self.loss_collision.append(build_loss(cfg))
+        # self.loss_collision = nn.ModuleList(self.loss_collision)
+
+        self.use_col_optim = use_col_optim
+        self.occ_filter_range = col_optim_args["occ_filter_range"]
+        self.sigma = col_optim_args["sigma"]
+        self.alpha_collision = col_optim_args["alpha_collision"]
+
+        # TODO: reimplement it with down-scaled feature_map
+        self.with_adapter = with_adapter
+        if with_adapter:
+            bev_adapter_block = nn.Sequential(
+                nn.Conv2d(embed_dims, embed_dims // 2, kernel_size=3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(embed_dims // 2, embed_dims, kernel_size=1),
+            )
+            N_Blocks = 3
+            bev_adapter = [copy.deepcopy(bev_adapter_block) for _ in range(N_Blocks)]
+            self.bev_adapter = nn.Sequential(*bev_adapter)
+
+    def forward_train(
+        self,
+        bev_embed,
+        outs_motion={},
+        sdc_planning=None,
+        sdc_planning_mask=None,
+        command=None,
+        gt_future_boxes=None,
+    ):
+        sdc_traj_query = outs_motion["sdc_traj_query"]
+        sdc_track_query = outs_motion["sdc_track_query"]
+        bev_pos = outs_motion["bev_pos"]
+
+        occ_mask = None
+
+        outs_planning = self(bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command)
+        loss_inputs = [sdc_planning, sdc_planning_mask, outs_planning, gt_future_boxes]
+        losses = self.loss(*loss_inputs)
+        ret_dict = dict(losses=losses, outs_motion=outs_planning)
+        return ret_dict
+
+    def forward_test(self, bev_embed, outs_motion={}, outs_occflow={}, command=None):
+        sdc_traj_query = outs_motion["sdc_traj_query"]
+        sdc_track_query = outs_motion["sdc_track_query"]
+        bev_pos = outs_motion["bev_pos"]
+        occ_mask = outs_occflow["seg_out"]
+
+        outs_planning = self(bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command)
+        return outs_planning
+
+    def forward(self, bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command):
+        sdc_track_query = sdc_track_query.detach()
+        sdc_traj_query = sdc_traj_query[-1]
+        P = sdc_traj_query.shape[1]
+        sdc_track_query = sdc_track_query[:, None].expand(-1, P, -1)
+
+        navi_embed = self.navi_embed.weight[command]
+
+        navi_embed = navi_embed[None].expand(-1, P, -1)
+        plan_query = torch.cat([sdc_traj_query, sdc_track_query, navi_embed], dim=-1)
+
+        plan_query = self.mlp_fuser(plan_query).max(1, keepdim=True)[
+            0
+        ]  # expand, then fuse  # [1, 6, 768] -> [1, 1, 256]
+        plan_query = rearrange(plan_query, "b p c -> p b c")
+
+        bev_pos = rearrange(bev_pos, "b c h w -> (h w) b c")
+
+        bev_feat = bev_embed + bev_pos
+
+        ##### Plugin adapter #####
+        if self.with_adapter:
+            bev_feat = rearrange(bev_feat, "(h w) b c -> b c h w", h=self.bev_h, w=self.bev_w)
+            bev_feat = bev_feat + self.bev_adapter(bev_feat)  # residual connection
+            bev_feat = rearrange(bev_feat, "b c h w -> (h w) b c")
+        ##########################
+
+        pos_embed = self.pos_embed.weight
+        plan_query = plan_query + pos_embed[None]  # [1, 1, 256]
+
+        # plan_query: [1, 1, 256]
+        # bev_feat: [40000, 1, 256]
+        plan_query = self.attn_module(plan_query, bev_feat)  # [1, 1, 256]
+
+        sdc_traj_all = self.reg_branch(plan_query).view((-1, self.planning_steps, 2))
+        sdc_traj_all[..., :2] = torch.cumsum(sdc_traj_all[..., :2], dim=1)
+        sdc_traj_all[0] = bivariate_gaussian_activation(sdc_traj_all[0])
+        if self.use_col_optim and not self.training:
+            # post process, only used when testing
+            assert occ_mask is not None
+            sdc_traj_all = self.collision_optimization(sdc_traj_all, occ_mask)
+
+        return sdc_traj_all
+        return dict(
+            sdc_traj=sdc_traj_all,
+            sdc_traj_all=sdc_traj_all,
+        )
+
+    def collision_optimization(self, sdc_traj_all, occ_mask):
+        pos_xy_t = []
+        valid_occupancy_num = 0
+
+        if occ_mask.shape[2] == 1:
+            occ_mask = occ_mask.squeeze(2)
+        occ_horizon = occ_mask.shape[1]
+        assert occ_horizon == 5
+
+        for t in range(self.planning_steps):
+            cur_t = min(t + 1, occ_horizon - 1)
+            pos_xy = torch.nonzero(occ_mask[0][cur_t], as_tuple=False)
+            pos_xy = pos_xy[:, [1, 0]]
+            pos_xy[:, 0] = (pos_xy[:, 0] - self.bev_h // 2) * 0.5 + 0.25
+            pos_xy[:, 1] = (pos_xy[:, 1] - self.bev_w // 2) * 0.5 + 0.25
+
+            # filter the occupancy in range
+            keep_index = (
+                torch.sum((sdc_traj_all[0, t, :2][None, :] - pos_xy[:, :2]) ** 2, axis=-1) < self.occ_filter_range**2
+            )
+            pos_xy_t.append(pos_xy[keep_index].cpu().detach().numpy())
+            valid_occupancy_num += torch.sum(keep_index > 0)
+        if valid_occupancy_num == 0:
+            return sdc_traj_all
+
+        col_optimizer = CollisionNonlinearOptimizer(
+            self.planning_steps, 0.5, self.sigma, self.alpha_collision, pos_xy_t
+        )
+        col_optimizer.set_reference_trajectory(sdc_traj_all[0].cpu().detach().numpy())
+        sol = col_optimizer.solve()
+        sdc_traj_optim = np.stack([sol.value(col_optimizer.position_x), sol.value(col_optimizer.position_y)], axis=-1)
+        return torch.tensor(sdc_traj_optim[None], device=sdc_traj_all.device, dtype=sdc_traj_all.dtype)
+
+    # def loss(self, sdc_planning, sdc_planning_mask, outs_planning, future_gt_bbox=None):
+    #     sdc_traj_all = outs_planning['sdc_traj_all'] # b, p, t, 5
+    #     loss_dict = dict()
+    #     for i in range(len(self.loss_collision)):
+    #         loss_collision = self.loss_collision[i](sdc_traj_all, sdc_planning[0, :, :self.planning_steps, :3], torch.any(sdc_planning_mask[0, :, :self.planning_steps], dim=-1), future_gt_bbox[0][1:self.planning_steps+1])
+    #         loss_dict[f'loss_collision_{i}'] = loss_collision
+    #     loss_ade = self.loss_planning(sdc_traj_all, sdc_planning[0, :, :self.planning_steps, :2], torch.any(sdc_planning_mask[0, :, :self.planning_steps], dim=-1))
+    #     loss_dict.update(dict(loss_ade=loss_ade))
+    #     return loss_dict

--- a/models/experimental/uniad/reference/query_interaction_module.py
+++ b/models/experimental/uniad/reference/query_interaction_module.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch.nn as nn
+
+
+import torch.nn.functional as F
+
+
+from models.experimental.uniad.reference.utils import Instances
+
+
+class QueryInteractionModule(nn.Module):
+    def __init__(
+        self,
+        dim_in=256,
+        hidden_dim=256,
+        dim_out=256,
+        random_drop=0.1,
+        fp_ratio=0.3,
+        update_query_pos=True,
+    ):
+        super(QueryInteractionModule, self).__init__()
+        self._build_layers(dim_in, hidden_dim, dim_out)
+        self.random_drop = random_drop
+        self.fp_ratio = fp_ratio
+        self.update_query_pos = update_query_pos
+
+    def _build_layers(self, dim_in, hidden_dim, dim_out, update_query_pos=True):
+        self.self_attn = nn.MultiheadAttention(dim_in, 8)
+        self.linear1 = nn.Linear(dim_in, hidden_dim)
+        self.linear2 = nn.Linear(hidden_dim, dim_in)
+
+        if update_query_pos:
+            self.linear_pos1 = nn.Linear(dim_in, hidden_dim)
+            self.linear_pos2 = nn.Linear(hidden_dim, dim_in)
+
+            self.norm_pos = nn.LayerNorm(dim_in)
+
+        self.linear_feat1 = nn.Linear(dim_in, hidden_dim)
+        self.linear_feat2 = nn.Linear(hidden_dim, dim_in)
+
+        self.norm_feat = nn.LayerNorm(dim_in)
+
+        self.norm1 = nn.LayerNorm(dim_in)
+        self.norm2 = nn.LayerNorm(dim_in)
+
+        self.activation = F.relu
+
+    def _update_track_embedding(self, track_instances: Instances) -> Instances:
+        print("track_instancestrack_instances", type(track_instances))
+        dim = track_instances.query.shape[1]
+        out_embed = track_instances.output_embedding
+        query_pos = track_instances.query[:, : dim // 2]
+        query_feat = track_instances.query[:, dim // 2 :]
+        q = k = query_pos + out_embed
+
+        # attention
+        tgt = out_embed
+        tgt2 = self.self_attn(q[:, None], k[:, None], value=tgt[:, None])[0][:, 0]
+
+        tgt = self.norm1(tgt)
+
+        # ffn
+        x = self.linear1(tgt)
+        x = self.activation(x)
+        tgt2 = self.linear2(x)
+
+        tgt = self.norm2(tgt)
+
+        if self.update_query_pos:
+            # ffn: linear_pos2
+            x = self.linear_pos1(tgt)
+            x = self.activation(x)
+            query_pos2 = self.linear_pos2(x)
+            query_pos = self.norm_pos(query_pos)
+            track_instances.query[:, : dim // 2] = query_pos
+
+        x = self.linear_feat1(tgt)
+        x = self.activation(x)
+        query_feat2 = self.linear_feat2(x)
+        query_feat = self.norm_feat(query_feat)
+        track_instances.query[:, dim // 2 :] = query_feat
+        # track_instances.ref_pts = inverse_sigmoid(track_instances.pred_boxes[:, :2].detach().clone())
+        # update ref_pts using track_instances.pred_boxes
+        return track_instances
+
+    def _select_active_tracks(self, data: dict) -> Instances:
+        track_instances: Instances = data["track_instances"]
+        print("Else is working")
+        active_track_instances = track_instances[track_instances.obj_idxes >= 0]
+
+        return active_track_instances
+
+    def forward(self, data) -> Instances:
+        # print("QueryInteractionModule forward", data)
+        # print("data Query interaction", print(data["init_track_instances"].get_fields()))
+        # print("init_track_instances",data["init_track_instances"], type(data["init_track_instances"]))
+        print("data ref_pts", data["init_track_instances"].ref_pts.shape)
+        print("data query", data["init_track_instances"].query.shape)
+        print("data output_embedding - zero tensors", data["init_track_instances"].output_embedding.shape)
+        # print("data obj_idxes -1 tensors", data["init_track_instances"].obj_idxes.shape)
+        # print("data matched_gt_idxes -1 tensor", data["init_track_instances"].matched_gt_idxes.shape)
+        # print("data disappear_time - 0 tensors", data["init_track_instances"].disappear_time.shape)
+        # print("data iou - 0 float tensor", data["init_track_instances"].iou.shape)
+        # print("data scores - 0 float tensor", data["init_track_instances"].scores.shape)
+        # print("data track_scores - 0 float tensor", data["init_track_instances"].track_scores.shape)
+        # print("data pred_boxes - 0 float tensor", data["init_track_instances"].pred_boxes.shape)
+        # print("data pred_logits: 0 float tensor", data["init_track_instances"].pred_logits.shape)
+        # print("data mem_bank: 0 float tensor", data["init_track_instances"].mem_bank.shape)
+        # print("data mem_padding_mask: bool True", data["init_track_instances"].mem_padding_mask.shape)
+        # print("data save_period: 0 float tensor", data["init_track_instances"].save_period.shape)
+
+        active_track_instances = self._select_active_tracks(data)
+        active_track_instances = self._update_track_embedding(active_track_instances)
+        init_track_instances: Inescalationstances = data["init_track_instances"]
+        merged_track_instances = Instances.cat([init_track_instances, active_track_instances])
+        return active_track_instances
+
+
+# class QueryInteractionModule(nn.Module):
+#     # def __init__(self, args, dim_in, hidden_dim, dim_out):
+#     def __init__(self,
+#     dim_in=256,
+#     hidden_dim=256,
+#     dim_out=256,
+#     random_drop=0.1,
+#     fp_ratio=0.3,
+#     update_query_pos=True,
+#     merger_dropout = 0,
+# ):
+#         super().__init__()
+#         self.random_drop = random_drop
+#         self.fp_ratio = fp_ratio
+#         self.update_query_pos = update_query_pos
+#         dropout = merger_dropout
+
+#         self.self_attn = nn.MultiheadAttention(dim_in, 8, dropout)
+#         self.linear1 = nn.Linear(dim_in, hidden_dim)
+#         self.linear2 = nn.Linear(hidden_dim, dim_in)
+#         self.dropout1 = nn.Dropout(dropout)
+#         self.dropout2 = nn.Dropout(dropout)
+#         self.norm1 = nn.LayerNorm(dim_in)
+#         self.norm2 = nn.LayerNorm(dim_in)
+
+#         self.activation = F.relu
+
+#         if self.update_query_pos:
+#             self.linear_pos1 = nn.Linear(dim_in, hidden_dim)
+#             self.linear_pos2 = nn.Linear(hidden_dim, dim_in)
+#             self.dropout_pos1 = nn.Dropout(dropout)
+#             self.dropout_pos2 = nn.Dropout(dropout)
+#             self.norm_pos = nn.LayerNorm(dim_in)
+
+#         self.linear_feat1 = nn.Linear(dim_in, hidden_dim)
+#         self.linear_feat2 = nn.Linear(hidden_dim, dim_in)
+#         self.dropout_feat1 = nn.Dropout(dropout)
+#         self.dropout_feat2 = nn.Dropout(dropout)
+#         self.norm_feat = nn.LayerNorm(dim_in)
+
+#     def _select_active_tracks(self, obj_idxes: torch.Tensor, ious: torch.Tensor, training: bool):
+#         if training:
+#             mask = (obj_idxes >= 0) & (ious > 0.5)
+#         else:
+#             mask = obj_idxes >= 0
+#         return mask
+
+#     def _update_track_embedding(self, query: torch.Tensor, output_embedding: torch.Tensor) -> torch.Tensor:
+#         if query.shape[0] == 0:
+#             return query
+
+#         dim = query.shape[1]
+#         query_pos = query[:, :dim // 2]
+#         query_feat = query[:, dim // 2:]
+
+#         q = k = query_pos + output_embedding
+#         tgt = output_embedding
+#         tgt2, _ = self.self_attn(q.unsqueeze(1), k.unsqueeze(1), tgt.unsqueeze(1))
+#         tgt2 = tgt2.squeeze(1)
+#         tgt = tgt + self.dropout1(tgt2)
+#         tgt = self.norm1(tgt)
+
+#         tgt2 = self.linear2(self.dropout2(self.activation(self.linear1(tgt))))
+#         tgt = tgt + self.dropout2(tgt2)
+#         tgt = self.norm2(tgt)
+
+#         if self.update_query_pos:
+#             query_pos2 = self.linear_pos2(self.dropout_pos1(self.activation(self.linear_pos1(tgt))))
+#             query_pos = query_pos + self.dropout_pos2(query_pos2)
+#             query_pos = self.norm_pos(query_pos)
+
+#         query_feat2 = self.linear_feat2(self.dropout_feat1(self.activation(self.linear_feat1(tgt))))
+#         query_feat = query_feat + self.dropout_feat2(query_feat2)
+#         query_feat = self.norm_feat(query_feat)
+
+#         updated_query = torch.cat([query_pos, query_feat], dim=1)
+#         return updated_query
+
+#     def forward(
+#         self,
+#         query: torch.Tensor,
+#         output_embedding: torch.Tensor,
+#         obj_idxes: torch.Tensor,
+#         ious: torch.Tensor,
+#         training: bool = False,
+#     ) -> torch.Tensor:
+#         """
+#         Args:
+#             query: Tensor of shape [N, C]
+#             output_embedding: Tensor of shape [N, C]
+#             obj_idxes: Tensor of shape [N]
+#             ious: Tensor of shape [N]
+#         Returns:
+#             updated_query: Tensor of shape [N, C] after updating valid ones
+#         """
+#         mask = self._select_active_tracks(obj_idxes, ious, training)
+
+#         if mask.sum() == 0:
+#             return query  # no active tracks
+
+#         # update only active queries
+#         updated_query = self._update_track_embedding(query[mask], output_embedding[mask])
+
+#         # clone and update the active indices only
+#         final_query = query.clone()
+#         final_query[mask] = updated_query
+#         return final_query

--- a/models/experimental/uniad/reference/seg_deformable_transformer.py
+++ b/models/experimental/uniad/reference/seg_deformable_transformer.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import math
+import torch
+import torch.nn as nn
+
+from models.experimental.uniad.reference.detr_transformer_encoder import DetrTransformerEncoder
+from models.experimental.uniad.reference.detr_transformer_decoder import DeformableDetrTransformerDecoder
+
+
+class Transformer(nn.Module):
+    def __init__(self, encoder=None, decoder=None, init_cfg=None):
+        # super(Transformer, self).__init__()
+        super().__init__()
+        self.encoder = DetrTransformerEncoder()
+        self.decoder = DeformableDetrTransformerDecoder(
+            num_layers=6,
+            embed_dim=256,
+            num_heads=8,
+        )
+        self.embed_dims = self.encoder.embed_dims
+
+    def forward(self, x, mask, query_embed, pos_embed):
+        # use `view` instead of `flatten` for dynamically exporting to ONNX
+        x = x.view(bs, c, -1).permute(2, 0, 1)  # [bs, c, h, w] -> [h*w, bs, c]
+        pos_embed = pos_embed.view(bs, c, -1).permute(2, 0, 1)
+        query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)  # [num_query, dim] -> [num_query, bs, dim]
+        mask = mask.view(bs, -1)  # [bs, h, w] -> [bs, h*w]
+        memory = self.encoder(query=x, key=None, value=None, query_pos=pos_embed, query_key_padding_mask=mask)
+        target = torch.zeros_like(query_embed)
+
+        bs, c, h, w = x.shape
+        out_dec = self.decoder(
+            query=target, key=memory, value=memory, key_pos=pos_embed, query_pos=query_embed, key_padding_mask=mask
+        )
+        out_dec = out_dec.transpose(1, 2)
+        memory = memory.permute(1, 2, 0).reshape(bs, c, h, w)
+        return out_dec, memory
+
+
+class SegDeformableTransformer(Transformer):
+    def __init__(self, as_two_stage=False, num_feature_levels=4, two_stage_num_proposals=300, **kwargs):
+        super(SegDeformableTransformer, self).__init__(**kwargs)
+        self.fp16_enabled = False
+        self.as_two_stage = as_two_stage
+        self.num_feature_levels = num_feature_levels
+        self.two_stage_num_proposals = two_stage_num_proposals
+        self.embed_dims = self.encoder.embed_dims
+        self.init_layers()
+
+    def init_layers(self):
+        self.level_embeds = nn.Parameter(torch.Tensor(self.num_feature_levels, self.embed_dims))
+
+        if self.as_two_stage:
+            self.enc_output = nn.Linear(self.embed_dims, self.embed_dims)
+            self.enc_output_norm = nn.LayerNorm(self.embed_dims)
+            self.pos_trans = nn.Linear(self.embed_dims * 2, self.embed_dims * 2)
+            self.pos_trans_norm = nn.LayerNorm(self.embed_dims * 2)
+        else:
+            self.reference_points = nn.Linear(self.embed_dims, 2)
+
+    def gen_encoder_output_proposals(self, memory, memory_padding_mask, spatial_shapes):
+        """Generate proposals from encoded memory.
+
+        Args:
+            memory (Tensor) : The output of encoder,
+                has shape (bs, num_key, embed_dim).  num_key is
+                equal the number of points on feature map from
+                all level.
+            memory_padding_mask (Tensor): Padding mask for memory.
+                has shape (bs, num_key).
+            spatial_shapes (Tensor): The shape of all feature maps.
+                has shape (num_level, 2).
+
+        Returns:
+            tuple: A tuple of feature map and bbox prediction.
+
+                - output_memory (Tensor): The input of decoder,  \
+                    has shape (bs, num_key, embed_dim).  num_key is \
+                    equal the number of points on feature map from \
+                    all levels.
+                - output_proposals (Tensor): The normalized proposal \
+                    after a inverse sigmoid, has shape \
+                    (bs, num_keys, 4).
+        """
+
+        N, S, C = memory.shape
+        proposals = []
+        _cur = 0
+        for lvl, (H, W) in enumerate(spatial_shapes):
+            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + H * W)].view(N, H, W, 1)
+            valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
+            valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
+
+            grid_y, grid_x = torch.meshgrid(
+                torch.linspace(0, H - 1, H, dtype=torch.float32, device=memory.device),
+                torch.linspace(0, W - 1, W, dtype=torch.float32, device=memory.device),
+            )
+            grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)
+
+            scale = torch.cat([valid_W.unsqueeze(-1), valid_H.unsqueeze(-1)], 1).view(N, 1, 1, 2)
+            grid = (grid.unsqueeze(0).expand(N, -1, -1, -1) + 0.5) / scale
+            wh = torch.ones_like(grid) * 0.05 * (2.0**lvl)
+            proposal = torch.cat((grid, wh), -1).view(N, -1, 4)
+            proposals.append(proposal)
+            _cur += H * W
+        output_proposals = torch.cat(proposals, 1)
+        output_proposals_valid = ((output_proposals > 0.01) & (output_proposals < 0.99)).all(-1, keepdim=True)
+        output_proposals = torch.log(output_proposals / (1 - output_proposals))
+        output_proposals = output_proposals.masked_fill(memory_padding_mask.unsqueeze(-1), float("inf"))
+        output_proposals = output_proposals.masked_fill(~output_proposals_valid, float("inf"))
+
+        output_memory = memory
+        output_memory = output_memory.masked_fill(memory_padding_mask.unsqueeze(-1), float(0))
+        output_memory = output_memory.masked_fill(~output_proposals_valid, float(0))
+        output_memory = self.enc_output_norm(self.enc_output(output_memory))
+        return output_memory, output_proposals
+
+    @staticmethod
+    def get_reference_points(spatial_shapes, valid_ratios, device):
+        reference_points_list = []
+        for lvl, (H, W) in enumerate(spatial_shapes):
+            #  TODO  check this 0.5
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=torch.float32, device=device),
+                torch.linspace(0.5, W - 0.5, W, dtype=torch.float32, device=device),
+            )
+            ref_y = ref_y.reshape(-1)[None] / (valid_ratios[:, None, lvl, 1] * H)
+            ref_x = ref_x.reshape(-1)[None] / (valid_ratios[:, None, lvl, 0] * W)
+            ref = torch.stack((ref_x, ref_y), -1)
+            reference_points_list.append(ref)
+        reference_points = torch.cat(reference_points_list, 1)
+        reference_points = reference_points[:, :, None] * valid_ratios[:, None]
+        return reference_points
+
+    def get_valid_ratio(self, mask):
+        """Get the valid radios of feature maps of all  level."""
+        _, H, W = mask.shape
+        valid_H = torch.sum(~mask[:, :, 0], 1)
+        valid_W = torch.sum(~mask[:, 0, :], 1)
+        valid_ratio_h = valid_H.float() / H
+        valid_ratio_w = valid_W.float() / W
+        valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
+        return valid_ratio
+
+    def get_proposal_pos_embed(self, proposals, num_pos_feats=128, temperature=10000):
+        """Get the position embedding of proposal."""
+        scale = 2 * math.pi
+        dim_t = torch.arange(num_pos_feats, dtype=torch.float32, device=proposals.device)
+        dim_t = temperature ** (2 * (dim_t // 2) / num_pos_feats)
+        # N, L, 4
+        proposals = proposals.sigmoid() * scale
+        # N, L, 4, 128
+        pos = proposals[:, :, :, None] / dim_t
+        # N, L, 4, 64, 2
+        pos = torch.stack((pos[:, :, :, 0::2].sin(), pos[:, :, :, 1::2].cos()), dim=4).flatten(2)
+        return pos
+
+    # @force_fp32(apply_to=('mlvl_feats', 'query_embed', 'mlvl_pos_embeds'))
+    def forward(
+        self,
+        mlvl_feats,
+        mlvl_masks,
+        query_embed,
+        mlvl_pos_embeds,
+        reg_branches=None,
+        cls_branches=None,
+        level_embeds=None,
+        **kwargs,
+    ):
+        assert self.as_two_stage or query_embed is not None
+        feat_flatten = []
+        mask_flatten = []
+        lvl_pos_embed_flatten = []
+        spatial_shapes = []
+        for lvl, (feat, mask, pos_embed) in enumerate(zip(mlvl_feats, mlvl_masks, mlvl_pos_embeds)):
+            bs, c, h, w = feat.shape
+            spatial_shape = (h, w)
+            spatial_shapes.append(spatial_shape)
+            feat = feat.flatten(2)
+            feat = feat.transpose(1, 2)
+            mask = mask.flatten(1)
+            pos_embed = pos_embed.flatten(2).transpose(1, 2)
+            lvl_pos_embed = pos_embed + self.level_embeds[lvl].view(1, 1, -1)
+            lvl_pos_embed_flatten.append(lvl_pos_embed)
+            feat_flatten.append(feat)
+            mask_flatten.append(mask)
+        feat_flatten = torch.cat(feat_flatten, 1)
+        mask_flatten = torch.cat(mask_flatten, 1)
+        lvl_pos_embed_flatten = torch.cat(lvl_pos_embed_flatten, 1)
+        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long, device=feat_flatten.device)
+
+        spatial_shapes_prod = spatial_shapes.prod(1)
+        spatial_shapes_cumsum = spatial_shapes_prod.cumsum(0)
+        spatial_shapes_cumsum_excl_last = spatial_shapes_cumsum[:-1]
+        zeros = spatial_shapes.new_zeros((1,))
+        level_start_index = torch.cat((zeros, spatial_shapes_cumsum_excl_last))
+        valid_ratios = torch.stack([self.get_valid_ratio(m) for m in mlvl_masks], 1)
+        reference_points = self.get_reference_points(spatial_shapes, valid_ratios, device=feat.device)
+
+        feat_flatten = feat_flatten.permute(1, 0, 2)
+        lvl_pos_embed_flatten = lvl_pos_embed_flatten.permute(1, 0, 2)
+        memory = self.encoder(
+            query=feat_flatten,
+            key=None,
+            value=None,
+            query_pos=lvl_pos_embed_flatten,
+            query_key_padding_mask=mask_flatten,
+            spatial_shapes=spatial_shapes,
+            reference_points=reference_points,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            **kwargs,
+        )
+        # return memory
+        memory = memory.permute(1, 0, 2)
+        bs, _, c = memory.shape
+        if self.as_two_stage:
+            output_memory, output_proposals = self.gen_encoder_output_proposals(memory, mask_flatten, spatial_shapes)
+            enc_outputs_class = cls_branches[self.decoder.num_layers](output_memory)
+            enc_outputs_coord_unact = reg_branches[self.decoder.num_layers](output_memory) + output_proposals
+
+            topk = self.two_stage_num_proposals
+            topk_proposals = torch.topk(enc_outputs_class[..., 0], topk, dim=1)[1]
+            topk_coords_unact = torch.gather(enc_outputs_coord_unact, 1, topk_proposals.unsqueeze(-1).repeat(1, 1, 4))
+            topk_coords_unact = topk_coords_unact.detach()
+            reference_points = topk_coords_unact.sigmoid()
+            init_reference_out = reference_points
+            pos_trans_out = self.pos_trans_norm(self.pos_trans(self.get_proposal_pos_embed(topk_coords_unact)))
+            query_pos, query = torch.split(pos_trans_out, c, dim=2)
+        else:
+            query_pos, query = torch.split(query_embed, c, dim=1)
+            query_pos = query_pos.unsqueeze(0).expand(bs, -1, -1)
+            query = query.unsqueeze(0).expand(bs, -1, -1)
+            reference_points = self.reference_points(query_pos).sigmoid()
+            init_reference_out = reference_points
+
+        # decoder
+        query = query.permute(1, 0, 2)
+        memory = memory.permute(1, 0, 2)
+        query_pos = query_pos.permute(1, 0, 2)
+        inter_states, inter_references = self.decoder(
+            query=query,
+            key=None,
+            value=memory,
+            query_pos=query_pos,
+            key_padding_mask=mask_flatten,
+            reference_points=reference_points,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            reg_branches=reg_branches,
+            **kwargs,
+        )
+        inter_references_out = inter_references
+        if self.as_two_stage:
+            return (
+                (memory, lvl_pos_embed_flatten, mask_flatten, query_pos),
+                inter_states,
+                init_reference_out,
+                inter_references_out,
+                enc_outputs_class,
+                enc_outputs_coord_unact,
+            )
+        return (
+            (memory, lvl_pos_embed_flatten, mask_flatten, query_pos),
+            inter_states,
+            init_reference_out,
+            inter_references_out,
+            None,
+            None,
+        )

--- a/models/experimental/uniad/reference/seg_mask_head.py
+++ b/models/experimental/uniad/reference/seg_mask_head.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+import copy
+from torch import Tensor
+from typing import Optional
+
+
+class AttentionTail(nn.Module):
+    def __init__(self, cfg, dim, num_heads=2, qkv_bias=False, qk_scale=None, attn_drop=0.0, proj_drop=0.0):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+        self.q = nn.Linear(dim, dim, bias=qkv_bias)
+        self.k = nn.Linear(dim, dim, bias=qkv_bias)
+        self.linear_l1 = nn.Sequential(
+            nn.Linear(self.num_heads, self.num_heads),
+            nn.ReLU(),
+        )
+
+        self.linear = nn.Sequential(
+            nn.Linear(self.num_heads, 1),
+            nn.ReLU(),
+        )
+
+    def forward(self, query, key, key_padding_mask, hw_lvl=None):
+        B, N, C = query.shape
+        _, L, _ = key.shape
+        q = self.q(query).reshape(B, N, self.num_heads, C // self.num_heads).permute(0, 2, 1, 3).contiguous()
+
+        k = self.k(key).reshape(B, L, self.num_heads, C // self.num_heads).permute(0, 2, 1, 3).contiguous()
+
+        attn = (q @ k.transpose(-2, -1).contiguous()) * self.scale
+
+        attn = attn.permute(0, 2, 3, 1)
+
+        new_feats = self.linear_l1(attn)
+        mask = self.linear(new_feats)
+
+        return mask
+
+
+count = 0
+
+
+class Mlp(nn.Module):
+    def __init__(self, in_features, hidden_features=None, out_features=None, act_layer=nn.GELU, drop=0.0):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class SelfAttention(nn.Module):
+    def __init__(self, cfg, dim, num_heads=2, qkv_bias=False, qk_scale=None, attn_drop=0.0, proj_drop=0.0):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x):
+        B, N, C = x.shape
+
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4).contiguous()
+        q, k, v = qkv[0], qkv[1], qkv[2]  # make torchscript happy (cannot use tensor as tuple)
+
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+
+        return x
+
+
+class Attention(nn.Module):
+    def __init__(self, cfg, dim, num_heads=2, qkv_bias=False, qk_scale=None, attn_drop=0.0, proj_drop=0.0):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+        self.q = nn.Linear(dim, dim, bias=qkv_bias)
+        self.k = nn.Linear(dim, dim, bias=qkv_bias)
+        self.v = nn.Linear(dim, dim, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.linear_l1 = nn.Sequential(
+            nn.Linear(self.num_heads, self.num_heads),
+            nn.ReLU(),
+        )
+        self.linear = nn.Sequential(
+            nn.Linear(self.num_heads, 1),
+            nn.ReLU(),
+        )
+
+    def forward(self, query, key, value, key_padding_mask, hw_lvl):
+        B, N, C = query.shape
+        _, L, _ = key.shape
+        q = (
+            self.q(query).reshape(B, N, self.num_heads, C // self.num_heads).permute(0, 2, 1, 3).contiguous()
+        )  # .permute(2, 0, 3, 1, 4)
+        k = (
+            self.k(key).reshape(B, L, self.num_heads, C // self.num_heads).permute(0, 2, 1, 3).contiguous()
+        )  # .permute(2, 0, 3, 1, 4)
+
+        v = (
+            self.v(value).reshape(B, L, self.num_heads, C // self.num_heads).permute(0, 2, 1, 3).contiguous()
+        )  # .permute(2, 0, 3, 1, 4)
+
+        attn = (q @ k.transpose(-2, -1).contiguous()) * self.scale
+
+        attn = attn.permute(0, 2, 3, 1)
+
+        new_feats = self.linear_l1(attn)
+        mask = self.linear(new_feats)
+
+        attn = attn.permute(0, 3, 1, 2)
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+
+        x = (attn @ v).transpose(1, 2).contiguous().reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+
+        return x, mask
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        cfg,
+        dim,
+        num_heads,
+        mlp_ratio=4.0,
+        qkv_bias=False,
+        qk_scale=None,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        act_layer=nn.GELU,
+        norm_layer=nn.LayerNorm,
+        self_attn=False,
+    ):
+        super().__init__()
+        self.head_norm1 = norm_layer(dim)
+        self.self_attn = self_attn
+        self.attn = Attention(
+            cfg, dim, num_heads=num_heads, qkv_bias=qkv_bias, qk_scale=qk_scale, attn_drop=attn_drop, proj_drop=drop
+        )
+        # NOTE: drop path for stochastic depth, we shall see if this is better than dropout here
+
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.head_norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+        if self.self_attn:
+            self.self_attention = SelfAttention(
+                cfg, dim, num_heads=num_heads, qkv_bias=qkv_bias, qk_scale=qk_scale, attn_drop=attn_drop, proj_drop=drop
+            )
+            self.norm3 = norm_layer(dim)
+
+    def forward(self, query, key, value, key_padding_mask=None, hw_lvl=None):
+        if self.self_attn:
+            query = query + self.drop_path(self.self_attention(query))
+            query = self.norm3(query)
+        x, mask = self.attn(query, key, value, key_padding_mask, hw_lvl=hw_lvl)
+        query = query + self.drop_path(x)
+        query = self.head_norm1(query)
+
+        query = query + self.drop_path(self.mlp(query))
+        query = self.head_norm2(query)
+        return query, mask
+
+
+def drop_path(x, drop_prob: float = 0.0, training: bool = False):
+    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
+    This is the same as the DropConnect impl I created for EfficientNet, etc networks, however,
+    the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper...
+    See discussion: https://github.com/tensorflow/tpu/issues/494#issuecomment-53296self.num_heads956 ... I've opted for
+    changing the layer and argument names to 'drop path' rather than mix DropConnect as a layer name and use
+    'survival rate' as the argument.
+    """
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1 - drop_prob
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)  # work with diff dim tensors, not just 2D ConvNets
+    random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+    random_tensor.floor_()  # binarize
+    output = x.div(keep_prob) * random_tensor
+    return output
+
+
+def _get_clones(module, N):
+    return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+
+class DropPath(nn.Module):
+    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+
+    def __init__(self, drop_prob=None):
+        super(DropPath, self).__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)
+
+
+class SegMaskHead(nn.Module):
+    def __init__(
+        self,
+        cfg=None,
+        d_model=16,
+        nhead=2,
+        num_encoder_layers=6,
+        num_decoder_layers=1,
+        dim_feedforward=64,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        self_attn=False,
+    ):
+        super().__init__()
+
+        mlp_ratio = 4
+        qkv_bias = True
+        qk_scale = None
+        block = Block(
+            cfg,
+            dim=d_model,
+            num_heads=nhead,
+            mlp_ratio=mlp_ratio,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+            self_attn=self_attn,
+        )
+        self.blocks = _get_clones(block, num_decoder_layers)
+        self.attnen = AttentionTail(
+            cfg,
+            d_model,
+            num_heads=nhead,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+        )
+
+    def with_pos_embed(self, tensor, pos: Optional[Tensor]):
+        if pos is None:
+            return tensor
+        else:
+            return tensor + pos
+
+    def forward(self, memory, mask_memory, pos_memory, query_embed, mask_query, pos_query, hw_lvl):
+        if mask_memory is not None and isinstance(mask_memory, torch.Tensor):
+            mask_memory = mask_memory.to(torch.bool)
+        masks = []
+        inter_query = []
+        for i, block in enumerate(self.blocks):
+            query_embed, mask = block(
+                self.with_pos_embed(query_embed, pos_query),
+                self.with_pos_embed(memory, pos_memory),
+                memory,
+                key_padding_mask=mask_memory,
+                hw_lvl=hw_lvl,
+            )
+            masks.append(mask)
+            inter_query.append(query_embed)
+        attn = self.attnen(
+            self.with_pos_embed(query_embed, pos_query),
+            self.with_pos_embed(memory, pos_memory),
+            key_padding_mask=mask_memory,
+            hw_lvl=hw_lvl,
+        )
+        return attn, masks, inter_query

--- a/models/experimental/uniad/reference/spatial_cross_attention.py
+++ b/models/experimental/uniad/reference/spatial_cross_attention.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+import torch
+import torch.nn as nn
+from models.experimental.uniad.reference.utils import multi_scale_deformable_attn_pytorch
+
+
+class SpatialCrossAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_cams=6,
+        pc_range=None,
+        dropout=0.1,
+        init_cfg=None,
+        batch_first=False,
+        deformable_attention=dict(type="MSDeformableAttention3D", embed_dims=256, num_levels=4),
+        **kwargs,
+    ):
+        super(SpatialCrossAttention, self).__init__()
+
+        self.init_cfg = init_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.pc_range = pc_range
+        self.fp16_enabled = False
+        self.deformable_attention = MSDeformableAttention3D()
+        self.embed_dims = embed_dims
+        self.num_cams = num_cams
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.batch_first = batch_first
+
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        residual=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        reference_points_cam=None,
+        bev_mask=None,
+        level_start_index=None,
+        flag="encoder",
+        **kwargs,
+    ):
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        if residual is None:
+            inp_residual = query
+            slots = torch.zeros_like(query)
+        if query_pos is not None:
+            query = query + query_pos
+
+        bs, num_query, _ = query.size()
+
+        D = reference_points_cam.size(3)
+        indexes = []
+        for i, mask_per_img in enumerate(bev_mask):
+            index_query_per_img = mask_per_img[0].sum(-1).nonzero().squeeze(-1)
+            indexes.append(index_query_per_img)
+        max_len = max([len(each) for each in indexes])
+
+        # each camera only interacts with its corresponding BEV queries. This step can  greatly save GPU memory.
+        queries_rebatch = query.new_zeros([bs, self.num_cams, max_len, self.embed_dims])
+        reference_points_rebatch = reference_points_cam.new_zeros([bs, self.num_cams, max_len, D, 2])
+
+        for j in range(bs):
+            for i, reference_points_per_img in enumerate(reference_points_cam):
+                index_query_per_img = indexes[i]
+                queries_rebatch[j, i, : len(index_query_per_img)] = query[j, index_query_per_img]
+                reference_points_rebatch[j, i, : len(index_query_per_img)] = reference_points_per_img[
+                    j, index_query_per_img
+                ]
+
+        num_cams, l, bs, embed_dims = key.shape
+
+        key = key.permute(2, 0, 1, 3).reshape(bs * self.num_cams, l, self.embed_dims)
+        value = value.permute(2, 0, 1, 3).reshape(bs * self.num_cams, l, self.embed_dims)
+        queries = self.deformable_attention(
+            query=queries_rebatch.view(bs * self.num_cams, max_len, self.embed_dims),
+            key=key,
+            value=value,
+            reference_points=reference_points_rebatch.view(bs * self.num_cams, max_len, D, 2),
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+        ).view(bs, self.num_cams, max_len, self.embed_dims)
+        for j in range(bs):
+            for i, index_query_per_img in enumerate(indexes):
+                slots[j, index_query_per_img] += queries[j, i, : len(index_query_per_img)]
+
+        count = bev_mask.sum(-1) > 0
+        count = count.permute(1, 2, 0).sum(-1)
+        count = torch.clamp(count, min=1.0)
+        slots = slots / count[..., None]
+        slots = self.output_proj(slots)
+
+        return self.dropout(slots) + inp_residual
+
+
+class MSDeformableAttention3D(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=8,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, " f"but got {embed_dims} and {num_heads}")
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.output_proj = None
+        self.fp16_enabled = False
+
+        # you'd better set dim_per_head to a power of 2
+        # which is more efficient in the CUDA implementation
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError("invalid input for _is_power_of_2: {} (type: {})".format(n, type(n)))
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.sampling_offsets = nn.Linear(embed_dims, num_heads * num_levels * num_points * 2)
+        self.attention_weights = nn.Linear(embed_dims, num_heads * num_levels * num_points)
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        if value is None:
+            value = query
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query)
+        sampling_offsets = sampling_offsets.view(bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(bs, num_query, self.num_heads, self.num_levels, self.num_points)
+
+        if reference_points.shape[-1] == 2:
+            """
+            For each BEV query, it owns `num_Z_anchors` in 3D space that having different heights.
+            After proejcting, each BEV query has `num_Z_anchors` reference points in each 2D image.
+            For each referent point, we sample `num_points` sampling points.
+            For `num_Z_anchors` reference points,  it has overall `num_points * num_Z_anchors` sampling points.
+            """
+            offset_normalizer = torch.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
+
+            bs, num_query, num_Z_anchors, xy = reference_points.shape
+            reference_points = reference_points[:, :, None, None, None, :, :]
+            sampling_offsets = sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            bs, num_query, num_heads, num_levels, num_all_points, xy = sampling_offsets.shape
+            sampling_offsets = sampling_offsets.view(
+                bs, num_query, num_heads, num_levels, num_all_points // num_Z_anchors, num_Z_anchors, xy
+            )
+            sampling_locations = reference_points + sampling_offsets
+            bs, num_query, num_heads, num_levels, num_points, num_Z_anchors, xy = sampling_locations.shape
+            assert num_all_points == num_points * num_Z_anchors
+
+            sampling_locations = sampling_locations.view(bs, num_query, num_heads, num_levels, num_all_points, xy)
+
+        elif reference_points.shape[-1] == 4:
+            assert False
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be" f" 2 or 4, but get {reference_points.shape[-1]} instead."
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, level_start_index, sampling_locations, attention_weights, self.im2col_step
+        )
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+
+        return output

--- a/models/experimental/uniad/reference/temporal_self_attention.py
+++ b/models/experimental/uniad/reference/temporal_self_attention.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+import torch
+import torch.nn as nn
+
+from models.experimental.uniad.reference.utils import multi_scale_deformable_attn_pytorch
+
+
+class TemporalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        num_bev_queue=2,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, " f"but got {embed_dims} and {num_heads}")
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        # you'd better set dim_per_head to a power of 2
+        # which is more efficient in the CUDA implementation
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError("invalid input for _is_power_of_2: {} (type: {})".format(n, type(n)))
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.num_bev_queue = num_bev_queue
+        self.sampling_offsets = nn.Linear(
+            embed_dims * self.num_bev_queue, num_bev_queue * num_heads * num_levels * num_points * 2
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims * self.num_bev_queue, num_bev_queue * num_heads * num_levels * num_points
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        # self.init_weights()
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+        if value is None:
+            assert self.batch_first
+            bs, len_bev, c = query.shape
+            value = torch.stack([query, query], 1).reshape(bs * 2, len_bev, c)
+
+            # value = torch.cat([query, query], 0)
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+        bs, num_query, embed_dims = query.shape
+        _, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+        assert self.num_bev_queue == 2
+
+        query = torch.cat([value[:bs], query], -1)
+        value = self.value_proj(value)
+
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+
+        value = value.reshape(bs * self.num_bev_queue, num_value, self.num_heads, -1)
+
+        sampling_offsets = self.sampling_offsets(query)
+        sampling_offsets = sampling_offsets.view(
+            bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels * self.num_points
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels, self.num_points
+        )
+
+        attention_weights = (
+            attention_weights.permute(0, 3, 1, 2, 4, 5)
+            .reshape(bs * self.num_bev_queue, num_query, self.num_heads, self.num_levels, self.num_points)
+            .contiguous()
+        )
+        sampling_offsets = sampling_offsets.permute(0, 3, 1, 2, 4, 5, 6).reshape(
+            bs * self.num_bev_queue, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :]
+                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+
+        elif reference_points.shape[-1] == 4:
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :2]
+                + sampling_offsets / self.num_points * reference_points[:, :, None, :, None, 2:] * 0.5
+            )
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be" f" 2 or 4, but get {reference_points.shape[-1]} instead."
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, level_start_index, sampling_locations, attention_weights, self.im2col_step
+        )
+
+        # output shape (bs*num_bev_queue, num_query, embed_dims)
+        # (bs*num_bev_queue, num_query, embed_dims)-> (num_query, embed_dims, bs*num_bev_queue)
+        output = output.permute(1, 2, 0)
+
+        output = output.view(num_query, embed_dims, bs, self.num_bev_queue)
+
+        output = output.mean(-1)
+
+        output = output.permute(2, 0, 1)
+
+        output = self.output_proj(output)
+
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+
+        output = self.dropout(output) + identity
+
+        return output

--- a/models/experimental/uniad/reference/utils.py
+++ b/models/experimental/uniad/reference/utils.py
@@ -11,6 +11,95 @@ from typing import Any, Dict, List, Tuple, Union, Sequence
 from torch import Tensor
 
 
+# Utils For Planning Head
+from typing import Any, Dict, List, Sequence, Tuple, Union
+import numpy as np
+import numpy.typing as npt
+from casadi import DM, Opti, sumsqr, vertcat, exp
+
+Pose = Tuple[float, float, float]  # (x, y, yaw)
+
+
+class CollisionNonlinearOptimizer:
+    def __init__(self, trajectory_len: int, dt: float, sigma, alpha_collision, obj_pixel_pos):
+        self.dt = dt
+        self.trajectory_len = trajectory_len
+        self.current_index = 0
+        self.sigma = sigma
+        self.alpha_collision = alpha_collision
+        self.obj_pixel_pos = obj_pixel_pos
+        # Use a array of dts to make it compatible to situations with varying dts across different time steps.
+        self._dts: npt.NDArray[np.float32] = np.asarray([[dt] * trajectory_len])
+        self._init_optimization()
+
+    def _init_optimization(self) -> None:
+        self.nx = 2  # state dim
+
+        self._optimizer = Opti()  # Optimization problem
+        self._create_decision_variables()
+        self._create_parameters()
+        self._set_objective()
+
+        # Set default solver options (quiet)
+        self._optimizer.solver("ipopt", {"ipopt.print_level": 0, "print_time": 0, "ipopt.sb": "yes"})
+
+    def set_reference_trajectory(self, reference_trajectory: Sequence[Pose]) -> None:
+        self._optimizer.set_value(self.ref_traj, DM(reference_trajectory).T)
+        self._set_initial_guess(reference_trajectory)
+
+    def set_solver_optimizerons(self, options: Dict[str, Any]) -> None:
+        self._optimizer.solver("ipopt", options)
+
+    def solve(self):
+        return self._optimizer.solve()
+
+    def _create_decision_variables(self) -> None:
+        # State trajectory (x, y)
+        self.state = self._optimizer.variable(self.nx, self.trajectory_len)
+        self.position_x = self.state[0, :]
+        self.position_y = self.state[1, :]
+
+    def _create_parameters(self) -> None:
+        self.ref_traj = self._optimizer.parameter(2, self.trajectory_len)  # (x, y)
+
+    def _set_objective(self) -> None:
+        # Follow reference, minimize control rates and absolute inputs
+        alpha_xy = 1.0
+        cost_stage = alpha_xy * sumsqr(self.ref_traj[:2, :] - vertcat(self.position_x, self.position_y))
+
+        alpha_collision = self.alpha_collision
+
+        cost_collision = 0
+        normalizer = 1 / (2.507 * self.sigma)
+        # TODO: vectorize this
+        for t in range(len(self.obj_pixel_pos)):
+            x, y = self.position_x[t], self.position_y[t]
+            for i in range(len(self.obj_pixel_pos[t])):
+                col_x, col_y = self.obj_pixel_pos[t][i]
+                cost_collision += (
+                    alpha_collision * normalizer * exp(-((x - col_x) ** 2 + (y - col_y) ** 2) / 2 / self.sigma**2)
+                )
+        self._optimizer.minimize(cost_stage + cost_collision)
+
+    def _set_initial_guess(self, reference_trajectory: Sequence[Pose]) -> None:
+        """Set a warm-start for the solver based on the reference trajectory."""
+        # Initialize state guess based on reference
+        self._optimizer.set_initial(self.state[:2, :], DM(reference_trajectory).T)  # (x, y, yaw)
+
+
+def bivariate_gaussian_activation(ip):
+    mu_x = ip[..., 0:1]
+    mu_y = ip[..., 1:2]
+    sig_x = ip[..., 2:3]
+    sig_y = ip[..., 3:4]
+    rho = ip[..., 4:5]
+    sig_x = torch.exp(sig_x)
+    sig_y = torch.exp(sig_y)
+    rho = torch.tanh(rho)
+    out = torch.cat([mu_x, mu_y, sig_x, sig_y, rho], dim=-1)
+    return out
+
+
 def multi_scale_deformable_attn_pytorch(
     value: torch.Tensor,
     value_spatial_shapes: torch.Tensor,

--- a/models/experimental/uniad/reference/utils.py
+++ b/models/experimental/uniad/reference/utils.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import torch.nn.functional as F
+
+
+def multi_scale_deformable_attn_pytorch(
+    value: torch.Tensor,
+    value_spatial_shapes: torch.Tensor,
+    level_start_index: torch.Tensor,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+    im2col_step: torch.Tensor,
+) -> torch.Tensor:
+    bs, num_keys, num_heads, head_dim = value.shape
+    num_levels = value_spatial_shapes.shape[0]
+    num_queries = sampling_locations.shape[1]
+    num_points = sampling_locations.shape[4]
+
+    # Split value into a list of tensors for each level
+    value_list = []
+    start = 0
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        len_l = h_l * w_l
+        value_l = value[:, start : start + len_l, :, :]
+        value_list.append(value_l)
+        start += len_l
+
+    # Normalize sampling locations to [-1, 1]
+    sampling_grids = []
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        grid = sampling_locations[:, :, :, lvl, :, :]
+        grid = grid.clone()
+        grid[..., 0] = grid[..., 0] / w_l * 2 - 1
+        grid[..., 1] = grid[..., 1] / h_l * 2 - 1
+        sampling_grids.append(grid)
+
+    # Perform sampling and attention
+    output = torch.zeros(bs, num_queries, num_heads, head_dim, device=value.device)
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        value_l = value_list[lvl].permute(0, 2, 3, 1).reshape(bs * num_heads, head_dim, h_l, w_l)
+        grid = sampling_grids[lvl].permute(0, 2, 1, 3, 4).reshape(bs * num_heads, num_queries * num_points, 1, 2)
+        sampled = F.grid_sample(value_l, grid, mode="bilinear", padding_mode="zeros", align_corners=False)
+        sampled = sampled.view(bs, num_heads, head_dim, num_queries, num_points).permute(0, 3, 1, 4, 2)
+        attn = attention_weights[:, :, :, lvl, :].unsqueeze(-1)
+        output += (sampled * attn).sum(-2)
+
+    return output.view(bs, num_queries, num_heads * head_dim)

--- a/models/experimental/uniad/tt/common.py
+++ b/models/experimental/uniad/tt/common.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+class TtnnConv2D:
+    def __init__(
+        self,
+        conv,
+        conv_pth,
+        device=None,
+        activation="",
+        weights_dtype=ttnn.bfloat8_b,
+        shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        is_blk=False,
+        dealloc_act=False,
+        is_fpn=False,
+        is_wdth=False,
+        config_override=None,
+    ):
+        if is_wdth:
+            shard_layout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
+        if is_blk:
+            shard_layout = ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        self.conv = conv
+        self.conv_pth = conv_pth
+        self.device = device
+        self.in_channels = conv.in_channels
+        self.out_channels = conv.out_channels
+        self.kernel_size = conv.kernel_size
+        self.padding = conv.padding
+        self.stride = conv.stride
+        self.groups = conv.groups
+        self.is_fpn = is_fpn
+        self.compute_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+            math_approx_mode=True,
+        )
+        self.conv_config = ttnn.Conv2dConfig(
+            weights_dtype=weights_dtype,
+            shard_layout=shard_layout,
+            output_layout=ttnn.TILE_LAYOUT,
+            deallocate_activation=dealloc_act,
+            enable_act_double_buffer=False,
+            enable_split_reader=False,
+            enable_subblock_padding=False,
+            reshard_if_not_optimal=True,
+            activation=activation,
+        )
+        if config_override and "act_block_h" in config_override:
+            self.conv_config.act_block_h_override = config_override["act_block_h"]
+
+        if conv_pth.bias is not None:
+            self.bias = conv_pth.bias
+        else:
+            self.bias = None
+
+        self.weight = conv_pth.weight
+
+    def __call__(self, x):
+        if self.is_fpn:
+            input_height = self.conv_pth["height"]
+            input_width = self.conv_pth["width"]
+            batch_size = self.conv_pth["batch"]
+        else:
+            input_height = self.conv.input_height
+            input_width = self.conv.input_width
+            batch_size = self.conv.batch_size
+        [x, [output_height, output_width], [self.weight, self.bias]] = ttnn.conv2d(
+            input_tensor=x,
+            weight_tensor=self.weight,
+            bias_tensor=self.bias,
+            device=self.device,
+            in_channels=self.in_channels,
+            out_channels=self.out_channels,
+            input_height=input_height,
+            input_width=input_width,
+            batch_size=batch_size,
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            conv_config=self.conv_config,
+            groups=self.groups,
+            compute_config=self.compute_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+        )
+        return x, output_height, output_width

--- a/models/experimental/uniad/tt/model_preprocessing_encoder.py
+++ b/models/experimental/uniad/tt/model_preprocessing_encoder.py
@@ -1,0 +1,440 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch.nn as nn
+from models.experimental.uniad.reference.fpn import FPN
+from models.experimental.uniad.reference.ffn import FFN
+from models.experimental.uniad.reference.encoder import BEVFormerEncoder
+from models.experimental.uniad.reference.temporal_self_attention import TemporalSelfAttention
+from models.experimental.uniad.reference.spatial_cross_attention import SpatialCrossAttention
+
+
+from ttnn.model_preprocessing import (
+    infer_ttnn_module_args,
+    preprocess_model_parameters,
+    preprocess_linear_weight,
+    preprocess_linear_bias,
+    preprocess_layernorm_parameter,
+)
+
+
+def custom_preprocessor(model, name):
+    parameters = {}
+    if isinstance(model, FPN):
+        parameters["fpn"] = {}
+
+        # Lateral Convs
+        parameters["fpn"]["lateral_convs"] = {}
+
+        parameters["fpn"]["lateral_convs"]["0"] = {}
+        parameters["fpn"]["lateral_convs"]["0"]["conv"] = {}
+        parameters["fpn"]["lateral_convs"]["0"]["conv"]["weight"] = ttnn.from_torch(
+            model.lateral_convs[0].conv.weight, dtype=ttnn.float32
+        )
+        bias = model.lateral_convs[0].conv.bias.reshape((1, 1, 1, -1))
+        parameters["fpn"]["lateral_convs"]["0"]["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["fpn"]["lateral_convs"]["0"]["conv"]["height"] = 80
+        parameters["fpn"]["lateral_convs"]["0"]["conv"]["width"] = 45
+        parameters["fpn"]["lateral_convs"]["0"]["conv"]["batch"] = 6
+
+        parameters["fpn"]["lateral_convs"]["1"] = {}
+        parameters["fpn"]["lateral_convs"]["1"]["conv"] = {}
+        parameters["fpn"]["lateral_convs"]["1"]["conv"]["weight"] = ttnn.from_torch(
+            model.lateral_convs[1].conv.weight, dtype=ttnn.float32
+        )
+        bias = model.lateral_convs[1].conv.bias.reshape((1, 1, 1, -1))
+        parameters["fpn"]["lateral_convs"]["1"]["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["fpn"]["lateral_convs"]["1"]["conv"]["height"] = 40
+        parameters["fpn"]["lateral_convs"]["1"]["conv"]["width"] = 23
+        parameters["fpn"]["lateral_convs"]["1"]["conv"]["batch"] = 6
+
+        parameters["fpn"]["lateral_convs"]["2"] = {}
+        parameters["fpn"]["lateral_convs"]["2"]["conv"] = {}
+        parameters["fpn"]["lateral_convs"]["2"]["conv"]["weight"] = ttnn.from_torch(
+            model.lateral_convs[2].conv.weight, dtype=ttnn.float32
+        )
+        bias = model.lateral_convs[2].conv.bias.reshape((1, 1, 1, -1))
+        parameters["fpn"]["lateral_convs"]["2"]["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["fpn"]["lateral_convs"]["2"]["conv"]["height"] = 20
+        parameters["fpn"]["lateral_convs"]["2"]["conv"]["width"] = 12
+        parameters["fpn"]["lateral_convs"]["2"]["conv"]["batch"] = 6
+        # FPN Convs
+        parameters["fpn"]["fpn_convs"] = {}
+
+        parameters["fpn"]["fpn_convs"]["0"] = {}
+        parameters["fpn"]["fpn_convs"]["0"]["conv"] = {}
+        parameters["fpn"]["fpn_convs"]["0"]["conv"]["weight"] = ttnn.from_torch(
+            model.fpn_convs[0].conv.weight, dtype=ttnn.float32
+        )
+        bias = model.fpn_convs[0].conv.bias.reshape((1, 1, 1, -1))
+        parameters["fpn"]["fpn_convs"]["0"]["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["fpn"]["fpn_convs"]["0"]["conv"]["height"] = 80
+        parameters["fpn"]["fpn_convs"]["0"]["conv"]["width"] = 45
+        parameters["fpn"]["fpn_convs"]["0"]["conv"]["batch"] = 6
+
+        parameters["fpn"]["fpn_convs"]["1"] = {}
+        parameters["fpn"]["fpn_convs"]["1"]["conv"] = {}
+        parameters["fpn"]["fpn_convs"]["1"]["conv"]["weight"] = ttnn.from_torch(
+            model.fpn_convs[1].conv.weight, dtype=ttnn.float32
+        )
+        bias = model.fpn_convs[1].conv.bias.reshape((1, 1, 1, -1))
+        parameters["fpn"]["fpn_convs"]["1"]["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["fpn"]["fpn_convs"]["1"]["conv"]["height"] = 40
+        parameters["fpn"]["fpn_convs"]["1"]["conv"]["width"] = 23
+        parameters["fpn"]["fpn_convs"]["1"]["conv"]["batch"] = 6
+
+        parameters["fpn"]["fpn_convs"]["2"] = {}
+        parameters["fpn"]["fpn_convs"]["2"]["conv"] = {}
+        parameters["fpn"]["fpn_convs"]["2"]["conv"]["weight"] = ttnn.from_torch(
+            model.fpn_convs[2].conv.weight, dtype=ttnn.float32
+        )
+        bias = model.fpn_convs[2].conv.bias.reshape((1, 1, 1, -1))
+        parameters["fpn"]["fpn_convs"]["2"]["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["fpn"]["fpn_convs"]["2"]["conv"]["height"] = 20
+        parameters["fpn"]["fpn_convs"]["2"]["conv"]["width"] = 12
+        parameters["fpn"]["fpn_convs"]["2"]["conv"]["batch"] = 6
+
+    if isinstance(model, TemporalSelfAttention):
+        parameters["temporal_self_attention"] = {}
+        parameters["temporal_self_attention"]["sampling_offsets"] = {}
+        parameters["temporal_self_attention"]["sampling_offsets"]["weight"] = preprocess_linear_weight(
+            model.sampling_offsets.weight, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["sampling_offsets"]["bias"] = preprocess_linear_bias(
+            model.sampling_offsets.bias, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["attention_weights"] = {}
+        parameters["temporal_self_attention"]["attention_weights"]["weight"] = preprocess_linear_weight(
+            model.attention_weights.weight, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["attention_weights"]["bias"] = preprocess_linear_bias(
+            model.attention_weights.bias, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["value_proj"] = {}
+        parameters["temporal_self_attention"]["value_proj"]["weight"] = preprocess_linear_weight(
+            model.value_proj.weight, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["value_proj"]["bias"] = preprocess_linear_bias(
+            model.value_proj.bias, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["output_proj"] = {}
+        parameters["temporal_self_attention"]["output_proj"]["weight"] = preprocess_linear_weight(
+            model.output_proj.weight, dtype=ttnn.bfloat16
+        )
+        parameters["temporal_self_attention"]["output_proj"]["bias"] = preprocess_linear_bias(
+            model.output_proj.bias, dtype=ttnn.bfloat16
+        )
+    # if isinstance(model, MultiheadAttention):
+    #     parameters = {
+    #         "attentions": {},
+    #     }
+    #     parameters["attentions"][f"attn{0}"] = {
+    #         "in_proj": {
+    #             "weight": preprocess_linear_weight(model.attn.in_proj_weight, dtype=ttnn.bfloat16),
+    #             "bias": preprocess_linear_bias(model.attn.in_proj_bias, dtype=ttnn.bfloat16),
+    #         },
+    #         "out_proj": {
+    #             "weight": preprocess_linear_weight(model.attn.out_proj.weight, dtype=ttnn.bfloat16),
+    #             "bias": preprocess_linear_bias(model.attn.out_proj.bias, dtype=ttnn.bfloat16),
+    #         },
+    #     }
+    if isinstance(model, FFN):
+        parameters = {
+            "ffn": {},
+        }
+        parameters["ffn"][f"ffn0"] = {
+            "linear1": {
+                "weight": preprocess_linear_weight(model.layers[0][0].weight, dtype=ttnn.bfloat16),
+                "bias": preprocess_linear_bias(model.layers[0][0].bias, dtype=ttnn.bfloat16),
+            },
+            "linear2": {
+                "weight": preprocess_linear_weight(model.layers[1].weight, dtype=ttnn.bfloat16),
+                "bias": preprocess_linear_bias(model.layers[1].bias, dtype=ttnn.bfloat16),
+            },
+        }
+
+    # if isinstance(model, CustomMSDeformableAttention):
+    #     parameters = {
+    #         "attentions": {},
+    #     }
+    #     parameters["attentions"][f"attn1"] = {
+    #         "sampling_offsets": {
+    #             "weight": preprocess_linear_weight(model.sampling_offsets.weight, dtype=ttnn.bfloat16),
+    #             "bias": preprocess_linear_bias(model.sampling_offsets.bias, dtype=ttnn.bfloat16),
+    #         },
+    #         "attention_weights": {
+    #             "weight": preprocess_linear_weight(model.attention_weights.weight, dtype=ttnn.bfloat16),
+    #             "bias": preprocess_linear_bias(model.attention_weights.bias, dtype=ttnn.bfloat16),
+    #         },
+    #         "value_proj": {
+    #             "weight": preprocess_linear_weight(model.value_proj.weight, dtype=ttnn.bfloat16),
+    #             "bias": preprocess_linear_bias(model.value_proj.bias, dtype=ttnn.bfloat16),
+    #         },
+    #         "output_proj": {
+    #             "weight": preprocess_linear_weight(model.output_proj.weight, dtype=ttnn.bfloat16),
+    #             "bias": preprocess_linear_bias(model.output_proj.bias, dtype=ttnn.bfloat16),
+    #         },
+    #     }
+
+    if isinstance(model, BEVFormerEncoder):
+        parameters = {"layers": {}}
+
+        for i, layer in enumerate(model.layers):  # BaseTransformerLayer
+            layer_dict = {
+                "attentions": {},
+                "ffn": {},
+                "norms": {},
+            }
+
+            # Norms
+            for n, norm in enumerate(layer.norms):
+                if isinstance(norm, nn.LayerNorm):
+                    layer_dict["norms"][f"norm{n}"] = {
+                        "weight": preprocess_layernorm_parameter(norm.weight, dtype=ttnn.bfloat16),
+                        "bias": preprocess_layernorm_parameter(norm.bias, dtype=ttnn.bfloat16),
+                    }
+
+            # FFNs
+            for k, ffn in enumerate(layer.ffns):
+                layer_dict["ffn"][f"ffn{k}"] = {
+                    "linear1": {
+                        "weight": preprocess_linear_weight(ffn.layers[0][0].weight, dtype=ttnn.bfloat16),
+                        "bias": preprocess_linear_bias(ffn.layers[0][0].bias, dtype=ttnn.bfloat16),
+                    },
+                    "linear2": {
+                        "weight": preprocess_linear_weight(ffn.layers[1].weight, dtype=ttnn.bfloat16),
+                        "bias": preprocess_linear_bias(ffn.layers[1].bias, dtype=ttnn.bfloat16),
+                    },
+                }
+
+            # Attentions
+            for j, attn in enumerate(layer.attentions):
+                if isinstance(attn, TemporalSelfAttention):
+                    layer_dict["attentions"][f"attn{j}"] = {
+                        "sampling_offsets": {
+                            "weight": preprocess_linear_weight(attn.sampling_offsets.weight, dtype=ttnn.bfloat16),
+                            "bias": preprocess_linear_bias(attn.sampling_offsets.bias, dtype=ttnn.bfloat16),
+                        },
+                        "attention_weights": {
+                            "weight": preprocess_linear_weight(attn.attention_weights.weight, dtype=ttnn.bfloat16),
+                            "bias": preprocess_linear_bias(attn.attention_weights.bias, dtype=ttnn.bfloat16),
+                        },
+                        "value_proj": {
+                            "weight": preprocess_linear_weight(attn.value_proj.weight, dtype=ttnn.bfloat16),
+                            "bias": preprocess_linear_bias(attn.value_proj.bias, dtype=ttnn.bfloat16),
+                        },
+                        "output_proj": {
+                            "weight": preprocess_linear_weight(attn.output_proj.weight, dtype=ttnn.bfloat16),
+                            "bias": preprocess_linear_bias(attn.output_proj.bias, dtype=ttnn.bfloat16),
+                        },
+                    }
+
+                elif isinstance(attn, SpatialCrossAttention):
+                    layer_dict["attentions"][f"attn{j}"] = {
+                        "sampling_offsets": {
+                            "weight": preprocess_linear_weight(
+                                attn.deformable_attention.sampling_offsets.weight, dtype=ttnn.bfloat16
+                            ),
+                            "bias": preprocess_linear_bias(
+                                attn.deformable_attention.sampling_offsets.bias, dtype=ttnn.bfloat16
+                            ),
+                        },
+                        "attention_weights": {
+                            "weight": preprocess_linear_weight(
+                                attn.deformable_attention.attention_weights.weight, dtype=ttnn.bfloat16
+                            ),
+                            "bias": preprocess_linear_bias(
+                                attn.deformable_attention.attention_weights.bias, dtype=ttnn.bfloat16
+                            ),
+                        },
+                        "value_proj": {
+                            "weight": preprocess_linear_weight(
+                                attn.deformable_attention.value_proj.weight, dtype=ttnn.bfloat16
+                            ),
+                            "bias": preprocess_linear_bias(
+                                attn.deformable_attention.value_proj.bias, dtype=ttnn.bfloat16
+                            ),
+                        },
+                        "output_proj": {
+                            "weight": preprocess_linear_weight(attn.output_proj.weight, dtype=ttnn.bfloat16),
+                            "bias": preprocess_linear_bias(attn.output_proj.bias, dtype=ttnn.bfloat16),
+                        },
+                    }
+
+            parameters["layers"][f"layer{i}"] = layer_dict
+
+        # if isinstance(model, MapDetectionTransformerDecoder or DetectionTransformerDecoder):
+        #     parameters = {"layers": {}}
+
+        #     for i, layer in enumerate(model.layers):  # BaseTransformerLayer
+        #         layer_dict = {
+        #             "attentions": {},
+        #             "ffn": {},
+        #             "norms": {},
+        #         }
+
+        #         # Norms
+        #         for n, norm in enumerate(layer.norms):
+        #             if isinstance(norm, nn.LayerNorm):
+        #                 layer_dict["norms"][f"norm{n}"] = {
+        #                     "weight": preprocess_layernorm_parameter(norm.weight, dtype=ttnn.bfloat16),
+        #                     "bias": preprocess_layernorm_parameter(norm.bias, dtype=ttnn.bfloat16),
+        #                 }
+
+        #         # FFNs
+        #         for k, ffn in enumerate(layer.ffns):
+        #             layer_dict["ffn"][f"ffn{k}"] = {
+        #                 "linear1": {
+        #                     "weight": preprocess_linear_weight(ffn.layers[0][0].weight, dtype=ttnn.bfloat16),
+        #                     "bias": preprocess_linear_bias(ffn.layers[0][0].bias, dtype=ttnn.bfloat16),
+        #                 },
+        #                 "linear2": {
+        #                     "weight": preprocess_linear_weight(ffn.layers[1].weight, dtype=ttnn.bfloat16),
+        #                     "bias": preprocess_linear_bias(ffn.layers[1].bias, dtype=ttnn.bfloat16),
+        #                 },
+        #             }
+
+        #         # Attentions
+        #         for j, attn in enumerate(layer.attentions):
+        #             if isinstance(attn, MultiheadAttention):
+        #                 layer_dict["attentions"][f"attn{j}"] = {
+        #                     "in_proj": {
+        #                         "weight": preprocess_linear_weight(attn.attn.in_proj_weight, dtype=ttnn.bfloat16),
+        #                         "bias": preprocess_linear_bias(attn.attn.in_proj_bias, dtype=ttnn.bfloat16),
+        #                     },
+        #                     "out_proj": {
+        #                         "weight": preprocess_linear_weight(attn.attn.out_proj.weight, dtype=ttnn.bfloat16),
+        #                         "bias": preprocess_linear_bias(attn.attn.out_proj.bias, dtype=ttnn.bfloat16),
+        #                     },
+        #                 }
+
+        #             elif isinstance(attn, CustomMSDeformableAttention):
+        #                 layer_dict["attentions"][f"attn{j}"] = {
+        #                     "sampling_offsets": {
+        #                         "weight": preprocess_linear_weight(attn.sampling_offsets.weight, dtype=ttnn.bfloat16),
+        #                         "bias": preprocess_linear_bias(attn.sampling_offsets.bias, dtype=ttnn.bfloat16),
+        #                     },
+        #                     "attention_weights": {
+        #                         "weight": preprocess_linear_weight(attn.attention_weights.weight, dtype=ttnn.bfloat16),
+        #                         "bias": preprocess_linear_bias(attn.attention_weights.bias, dtype=ttnn.bfloat16),
+        #                     },
+        #                     "value_proj": {
+        #                         "weight": preprocess_linear_weight(attn.value_proj.weight, dtype=ttnn.bfloat16),
+        #                         "bias": preprocess_linear_bias(attn.value_proj.bias, dtype=ttnn.bfloat16),
+        #                     },
+        #                     "output_proj": {
+        #                         "weight": preprocess_linear_weight(attn.output_proj.weight, dtype=ttnn.bfloat16),
+        #                         "bias": preprocess_linear_bias(attn.output_proj.bias, dtype=ttnn.bfloat16),
+        #                     },
+        #                 }
+
+        #         parameters["layers"][f"layer{i}"] = layer_dict
+
+        return parameters
+
+    return parameters
+
+
+def create_uniad_FPN_parameters(model, input_tensors, device=None):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters.conv_args = {}
+    parameters.conv_args = infer_ttnn_module_args(
+        model=model, run_model=lambda model: model(input_tensors), device=device
+    )
+    parameters["model_args"] = model
+    # assert parameters is not None
+    # for key in parameters.conv_args.keys():
+    #     parameters.conv_args[key].module = getattr(model, key)
+    return parameters
+
+
+def create_uniad_model_parameters(model, input_tensors, device=None):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters.conv_args = {}
+    parameters.conv_args = infer_ttnn_module_args(
+        model=model, run_model=lambda model: model(input_tensors), device=device
+    )
+    parameters["model_args"] = model.img_neck
+    # assert parameters is not None
+    # for key in parameters.conv_args.keys():
+    #     parameters.conv_args[key].module = getattr(model, key)
+    return parameters
+
+
+def create_uniad_model_parameters_sca(model, input_tensor, device=None):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters.conv_args = {}
+    parameters.conv_args = infer_ttnn_module_args(
+        model=model,
+        run_model=lambda model: model(
+            input_tensor[0],
+            key=input_tensor[1],
+            value=input_tensor[2],
+            reference_points=input_tensor[3],
+            spatial_shapes=input_tensor[4],
+            reference_points_cam=input_tensor[5],
+            bev_mask=input_tensor[6],
+            level_start_index=input_tensor[7],
+        ),
+        device=None,
+    )
+    assert parameters is not None
+    for key in parameters.conv_args.keys():
+        parameters.conv_args[key].module = getattr(model, key)
+    return parameters
+
+
+def create_uniad_model_parameters_tsa(model, input_tensor, device=None):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters.conv_args = {}
+    parameters.conv_args = infer_ttnn_module_args(
+        model=model,
+        run_model=lambda model: model(
+            input_tensor[0],
+            query_pos=input_tensor[1],
+            reference_points=input_tensor[2],
+            spatial_shapes=input_tensor[3],
+            level_start_index=input_tensor[4],
+        ),
+        device=None,
+    )
+    assert parameters is not None
+    for key in parameters.conv_args.keys():
+        parameters.conv_args[key].module = getattr(model, key)
+    return parameters
+
+
+# def create_uniad_model_parameters_decoder(model: ResNet, input_tensor, device=None):
+#     parameters = preprocess_model_parameters(
+#         initialize_model=lambda: model,
+#         custom_preprocessor=custom_preprocessor,
+#         device=device,
+#     )
+#     return parameters
+
+
+def create_uniad_model_parameters_encoder(model, device=None):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    return parameters

--- a/models/experimental/uniad/tt/tt_detr_transformer_decoder.py
+++ b/models/experimental/uniad/tt/tt_detr_transformer_decoder.py
@@ -186,8 +186,6 @@ class TtDetrTransformerDecoderLayer:
                     weight=self.params.norms[norm_index].weight,  # Changed here
                     bias=self.params.norms[norm_index].bias,  # Changed here
                 )
-                ttnn.deallocate(self.params.norms[norm_index].weight)  # Changed here
-                ttnn.deallocate(self.params.norms[norm_index].bias)  # Changed here
                 norm_index += 1
 
             elif layer == "cross_attn":
@@ -299,14 +297,14 @@ class TtDeformableDetrTransformerDecoder:
             if reg_branches is not None:
                 # Select reg_branch layers for current lid
                 layers = self.params_branches[lid]
-
+                tmp = output
                 for i in range(0, 5, 2):
                     tmp = ttnn.linear(
-                        output,
+                        tmp,
                         layers[i]["weight"],
                         bias=layers[i]["bias"],
                     )
-                    if i < 2:
+                    if i <= 2:
                         tmp = ttnn.relu(tmp)
 
                 if reference_points.shape[-1] == 4:

--- a/models/experimental/uniad/tt/tt_detr_transformer_decoder.py
+++ b/models/experimental/uniad/tt/tt_detr_transformer_decoder.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import warnings
+from models.experimental.uniad.tt.tt_ffn import TtFFN
+from models.experimental.uniad.tt.ttnn_mha import TtMultiheadAttention
+from models.experimental.uniad.tt.tt_detr_transformer_encoder import TtMultiScaleDeformableAttention
+import copy
+
+
+def inverse_sigmoid(x, eps: float = 1e-5):
+    x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)
+    x = ttnn.clamp(x, min=0, max=1)
+    x1 = ttnn.clamp(x, min=eps)
+    if len(x.shape) == 3:
+        x_temp = ttnn.ones(shape=[x.shape[0], x.shape[1], x.shape[2]], layout=ttnn.TILE_LAYOUT, device=x.device())
+    else:
+        x_temp = ttnn.ones(
+            shape=[x.shape[0], x.shape[1], x.shape[2], x.shape[3]], layout=ttnn.TILE_LAYOUT, device=x.device()
+        )
+    x_temp = x_temp - x
+    x2 = ttnn.clamp(x_temp, min=eps)
+    return ttnn.log(ttnn.div(x1, x2))
+
+
+class TtDetrTransformerDecoderLayer:
+    def __init__(
+        self,
+        params,
+        device,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=1024,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=None,
+        norm_cfg=dict(type="LN"),
+        init_cfg=None,
+        batch_first=False,
+        **kwargs,
+    ):
+        self.params = params
+
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels", ffn_dropout="ffn_drop", ffn_num_fcs="num_fcs"
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                warnings.warn(
+                    f"The arguments `{ori_name}` in BaseTransformerLayer "
+                    f"has been deprecated, now you should set `{new_name}` "
+                    f"and other FFN related arguments "
+                    f"to a dict named `ffn_cfgs`. "
+                )
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super(TtDetrTransformerDecoderLayer, self).__init__()
+
+        self.batch_first = batch_first
+        self.device = device
+
+        assert set(operation_order) & set(["self_attn", "norm", "ffn", "cross_attn"]) == set(operation_order), (
+            f"The operation_order of"
+            f" {self.__class__.__name__} should "
+            f"contains all four operation type "
+            f"{['self_attn', 'norm', 'ffn', 'cross_attn']}"
+        )
+
+        num_attn = operation_order.count("self_attn") + operation_order.count("cross_attn")
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+        self.attentions = []
+
+        index = 0
+        for operation_name in operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                if "batch_first" in attn_cfgs[index]:
+                    assert self.batch_first == attn_cfgs[index]["batch_first"]
+                else:
+                    attn_cfgs[index]["batch_first"] = self.batch_first
+                if attn_cfgs[index]["type"] == "MultiheadAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = TtMultiheadAttention(params.attentions[0], device, **attn_cfgs[index])  # Changed here
+                    attn_cfgs[index]["type"] = "MultiheadAttention"
+                elif attn_cfgs[index]["type"] == "MultiScaleDeformableAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = TtMultiScaleDeformableAttention(
+                        params.attentions[1], device, **attn_cfgs[index]
+                    )  # Changed here
+                    attn_cfgs[index]["type"] = "MultiScaleDeformableAttention"
+
+                self.attentions.append(attention)
+                index += 1
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.pre_norm = operation_order[0] == "norm"
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        num_attn = operation_order.count("self_attn") + operation_order.count("cross_attn")
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.ffns = []
+        num_ffns = operation_order.count("ffn")
+
+        for i in range(num_ffns):
+            self.ffns.append(TtFFN(params.ffns[0].ffn.ffn0, self.device))  # Changed here
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        elif isinstance(attn_masks, ttnn.Tensor):
+            attn_masks = [copy.deepcopy(attn_masks) for _ in range(self.num_attn)]
+            warnings.warn(f"Use same attn_mask in all attentions in " f"{self.__class__.__name__} ")
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                temp_key = temp_value = query
+                query = self.attentions[attn_index](
+                    query,
+                    temp_key,
+                    temp_value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=query_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = ttnn.layer_norm(
+                    query,
+                    weight=self.params.norms[norm_index].weight,  # Changed here
+                    bias=self.params.norms[norm_index].bias,  # Changed here
+                )
+                ttnn.deallocate(self.params.norms[norm_index].weight)  # Changed here
+                ttnn.deallocate(self.params.norms[norm_index].bias)  # Changed here
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+class TtDeformableDetrTransformerDecoder:
+    def __init__(self, num_layers, embed_dim, num_heads, params, device, params_branches=None):
+        self.return_intermediate = True
+        self.device = device
+        self.params = params
+        self.params_branches = params_branches
+        self.layers = [
+            TtDetrTransformerDecoderLayer(
+                params.layers[i],  # Changed here
+                self.device,
+                attn_cfgs=[
+                    {
+                        "type": "MultiheadAttention",
+                        "embed_dims": embed_dim,
+                        "num_heads": num_heads,
+                    },
+                    {
+                        "type": "MultiScaleDeformableAttention",
+                        "embed_dims": embed_dim,
+                        "num_levels": 4,
+                    },
+                ],
+                ffn_cfgs={
+                    "type": "FFN",
+                    "embed_dims": embed_dim,
+                    "feedforward_channels": 512,
+                    "num_fcs": 2,
+                    "ffn_drop": 0.0,
+                    "act_cfg": {"type": "ReLU", "inplace": True},
+                },
+                operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+                norm_cfg={"type": "LN"},
+                init_cfg=None,
+                batch_first=False,
+                kwargs={
+                    "feedforward_channels": 512,
+                    "act_cfg": {"type": "ReLU", "inplace": True},
+                    "ffn_num_fcs": 2,
+                },
+            )
+            for i in range(num_layers)
+        ]
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        reg_branches=None,
+        cls_branches=None,
+        valid_ratios=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        output = query
+        intermediate = []
+        intermediate_reference_points = []
+        for lid, layer in enumerate(self.layers):
+            if reference_points.shape[-1] == 4:
+                valid_ratios_concat = ttnn.concat([valid_ratios, valid_ratios], dim=-1)
+                reference_points_unsq = ttnn.unsqueeze(reference_points, dim=2)
+                valid_ratios_unsq = ttnn.unsqueeze(valid_ratios_concat, dim=1)
+                reference_points_input = ttnn.mul(reference_points_unsq, valid_ratios_unsq)
+            else:
+                assert reference_points.shape[-1] == 2
+                reference_points_unsq = ttnn.unsqueeze(reference_points, dim=2)
+                valid_ratios_unsq = ttnn.unsqueeze(valid_ratios, dim=1)
+                reference_points_input = ttnn.mul(reference_points_unsq, valid_ratios_unsq)
+
+            output = layer(
+                output,
+                key=key,
+                value=value,
+                query_pos=query_pos,
+                reference_points=reference_points_input,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+            )
+            output = ttnn.permute(output, (1, 0, 2))
+
+            if reg_branches is not None:
+                # Select reg_branch layers for current lid
+                layers = self.params_branches[lid]
+
+                for i in range(0, 5, 2):
+                    tmp = ttnn.linear(
+                        output,
+                        layers[i]["weight"],
+                        bias=layers[i]["bias"],
+                    )
+                    if i < 2:
+                        tmp = ttnn.relu(tmp)
+
+                if reference_points.shape[-1] == 4:
+                    inv = inverse_sigmoid(reference_points)
+                    new_reference_points = tmp + inv
+                    new_reference_points = ttnn.sigmoid(new_reference_points)
+                else:
+                    assert reference_points.shape[-1] == 2
+                    inv = inverse_sigmoid(reference_points)
+                    new_reference_points = tmp
+
+                    new_reference_points = ttnn.to_torch(new_reference_points)
+                    tmp = ttnn.to_torch(tmp)
+                    inv = ttnn.to_torch(inv)
+                    new_reference_points[..., :2] = tmp[..., :2] + inv
+                    new_reference_points = ttnn.from_torch(
+                        new_reference_points, device=self.device, layout=ttnn.TILE_LAYOUT
+                    )
+                    new_reference_points = ttnn.sigmoid(new_reference_points)
+                reference_points = new_reference_points
+
+            output = ttnn.permute(output, (1, 0, 2))
+            if self.return_intermediate:
+                intermediate.append(output)
+                intermediate_reference_points.append(reference_points)
+
+        if self.return_intermediate:
+            a = ttnn.stack(intermediate, dim=0)
+            b = ttnn.stack(intermediate_reference_points, dim=0)
+            return a, b
+        return output, reference_points

--- a/models/experimental/uniad/tt/tt_detr_transformer_encoder.py
+++ b/models/experimental/uniad/tt/tt_detr_transformer_encoder.py
@@ -93,9 +93,6 @@ class TtMultiScaleDeformableAttention:
             sampling_offsets, (bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
         )
         attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
-        ttnn.deallocate(params.attention_weights.weight)
-        ttnn.deallocate(params.attention_weights.bias)
-        ttnn.deallocate(query)
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
         )
@@ -134,9 +131,7 @@ class TtMultiScaleDeformableAttention:
             value, spatial_shapes, None, sampling_locations, attention_weights, None, self.device
         )
 
-        output = output = ttnn.linear(output, params.output_proj.weight, bias=params.output_proj.bias)
-        ttnn.deallocate(params.output_proj.weight)
-        ttnn.deallocate(params.output_proj.bias)
+        output = ttnn.linear(output, params.output_proj.weight, bias=params.output_proj.bias)
         if not self.batch_first:
             output = ttnn.permute(output, (1, 0, 2))
 

--- a/models/experimental/uniad/tt/tt_detr_transformer_encoder.py
+++ b/models/experimental/uniad/tt/tt_detr_transformer_encoder.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.uniad.tt.tt_temporal_self_attention import multi_scale_deformable_attn_pytorch
+from models.experimental.uniad.tt.tt_ffn import TtFFN
+
+
+class TtMultiScaleDeformableAttention:
+    def __init__(
+        self,
+        params,
+        device,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=False,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, " f"but got {embed_dims} and {num_heads}")
+        dim_per_head = embed_dims // num_heads
+        self.params = params
+        self.device = device
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError("invalid input for _is_power_of_2: {} (type: {})".format(n, type(n)))
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        params = self.params
+        if value is None:
+            value = query
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = ttnn.permute(query, (1, 0, 2))
+            value = ttnn.permute(value, (1, 0, 2))
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (ttnn.sum(spatial_shapes[:, 0] * spatial_shapes[:, 1])) == num_value
+        value = ttnn.to_layout(value, ttnn.TILE_LAYOUT)
+        value = ttnn.linear(value, params.value_proj.weight, bias=params.value_proj.bias)
+        if key_padding_mask is not None:
+            mask = ttnn.unsqueeze(key_padding_mask, dim=-1)
+            mask = ttnn.to_layout(mask, ttnn.TILE_LAYOUT)
+            value = ttnn.where(mask, ttnn.zeros_like(value, device=self.device, layout=ttnn.TILE_LAYOUT), value)
+        value = ttnn.reshape(value, (bs, num_value, self.num_heads, -1))
+        query = ttnn.to_layout(query, ttnn.TILE_LAYOUT)
+        sampling_offsets = ttnn.linear(query, params.sampling_offsets.weight, bias=params.sampling_offsets.bias)
+        sampling_offsets = ttnn.reshape(
+            sampling_offsets, (bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
+        )
+        attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
+        ttnn.deallocate(params.attention_weights.weight)
+        ttnn.deallocate(params.attention_weights.bias)
+        ttnn.deallocate(query)
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
+        )
+
+        attention_weights = ttnn.softmax(attention_weights, dim=-1)
+
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_levels, self.num_points)
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = ttnn.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], dim=-1)  # [num_levels, 2]
+            offset_normalizer_xy = ttnn.reshape(offset_normalizer, (1, 1, 1, offset_normalizer.shape[0], 1, 2))
+            reference_xy = ttnn.reshape(
+                reference_points,
+                (reference_points.shape[0], reference_points.shape[1], 1, reference_points.shape[2], 1, 2),
+            )
+            sampling_offsets = ttnn.to_layout(sampling_offsets, ttnn.TILE_LAYOUT)
+            offset_normalizer_xy = ttnn.to_layout(offset_normalizer_xy, ttnn.TILE_LAYOUT)
+            sampling_offsets = ttnn.div(sampling_offsets, offset_normalizer_xy)
+
+            sampling_locations = ttnn.add(reference_xy, sampling_offsets)
+        elif reference_points.shape[-1] == 4:
+            reference_points = ttnn.unsqueeze(reference_points, dim=2)
+            reference_points = ttnn.unsqueeze(reference_points, dim=2)
+            reference_points_reshape = reference_points[:, :, :, :, :, :2]
+            sampling_locations = (
+                reference_points_reshape + ttnn.div(sampling_offsets, self.num_points) * reference_points_reshape * 0.5
+            )
+
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be 2 or 4, " f"but got {reference_points.shape[-1]} instead."
+            )
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, None, sampling_locations, attention_weights, None, self.device
+        )
+
+        output = output = ttnn.linear(output, params.output_proj.weight, bias=params.output_proj.bias)
+        ttnn.deallocate(params.output_proj.weight)
+        ttnn.deallocate(params.output_proj.bias)
+        if not self.batch_first:
+            output = ttnn.permute(output, (1, 0, 2))
+
+        output = ttnn.add(output, identity)
+
+        return output
+
+
+class TtDetrTransformerEncoder:
+    def __init__(
+        self,
+        params,
+        device,
+        embed_dims=256,
+        num_layers=6,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=False,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        self.device = device
+        self.params = params
+        self.num_layers = num_layers
+        self.layers = []
+        for i in range(num_layers):
+            attn = TtMultiScaleDeformableAttention(
+                params=params.layers[i].attentions[0],
+                device=device,
+            )
+            ffn = TtFFN(
+                params=params.layers[i].ffns[0].ffn.ffn0,
+                device=device,
+            )
+            self.layers.append([attn, ffn])
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        query_key_padding_mask=None,
+        **kwargs,
+    ):
+        for i, layer in enumerate(self.layers):
+            temp_key = temp_value = query
+            query = layer[0](
+                query,
+                temp_key,
+                temp_value,
+                identity=None,
+                query_pos=query_pos,
+                key_pos=query_pos,
+                attn_mask=None,
+                spatial_shapes=spatial_shapes,
+                reference_points=reference_points,
+                key_padding_mask=query_key_padding_mask,
+            )
+            identity = query
+
+            query = ttnn.layer_norm(
+                query,
+                weight=self.params.layers[i].norms[0].weight,
+                bias=self.params.layers[i].norms[0].bias,
+            )
+            query = layer[1](query)
+            query = ttnn.layer_norm(
+                query,
+                weight=self.params.layers[i].norms[1].weight,
+                bias=self.params.layers[i].norms[1].bias,
+            )
+
+        return query

--- a/models/experimental/uniad/tt/tt_encoder.py
+++ b/models/experimental/uniad/tt/tt_encoder.py
@@ -66,88 +66,141 @@ class TtBEVFormerEncoder:
             self.layers.append(TtBEVFormerLayer(self.device, params.layers[f"layer{i}"], **transformer_layers))
 
     @staticmethod
-    def get_reference_points(H, W, Z=8, num_points_in_pillar=4, dim="3d", bs=1, device="cuda", dtype=torch.float):
-        # reference points in 3D space, used in spatial cross-attention (SCA)
+    def get_reference_points_ttnn(H, W, Z=8, num_points_in_pillar=4, dim="3d", bs=1, device=None, dtype=ttnn.bfloat16):
         if dim == "3d":
-            zs = (
-                torch.linspace(0.5, Z - 0.5, num_points_in_pillar, dtype=dtype, device=device)
-                .view(-1, 1, 1)
-                .expand(num_points_in_pillar, H, W)
-                / Z
-            )
-            xs = (
-                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device)
-                .view(1, 1, W)
-                .expand(num_points_in_pillar, H, W)
-                / W
-            )
-            ys = (
-                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device)
-                .view(1, H, 1)
-                .expand(num_points_in_pillar, H, W)
-                / H
-            )
-            ref_3d = torch.stack((xs, ys, zs), -1)
-            ref_3d = ref_3d.permute(0, 3, 1, 2).flatten(2).permute(0, 2, 1)
-            ref_3d = ref_3d[None].repeat(bs, 1, 1, 1)
-            return ref_3d
 
-        # reference points on 2D bev plane, used in temporal self-attention (TSA).
+            def _linspace_ttnn(start, end, steps):
+                idx = ttnn.arange(0, steps, dtype=ttnn.bfloat16, device=device)
+                step_size = (end - start) / (steps - 1)
+                return ttnn.add(ttnn.multiply(idx, step_size), start)
+
+            # Generate z-values
+            z_vals = _linspace_ttnn(0.5, Z - 0.5, num_points_in_pillar)
+            z_vals = ttnn.reshape(z_vals, (num_points_in_pillar, 1, 1))
+            z_vals = ttnn.expand(z_vals, (num_points_in_pillar, H, W))
+            z_vals = ttnn.divide(z_vals, Z)
+
+            # Generate x-values
+            x_vals = _linspace_ttnn(0.5, W - 0.5, W)
+            x_vals = ttnn.reshape(x_vals, (1, 1, W))
+            x_vals = ttnn.expand(x_vals, (num_points_in_pillar, H, W))
+            x_vals = ttnn.divide(x_vals, W)
+
+            # Generate y-values
+            y_vals = _linspace_ttnn(0.5, H - 0.5, H)
+            y_vals = ttnn.reshape(y_vals, (1, H, 1))
+            y_vals = ttnn.expand(y_vals, (num_points_in_pillar, H, W))
+            y_vals = ttnn.divide(y_vals, H)
+
+            ref = ttnn.stack((x_vals, y_vals, z_vals), dim=-1)  # [P, H, W, 3]
+            ref = ttnn.permute(ref, (0, 3, 1, 2))  # [P, 3, H, W]
+            ref = ttnn.reshape(ref, (num_points_in_pillar, 3, H * W))
+            ref = ttnn.permute(ref, (0, 2, 1))  # [P, H*W, 3]
+            ref = ttnn.reshape(ref, (1, num_points_in_pillar, H * W, 3))
+
+            ref = ttnn.repeat(ref, (bs, 1, 1, 1))  # [B, P, HW, 3]
+            return ref
+
         elif dim == "2d":
-            ref_y, ref_x = torch.meshgrid(
-                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device),
-                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device),
-            )
-            ref_y = ref_y.reshape(-1)[None] / H
-            ref_x = ref_x.reshape(-1)[None] / W
-            ref_2d = torch.stack((ref_x, ref_y), -1)
-            ref_2d = ref_2d.repeat(bs, 1, 1).unsqueeze(2)
-        return ref_2d
+            y_vals = ttnn.arange(0, H, device=device, memory_config=ttnn.L1_MEMORY_CONFIG)
+            x_vals = ttnn.arange(0, W, device=device, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-    def point_sampling(self, reference_points, pc_range, img_metas):  # TODO Handle fp32
+            y_vals = ttnn.add(y_vals, 0.5)
+            x_vals = ttnn.add(x_vals, 0.5)
+
+            y_vals = ttnn.divide(y_vals, H)
+            x_vals = ttnn.divide(x_vals, W)
+
+            y_vals = ttnn.reshape(y_vals, (H, 1))
+            y_vals = ttnn.repeat(y_vals, (1, W))  # [H, W]
+
+            x_vals = ttnn.reshape(x_vals, (1, W))
+            x_vals = ttnn.repeat(x_vals, (H, 1))  # [H, W]
+
+            y_vals = ttnn.reshape(y_vals, (-1,))
+            y_vals = ttnn.unsqueeze(y_vals, 0)  # [1, H*W]
+            x_vals = ttnn.reshape(x_vals, (-1,))
+            x_vals = ttnn.unsqueeze(x_vals, 0)  # [1, H*W]
+
+            ref = ttnn.stack((x_vals, y_vals), dim=-1)  # [1, H*W, 2]
+
+            ref = ttnn.repeat(ref, (bs, 1, 1))  # [bs, H*W, 2]
+            ref = ttnn.reshape(ref, (bs, H * W, 1, 2))  # [bs, H*W, 1, 2]
+
+            return ref
+
+    def point_sampling_ttnn(self, reference_points, pc_range, img_metas):
         lidar2img = []
         for img_meta in img_metas:
             lidar2img.append(img_meta["lidar2img"])
         lidar2img = np.asarray(lidar2img)
+        reference_points = ttnn.to_torch(reference_points)
         lidar2img = reference_points.new_tensor(lidar2img)  # (B, N, 4, 4)
-        reference_points = reference_points.clone()
+        reference_points = ttnn.from_torch(
+            reference_points, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+        lidar2img = ttnn.from_torch(lidar2img, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device)
+        ref = ttnn.clone(reference_points)
 
-        reference_points[..., 0:1] = reference_points[..., 0:1] * (pc_range[3] - pc_range[0]) + pc_range[0]
-        reference_points[..., 1:2] = reference_points[..., 1:2] * (pc_range[4] - pc_range[1]) + pc_range[1]
-        reference_points[..., 2:3] = reference_points[..., 2:3] * (pc_range[5] - pc_range[2]) + pc_range[2]
+        x, y, z = ttnn.split(ref, (1, 1, 1), dim=3)
 
-        reference_points = torch.cat((reference_points, torch.ones_like(reference_points[..., :1])), -1)
+        x = x * (pc_range[3] - pc_range[0]) + pc_range[0]
+        y = y * (pc_range[4] - pc_range[1]) + pc_range[1]
+        z = z * (pc_range[5] - pc_range[2]) + pc_range[2]
 
-        reference_points = reference_points.permute(1, 0, 2, 3)
-        D, B, num_query = reference_points.size()[:3]
-        num_cam = lidar2img.size(1)
+        reference_points = ttnn.concat((x, y, z), dim=-1)
+        ones = ttnn.ones_like(reference_points[..., :1])
+        reference_points = ttnn.concat((reference_points, ones), dim=-1)
 
-        reference_points = reference_points.view(D, B, 1, num_query, 4).repeat(1, 1, num_cam, 1, 1).unsqueeze(-1)
+        reference_points = ttnn.permute(reference_points, (1, 0, 2, 3))  # [D, B, Q, 4]
+        D = reference_points.shape[0]
+        B = reference_points.shape[1]
+        num_query = reference_points.shape[2]
+        num_cam = lidar2img.shape[1]
 
-        lidar2img = lidar2img.view(1, B, num_cam, 1, 4, 4).repeat(D, 1, 1, num_query, 1, 1)
+        reference_points = ttnn.unsqueeze(reference_points, 2)
+        reference_points = ttnn.repeat(reference_points, (1, 1, num_cam, 1, 1))
+        reference_points = ttnn.unsqueeze(reference_points, -1)
 
-        reference_points_cam = torch.matmul(lidar2img.to(torch.float32), reference_points.to(torch.float32)).squeeze(-1)
+        lidar2img = ttnn.unsqueeze(lidar2img, 0)
+        lidar2img = ttnn.unsqueeze(lidar2img, 3)
+        lidar2img = ttnn.repeat(lidar2img, (D, 1, 1, num_query, 1, 1))
+
+        reference_points_cam = ttnn.matmul(lidar2img, reference_points)
+        reference_points_cam = ttnn.squeeze(reference_points_cam, -1)
+
         eps = 1e-5
+        z = reference_points_cam[..., 2:3]
+        bev_mask = z > eps
 
-        bev_mask = reference_points_cam[..., 2:3] > eps
-        reference_points_cam = reference_points_cam[..., 0:2] / torch.maximum(
-            reference_points_cam[..., 2:3], torch.ones_like(reference_points_cam[..., 2:3]) * eps
+        reference_points_cam = ttnn.divide(
+            reference_points_cam[..., 0:2],
+            ttnn.maximum(reference_points_cam[..., 2:3], ttnn.ones_like(reference_points_cam[..., 2:3]) * eps),
         )
+        x = reference_points_cam[..., 0]
+        y = reference_points_cam[..., 1]
 
-        reference_points_cam[..., 0] /= img_metas[0]["img_shape"][0][1]
-        reference_points_cam[..., 1] /= img_metas[0]["img_shape"][0][0]
+        x = ttnn.divide(x, img_metas[0]["img_shape"][0][1])
+        y = ttnn.divide(y, img_metas[0]["img_shape"][0][0])
+        x = ttnn.unsqueeze(x, dim=-1)
+        y = ttnn.unsqueeze(y, dim=-1)
+        reference_points_cam = ttnn.concat([x, y], dim=-1)
 
-        bev_mask = (
-            bev_mask
-            & (reference_points_cam[..., 1:2] > 0.0)
-            & (reference_points_cam[..., 1:2] < 1.0)
-            & (reference_points_cam[..., 0:1] < 1.0)
-            & (reference_points_cam[..., 0:1] > 0.0)
-        )
-        # TODO handle
-        bev_mask = torch.nan_to_num(bev_mask)
-        reference_points_cam = reference_points_cam.permute(2, 1, 3, 0, 4)
-        bev_mask = bev_mask.permute(2, 1, 3, 0, 4).squeeze(-1)
+        a = reference_points_cam[..., 1:2]
+        b = reference_points_cam[..., 0:1]
+        y_gt_0 = ttnn.gt(a, 0.0)
+        y_lt_1 = ttnn.lt(a, 1.0)
+        x_gt_0 = ttnn.gt(b, 0.0)
+        x_lt_1 = ttnn.lt(b, 1.0)
+        bev_mask = ttnn.logical_and(bev_mask, y_gt_0)
+        bev_mask = ttnn.logical_and(bev_mask, y_lt_1)
+        bev_mask = ttnn.logical_and(bev_mask, x_gt_0)
+        bev_mask = ttnn.logical_and(bev_mask, x_lt_1)
+
+        bev_mask = ttnn.where(ttnn.isnan(bev_mask), ttnn.zeros_like(bev_mask), bev_mask)
+        reference_points_cam = ttnn.permute(reference_points_cam, [2, 1, 3, 0, 4])
+        bev_mask = ttnn.permute(bev_mask, [2, 1, 3, 0, 4])
+        bev_mask = ttnn.squeeze(bev_mask, dim=-1)
 
         return reference_points_cam, bev_mask
 
@@ -171,26 +224,19 @@ class TtBEVFormerEncoder:
         output = bev_query
         intermediate = []
 
-        ref_3d = self.get_reference_points(
+        ref_3d = self.get_reference_points_ttnn(
             bev_h,
             bev_w,
             self.pc_range[5] - self.pc_range[2],
             self.num_points_in_pillar,
             dim="3d",
-            bs=bev_query.size(1),
-            device=bev_query.device,
-            dtype=bev_query.dtype,
+            bs=bev_query.shape[1],
+            device=self.device,
         )
 
-        ref_2d = self.get_reference_points(
-            bev_h, bev_w, dim="2d", bs=bev_query.size(1), device=bev_query.device, dtype=bev_query.dtype
-        )
+        ref_2d = self.get_reference_points_ttnn(bev_h, bev_w, dim="2d", bs=bev_query.shape[1], device=self.device)
 
-        reference_points_cam, bev_mask = self.point_sampling(ref_3d, self.pc_range, kwargs["img_metas"])
-
-        bev_mask = ttnn.from_torch(bev_mask, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
-        ref_2d = ttnn.from_torch(ref_2d, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
-        bev_query = ttnn.from_torch(bev_query, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
+        reference_points_cam, bev_mask = self.point_sampling_ttnn(ref_3d, self.pc_range, kwargs["img_metas"])
 
         shift_ref_2d = ttnn.clone(ref_2d, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         shift = ttnn.reshape(shift, (shift.shape[0], 1, 1, shift.shape[1]))
@@ -208,8 +254,7 @@ class TtBEVFormerEncoder:
         else:
             hybird_ref_2d = ttnn.stack([ref_2d, ref_2d], 1)
             hybird_ref_2d = ttnn.reshape(hybird_ref_2d, (bs * 2, len_bev, num_bev_level, 2))
-            # hybird_ref_2d = torch.load("orig_hybird_ref_2d.pt")
-            # hybird_ref_2d = ttnn.from_torch(hybird_ref_2d, device = self.device)
+        reference_points_cam = ttnn.to_torch(reference_points_cam)
         for lid, layer in enumerate(self.layers):
             output = layer(
                 bev_query,

--- a/models/experimental/uniad/tt/tt_encoder.py
+++ b/models/experimental/uniad/tt/tt_encoder.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import numpy as np
+import copy
+import warnings
+import ttnn
+from models.experimental.uniad.tt.tt_temporal_self_attention import TtTemporalSelfAttention
+from models.experimental.uniad.tt.tt_spatial_cross_attention import TtSpatialCrossAttention
+from models.experimental.uniad.tt.tt_ffn import TtFFN
+
+
+class TtBEVFormerEncoder:
+    def __init__(
+        self,
+        params,
+        device,
+        num_layers=6,
+        pc_range=None,
+        num_points_in_pillar=4,
+        return_intermediate=False,
+        embed_dims=256,
+        num_heads=8,
+        dilation=1,
+        kernel_size=(3, 5),
+        im2col_step=192,
+        feedforward_channels=512,
+        ffn_dropout=0.1,
+        operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+    ):
+        super(TtBEVFormerEncoder, self).__init__()
+        self.device = device
+        self.params = params
+        self.return_intermediate = return_intermediate
+        self.num_points_in_pillar = num_points_in_pillar
+        self.pc_range = pc_range
+        self.num_layers = num_layers
+        self.fp16_enabled = False
+
+        transformer_layers = dict(
+            attn_cfgs=[
+                dict(type="TemporalSelfAttention", embed_dims=embed_dims, num_levels=1),
+                dict(
+                    type="SpatialCrossAttention",
+                    pc_range=pc_range,
+                    attention=dict(
+                        embed_dims=embed_dims,
+                        num_heads=num_heads,
+                        dilation=dilation,
+                        kernel_size=kernel_size,
+                        num_levels=1,
+                        im2col_step=im2col_step,
+                    ),
+                    embed_dims=embed_dims,
+                ),
+            ],
+            feedforward_channels=feedforward_channels,
+            ffn_dropout=ffn_dropout,
+            operation_order=operation_order,
+        )
+
+        self.layers = []
+        for i in range(self.num_layers):
+            self.layers.append(TtBEVFormerLayer(self.device, params.layers[f"layer{i}"], **transformer_layers))
+
+    @staticmethod
+    def get_reference_points(H, W, Z=8, num_points_in_pillar=4, dim="3d", bs=1, device="cuda", dtype=torch.float):
+        # reference points in 3D space, used in spatial cross-attention (SCA)
+        if dim == "3d":
+            zs = (
+                torch.linspace(0.5, Z - 0.5, num_points_in_pillar, dtype=dtype, device=device)
+                .view(-1, 1, 1)
+                .expand(num_points_in_pillar, H, W)
+                / Z
+            )
+            xs = (
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device)
+                .view(1, 1, W)
+                .expand(num_points_in_pillar, H, W)
+                / W
+            )
+            ys = (
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device)
+                .view(1, H, 1)
+                .expand(num_points_in_pillar, H, W)
+                / H
+            )
+            ref_3d = torch.stack((xs, ys, zs), -1)
+            ref_3d = ref_3d.permute(0, 3, 1, 2).flatten(2).permute(0, 2, 1)
+            ref_3d = ref_3d[None].repeat(bs, 1, 1, 1)
+            return ref_3d
+
+        # reference points on 2D bev plane, used in temporal self-attention (TSA).
+        elif dim == "2d":
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device),
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device),
+            )
+            ref_y = ref_y.reshape(-1)[None] / H
+            ref_x = ref_x.reshape(-1)[None] / W
+            ref_2d = torch.stack((ref_x, ref_y), -1)
+            ref_2d = ref_2d.repeat(bs, 1, 1).unsqueeze(2)
+        return ref_2d
+
+    def point_sampling(self, reference_points, pc_range, img_metas):  # TODO Handle fp32
+        lidar2img = []
+        for img_meta in img_metas:
+            lidar2img.append(img_meta["lidar2img"])
+        lidar2img = np.asarray(lidar2img)
+        lidar2img = reference_points.new_tensor(lidar2img)  # (B, N, 4, 4)
+        reference_points = reference_points.clone()
+
+        reference_points[..., 0:1] = reference_points[..., 0:1] * (pc_range[3] - pc_range[0]) + pc_range[0]
+        reference_points[..., 1:2] = reference_points[..., 1:2] * (pc_range[4] - pc_range[1]) + pc_range[1]
+        reference_points[..., 2:3] = reference_points[..., 2:3] * (pc_range[5] - pc_range[2]) + pc_range[2]
+
+        reference_points = torch.cat((reference_points, torch.ones_like(reference_points[..., :1])), -1)
+
+        reference_points = reference_points.permute(1, 0, 2, 3)
+        D, B, num_query = reference_points.size()[:3]
+        num_cam = lidar2img.size(1)
+
+        reference_points = reference_points.view(D, B, 1, num_query, 4).repeat(1, 1, num_cam, 1, 1).unsqueeze(-1)
+
+        lidar2img = lidar2img.view(1, B, num_cam, 1, 4, 4).repeat(D, 1, 1, num_query, 1, 1)
+
+        reference_points_cam = torch.matmul(lidar2img.to(torch.float32), reference_points.to(torch.float32)).squeeze(-1)
+        eps = 1e-5
+
+        bev_mask = reference_points_cam[..., 2:3] > eps
+        reference_points_cam = reference_points_cam[..., 0:2] / torch.maximum(
+            reference_points_cam[..., 2:3], torch.ones_like(reference_points_cam[..., 2:3]) * eps
+        )
+
+        reference_points_cam[..., 0] /= img_metas[0]["img_shape"][0][1]
+        reference_points_cam[..., 1] /= img_metas[0]["img_shape"][0][0]
+
+        bev_mask = (
+            bev_mask
+            & (reference_points_cam[..., 1:2] > 0.0)
+            & (reference_points_cam[..., 1:2] < 1.0)
+            & (reference_points_cam[..., 0:1] < 1.0)
+            & (reference_points_cam[..., 0:1] > 0.0)
+        )
+        # TODO handle
+        bev_mask = torch.nan_to_num(bev_mask)
+        reference_points_cam = reference_points_cam.permute(2, 1, 3, 0, 4)
+        bev_mask = bev_mask.permute(2, 1, 3, 0, 4).squeeze(-1)
+
+        return reference_points_cam, bev_mask
+
+    # TODO Handle fp16
+    def __call__(
+        self,
+        bev_query,
+        key,
+        value,
+        *args,
+        bev_h=None,
+        bev_w=None,
+        bev_pos=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        valid_ratios=None,
+        prev_bev=None,
+        shift=0.0,
+        **kwargs,
+    ):
+        output = bev_query
+        intermediate = []
+
+        ref_3d = self.get_reference_points(
+            bev_h,
+            bev_w,
+            self.pc_range[5] - self.pc_range[2],
+            self.num_points_in_pillar,
+            dim="3d",
+            bs=bev_query.size(1),
+            device=bev_query.device,
+            dtype=bev_query.dtype,
+        )
+
+        ref_2d = self.get_reference_points(
+            bev_h, bev_w, dim="2d", bs=bev_query.size(1), device=bev_query.device, dtype=bev_query.dtype
+        )
+
+        reference_points_cam, bev_mask = self.point_sampling(ref_3d, self.pc_range, kwargs["img_metas"])
+
+        bev_mask = ttnn.from_torch(bev_mask, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
+        ref_2d = ttnn.from_torch(ref_2d, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
+        bev_query = ttnn.from_torch(bev_query, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
+
+        shift_ref_2d = ttnn.clone(ref_2d, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        shift = ttnn.reshape(shift, (shift.shape[0], 1, 1, shift.shape[1]))
+        shift_ref_2d = shift_ref_2d + shift
+
+        bev_query = ttnn.permute(bev_query, (1, 0, 2))
+        bev_pos = ttnn.permute(bev_pos, (1, 0, 2))
+        bs, len_bev, num_bev_level, _ = ref_2d.shape
+        if prev_bev is not None:
+            prev_bev = ttnn.permute(prev_bev, (1, 0, 2))
+            prev_bev = ttnn.stack([prev_bev, bev_query], 1)
+            prev_bev = ttnn.reshape(prev_bev, (bs * 2, len_bev, -1))
+            hybird_ref_2d = ttnn.stack([shift_ref_2d, ref_2d], 1)
+            hybird_ref_2d = ttnn.reshape(hybird_ref_2d, (bs * 2, len_bev, num_bev_level, 2))
+        else:
+            hybird_ref_2d = ttnn.stack([ref_2d, ref_2d], 1)
+            hybird_ref_2d = ttnn.reshape(hybird_ref_2d, (bs * 2, len_bev, num_bev_level, 2))
+            # hybird_ref_2d = torch.load("orig_hybird_ref_2d.pt")
+            # hybird_ref_2d = ttnn.from_torch(hybird_ref_2d, device = self.device)
+        for lid, layer in enumerate(self.layers):
+            output = layer(
+                bev_query,
+                key,
+                value,
+                *args,
+                bev_pos=bev_pos,
+                ref_2d=hybird_ref_2d,
+                ref_3d=ref_3d,
+                bev_h=bev_h,
+                bev_w=bev_w,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+                reference_points_cam=reference_points_cam,
+                bev_mask=bev_mask,
+                prev_bev=prev_bev,
+                **kwargs,
+            )
+
+            bev_query = output
+            if self.return_intermediate:
+                intermediate.append(output)
+
+        if self.return_intermediate:
+            return ttnn.stack(intermediate)
+
+        return output
+
+
+class TtBEVFormerLayer:
+    def __init__(
+        self,
+        device,
+        params,
+        attn_cfgs,
+        feedforward_channels,
+        ffn_dropout=0.0,
+        operation_order=None,
+        ffn_num_fcs=2,
+        **kwargs,
+    ):
+        super(TtBEVFormerLayer, self).__init__()
+        self.params = params
+        self.device = device
+        self.attn_cfgs = attn_cfgs
+        self.feedforward_channels = feedforward_channels
+        self.ffn_dropout = ffn_dropout
+        self.operation_order = operation_order
+        self.ffn_num_fcs = ffn_num_fcs
+        self.fp16_enabled = False
+        self.batch_first = True
+        self.attentions = []
+        index = 0
+        for operation_name in self.operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                if "batch_first" in attn_cfgs[index]:
+                    assert self.batch_first == attn_cfgs[index]["batch_first"]
+                else:
+                    attn_cfgs[index]["batch_first"] = self.batch_first
+                if attn_cfgs[index]["type"] == "TemporalSelfAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = TtTemporalSelfAttention(device, params.attentions[f"attn0"], **attn_cfgs[index])
+                    attn_cfgs[index]["type"] = "TemporalSelfAttention"
+                elif attn_cfgs[index]["type"] == "SpatialCrossAttention":
+                    type = attn_cfgs[index].pop("type")
+                    attention = TtSpatialCrossAttention(device, params.attentions[f"attn1"], **attn_cfgs[index])
+                    attn_cfgs[index]["type"] = "SpatialCrossAttention"
+
+                self.attentions.append(attention)
+                index += 1
+
+        self.pre_norm = operation_order[0] == "norm"
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        num_attn = operation_order.count("self_attn") + operation_order.count("cross_attn")
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.ffns = []
+        num_ffns = operation_order.count("ffn")
+
+        for i in range(num_ffns):
+            self.ffns.append(TtFFN(params.ffn[f"ffn{i}"], self.device))
+
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])
+
+    def __call__(
+        self,
+        query,
+        key,
+        value,
+        bev_pos=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        ref_2d=None,
+        ref_3d=None,
+        bev_h=None,
+        bev_w=None,
+        reference_points_cam=None,
+        mask=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+        bev_mask = kwargs.get("bev_mask", None)
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        elif isinstance(attn_masks, ttnn.Tensor):
+            attn_masks = [copy.deepcopy(attn_masks) for _ in range(self.num_attn)]
+            warnings.warn(f"Use same attn_mask in all attentions in " f"{self.__class__.__name__} ")
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                spatial_shapes_1 = torch.tensor([[bev_h, bev_w]])
+                spatial_shapes_1 = ttnn.from_torch(
+                    spatial_shapes_1, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device
+                )
+                query = self.attentions[attn_index](
+                    query,
+                    prev_bev,
+                    prev_bev,
+                    identity if self.pre_norm else None,
+                    query_pos=bev_pos,
+                    key_pos=bev_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    reference_points=ref_2d,
+                    spatial_shapes=spatial_shapes_1,
+                    level_start_index=level_start_index,
+                    **kwargs,
+                )
+                attn_index += 1
+
+                identity = query
+
+            elif layer == "norm":
+                query = ttnn.layer_norm(
+                    query,
+                    weight=self.params.norms[f"norm{norm_index}"].weight,
+                    bias=self.params.norms[f"norm{norm_index}"].bias,
+                )
+                ttnn.deallocate(self.params.norms[f"norm{norm_index}"].weight)
+                ttnn.deallocate(self.params.norms[f"norm{norm_index}"].bias)
+                norm_index += 1
+
+            # spaital cross attention
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    reference_points=ref_3d,
+                    reference_points_cam=reference_points_cam,
+                    mask=mask,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    spatial_shapes=spatial_shapes,
+                    level_start_index=level_start_index,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+
+                ffn_index += 1
+
+        return query

--- a/models/experimental/uniad/tt/tt_ffn.py
+++ b/models/experimental/uniad/tt/tt_ffn.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+class TtFFN:
+    def __init__(self, params, device):
+        self.device = device
+        self.linear1_weight = params.linear1.weight
+        self.linear2_weight = params.linear2.weight
+        self.linear1_bias = params.linear1.bias
+        self.linear2_bias = params.linear2.bias
+
+    def __call__(self, x, identity=None):
+        if identity is None:
+            identity = x
+
+        x = ttnn.linear(x, self.linear1_weight, bias=self.linear1_bias)
+        x = ttnn.relu(x)
+
+        x = ttnn.linear(x, self.linear2_weight, bias=self.linear2_bias)
+
+        x = ttnn.add(x, identity)
+
+        return x

--- a/models/experimental/uniad/tt/tt_fpn.py
+++ b/models/experimental/uniad/tt/tt_fpn.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.uniad.tt.common import TtnnConv2D
+
+
+class TtConvModule:
+    def __init__(self, conv_args, conv_pth, device=None, is_blk=False, config_override=None):
+        self.device = device
+        self.conv = TtnnConv2D(
+            conv_args.conv,
+            conv_pth.conv,
+            device=self.device,
+            dealloc_act=True,
+            is_fpn=True,
+            is_blk=is_blk,
+            config_override=config_override,
+        )
+
+    def __call__(self, x):
+        x = self.conv(x)
+        return x[0]
+
+
+class TtFPN:
+    def __init__(
+        self,
+        conv_args,
+        conv_pth,
+        device,
+    ):
+        self.device = device
+        self.start_level = 0
+        self.lateral_convs = []
+        self.fpn_convs = []
+        self.conv_pth = conv_pth
+        for i in range(3):
+            self.lateral_convs.append(
+                TtConvModule(conv_args.lateral_convs[i], conv_pth.fpn.lateral_convs[str(i)], device=device)
+            )
+        for i in range(3):
+            if i == 0:
+                self.fpn_convs.append(
+                    TtConvModule(
+                        conv_args.fpn_convs[i],
+                        conv_pth.fpn.fpn_convs[str(i)],
+                        device=device,
+                        is_blk=True,
+                        config_override={"act_block_h": 128},
+                    )
+                )
+            else:
+                self.fpn_convs.append(
+                    TtConvModule(conv_args.fpn_convs[i], conv_pth.fpn.fpn_convs[str(i)], device=device)
+                )
+
+    def __call__(self, input_tensor):
+        laterals = []
+        for i, lateral_conv in enumerate(self.lateral_convs):
+            output = lateral_conv(input_tensor[i])
+            ttnn.deallocate(input_tensor[i])
+            laterals.append(output)
+
+        outs = []
+        used_backbone_levels = len(laterals)
+
+        for i in range(used_backbone_levels - 1, 0, -1):
+            laterals[i] = ttnn.to_layout(laterals[i], ttnn.ROW_MAJOR_LAYOUT)
+            inp_dim = self.conv_pth.fpn.fpn_convs[str(i)].conv
+            laterals[i] = ttnn.reshape(
+                laterals[i], (inp_dim.batch, inp_dim.height, inp_dim.width, laterals[i].shape[-1])
+            )
+            laterals[i] = ttnn.upsample(laterals[i], 2)
+            laterals[i] = laterals[i][:, :, :-1, :]
+            laterals[i] = ttnn.reshape(
+                laterals[i],
+                [1, 1, laterals[i].shape[0] * laterals[i].shape[1] * laterals[i].shape[2], laterals[i].shape[-1]],
+            )
+            laterals[i] = ttnn.sharded_to_interleaved(laterals[i], memory_config=ttnn.L1_MEMORY_CONFIG)
+            laterals[i] = ttnn.to_layout(laterals[i], ttnn.TILE_LAYOUT)
+            laterals[i - 1] = laterals[i - 1] + laterals[i]
+
+        for i in range(used_backbone_levels):
+            # laterals[i] = ttnn.to_layout(laterals[i], ttnn.TILE_LAYOUT)
+            output = self.fpn_convs[i](laterals[i])
+            outs.append(output)
+
+        return tuple(outs)

--- a/models/experimental/uniad/tt/tt_memory_bank.py
+++ b/models/experimental/uniad/tt/tt_memory_bank.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+from models.experimental.uniad.tt.utils import Instances
+from models.experimental.uniad.tt.tt_multi_head_attention import TtMultiheadAttention
+
+
+class TtMemoryBank:
+    def __init__(
+        self,
+        dim_in=256,
+        hidden_dim=256,
+        dim_out=256,
+        fp_ratio=0.3,
+        memory_bank_score_thresh=0,
+        memory_bank_len=4,
+        params=None,
+        device=None,
+        eps=1e-05,
+        model_args=None,
+    ):
+        self.device = device
+        self.params = params
+        self.dim_in = dim_in
+        self.hidden_dim = hidden_dim
+        self.dim_out = dim_out
+        self.eps = eps
+
+        self.temporal_attn = TtMultiheadAttention(device, params.temporal_attn, embed_dim=dim_in, num_heads=8)
+
+        self.memory_bank_score_thresh = memory_bank_score_thresh
+        self.save_period = 3
+
+    def update(self, track_instances, memory_bank_score_thresh):
+        embed = track_instances.output_embedding[:, None]
+
+        scores = track_instances.scores
+        mem_padding_mask = track_instances.mem_padding_mask
+
+        save_period = track_instances.save_period
+
+        cond1 = ttnn.eq(save_period, 0)
+        cond2 = ttnn.gt(scores, memory_bank_score_thresh)
+        saved_idxes = ttnn.logical_and(cond1, cond2)
+
+        mask = ttnn.gt(save_period, 0)
+
+        decrement = ttnn.where(mask, save_period - 1, save_period)
+        save_period = decrement
+
+        save_period = ttnn.where(saved_idxes, self.save_period, save_period)
+
+    def _forward_temporal_attn(self, track_instances):
+        key_padding_mask = track_instances.mem_padding_mask
+
+        valid_idxes = key_padding_mask[:, -1] == 0
+
+        mask_tensor = ttnn.from_torch(valid_idxes, dtype=ttnn.uint32, device=self.device)
+        mask_tensor = ttnn.unsqueeze(mask_tensor, 0)
+        mask_tensor = ttnn.unsqueeze(mask_tensor, 0)
+        mask_tensor = ttnn.unsqueeze(mask_tensor, 0)
+
+        output_tensor = ttnn.nonzero(mask_tensor)
+        output_tensor1 = ttnn.to_torch(output_tensor[0])
+        output_tensor2 = ttnn.to_torch(output_tensor[1])
+
+        no_of_non_zero_indices = output_tensor1[..., 0].item()
+        indices_tensor = output_tensor2[:, :, :, :no_of_non_zero_indices]
+        indices_tensor = ttnn.from_torch(indices_tensor, device=self.device)
+
+        indices_tensor = ttnn.reshape(indices_tensor, (-1,))
+        indices_tensor = ttnn.to_layout(indices_tensor, ttnn.TILE_LAYOUT)
+        indices_tensor = ttnn.typecast(indices_tensor, dtype=ttnn.uint32)
+        ttnn_output = ttnn.embedding(indices_tensor, track_instances.output_embedding)
+        ttnn_output = ttnn.to_layout(ttnn_output, ttnn.TILE_LAYOUT)
+        ttnn_output = ttnn.typecast(ttnn_output, dtype=ttnn.float32)
+        ttnn_output = ttnn.to_torch(ttnn_output)
+        embed = ttnn_output
+
+        embed = ttnn.to_torch(track_instances.output_embedding)[valid_idxes]
+
+        if len(embed) > 0:
+            A, B, C = track_instances.mem_bank.shape
+            track_instances.mem_bank = ttnn.reshape(track_instances.mem_bank, (A, B * C))
+            ttnn_output = ttnn.embedding(indices_tensor, track_instances.mem_bank)
+            ttnn_output = ttnn.to_layout(ttnn_output, ttnn.TILE_LAYOUT)
+            ttnn_output = ttnn.typecast(ttnn_output, dtype=ttnn.bfloat16)
+            ttnn_output = ttnn.reshape(ttnn_output, (ttnn_output.shape[0], B, C))
+            # ttnn_output = ttnn.to_torch(ttnn_output)
+            prev_embed = ttnn_output
+
+            x_tensor = ttnn.from_torch(key_padding_mask, dtype=ttnn.bfloat16, device=self.device)
+
+            ttnn_output = ttnn.embedding(indices_tensor, x_tensor)
+            ttnn_output = ttnn.to_layout(ttnn_output, ttnn.TILE_LAYOUT)
+            ttnn_output = ttnn.typecast(ttnn_output, dtype=ttnn.float32)
+            ttnn_output = ttnn.to_torch(ttnn_output)
+            key_padding_mask = ttnn_output
+            embed = embed.unsqueeze(0)
+            embed = ttnn.from_torch(embed, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device)
+            prev_embed = ttnn.permute(prev_embed, (1, 0, 2))
+            embed2 = self.temporal_attn(
+                embed,
+                prev_embed,
+                prev_embed,
+                key_padding_mask=key_padding_mask,
+            )[
+                0
+            ][0]
+
+            out = embed + embed2
+
+            embed = ttnn.layer_norm(
+                out,
+                weight=self.params.temporal_norm1.weight,
+                bias=self.params.temporal_norm1.bias,
+                epsilon=self.eps,
+            )
+
+            x = ttnn.linear(embed, self.params.temporal_fc1.weight, bias=self.params.temporal_fc1.bias)
+            x = ttnn.relu(x)
+            embed2 = ttnn.linear(x, self.params.temporal_fc2.weight, bias=self.params.temporal_fc2.bias)
+
+            embed = ttnn.layer_norm(
+                embed + embed2,
+                weight=self.params.temporal_norm2.weight,
+                bias=self.params.temporal_norm2.bias,
+                epsilon=self.eps,
+            )
+            track_instances.output_embedding = ttnn.to_torch(track_instances.output_embedding, dtype=torch.float32)
+            embed = ttnn.to_torch(embed, dtype=torch.float32)
+            track_instances.output_embedding = track_instances.output_embedding.clone()
+
+            track_instances.output_embedding[valid_idxes] = embed
+
+        return track_instances
+
+    def forward(self, track_instances: Instances, update_bank=True) -> Instances:
+        track_instances = self._forward_temporal_attn(track_instances)
+        if update_bank:
+            self.update(track_instances, self.memory_bank_score_thresh)
+        return track_instances

--- a/models/experimental/uniad/tt/tt_memory_bank.py
+++ b/models/experimental/uniad/tt/tt_memory_bank.py
@@ -35,6 +35,7 @@ class TtMemoryBank:
         self.save_period = 3
 
     def update(self, track_instances, memory_bank_score_thresh):
+        track_instances.output_embedding = ttnn.to_torch(track_instances.output_embedding)
         embed = track_instances.output_embedding[:, None]
 
         scores = track_instances.scores
@@ -50,91 +51,54 @@ class TtMemoryBank:
 
         decrement = ttnn.where(mask, save_period - 1, save_period)
         save_period = decrement
-
         save_period = ttnn.where(saved_idxes, self.save_period, save_period)
+        saved_idxes = ttnn.to_torch((saved_idxes)).to(dtype=torch.bool)
+        save_period = ttnn.to_torch(save_period)
+        save_period[saved_idxes] = self.save_period
+        track_instances.save_period = save_period
+        track_instances.save_period = ttnn.from_torch(
+            track_instances.save_period, dtype=ttnn.bfloat16, device=self.device
+        )
+        saved_embed = embed[saved_idxes]
+        if len(saved_embed) > 0:
+            track_instances.mem_bank = ttnn.to_torch(track_instances.mem_bank)
+            prev_embed = track_instances.mem_bank[saved_idxes]
+            saved_embed = ttnn.from_torch(saved_embed, dtype=ttnn.bfloat16, device=self.device)
+            saved_embed = ttnn.to_layout(saved_embed, layout=ttnn.TILE_LAYOUT)
+            save_embed = ttnn.linear(
+                saved_embed,
+                self.params.save_proj.weight,
+                bias=self.params.save_proj.bias,
+            )
+            saved_embed = ttnn.to_torch(saved_embed)
+            tensor1 = mem_padding_mask[saved_idxes, 1:]
+            tensor1 = ttnn.from_torch(tensor1, dtype=ttnn.bfloat16, device=self.device)
+            tensor2 = torch.zeros((len(saved_embed), 1), dtype=torch.bool)
+            tensor2 = ttnn.from_torch(tensor2, dtype=ttnn.bfloat16, device=self.device)
+            out = ttnn.concat(
+                [
+                    tensor1,
+                    tensor2,
+                ],
+                dim=1,
+            )
+            mem_padding_mask[saved_idxes] = ttnn.to_torch(out).to(dtype=torch.bool)
+            track_instances.mem_bank = track_instances.mem_bank.clone()
+            prev_embed = ttnn.from_torch(prev_embed, dtype=ttnn.bfloat16, device=self.device)
+            prev_embed = ttnn.to_layout(prev_embed, layout=ttnn.TILE_LAYOUT)
+            out = ttnn.concat([prev_embed[:, 1:], save_embed], dim=1)
+            track_instances.mem_bank[saved_idxes] = ttnn.to_torch(out)
+            track_instances.mem_bank = ttnn.from_torch(
+                track_instances.mem_bank, dtype=ttnn.bfloat16, device=self.device
+            )
+        track_instances.output_embedding = ttnn.from_torch(
+            track_instances.output_embedding, dtype=ttnn.bfloat16, device=self.device
+        )
 
     def _forward_temporal_attn(self, track_instances):
         key_padding_mask = track_instances.mem_padding_mask
 
         valid_idxes = key_padding_mask[:, -1] == 0
-
-        mask_tensor = ttnn.from_torch(valid_idxes, dtype=ttnn.uint32, device=self.device)
-        mask_tensor = ttnn.unsqueeze(mask_tensor, 0)
-        mask_tensor = ttnn.unsqueeze(mask_tensor, 0)
-        mask_tensor = ttnn.unsqueeze(mask_tensor, 0)
-
-        output_tensor = ttnn.nonzero(mask_tensor)
-        output_tensor1 = ttnn.to_torch(output_tensor[0])
-        output_tensor2 = ttnn.to_torch(output_tensor[1])
-
-        no_of_non_zero_indices = output_tensor1[..., 0].item()
-        indices_tensor = output_tensor2[:, :, :, :no_of_non_zero_indices]
-        indices_tensor = ttnn.from_torch(indices_tensor, device=self.device)
-
-        indices_tensor = ttnn.reshape(indices_tensor, (-1,))
-        indices_tensor = ttnn.to_layout(indices_tensor, ttnn.TILE_LAYOUT)
-        indices_tensor = ttnn.typecast(indices_tensor, dtype=ttnn.uint32)
-        ttnn_output = ttnn.embedding(indices_tensor, track_instances.output_embedding)
-        ttnn_output = ttnn.to_layout(ttnn_output, ttnn.TILE_LAYOUT)
-        ttnn_output = ttnn.typecast(ttnn_output, dtype=ttnn.float32)
-        ttnn_output = ttnn.to_torch(ttnn_output)
-        embed = ttnn_output
-
-        embed = ttnn.to_torch(track_instances.output_embedding)[valid_idxes]
-
-        if len(embed) > 0:
-            A, B, C = track_instances.mem_bank.shape
-            track_instances.mem_bank = ttnn.reshape(track_instances.mem_bank, (A, B * C))
-            ttnn_output = ttnn.embedding(indices_tensor, track_instances.mem_bank)
-            ttnn_output = ttnn.to_layout(ttnn_output, ttnn.TILE_LAYOUT)
-            ttnn_output = ttnn.typecast(ttnn_output, dtype=ttnn.bfloat16)
-            ttnn_output = ttnn.reshape(ttnn_output, (ttnn_output.shape[0], B, C))
-            # ttnn_output = ttnn.to_torch(ttnn_output)
-            prev_embed = ttnn_output
-
-            x_tensor = ttnn.from_torch(key_padding_mask, dtype=ttnn.bfloat16, device=self.device)
-
-            ttnn_output = ttnn.embedding(indices_tensor, x_tensor)
-            ttnn_output = ttnn.to_layout(ttnn_output, ttnn.TILE_LAYOUT)
-            ttnn_output = ttnn.typecast(ttnn_output, dtype=ttnn.float32)
-            ttnn_output = ttnn.to_torch(ttnn_output)
-            key_padding_mask = ttnn_output
-            embed = embed.unsqueeze(0)
-            embed = ttnn.from_torch(embed, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device)
-            prev_embed = ttnn.permute(prev_embed, (1, 0, 2))
-            embed2 = self.temporal_attn(
-                embed,
-                prev_embed,
-                prev_embed,
-                key_padding_mask=key_padding_mask,
-            )[
-                0
-            ][0]
-
-            out = embed + embed2
-
-            embed = ttnn.layer_norm(
-                out,
-                weight=self.params.temporal_norm1.weight,
-                bias=self.params.temporal_norm1.bias,
-                epsilon=self.eps,
-            )
-
-            x = ttnn.linear(embed, self.params.temporal_fc1.weight, bias=self.params.temporal_fc1.bias)
-            x = ttnn.relu(x)
-            embed2 = ttnn.linear(x, self.params.temporal_fc2.weight, bias=self.params.temporal_fc2.bias)
-
-            embed = ttnn.layer_norm(
-                embed + embed2,
-                weight=self.params.temporal_norm2.weight,
-                bias=self.params.temporal_norm2.bias,
-                epsilon=self.eps,
-            )
-            track_instances.output_embedding = ttnn.to_torch(track_instances.output_embedding, dtype=torch.float32)
-            embed = ttnn.to_torch(embed, dtype=torch.float32)
-            track_instances.output_embedding = track_instances.output_embedding.clone()
-
-            track_instances.output_embedding[valid_idxes] = embed
 
         return track_instances
 

--- a/models/experimental/uniad/tt/tt_multi_head_attention.py
+++ b/models/experimental/uniad/tt/tt_multi_head_attention.py
@@ -1,0 +1,216 @@
+import math
+from typing import Optional
+import torch
+from torch import Tensor
+
+import ttnn
+
+
+def _canonical_mask(
+    mask: Optional[Tensor],
+    mask_name: str,
+    other_type,
+    other_name: str,
+    target_type,
+    check_other: bool = True,
+) -> Optional[Tensor]:
+    if mask is not None:
+        _mask_is_float = torch.is_floating_point(mask)
+        if not _mask_is_float:
+            mask = torch.zeros_like(mask, dtype=target_type).masked_fill_(mask, float("-inf"))
+    return mask
+
+
+def _in_projection_packed(
+    q: Tensor, k: Tensor, v: Tensor, w: Tensor, b: Optional[Tensor] = None, embed_dims=256
+) -> list[Tensor]:
+    w_q, w_k, w_v = ttnn.chunk(w, 3, dim=0)
+    b_q, b_k, b_v = ttnn.chunk(b, 3, dim=0)
+
+    w_q, b_q = ttnn.permute(w_q, (1, 0)), ttnn.reshape(b_q, (1, -1))
+    w_k, b_k = ttnn.permute(w_k, (1, 0)), ttnn.reshape(b_k, (1, -1))
+    w_v, b_v = ttnn.permute(w_v, (1, 0)), ttnn.reshape(b_v, (1, -1))
+
+    a = ttnn.linear(q, w_q, bias=b_q)
+    b = ttnn.linear(k, w_k, bias=b_k)
+    c = ttnn.linear(v, w_v, bias=b_v)
+    return a, b, c
+
+
+def multi_head_attention_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    embed_dim_to_check: int,
+    num_heads: int,
+    in_proj_weight: Optional[Tensor],
+    in_proj_bias: Optional[Tensor],
+    bias_k: Optional[Tensor],
+    bias_v: Optional[Tensor],
+    add_zero_attn: bool,
+    dropout_p: float,
+    out_proj_weight: Tensor,
+    out_proj_bias: Optional[Tensor],
+    training: bool = True,
+    key_padding_mask: Optional[Tensor] = None,
+    need_weights: bool = True,
+    attn_mask: Optional[Tensor] = None,
+    use_separate_proj_weight: bool = False,
+    q_proj_weight: Optional[Tensor] = None,
+    k_proj_weight: Optional[Tensor] = None,
+    v_proj_weight: Optional[Tensor] = None,
+    static_k: Optional[Tensor] = None,
+    static_v: Optional[Tensor] = None,
+    average_attn_weights: bool = True,
+    is_causal: bool = False,
+    device=None,
+) -> tuple[Tensor, Optional[Tensor]]:
+    tgt_len, bsz, embed_dim = query.shape
+    src_len, _, _ = key.shape
+
+    key_padding_mask = _canonical_mask(
+        mask=key_padding_mask,
+        mask_name="key_padding_mask",
+        other_type=None,
+        other_name="attn_mask",
+        target_type=torch.float32,
+    )
+
+    if is_causal and key_padding_mask is None and not need_weights:
+        attn_mask = None
+    else:
+        attn_mask = _canonical_mask(
+            mask=attn_mask,
+            mask_name="attn_mask",
+            other_type=None,
+            other_name="",
+            target_type=query.dtype,
+            check_other=False,
+        )
+
+        if key_padding_mask is not None:
+            is_causal = False
+
+    head_dim = embed_dim // num_heads
+
+    if not use_separate_proj_weight:
+        assert in_proj_weight is not None, "use_separate_proj_weight is False but in_proj_weight is None"
+        q, k, v = _in_projection_packed(query, key, value, in_proj_weight, in_proj_bias, embed_dims=embed_dim)
+    else:
+        raise ValueError("This implementation won't work")
+
+    # q, k, v PC: 0.9999 ATOL: 0.04
+
+    q = ttnn.transpose(ttnn.reshape(q, (tgt_len, bsz * num_heads, head_dim)), 0, 1)
+    k = ttnn.transpose(ttnn.reshape(k, (k.shape[0], bsz * num_heads, head_dim)), 0, 1)
+    v = ttnn.transpose(ttnn.reshape(v, (v.shape[0], bsz * num_heads, head_dim)), 0, 1)
+
+    # update source sequence length after adjustments
+    src_len = k.shape[1]
+
+    if key_padding_mask is not None:
+        key_padding_mask = ttnn.from_torch(
+            key_padding_mask, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device
+        )
+
+        key_padding_mask = ttnn.reshape(key_padding_mask, (bsz, 1, 1, src_len))
+        key_padding_mask = ttnn.expand(key_padding_mask, (-1, num_heads, -1, -1))
+        key_padding_mask = ttnn.reshape(key_padding_mask, (bsz * num_heads, 1, src_len))
+        if attn_mask is None:
+            attn_mask = key_padding_mask
+        else:
+            attn_mask = attn_mask + key_padding_mask
+
+    if need_weights:  # True
+        _B, _Nt, E = q.shape
+        q_scaled = q * math.sqrt(1.0 / float(E))
+
+        assert not (is_causal and attn_mask is None), "FIXME: is_causal not implemented for need_weights"
+
+        if attn_mask is not None:
+            qk = ttnn.matmul(q_scaled, ttnn.transpose(k, -2, -1))
+            attn_output_weights = qk + attn_mask  # Ensure attn_mask is of shape [B, N, M] or broadcastable
+        else:
+            attn_output_weights = ttnn.matmul(q_scaled, ttnn.transpose(k, -2, -1))
+
+        attn_output_weights = ttnn.softmax(attn_output_weights, dim=-1)
+        attn_output = ttnn.matmul(attn_output_weights, v)  # [B, N, D]
+
+        attn_output = ttnn.transpose(attn_output, 0, 1)
+        attn_output = ttnn.reshape(attn_output, (tgt_len * bsz, embed_dim))
+        attn_output = ttnn.linear(attn_output, out_proj_weight, bias=out_proj_bias)
+        attn_output = ttnn.reshape(attn_output, (tgt_len, bsz, attn_output.shape[1]))
+
+        # optionally average attention weights over heads
+        attn_output_weights = ttnn.reshape(attn_output_weights, (bsz, num_heads, tgt_len, src_len))
+        if average_attn_weights:
+            attn_output_weights = ttnn.mean(attn_output_weights, dim=1)
+
+        return attn_output, attn_output_weights
+
+
+class TtMultiheadAttention:
+    def __init__(
+        self,
+        device,
+        parameters,
+        embed_dim,
+        num_heads,
+        need_weights=True,
+        attn_mask=None,
+        is_causal=False,
+        average_attn_weights=True,
+        batch_first=False,
+    ):
+        self.device = device
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.in_proj_weight = ttnn.to_layout(parameters.in_proj_weight, ttnn.TILE_LAYOUT)
+        self.in_proj_bias = ttnn.to_layout(parameters.in_proj_bias, ttnn.TILE_LAYOUT)
+        self.out_proj_weight = parameters.out_proj.weight
+        self.out_proj_bias = parameters.out_proj.bias
+
+        # base_config
+        self.need_weights = need_weights
+        self.attn_mask = attn_mask
+        self.is_causal = is_causal
+        self.average_attn_weights = average_attn_weights
+        self.batch_first = batch_first
+
+    def __call__(self, query, key, value, key_padding_mask=None):
+        if self.batch_first:
+            query = ttnn.transpose(query, 0, 1)
+            key = ttnn.transpose(key, 0, 1)
+            value = ttnn.transpose(value, 0, 1)
+        attn_output, _ = multi_head_attention_forward(
+            query=query,
+            key=key,
+            value=value,
+            embed_dim_to_check=self.embed_dim,
+            num_heads=self.num_heads,
+            in_proj_weight=self.in_proj_weight,
+            in_proj_bias=self.in_proj_bias,
+            bias_k=None,
+            bias_v=None,
+            add_zero_attn=False,
+            dropout_p=0.0,
+            out_proj_weight=self.out_proj_weight,
+            out_proj_bias=self.out_proj_bias,
+            training=False,
+            key_padding_mask=key_padding_mask,
+            need_weights=self.need_weights,
+            attn_mask=self.attn_mask,
+            use_separate_proj_weight=False,
+            q_proj_weight=None,
+            k_proj_weight=None,
+            v_proj_weight=None,
+            static_k=None,
+            static_v=None,
+            average_attn_weights=self.average_attn_weights,
+            is_causal=self.is_causal,
+            device=self.device,
+        )
+
+        if self.batch_first:
+            attn_output = ttnn.transpose(attn_output, 0, 1)
+        return attn_output, None

--- a/models/experimental/uniad/tt/tt_pan_segformer_head.py
+++ b/models/experimental/uniad/tt/tt_pan_segformer_head.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import torch.nn as nn
+import math
+from models.experimental.uniad.tt.tt_seg_deformable_transformer import TtSegDeformableTransformer
+from models.experimental.uniad.tt.tt_seg_mask_head import TtSegMaskHead
+
+
+def IOU(intputs, targets):
+    numerator = (intputs * targets).sum(dim=1)
+    denominator = intputs.sum(dim=1) + targets.sum(dim=1) - numerator
+    loss = numerator / (denominator + 0.0000000000001)
+    return loss.cpu(), numerator.cpu(), denominator.cpu()
+
+
+def inverse_sigmoid(x, eps: float = 1e-5):
+    x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)
+    x = ttnn.clamp(x, min=0, max=1)
+    x1 = ttnn.clamp(x, min=eps)
+    if len(x.shape) == 3:
+        x_temp = ttnn.ones(shape=[x.shape[0], x.shape[1], x.shape[2]], layout=ttnn.TILE_LAYOUT, device=x.device())
+    else:
+        x_temp = ttnn.ones(
+            shape=[x.shape[0], x.shape[1], x.shape[2], x.shape[3]], layout=ttnn.TILE_LAYOUT, device=x.device()
+        )
+    x_temp = x_temp - x
+    x2 = ttnn.clamp(x_temp, min=eps)
+    return ttnn.log(ttnn.div(x1, x2))
+
+
+def bbox_cxcywh_to_xyxy(bbox, device=None):
+    bbox = ttnn.from_torch(bbox, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    cx = bbox[..., 0:1]
+    cy = bbox[..., 1:2]
+    w = bbox[..., 2:3]
+    h = bbox[..., 3:4]
+    bbox_new = [(cx - 0.5 * w), (cy - 0.5 * h), (cx + 0.5 * w), (cy + 0.5 * h)]
+    out = ttnn.concat(bbox_new, dim=-1)
+    out = ttnn.to_torch(out)
+    return out
+
+
+class TtSinePositionalEncoding(nn.Module):
+    def __init__(
+        self,
+        num_feats,
+        temperature=10000,
+        normalize=False,
+        scale=2 * math.pi,
+        eps=1e-6,
+        offset=0.0,
+        init_cfg=None,
+        device=None,
+    ):
+        super(TtSinePositionalEncoding, self).__init__()
+        if normalize:
+            assert isinstance(scale, (float, int)), (
+                "when normalize is set," "scale should be provided and in float or int type, " f"found {type(scale)}"
+            )
+        self.device = device
+        self.num_feats = num_feats
+        self.temperature = temperature
+        self.normalize = normalize
+        self.scale = scale
+        self.eps = eps
+        self.offset = offset
+
+    def forward(self, mask):
+        one_tensor = ttnn.ones(mask.shape, layout=ttnn.TILE_LAYOUT, device=self.device)
+        not_mask = ttnn.subtract(one_tensor, mask)
+        y_embed = ttnn.cumsum(not_mask, dim=1)
+        x_embed = ttnn.cumsum(not_mask, dim=2)
+        if self.normalize:
+            y_embed = y_embed + self.offset
+            norm_factor = y_embed[:, -1:, :] + self.eps
+            y_embed = ttnn.div(y_embed, norm_factor)
+            y_embed = y_embed * self.scale
+
+            x_embed = x_embed + self.offset
+            norm_factor = x_embed[:, :, -1:] + self.eps
+            x_embed = ttnn.div(x_embed, norm_factor)
+            x_embed = x_embed * self.scale
+
+        dim_t = ttnn.arange(0, self.num_feats)
+        dim_t = 2 * ttnn.to_torch(dim_t) // 2
+        dim_t = ttnn.from_torch(dim_t, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        power = ttnn.div(dim_t, self.num_feats)
+        dim_t = ttnn.pow(self.temperature, power)
+        x_embed = ttnn.unsqueeze(x_embed, dim=-1)
+        y_embed = ttnn.unsqueeze(y_embed, dim=-1)
+        pos_x = ttnn.div(x_embed, dim_t)
+        pos_y = ttnn.div(y_embed, dim_t)
+        B, H, W = mask.shape[0], mask.shape[1], mask.shape[2]
+
+        sin_part = ttnn.sin(pos_x[:, :, :, 0::2])
+        cos_part = ttnn.cos(pos_x[:, :, :, 1::2])
+        stacked = ttnn.stack((sin_part, cos_part), dim=4)
+        pos_x = ttnn.reshape(stacked, (B, H, W, -1))
+
+        sin_part = ttnn.sin(pos_y[:, :, :, 0::2])
+        cos_part = ttnn.cos(pos_y[:, :, :, 1::2])
+        stacked = ttnn.stack((sin_part, cos_part), dim=4)
+        pos_y = ttnn.reshape(stacked, (B, H, W, -1))
+        pos = ttnn.concat([pos_y, pos_x], dim=3)
+        pos = ttnn.permute(pos, (0, 3, 1, 2))
+        return pos
+
+
+class TtPansegformerHead(nn.Module):
+    def __init__(
+        self,
+        params,
+        device,
+        *args,
+        bev_h,
+        bev_w,
+        canvas_size,
+        pc_range,
+        num_reg_fcs=2,
+        with_box_refine=False,
+        as_two_stage=False,
+        transformer=None,
+        quality_threshold_things=0.25,
+        quality_threshold_stuff=0.25,
+        overlap_threshold_things=0.4,
+        overlap_threshold_stuff=0.2,
+        **kwargs,
+    ):
+        self.params = params
+        self.device = device
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.canvas_size = canvas_size
+        self.pc_range = pc_range
+        self.real_w = self.pc_range[3] - self.pc_range[0]
+        self.real_h = self.pc_range[4] - self.pc_range[1]
+
+        self.with_box_refine = with_box_refine
+        self.as_two_stage = as_two_stage
+        self.quality_threshold_things = 0.1
+        self.quality_threshold_stuff = quality_threshold_stuff
+        self.overlap_threshold_things = overlap_threshold_things
+        self.overlap_threshold_stuff = overlap_threshold_stuff
+
+        self.num_dec_things = 4
+        self.num_dec_stuff = 6
+        super(TtPansegformerHead, self).__init__()
+
+        self.positional_encoding = TtSinePositionalEncoding(
+            num_feats=128, normalize=True, scale=6.283185307179586, device=self.device
+        )
+        self.transformer = TtSegDeformableTransformer(
+            device, params.transformer, params_branches=kwargs["parameters_branches"]
+        )
+        self.reg_branches = params.reg_branches
+        self.as_two_stag = False
+        self.embed_dims = 256
+        self.cls_out_channels = 3
+        self.num_reg_fcs = num_reg_fcs
+        self.num_query = 300
+        self.num_stuff_classes = 1
+        self.num_things_classes = 3
+        self.things_mask_head = TtSegMaskHead(
+            params.things_mask_head,
+            device,
+            cfg=None,
+            d_model=256,
+            nhead=8,
+            num_encoder_layers=6,
+            num_decoder_layers=4,
+            dim_feedforward=64,
+            activation="relu",
+            normalize_before=False,
+            return_intermediate_dec=False,
+            self_attn=False,
+        )
+        self.stuff_mask_head = TtSegMaskHead(
+            params.stuff_mask_head,
+            device,
+            cfg=None,
+            d_model=256,
+            nhead=8,
+            num_encoder_layers=6,
+            num_decoder_layers=6,
+            dim_feedforward=64,
+            activation="relu",
+            normalize_before=False,
+            return_intermediate_dec=False,
+            self_attn=True,
+        )
+
+    def _get_bboxes_single(self, cls_score, bbox_pred, img_shape, scale_factor, rescale=False):
+        """ """
+        max_per_img = 100
+        # exclude background
+        self.loss_cls = True
+        if self.loss_cls:
+            cls_score = cls_score.sigmoid()
+            scores, indexes = cls_score.view(-1).topk(max_per_img)
+            det_labels = indexes % self.num_things_classes
+            bbox_index = indexes // self.num_things_classes
+            bbox_pred = bbox_pred[bbox_index]
+
+        det_bboxes = bbox_cxcywh_to_xyxy(bbox_pred, device=self.device)
+        det_bboxes[:, 0::2] = det_bboxes[:, 0::2] * img_shape[1]
+        det_bboxes[:, 1::2] = det_bboxes[:, 1::2] * img_shape[0]
+        det_bboxes[:, 0::2].clamp_(min=0, max=img_shape[1])
+        det_bboxes[:, 1::2].clamp_(min=0, max=img_shape[0])
+        if rescale:
+            det_bboxes /= det_bboxes.new_tensor(scale_factor)
+        det_bboxes = torch.cat((det_bboxes, scores.unsqueeze(1)), -1)
+        return bbox_index, det_bboxes, det_labels
+
+    def get_bboxes(
+        self,
+        all_cls_scores,
+        all_bbox_preds,
+        enc_cls_scores,
+        enc_bbox_preds,
+        args_tuple,
+        reference,
+        img_metas,
+        rescale=False,
+    ):
+        cls_scores = all_cls_scores[-1]
+        bbox_preds = all_bbox_preds[-1]
+        memory, memory_mask, memory_pos, query, _, query_pos, hw_lvl = args_tuple
+
+        seg_list = []
+        stuff_score_list = []
+        panoptic_list = []
+        bbox_list = []
+        labels_list = []
+        drivable_list = []
+        lane_list = []
+        lane_score_list = []
+        score_list = []
+        for img_id in range(len(img_metas)):
+            cls_score = cls_scores[img_id]
+            bbox_pred = bbox_preds[img_id]
+            img_shape = (self.canvas_size[0], self.canvas_size[1], 3)
+            ori_shape = (self.canvas_size[0], self.canvas_size[1], 3)
+            scale_factor = 1
+            cls_score = ttnn.to_torch(cls_score)
+            bbox_pred = ttnn.to_torch(bbox_pred)
+            index, bbox, labels = self._get_bboxes_single(cls_score, bbox_pred, img_shape, scale_factor, rescale)
+
+            i = img_id
+            index = index.long()
+            query = ttnn.to_torch(query)
+            query_pos = ttnn.to_torch(query_pos)
+
+            thing_query = query[i : i + 1, index, :]
+            thing_query_pos = query_pos[i : i + 1, index, :]
+            thing_query = ttnn.from_torch(thing_query, device=self.device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+            thing_query_pos = ttnn.from_torch(
+                thing_query_pos, device=self.device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+            )
+
+            query_weight = self.params.stuff_query.weight  # [None, :, :self.embed_dims])
+            query_weight = ttnn.unsqueeze(query_weight, dim=0)
+            query_weight = query_weight[:, :, : self.embed_dims]
+            query_weight = ttnn.to_layout(query_weight, ttnn.TILE_LAYOUT)
+
+            joint_query = ttnn.concat([thing_query, query_weight], dim=1)
+
+            stuff_query_pos = self.params.stuff_query.weight  # [None, :,self.embed_dims:]
+            stuff_query_pos = ttnn.unsqueeze(stuff_query_pos, 0)
+            stuff_query_pos = stuff_query_pos[:, :, self.embed_dims :]
+
+            mask_things, mask_inter_things, query_inter_things = self.things_mask_head.forward(
+                memory[i : i + 1],
+                memory_mask[i : i + 1],
+                None,
+                joint_query[:, : -self.num_stuff_classes],
+                None,
+                None,
+                hw_lvl=hw_lvl,
+            )
+
+            mask_stuff, mask_inter_stuff, query_inter_stuff = self.stuff_mask_head.forward(
+                memory[i : i + 1],
+                memory_mask[i : i + 1],
+                None,
+                joint_query[:, -self.num_stuff_classes :],
+                None,
+                stuff_query_pos,
+                hw_lvl=hw_lvl,
+            )
+
+            attn_map = ttnn.concat([mask_things, mask_stuff], dim=1)
+            attn_map = ttnn.squeeze(attn_map, dim=-1)
+
+            stuff_query = query_inter_stuff[-1]
+
+            raw_scores = ttnn.linear(
+                stuff_query, self.params.cls_stuff_branches[-1].weight, bias=self.params.cls_stuff_branches[-1].bias
+            )
+            scores_sigmoid = ttnn.sigmoid(raw_scores)
+            scores_stuff = ttnn.reshape(scores_sigmoid, (-1,))
+
+            mask_pred = ttnn.reshape(attn_map, (-1, *hw_lvl[0]))
+
+            mask_pred = ttnn.unsqueeze(mask_pred, 0)
+            target_size = (ori_shape[0], ori_shape[1])  # check ttnn.upsample
+            mask_pred = ttnn.to_layout(mask_pred, ttnn.ROW_MAJOR_LAYOUT)
+            mask_pred = ttnn.upsample(mask_pred, scale_factor=1)
+            mask_pred = ttnn.squeeze(mask_pred, 0)
+
+            masks_all = mask_pred
+            score_list.append(masks_all)
+            out = masks_all[-1] > 0.5
+            drivable_list.append(ttnn.to_torch(out))
+            masks_all = masks_all[: -self.num_stuff_classes]
+            seg_all = masks_all > 0.5
+            sum_seg_all = ttnn.sum(seg_all, dim=(1, 2))
+            sum_seg_all = ttnn.add(sum_seg_all, 1)
+
+            scores_all = bbox[:, -1]
+            bboxes_all = bbox
+            labels_all = labels
+
+            product = masks_all * seg_all
+            summed = ttnn.sum(product, dim=(1, 2))
+            seg_scores = ttnn.div(summed, sum_seg_all)
+
+            seg_scores = ttnn.pow(seg_scores, 2)
+            scores_all = ttnn.from_torch(scores_all, device=self.device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+
+            scores_all = ttnn.mul(scores_all, seg_scores)
+
+            scores_all = ttnn.unsqueeze(scores_all, dim=0)  # added by me
+            scores_all, index = ttnn.sort(scores_all, descending=True)
+            scores_all = ttnn.squeeze(scores_all, dim=0)
+            index = ttnn.squeeze(index, dim=0)
+            index = ttnn.to_torch(index).to(torch.int64)
+            masks_all = ttnn.to_torch(masks_all).to(torch.float32)
+            labels_all = labels_all.to(torch.float32)
+            seg_all = ttnn.to_torch(seg_all).to(torch.float32)
+            scores_all = ttnn.to_torch(scores_all)
+
+            masks_all = masks_all[index]
+            labels_all = labels_all[index]
+            bboxes_all = bboxes_all[index]
+            seg_all = seg_all[index]
+
+            bboxes_all[:, -1] = scores_all
+
+            # MDS: select things for instance segmeantion
+            things_selected = labels_all < self.num_things_classes
+            stuff_selected = labels_all >= self.num_things_classes
+            bbox_th = bboxes_all[things_selected][:100]
+            labels_th = labels_all[things_selected][:100]
+            seg_th = seg_all[things_selected][:100]
+            labels_st = labels_all[stuff_selected]
+            scores_st = scores_all[stuff_selected]
+            masks_st = masks_all[stuff_selected]
+
+            stuff_score_list.append(scores_st)
+            results = ttnn.zeros(shape=[2, mask_pred.shape[-2], mask_pred.shape[-1]], device=self.device)
+
+            id_unique = 1
+
+            lane = ttnn.zeros(
+                shape=[self.num_things_classes, mask_pred.shape[-2], mask_pred.shape[-1]], device=self.device
+            )
+
+            lane_score = ttnn.zeros(
+                shape=[self.num_things_classes, mask_pred.shape[-2], mask_pred.shape[-1]], device=self.device
+            )
+
+            for i, scores in enumerate(scores_all):
+                # MDS: things and sutff have different threholds may perform a little bit better
+                if labels_all[i] < self.num_things_classes and scores < self.quality_threshold_things:
+                    continue
+                elif labels_all[i] >= self.num_things_classes and scores < self.quality_threshold_stuff:
+                    continue
+                _mask = masks_all[i] > 0.5
+                mask_area = _mask.sum().item()
+                intersect = _mask & (results[0] > 0)
+                intersect_area = intersect.sum().item()
+                if labels_all[i] < self.num_things_classes:
+                    if mask_area == 0 or (intersect_area * 1.0 / mask_area) > self.overlap_threshold_things:
+                        continue
+                else:
+                    if mask_area == 0 or (intersect_area * 1.0 / mask_area) > self.overlap_threshold_stuff:
+                        continue
+                if intersect_area > 0:
+                    _mask = _mask & (results[0] == 0)
+                results[0, _mask] = labels_all[i]
+                if labels_all[i] < self.num_things_classes:
+                    lane[labels_all[i], _mask] = 1
+                    lane_score[labels_all[i], _mask] = masks_all[i][_mask]
+                    results[1, _mask] = id_unique
+                    id_unique += 1
+
+            file_name = img_metas[img_id]["pts_filename"].split("/")[-1].split(".")[0]
+            panoptic_list.append((ttnn.permute(results, (1, 2, 0)), file_name, ori_shape))
+
+            bbox_list.append(bbox_th)
+            labels_list.append(labels_th)
+            seg_list.append(seg_th)
+            lane_list.append(ttnn.to_torch(lane))
+            lane_score_list.append(ttnn.to_torch(lane_score))
+
+        results = []
+        for i in range(len(img_metas)):
+            results.append(
+                {
+                    "bbox": bbox_list[i],
+                    "segm": seg_list[i],
+                    "labels": labels_list[i],
+                    "panoptic": panoptic_list[i],
+                    "drivable": drivable_list[i],
+                    "score_list": score_list[i],
+                    "lane": lane_list[i],
+                    "lane_score": lane_score_list[i],
+                    "stuff_score_list": stuff_score_list[i],
+                }
+            )
+        return results
+
+    def forward(self, bev_embed, level_embeds=None):
+        _, bs, _ = bev_embed.shape
+
+        bev_embed = ttnn.reshape(bev_embed, (bs, self.bev_h, self.bev_w, -1))
+        bev_embed = ttnn.permute(bev_embed, (0, 3, 1, 2))
+        mlvl_feats = [bev_embed]
+
+        img_masks = ttnn.zeros((bs, self.bev_h, self.bev_w), device=self.device)
+
+        hw_lvl = []
+        for feat_lvl in mlvl_feats:
+            h, w = feat_lvl.shape[-2], feat_lvl.shape[-1]
+            hw_lvl.append([h, w])
+
+        mlvl_masks = []
+        mlvl_positional_encodings = []
+        for feat in mlvl_feats:
+            img_masks = ttnn.unsqueeze(img_masks, 0)
+            out = ttnn.upsample(img_masks, scale_factor=1)
+            out = ttnn.squeeze(out, 0)
+            img_masks = ttnn.squeeze(img_masks, 0)
+            mlvl_masks.append(out)
+        out = self.positional_encoding(mlvl_masks[-1])
+        mlvl_positional_encodings.append(out)
+
+        query_embeds = None
+        if not self.as_two_stage:
+            query_embeds = self.params.query_embedding.weight
+
+        out = self.transformer.forward(
+            mlvl_feats,
+            mlvl_masks,
+            query_embeds,
+            mlvl_positional_encodings,
+            level_embeds=level_embeds,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+        )
+
+        (
+            (memory, memory_pos, memory_mask, query_pos),
+            hs,
+            init_reference,
+            inter_references,
+            enc_outputs_class,
+            enc_outputs_coord,
+        ) = self.transformer.forward(
+            mlvl_feats,
+            mlvl_masks,
+            query_embeds,
+            mlvl_positional_encodings,
+            level_embeds=level_embeds,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+        )
+
+        memory = ttnn.permute(memory, (1, 0, 2))
+        query = ttnn.permute(hs[-1], (1, 0, 2))
+        query_pos = ttnn.permute(query_pos, (1, 0, 2))
+        memory_pos = ttnn.permute(memory_pos, (1, 0, 2))
+
+        args_tuple = [memory, memory_mask, memory_pos, query, None, query_pos, hw_lvl]
+
+        hs = ttnn.permute(hs, (0, 2, 1, 3))
+        outputs_classes = []
+        outputs_coords = []
+        for lvl in range(hs.shape[0]):
+            if lvl == 0:
+                reference = init_reference
+            else:
+                reference = inter_references[lvl - 1]
+
+            reference = inverse_sigmoid(reference)
+
+            outputs_class = ttnn.linear(
+                hs[lvl], self.params.cls_branches[lvl].weight, bias=self.params.cls_branches[lvl].bias
+            )
+
+            tmp = ttnn.linear(
+                hs[lvl], self.params.reg_branches[lvl][0].weight, bias=self.params.reg_branches[lvl][0].bias
+            )
+            tmp = ttnn.relu(tmp)
+            tmp = ttnn.linear(tmp, self.params.reg_branches[lvl][2].weight, bias=self.params.reg_branches[lvl][2].bias)
+            tmp = ttnn.relu(tmp)
+            tmp = ttnn.linear(tmp, self.params.reg_branches[lvl][4].weight, bias=self.params.reg_branches[lvl][4].bias)
+
+            if reference.shape[-1] == 4:
+                tmp += reference
+            else:
+                tmp = ttnn.to_torch(tmp)
+                reference = ttnn.to_torch(reference)
+                assert reference.shape[-1] == 2
+                tmp[..., :2] += reference
+                reference = ttnn.from_torch(reference, device=self.device, layout=ttnn.TILE_LAYOUT)
+                tmp = ttnn.from_torch(tmp, device=self.device, layout=ttnn.TILE_LAYOUT)
+
+            outputs_coord = ttnn.sigmoid(tmp)
+            outputs_classes.append(outputs_class)
+            outputs_coords.append(outputs_coord)
+
+        outputs_classes = ttnn.stack(outputs_classes, dim=0)
+
+        outputs_coords = ttnn.stack(outputs_coords, dim=0)
+
+        outs = {
+            "bev_embed": None if self.as_two_stage else bev_embed,
+            "outputs_classes": outputs_classes,
+            "outputs_coords": outputs_coords,
+            "enc_outputs_class": enc_outputs_class if self.as_two_stage else None,
+            "enc_outputs_coord": enc_outputs_coord.sigmoid() if self.as_two_stage else None,
+            "args_tuple": args_tuple,
+            "reference": reference,
+        }
+
+        return outs
+
+    def forward_test(
+        self, pts_feats=None, gt_lane_labels=None, gt_lane_masks=None, img_metas=None, rescale=False, level_embeds=None
+    ):
+        bbox_list = [dict() for i in range(len(img_metas))]
+
+        pred_seg_dict = self.forward(pts_feats, level_embeds=level_embeds)
+
+        results = self.get_bboxes(
+            pred_seg_dict["outputs_classes"],
+            pred_seg_dict["outputs_coords"],
+            pred_seg_dict["enc_outputs_class"],
+            pred_seg_dict["enc_outputs_coord"],
+            pred_seg_dict["args_tuple"],
+            pred_seg_dict["reference"],
+            img_metas,
+            rescale=rescale,
+        )
+
+        with torch.no_grad():
+            drivable_pred = results[0]["drivable"]
+            drivable_gt = gt_lane_masks[0][0, -1]
+            drivable_gt = ttnn.to_torch(drivable_gt)
+            drivable_iou, drivable_intersection, drivable_union = IOU(
+                drivable_pred.view(1, -1), drivable_gt.view(1, -1)
+            )
+
+            # results[0]['lane'] = ttnn.to_torch(results[0]['lane'])
+            # gt_lane_masks[0][0] = ttnn.to_torch(gt_lane_masks[0][0])
+            lane_pred = results[0]["lane"]
+            lanes_pred = (results[0]["lane"].sum(0) > 0).int()
+            lanes_gt = (ttnn.to_torch(gt_lane_masks[0][0][:-1]).sum(0) > 0).int()
+            lanes_iou, lanes_intersection, lanes_union = IOU(lanes_pred.view(1, -1), lanes_gt.view(1, -1))
+
+            # gt_lane_masks[0][0][gt_lane_labels[0][0]] = ttnn.to_torch(gt_lane_masks[0][0][gt_lane_labels[0][0]])
+            divider_gt = (ttnn.to_torch(gt_lane_masks[0][0])[ttnn.to_torch(gt_lane_labels[0][0]) == 0].sum(0) > 0).int()
+            crossing_gt = (
+                ttnn.to_torch(gt_lane_masks[0][0])[ttnn.to_torch(gt_lane_labels[0][0]) == 1].sum(0) > 0
+            ).int()
+            contour_gt = (ttnn.to_torch(gt_lane_masks[0][0])[ttnn.to_torch(gt_lane_labels[0][0]) == 2].sum(0) > 0).int()
+            divider_iou, divider_intersection, divider_union = IOU(lane_pred[0].view(1, -1), divider_gt.view(1, -1))
+            crossing_iou, crossing_intersection, crossing_union = IOU(lane_pred[1].view(1, -1), crossing_gt.view(1, -1))
+            contour_iou, contour_intersection, contour_union = IOU(lane_pred[2].view(1, -1), contour_gt.view(1, -1))
+
+            ret_iou = {
+                "drivable_intersection": drivable_intersection,
+                "drivable_union": drivable_union,
+                "lanes_intersection": lanes_intersection,
+                "lanes_union": lanes_union,
+                "divider_intersection": divider_intersection,
+                "divider_union": divider_union,
+                "crossing_intersection": crossing_intersection,
+                "crossing_union": crossing_union,
+                "contour_intersection": contour_intersection,
+                "contour_union": contour_union,
+                "drivable_iou": drivable_iou,
+                "lanes_iou": lanes_iou,
+                "divider_iou": divider_iou,
+                "crossing_iou": crossing_iou,
+                "contour_iou": contour_iou,
+            }
+        for result_dict, pts_bbox in zip(bbox_list, results):
+            result_dict["pts_bbox"] = pts_bbox
+            result_dict["ret_iou"] = ret_iou
+            result_dict["args_tuple"] = pred_seg_dict["args_tuple"]
+        return bbox_list

--- a/models/experimental/uniad/tt/tt_planning_head.py
+++ b/models/experimental/uniad/tt/tt_planning_head.py
@@ -1,0 +1,403 @@
+import ttnn
+
+import torch
+from models.experimental.uniad.tt.utils import bivariate_gaussian_activation
+from models.experimental.uniad.reference.utils import CollisionNonlinearOptimizer
+import numpy as np
+import ttnn
+
+from models.experimental.uniad.tt.ttnn_transformer_decoder_layer import TtTransformerDecoderLayer
+
+
+class TtConv2d:
+    def __init__(
+        self,
+        device,
+        parameters,
+        conv_pt,
+        *,
+        has_bias=True,
+        act_block_h=32,
+        reshard=False,
+        deallocate=False,
+        activation="relu",
+        shard_type="HS",
+        dtype=ttnn.bfloat16,
+        slice_type=None,
+        num_slices=None,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    ) -> None:
+        self.weights = parameters.conv.weight
+
+        self.conv_pt = conv_pt
+        self.has_bias = has_bias
+        if self.has_bias:
+            self.bias = parameters.conv.bias
+
+        self.kernel_size = (self.weights.shape[2], self.weights.shape[3])
+        self.stride = conv_pt.stride
+        self.padding = conv_pt.padding
+        self.in_channels = conv_pt.in_channels
+        self.out_channels = conv_pt.out_channels
+        self.dilation = conv_pt.dilation
+        self.act_block_h = act_block_h
+        self.reshard = reshard
+        self.dtype = dtype
+        self.slice_type = slice_type
+        self.num_slices = num_slices
+        self.device = device
+        self.memory_config = memory_config
+
+        if shard_type == "WS":
+            self.shard_layout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
+        elif shard_type == "HS":
+            self.shard_layout = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+        elif shard_type == "BS":
+            self.shard_layout = ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        else:
+            self.shard_layout = None
+
+        self.deallocate = deallocate
+        self.activation = activation
+
+    def __str__(self) -> str:
+        return f"Conv: {self.weights.shape} {self.bias.shape if self.has_bias else ''} {self.kernel_size}"
+
+    def __call__(self, input_tensor, inp_h, inp_w):
+        if self.slice_type is not None and self.num_slices is not None:
+            slice_config = ttnn.Conv2dSliceConfig(
+                slice_type=self.slice_type,
+                num_slices=self.num_slices,
+            )
+        else:
+            slice_config = None
+        conv_config = ttnn.Conv2dConfig(
+            # dtype=self.dtype,
+            weights_dtype=self.dtype,
+            shard_layout=self.shard_layout,
+            deallocate_activation=self.deallocate,
+            activation=self.activation,
+            # reshard_if_not_optimal=True,
+        )
+        compute_config = ttnn.init_device_compute_kernel_config(
+            self.device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,  # PCC drop for few cases
+        )
+        if self.act_block_h is not None:
+            conv_config.act_block_h_override = self.act_block_h
+
+        [output_tensor, [out_h, out_w]] = ttnn.conv2d(
+            input_tensor=input_tensor,
+            weight_tensor=self.weights,
+            bias_tensor=self.bias if self.has_bias else None,
+            in_channels=self.in_channels,
+            out_channels=self.out_channels,
+            device=self.device,
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            batch_size=1,
+            input_height=inp_h,
+            input_width=inp_w,
+            conv_config=conv_config,
+            compute_config=compute_config,
+            slice_config=slice_config,
+            return_output_dim=True,
+            memory_config=self.memory_config,
+        )
+        return output_tensor, out_h, out_w
+
+
+class TtPlanningHeadSingleMode:
+    def __init__(
+        self,
+        device,
+        parameters,
+        conv_pt,
+        bev_h=200,
+        bev_w=200,
+        embed_dims=256,
+        planning_steps=6,
+        loss_planning=None,
+        loss_collision=None,
+        planning_eval=True,
+        use_col_optim=True,
+        col_optim_args=dict(
+            occ_filter_range=5.0,
+            sigma=1.0,
+            alpha_collision=5.0,
+        ),
+        with_adapter=True,
+    ):
+        self.device = device
+        self.params = parameters
+        self.eps = 1e-05
+
+        # Nuscenes
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.navi_embed = parameters.navi_embed.weight
+
+        self.reg_branch = [
+            ttnn.linear,
+            ttnn.relu,
+            ttnn.linear,
+        ]
+
+        # # self.loss_planning = build_loss(loss_planning)
+        self.planning_steps = planning_steps
+        self.training = False
+        # self.planning_eval = planning_eval
+
+        # #### planning head
+        self.attn_module = [
+            TtTransformerDecoderLayer(
+                parameters=parameters.attn_module.layers[0],
+                device=device,
+                d_model=embed_dims,
+                nhead=8,
+                dim_feedforward=embed_dims * 2,
+                batch_first=False,
+            ),
+            TtTransformerDecoderLayer(
+                parameters=parameters.attn_module.layers[1],
+                device=device,
+                d_model=embed_dims,
+                nhead=8,
+                dim_feedforward=embed_dims * 2,
+                batch_first=False,
+            ),
+            TtTransformerDecoderLayer(
+                parameters=parameters.attn_module.layers[2],
+                device=device,
+                d_model=embed_dims,
+                nhead=8,
+                dim_feedforward=embed_dims * 2,
+                batch_first=False,
+            ),
+        ]
+
+        self.mlp_fuser = [ttnn.linear, ttnn.layer_norm, ttnn.relu]
+        self.pos_embed = parameters.pos_embed.weight
+
+        # # self.loss_collision = []
+        # # for cfg in loss_collision:
+        # #     self.loss_collision.append(build_loss(cfg))
+        # # self.loss_collision = nn.ModuleList(self.loss_collision)
+
+        self.use_col_optim = use_col_optim
+        self.occ_filter_range = col_optim_args["occ_filter_range"]
+        self.sigma = col_optim_args["sigma"]
+        self.alpha_collision = col_optim_args["alpha_collision"]
+
+        # TODO: reimplement it with down-scaled feature_map
+        self.with_adapter = with_adapter
+        if with_adapter:
+            self.bev_adapter = [
+                TtConv2d(device, parameters=parameters.bev_adapter[0][0], conv_pt=conv_pt.bev_adapter[0][0]),
+                TtConv2d(
+                    device, parameters=parameters.bev_adapter[0][2], conv_pt=conv_pt.bev_adapter[0][2], activation=""
+                ),
+                TtConv2d(device, parameters=parameters.bev_adapter[1][0], conv_pt=conv_pt.bev_adapter[1][0]),
+                TtConv2d(
+                    device, parameters=parameters.bev_adapter[1][2], conv_pt=conv_pt.bev_adapter[1][2], activation=""
+                ),
+                TtConv2d(device, parameters=parameters.bev_adapter[2][0], conv_pt=conv_pt.bev_adapter[2][0]),
+                TtConv2d(
+                    device, parameters=parameters.bev_adapter[2][2], conv_pt=conv_pt.bev_adapter[2][2], activation=""
+                ),
+            ]
+
+        # self.occ_filter_range_tt = ttnn.from_torch(torch.tensor([col_optim_args['occ_filter_range']**2]), layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+
+    def __call__(self, bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command=None):
+        sdc_traj_query = sdc_traj_query[-1]
+        P = sdc_traj_query.shape[1]
+        sdc_track_query = ttnn.unsqueeze(sdc_track_query, 1)
+        sdc_track_query = ttnn.expand(sdc_track_query, (-1, P, -1))
+
+        navi_embed = self.navi_embed[:1, :]  # 1.0 if FP32 else 0.9999
+
+        navi_embed = ttnn.unsqueeze(navi_embed, 0)
+        navi_embed = ttnn.expand(navi_embed, (-1, P, -1))
+        plan_query = ttnn.concat([sdc_traj_query, sdc_track_query, navi_embed], dim=-1)
+
+        # mlp_fuser
+        plan_query = self.mlp_fuser[0](plan_query, self.params.mlp_fuser[0].weight, bias=self.params.mlp_fuser[0].bias)
+        plan_query = self.mlp_fuser[1](
+            plan_query, weight=self.params.mlp_fuser[1].weight, bias=self.params.mlp_fuser[1].bias, epsilon=self.eps
+        )
+        plan_query = self.mlp_fuser[2](plan_query)
+
+        plan_query = ttnn.max(plan_query, dim=1)  # expand, then fuse  # [1, 6, 768] -> [1, 1, 256]
+        plan_query = ttnn.unsqueeze(plan_query, 0)
+
+        plan_query = ttnn.permute(plan_query, (1, 0, 2))  # rearrange(plan_query, 'b p c -> p b c')
+        b, c, h, w = bev_pos.shape
+        bev_pos = ttnn.reshape(bev_pos, (b, c, h * w))
+        bev_pos = ttnn.permute(bev_pos, (2, 0, 1))
+
+        bev_feat = bev_embed + bev_pos
+
+        ##### Plugin adapter #####
+        if self.with_adapter:
+            bev_feat = ttnn.reshape(
+                bev_feat, (self.bev_h, self.bev_w, bev_feat.shape[1], bev_feat.shape[-1])
+            )  # '(h w) b c -> b c h w'
+            bev_feat = ttnn.permute(bev_feat, (2, 0, 1, 3))  # b, h, w, c for ttnn conv input
+
+            b, h, w, c = bev_feat.shape
+            bev_feat = ttnn.reshape(bev_feat, (1, 1, b * h * w, c))
+            bev_feat_copy = bev_feat
+
+            bev_feat, out_h, out_w = self.bev_adapter[0](bev_feat, h, w)
+            bev_feat, out_h, out_w = self.bev_adapter[1](bev_feat, out_h, out_w)
+            bev_feat, out_h, out_w = self.bev_adapter[2](bev_feat, out_h, out_w)
+            bev_feat, out_h, out_w = self.bev_adapter[3](bev_feat, out_h, out_w)
+            bev_feat, out_h, out_w = self.bev_adapter[4](bev_feat, out_h, out_w)
+            bev_feat, out_h, out_w = self.bev_adapter[5](bev_feat, out_h, out_w)
+
+            bev_feat = bev_feat + bev_feat_copy  # residual connection # b, h, w, c
+            bev_feat = ttnn.reshape(bev_feat, (bev_feat.shape[0], out_h, out_w, bev_feat.shape[-1]))
+
+            bev_feat = ttnn.permute(bev_feat, (1, 2, 0, 3))
+            bev_feat = ttnn.reshape(
+                bev_feat, (out_h * out_w, bev_feat.shape[2], bev_feat.shape[-1])
+            )  # rearrange(bev_feat, 'b c h w -> (h w) b c')
+
+        ##########################
+
+        pos_embed = ttnn.unsqueeze(self.pos_embed, 0)
+        plan_query = plan_query + pos_embed  # [1, 1, 256]
+
+        plan_query = self.attn_module[0](plan_query, bev_feat)
+        plan_query = self.attn_module[1](plan_query, bev_feat)
+        plan_query = self.attn_module[2](plan_query, bev_feat)
+
+        sdc_traj_all = self.reg_branch[0](
+            plan_query, self.params.reg_branch[0].weight, bias=self.params.reg_branch[0].bias
+        )  # reg_branch.linear1
+        sdc_traj_all = self.reg_branch[1](sdc_traj_all)  # relu
+        sdc_traj_all = self.reg_branch[2](
+            sdc_traj_all, self.params.reg_branch[2].weight, bias=self.params.reg_branch[2].bias
+        )  # reg_branch.linear2
+
+        sdc_traj_all = ttnn.reshape(sdc_traj_all, (-1, self.planning_steps, 2))
+        sdc_traj_all = ttnn.cumsum(sdc_traj_all, dim=1)  # No need to slice sice last dim is 2
+
+        sdc_traj_all = bivariate_gaussian_activation(sdc_traj_all[0])
+        sdc_traj_all = ttnn.unsqueeze(sdc_traj_all, 0)
+
+        sdc_traj_all = ttnn.to_torch(sdc_traj_all, dtype=torch.float32)
+        occ_mask = ttnn.to_torch(occ_mask, dtype=torch.float32)
+
+        if self.use_col_optim and not self.training:
+            # post process, only used when testing
+            assert occ_mask is not None
+            sdc_traj_all = self.collision_optimization(sdc_traj_all, occ_mask)
+
+        return sdc_traj_all
+
+        return dict(
+            sdc_traj=sdc_traj_all,
+            sdc_traj_all=sdc_traj_all,
+        )
+
+    def collision_optimization_tt(self, sdc_traj_all, occ_mask):
+        pos_xy_t = []
+        valid_occupancy_num = 0
+
+        if occ_mask.shape[2] == 1:
+            occ_mask = ttnn.squeeze(occ_mask, 2)
+        occ_horizon = occ_mask.shape[1]
+        assert occ_horizon == 5
+
+        sdc_traj_all = ttnn.to_torch(sdc_traj_all, dtype=torch.float32)
+
+        for t in range(self.planning_steps):
+            cur_t = min(t + 1, occ_horizon - 1)
+
+            temp = ttnn.to_torch(occ_mask[0][cur_t])
+            pos_xy = torch.nonzero(temp, as_tuple=False)
+            pos_xy = pos_xy[:, [1, 0]]
+            pos_xy = ttnn.from_torch(pos_xy, layout=ttnn.TILE_LAYOUT, dtype=ttnn.float32, device=self.device)
+
+            a = (pos_xy[:, 0] - self.bev_h // 2) * 0.5 + 0.25
+            b = (pos_xy[:, 1] - self.bev_w // 2) * 0.5 + 0.25
+
+            a = ttnn.unsqueeze(a, 1)
+            b = ttnn.unsqueeze(b, 1)
+            pos_xy = ttnn.concat([a, b], dim=-1)  # PCC:1.0
+
+            # filter the occupancy in range
+            # sdc_pos = ttnn.expand(ttnn.unsqueeze(sdc_traj_all[0, t, :2], 0), (pos_xy.shape[0], pos_xy.shape[1]))
+            # points = pos_xy[:, :2]
+            # diff = sdc_pos - points
+            # diff_pow = ttnn.pow(diff, 2)
+            # dist_squared = ttnn.sum(diff_pow, dim=-1) # shape: [N]
+            # keep_index = dist_squared < self.occ_filter_range_tt
+            # return keep_index
+
+            pos_xy = ttnn.to_torch(pos_xy)
+
+            keep_index = (
+                torch.sum((sdc_traj_all[0, t, :2][None, :] - pos_xy[:, :2]) ** 2, axis=-1) < self.occ_filter_range**2
+            )
+            pos_xy_t.append(pos_xy[keep_index].cpu().detach().numpy())
+
+            pos_xy = ttnn.from_torch(pos_xy, layout=ttnn.TILE_LAYOUT)
+            # keep_index = ttnn.from_torch(keep_index, layout=ttnn.TILE_LAYOUT)
+
+            # valid_occupancy_num += torch.sum(keep_index>0)
+
+        # if valid_occupancy_num == 0:
+        #     return sdc_traj_all
+
+        # sdc_traj_all = ttnn.to_torch(sdc_traj_all)
+        col_optimizer = CollisionNonlinearOptimizer(
+            self.planning_steps, 0.5, self.sigma, self.alpha_collision, pos_xy_t
+        )
+        col_optimizer.set_reference_trajectory(sdc_traj_all[0].cpu().detach().numpy())
+        sol = col_optimizer.solve()
+        sdc_traj_optim = np.stack([sol.value(col_optimizer.position_x), sol.value(col_optimizer.position_y)], axis=-1)
+        return torch.tensor(sdc_traj_optim[None], device=sdc_traj_all.device, dtype=sdc_traj_all.dtype)
+
+    def collision_optimization(self, sdc_traj_all, occ_mask):
+        pos_xy_t = []
+        valid_occupancy_num = 0
+
+        if occ_mask.shape[2] == 1:
+            occ_mask = occ_mask.squeeze(2)
+        occ_horizon = occ_mask.shape[1]
+        assert occ_horizon == 5
+
+        for t in range(self.planning_steps):
+            cur_t = min(t + 1, occ_horizon - 1)
+            pos_xy = torch.nonzero(occ_mask[0][cur_t], as_tuple=False)
+            pos_xy = pos_xy[:, [1, 0]]
+            pos_xy[:, 0] = (pos_xy[:, 0] - self.bev_h // 2) * 0.5 + 0.25
+            pos_xy[:, 1] = (pos_xy[:, 1] - self.bev_w // 2) * 0.5 + 0.25
+
+            # filter the occupancy in range
+            keep_index = (
+                torch.sum((sdc_traj_all[0, t, :2][None, :] - pos_xy[:, :2]) ** 2, axis=-1) < self.occ_filter_range**2
+            )
+            pos_xy_t.append(pos_xy[keep_index].cpu().detach().numpy())
+            valid_occupancy_num += torch.sum(keep_index > 0)
+        if valid_occupancy_num == 0:
+            return sdc_traj_all
+
+        col_optimizer = CollisionNonlinearOptimizer(
+            self.planning_steps, 0.5, self.sigma, self.alpha_collision, pos_xy_t
+        )
+        col_optimizer.set_reference_trajectory(sdc_traj_all[0].cpu().detach().numpy())
+        sol = col_optimizer.solve()
+        sdc_traj_optim = np.stack([sol.value(col_optimizer.position_x), sol.value(col_optimizer.position_y)], axis=-1)
+        result = torch.tensor(sdc_traj_optim[None], device=sdc_traj_all.device, dtype=sdc_traj_all.dtype)
+
+        # convert to ttnn
+        result = ttnn.from_torch(result, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device)
+        return result

--- a/models/experimental/uniad/tt/tt_query_interaction_module.py
+++ b/models/experimental/uniad/tt/tt_query_interaction_module.py
@@ -50,66 +50,66 @@ class TtQueryInteractionModule:
         value = ttnn.reshape(tgt, (tgt.shape[0], 1, tgt.shape[1]))
         value = ttnn.to_layout(value, ttnn.TILE_LAYOUT)
 
-        # tgt2 = self.self_attn(q[:, None], k[:, None], value=tgt[:, None])[0][:, 0]  # torch
-        tgt2 = self.self_attn(q, k, value=value)[0]  # torch
+        if q.shape[0] > 0 and k.shape[0] > 0:
+            tgt2 = self.self_attn(q, k, value=value)[0]
 
-        tgt2 = ttnn.to_torch(tgt2)
-        tgt = ttnn.to_torch(tgt)
+            tgt2 = ttnn.to_torch(tgt2)
+            tgt = ttnn.to_torch(tgt)
 
-        tgt2 = tgt2[:, 0]
+            tgt2 = tgt2[:, 0]
 
-        tgt = ttnn.from_torch(tgt, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-        tgt2 = ttnn.from_torch(tgt2, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+            tgt = ttnn.from_torch(tgt, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+            tgt2 = ttnn.from_torch(tgt2, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
 
-        tgt = ttnn.layer_norm(
-            tgt,
-            weight=self.params.norm1.weight,
-            bias=self.params.norm1.bias,
-            epsilon=self.eps,
-        )
+            tgt = ttnn.layer_norm(
+                tgt,
+                weight=self.params.norm1.weight,
+                bias=self.params.norm1.bias,
+                epsilon=self.eps,
+            )
 
-        x = ttnn.linear(tgt, self.params.linear1.weight, bias=self.params.linear1.bias)
-        x = ttnn.relu(x)
-        tgt2 = ttnn.linear(x, self.params.linear2.weight, bias=self.params.linear2.bias)
-
-        # tgt = tgt + tgt2
-        tgt = ttnn.layer_norm(
-            tgt,
-            weight=self.params.norm2.weight,
-            bias=self.params.norm2.bias,
-            epsilon=self.eps,
-        )
-
-        if self.update_query_pos:
-            x = ttnn.linear(tgt, self.params.linear_pos1.weight, bias=self.params.linear_pos1.bias)
+            x = ttnn.linear(tgt, self.params.linear1.weight, bias=self.params.linear1.bias)
             x = ttnn.relu(x)
-            query_pos2 = ttnn.linear(x, self.params.linear_pos2.weight, bias=self.params.linear_pos2.bias)
+            tgt2 = ttnn.linear(x, self.params.linear2.weight, bias=self.params.linear2.bias)
 
-            query_pos = ttnn.layer_norm(
-                query_pos,
-                weight=self.params.norm_pos.weight,
-                bias=self.params.norm_pos.bias,
+            # tgt = tgt + tgt2
+            tgt = ttnn.layer_norm(
+                tgt,
+                weight=self.params.norm2.weight,
+                bias=self.params.norm2.bias,
+                epsilon=self.eps,
+            )
+
+            if self.update_query_pos:
+                x = ttnn.linear(tgt, self.params.linear_pos1.weight, bias=self.params.linear_pos1.bias)
+                x = ttnn.relu(x)
+                query_pos2 = ttnn.linear(x, self.params.linear_pos2.weight, bias=self.params.linear_pos2.bias)
+
+                query_pos = ttnn.layer_norm(
+                    query_pos,
+                    weight=self.params.norm_pos.weight,
+                    bias=self.params.norm_pos.bias,
+                    epsilon=self.eps,
+                )
+
+                track_instances.query = ttnn.to_torch(track_instances.query)
+                track_instances.query[:, : dim // 2] = ttnn.to_torch(query_pos)
+                track_instances.query = ttnn.from_torch(track_instances.query, device=self.device)
+
+            x = ttnn.linear(tgt, self.params.linear_feat1.weight, bias=self.params.linear_feat1.bias)
+            x = ttnn.relu(x)
+            query_feat2 = ttnn.linear(x, self.params.linear_feat2.weight, bias=self.params.linear_feat2.bias)
+
+            query_feat = ttnn.layer_norm(
+                query_feat,
+                weight=self.params.norm_feat.weight,
+                bias=self.params.norm_feat.bias,
                 epsilon=self.eps,
             )
 
             track_instances.query = ttnn.to_torch(track_instances.query)
-            track_instances.query[:, : dim // 2] = ttnn.to_torch(query_pos)
+            track_instances.query[:, dim // 2 :] = ttnn.to_torch(query_feat)
             track_instances.query = ttnn.from_torch(track_instances.query, device=self.device)
-
-        x = ttnn.linear(tgt, self.params.linear_feat1.weight, bias=self.params.linear_feat1.bias)
-        x = ttnn.relu(x)
-        query_feat2 = ttnn.linear(x, self.params.linear_feat2.weight, bias=self.params.linear_feat2.bias)
-
-        query_feat = ttnn.layer_norm(
-            query_feat,
-            weight=self.params.norm_feat.weight,
-            bias=self.params.norm_feat.bias,
-            epsilon=self.eps,
-        )
-
-        track_instances.query = ttnn.to_torch(track_instances.query)
-        track_instances.query[:, dim // 2 :] = ttnn.to_torch(query_feat)
-        track_instances.query = ttnn.from_torch(track_instances.query, device=self.device)
 
         return track_instances
 
@@ -118,4 +118,4 @@ class TtQueryInteractionModule:
         active_track_instances = self._update_track_embedding(active_track_instances)
         init_track_instances = data["init_track_instances"]
         merged_track_instances = Instances.cat([init_track_instances, active_track_instances])
-        return active_track_instances
+        return merged_track_instances

--- a/models/experimental/uniad/tt/tt_query_interaction_module.py
+++ b/models/experimental/uniad/tt/tt_query_interaction_module.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.uniad.tt.utils import Instances
+from models.experimental.uniad.tt.tt_multi_head_attention import TtMultiheadAttention
+
+
+class TtQueryInteractionModule:
+    def __init__(
+        self,
+        dim_in=256,
+        hidden_dim=256,
+        dim_out=256,
+        fp_ratio=0.3,
+        update_query_pos=True,
+        params=None,
+        device=None,
+        eps=1e-05,
+    ):
+        self.device = device
+        self.dim_in = dim_in
+        self.hidden_dim = hidden_dim
+        self.dim_out = dim_out
+        self.fp_ratio = fp_ratio
+        self.update_query_pos = update_query_pos
+        self.params = params
+        self.eps = eps
+        self.self_attn = TtMultiheadAttention(device, params.self_attn, embed_dim=dim_in, num_heads=8)
+
+    def _select_active_tracks(self, data: dict) -> Instances:
+        track_instances: Instances = data["track_instances"]
+        active_track_instances = track_instances[track_instances.obj_idxes >= 0]
+
+        return active_track_instances
+
+    def _update_track_embedding(self, track_instances: Instances) -> Instances:
+        dim = track_instances.query.shape[1]
+        out_embed = track_instances.output_embedding
+        query_pos = track_instances.query[:, : dim // 2]
+        query_feat = track_instances.query[:, dim // 2 :]
+        q = k = query_pos + out_embed
+
+        # attention
+        tgt = out_embed
+
+        q = ttnn.reshape(q, (q.shape[0], 1, q.shape[1]))
+        k = ttnn.reshape(k, (k.shape[0], 1, k.shape[1]))
+        value = ttnn.reshape(tgt, (tgt.shape[0], 1, tgt.shape[1]))
+        value = ttnn.to_layout(value, ttnn.TILE_LAYOUT)
+
+        # tgt2 = self.self_attn(q[:, None], k[:, None], value=tgt[:, None])[0][:, 0]  # torch
+        tgt2 = self.self_attn(q, k, value=value)[0]  # torch
+
+        tgt2 = ttnn.to_torch(tgt2)
+        tgt = ttnn.to_torch(tgt)
+
+        tgt2 = tgt2[:, 0]
+
+        tgt = ttnn.from_torch(tgt, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        tgt2 = ttnn.from_torch(tgt2, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+        tgt = ttnn.layer_norm(
+            tgt,
+            weight=self.params.norm1.weight,
+            bias=self.params.norm1.bias,
+            epsilon=self.eps,
+        )
+
+        x = ttnn.linear(tgt, self.params.linear1.weight, bias=self.params.linear1.bias)
+        x = ttnn.relu(x)
+        tgt2 = ttnn.linear(x, self.params.linear2.weight, bias=self.params.linear2.bias)
+
+        # tgt = tgt + tgt2
+        tgt = ttnn.layer_norm(
+            tgt,
+            weight=self.params.norm2.weight,
+            bias=self.params.norm2.bias,
+            epsilon=self.eps,
+        )
+
+        if self.update_query_pos:
+            x = ttnn.linear(tgt, self.params.linear_pos1.weight, bias=self.params.linear_pos1.bias)
+            x = ttnn.relu(x)
+            query_pos2 = ttnn.linear(x, self.params.linear_pos2.weight, bias=self.params.linear_pos2.bias)
+
+            query_pos = ttnn.layer_norm(
+                query_pos,
+                weight=self.params.norm_pos.weight,
+                bias=self.params.norm_pos.bias,
+                epsilon=self.eps,
+            )
+
+            track_instances.query = ttnn.to_torch(track_instances.query)
+            track_instances.query[:, : dim // 2] = ttnn.to_torch(query_pos)
+            track_instances.query = ttnn.from_torch(track_instances.query, device=self.device)
+
+        x = ttnn.linear(tgt, self.params.linear_feat1.weight, bias=self.params.linear_feat1.bias)
+        x = ttnn.relu(x)
+        query_feat2 = ttnn.linear(x, self.params.linear_feat2.weight, bias=self.params.linear_feat2.bias)
+
+        query_feat = ttnn.layer_norm(
+            query_feat,
+            weight=self.params.norm_feat.weight,
+            bias=self.params.norm_feat.bias,
+            epsilon=self.eps,
+        )
+
+        track_instances.query = ttnn.to_torch(track_instances.query)
+        track_instances.query[:, dim // 2 :] = ttnn.to_torch(query_feat)
+        track_instances.query = ttnn.from_torch(track_instances.query, device=self.device)
+
+        return track_instances
+
+    def __call__(self, data):
+        active_track_instances = self._select_active_tracks(data)
+        active_track_instances = self._update_track_embedding(active_track_instances)
+        init_track_instances = data["init_track_instances"]
+        merged_track_instances = Instances.cat([init_track_instances, active_track_instances])
+        return active_track_instances

--- a/models/experimental/uniad/tt/tt_seg_deformable_transformer.py
+++ b/models/experimental/uniad/tt/tt_seg_deformable_transformer.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+from models.experimental.uniad.tt.tt_detr_transformer_encoder import TtDetrTransformerEncoder
+from models.experimental.uniad.tt.tt_detr_transformer_decoder import TtDeformableDetrTransformerDecoder
+
+
+class TtSegDeformableTransformer:
+    def __init__(self, device, params, as_two_stage=False, num_feature_levels=4, two_stage_num_proposals=300, **kwargs):
+        super().__init__()
+        self.fp16_enabled = False
+        self.as_two_stage = as_two_stage
+        self.num_feature_levels = num_feature_levels
+        self.two_stage_num_proposals = two_stage_num_proposals
+        self.embed_dims = 256
+        self.device = device
+        self.params = params
+        self.encoder = TtDetrTransformerEncoder(
+            params=params.encoder,
+            device=device,
+        )
+
+        self.decoder = TtDeformableDetrTransformerDecoder(
+            params=params.decoder,
+            device=device,
+            num_layers=6,
+            embed_dim=256,
+            num_heads=8,
+            params_branches=kwargs["params_branches"],
+        )
+
+    @staticmethod
+    def get_reference_points(spatial_shapes, valid_ratios, device):
+        reference_points_list = []
+        for lvl, (H, W) in enumerate(spatial_shapes):
+            H = int(H)
+            W = int(W)
+            #  TODO  check this 0.5
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=torch.float32, device=device),
+                torch.linspace(0.5, W - 0.5, W, dtype=torch.float32, device=device),
+            )
+            ref_y = ref_y.reshape(-1)[None] / (valid_ratios[:, None, lvl, 1] * H)
+            ref_x = ref_x.reshape(-1)[None] / (valid_ratios[:, None, lvl, 0] * W)
+            ref = torch.stack((ref_x, ref_y), -1)
+            reference_points_list.append(ref)
+        reference_points = torch.cat(reference_points_list, 1)
+        reference_points = reference_points[:, :, None] * valid_ratios[:, None]
+        return reference_points
+
+    def get_valid_ratio(self, mask, device=None):
+        """Get the valid radios of feature maps of all  level."""
+        mask = ttnn.to_torch(mask).to(torch.int32)
+        _, H, W = mask.shape
+        valid_H = torch.sum(~mask[:, :, 0], 1)
+        valid_W = torch.sum(~mask[:, 0, :], 1)
+        valid_ratio_h = valid_H.float() / H
+        valid_ratio_w = valid_W.float() / W
+        valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
+        valid_ratio = ttnn.from_torch(valid_ratio, device=device, layout=ttnn.TILE_LAYOUT)
+        # _, H, W = mask.shape
+        # one_tensor = ttnn.ones(mask.shape, layout=ttnn.TILE_LAYOUT, device = self.device)
+        # neg_mask = ttnn.subtract(one_tensor, mask)
+        # valid_H = ttnn.sum(neg_mask[:, :, 0], dim=1)
+        # valid_W = ttnn.sum(neg_mask[:, 0, :], dim=1)
+        # valid_ratio_h = ttnn.divide(valid_H, H)
+        # valid_ratio_w = ttnn.divide(valid_W, W)
+        # valid_ratio = ttnn.stack([valid_ratio_w, valid_ratio_h], dim=-1)
+        return valid_ratio
+
+    def forward(
+        self,
+        mlvl_feats,
+        mlvl_masks,
+        query_embed,
+        mlvl_pos_embeds,
+        reg_branches=None,
+        cls_branches=None,
+        level_embeds=None,
+        **kwargs,
+    ):
+        assert self.as_two_stage or query_embed is not None
+        feat_flatten = []
+        mask_flatten = []
+        lvl_pos_embed_flatten = []
+        spatial_shapes = []
+        for lvl, (feat, mask, pos_embed) in enumerate(zip(mlvl_feats, mlvl_masks, mlvl_pos_embeds)):
+            bs, c, h, w = feat.shape
+            spatial_shape = (h, w)
+            spatial_shapes.append(spatial_shape)
+            feat = ttnn.reshape(feat, (feat.shape[0], feat.shape[1], -1))
+            feat = ttnn.permute(feat, (0, 2, 1))
+            mask = ttnn.reshape(mask, (mask.shape[0], -1))
+            pos_embed = ttnn.reshape(pos_embed, (pos_embed.shape[0], pos_embed.shape[1], -1))
+            pos_embed = ttnn.permute(pos_embed, (0, 2, 1))
+            out = ttnn.reshape(level_embeds[lvl : lvl + 1], (1, 1, -1))
+            lvl_pos_embed = pos_embed + out
+            lvl_pos_embed_flatten.append(lvl_pos_embed)
+            feat_flatten.append(feat)
+            mask_flatten.append(mask)
+        feat_flatten = ttnn.concat(feat_flatten, 1)
+        mask_flatten = ttnn.concat(mask_flatten, 1)
+        lvl_pos_embed_flatten = ttnn.concat(lvl_pos_embed_flatten, 1)
+
+        spatial_shapes = ttnn.from_torch(
+            torch.as_tensor(spatial_shapes, dtype=torch.long),
+            device=self.device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.float32,
+        )
+        prod = ttnn.prod(spatial_shapes, dim=1)  # ttnn.prod give 2496.00000 instead 2500.0000
+        cumsum = ttnn.cumsum(prod, dim=0)
+        cumsum_excl_last = cumsum[: cumsum.shape[0] - 1]
+        zero = ttnn.zeros(
+            (1,),
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+        )
+        level_start_index = zero
+        print("level_start_index", level_start_index)
+
+        # valid_ratios computation
+        valid_ratios_list = [self.get_valid_ratio(m, device=self.device) for m in mlvl_masks]
+        valid_ratios = ttnn.stack(valid_ratios_list, dim=1)  # values changes in tnnn
+
+        print("spatial_shapes", spatial_shapes, spatial_shapes.shape)
+        print("valid_ratios", valid_ratios, valid_ratios.shape)
+        # return valid_ratios
+        spatial_shapes = ttnn.to_torch(spatial_shapes)
+        valid_ratios = ttnn.to_torch(valid_ratios)
+        reference_points = self.get_reference_points(spatial_shapes, valid_ratios, device="cpu")
+        reference_points = ttnn.from_torch(reference_points, device=self.device, layout=ttnn.TILE_LAYOUT)
+        spatial_shapes = ttnn.from_torch(
+            spatial_shapes, device=self.device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+        )
+        valid_ratios = ttnn.from_torch(valid_ratios, device=self.device, layout=ttnn.TILE_LAYOUT)
+        feat_flatten = ttnn.permute(feat_flatten, (1, 0, 2))
+        lvl_pos_embed_flatten = ttnn.permute(lvl_pos_embed_flatten, (1, 0, 2))
+        memory = self.encoder(
+            query=feat_flatten,
+            key=None,
+            value=None,
+            query_pos=lvl_pos_embed_flatten,
+            query_key_padding_mask=mask_flatten,
+            spatial_shapes=spatial_shapes,
+            reference_points=reference_points,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            **kwargs,
+        )
+        memory = ttnn.permute(memory, (1, 0, 2))
+        bs, _, c = memory.shape
+
+        query_pos = query_embed[:, :c, ...]
+        query = query_embed[:, c:, ...]
+        query_pos = ttnn.unsqueeze(query_pos, 0)
+        query_pos = ttnn.expand(query_pos, (bs, -1, -1))
+        query = ttnn.unsqueeze(query, 0)
+        query = ttnn.expand(query, (bs, -1, -1))
+        # query_pos_layout = ttnn.to_layout(query_pos, ttnn.ROW_MAJOR_LAYOUT)
+        # reference_points = self.reference_points(query_pos_layout)
+        query_pos = ttnn.to_layout(query_pos, ttnn.TILE_LAYOUT)
+        reference_points = ttnn.linear(
+            query_pos, self.params.reference_points.weight, bias=self.params.reference_points.bias
+        )
+        reference_points = ttnn.sigmoid(reference_points)
+        init_reference_out = reference_points
+
+        query = ttnn.permute(query, (1, 0, 2))
+        memory = ttnn.permute(memory, (1, 0, 2))
+        query_pos = ttnn.permute(query_pos, (1, 0, 2))
+
+        inter_states, inter_references = self.decoder(
+            query=query,
+            key=None,
+            value=memory,
+            query_pos=query_pos,
+            key_padding_mask=mask_flatten,
+            reference_points=reference_points,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            reg_branches=reg_branches,
+            **kwargs,
+        )
+
+        inter_references_out = inter_references
+        if self.as_two_stage:
+            return (
+                (memory, lvl_pos_embed_flatten, mask_flatten, query_pos),
+                inter_states,
+                init_reference_out,
+                inter_references_out,
+                enc_outputs_class,
+                enc_outputs_coord_unact,
+            )
+        return (
+            (memory, lvl_pos_embed_flatten, mask_flatten, query_pos),
+            inter_states,
+            init_reference_out,
+            inter_references_out,
+            None,
+            None,
+        )

--- a/models/experimental/uniad/tt/tt_seg_mask_head.py
+++ b/models/experimental/uniad/tt/tt_seg_mask_head.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+class TtAttentionTail:
+    def __init__(
+        self,
+        params,
+        device,
+        cfg,
+        dim,
+        num_heads=2,
+        qkv_bias=False,
+        qk_scale=None,
+    ):
+        super().__init__()
+        self.device = device
+        self.params = params
+        self.fp16_enabled = False
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+    def forward(self, query, key, key_padding_mask, hw_lvl=None):
+        B, N, C = query.shape
+        _, L, _ = key.shape
+
+        q_proj = ttnn.linear(query, self.params.q.weight, bias=self.params.q.bias)
+        q_reshaped = ttnn.reshape(q_proj, (B, N, self.num_heads, C // self.num_heads))
+        q = ttnn.permute(q_reshaped, (0, 2, 1, 3))
+
+        k_proj = ttnn.linear(key, self.params.k.weight, bias=self.params.k.bias)
+        k_reshaped = ttnn.reshape(k_proj, (B, L, self.num_heads, C // self.num_heads))
+        k = ttnn.permute(k_reshaped, (0, 2, 1, 3))
+
+        k_transposed = ttnn.permute(k, (0, 1, 3, 2))
+        qk_matmul = ttnn.matmul(q, k_transposed)
+        attn = qk_matmul * self.scale
+
+        attn = ttnn.permute(attn, (0, 2, 3, 1))
+
+        new_feats = ttnn.linear(attn, self.params.linear_l1[0].weight, bias=self.params.linear_l1[0].bias)
+        new_feats = ttnn.relu(new_feats)
+        mask = ttnn.linear(new_feats, self.params.linear[0].weight, bias=self.params.linear[0].bias)
+        mask = ttnn.relu(mask)
+
+        return mask
+
+
+class TtMlp:
+    def __init__(
+        self,
+        params,
+        device,
+    ):
+        super().__init__()
+        self.params = params
+        self.device = device
+
+    def forward(self, x):
+        x = ttnn.linear(x, self.params.fc1.weight, bias=self.params.fc1.bias)
+        x = ttnn.gelu(x)
+        x = ttnn.linear(x, self.params.fc2.weight, bias=self.params.fc2.bias)
+        return x
+
+
+class TtSelfAttention:
+    def __init__(
+        self,
+        params,
+        device,
+        cfg,
+        dim,
+        num_heads=2,
+        qkv_bias=False,
+        qk_scale=None,
+    ):
+        super().__init__()
+        self.params = params
+        self.device = device
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+    def forward(self, x):
+        B, N, C = x.shape
+
+        qkv = ttnn.linear(x, self.params.qkv.weight, bias=self.params.qkv.bias)
+        qkv = ttnn.reshape(qkv, (B, N, 3, self.num_heads, C // self.num_heads))
+        qkv = ttnn.permute(qkv, (2, 0, 3, 1, 4))
+
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        k_t = ttnn.permute(k, (0, 1, 3, 2))
+        qk = ttnn.matmul(q, k_t)
+        attn = qk * self.scale
+
+        attn = ttnn.softmax(attn, dim=-1)
+
+        attn_v = ttnn.matmul(attn, v)
+        attn_v_p = ttnn.permute(attn_v, (0, 2, 1, 3))
+        x = ttnn.reshape(attn_v_p, (B, N, C))
+
+        x = ttnn.linear(x, self.params.proj.weight, bias=self.params.proj.bias)
+
+        return x
+
+
+class TtAttention:
+    def __init__(
+        self,
+        params,
+        device,
+        cfg,
+        dim,
+        num_heads=2,
+        qkv_bias=False,
+        qk_scale=None,
+    ):
+        super().__init__()
+        self.device = device
+        self.params = params
+        self.fp16_enabled = False
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+    def forward(self, query, key, value, key_padding_mask, hw_lvl):
+        B, N, C = query.shape
+        _, L, _ = key.shape
+
+        q_proj = ttnn.linear(query, self.params.q.weight, bias=self.params.q.bias)
+        q_reshaped = ttnn.reshape(q_proj, (B, N, self.num_heads, C // self.num_heads))
+        q = ttnn.permute(q_reshaped, (0, 2, 1, 3))
+
+        k_proj = ttnn.linear(key, self.params.k.weight, bias=self.params.k.bias)
+        k_reshaped = ttnn.reshape(k_proj, (B, L, self.num_heads, C // self.num_heads))
+        k = ttnn.permute(k_reshaped, (0, 2, 1, 3))
+
+        v_proj = ttnn.linear(value, self.params.v.weight, bias=self.params.v.bias)
+        v_reshaped = ttnn.reshape(v_proj, (B, L, self.num_heads, C // self.num_heads))
+        v = ttnn.permute(v_reshaped, (0, 2, 1, 3))
+
+        k_transposed = ttnn.permute(k, (0, 1, 3, 2))
+        qk_matmul = ttnn.matmul(q, k_transposed)
+        attn = qk_matmul * self.scale
+
+        attn = ttnn.permute(attn, (0, 2, 3, 1))
+
+        new_feats = ttnn.linear(attn, self.params.linear_l1[0].weight, bias=self.params.linear_l1[0].bias)
+        new_feats = ttnn.relu(new_feats)
+        mask = ttnn.linear(new_feats, self.params.linear[0].weight, bias=self.params.linear[0].bias)
+        mask = ttnn.relu(mask)
+
+        attn = ttnn.permute(attn, (0, 3, 1, 2))
+        attn = ttnn.softmax(attn, dim=-1)
+
+        attn_v = ttnn.matmul(attn, v)
+        attn_v_t = ttnn.permute(attn_v, (0, 2, 1, 3))
+        x = ttnn.reshape(attn_v_t, (B, N, C))
+
+        x = ttnn.linear(x, self.params.proj.weight, bias=self.params.proj.bias)
+
+        return x, mask
+
+
+class TtBlock:
+    def __init__(
+        self, params, device, cfg, dim, num_heads, mlp_ratio=4.0, qkv_bias=False, qk_scale=None, self_attn=False
+    ):
+        super().__init__()
+        self.device = device
+        self.params = params
+        self.eps = 1e-06
+        self.self_attn = self_attn
+        self.attn = TtAttention(
+            params.attn,
+            device,
+            cfg,
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+        )
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = TtMlp(
+            params=params.mlp,
+            device=device,
+        )
+        if self.self_attn:
+            self.self_attention = TtSelfAttention(
+                params.self_attention,
+                device,
+                cfg,
+                dim,
+                num_heads=num_heads,
+                qkv_bias=qkv_bias,
+                qk_scale=qk_scale,
+            )
+
+    def forward(self, query, key, value, key_padding_mask=None, hw_lvl=None):
+        if self.self_attn:
+            query = query + self.self_attention.forward(query)
+            query = ttnn.layer_norm(
+                query,
+                weight=self.params.norm3.weight,
+                bias=self.params.norm3.bias,
+                epsilon=self.eps,
+            )
+
+        x, mask = self.attn.forward(query, key, value, key_padding_mask, hw_lvl=hw_lvl)
+
+        query = query + x
+
+        query = ttnn.layer_norm(
+            query,
+            weight=self.params.head_norm1.weight,
+            bias=self.params.head_norm1.bias,
+            epsilon=self.eps,
+        )
+
+        query = query + self.mlp.forward(query)
+
+        query = ttnn.layer_norm(
+            query,
+            weight=self.params.head_norm2.weight,
+            bias=self.params.head_norm2.bias,
+            epsilon=self.eps,
+        )
+
+        return query, mask
+
+
+class TtSegMaskHead:
+    def __init__(
+        self,
+        params,
+        device,
+        cfg=None,
+        d_model=16,
+        nhead=2,
+        num_encoder_layers=6,
+        num_decoder_layers=1,
+        dim_feedforward=64,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        self_attn=False,
+    ):
+        super().__init__()
+        mlp_ratio = 4
+        qkv_bias = True
+        qk_scale = None
+        self.blocks = []
+        for i in range(num_decoder_layers):
+            self.blocks.append(
+                TtBlock(
+                    params.blocks[i],
+                    device,
+                    cfg,
+                    dim=d_model,
+                    num_heads=nhead,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                    qk_scale=qk_scale,
+                    self_attn=self_attn,
+                )
+            )
+        self.attnen = TtAttentionTail(
+            params.attnen,
+            device,
+            cfg,
+            d_model,
+            num_heads=nhead,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+        )
+
+    def with_pos_embed(self, tensor, pos):
+        if pos is None:
+            return tensor
+        else:
+            return tensor + pos
+
+    def forward(self, memory, mask_memory, pos_memory, query_embed, mask_query, pos_query, hw_lvl):
+        # if mask_memory is not None and isinstance(mask_memory, torch.Tensor):
+        # mask_memory = mask_memory.to(torch.bool)
+        masks = []
+        inter_query = []
+        for i, block in enumerate(self.blocks):
+            query_embed, mask = block.forward(
+                self.with_pos_embed(query_embed, pos_query),
+                self.with_pos_embed(memory, pos_memory),
+                memory,
+                key_padding_mask=mask_memory,
+                hw_lvl=hw_lvl,
+            )
+            masks.append(mask)
+            inter_query.append(query_embed)
+
+        attn = self.attnen.forward(
+            self.with_pos_embed(query_embed, pos_query),
+            self.with_pos_embed(memory, pos_memory),
+            key_padding_mask=mask_memory,
+            hw_lvl=hw_lvl,
+        )
+        return attn, masks, inter_query

--- a/models/experimental/uniad/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/uniad/tt/tt_spatial_cross_attention.py
@@ -178,9 +178,6 @@ class TtMSDeformableAttention3D:
         self.num_levels = num_levels
         self.num_heads = num_heads
         self.num_points = num_points
-        # self.sampling_offsets = nn.Linear(embed_dims, num_heads * num_levels * num_points * 2)
-        # self.attention_weights = nn.Linear(embed_dims, num_heads * num_levels * num_points)
-        # self.value_proj = nn.Linear(embed_dims, embed_dims)
 
     def __call__(
         self,
@@ -217,7 +214,6 @@ class TtMSDeformableAttention3D:
             mask = key_padding_mask[..., None]
             value = ttnn.where(mask, ttnn.zeros_like(value), value)
         value = ttnn.reshape(value, (bs, num_value, self.num_heads, -1))
-        # query = ttnn.from_torch(query, dtype=ttnn.bfloat16, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT)
         query = ttnn.to_layout(query, ttnn.TILE_LAYOUT)
 
         sampling_offsets = ttnn.linear(query, params.sampling_offsets.weight, bias=params.sampling_offsets.bias)
@@ -227,22 +223,14 @@ class TtMSDeformableAttention3D:
         attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
         ttnn.deallocate(params.attention_weights.weight)
         ttnn.deallocate(params.attention_weights.bias)
-        # ttnn.deallocate(query)
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
         )
-        attention_weights = ttnn.to_torch(attention_weights)
-        attention_weights = attention_weights.softmax(-1)
-        attention_weights = ttnn.from_torch(
-            attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
-        )
+        attention_weights = ttnn.softmax(attention_weights, -1)
 
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels, self.num_points)
         )
-        # reference_points = ttnn.from_torch(
-        #     reference_points, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=self.device
-        # )
         if reference_points.shape[-1] == 2:
             offset_normalizer = ttnn.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], dim=-1)
             bs_r, num_query, num_Z_anchors, _ = reference_points.shape
@@ -253,8 +241,6 @@ class TtMSDeformableAttention3D:
                 offset_normalizer, (1, 1, 1, offset_normalizer.shape[0], 1, offset_normalizer.shape[1])
             )
 
-            # sampling_offsets = ttnn.to_layout(sampling_offsets, ttnn.TILE_LAYOUT)
-            offset_normalizer_xy = ttnn.to_layout(offset_normalizer_xy, ttnn.TILE_LAYOUT)
             sampling_offsets = ttnn.to_torch(sampling_offsets)
             offset_normalizer_xy = ttnn.to_torch(offset_normalizer_xy)
             sampling_locations = sampling_offsets / offset_normalizer_xy

--- a/models/experimental/uniad/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/uniad/tt/tt_spatial_cross_attention.py
@@ -1,0 +1,290 @@
+import warnings
+import ttnn
+from models.experimental.uniad.tt.tt_temporal_self_attention import multi_scale_deformable_attn_pytorch
+
+
+class TtSpatialCrossAttention:
+    def __init__(
+        self,
+        device,
+        params,
+        embed_dims=256,
+        num_cams=6,
+        pc_range=None,
+        dropout=0.1,
+        init_cfg=None,
+        batch_first=False,
+        deformable_attention=dict(type="MSDeformableAttention3D", embed_dims=256, num_levels=4),
+        **kwargs,
+    ):
+        super(TtSpatialCrossAttention, self).__init__()
+
+        self.device = device
+        self.params = params
+        self.init_cfg = init_cfg
+        self.pc_range = pc_range
+        self.fp16_enabled = False
+        self.deformable_attention = TtMSDeformableAttention3D(device=self.device, params=params, num_levels=4)
+        self.embed_dims = embed_dims
+        self.num_cams = num_cams
+        # self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.batch_first = batch_first
+
+    def __call__(
+        self,
+        query,
+        key,
+        value,
+        residual=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        reference_points_cam=None,
+        bev_mask=None,
+        level_start_index=None,
+        flag="encoder",
+        **kwargs,
+    ):
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        if residual is None:
+            inp_residual = query  # ttnn.from_torch(query, dtype = ttnn.bfloat16, layout = ttnn.ROW_MAJOR_LAYOUT, device = self.device)
+            slots = ttnn.zeros_like(query)
+            slots = ttnn.to_torch(slots)
+        if query_pos is not None:
+            query = query + query_pos
+
+        bs, num_query, _ = query.shape
+
+        D = reference_points_cam.size(3)
+        indexes = []
+        indexes = []
+        for i, mask_per_img in enumerate(bev_mask):
+            index_query_per_img = ttnn.sum(mask_per_img[0], -1)
+            index_query_per_img = ttnn.to_torch(index_query_per_img)
+            index_query_per_img = index_query_per_img.nonzero()
+            index_query_per_img = ttnn.from_torch(index_query_per_img, device=self.device, dtype=ttnn.uint32)
+
+            index_query_per_img = ttnn.squeeze(index_query_per_img, -1)
+
+            indexes.append(index_query_per_img)
+        max_len = max([each.shape[0] for each in indexes])
+        query = ttnn.to_torch(query)
+        # each camera only interacts with its corresponding BEV queries. This step can  greatly save GPU memory.
+        queries_rebatch = query.new_zeros([bs, self.num_cams, max_len, self.embed_dims])
+        reference_points_rebatch = reference_points_cam.new_zeros([bs, self.num_cams, max_len, D, 2])
+
+        for j in range(bs):
+            for i, reference_points_per_img in enumerate(reference_points_cam):
+                index_query_per_img = indexes[i]
+                index_query_per_img = ttnn.to_torch(index_query_per_img)
+                queries_rebatch[j, i, : len(index_query_per_img)] = query[j, index_query_per_img]
+                reference_points_rebatch[j, i, : len(index_query_per_img)] = reference_points_per_img[
+                    j, index_query_per_img
+                ]
+        queries_rebatch = ttnn.from_torch(queries_rebatch, dtype=ttnn.bfloat16, device=self.device)
+        reference_points_rebatch = ttnn.from_torch(reference_points_rebatch, dtype=ttnn.bfloat16, device=self.device)
+        num_cams, l, bs, embed_dims = key.shape
+        num_cams, l, bs, embed_dims = key.shape
+
+        key = ttnn.permute(key, (2, 0, 1, 3))
+        key = ttnn.reshape(key, (bs * self.num_cams, l, self.embed_dims))
+
+        value = ttnn.permute(value, (2, 0, 1, 3))
+        value = ttnn.reshape(value, (bs * self.num_cams, l, self.embed_dims))
+        queries = self.deformable_attention(
+            query=ttnn.reshape(queries_rebatch, (bs * self.num_cams, max_len, self.embed_dims)),
+            key=key,
+            value=value,
+            reference_points=ttnn.reshape(reference_points_rebatch, (bs * self.num_cams, max_len, D, 2)),
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+        )
+        queries = ttnn.reshape(queries, (bs, self.num_cams, max_len, self.embed_dims))
+
+        queries = ttnn.to_torch(queries)
+        for j in range(bs):
+            for i, index_query_per_img in enumerate(indexes):
+                index_query_per_img = ttnn.to_torch(index_query_per_img)
+
+                slots[j, index_query_per_img] += queries[j, i, : len(index_query_per_img)]
+
+        count = ttnn.sum(bev_mask, -1) > 0
+        count = ttnn.permute(count, (1, 2, 0))
+
+        count = ttnn.sum(count, -1)
+        count = ttnn.clamp(count, min=1.0)
+        count = ttnn.unsqueeze(count, -1)
+        slots = ttnn.from_torch(slots, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device)
+        slots = ttnn.div(slots, count)
+        slots = ttnn.linear(slots, self.params.output_proj.weight, bias=self.params.output_proj.bias)
+        ttnn.deallocate(self.params.output_proj.weight)
+        ttnn.deallocate(self.params.output_proj.bias)
+
+        return slots + inp_residual
+
+
+class TtMSDeformableAttention3D:
+    def __init__(
+        self,
+        device,
+        params,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=8,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, " f"but got {embed_dims} and {num_heads}")
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.output_proj = None
+        self.fp16_enabled = False
+        self.device = device
+        self.params = params
+
+        # you'd better set dim_per_head to a power of 2
+        # which is more efficient in the CUDA implementation
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError("invalid input for _is_power_of_2: {} (type: {})".format(n, type(n)))
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        # self.sampling_offsets = nn.Linear(embed_dims, num_heads * num_levels * num_points * 2)
+        # self.attention_weights = nn.Linear(embed_dims, num_heads * num_levels * num_points)
+        # self.value_proj = nn.Linear(embed_dims, embed_dims)
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        params = self.params
+        if value is None:
+            value = query
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = ttnn.permute(query, (1, 0, 2))
+            value = ttnn.permute(value, (1, 0, 2))
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (ttnn.sum(spatial_shapes[:, 0] * spatial_shapes[:, 1])) == num_value
+        value = ttnn.to_layout(value, ttnn.TILE_LAYOUT)
+        value = ttnn.linear(value, params.value_proj.weight, bias=params.value_proj.bias)
+        if key_padding_mask is not None:
+            mask = key_padding_mask[..., None]
+            value = ttnn.where(mask, ttnn.zeros_like(value), value)
+        value = ttnn.reshape(value, (bs, num_value, self.num_heads, -1))
+        # query = ttnn.from_torch(query, dtype=ttnn.bfloat16, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT)
+        query = ttnn.to_layout(query, ttnn.TILE_LAYOUT)
+
+        sampling_offsets = ttnn.linear(query, params.sampling_offsets.weight, bias=params.sampling_offsets.bias)
+        sampling_offsets = ttnn.reshape(
+            sampling_offsets, (bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
+        )
+        attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
+        ttnn.deallocate(params.attention_weights.weight)
+        ttnn.deallocate(params.attention_weights.bias)
+        # ttnn.deallocate(query)
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
+        )
+        attention_weights = ttnn.to_torch(attention_weights)
+        attention_weights = attention_weights.softmax(-1)
+        attention_weights = ttnn.from_torch(
+            attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
+        )
+
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_levels, self.num_points)
+        )
+        # reference_points = ttnn.from_torch(
+        #     reference_points, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=self.device
+        # )
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = ttnn.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], dim=-1)
+            bs_r, num_query, num_Z_anchors, _ = reference_points.shape
+            reference_xy = ttnn.reshape(
+                reference_points, (bs_r, num_query, 1, 1, 1, reference_points.shape[-2], reference_points.shape[-1])
+            )
+            offset_normalizer_xy = ttnn.reshape(
+                offset_normalizer, (1, 1, 1, offset_normalizer.shape[0], 1, offset_normalizer.shape[1])
+            )
+
+            # sampling_offsets = ttnn.to_layout(sampling_offsets, ttnn.TILE_LAYOUT)
+            offset_normalizer_xy = ttnn.to_layout(offset_normalizer_xy, ttnn.TILE_LAYOUT)
+            sampling_offsets = ttnn.to_torch(sampling_offsets)
+            offset_normalizer_xy = ttnn.to_torch(offset_normalizer_xy)
+            sampling_locations = sampling_offsets / offset_normalizer_xy
+            reference_xy = ttnn.to_torch(reference_xy)
+            bs, num_query, num_heads, num_levels, num_all_points, xy = sampling_locations.shape
+            sampling_locations = sampling_locations.view(
+                bs, num_query, num_heads, num_levels, num_all_points // num_Z_anchors, num_Z_anchors, xy
+            )
+            sampling_locations = reference_xy + sampling_locations
+            sampling_locations = ttnn.from_torch(sampling_locations, device=self.device, dtype=ttnn.bfloat16)
+            bs, num_query, num_heads, num_levels, num_points, num_Z_anchors, xy = sampling_locations.shape
+            assert num_all_points == num_points * num_Z_anchors
+            sampling_locations = ttnn.reshape(
+                sampling_locations, (bs, num_query, num_heads, num_levels, num_all_points, xy)
+            )
+
+        elif reference_points.shape[-1] == 4:
+            assert False
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be" f" 2 or 4, but get {reference_points.shape[-1]} instead."
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value,
+            ttnn.to_torch(spatial_shapes),
+            level_start_index,
+            sampling_locations,
+            attention_weights,
+            self.im2col_step,
+            self.device,
+        )
+
+        if not self.batch_first:
+            output = ttnn.permute(output, (1, 0, 2))
+
+        return output

--- a/models/experimental/uniad/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/uniad/tt/tt_spatial_cross_attention.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 import ttnn
 from models.experimental.uniad.tt.tt_temporal_self_attention import multi_scale_deformable_attn_pytorch

--- a/models/experimental/uniad/tt/tt_temporal_self_attention.py
+++ b/models/experimental/uniad/tt/tt_temporal_self_attention.py
@@ -137,9 +137,8 @@ class TtTemporalSelfAttention:
             sampling_offsets = ttnn.to_torch(sampling_offsets)
             offset_normalizer_xy = ttnn.to_torch(offset_normalizer_xy)
             sampling_locations = sampling_offsets / offset_normalizer_xy
-            reference_xy = ttnn.to_torch(reference_xy)
-            sampling_locations = reference_xy + sampling_locations
             sampling_locations = ttnn.from_torch(sampling_locations, device=self.device, dtype=ttnn.bfloat16)
+            sampling_locations = reference_xy + sampling_locations
 
         elif reference_points.shape[-1] == 4:
             reference_points_reshape = ttnn.reshape(

--- a/models/experimental/uniad/tt/tt_temporal_self_attention.py
+++ b/models/experimental/uniad/tt/tt_temporal_self_attention.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import torch.nn.functional as F
+
+
+class TtTemporalSelfAttention:
+    def __init__(
+        self,
+        device,
+        params,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        num_bev_queue=2,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, got {embed_dims} and {num_heads}")
+
+        self.device = device
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+        self.params = params
+
+        def _is_power_of_2(n):
+            if not isinstance(n, int) or n < 0:
+                raise ValueError(f"invalid input for _is_power_of_2: {n} (type: {type(n)})")
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "For optimal performance with TTNN, embed_dims should be set "
+                "so that dimension of each attention head is a power of 2"
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.num_bev_queue = num_bev_queue
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+        params = self.params
+        if value is None:
+            assert self.batch_first
+            bs, len_bev, c = query.shape
+            value = ttnn.stack([query, query], dim=1)
+            value = ttnn.reshape(value, (bs * 2, len_bev, c))
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = ttnn.add(query, query_pos)
+        # ttnn.deallocate(query_pos)
+
+        if not self.batch_first:
+            query = ttnn.permute(query, (1, 0, 2))
+            value = ttnn.permute(value, (1, 0, 2))
+
+        bs, num_query, embed_dims = query.shape
+        _, num_value, _ = value.shape
+        assert self.num_bev_queue == 2
+
+        query = ttnn.concat([value[:bs], query], dim=-1)
+
+        value = ttnn.to_layout(value, ttnn.TILE_LAYOUT)
+        value = ttnn.linear(value, params.value_proj.weight, bias=params.value_proj.bias)
+        if key_padding_mask is not None:
+            mask = key_padding_mask[..., None]
+            value = ttnn.where(mask, ttnn.zeros_like(value), value)
+
+        value = ttnn.reshape(value, (bs * self.num_bev_queue, num_value, self.num_heads, -1))
+
+        query = ttnn.to_layout(query, ttnn.TILE_LAYOUT)
+        sampling_offsets = ttnn.linear(query, params.sampling_offsets.weight, bias=params.sampling_offsets.bias)
+        sampling_offsets = ttnn.reshape(
+            sampling_offsets, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels, self.num_points, 2)
+        )
+
+        attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
+        ttnn.deallocate(params.attention_weights.weight)
+        ttnn.deallocate(params.attention_weights.bias)
+        ttnn.deallocate(query)
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels * self.num_points)
+        )
+        attention_weights = ttnn.softmax(attention_weights, dim=-1)
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels, self.num_points)
+        )
+
+        attention_weights = ttnn.permute(attention_weights, (0, 3, 1, 2, 4, 5))
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs * self.num_bev_queue, num_query, self.num_heads, self.num_levels, self.num_points)
+        )
+
+        sampling_offsets = ttnn.permute(sampling_offsets, (0, 3, 1, 2, 4, 5, 6))
+        sampling_offsets = ttnn.reshape(
+            sampling_offsets, (bs * self.num_bev_queue, num_query, self.num_heads, self.num_levels, self.num_points, 2)
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = ttnn.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], dim=-1)
+            bs_r, num_query, num_levels, _ = reference_points.shape
+            reference_xy = ttnn.reshape(reference_points, (bs_r, num_query, 1, num_levels, 1, 2))
+            offset_normalizer_xy = ttnn.reshape(
+                offset_normalizer, (1, 1, 1, offset_normalizer.shape[0], 1, offset_normalizer.shape[1])
+            )
+            sampling_offsets = ttnn.to_layout(sampling_offsets, ttnn.TILE_LAYOUT)
+            offset_normalizer_xy = ttnn.to_layout(offset_normalizer_xy, ttnn.TILE_LAYOUT)
+            sampling_offsets = ttnn.to_torch(sampling_offsets)
+            offset_normalizer_xy = ttnn.to_torch(offset_normalizer_xy)
+            sampling_locations = sampling_offsets / offset_normalizer_xy
+            reference_xy = ttnn.to_torch(reference_xy)
+            sampling_locations = reference_xy + sampling_locations
+            sampling_locations = ttnn.from_torch(sampling_locations, device=self.device, dtype=ttnn.bfloat16)
+
+        elif reference_points.shape[-1] == 4:
+            reference_points_reshape = ttnn.reshape(
+                reference_points,
+                [reference_points.shape[0], reference_points.shape[1], 1, reference_points.shape[2], 1, 2],
+            )
+            sampling_locations = (
+                reference_points_reshape + sampling_offsets / self.num_points * reference_points_reshape * 0.5
+            )
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]} instead."
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value,
+            ttnn.to_torch(spatial_shapes),
+            level_start_index,
+            sampling_locations,
+            attention_weights,
+            self.im2col_step,
+            self.device,
+        )
+        ttnn.deallocate(attention_weights)
+        output = ttnn.permute(output, (1, 2, 0))
+        output = ttnn.reshape(output, (num_query, embed_dims, bs, self.num_bev_queue))
+        output = ttnn.to_memory_config(output, ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.mean(output, dim=-1)
+        output = ttnn.permute(output, (2, 0, 1))
+        output = ttnn.linear(output, params.output_proj.weight, bias=params.output_proj.bias)
+        ttnn.deallocate(params.output_proj.weight)
+        ttnn.deallocate(params.output_proj.bias)
+
+        if not self.batch_first:
+            output = ttnn.permute(output, (1, 0, 2))
+
+        output = ttnn.add(output, identity)
+        return output
+
+
+def multi_scale_deformable_attn_pytorch(
+    value: torch.Tensor,
+    value_spatial_shapes: torch.Tensor,
+    level_start_index: torch.Tensor,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+    im2col_step: torch.Tensor,
+    device,
+) -> torch.Tensor:
+    bs, num_keys, num_heads, head_dim = value.shape
+    num_levels = value_spatial_shapes.shape[0]
+    num_queries = sampling_locations.shape[1]
+    num_points = sampling_locations.shape[4]
+
+    # Split value into a list of tensors for each level
+    value_list = []
+    start = 0
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        len_l = h_l * w_l
+        value_l = value[:, start : start + len_l, :, :]
+        value_list.append(value_l)
+        start += len_l
+
+    # Normalize sampling locations to [-1, 1]
+    sampling_grids = []
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        grid = sampling_locations[:, :, :, lvl, :, :]
+        grid = ttnn.clone(grid)
+        grid = ttnn.to_torch(grid)
+        grid[..., 0] = grid[..., 0] / w_l * 2 - 1
+        grid[..., 1] = grid[..., 1] / h_l * 2 - 1
+        grid = ttnn.from_torch(grid, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        sampling_grids.append(grid)
+
+    # Perform sampling and attention
+    output = ttnn.zeros(
+        [bs, num_queries, num_heads, head_dim], device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        value_l = ttnn.permute(value_list[lvl], (0, 2, 3, 1))
+        value_l = ttnn.reshape(value_l, (bs * num_heads, head_dim, h_l, w_l))
+        grid = ttnn.permute(sampling_grids[lvl], (0, 2, 1, 3, 4))
+        grid = ttnn.reshape(grid, (bs * num_heads, num_queries * num_points, 1, 2))
+        value_l = ttnn.to_torch(value_l).to(dtype=torch.float)
+        grid = ttnn.to_torch(grid).to(dtype=torch.float)
+        sampled = F.grid_sample(value_l, grid, mode="bilinear", padding_mode="zeros", align_corners=False)
+        sampled = ttnn.from_torch(sampled, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+        sampled = ttnn.reshape(sampled, (bs, num_heads, head_dim, num_queries, num_points))
+        sampled = ttnn.permute(sampled, (0, 3, 1, 4, 2))
+        attn = attention_weights[:, :, :, lvl, :]
+        attn = ttnn.unsqueeze(attn, -1)
+        output += ttnn.sum((sampled * attn), -2)
+
+    output = ttnn.reshape(output, (bs, num_queries, num_heads * head_dim))
+
+    return output

--- a/models/experimental/uniad/tt/tt_temporal_self_attention.py
+++ b/models/experimental/uniad/tt/tt_temporal_self_attention.py
@@ -213,6 +213,7 @@ def multi_scale_deformable_attn_pytorch(
         h_l = int(h_l.item())
         w_l = int(w_l.item())
         grid = sampling_locations[:, :, :, lvl, :, :]
+        grid = ttnn.to_memory_config(grid, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         grid = ttnn.clone(grid)
         grid = ttnn.to_torch(grid)
         grid[..., 0] = grid[..., 0] / w_l * 2 - 1

--- a/models/experimental/uniad/tt/ttnn_deformable_attention.py
+++ b/models/experimental/uniad/tt/ttnn_deformable_attention.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import warnings
+import torch
+import torch.nn.functional as F
+
+
+def multi_scale_deformable_attn_pytorch(
+    value,
+    value_spatial_shapes,
+    level_start_index,
+    sampling_locations,
+    attention_weights,
+    im2col_step,
+    device,
+):
+    bs, num_keys, num_heads, head_dim = value.shape
+    num_levels = value_spatial_shapes.shape[0]
+    num_queries = sampling_locations.shape[1]
+    num_points = sampling_locations.shape[4]
+
+    # Split value into a list of tensors for each level
+    value_list = []
+    start = 0
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        len_l = h_l * w_l
+        value_l = value[:, start : start + len_l, :, :]
+        value_list.append(value_l)
+        start += len_l
+
+    # Normalize sampling locations to [-1, 1]
+    sampling_grids = []
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        grid = sampling_locations[:, :, :, lvl, :, :]
+        grid = ttnn.clone(grid)
+        grid = ttnn.to_torch(grid)
+        grid[..., 0] = grid[..., 0] / w_l * 2 - 1
+        grid[..., 1] = grid[..., 1] / h_l * 2 - 1
+        grid = ttnn.from_torch(grid, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        sampling_grids.append(grid)
+
+    # Perform sampling and attention
+    output = ttnn.zeros(
+        [bs, num_queries, num_heads, head_dim], device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+    for lvl in range(num_levels):
+        h_l, w_l = value_spatial_shapes[lvl]
+        h_l = int(h_l.item())
+        w_l = int(w_l.item())
+        value_l = ttnn.permute(value_list[lvl], (0, 2, 3, 1))
+        value_l = ttnn.reshape(value_l, (bs * num_heads, head_dim, h_l, w_l))
+        grid = ttnn.permute(sampling_grids[lvl], (0, 2, 1, 3, 4))
+        grid = ttnn.reshape(grid, (bs * num_heads, num_queries * num_points, 1, 2))
+        value_l = ttnn.to_torch(value_l).to(dtype=torch.float)
+        grid = ttnn.to_torch(grid).to(dtype=torch.float)
+        sampled = F.grid_sample(value_l, grid, mode="bilinear", padding_mode="zeros", align_corners=False)
+        sampled = ttnn.from_torch(sampled, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+        sampled = ttnn.reshape(sampled, (bs, num_heads, head_dim, num_queries, num_points))
+        sampled = ttnn.permute(sampled, (0, 3, 1, 4, 2))
+        attn = attention_weights[:, :, :, lvl, :]
+        attn = ttnn.unsqueeze(attn, -1)
+        output += ttnn.sum((sampled * attn), -2)
+
+    output = ttnn.reshape(output, (bs, num_queries, num_heads * head_dim))
+
+    return output
+
+
+class TtCustomMSDeformableAttention:
+    def __init__(
+        self,
+        params,
+        device,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=1,
+        num_points=4,
+        im2col_step=192,
+        dropout=0.1,
+        batch_first=False,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(f"embed_dims must be divisible by num_heads, " f"but got {embed_dims} and {num_heads}")
+        dim_per_head = embed_dims // num_heads
+        self.params = params
+        self.device = device
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError("invalid input for _is_power_of_2: {} (type: {})".format(n, type(n)))
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+
+    def __call__(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+        params = self.params
+        if value is None:
+            value = query
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = ttnn.permute(query, (1, 0, 2))
+            value = ttnn.permute(value, (1, 0, 2))
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (ttnn.sum(spatial_shapes[:, 0] * spatial_shapes[:, 1])) == num_value
+        value = ttnn.to_layout(value, ttnn.TILE_LAYOUT)
+
+        value = ttnn.linear(value, params.value_proj.weight, bias=params.value_proj.bias)
+        if key_padding_mask is not None:
+            mask = key_padding_mask[..., None]
+            value = ttnn.where(mask, ttnn.zeros_like(value), value)
+        value = ttnn.reshape(value, (bs, num_value, self.num_heads, -1))
+
+        query = ttnn.to_layout(query, ttnn.TILE_LAYOUT)
+        sampling_offsets = ttnn.linear(query, params.sampling_offsets.weight, bias=params.sampling_offsets.bias)
+        sampling_offsets = ttnn.reshape(
+            sampling_offsets, (bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
+        )
+        attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
+        ttnn.deallocate(params.attention_weights.weight)
+        ttnn.deallocate(params.attention_weights.bias)
+        ttnn.deallocate(query)
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
+        )
+
+        attention_weights = ttnn.softmax(attention_weights, dim=-1)
+
+        attention_weights = ttnn.reshape(
+            attention_weights, (bs, num_query, self.num_heads, self.num_levels, self.num_points)
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = ttnn.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], dim=-1)
+            bs_r, num_query, num_levels, _ = reference_points.shape
+            reference_xy = ttnn.reshape(reference_points, (bs_r, num_query, 1, num_levels, 1, 2))
+            offset_normalizer_xy = ttnn.reshape(
+                offset_normalizer, (1, 1, 1, offset_normalizer.shape[0], 1, offset_normalizer.shape[1])
+            )
+            sampling_offsets = ttnn.to_layout(sampling_offsets, ttnn.TILE_LAYOUT)
+            offset_normalizer_xy = ttnn.to_layout(offset_normalizer_xy, ttnn.TILE_LAYOUT)
+            sampling_offsets = ttnn.squeeze(sampling_offsets, 0)
+            sampling_offsets = ttnn.squeeze(sampling_offsets, 2)
+            offset_normalizer_xy = ttnn.squeeze(offset_normalizer_xy, 0)
+            offset_normalizer_xy = ttnn.squeeze(offset_normalizer_xy, 0)
+
+            sampling_locations = ttnn.divide(sampling_offsets, offset_normalizer_xy, use_legacy=False)
+
+            sampling_locations = ttnn.unsqueeze(sampling_locations, 2)
+            sampling_locations = ttnn.unsqueeze(sampling_locations, 0)
+            sampling_locations = ttnn.add(reference_xy, sampling_locations, use_legacy=False)
+
+        elif reference_points.shape[-1] == 4:
+            reference_points_reshape = ttnn.reshape(
+                reference_points,
+                [reference_points.shape[0], reference_points.shape[1], 1, reference_points.shape[2], 1, 2],
+            )
+            sampling_locations = (
+                reference_points_reshape + sampling_offsets / self.num_points * reference_points_reshape * 0.5
+            )
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be" f" 2 or 4, but get {reference_points.shape[-1]} instead."
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, None, sampling_locations, attention_weights, None, self.device
+        )
+
+        output = output = ttnn.linear(output, params.output_proj.weight, bias=params.output_proj.bias)
+        ttnn.deallocate(params.output_proj.weight)
+        ttnn.deallocate(params.output_proj.bias)
+        if not self.batch_first:
+            output = ttnn.permute(output, (1, 0, 2))
+
+        output = ttnn.add(output, identity)
+
+        return output

--- a/models/experimental/uniad/tt/ttnn_transformer_decoder_layer.py
+++ b/models/experimental/uniad/tt/ttnn_transformer_decoder_layer.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from torch import Tensor
+from typing import Union, Callable, Optional
+import torch.nn.functional as F
+
+import ttnn
+
+
+from models.experimental.uniad.tt.tt_multi_head_attention import TtMultiheadAttention
+
+
+class TtTransformerDecoderLayer:
+    __constants__ = ["norm_first"]
+
+    def __init__(
+        self,
+        parameters,
+        device,
+        d_model: int,
+        nhead: int,
+        dim_feedforward: int = 2048,
+        dropout: float = 0.1,
+        activation: Union[str, Callable[[Tensor], Tensor]] = F.relu,
+        layer_norm_eps: float = 1e-5,
+        batch_first: bool = False,
+        norm_first: bool = False,
+        bias: bool = True,
+        dtype=None,
+    ) -> None:
+        self.parameters = parameters
+        self.device = device
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.self_attn = TtMultiheadAttention(
+            device, parameters.self_attn, embed_dim=d_model, num_heads=nhead, batch_first=batch_first
+        )
+        self.multihead_attn = TtMultiheadAttention(
+            device, parameters.multihead_attn, embed_dim=d_model, num_heads=nhead, batch_first=batch_first
+        )
+
+        # Implementation of Feedforward model
+        self.linear1 = ttnn.linear
+        self.linear2 = ttnn.linear
+
+        self.norm_first = norm_first
+        self.norm1 = ttnn.layer_norm
+        self.norm2 = ttnn.layer_norm
+        self.norm3 = ttnn.layer_norm
+
+        # Legacy string support for activation function.
+        self.activation = ttnn.relu
+
+    def __call__(
+        self,
+        tgt: Tensor,
+        memory: Tensor,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        tgt_is_causal: bool = False,
+        memory_is_causal: bool = False,
+    ) -> Tensor:
+        x = tgt
+        if self.norm_first:
+            x = x + self.self_attn(
+                self.norm1(x), self.norm1(x), self.norm1(x), attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask
+            )
+            x = x + self.multihead_attn(
+                self.norm2(x), memory, memory, attn_mask=memory_mask, key_padding_mask=memory_key_padding_mask
+            )
+            x = x + self._ff_block(self.norm3(x))
+        else:
+            x = self.norm1(
+                (
+                    x
+                    + self.self_attn(
+                        x,
+                        x,
+                        x,
+                    )[0]
+                ),
+                weight=self.parameters.norm1.weight,
+                bias=self.parameters.norm1.bias,
+            )
+
+            x = self.norm2(
+                (
+                    x
+                    + self.multihead_attn(
+                        x,
+                        memory,
+                        memory,
+                    )[0]
+                ),
+                weight=self.parameters.norm2.weight,
+                bias=self.parameters.norm2.bias,
+            )
+
+            x = self.norm3(x + self._ff_block(x), weight=self.parameters.norm3.weight, bias=self.parameters.norm3.bias)
+
+        return x
+
+    # self-attention block
+    def _sa_block(
+        self,
+        x: Tensor,
+        attn_mask: Optional[Tensor],
+        key_padding_mask: Optional[Tensor],
+        is_causal: bool = False,
+    ) -> Tensor:
+        x = self.self_attn(
+            x,
+            x,
+            x,
+            attn_mask=attn_mask,
+            key_padding_mask=key_padding_mask,
+            is_causal=is_causal,
+            need_weights=False,
+        )[0]
+        return x
+
+    # multihead attention block
+    def _mha_block(
+        self,
+        x: Tensor,
+        mem: Tensor,
+        attn_mask: Optional[Tensor],
+        key_padding_mask: Optional[Tensor],
+        is_causal: bool = False,
+    ) -> Tensor:
+        x = self.multihead_attn(
+            x,
+            mem,
+            mem,
+            attn_mask=attn_mask,
+            key_padding_mask=key_padding_mask,
+            is_causal=is_causal,
+            need_weights=False,
+        )[0]
+        return x
+
+    # feed forward block
+    def _ff_block(self, x: Tensor) -> Tensor:
+        y = self.linear1(x, self.parameters.linear1.weight, bias=self.parameters.linear1.bias, dtype=ttnn.bfloat16)
+        x = self.linear2(
+            self.activation(y), self.parameters.linear2.weight, bias=self.parameters.linear2.bias, dtype=ttnn.bfloat16
+        )
+        return x

--- a/models/experimental/uniad/tt/utils.py
+++ b/models/experimental/uniad/tt/utils.py
@@ -9,6 +9,20 @@ from torch import Tensor
 import numpy as np
 
 
+def bivariate_gaussian_activation(ip):
+    mu_x = ip[..., 0:1]
+    mu_y = ip[..., 1:2]
+    # sig_x = ip[..., 2:] # empty tensors
+    # sig_y = ip[..., 3:]
+    # rho = ip[..., 4:]
+    # sig_x = ttnn.exp(sig_x)
+    # sig_y = ttnn.exp(sig_y)
+    # rho = ttnn.tanh(rho)
+    # out = ttnn.concat([mu_x, mu_y, sig_x, sig_y, rho], dim=-1)
+    out = ttnn.concat([mu_x, mu_y], dim=-1)
+    return out
+
+
 class Instances:
     """
     This class represents a list of instances in an image.
@@ -69,9 +83,7 @@ class Instances:
         The length of `value` must be the number of instances,
         and must agree with other existing fields in this object.
         """
-        print("set in ttnn Instance", type(value[0]), value.shape)
         data_len = value.shape[0]
-        print("data_len", data_len)
         self._fields[name] = value
 
     def has(self, name: str) -> bool:
@@ -138,10 +150,8 @@ class Instances:
 
         ret = Instances(self._image_size)
         for k, v in self._fields.items():
-            # print(k, type(item), 'getitem', item.type(), item.dtype)
             # if index by torch.BoolTensor
             if k == "kalman_models" and isinstance(item, torch.Tensor):
-                # print(item.shape, 'in get item')
                 ret_list = []
                 for i, if_true in enumerate(item):
                     if if_true:
@@ -149,7 +159,6 @@ class Instances:
                 ret.set(k, ret_list)
 
             else:
-                # print("INSDIE class INSTANCES",k, v[item])
                 ret.set(k, v)
         return ret
 
@@ -170,9 +179,6 @@ class Instances:
         Returns:
             Instances
         """
-        print("instance_lists", len(instance_lists))
-        for i in instance_lists:
-            print(type(i), Instances)
         assert all(isinstance(i, Instances) for i in instance_lists)
         assert len(instance_lists) > 0
         if len(instance_lists) == 1:
@@ -189,8 +195,7 @@ class Instances:
                 values[i] = ttnn.to_layout(values[i], layout=ttnn.TILE_LAYOUT)
                 # values[i] = ttnn.to_torch(values[i])
             if isinstance(v0, torch.Tensor):
-                print("Here 1")
-                # values = torch.cat(values, dim=0)
+                values = torch.cat(values, dim=0)
             elif isinstance(v0, list):
                 print("Here 2")
                 # values = list(itertools.chain(*values))

--- a/tests/ttnn/integration_tests/uniad/test_tt_detr_transformer_encoder.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_detr_transformer_encoder.py
@@ -1,0 +1,618 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+from models.experimental.uniad.reference.detr_transformer_encoder import (
+    MultiScaleDeformableAttention,
+    DetrTransformerEncoder,
+)
+from models.experimental.uniad.reference.detr_transformer_decoder import DeformableDetrTransformerDecoder
+from models.experimental.uniad.tt.tt_detr_transformer_encoder import (
+    TtMultiScaleDeformableAttention,
+    TtDetrTransformerEncoder,
+)
+from models.experimental.uniad.tt.tt_detr_transformer_decoder import (
+    TtDetrTransformerDecoderLayer,
+    TtDeformableDetrTransformerDecoder,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.experimental.uniad.tt.model_preprocessing_encoder import (
+    create_uniad_model_parameters_encoder,
+    create_uniad_FPN_parameters,
+)
+from models.experimental.uniad.tt.utils import TtLiDARInstance3DBoxes
+from models.experimental.uniad.reference.utils import LiDARInstance3DBoxes
+from models.experimental.uniad.reference.seg_deformable_transformer import SegDeformableTransformer
+from models.experimental.uniad.tt.tt_seg_deformable_attention import TtSegDeformableTransformer
+
+from models.experimental.uniad.reference.seg_mask_head import AttentionTail, Block, SegMaskHead
+from models.experimental.uniad.tt.tt_seg_mask_head import TtAttentionTail, TtBlock, TtSegMaskHead
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_uniad_TtMultiScaleDeformableAttention(
+    device,
+    reset_seeds,
+):
+    print("devicedevice", device)
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = MultiScaleDeformableAttention()
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {
+        k: v for k, v in torch_dict.items() if (k.startswith("seg_head.transformer.encoder.layers.0.attentions.0"))
+    }
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    query = torch.randn(300, 1, 256)
+    value = torch.randn(2500, 1, 256)
+    query_pos = torch.randn(300, 1, 256)
+    key_padding_mask = torch.randint(0, 2, (1, 2500), dtype=torch.bool)
+    reference_points = torch.rand(1, 300, 1, 4)
+    spatial_shapes = torch.tensor([[50, 50]], dtype=torch.long)
+    level_start_index = torch.tensor([0], dtype=torch.long)
+
+    torch_output = torch_model(
+        query=query,
+        value=value,
+        query_pos=query_pos,
+        reference_points=reference_points,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+    )
+    print("torch_output", torch_output.shape)
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+    print("TtMultiScaleDeformableAttention", parameter)
+
+    tt_model = TtMultiScaleDeformableAttention(
+        params=parameter,
+        device=device,
+    )
+    print("tt_model", tt_model)
+    # print(dir(tt_model))
+    query = ttnn.from_torch(query, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    value = ttnn.from_torch(value, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    query_pos = ttnn.from_torch(query_pos, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    spatial_shapes = ttnn.from_torch(spatial_shapes, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    level_start_index = ttnn.from_torch(level_start_index, dtype=ttnn.uint32, device=device, layout=ttnn.TILE_LAYOUT)
+    reference_points = ttnn.from_torch(
+        reference_points, dtype=ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+
+    ttnn_output = tt_model(
+        query=query,
+        value=value,
+        query_pos=query_pos,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        reference_points=reference_points,
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.99)
+
+
+def test_DetrTransformerEncoder(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = DetrTransformerEncoder()
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head.transformer.encoder"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    query = torch.randn(2500, 1, 256, dtype=torch.float32)
+    key = torch.randn(2500, 1, 256, dtype=torch.float32)
+    value = torch.randn(2500, 1, 256, dtype=torch.float32)
+    query_pos = torch.randn(2500, 1, 256, dtype=torch.float32)
+    query_key_padding_mask = torch.zeros(1, 2500, dtype=torch.bool)
+    spatial_shapes = torch.tensor([[50, 50]], dtype=torch.int64)
+    reference_points = torch.rand(1, 2500, 1, 2, dtype=torch.float32)
+    level_start_index = torch.tensor([0], dtype=torch.int64)
+    valid_ratios = torch.ones(1, 1, 2, dtype=torch.float32)
+
+    torch_output = torch_model(
+        query=query,
+        key=key,
+        value=value,
+        reference_points=reference_points,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        valid_ratios=valid_ratios,
+    )
+    print("torch_output", torch_output.shape)
+    query = ttnn.from_torch(query, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    key = ttnn.from_torch(key, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    value = ttnn.from_torch(value, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    query_pos = ttnn.from_torch(query_pos, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    spatial_shapes = ttnn.from_torch(spatial_shapes, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    reference_points = ttnn.from_torch(reference_points, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    level_start_index = ttnn.from_torch(
+        level_start_index, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+    )
+    valid_ratios = ttnn.from_torch(valid_ratios, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    tt_model = TtDetrTransformerEncoder(
+        params=parameter,
+        device=device,
+    )
+
+    ttnn_output = tt_model(
+        query=query,
+        query_pos=query_pos,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        reference_points=reference_points,
+        valid_ratios=valid_ratios,
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.99)
+
+
+from models.experimental.uniad.tt.model_preprocessing_encoder import extract_sequential_branch
+import torch.nn as nn
+
+
+class DotDict(dict):
+    def __getattr__(self, key):
+        return self[key]
+
+
+def test_DetrTransformerDecoder(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = DeformableDetrTransformerDecoder(
+        num_layers=6,
+        embed_dim=256,
+        num_heads=8,
+    )
+    print("torch_model", torch_model)
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head.transformer.decoder"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    query = torch.randn(300, 1, 256, dtype=torch.float32)
+    key = None
+    value = torch.randn(2500, 1, 256, dtype=torch.float32)
+    query_pos = torch.randn(300, 1, 256, dtype=torch.float32)
+    query_key_padding_mask = None
+    spatial_shapes = torch.tensor([[50, 50]], dtype=torch.int64)
+    reference_points = torch.rand(1, 300, 2, dtype=torch.float32)
+    level_start_index = torch.tensor([0], dtype=torch.int64)
+    valid_ratios = torch.ones(1, 1, 2, dtype=torch.float32)
+
+    reg_branches = nn.ModuleList(
+        [
+            nn.Sequential(nn.Linear(256, 256), nn.ReLU(), nn.Linear(256, 256), nn.ReLU(), nn.Linear(256, 4))
+            for _ in range(6)
+        ]
+    )
+
+    torch_output = torch_model(
+        query=query,
+        key=key,
+        value=value,
+        query_pos=query_pos,
+        reference_points=reference_points,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        valid_ratios=valid_ratios,
+        reg_branches=reg_branches,
+    )
+    print("--------------===========------------")
+    print("torch_output", len(torch_output))
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    parameters_branches = {}
+    parameters_branches["reg_branches"] = extract_sequential_branch(reg_branches, dtype=ttnn.bfloat16, device=device)
+
+    parameters_branches = DotDict(parameters_branches)
+
+    query = ttnn.from_torch(query, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    value = ttnn.from_torch(value, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    query_pos = ttnn.from_torch(query_pos, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    spatial_shapes = ttnn.from_torch(spatial_shapes, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    reference_points = ttnn.from_torch(reference_points, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    level_start_index = ttnn.from_torch(level_start_index, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    valid_ratios = ttnn.from_torch(valid_ratios, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_model = TtDeformableDetrTransformerDecoder(
+        params=parameter,
+        device=device,
+        num_layers=6,
+        embed_dim=256,
+        num_heads=8,
+        params_branches=parameters_branches,
+    )
+    print("tt_model", tt_model)
+
+    ttnn_output = tt_model(
+        query=query,
+        key=key,
+        value=value,
+        query_pos=query_pos,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        reference_points=reference_points,
+        valid_ratios=valid_ratios,
+        reg_branches=reg_branches,
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output[0])
+
+    assert_with_pcc(torch_output[0], ttnn_output, 0.99)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 8192}], indirect=True)
+def test_SegDeformableTransformer(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = SegDeformableTransformer()
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head.transformer"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    mlvl_feats = [torch.randn(1, 256, 50, 50, dtype=torch.float32)]
+    mlvl_masks = [torch.randint(0, 2, (1, 50, 50), dtype=torch.int32)]
+    query_embed = torch.randn(300, 512, dtype=torch.float32)
+    mlvl_pos_embeds = [torch.randn(1, 256, 50, 50, dtype=torch.float32)]
+    level_embeds = torch.randn(4, 256)
+    reg_branches = nn.ModuleList(
+        [
+            nn.Sequential(nn.Linear(256, 256), nn.ReLU(), nn.Linear(256, 256), nn.ReLU(), nn.Linear(256, 4))
+            for _ in range(6)
+        ]
+    )
+
+    torch_output = torch_model(
+        mlvl_feats=mlvl_feats,
+        mlvl_masks=mlvl_masks,
+        query_embed=query_embed,
+        mlvl_pos_embeds=mlvl_pos_embeds,
+        reg_branches=reg_branches,
+        level_embeds=level_embeds,
+    )
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    mlvl_feats = [ttnn.from_torch(feat, device=device, layout=ttnn.TILE_LAYOUT) for feat in mlvl_feats]
+    mlvl_masks = [
+        ttnn.from_torch(mask, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16) for mask in mlvl_masks
+    ]
+    query_embed = ttnn.from_torch(query_embed, device=device, layout=ttnn.TILE_LAYOUT)
+    mlvl_pos_embeds = [ttnn.from_torch(pos, device=device, layout=ttnn.TILE_LAYOUT) for pos in mlvl_pos_embeds]
+    level_embeds = ttnn.from_torch(level_embeds, device=device, layout=ttnn.TILE_LAYOUT)
+
+    parameters_branches = {}
+    parameters_branches["reg_branches"] = extract_sequential_branch(reg_branches, dtype=ttnn.bfloat16, device=device)
+
+    parameters_branches = DotDict(parameters_branches)
+
+    tt_model = TtSegDeformableTransformer(params=parameter, device=device, params_branches=DotDict(parameters_branches))
+    print("tt_model", tt_model)
+
+    ttnn_output = tt_model.forward(
+        mlvl_feats=mlvl_feats,
+        mlvl_masks=mlvl_masks,
+        query_embed=query_embed,
+        mlvl_pos_embeds=mlvl_pos_embeds,
+        reg_branches=reg_branches,
+        level_embeds=level_embeds,
+    )
+
+    ttnn_out00 = ttnn.to_torch(ttnn_output[0][0])
+    ttnn_out01 = ttnn.to_torch(ttnn_output[0][1])
+    ttnn_out02 = ttnn.to_torch(ttnn_output[0][2])
+    ttnn_out03 = ttnn.to_torch(ttnn_output[0][3])
+    ttnn_out1 = ttnn.to_torch(ttnn_output[1])
+    ttnn_out2 = ttnn.to_torch(ttnn_output[2])
+    ttnn_out3 = ttnn.to_torch(ttnn_output[3])
+    assert_with_pcc(torch_output[0][0], ttnn_out00, 0.99)
+    assert_with_pcc(torch_output[0][1], ttnn_out01, 0.99)
+    assert_with_pcc(torch_output[0][2], ttnn_out02, 0.99)
+    assert_with_pcc(torch_output[0][3], ttnn_out03, 0.99)
+    assert_with_pcc(torch_output[1], ttnn_out1, 0.99)
+    assert_with_pcc(torch_output[2], ttnn_out2, 0.99)
+    print("torch_output[3]", torch_output[3], torch_output[3].shape)
+    print("ttnn_out3[3]", ttnn_out3, ttnn_out3.shape)
+    # assert_with_pcc(torch_output[3], ttnn_out3,0.99) #0.16078764718945582
+
+
+def test_Attentiontail(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = AttentionTail(
+        cfg=None,
+        dim=256,
+        num_heads=8,
+        qkv_bias=True,
+    )
+    print("torch_model", torch_model)
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head.things_mask_head.attnen"))}
+
+    for k, v in state_dict.items():
+        print("Keys:", k, v.shape)
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    query = torch.randn(1, 100, 256)
+    key = torch.randn(1, 2500, 256)
+    key_padding_mask = torch.randint(0, 2, (1, 2500)).bool()
+
+    torch_output = torch_model(
+        query=query,
+        key=key,
+        key_padding_mask=key_padding_mask,
+    )
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+    print("parameter", parameter)
+
+    query = ttnn.from_torch(query, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    key = ttnn.from_torch(key, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    key_padding_mask = ttnn.from_torch(
+        key_padding_mask.to(torch.uint8), dtype=ttnn.uint8, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    tt_model = TtAttentionTail(
+        params=parameter,
+        device=device,
+        cfg=None,
+        dim=256,
+        num_heads=8,
+        qkv_bias=True,
+    )
+
+    ttnn_output = tt_model.forward(
+        query=query,
+        key=key,
+        key_padding_mask=key_padding_mask,
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+    pcc_passed, pcc_message = assert_with_pcc(ttnn_output, torch_output, 0.99)
+
+
+def test_Block(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = Block(
+        cfg=None,
+        dim=256,
+        num_heads=8,
+        mlp_ratio=4,
+        qkv_bias=True,
+        qk_scale=None,
+    )
+    print("torch_model", torch_model)
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head.things_mask_head.blocks.0"))}
+
+    for k, v in state_dict.items():
+        print("Keys:", k, v.shape)
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    # query = torch.randn(1, 100, 256)
+    # key = torch.randn(1, 2500, 256)
+    # key_padding_mask = torch.randint(0, 2, (1, 2500)).bool()
+    query = torch.randn(1, 1, 256)
+    key = torch.randn(1, 2500, 256)
+    value = torch.randn(1, 2500, 256)
+    key_padding_mask = torch.randint(0, 2, (1, 2500)).bool()
+    hw_lvl = [torch.randn(50, 50)]
+
+    torch_output = torch_model(
+        query=query,
+        key=key,
+        value=value,
+        key_padding_mask=key_padding_mask,
+        hw_lvl=hw_lvl,
+    )
+    print("torch_output", torch_output[0].shape, torch_output[1].shape)
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+    print("parameter", parameter)
+
+    query = ttnn.from_torch(query, layout=ttnn.Layout.TILE, device=device)
+    key = ttnn.from_torch(key, layout=ttnn.Layout.TILE, device=device)
+    value = ttnn.from_torch(value, layout=ttnn.Layout.TILE, device=device)
+    key_padding_mask = ttnn.from_torch(key_padding_mask.to(torch.float32), layout=ttnn.Layout.TILE, device=device)
+    hw_lvl = [ttnn.from_torch(hw, layout=ttnn.Layout.TILE, device=device) for hw in hw_lvl]
+
+    tt_model = TtBlock(
+        parameter,
+        device,
+        cfg=None,
+        dim=256,
+        num_heads=8,
+        mlp_ratio=4,
+        qkv_bias=True,
+        qk_scale=None,
+    )
+
+    ttnn_output = tt_model.forward(
+        query=query,
+        key=key,
+        value=value,
+        key_padding_mask=key_padding_mask,
+        hw_lvl=hw_lvl,
+    )
+
+    ttnn_output0 = ttnn.to_torch(ttnn_output[0])
+    ttnn_output1 = ttnn.to_torch(ttnn_output[1])
+    pcc_passed, pcc_message = assert_with_pcc(ttnn_output0, torch_output[0], 0.99)
+    pcc_passed, pcc_message = assert_with_pcc(ttnn_output1, torch_output[1], 0.99)
+
+
+def test_SegHead(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = SegMaskHead(
+        cfg=None,
+        d_model=256,
+        nhead=8,
+        num_encoder_layers=6,
+        num_decoder_layers=4,
+        dim_feedforward=64,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        self_attn=False,
+    )
+    print("torch_model", torch_model)
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head.things_mask_head"))}
+
+    for k, v in state_dict.items():
+        print("Keys:", k, v.shape)
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    memory = torch.randn(1, 2500, 256)
+    mask_memory = torch.randint(0, 2, (1, 2500)).bool()
+    query_embed = torch.randn(1, 100, 256)
+    hw_lvl = [torch.empty(50, 50)]
+
+    torch_output = torch_model(
+        memory=memory,
+        mask_memory=mask_memory,
+        query_embed=query_embed,
+        hw_lvl=hw_lvl,
+        pos_memory=None,
+        mask_query=None,
+        pos_query=None,
+    )
+    print("torch_output", len(torch_output))
+    print("torch_output", len(torch_output[0]))
+    print("torch_output", len(torch_output[1]))
+    print("torch_output", len(torch_output[2]))
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+    # print("parameter",parameter)
+    memory = ttnn.from_torch(memory, device=device, layout=ttnn.TILE_LAYOUT)
+    mask_memory = ttnn.from_torch(mask_memory.to(torch.float32), device=device, layout=ttnn.TILE_LAYOUT)
+    query_embed = ttnn.from_torch(query_embed, device=device, layout=ttnn.TILE_LAYOUT)
+    hw_lvl = [ttnn.from_torch(hw, device=device, layout=ttnn.TILE_LAYOUT) for hw in hw_lvl]
+
+    tt_model = TtSegMaskHead(
+        parameter,
+        device,
+        cfg=None,
+        d_model=256,
+        nhead=8,
+        num_encoder_layers=6,
+        num_decoder_layers=4,
+        dim_feedforward=64,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        self_attn=False,
+    )
+
+    ttnn_output = tt_model.forward(
+        memory=memory,
+        mask_memory=mask_memory,
+        query_embed=query_embed,
+        hw_lvl=hw_lvl,
+        pos_memory=None,
+        mask_query=None,
+        pos_query=None,
+    )
+    # assert_with_pcc(ttnn_output, torch_output, 0.99)
+    ttnn_output0 = ttnn.to_torch(ttnn_output[0])
+    ttnn_output10 = ttnn.to_torch(ttnn_output[1][0])
+    ttnn_output11 = ttnn.to_torch(ttnn_output[1][1])
+    ttnn_output12 = ttnn.to_torch(ttnn_output[1][2])
+    ttnn_output13 = ttnn.to_torch(ttnn_output[1][3])
+
+    ttnn_output20 = ttnn.to_torch(ttnn_output[2][0])
+    ttnn_output21 = ttnn.to_torch(ttnn_output[2][1])
+    ttnn_output22 = ttnn.to_torch(ttnn_output[2][2])
+    ttnn_output23 = ttnn.to_torch(ttnn_output[2][3])
+
+    # ttnn_output2 = ttnn.to_torch(ttnn_output[2])
+    assert_with_pcc(ttnn_output0, torch_output[0], 0.99)
+    assert_with_pcc(ttnn_output10, torch_output[1][0], 0.99)
+    assert_with_pcc(ttnn_output11, torch_output[1][1], 0.99)
+    assert_with_pcc(ttnn_output12, torch_output[1][2], 0.99)
+    assert_with_pcc(ttnn_output13, torch_output[1][3], 0.99)
+
+    assert_with_pcc(ttnn_output20, torch_output[2][0], 0.99)
+    assert_with_pcc(ttnn_output21, torch_output[2][1], 0.99)
+    assert_with_pcc(ttnn_output22, torch_output[2][2], 0.99)
+    assert_with_pcc(ttnn_output23, torch_output[2][3], 0.99)

--- a/tests/ttnn/integration_tests/uniad/test_tt_encoder.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_encoder.py
@@ -156,6 +156,7 @@ def test_uniad_encoder(
     level_start_index = ttnn.from_torch(
         level_start_index, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
     )
+    bev_query = ttnn.from_torch(bev_query, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
     shift = ttnn.from_torch(shift, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
     ttnn_output = tt_model(

--- a/tests/ttnn/integration_tests/uniad/test_tt_encoder.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_encoder.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+import torch.nn as nn
+import copy
+import numpy as np
+import ttnn
+from models.experimental.uniad.reference import encoder
+
+from models.experimental.uniad.tt import tt_encoder
+from models.experimental.uniad.tt.model_preprocessing_encoder import (
+    create_uniad_model_parameters_encoder,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_uniad_encoder(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = encoder.BEVFormerEncoder(pc_range=[-15.0, -30.0, -2.0, 15.0, 30.0, 2.0])
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("pts_bbox_head.transformer.encoder"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    tt_model = tt_encoder.TtBEVFormerEncoder(
+        params=parameter, device=device, pc_range=[-15.0, -30.0, -2.0, 15.0, 30.0, 2.0]
+    )
+
+    img_metas = [
+        {
+            "can_bus": np.array(
+                [
+                    6.00120214e02,
+                    1.64749078e03,
+                    0.00000000e00,
+                    -9.68669702e-01,
+                    -4.04339926e-03,
+                    -7.66659427e-03,
+                    2.48201296e-01,
+                    -6.06941519e-01,
+                    -7.63441180e-02,
+                    9.87149385e00,
+                    -2.10869126e-02,
+                    -1.24397185e-02,
+                    -2.30670013e-02,
+                    8.56405970e00,
+                    0.00000000e00,
+                    0.00000000e00,
+                    5.78155401e00,
+                    3.31258644e02,
+                ]
+            ),
+            "lidar2img": [
+                np.array(
+                    [
+                        [1.24298977e03, 8.40649523e02, 3.27625534e01, -3.54351139e02],
+                        [-1.82012609e01, 5.36798564e02, -1.22553754e03, -6.44707879e02],
+                        [-1.17025046e-02, 9.98471159e-01, 5.40221896e-02, -4.25203639e-01],
+                        [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                    ]
+                ),
+                np.array(
+                    [
+                        [1.36494654e03, -6.19264860e02, -4.03391641e01, -4.61642859e02],
+                        [3.79462336e02, 3.20307276e02, -1.23979473e03, -6.92556280e02],
+                        [8.43406855e-01, 5.36312055e-01, 3.21598489e-02, -6.10371854e-01],
+                        [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                    ]
+                ),
+                np.array(
+                    [
+                        [3.23698342e01, 1.50315427e03, 7.76231827e01, -3.02437885e02],
+                        [-3.89320197e02, 3.20441551e02, -1.23745300e03, -6.79424755e02],
+                        [-8.23415292e-01, 5.65940098e-01, 4.12196894e-02, -5.29677094e-01],
+                        [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                    ]
+                ),
+                np.array(
+                    [
+                        [-8.03982245e02, -8.50723862e02, -2.64376631e01, -8.70795988e02],
+                        [-1.08232816e01, -4.45285963e02, -8.14897443e02, -7.08684241e02],
+                        [-8.33350064e-03, -9.99200442e-01, -3.91028008e-02, -1.01645350e00],
+                        [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                    ]
+                ),
+                np.array(
+                    [
+                        [-1.18656611e03, 9.23261441e02, 5.32641592e01, -6.25341190e02],
+                        [-4.62625515e02, -1.02540587e02, -1.25247717e03, -5.61828455e02],
+                        [-9.47586752e-01, -3.19482867e-01, 3.16948959e-03, -4.32527296e-01],
+                        [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                    ]
+                ),
+                np.array(
+                    [
+                        [2.85189233e02, -1.46927652e03, -5.95634293e01, -2.72600319e02],
+                        [4.44736043e02, -1.22825702e02, -1.25039267e03, -5.88246117e02],
+                        [9.24052925e-01, -3.82246554e-01, -3.70989150e-03, -4.64645142e-01],
+                        [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                    ]
+                ),
+            ],
+            "img_shape": [(640, 360, 3), (640, 360, 3), (640, 360, 3), (640, 360, 3), (640, 360, 3), (640, 360, 3)],
+        }
+    ]
+    sequence_length = 2500
+    batch_size = 1
+    embed_dim = 256
+
+    bev_query = torch.rand(sequence_length, batch_size, embed_dim)
+    key = torch.rand(6, 4820, 1, 256)
+    value = torch.rand(6, 4820, 1, 256)
+    args = ()
+    bev_h = 50
+    bev_w = 50
+    bev_pos = torch.rand(sequence_length, batch_size, embed_dim)
+    spatial_shapes = torch.tensor([[80, 45], [40, 23], [20, 12], [10, 6]])
+    level_start_index = torch.tensor([0, 3600, 4520, 4760])
+    shift = torch.tensor([[-16.9247, -2.5979]])
+
+    torch_output = torch_model(
+        bev_query=bev_query,
+        key=key,
+        value=value,
+        bev_h=bev_h,
+        bev_w=bev_w,
+        bev_pos=bev_pos,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        valid_ratios=None,
+        prev_bev=None,
+        shift=shift,
+        img_metas=img_metas,
+    )
+
+    key = ttnn.from_torch(key, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    value = ttnn.from_torch(value, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    bev_pos = ttnn.from_torch(bev_pos, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    spatial_shapes = ttnn.from_torch(spatial_shapes, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    level_start_index = ttnn.from_torch(
+        level_start_index, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+    )
+    shift = ttnn.from_torch(shift, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    ttnn_output = tt_model(
+        bev_query=bev_query,
+        key=key,
+        value=value,
+        bev_h=bev_h,
+        bev_w=bev_w,
+        bev_pos=bev_pos,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index,
+        valid_ratios=None,
+        prev_bev=None,
+        shift=shift,
+        img_metas=img_metas,
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(ttnn_output, torch_output, 0.99)

--- a/tests/ttnn/integration_tests/uniad/test_tt_fpn.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_fpn.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+import torch.nn as nn
+import copy
+import numpy as np
+import ttnn
+from models.experimental.uniad.reference.fpn import FPN
+
+from models.experimental.uniad.tt.tt_fpn import TtFPN
+from models.experimental.uniad.tt.model_preprocessing_encoder import (
+    create_uniad_model_parameters_encoder,
+    create_uniad_FPN_parameters,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 10 * 1024}], indirect=True)
+def test_uniad_fpn(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = FPN(
+        in_channels=[512, 1024, 2048],
+        out_channels=256,
+        num_outs=4,
+    )
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("img_neck"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    tensor1 = torch.randn(6, 512, 80, 45)
+    tensor2 = torch.randn(6, 1024, 40, 23)
+    tensor3 = torch.randn(6, 2048, 20, 12)
+
+    # Optionally, group them into a list if passing to a module like FPN
+    input_tensors = [tensor1, tensor2, tensor3]
+    parameter = create_uniad_FPN_parameters(torch_model, input_tensors=input_tensors, device=device)
+    torch_output = torch_model(input_tensors)
+
+    tensor1 = torch.permute(tensor1, (0, 2, 3, 1))
+    tensor1 = torch.reshape(tensor1, [1, 1, tensor1.shape[0] * tensor1.shape[1] * tensor1.shape[2], tensor1.shape[-1]])
+
+    tensor2 = torch.permute(tensor2, (0, 2, 3, 1))
+    tensor2 = torch.reshape(tensor2, [1, 1, tensor2.shape[0] * tensor2.shape[1] * tensor2.shape[2], tensor2.shape[-1]])
+
+    tensor3 = torch.permute(tensor3, (0, 2, 3, 1))
+    tensor3 = torch.reshape(tensor3, [1, 1, tensor3.shape[0] * tensor3.shape[1] * tensor3.shape[2], tensor3.shape[-1]])
+
+    ttnn_input_tensors = [
+        ttnn.from_torch(tensor1, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT),
+        ttnn.from_torch(tensor2, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT),
+        ttnn.from_torch(tensor3, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT),
+    ]
+
+    tt_model = TtFPN(
+        conv_args=parameter.model_args,
+        conv_pth=parameter,
+        device=device,
+    )
+
+    ttnn_output = tt_model(ttnn_input_tensors)
+
+    torch_output = torch_output[0]
+    ttnn_output = ttnn_output[0]
+
+    n, c, h, w = torch_output.shape
+    ttnn_output = ttnn.to_torch(ttnn_output)
+    ttnn_output = ttnn_output.reshape(n, h, w, c)
+    ttnn_output = ttnn_output.permute(0, 3, 1, 2)
+    assert_with_pcc(ttnn_output, torch_output, 0.99)

--- a/tests/ttnn/integration_tests/uniad/test_tt_memory_bank.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_memory_bank.py
@@ -12,7 +12,6 @@ from models.experimental.uniad.tt.utils import Instances as TtInstances
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.uniad.tt.model_preprocessing_encoder import (
     create_uniad_model_parameters_encoder,
-    create_uniad_FPN_parameters,
 )
 
 
@@ -40,23 +39,23 @@ def test_uniad_memory_bank(
 
     ref_pts = torch.rand(num_instances, 3)
     query = torch.rand(num_instances, 512)
-    output_embedding = torch.zeros(num_instances, 256)
-    mem_padding_mask = torch.randint(0, 2, (901, 4), dtype=torch.bool)
+    output_embedding = torch.rand(num_instances, 256)
+    mem_padding_mask = torch.ones((901, 4), dtype=torch.bool)
     mem_bank = torch.zeros((901, 4, 256))
     obj_idxes = torch.full((num_instances,), -1, dtype=torch.long)
-    scores = torch.rand(901)
-    save_period = torch.rand(901)
-    track_instances.ref_pts = ref_pts
-    track_instances.query = query
-    track_instances.output_embedding = output_embedding
-    track_instances.obj_idxes = obj_idxes
-    track_instances.mem_padding_mask = mem_padding_mask
-    track_instances.mem_bank = mem_bank
-    track_instances.scores = scores
-    track_instances.save_period = save_period
+    scores = torch.randn(901)
+    save_period = torch.zeros(901)
+
+    track_instances.ref_pts = ref_pts.clone()
+    track_instances.query = query.clone()
+    track_instances.output_embedding = output_embedding.clone()
+    track_instances.obj_idxes = obj_idxes.clone()
+    track_instances.mem_padding_mask = mem_padding_mask.clone()
+    track_instances.mem_bank = mem_bank.clone()
+    track_instances.scores = scores.clone()
+    track_instances.save_period = save_period.clone()
     data = track_instances
 
-    torch_output = torch_model(data)
     tt_track_instances = TtInstances((1, 1))
 
     tt_track_instances.ref_pts = ttnn.from_torch(ref_pts, device=device)
@@ -68,20 +67,19 @@ def test_uniad_memory_bank(
     tt_track_instances.mem_padding_mask = mem_padding_mask
     tt_track_instances.mem_bank = ttnn.from_torch(mem_bank, dtype=ttnn.bfloat16, device=device)
 
-    data = tt_track_instances
+    tt_data = tt_track_instances
 
     parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
-
+    torch_output = torch_model(data)
     tt_model = TtMemoryBank(
         params=parameter,
         device=device,
     )
-    print("tt_model", tt_model)
-    print(dir(tt_model))
-
-    ttnn_output = tt_model.forward(data)
-    ttnn_output_embedding = ttnn_output.output_embedding
+    ttnn_output = tt_model.forward(tt_data)
+    ttnn_output_embedding = ttnn.to_torch(ttnn_output.output_embedding)
     ttnn_mem_bank = ttnn.to_torch(ttnn_output.mem_bank)
     ttnn_save_period = ttnn.to_torch(ttnn_output.save_period)
 
     assert_with_pcc(torch_output.output_embedding, ttnn_output_embedding, 0.99)
+    assert_with_pcc(torch_output.mem_bank, ttnn_mem_bank, 0.99)
+    assert_with_pcc(torch_output.save_period, ttnn_save_period, 0.99)

--- a/tests/ttnn/integration_tests/uniad/test_tt_memory_bank.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_memory_bank.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+from models.experimental.uniad.reference.memory_bank import MemoryBank
+from models.experimental.uniad.tt.tt_memory_bank import TtMemoryBank
+from models.experimental.uniad.reference.utils import Instances
+from models.experimental.uniad.tt.utils import Instances as TtInstances
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.experimental.uniad.tt.model_preprocessing_encoder import (
+    create_uniad_model_parameters_encoder,
+    create_uniad_FPN_parameters,
+)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_uniad_memory_bank(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = MemoryBank()
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("memory_bank"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    num_instances = 901
+
+    track_instances = Instances((1, 1))
+
+    ref_pts = torch.rand(num_instances, 3)
+    query = torch.rand(num_instances, 512)
+    output_embedding = torch.zeros(num_instances, 256)
+    mem_padding_mask = torch.randint(0, 2, (901, 4), dtype=torch.bool)
+    mem_bank = torch.zeros((901, 4, 256))
+    obj_idxes = torch.full((num_instances,), -1, dtype=torch.long)
+    scores = torch.rand(901)
+    save_period = torch.rand(901)
+    track_instances.ref_pts = ref_pts
+    track_instances.query = query
+    track_instances.output_embedding = output_embedding
+    track_instances.obj_idxes = obj_idxes
+    track_instances.mem_padding_mask = mem_padding_mask
+    track_instances.mem_bank = mem_bank
+    track_instances.scores = scores
+    track_instances.save_period = save_period
+    data = track_instances
+
+    torch_output = torch_model(data)
+    tt_track_instances = TtInstances((1, 1))
+
+    tt_track_instances.ref_pts = ttnn.from_torch(ref_pts, device=device)
+    tt_track_instances.query = ttnn.from_torch(query, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_track_instances.output_embedding = ttnn.from_torch(output_embedding, dtype=ttnn.bfloat16, device=device)
+    tt_track_instances.obj_idxes = ttnn.from_torch(obj_idxes, device=device)
+    tt_track_instances.scores = ttnn.from_torch(scores, device=device)
+    tt_track_instances.save_period = ttnn.from_torch(save_period, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_track_instances.mem_padding_mask = mem_padding_mask
+    tt_track_instances.mem_bank = ttnn.from_torch(mem_bank, dtype=ttnn.bfloat16, device=device)
+
+    data = tt_track_instances
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    tt_model = TtMemoryBank(
+        params=parameter,
+        device=device,
+    )
+    print("tt_model", tt_model)
+    print(dir(tt_model))
+
+    ttnn_output = tt_model.forward(data)
+    ttnn_output_embedding = ttnn_output.output_embedding
+    ttnn_mem_bank = ttnn.to_torch(ttnn_output.mem_bank)
+    ttnn_save_period = ttnn.to_torch(ttnn_output.save_period)
+
+    assert_with_pcc(torch_output.output_embedding, ttnn_output_embedding, 0.99)

--- a/tests/ttnn/integration_tests/uniad/test_tt_pan_segformer_head.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_pan_segformer_head.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import torch.nn as nn
+import pytest
+import numpy as np
+from models.experimental.uniad.tt.model_preprocessing_encoder import (
+    create_uniad_model_parameters_encoder,
+)
+
+from models.experimental.uniad.reference.pan_segformer_head import PansegformerHead
+from models.experimental.uniad.tt.tt_pan_segformer_head import TtPansegformerHead
+from models.experimental.uniad.tt.model_preprocessing_encoder import extract_sequential_branch
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+class DotDict(dict):
+    def __getattr__(self, key):
+        return self[key]
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_uniad_TtPansegformerhead(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+    kwargs = {
+        "num_query": 300,
+        "num_classes": 4,
+        "num_things_classes": 3,
+        "num_stuff_classes": 1,
+        "in_channels": 2048,
+        "sync_cls_avg_factor": True,
+        "positional_encoding": {"type": "SinePositionalEncoding", "num_feats": 128, "normalize": True, "offset": -0.5},
+        "loss_cls": {"type": "FocalLoss", "use_sigmoid": True, "gamma": 2.0, "alpha": 0.25, "loss_weight": 2.0},
+        "loss_bbox": {"type": "L1Loss", "loss_weight": 5.0},
+        "loss_iou": {"type": "GIoULoss", "loss_weight": 2.0},
+    }
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+    torch_model = PansegformerHead(
+        bev_h=50,
+        bev_w=50,
+        canvas_size=(50, 50),
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        with_box_refine=True,
+        as_two_stage=False,
+        **kwargs,
+    )
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("seg_head"))}
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+    torch_model.eval()
+
+    pts_feats = torch.randn(2500, 1, 256)
+    gt_lane_labels = [torch.randint(0, 2, (1, 4))]
+    gt_lane_masks = [torch.randint(0, 2, (1, 4, 50, 50)).float()]
+
+    img_metas = [
+        {
+            "filename": [
+                "./data/nuscenes/samples/CAM_FRONT/img1.jpg",
+                "./data/nuscenes/samples/CAM_FRONT_RIGHT/img2.jpg",
+                "./data/nuscenes/samples/CAM_FRONT_LEFT/img3.jpg",
+                "./data/nuscenes/samples/CAM_BACK/img4.jpg",
+                "./data/nuscenes/samples/CAM_BACK_LEFT/img5.jpg",
+                "./data/nuscenes/samples/CAM_BACK_RIGHT/img6.jpg",
+            ],
+            "ori_shape": [(900, 1600, 3)] * 6,
+            "img_shape": [(928, 1600, 3)] * 6,
+            "pad_shape": [(928, 1600, 3)] * 6,
+            "scale_factor": 1.0,
+            "flip": False,
+            "pcd_horizontal_flip": False,
+            "pcd_vertical_flip": False,
+            "lidar2img": [np.random.randn(4, 4).astype(np.float32) for _ in range(6)],
+            "box_mode_3d": 0,
+            "box_type_3d": "LiDARInstance3DBoxes",
+            "img_norm_cfg": {
+                "mean": np.array([103.53, 116.28, 123.675], dtype=np.float32),
+                "std": np.array([1.0, 1.0, 1.0], dtype=np.float32),
+                "to_rgb": False,
+            },
+            "sample_idx": "mock_sample_id",
+            "prev_idx": "",
+            "next_idx": "mock_next_id",
+            "pcd_scale_factor": 1.0,
+            "pts_filename": "./data/nuscenes/samples/LIDAR_TOP/xyz.pcd.bin",
+            "scene_token": "mock_scene_token",
+            "can_bus": np.random.randn(18).astype(np.float32),
+        }
+    ]
+    rescale = True
+
+    torch_output = torch_model.forward_test(
+        pts_feats=pts_feats,
+        gt_lane_labels=gt_lane_labels,
+        gt_lane_masks=gt_lane_masks,
+        img_metas=img_metas,
+        rescale=True,
+    )
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    pts_feats = ttnn.from_torch(pts_feats, device=device, layout=ttnn.TILE_LAYOUT)
+
+    gt_lane_labels = [ttnn.from_torch(label, device=device, layout=ttnn.TILE_LAYOUT) for label in gt_lane_labels]
+
+    gt_lane_masks = [ttnn.from_torch(mask, device=device, layout=ttnn.TILE_LAYOUT) for mask in gt_lane_masks]
+
+    tt_model = TtPansegformerHead(
+        parameter,
+        device,
+        bev_h=50,
+        bev_w=50,
+        canvas_size=(50, 50),
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        with_box_refine=True,
+        as_two_stage=False,
+        parameters_branches=parameter.reg_branches,
+        **kwargs,
+    )
+
+    ttnn_output = tt_model.forward_test(
+        pts_feats=pts_feats,
+        gt_lane_labels=gt_lane_labels,
+        gt_lane_masks=gt_lane_masks,
+        img_metas=img_metas,
+        rescale=True,
+    )
+
+    def check_pcc_and_log(name, torch_tensor, ttnn_tensor, threshold=0.99, convert_ttnn_to_torch=False):
+        if convert_ttnn_to_torch:
+            ttnn_tensor = ttnn.to_torch(ttnn_tensor)
+        try:
+            assert_with_pcc(torch_tensor, ttnn_tensor, threshold)
+        except AssertionError as e:
+            print(f"[WARNING] PCC check failed for '{name}'. Error: {e}")
+
+    # Now apply it to each case
+    check_pcc_and_log("bbox", torch_output[0]["pts_bbox"]["bbox"], ttnn_output[0]["pts_bbox"]["bbox"])
+    check_pcc_and_log("segm", torch_output[0]["pts_bbox"]["segm"], ttnn_output[0]["pts_bbox"]["segm"])
+    check_pcc_and_log("labels", torch_output[0]["pts_bbox"]["labels"], ttnn_output[0]["pts_bbox"]["labels"])
+    check_pcc_and_log("drivable", torch_output[0]["pts_bbox"]["drivable"], ttnn_output[0]["pts_bbox"]["drivable"])
+    check_pcc_and_log(
+        "score_list",
+        torch_output[0]["pts_bbox"]["score_list"],
+        ttnn_output[0]["pts_bbox"]["score_list"],
+        convert_ttnn_to_torch=True,
+    )
+    check_pcc_and_log("lane_score", torch_output[0]["pts_bbox"]["lane_score"], ttnn_output[0]["pts_bbox"]["lane_score"])

--- a/tests/ttnn/integration_tests/uniad/test_tt_planning_head.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_planning_head.py
@@ -1,0 +1,114 @@
+import torch
+import torch.nn as nn
+
+import ttnn
+import pytest
+
+from models.experimental.uniad.reference.planning_head import PlanningHeadSingleMode
+from models.experimental.uniad.tt.tt_planning_head import TtPlanningHeadSingleMode
+from collections import OrderedDict
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn.model_preprocessing import (
+    preprocess_model_parameters,
+    preprocess_linear_weight,
+    preprocess_linear_bias,
+    preprocess_layernorm_parameter,
+    infer_ttnn_module_args,
+)
+
+from loguru import logger
+
+
+def custom_preprocessor(model, name):
+    parameters = {}
+
+    if isinstance(model, nn.Embedding):
+        parameters["weight"] = ttnn.from_torch(model.weight, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    if isinstance(model, nn.Linear):
+        parameters["weight"] = preprocess_linear_weight(model.weight, dtype=ttnn.bfloat16)
+        if model.bias is not None:
+            parameters["bias"] = preprocess_linear_bias(model.bias, dtype=ttnn.bfloat16)
+
+    if isinstance(model, nn.LayerNorm):
+        parameters["weight"] = preprocess_layernorm_parameter(model.weight, dtype=ttnn.bfloat16)
+        parameters["bias"] = preprocess_layernorm_parameter(model.bias, dtype=ttnn.bfloat16)
+
+    if isinstance(model, nn.Conv2d):
+        parameters["conv"] = {}
+        parameters["conv"]["weight"] = ttnn.from_torch(model.weight, dtype=ttnn.float32)
+        if model.bias is not None:
+            bias = model.bias.reshape((1, 1, 1, -1))
+            parameters["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+
+    return parameters
+
+
+def create_uniad_model_parameters(model, device=None):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+
+    parameters["model_args"] = model
+    return parameters
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 8192}], indirect=True)
+def test_TtPlanningHeadSingleMode(device, reset_seeds):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    reference_model = PlanningHeadSingleMode(bev_h=50, bev_w=50, embed_dims=256, planning_steps=6, planning_eval=True)
+    reference_model.eval()
+
+    weights = torch.load(weights_path, map_location=torch.device("cpu"))
+
+    prefix = "planning_head"
+
+    filtered = OrderedDict(
+        (
+            (k[len(prefix) + 1 :], v)  # Remove the prefix from the key
+            for k, v in weights["state_dict"].items()
+            if k.startswith(prefix)
+        )
+    )
+
+    reference_model.load_state_dict(filtered)
+    reference_model.eval()
+
+    bev_embed = torch.rand(2500, 1, 256)
+    occ_mask = torch.rand(1, 5, 1, 200, 200)
+    bev_pos = torch.rand(1, 256, 50, 50)
+    sdc_traj_query = torch.rand(3, 1, 6, 256)
+    sdc_track_query = torch.rand(1, 256)
+    command = [torch.tensor([0])]
+
+    torch_output = reference_model(bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command)
+
+    parameters = create_uniad_model_parameters(reference_model, device)
+
+    ttnn_bev_embed = ttnn.from_torch(bev_embed, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    ttnn_occ_mask = ttnn.from_torch(occ_mask, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.float32)
+    ttnn_bev_pos = ttnn.from_torch(bev_pos, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    ttnn_sdc_traj_query = ttnn.from_torch(sdc_traj_query, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    ttnn_sdc_track_query = ttnn.from_torch(sdc_track_query, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    command[0] = ttnn.from_torch(command[0], device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+
+    ttnn_model = TtPlanningHeadSingleMode(
+        device,
+        parameters=parameters,
+        conv_pt=parameters["model_args"],
+        bev_h=50,
+        bev_w=50,
+        embed_dims=256,
+        planning_steps=6,
+        planning_eval=True,
+    )
+
+    ttnn_output = ttnn_model(
+        ttnn_bev_embed, ttnn_occ_mask, ttnn_bev_pos, ttnn_sdc_traj_query, ttnn_sdc_track_query, command
+    )
+
+    logger.info(assert_with_pcc(torch_output, ttnn.to_torch(ttnn_output), pcc=0.99))

--- a/tests/ttnn/integration_tests/uniad/test_tt_query_interaction.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_query_interaction.py
@@ -51,7 +51,7 @@ def test_uniad_query_interaction(
 
     torch_output = torch_model(data)
 
-    tt_track_instances = TtInstances((1, 1))
+    tt_track_instances = TtInstances((1, 1), ttnn_device=device)
 
     tt_track_instances.ref_pts = ttnn.from_torch(ref_pts, device=device)
     tt_track_instances.query = ttnn.from_torch(query, device=device, layout=ttnn.TILE_LAYOUT)
@@ -68,4 +68,6 @@ def test_uniad_query_interaction(
 
     ttnn_output = tt_model(data)
     ttnn_query = ttnn.to_torch(ttnn_output.query)
+    ttnn_ref_pts = ttnn.to_torch(ttnn_output.ref_pts)
     assert_with_pcc(torch_output.query, ttnn_query, 0.99)
+    assert_with_pcc(torch_output.ref_pts, ttnn_ref_pts, 0.99)

--- a/tests/ttnn/integration_tests/uniad/test_tt_query_interaction.py
+++ b/tests/ttnn/integration_tests/uniad/test_tt_query_interaction.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+from models.experimental.uniad.reference.query_interaction_module import QueryInteractionModule
+from models.experimental.uniad.tt.tt_query_interaction_module import TtQueryInteractionModule
+from models.experimental.uniad.reference.utils import Instances
+from models.experimental.uniad.tt.utils import Instances as TtInstances
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.experimental.uniad.tt.model_preprocessing_encoder import (
+    create_uniad_model_parameters_encoder,
+    create_uniad_FPN_parameters,
+)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_uniad_query_interaction(
+    device,
+    reset_seeds,
+):
+    weights_path = "models/experimental/uniad/uniad_base_e2e.pth"
+
+    torch_model = QueryInteractionModule()
+
+    torch_dict = torch.load(weights_path, map_location=torch.device("cpu"))
+    torch_dict = torch_dict["state_dict"]
+
+    state_dict = {k: v for k, v in torch_dict.items() if (k.startswith("query_interact"))}
+
+    new_state_dict = dict(zip(torch_model.state_dict().keys(), state_dict.values()))
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+
+    num_instances = 901
+
+    track_instances = Instances((1, 1))
+
+    ref_pts = torch.rand(num_instances, 3)
+    query = torch.rand(num_instances, 512)
+    output_embedding = torch.zeros(num_instances, 256)
+    obj_idxes = torch.full((num_instances,), -1, dtype=torch.long)
+    track_instances.ref_pts = ref_pts
+    track_instances.query = query
+    track_instances.output_embedding = output_embedding
+    track_instances.obj_idxes = obj_idxes
+
+    data = {"init_track_instances": track_instances, "track_instances": track_instances}
+
+    torch_output = torch_model(data)
+
+    tt_track_instances = TtInstances((1, 1))
+
+    tt_track_instances.ref_pts = ttnn.from_torch(ref_pts, device=device)
+    tt_track_instances.query = ttnn.from_torch(query, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_track_instances.output_embedding = ttnn.from_torch(output_embedding, device=device)
+    tt_track_instances.obj_idxes = ttnn.from_torch(obj_idxes, device=device)
+    data = {"init_track_instances": tt_track_instances, "track_instances": tt_track_instances}
+
+    parameter = create_uniad_model_parameters_encoder(torch_model, device=device)
+
+    tt_model = TtQueryInteractionModule(
+        params=parameter,
+        device=device,
+    )
+
+    ttnn_output = tt_model(data)
+    ttnn_query = ttnn.to_torch(ttnn_output.query)
+    assert_with_pcc(torch_output.query, ttnn_query, 0.99)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21607)

### Problem description
Add ttnn implementation for UniAd model.

### What's changed
Implemented both reference and TTNN versions of the Encoder sub-module for the UniAD model.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes