### PR TITLE
Move TensorAccessorArgs to Metal, update documentation to use TensorAccessor everywhere

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -108,7 +108,7 @@ void kernel_main() {
     constexpr auto args_a = TensorAccessorArgs<0>();
     const auto a = TensorAccessor(args_a, a_addr, tile_size_bytes);
 
-    constexpr auto args_b = TensorAccessorArgs<args_a.compile_time_args_skip()>();
+    constexpr auto args_b = TensorAccessorArgs<args_a.next_compile_time_args_offset()>();
     const auto b = TensorAccessor(args_b, b_addr, tile_size_bytes);
 
     // Read inputs from DRAM into circular buffers

--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -105,16 +105,11 @@ void kernel_main() {
 
     const uint32_t tile_size_bytes = get_tile_size(cb_in0);
 
-    const InterleavedAddrGenFast<true> a = {
-        .bank_base_address = a_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b
-    };
-    const InterleavedAddrGenFast<true> b = {
-        .bank_base_address = b_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b
-    };
+    constexpr auto args_a = TensorAccessorArgs<0>();
+    const auto a = TensorAccessor(args_a, a_addr, tile_size_bytes);
+
+    constexpr auto args_b = TensorAccessorArgs<args_a.compile_time_args_skip()>();
+    const auto b = TensorAccessor(args_b, b_addr, tile_size_bytes);
 
     // Read inputs from DRAM into circular buffers
     for (uint32_t i = 0; i < n_tiles; i++) {
@@ -193,11 +188,8 @@ void kernel_main() {
 
     const uint32_t tile_size_bytes = get_tile_size(cb_out);
 
-    const InterleavedAddrGenFast<true> c = {
-        .bank_base_address = c_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b
-    };
+    constexpr auto args_c = TensorAccessorArgs<0>();
+    const auto c = TensorAccessor(args_c, c_addr, tile_size_bytes);
 
     // Read outputs from circular buffers into DRAM
     for (uint32_t i = 0; i < n_tiles; i++) {
@@ -376,16 +368,21 @@ CBHandle cb_out = CreateCircularBuffer(
 Then, we compile the kernels for data movement and computation. For simplicity, this example targets a single Tensix at coordinates (0, 0). Runtime arguments are then configured for each kernel to specify their operational parameters.
 
 ```c++
+std::vector<uint32_t> reader_args;
+TensorAccessorArgs(*a).append_args(reader_args);
+TensorAccessorArgs(*b).append_args(reader_args);
 auto reader = CreateKernel(
     program,
     "path/to/reader_kernel.cpp",
     core,
-    DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_args});
+std::vector<uint32_t> writer_args;
+TensorAccessorArgs(*c).append_args(writer_args);
 auto writer = CreateKernel(
     program,
     "path/to/writer_kernel.cpp",
     core,
-    DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = writer_args});
 auto compute = CreateKernel(
     program,
     "path/to/compute_kernel.cpp",

--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -369,15 +369,15 @@ Then, we compile the kernels for data movement and computation. For simplicity, 
 
 ```c++
 std::vector<uint32_t> reader_args;
-TensorAccessorArgs(*a).append_args(reader_args);
-TensorAccessorArgs(*b).append_args(reader_args);
+TensorAccessorArgs(*a).append_to(reader_args);
+TensorAccessorArgs(*b).append_to(reader_args);
 auto reader = CreateKernel(
     program,
     "path/to/reader_kernel.cpp",
     core,
     DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_args});
 std::vector<uint32_t> writer_args;
-TensorAccessorArgs(*c).append_args(writer_args);
+TensorAccessorArgs(*c).append_to(writer_args);
 auto writer = CreateKernel(
     program,
     "path/to/writer_kernel.cpp",

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -154,7 +154,7 @@ The ``TensorAccessor`` object handles bank addressing and page size automaticall
         constexpr auto in0_args = TensorAccessorArgs<0>();
         const auto in0 = TensorAccessor(in0_args, dram_buffer_src_addr, tile_size_bytes);
 
-        constexpr auto out0_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+        constexpr auto out0_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
         const auto out0 = TensorAccessor(out0_args, dram_buffer_dst_addr, tile_size_bytes);
 
         for(uint32_t i=0;i<num_tiles;i++) {

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -116,8 +116,8 @@ Create a kernel that will copy data from DRAM to L1 and back. Since we are only 
 
     constexpr CoreCoord core = {0, 0};
     std::vector<uint32_t> compile_args;
-    TensorAccessorArgs(*input_dram_buffer).append_args(compile_args);
-    TensorAccessorArgs(*output_dram_buffer).append_args(compile_args);
+    TensorAccessorArgs(*input_dram_buffer).append_to(compile_args);
+    TensorAccessorArgs(*output_dram_buffer).append_to(compile_args);
 
     KernelHandle dram_copy_kernel_id = CreateKernel(
         program,

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -115,12 +115,15 @@ Create a kernel that will copy data from DRAM to L1 and back. Since we are only 
 .. code-block:: cpp
 
     constexpr CoreCoord core = {0, 0};
+    std::vector<uint32_t> compile_args;
+    TensorAccessorArgs(*input_dram_buffer).append_args(compile_args);
+    TensorAccessorArgs(*output_dram_buffer).append_args(compile_args);
 
     KernelHandle dram_copy_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = compile_args}
     );
 
 .. note::
@@ -135,7 +138,7 @@ Create a kernel that will copy data from DRAM to L1 and back. Since we are only 
 
 The kernel itself is simple. It takes the address and bank indices we just created. Copies data from the input DRAM buffer to the L1 buffer and then back out to the output DRAM buffer. You might notice that the kernel is using ``uint32_t`` instead of pointers for addresses. This is intended design as the DRAM is not directly addressable by the kernels. Instead, access requests are sent to the NoC (Network on Chip) and be brought to the L1 before the kernel can access it in a meaningful way. However, letting the RISC-V core directly access the L1 is not the most efficient way to move data around. Thus the L1 address is also an integer.
 
-The ``InterleavedAddrGenFast`` object handles bank addressing and page size automatically, simplifying interleaved buffer access. Data transfers are asynchronous, allowing the kernel to issue multiple requests while transfers are in progress. This improves performance by utilizing on-core resources more efficiently. In this example, we use ``noc_async_read_barrier()`` and ``noc_async_write_barrier()`` after each operation to ensure data integrity before proceeding to the next loop iteration.
+The ``TensorAccessor`` object handles bank addressing and page size automatically, simplifying interleaved or sharded buffer access. Data transfers are asynchronous, allowing the kernel to issue multiple requests while transfers are in progress. This improves performance by utilizing on-core resources more efficiently. In this example, we use ``noc_async_read_barrier()`` and ``noc_async_write_barrier()`` after each operation to ensure data integrity before proceeding to the next loop iteration.
 
 .. code-block:: cpp
 
@@ -147,17 +150,12 @@ The ``InterleavedAddrGenFast`` object handles bank addressing and page size auto
         std::uint32_t num_tiles             = get_arg_val<uint32_t>(3);
 
         const uint32_t tile_size_bytes = 32 * 32 * 2; // same tile size as in the host code
-        const InterleavedAddrGenFast<true> in0 = {
-            .bank_base_address = dram_buffer_src_addr, // The base address of the buffer
-            .page_size = tile_size_bytes,              // The size of a buffer page
-            .data_format = DataFormat::Float16_b,      // The data format of the buffer
-        };
 
-        const InterleavedAddrGenFast<true> out0 = {
-            .bank_base_address = dram_buffer_dst_addr,
-            .page_size = tile_size_bytes,
-            .data_format = DataFormat::Float16_b,
-        };
+        constexpr auto in0_args = TensorAccessorArgs<0>();
+        const auto in0 = TensorAccessor(in0_args, dram_buffer_src_addr, tile_size_bytes);
+
+        constexpr auto out0_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+        const auto out0 = TensorAccessor(out0_args, dram_buffer_dst_addr, tile_size_bytes);
 
         for(uint32_t i=0;i<num_tiles;i++) {
             noc_async_read_tile(i, in0, l1_buffer_addr);
@@ -169,7 +167,7 @@ The ``InterleavedAddrGenFast`` object handles bank addressing and page size auto
     }
 
 .. note::
-  ``InterleavedAddrGenFast`` handles address generation for tiled interleaved buffers automatically. For none tiled layouts or when manual address control is needed, use ``InterleavedAddrGen`` or calculate addresses manually. Without the helper, the kernel implementation would be:
+  ``TensorAccessor`` handles address generation for all kinds of buffers automatically. Without the helper, the kernel implementation would be:
 
   .. code-block:: cpp
 

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
@@ -169,7 +169,7 @@ To do so, the reader creates 2 interleaved address generators. Unlike on most pr
         constexpr auto in0_args = TensorAccessorArgs<0>();
         const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
 
-        constexpr auto in1_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+        constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
         const auto in1 = TensorAccessor(in1_args, in1_addr, tile_size_bytes);
 
         for (uint32_t i = 0; i < n_tiles; i++) {

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
@@ -126,15 +126,15 @@ In the previous example (DRAM loopback), we used a single kernel to perform the 
 .. code-block:: cpp
 
     std::vector<uint32_t> reader_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_args);
     auto reader = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_binary/kernels/dataflow/read_tiles.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_args});
     std::vector<uint32_t> writer_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_args);
     auto writer = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_binary/kernels/dataflow/write_tile.cpp",

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
@@ -125,16 +125,21 @@ In the previous example (DRAM loopback), we used a single kernel to perform the 
 
 .. code-block:: cpp
 
+    std::vector<uint32_t> reader_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_args);
     auto reader = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_binary/kernels/dataflow/read_tiles.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_args});
+    std::vector<uint32_t> writer_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
     auto writer = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_binary/kernels/dataflow/write_tile.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = writer_args});
     auto compute = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_binary/kernels/compute/tiles_add.cpp",
@@ -161,16 +166,11 @@ To do so, the reader creates 2 interleaved address generators. Unlike on most pr
 
         const uint32_t tile_size_bytes = get_tile_size(cb_in0);
 
-        const InterleavedAddrGenFast<true> in0 = {
-            .bank_base_address = in0_addr,
-            .page_size = tile_size_bytes,
-            .data_format = DataFormat::Float16_b,
-        };
-        const InterleavedAddrGenFast<true> in1 = {
-            .bank_base_address = in1_addr,
-            .page_size = tile_size_bytes,
-            .data_format = DataFormat::Float16_b,
-        };
+        constexpr auto in0_args = TensorAccessorArgs<0>();
+        const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
+
+        constexpr auto in1_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+        const auto in1 = TensorAccessor(in1_args, in1_addr, tile_size_bytes);
 
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_reserve_back(cb_in0, 1);
@@ -237,11 +237,8 @@ The writer kernel looks similar to the reader kernel. Instead of reading, it wri
 
         const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
-        const InterleavedAddrGenFast<true> out = {
-            .bank_base_address = out_addr,
-            .page_size = tile_size_bytes,
-            .data_format = DataFormat::Float16_b,
-        };
+        constexpr auto out_args = TensorAccessorArgs<0>();
+        const auto out = TensorAccessor(out_args, out_addr, tile_size_bytes);
 
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_wait_front(cb_out0, 1);

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
@@ -76,7 +76,7 @@ Next, create the kernels. Nothing different from the previous examples besides b
 .. code-block:: cpp
 
     std::vector<uint32_t> reader_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_args);
     KernelHandle unary_reader_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/read_tile.cpp",
@@ -84,7 +84,7 @@ Next, create the kernels. Nothing different from the previous examples besides b
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
 
     std::vector<uint32_t> writer_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_args);
     KernelHandle unary_writer_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/write_tile.cpp",

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
@@ -75,17 +75,21 @@ Next, create the kernels. Nothing different from the previous examples besides b
 
 .. code-block:: cpp
 
+    std::vector<uint32_t> reader_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
     KernelHandle unary_reader_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/read_tile.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
 
+    std::vector<uint32_t> writer_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
     KernelHandle unary_writer_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/write_tile.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_args});
     KernelHandle eltwise_sfpu_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/eltwise_sfpu/kernels/compute/eltwise_sfpu.cpp",
@@ -111,11 +115,8 @@ The reader kernel takes in the address of the source buffer and the number of ti
         constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
 
         const uint32_t tile_size_bytes = get_tile_size(cb_in0);
-        const InterleavedAddrGenFast<true> in0 = {
-            .bank_base_address = in0_addr,         // The base address of the buffer
-            .page_size = tile_size_bytes,          // The size of a buffer page
-            .data_format = DataFormat::Float16_b,  // The data format of the buffer
-        };
+        constexpr auto in0_args = TensorAccessorArgs<0>();
+        const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
 
         // Read in the data from the source buffer and write to the circular buffer
         // in a loop.
@@ -146,11 +147,8 @@ The writer kernel is the exact same as the previous example.
         const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
         // Address of the output buffer
-        const InterleavedAddrGenFast<true> out0 = {
-            .bank_base_address = c_addr,
-            .page_size = tile_size_bytes,
-            .data_format = DataFormat::Float16_b,
-        };
+        constexpr auto out0_args = TensorAccessorArgs<0>();
+        const auto out0 = TensorAccessor(out0_args, c_addr, tile_size_bytes);
 
         // Loop over all the tiles and write them to the output buffer
         for (uint32_t i = 0; i < n_tiles; i++) {

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -207,7 +207,6 @@ To support work distribution, the kernel is updated so that each core processes 
         constexpr uint32_t cb_id_out = tt::CBIndex::c_16;
 
         const uint32_t tile_bytes = get_tile_size(cb_id_out);
-        const DataFormat data_format = get_dataformat(cb_id_out);
 
         constexpr auto c_args = TensorAccessorArgs<0>();
         const auto c = TensorAccessor(c_args, dst_addr, tile_bytes);
@@ -279,9 +278,7 @@ The reader kernel is responsible for reading the input data from the DRAM buffer
         constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
 
         const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
-        const DataFormat in0_data_format = get_dataformat(cb_id_in0);
         const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
-        const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
         constexpr auto a_args = TensorAccessorArgs<0>();
         const auto a = TensorAccessor(a_args, src0_addr, in0_tile_bytes);

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -331,8 +331,8 @@ With the work distribution calculated, you can now create the kernels and set up
 
     MathFidelity math_fidelity = MathFidelity::HiFi4;  // High fidelity math for accurate results
     std::vector<uint32_t> reader_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp",
@@ -341,7 +341,7 @@ With the work distribution calculated, you can now create the kernels and set up
             .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
 
     std::vector<uint32_t> writer_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp",

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -283,7 +283,7 @@ The reader kernel is responsible for reading the input data from the DRAM buffer
         constexpr auto a_args = TensorAccessorArgs<0>();
         const auto a = TensorAccessor(a_args, src0_addr, in0_tile_bytes);
 
-        constexpr auto b_args = TensorAccessorArgs<a_args.compile_time_args_skip()>();
+        constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
         const auto b = TensorAccessor(b_args, src1_addr, in1_tile_bytes);
 
         // Loop through the output tiles assigned to this core

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -209,8 +209,8 @@ To support work distribution, the kernel is updated so that each core processes 
         const uint32_t tile_bytes = get_tile_size(cb_id_out);
         const DataFormat data_format = get_dataformat(cb_id_out);
 
-        const InterleavedAddrGenFast<true> c = {
-            .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+        constexpr auto c_args = TensorAccessorArgs<0>();
+        const auto c = TensorAccessor(c_args, dst_addr, tile_bytes);
 
         // Each core writes only its assigned tiles
         for (uint32_t i = 0; i < num_tiles; ++i) {
@@ -283,11 +283,11 @@ The reader kernel is responsible for reading the input data from the DRAM buffer
         const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
         const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-        const InterleavedAddrGenFast<true> a = {
-            .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+        constexpr auto a_args = TensorAccessorArgs<0>();
+        const auto a = TensorAccessor(a_args, src0_addr, in0_tile_bytes);
 
-        const InterleavedAddrGenFast<true> b = {
-            .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+        constexpr auto b_args = TensorAccessorArgs<a_args.compile_time_args_skip()>();
+        const auto b = TensorAccessor(b_args, src1_addr, in1_tile_bytes);
 
         // Loop through the output tiles assigned to this core
         for (uint32_t output_tile = 0; output_tile < num_output_tiles; output_tile++) {
@@ -333,19 +333,24 @@ With the work distribution calculated, you can now create the kernels and set up
 .. code-block:: cpp
 
     MathFidelity math_fidelity = MathFidelity::HiFi4;  // High fidelity math for accurate results
+    std::vector<uint32_t> reader_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp",
         all_cores,
         tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = {}});
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
 
+    std::vector<uint32_t> writer_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
         all_cores,
         tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {}});
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_args});
 
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
@@ -165,8 +165,8 @@ The matrix multiplication is performed by a pipeline of three specialized kernel
 
     // Reader kernel - reads tiles from DRAM into circular buffers
     std::vector<uint32_t> reader_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp",
@@ -175,7 +175,7 @@ The matrix multiplication is performed by a pipeline of three specialized kernel
 
     // Writer kernel - writes result tiles from circular buffer to DRAM
     std::vector<uint32_t> writer_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp",

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
@@ -221,7 +221,7 @@ maps tiles in the row-major order of the matrices in DRAM to read into the circu
         // buffers in the host code, so we can use the same address for both DRAM and CBs.
         constexpr auto s0_args = TensorAccessorArgs<0>();
         const auto s0 = TensorAccessor(s0_args, src0_addr, get_tile_size(cb_id_in0));
-        constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+        constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
         const auto s1 = TensorAccessor(s1_args, src1_addr, get_tile_size(cb_id_in1));
 
         // Loop through the dimensions of the matrices. Read them and push to the circular buffers.

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
@@ -164,18 +164,23 @@ The matrix multiplication is performed by a pipeline of three specialized kernel
 .. code-block:: cpp
 
     // Reader kernel - reads tiles from DRAM into circular buffers
+    std::vector<uint32_t> reader_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp",
         core,
-        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
 
     // Writer kernel - writes result tiles from circular buffer to DRAM
+    std::vector<uint32_t> writer_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         "tt_metal/programming_examples/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp",
         core,
-        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_args});
 
     // Compute kernel - performs matrix multiplication using the matrix engine
     MathFidelity math_fidelity = MathFidelity::HiFi4;
@@ -214,14 +219,10 @@ maps tiles in the row-major order of the matrices in DRAM to read into the circu
 
         // Declare address in which we stored the source matrices. We have set the exact same format between CBs and DRAM
         // buffers in the host code, so we can use the same address for both DRAM and CBs.
-        const InterleavedAddrGenFast<true> s0 = {
-            .bank_base_address = src0_addr,
-            .page_size = get_tile_size(cb_id_in0),
-            .data_format = get_dataformat(cb_id_in0)};
-        const InterleavedAddrGenFast<true> s1 = {
-            .bank_base_address = src1_addr,
-            .page_size = get_tile_size(cb_id_in1),
-            .data_format = get_dataformat(cb_id_in1)};
+        constexpr auto s0_args = TensorAccessorArgs<0>();
+        const auto s0 = TensorAccessor(s0_args, src0_addr, get_tile_size(cb_id_in0));
+        constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+        const auto s1 = TensorAccessor(s1_args, src1_addr, get_tile_size(cb_id_in1));
 
         // Loop through the dimensions of the matrices. Read them and push to the circular buffers.
         // Dimension names are called M, N and K. `t` in `mt` means tile.
@@ -325,11 +326,8 @@ The writer kernel consumes tiles from the output circular buffer ``cb_id_out0`` 
 
         constexpr uint32_t cb_id_out0 = 16;
 
-
-        const InterleavedAddrGenFast<true> s = {
-            .bank_base_address = dst_addr,
-            .page_size = get_tile_size(cb_id_out0),
-            .data_format = get_dataformat(cb_id_out0)};
+        constexpr auto s_args = TensorAccessorArgs<0>();
+        const auto s = TensorAccessor(s_args, dst_addr, get_tile_size(cb_id_out0));
 
         for (uint32_t mt = 0; mt < Mt; ++mt) {
             for (uint32_t nt = 0; nt < Nt; ++nt) {

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -147,11 +147,11 @@ Since each of these rows will be padded to match the size of the output tensor\'
 # Create data movement kernels
 
 ``` cpp
-bool src_is_dram = src_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
-bool pad_is_dram = pad_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
-bool dst_is_dram = dst_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
-std::vector<uint32_t> reader_compile_time_args = {(uint32_t) src_is_dram, (uint32_t) pad_is_dram};
-std::vector<uint32_t> writer_compile_time_args = {(uint32_t) dst_is_dram};
+std::vector<uint32_t> reader_compile_time_args;
+TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+TensorAccessorArgs(*pad_buffer).append_args(reader_compile_time_args);
+std::vector<uint32_t> writer_compile_time_args;
+TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
 ```
 
 We set the compile-time arguments of the respective kernel functions to be the buffer types, in order to generate the correct addresses for manipulating the data stored inside of the DRAM buffers.
@@ -220,14 +220,10 @@ Note that for this example, on the host side, we define the kernel arguments bas
 # Reader kernel function
 
 ``` cpp
-const InterleavedAddrGen<src_is_dram> s0 = {
-    .bank_base_address = src_addr,
-    .page_size = data_size_bytes
-};
-const InterleavedAddrGen<pad_is_dram> s1 = {
-    .bank_base_address = pad_addr,
-    .page_size = data_size_bytes
-};
+constexpr auto s0_args = TensorAccessorArgs<0>();
+const auto s0 = TensorAccessor(s0_args, src_addr, data_size_bytes);
+constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+const auto s1 = TensorAccessor(s1_args, pad_addr, data_size_bytes);
 ```
 
 In the reader kernel, we specify the DRAM buffer address generators for the input tensor and the buffer containing the pad value.
@@ -262,10 +258,8 @@ Using the start and end index, the kernel reads the pad value into the circular 
 # Writer kernel function
 
 ``` cpp
-const InterleavedAddrGen<dst_is_dram> s1 = {
-    .bank_base_address = dst_addr,
-    .page_size = data_size_bytes
-};
+constexpr auto s1_args = TensorAccessorArgs<0>();
+const auto s1 = TensorAccessor(s1_args, dst_addr, data_size_bytes);
 
 uint32_t dst_stick_id = start_dst_stick_id;
 for (uint32_t row_idx = 0; row_idx < num_rows_per_core; row_idx++) {

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -222,7 +222,7 @@ Note that for this example, on the host side, we define the kernel arguments bas
 ``` cpp
 constexpr auto s0_args = TensorAccessorArgs<0>();
 const auto s0 = TensorAccessor(s0_args, src_addr, data_size_bytes);
-constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
 const auto s1 = TensorAccessor(s1_args, pad_addr, data_size_bytes);
 ```
 

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -148,10 +148,10 @@ Since each of these rows will be padded to match the size of the output tensor\'
 
 ``` cpp
 std::vector<uint32_t> reader_compile_time_args;
-TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
-TensorAccessorArgs(*pad_buffer).append_args(reader_compile_time_args);
+TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+TensorAccessorArgs(*pad_buffer).append_to(reader_compile_time_args);
 std::vector<uint32_t> writer_compile_time_args;
-TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 ```
 
 We set the compile-time arguments of the respective kernel functions to be the buffer types, in order to generate the correct addresses for manipulating the data stored inside of the DRAM buffers.

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -90,7 +90,6 @@ Data will be read to the circular buffers on each core through the DRAM buffer, 
 # Configure circular buffers
 
 ``` cpp
-bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
 uint32_t input_cb_index = CBIndex::c_0;
 CircularBufferConfig input_cb_config = CircularBufferConfig(shard_size * input_unit_size, {{input_cb_index, cb_data_format}})
     .set_page_size(input_cb_index, input_unit_size);
@@ -103,9 +102,8 @@ The corresponding `CircularBuffer` objects are then allocated with this configur
 # Create data movement kernels for sharding
 
 ``` cpp
-std::vector<uint32_t> reader_compile_time_args = {
-    (std::uint32_t)input_cb_index,
-    (std::uint32_t)src_is_dram};
+std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index};
+TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
 auto reader_id = tt_metal::CreateKernel(
     program,
     "tt_metal/programming_examples/sharding/kernels/reader_sharded_rm.cpp",
@@ -147,10 +145,8 @@ For each core, the kernel function runtime arguments are set as a prerequisite f
 # Sharding kernel function
 
 ``` cpp
-const InterleavedAddrGen<src_is_dram> s0 = {
-    .bank_base_address = src_addr,
-    .page_size = stick_size
-};
+constexpr auto s0_args = TensorAccessorArgs<1>();
+const auto s0 = TensorAccessor(s1_args, src_addr, stick_size);
 uint32_t stick_id = start_id;
 cb_reserve_back(cb_id_in0, shard_height);
 uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
@@ -169,7 +165,7 @@ noc_async_read_barrier();
 cb_push_back(cb_id_in0, shard_height);
 ```
 
-The `InterleavedAddrGen` object allows us to retrieve the data stored in the DRAM by incrementing by stick size. The stick size determines the difference between addresses of each piece of source data in the DRAM buffer; its value in this case is the size of a `uint32_t` data type.
+The `TensorAccessor` object allows us to retrieve the data stored in the DRAM by incrementing by stick size. The stick size determines the difference between addresses of each piece of source data in the DRAM buffer; its value in this case is the size of a `uint32_t` data type.
 Each stick will then contain 2 of the BFloat16 tensor values. The generator is used to ensure that the correct address is read from the DRAM buffer into a given core\'s L1 memory.
 
 In the indicated kernel function file, we call `cb_reserve_back` for the indicated circular buffer in order to wait for space of the specified data segment size to be free, then load the data into the circular buffer by reading the value from the NoC address (indicated by `src_noc_addr`) to the L1 memory address (indicated by `l1_write_addr`).

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -103,7 +103,7 @@ The corresponding `CircularBuffer` objects are then allocated with this configur
 
 ``` cpp
 std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index};
-TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 auto reader_id = tt_metal::CreateKernel(
     program,
     "tt_metal/programming_examples/sharding/kernels/reader_sharded_rm.cpp",

--- a/tech_reports/tensor_accessor/tensor_accessor.md
+++ b/tech_reports/tensor_accessor/tensor_accessor.md
@@ -62,9 +62,9 @@ auto args = TensorAccessorArgs<base_idx_cta, base_idx_crta>();
 // runtime base index can be a runtime variable too:
 auto args = TensorAccessorArgs<base_idx_cta>(base_idx_crta);
 
-constexpr uint32_t new_base_idx_cta = base_idx_cta + args.compile_time_args_skip();
+constexpr uint32_t new_base_idx_cta = args.next_compile_time_args_offset();
 // new_base_idx_crta might be constexpr if rank and number of banks are static
-uint32_t new_base_idx_crta = base_idx_crta + args.runtime_args_skip();
+uint32_t new_base_idx_crta = args.next_common_runtime_args_offset();
 
 // Create a TensorAccessor with runtime page size
 auto tensor_accessor = TensorAccessor(args, bank_base_address, page_size);

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -154,8 +154,8 @@ Program create_simple_datamovement_program(
     constexpr CoreCoord core = {0, 0};
 
     std::vector<uint32_t> compile_time_args;
-    TensorAccessorArgs(input).append_args(compile_time_args);
-    TensorAccessorArgs(output).append_args(compile_time_args);
+    TensorAccessorArgs(input).append_to(compile_time_args);
+    TensorAccessorArgs(output).append_to(compile_time_args);
     KernelHandle dram_copy_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "gtest/gtest.h"
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
@@ -152,11 +153,17 @@ Program create_simple_datamovement_program(
     IDevice* device = input.device();
     constexpr CoreCoord core = {0, 0};
 
+    std::vector<uint32_t> compile_time_args;
+    TensorAccessorArgs(input).append_args(compile_time_args);
+    TensorAccessorArgs(output).append_args(compile_time_args);
     KernelHandle dram_copy_kernel_id = CreateKernel(
         program,
         "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
 
     // Since all interleaved buffers have size == page_size, they are entirely contained in the first DRAM bank
     const uint32_t input_bank_id = 0;

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -111,8 +111,8 @@ int main(int argc, char** argv) {
             constexpr CoreCoord core = {0, 0};
 
             std::vector<uint32_t> compile_time_args;
-            TensorAccessorArgs(*input_dram_buffer).append_args(compile_time_args);
-            TensorAccessorArgs(*output_dram_buffer).append_args(compile_time_args);
+            TensorAccessorArgs(*input_dram_buffer).append_to(compile_time_args);
+            TensorAccessorArgs(*output_dram_buffer).append_to(compile_time_args);
             KernelHandle dram_copy_kernel_id = CreateKernel(
                 program,
                 "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 
@@ -79,16 +80,6 @@ int main(int argc, char** argv) {
             * Setup program and command queue to execute along with its buffers and kernels to use
             */
             CommandQueue& cq = device->command_queue();
-            Program program = CreateProgram();
-
-            constexpr CoreCoord core = {0, 0};
-
-            KernelHandle dram_copy_kernel_id = CreateKernel(
-                program,
-                "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
-                core,
-                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}
-            );
 
             constexpr uint32_t single_tile_size = 2 * (32 * 32);
             constexpr uint32_t num_tiles = 50;
@@ -114,6 +105,22 @@ int main(int argc, char** argv) {
 
             auto output_dram_buffer = CreateBuffer(dram_config);
             const uint32_t output_dram_buffer_addr = output_dram_buffer->address();
+
+            Program program = CreateProgram();
+
+            constexpr CoreCoord core = {0, 0};
+
+            std::vector<uint32_t> compile_time_args;
+            TensorAccessorArgs(*input_dram_buffer).append_args(compile_time_args);
+            TensorAccessorArgs(*output_dram_buffer).append_args(compile_time_args);
+            KernelHandle dram_copy_kernel_id = CreateKernel(
+                program,
+                "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
+                core,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = NOC::RISCV_0_default,
+                    .compile_args = compile_time_args});
 
             /*
             * Create input data and runtime arguments, then execute

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local.cpp
@@ -18,14 +18,12 @@ void kernel_main() {
     uint32_t num_cores = get_arg_val<uint32_t>(3);
     uint32_t num_shards = get_arg_val<uint32_t>(4);
 
-    auto args_src = make_tensor_accessor_args<1, 0>();
-    constexpr uint32_t base_idx_cta_src = 1 + args_src.compile_time_args_skip();
-    constexpr uint32_t base_idx_crta_src = args_src.runtime_args_skip();
+    auto args_src = TensorAccessorArgs<1, 0>();
+    auto args_dst =
+        TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
 
-    auto args_dst = make_tensor_accessor_args<base_idx_cta_src, base_idx_crta_src>();
-
-    auto tensor_accessor_src = make_tensor_accessor_from_args(args_src, input_base_address, page_size);
-    auto tensor_accessor_dst = make_tensor_accessor_from_args(args_dst, output_base_address, page_size);
+    auto tensor_accessor_src = TensorAccessor(args_src, input_base_address, page_size);
+    auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address, page_size);
 
     for (uint32_t i = 0; i < num_shards; ++i) {
         uint32_t shard_id = first_shard_id + i * num_cores;

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_reshard.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_reshard.cpp
@@ -7,8 +7,8 @@
 
 void kernel_main() {
     auto args = TensorAccessorArgs<0, 0>();
-    constexpr uint32_t base_idx_cta = args.compile_time_args_skip();
-    uint32_t base_idx_crta = args.runtime_args_skip();
+    constexpr uint32_t base_idx_cta = args.next_compile_time_args_offset();
+    uint32_t base_idx_crta = args.next_common_runtime_args_offset();
 
     constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
     constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_reshard.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_reshard.cpp
@@ -7,8 +7,8 @@
 
 void kernel_main() {
     auto args = TensorAccessorArgs<0, 0>();
-    constexpr uint32_t base_idx_cta = args.compile_time_args_skip();
-    uint32_t base_idx_crta = args.runtime_args_skip();
+    constexpr uint32_t base_idx_cta = args.next_compile_time_args_offset();
+    uint32_t base_idx_crta = args.next_common_runtime_args_offset();
 
     constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
     constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 
-#include <ttnn/tensor/tensor_accessor_args.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace accessor_benchmarks {
 

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 
-#include <ttnn/tensor/tensor_accessor_args.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 // Defines to include tt_metal/hw/inc/accessor/tensor_accessor.h but won't need these
 #if !(defined(KERNEL_BUILD) || defined(FW_BUILD))

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -156,8 +156,8 @@ static void test_multi_core_copy(const CopyParams& params, tt::tt_metal::distrib
     const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
 
     std::vector<uint32_t> compile_time_args{aligned_page_size};
-    input_accessor_args.append_args(compile_time_args);
-    output_accessor_args.append_args(compile_time_args);
+    input_accessor_args.append_to(compile_time_args);
+    output_accessor_args.append_to(compile_time_args);
 
     KernelHandle kernel_id = CreateKernel(
         program,

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -16,9 +16,9 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/tensor/tensor_accessor_args.hpp"
 
 namespace tensor_accessor_device_tests {
 

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer.hpp>
+#include <hostdevcommon/tensor_accessor/arg_config.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace tt::tt_metal {
+
+class TensorAccessorArgs {
+public:
+    explicit TensorAccessorArgs(
+        const Buffer& buffer, tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
+
+    void append_args(std::vector<uint32_t>& compile_time_args) const;
+    void append_args(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
+
+    std::vector<uint32_t> get_compile_time_args() const;
+    std::vector<uint32_t> get_common_runtime_args() const;
+
+private:
+    const Buffer* buffer_ = nullptr;
+    tensor_accessor::ArgsConfig args_config_ = tensor_accessor::ArgConfig::None;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -23,6 +23,8 @@ public:
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;
 
+    static constexpr size_t MAX_NUM_DIMENSIONS = 8;
+
 private:
     const Buffer* buffer_ = nullptr;
     tensor_accessor::ArgsConfig args_config_ = tensor_accessor::ArgConfig::None;

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -17,8 +17,8 @@ public:
     explicit TensorAccessorArgs(
         const Buffer& buffer, tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
 
-    void append_args(std::vector<uint32_t>& compile_time_args) const;
-    void append_args(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
+    void append_to(std::vector<uint32_t>& compile_time_args) const;
+    void append_to(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
 
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;

--- a/tt_metal/hw/inc/accessor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/accessor/tensor_accessor_args.h
@@ -120,11 +120,13 @@ public:
 
     /**
      * @brief Calculates the number of compile-time arguments used when building a DistributionSpec. Note that
-     * compile_time_args_skip is required to be constexpr since cta argument index must be constexpr
+     * num_compile_time_args is required to be constexpr since cta argument index must be constexpr
      *
      * @return constexpr uint32_t Number of compile-time arguments used by the DistributionSpec.
      */
-    static constexpr uint32_t compile_time_args_skip() { return NumArgsCT; }
+    static constexpr uint32_t num_compile_time_args() { return NumArgsCT; }
+
+    static constexpr uint32_t next_compile_time_args_offset() { return CTA_OFFSET + num_compile_time_args(); }
 
     /**
      * @brief Calculates the number of common runtime arguments used when building a DistributionSpec.
@@ -132,10 +134,12 @@ public:
      *
      * @return constexpr uint32_t Number of common runtime arguments used by the DistributionSpec.
      */
-    constexpr uint32_t runtime_args_skip() const {
+    constexpr uint32_t num_common_runtime_args() const {
         if constexpr (!is_sharded) {
             return 0;
         }
         return bank_coords_crta_offset() + (bank_coords_is_crta ? get_physical_num_banks() : 0) - crta_offset();
     }
+
+    constexpr uint32_t next_common_runtime_args_offset() const { return crta_offset() + num_common_runtime_args(); }
 };

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -9,6 +9,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_distribution_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_page_mapping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/tensor_accessor_args.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer_config.cpp

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -27,7 +27,10 @@ void append_sharded_args(
 
     size_t rank = tensor_shape.size();
     size_t n_banks = bank_coords.size();
-    TT_FATAL(rank <= 8, "Rank must be less than or equal to 8");
+    TT_FATAL(
+        rank <= TensorAccessorArgs::MAX_NUM_DIMENSIONS,
+        "Rank must be less than or equal to {}",
+        TensorAccessorArgs::MAX_NUM_DIMENSIONS);
 
     size_t n_args =
         add_rank + add_num_banks + rank * add_tensor_shape + rank * add_shard_shape + n_banks * add_bank_coords;

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <ttnn/tensor/tensor_accessor_args.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include <tt-metalium/device.hpp>
-#include <ttnn/tensor/types.hpp>
 
 namespace tt::tt_metal {
 
@@ -28,10 +27,7 @@ void append_sharded_args(
 
     size_t rank = tensor_shape.size();
     size_t n_banks = bank_coords.size();
-    TT_FATAL(
-        rank <= tt::tt_metal::MAX_NUM_DIMENSIONS,
-        "Rank must be less than or equal to {} for rank",
-        tt::tt_metal::MAX_NUM_DIMENSIONS);
+    TT_FATAL(rank <= 8, "Rank must be less than or equal to 8");
 
     size_t n_args =
         add_rank + add_num_banks + rank * add_tensor_shape + rank * add_shard_shape + n_banks * add_bank_coords;

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -104,7 +104,7 @@ TensorAccessorArgs::TensorAccessorArgs(const Buffer& buffer, tensor_accessor::Ar
     }
 }
 
-void TensorAccessorArgs::append_args(
+void TensorAccessorArgs::append_to(
     std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const {
     if (args_config_.test(tensor_accessor::ArgConfig::Sharded)) {
         CMAKE_UNIQUE_NAMESPACE::append_sharded_args(*buffer_, args_config_, compile_time_args, /* is_runtime */ false);
@@ -114,7 +114,7 @@ void TensorAccessorArgs::append_args(
     }
 }
 
-void TensorAccessorArgs::append_args(std::vector<uint32_t>& compile_time_args) const {
+void TensorAccessorArgs::append_to(std::vector<uint32_t>& compile_time_args) const {
     TT_FATAL(
         (args_config_ & tensor_accessor::ArgConfig::Runtime).raw() == 0,
         "Common runtime arguments are required for ArgsConfig {}",

--- a/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/reader0.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/reader0.cpp
@@ -14,15 +14,12 @@ void kernel_main() {
 
     // Compile time args
     constexpr uint32_t src0_cb_index = get_compile_time_arg_val(0);
-    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
 
     // Input data config
     const uint32_t input_data_tile_size_bytes = get_tile_size(src0_cb_index);
-    const DataFormat input_data_format = get_dataformat(src0_cb_index);
-    const InterleavedAddrGenFast<input_is_dram> interleaved_accessor = {
-        .bank_base_address = input_buffer_addr,
-        .page_size = input_data_tile_size_bytes,
-        .data_format = input_data_format};
+    constexpr auto interleaved_accessor_args = TensorAccessorArgs<1>();
+    const auto interleaved_accessor =
+        TensorAccessor(interleaved_accessor_args, input_buffer_addr, input_data_tile_size_bytes);
 
     // Constants
     constexpr uint32_t one_tile = 1;

--- a/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/writer1.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/writer1.cpp
@@ -12,18 +12,15 @@ void kernel_main() {
 
     // Compile time args
     constexpr uint32_t src1_cb_index = get_compile_time_arg_val(0);
-    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
 
     // Constants
     constexpr uint32_t one_tile = 1;
 
     // Output data config
     constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(src1_cb_index);
-    constexpr DataFormat output_tensor_data_format = get_dataformat(src1_cb_index);
-    const InterleavedAddrGenFast<output_is_dram> output_tensor_dram = {
-        .bank_base_address = output_tensor_buffer_addr,
-        .page_size = output_tensor_tile_size_bytes,
-        .data_format = output_tensor_data_format};
+    constexpr auto output_tensor_dram_args = TensorAccessorArgs<1>();
+    const auto output_tensor_dram =
+        TensorAccessor(output_tensor_dram_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
     // Wait for incoming data from reader1
     cb_wait_front(src1_cb_index, one_tile);

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -75,7 +75,7 @@ int main() {
     // Kernels setup
     // Core 0 kernels
     std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*src_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src_dram_buffer).append_to(reader_compile_time_args);
     KernelHandle core0_reader_kernel_id = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader0.cpp",
@@ -94,7 +94,7 @@ int main() {
         core1,
         tt::tt_metal::ReaderDataMovementConfig{{src0_cb_index, src1_cb_index}});
     std::vector<uint32_t> writer_compile_time_args = {src1_cb_index};
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
     KernelHandle core1_writer_kernel_id = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer1.cpp",

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -73,11 +74,13 @@ int main() {
 
     // Kernels setup
     // Core 0 kernels
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    TensorAccessorArgs(*src_dram_buffer).append_args(reader_compile_time_args);
     KernelHandle core0_reader_kernel_id = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader0.cpp",
         core0,
-        tt::tt_metal::ReaderDataMovementConfig{{src0_cb_index, static_cast<uint32_t>(input_tensor_is_dram)}});
+        tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
     KernelHandle core0_writer_kernel_id = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer0.cpp",
@@ -90,11 +93,13 @@ int main() {
         OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader1.cpp",
         core1,
         tt::tt_metal::ReaderDataMovementConfig{{src0_cb_index, src1_cb_index}});
+    std::vector<uint32_t> writer_compile_time_args = {src1_cb_index};
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
     KernelHandle core1_writer_kernel_id = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer1.cpp",
         core1,
-        tt::tt_metal::WriterDataMovementConfig{{src1_cb_index, static_cast<uint32_t>(output_tensor_is_dram)}});
+        tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
 
     // Runtime args setup
     SetRuntimeArgs(program, core0_reader_kernel_id, core0, {src_dram_buffer->address()});

--- a/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp
@@ -14,8 +14,8 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = tt::CB::c_out0;  // CBIndex::c_16
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);
-    const InterleavedAddrGenFast<true> dram_writer = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto dram_writer_args = TensorAccessorArgs<0>();
+    const auto dram_writer = TensorAccessor(dram_writer_args, dst_addr, tile_bytes);
 
     cb_wait_front(cb_id_out0, 1);
     uint32_t l1_read_addr = get_read_ptr(cb_id_out0);

--- a/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp
@@ -13,7 +13,6 @@ void kernel_main() {
     ////////// BUFFER SETUP //////////
     constexpr uint32_t cb_id_out0 = tt::CB::c_out0;  // CBIndex::c_16
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
-    const DataFormat data_format = get_dataformat(cb_id_out0);
     constexpr auto dram_writer_args = TensorAccessorArgs<0>();
     const auto dram_writer = TensorAccessor(dram_writer_args, dst_addr, tile_bytes);
 

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <cstdint>
 #include <vector>
 #include <memory>
@@ -171,9 +172,26 @@ int main(int argc, char **argv) {
         // reference for num of receivers.
         size_t num_dests = receiver_cores_logical.size();
 
+        ////////// SEMAPHORE SETUP //////////
+        uint32_t sender = CreateSemaphore(program, all_cores_logical, 0);
+        uint32_t receiver = CreateSemaphore(program, all_cores_logical, 0);
+
+        ////////// DRAM & SRAM BUFFERS SETUP //////////
+        constexpr uint32_t num_tiles = 1;
+        uint32_t dram_bank_id = 0;
+        auto src0_dram_buffer = MakeBufferBFP16(device, num_tiles, false);
+        auto output_dram_buffer = MakeBufferBFP16(device, num_dests * num_tiles, false);
+        auto cb_src0 = MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_0, num_tiles);
+        auto cb_output = MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_16, num_tiles);
+
         ////////// DATA MOVEMENT CONFIG SETUP //////////
         DataMovementConfig DataMovementConfigIn = {.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
-        DataMovementConfig DataMovementConfigOut = {.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default};
+        std::vector<uint32_t> writer_compile_time_args;
+        TensorAccessorArgs(*output_dram_buffer).append_args(writer_compile_time_args);
+        DataMovementConfig DataMovementConfigOut = {
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = writer_compile_time_args};
 
         ////////// COORDINATOR KERNEL SETUP //////////
         KernelHandle coordinator_kernel_id = CreateKernel(
@@ -210,18 +228,6 @@ int main(int argc, char **argv) {
                 .compile_args = compute_kernel_args
             }
         );
-
-        ////////// SEMAPHORE SETUP //////////
-        uint32_t sender = CreateSemaphore(program, all_cores_logical, 0);
-        uint32_t receiver = CreateSemaphore(program, all_cores_logical, 0);
-
-        ////////// DRAM & SRAM BUFFERS SETUP //////////
-        constexpr uint32_t num_tiles = 1;
-        uint32_t dram_bank_id = 0;
-        auto src0_dram_buffer = MakeBufferBFP16(device, num_tiles, false);
-        auto output_dram_buffer = MakeBufferBFP16(device, num_dests * num_tiles, false);
-        auto cb_src0 = MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_0, num_tiles);
-        auto cb_output = MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_16, num_tiles);
 
         ////////// IDENTITY MATRIX TILE SETUP //////////
         std::vector<bfloat16> identity_tile = create_identity_matrix(TILE_WIDTH, TILE_HEIGHT, TILE_WIDTH);

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
         ////////// DATA MOVEMENT CONFIG SETUP //////////
         DataMovementConfig DataMovementConfigIn = {.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
         std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*output_dram_buffer).append_args(writer_compile_time_args);
+        TensorAccessorArgs(*output_dram_buffer).append_to(writer_compile_time_args);
         DataMovementConfig DataMovementConfigOut = {
             .processor = DataMovementProcessor::RISCV_1,
             .noc = NOC::RISCV_1_default,

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/interleaved_tile_read.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/interleaved_tile_read.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     // easy. But may not be the most efficient way to do it in all cases.
     constexpr auto a_args = TensorAccessorArgs<0>();
     const auto a = TensorAccessor(a_args, a_addr, tile_size_bytes);
-    constexpr auto b_args = TensorAccessorArgs<a_args.compile_time_args_skip()>();
+    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
     const auto b = TensorAccessor(b_args, b_addr, tile_size_bytes);
 
     // Now we loop over all the tiles and read them into the circular buffers

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/interleaved_tile_read.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/interleaved_tile_read.cpp
@@ -24,16 +24,10 @@ void kernel_main() {
     // Setting the page size to be tile_size_bytes works because we set it up
     // explicitly in host code. This is usually a good idea as it makes coding
     // easy. But may not be the most efficient way to do it in all cases.
-    const InterleavedAddrGenFast<true> a = {
-        .bank_base_address = a_addr,           // The base address of the buffer
-        .page_size = tile_size_bytes,          // The size of a buffer page
-        .data_format = DataFormat::Float16_b,  // The data format of the buffer
-    };
-    const InterleavedAddrGenFast<true> b = {
-        .bank_base_address = b_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto a_args = TensorAccessorArgs<0>();
+    const auto a = TensorAccessor(a_args, a_addr, tile_size_bytes);
+    constexpr auto b_args = TensorAccessorArgs<a_args.compile_time_args_skip()>();
+    const auto b = TensorAccessor(b_args, b_addr, tile_size_bytes);
 
     // Now we loop over all the tiles and read them into the circular buffers
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/tile_write.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/tile_write.cpp
@@ -13,11 +13,8 @@ void kernel_main() {
     const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
     // Address generator for the output buffer. This is faster than doing plain DRAM writes.
-    const InterleavedAddrGenFast<true> c = {
-        .bank_base_address = c_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto c_args = TensorAccessorArgs<0>();
+    const auto c = TensorAccessor(c_args, c_addr, tile_size_bytes);
 
     // Loop over all the tiles and write them to the output buffer
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -141,16 +142,27 @@ int main(int argc, char** argv) {
     // into 2 circular buffers. `add` reads tiles from the circular buffers, adds them together, and dumps the result
     // into a third circular buffer. `tile_write` reads tiles from the third circular buffer and writes them to the
     // output buffer C.
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*a).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*b).append_args(reader_compile_time_args);
     auto reader = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/interleaved_tile_read.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = reader_compile_time_args});
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*c).append_args(writer_compile_time_args);
     auto writer = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/tile_write.cpp",
         core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = writer_compile_time_args});
     auto compute = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/add.cpp",

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -143,8 +143,8 @@ int main(int argc, char** argv) {
     // into a third circular buffer. `tile_write` reads tiles from the third circular buffer and writes them to the
     // output buffer C.
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*a).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*b).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*a).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*b).append_to(reader_compile_time_args);
     auto reader = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/interleaved_tile_read.cpp",
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
             .noc = NOC::RISCV_0_default,
             .compile_args = reader_compile_time_args});
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*c).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*c).append_to(writer_compile_time_args);
     auto writer = CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/tile_write.cpp",

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -110,16 +111,21 @@ int main(int argc, char** argv) {
         // These kernels work together to form a pipeline. The reader reads data from the DRAM buffer and makes them available in the
         // compute kernel. The compute kernel does math and pushes the result into the writer kernel. The writer kernel writes the result
         // back to DRAM.
+        std::vector<uint32_t> reader_compile_time_args;
+        TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
+        TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
         auto reader = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/read_tiles.cpp",
             core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_compile_time_args});
+        std::vector<uint32_t> writer_compile_time_args;
+        TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
         auto writer = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/write_tile.cpp",
             core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = writer_compile_time_args});
         auto compute = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/compute/tiles_add.cpp",

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -112,15 +112,15 @@ int main(int argc, char** argv) {
         // compute kernel. The compute kernel does math and pushes the result into the writer kernel. The writer kernel writes the result
         // back to DRAM.
         std::vector<uint32_t> reader_compile_time_args;
-        TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
-        TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
+        TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
+        TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
         auto reader = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/read_tiles.cpp",
             core,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_compile_time_args});
         std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+        TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
         auto writer = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/write_tile.cpp",

--- a/tt_metal/programming_examples/eltwise_binary/kernels/dataflow/read_tiles.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/kernels/dataflow/read_tiles.cpp
@@ -24,16 +24,10 @@ void kernel_main() {
     // Setting the page size to be tile_size_bytes works because we set it up
     // explicitly in host code. This is usually a good idea as it makes coding
     // easy.
-    const InterleavedAddrGenFast<true> in0 = {
-        .bank_base_address = in0_addr,         // The base address of the buffer
-        .page_size = tile_size_bytes,          // The size of a buffer page
-        .data_format = DataFormat::Float16_b,  // The data format of the buffer
-    };
-    const InterleavedAddrGenFast<true> in1 = {
-        .bank_base_address = in1_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+    const auto in1 = TensorAccessor(in1_args, in1_addr, tile_size_bytes);
 
     // Loop over all the tiles and read them into the circular buffers
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/eltwise_binary/kernels/dataflow/read_tiles.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/kernels/dataflow/read_tiles.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     // easy.
     constexpr auto in0_args = TensorAccessorArgs<0>();
     const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
-    constexpr auto in1_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
     const auto in1 = TensorAccessor(in1_args, in1_addr, tile_size_bytes);
 
     // Loop over all the tiles and read them into the circular buffers

--- a/tt_metal/programming_examples/eltwise_binary/kernels/dataflow/write_tile.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/kernels/dataflow/write_tile.cpp
@@ -13,11 +13,8 @@ void kernel_main() {
     const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
     // Address of the output buffer
-    const InterleavedAddrGenFast<true> out0 = {
-        .bank_base_address = c_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto out0_args = TensorAccessorArgs<0>();
+    const auto out0 = TensorAccessor(out0_args, c_addr, tile_size_bytes);
 
     // Loop over all the tiles and write them to the output buffer
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -71,7 +71,7 @@ int main() {
 
         // Create the 2 data movement kernels and the compute kernel.
         std::vector<uint32_t> reader_compile_time_args;
-        TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
+        TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
         KernelHandle unary_reader_kernel_id = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/read_tile.cpp",
@@ -82,7 +82,7 @@ int main() {
                 .compile_args = reader_compile_time_args});
 
         std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+        TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
         KernelHandle unary_writer_kernel_id = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/write_tile.cpp",

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -69,17 +70,27 @@ int main() {
         tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
         // Create the 2 data movement kernels and the compute kernel.
+        std::vector<uint32_t> reader_compile_time_args;
+        TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
         KernelHandle unary_reader_kernel_id = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/read_tile.cpp",
             core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = reader_compile_time_args});
 
+        std::vector<uint32_t> writer_compile_time_args;
+        TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
         KernelHandle unary_writer_kernel_id = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/write_tile.cpp",
             core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = writer_compile_time_args});
         KernelHandle eltwise_sfpu_kernel_id = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/compute/eltwise_sfpu.cpp",

--- a/tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/read_tile.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/read_tile.cpp
@@ -22,11 +22,8 @@ void kernel_main() {
     // Setting the page size to be tile_size_bytes works because we set it up
     // explicitly in host code. This is usually a good idea as it makes coding
     // easy.
-    const InterleavedAddrGenFast<true> in0 = {
-        .bank_base_address = in0_addr,         // The base address of the buffer
-        .page_size = tile_size_bytes,          // The size of a buffer page
-        .data_format = DataFormat::Float16_b,  // The data format of the buffer
-    };
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
 
     // Loop over all the tiles and read them into the circular buffers
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/write_tile.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/kernels/dataflow/write_tile.cpp
@@ -13,11 +13,8 @@ void kernel_main() {
     const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
     // Address of the output buffer
-    const InterleavedAddrGenFast<true> out0 = {
-        .bank_base_address = c_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto out0_args = TensorAccessorArgs<0>();
+    const auto out0 = TensorAccessor(out0_args, c_addr, tile_size_bytes);
 
     // Loop over all the tiles and write them to the output buffer
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
+++ b/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
@@ -22,17 +22,11 @@ void kernel_main() {
     // Note that this is the same as the tile size used in the host code
     // when creating the buffers.
     const uint32_t tile_size_bytes = 32 * 32 * 2;
-    const InterleavedAddrGenFast<true> in0 = {
-        .bank_base_address = dram_buffer_src_addr,  // The base address of the buffer
-        .page_size = tile_size_bytes,               // The size of a buffer page
-        .data_format = DataFormat::Float16_b,       // The data format of the buffer
-    };
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    const auto in0 = TensorAccessor(in0_args, dram_buffer_src_addr, tile_size_bytes);
 
-    const InterleavedAddrGenFast<true> out0 = {
-        .bank_base_address = dram_buffer_dst_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto out0_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+    const auto out0 = TensorAccessor(out0_args, dram_buffer_dst_addr, tile_size_bytes);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
         // Issue a read to the NoC and write to the L1 buffer. This operation is asynchronous.

--- a/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
+++ b/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
     constexpr auto in0_args = TensorAccessorArgs<0>();
     const auto in0 = TensorAccessor(in0_args, dram_buffer_src_addr, tile_size_bytes);
 
-    constexpr auto out0_args = TensorAccessorArgs<in0_args.compile_time_args_skip()>();
+    constexpr auto out0_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
     const auto out0 = TensorAccessor(out0_args, dram_buffer_dst_addr, tile_size_bytes);
 
     for (uint32_t i = 0; i < num_tiles; i++) {

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 // This example demonstrates a simple data copy from DRAM into L1(SRAM) and to another place in DRAM.
 // The general flow is as follows:
@@ -35,22 +36,6 @@ int main() {
         // In Metalium, submitting operations to the device is done through a command queue. This includes
         // uploading/downloading data to/from the device, and executing programs.
         CommandQueue& cq = device->command_queue();
-        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-        // same kernel at a given time. Metalium allows you to run different kernels on different cores
-        // simultaneously.
-        Program program = CreateProgram();
-
-        // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
-        constexpr CoreCoord core = {0, 0};
-
-        // Create the data movement kernel. This kernel will be used to copy data from DRAM to DRAM (see the
-        // `loopback_dram_copy.cpp` file for the actual implementation). The kernel is created on the Tensix core
-        // {0, 0} and uses the default NoC.
-        KernelHandle dram_copy_kernel_id = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "loopback/kernels/loopback_dram_copy.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
         // Data on Tensix is stored in tiles. A tile is a 2D array of (usually) 32x32 values. And the Tensix uses
         // BFloat16 as the most well supported data type. Thus the tile size is 32x32x2 = 2048 bytes.
@@ -76,6 +61,29 @@ int main() {
         auto l1_buffer = CreateBuffer(l1_config);
         auto input_dram_buffer = CreateBuffer(dram_config);
         auto output_dram_buffer = CreateBuffer(dram_config);
+
+        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
+        // same kernel at a given time. Metalium allows you to run different kernels on different cores
+        // simultaneously.
+        Program program = CreateProgram();
+
+        // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
+        constexpr CoreCoord core = {0, 0};
+
+        // Create the data movement kernel. This kernel will be used to copy data from DRAM to DRAM (see the
+        // `loopback_dram_copy.cpp` file for the actual implementation). The kernel is created on the Tensix core
+        // {0, 0} and uses the default NoC.
+        std::vector<uint32_t> dram_copy_compile_time_args;
+        TensorAccessorArgs(*input_dram_buffer).append_args(dram_copy_compile_time_args);
+        TensorAccessorArgs(*output_dram_buffer).append_args(dram_copy_compile_time_args);
+        KernelHandle dram_copy_kernel_id = CreateKernel(
+            program,
+            OVERRIDE_KERNEL_PREFIX "loopback/kernels/loopback_dram_copy.cpp",
+            core,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = dram_copy_compile_time_args});
 
         // Initialize the input buffer with random data.
         std::vector<bfloat16> input_vec(elements_per_tile * num_tiles);

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -74,8 +74,8 @@ int main() {
         // `loopback_dram_copy.cpp` file for the actual implementation). The kernel is created on the Tensix core
         // {0, 0} and uses the default NoC.
         std::vector<uint32_t> dram_copy_compile_time_args;
-        TensorAccessorArgs(*input_dram_buffer).append_args(dram_copy_compile_time_args);
-        TensorAccessorArgs(*output_dram_buffer).append_args(dram_copy_compile_time_args);
+        TensorAccessorArgs(*input_dram_buffer).append_to(dram_copy_compile_time_args);
+        TensorAccessorArgs(*output_dram_buffer).append_to(dram_copy_compile_time_args);
         KernelHandle dram_copy_kernel_id = CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "loopback/kernels/loopback_dram_copy.cpp",

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -31,9 +31,7 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
     const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
-    const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
     uint32_t itileA = output_tile_start_id / Nt * Kt;  // input0 row = output row * input0 width
 

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
 
     constexpr auto s0_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(s0_args, src0_addr, in0_tile_bytes);
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(s1_args, src1_addr, in1_tile_bytes);
 
     for (uint32_t n = 0; n < num_output_tiles; n++) {

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -22,9 +22,6 @@ void kernel_main() {
     uint32_t num_output_tiles = get_arg_val<uint32_t>(10);
     uint32_t MtNt = get_arg_val<uint32_t>(11);
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
-
     // DPRINT << "Mt=" << Mt << " Kt=" << Kt << " Nt=" << Nt << " MtKt=" << MtKt << "KtNt=" << KtNt << ENDL();
     // DPRINT << "src0=" << src0_addr << " src1=" << src1_addr << ENDL();
     // DPRINT << "batch=" << batch << ENDL();
@@ -48,11 +45,10 @@ void kernel_main() {
         itileB += output_tile_start_id / MtNt * KtNt;  // offset into correct batch if not bcasting
     }
 
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
-
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, src0_addr, in0_tile_bytes);
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    const auto s1 = TensorAccessor(s1_args, src1_addr, in1_tile_bytes);
 
     for (uint32_t n = 0; n < num_output_tiles; n++) {
         for (uint32_t kt = 0; kt < Kt; kt++) {

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -39,25 +39,19 @@ void kernel_main() {
     uint32_t batch = get_arg_val<uint32_t>(19);
     uint32_t bcast_B = get_arg_val<uint32_t>(20);
 
-    constexpr bool in0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool in1_is_dram = get_compile_time_arg_val(1) == 1;
-
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
     const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
     const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
-    const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;
 
-    const InterleavedAddrGenFast<in0_is_dram> s0 = {
-        .bank_base_address = in0_tensor_addr, .page_size = in0_single_tile_size_bytes, .data_format = in0_data_format};
-
-    const InterleavedAddrGenFast<in1_is_dram> s1 = {
-        .bank_base_address = in1_tensor_addr, .page_size = in1_single_tile_size_bytes, .data_format = in1_data_format};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, in0_tensor_addr, in0_single_tile_size_bytes);
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    const auto s1 = TensorAccessor(s1_args, in1_tensor_addr, in1_single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 
     constexpr auto s0_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(s0_args, in0_tensor_addr, in0_single_tile_size_bytes);
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(s1_args, in1_tensor_addr, in1_single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
@@ -62,14 +62,10 @@ void kernel_main() {
     uint32_t batch = get_arg_val<uint32_t>(37);
     uint32_t bcast_B = get_arg_val<uint32_t>(38);
 
-    constexpr bool in0_is_dram = get_compile_time_arg_val(0) == 1;  // not used
-    constexpr bool in1_is_dram = get_compile_time_arg_val(1) == 1;
-
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in1);
-    const DataFormat data_format = get_dataformat(cb_id_in1);
 
     uint32_t l1_write_addr_in1;
 
@@ -85,8 +81,9 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
 
-    const InterleavedAddrGenFast<in1_is_dram> s1 = {
-        .bank_base_address = in1_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    const auto s1 = TensorAccessor(s1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
@@ -82,7 +82,7 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
 
     constexpr auto s0_args = TensorAccessorArgs<0>();
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(s1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
@@ -62,14 +62,10 @@ void kernel_main() {
     uint32_t batch = get_arg_val<uint32_t>(37);
     uint32_t bcast_B = get_arg_val<uint32_t>(38);
 
-    constexpr bool in0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool in1_is_dram = get_compile_time_arg_val(1) == 1;  // not used
-
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
 
     uint32_t l1_write_addr_in0;
 
@@ -85,8 +81,8 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
 
-    const InterleavedAddrGenFast<in0_is_dram> s0 = {
-        .bank_base_address = in0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, in0_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
@@ -94,7 +94,7 @@ void kernel_main() {
 
     constexpr auto s0_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(s0_args, in0_tensor_addr, single_tile_size_bytes);
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(s1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
@@ -62,14 +62,10 @@ void kernel_main() {
     uint32_t batch = get_arg_val<uint32_t>(37);
     uint32_t bcast_B = get_arg_val<uint32_t>(38);
 
-    constexpr bool in0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool in1_is_dram = get_compile_time_arg_val(1) == 1;
-
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;
@@ -96,11 +92,10 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
 
-    const InterleavedAddrGenFast<in0_is_dram> s0 = {
-        .bank_base_address = in0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
-
-    const InterleavedAddrGenFast<in1_is_dram> s1 = {
-        .bank_base_address = in1_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, in0_tensor_addr, single_tile_size_bytes);
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    const auto s1 = TensorAccessor(s1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -24,16 +24,13 @@ void kernel_main() {
     uint32_t MtNt = get_arg_val<uint32_t>(11);  // if 0
     uint32_t batch = get_arg_val<uint32_t>(12);
 
-    constexpr bool out_is_dram = get_compile_time_arg_val(0) == 1;
-
     constexpr uint32_t cb_id_out0 = 16;
 
     // single-tile
     const uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
-    const DataFormat data_format = get_dataformat(cb_id_out0);
 
-    const InterleavedAddrGenFast<out_is_dram> s = {
-        .bank_base_address = out_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+    constexpr auto s_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(s_args, out_tensor_addr, single_tile_size_bytes);
 
     bool one_time_profile = true;
     for (uint32_t b = 0; b < batch; b++) {

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -20,10 +20,9 @@ void kernel_main() {
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto s_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(s_args, dst_addr, tile_bytes);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_tiles;

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp
@@ -24,15 +24,13 @@ void kernel_main() {
     // Declare address in which we stored the source matrices. We have set the exact same format between CBs and DRAM
     // buffers in the host code, so we can use the same address for both DRAM and CBs.
     const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
-    const DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<true> a = {
-        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+    constexpr auto a_args = TensorAccessorArgs<0>();
+    const auto a = TensorAccessor(a_args, src0_addr, in0_tile_bytes);
 
-    const InterleavedAddrGenFast<true> b = {
-        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+    constexpr auto b_args = TensorAccessorArgs<a_args.compile_time_args_skip()>();
+    const auto b = TensorAccessor(b_args, src1_addr, in1_tile_bytes);
 
     // Simple 2D matmul: A[Mt, Kt] @ B[Kt, Nt] = C[Mt, Nt]
     for (uint32_t output_tile = 0; output_tile < num_output_tiles; output_tile++) {

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     constexpr auto a_args = TensorAccessorArgs<0>();
     const auto a = TensorAccessor(a_args, src0_addr, in0_tile_bytes);
 
-    constexpr auto b_args = TensorAccessorArgs<a_args.compile_time_args_skip()>();
+    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
     const auto b = TensorAccessor(b_args, src1_addr, in1_tile_bytes);
 
     // Simple 2D matmul: A[Mt, Kt] @ B[Kt, Nt] = C[Mt, Nt]

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -17,10 +17,9 @@ void kernel_main() {
     // the same parameters from the circular buffer as we would from the DRAM buffer.
     constexpr uint32_t onetile = 1;  // single-tile ublocks
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<true> c = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto c_args = TensorAccessorArgs<0>();
+    const auto c = TensorAccessor(c_args, dst_addr, tile_bytes);
 
     // Loop through the tile indices and write each tile to DRAM in order.
     uint32_t end_id = start_id + num_tiles;

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
@@ -189,8 +189,8 @@ void matmul_multi_core(
     // All kernels run across all cores to enable parallel execution
     MathFidelity math_fidelity = MathFidelity::HiFi4;  // High fidelity math for accurate results
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp",
@@ -201,7 +201,7 @@ void matmul_multi_core(
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp",

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <bmm_op.hpp>
 #include <tt-metalium/device.hpp>
 #include <fmt/core.h>
@@ -187,19 +188,28 @@ void matmul_multi_core(
     // - Compute kernel: Performs the actual matrix multiplication computation
     // All kernels run across all cores to enable parallel execution
     MathFidelity math_fidelity = MathFidelity::HiFi4;  // High fidelity math for accurate results
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp",
         all_cores,
         tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = {}});
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
 
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
         all_cores,
         tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {}});
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_compile_time_args});
 
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <bmm_op.hpp>
 #include <fmt/core.h>
 #include <iostream>
@@ -234,13 +235,12 @@ void matmul_multicore_reuse(
     /*
      * Compile time arguments
      */
-    bool src0_is_dram = src0_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
 
-    bool dst_is_dram = dst_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    // std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t) output_cb_index, (uint32_t)dst_is_dram};
-    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
 
     /*
      * Create Kernels (Reader, Writer, Compute)

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -236,11 +236,11 @@ void matmul_multicore_reuse(
      * Compile time arguments
      */
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
 
     /*
      * Create Kernels (Reader, Writer, Compute)

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -266,11 +266,11 @@ void matmul_multicore_reuse_mcast(
      * Compile time arguments
      */
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
 
     /*
      * Create Kernels (Reader, Writer, Compute)

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <matmul_common/bmm_op.hpp>
 #include <algorithm>
 #include "tt-metalium/core_coord.hpp"
@@ -264,13 +265,12 @@ void matmul_multicore_reuse_mcast(
     /*
      * Compile time arguments
      */
-    bool src0_is_dram = src0_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool src1_is_dram = src1_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
 
-    bool dst_is_dram = dst_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    // std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t) output_cb_index, (uint32_t)dst_is_dram};
-    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
 
     /*
      * Create Kernels (Reader, Writer, Compute)

--- a/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     // buffers in the host code, so we can use the same address for both DRAM and CBs.
     constexpr auto s0_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(s0_args, src0_addr, get_tile_size(cb_id_in0));
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(s1_args, src1_addr, get_tile_size(cb_id_in1));
 
     // Loop through the dimensions of the matrices. Read them and push to the circular buffers.

--- a/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp
@@ -20,14 +20,10 @@ void kernel_main() {
 
     // Declare address in which we stored the source matrices. We have set the exact same format between CBs and DRAM
     // buffers in the host code, so we can use the same address for both DRAM and CBs.
-    const InterleavedAddrGenFast<true> s0 = {
-        .bank_base_address = src0_addr,
-        .page_size = get_tile_size(cb_id_in0),
-        .data_format = get_dataformat(cb_id_in0)};
-    const InterleavedAddrGenFast<true> s1 = {
-        .bank_base_address = src1_addr,
-        .page_size = get_tile_size(cb_id_in1),
-        .data_format = get_dataformat(cb_id_in1)};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, src0_addr, get_tile_size(cb_id_in0));
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    const auto s1 = TensorAccessor(s1_args, src1_addr, get_tile_size(cb_id_in1));
 
     // Loop through the dimensions of the matrices. Read them and push to the circular buffers.
     // Dimension names are called M, N and K. `t` in `mt` means tile.

--- a/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp
@@ -15,10 +15,8 @@ void kernel_main() {
     // Create the address generator for the output buffer. Due to us sharing buffer and circular buffer
     // configuration parameters (e.g. same data type and same page size) in the host code, we can grab
     // the same parameters from the circular buffer as we would from the DRAM buffer.
-    const InterleavedAddrGenFast<true> s = {
-        .bank_base_address = dst_addr,
-        .page_size = get_tile_size(cb_id_out0),
-        .data_format = get_dataformat(cb_id_out0)};
+    constexpr auto s_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(s_args, dst_addr, get_tile_size(cb_id_out0));
 
     // Loop through the matrix dimensions Mt and Nt. bmm will generate C's tiles C=A*B, MN=MK*KN,
     // in row major order, we just read them from CB and write out to DRAM

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/command_queue.hpp>
 #include <bmm_op.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "tt-metalium/core_coord.hpp"
 
 using namespace tt::constants;
@@ -131,17 +132,28 @@ void matmul_single_core(
     tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
     // Create the data movement kernels and the compute kernel
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp",
         core,
-        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        tt_metal::DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
 
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp",
         core,
-        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        tt_metal::DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_compile_time_args});
 
     // Compile time arguments for the kernels
     // Note that these take effect at the kernel's compile time. Chaning these values will require recompilation of the

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -133,8 +133,8 @@ void matmul_single_core(
 
     // Create the data movement kernels and the compute kernel
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp",
@@ -145,7 +145,7 @@ void matmul_single_core(
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
     auto writer_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp",

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
 
     constexpr auto s0_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(s0_args, src_addr, data_size_bytes);
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(s1_args, pad_addr, data_size_bytes);
 
     // pad based on page

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
@@ -14,12 +14,12 @@ void kernel_main() {
     const uint32_t data_size_bytes = get_arg_val<uint32_t>(5);
     const uint32_t num_rows_per_core = get_arg_val<uint32_t>(6);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool pad_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t cb_id = tt::CBIndex::c_0;
 
-    const InterleavedAddrGen<src_is_dram> s0 = {.bank_base_address = src_addr, .page_size = data_size_bytes};
-    const InterleavedAddrGen<pad_is_dram> s1 = {.bank_base_address = pad_addr, .page_size = data_size_bytes};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, src_addr, data_size_bytes);
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.compile_time_args_skip()>();
+    const auto s1 = TensorAccessor(s1_args, pad_addr, data_size_bytes);
 
     // pad based on page
     uint32_t src_stick_id = start_src_stick_id;

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp
@@ -12,10 +12,10 @@ void kernel_main() {
     const uint32_t data_size_bytes = get_arg_val<uint32_t>(3);
     const uint32_t num_rows_per_core = get_arg_val<uint32_t>(4);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_id = tt::CBIndex::c_0;
 
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = data_size_bytes};
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, dst_addr, data_size_bytes);
 
     uint32_t dst_stick_id = start_dst_stick_id;
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; row_idx++) {

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -97,10 +97,10 @@ int main() {
 
     // specify compile time args
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*pad_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*pad_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // create kernels
     KernelHandle reader_id = CreateKernel(

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -95,11 +96,11 @@ int main() {
     tt_metal::CreateCircularBuffer(program, cores, cb_config);
 
     // specify compile time args
-    bool src_is_dram = src_buffer->buffer_type() == BufferType::DRAM;
-    bool pad_is_dram = pad_buffer->buffer_type() == BufferType::DRAM;
-    bool dst_is_dram = dst_buffer->buffer_type() == BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, (uint32_t)pad_is_dram};
-    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)dst_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*pad_buffer).append_args(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
 
     // create kernels
     KernelHandle reader_id = CreateKernel(

--- a/tt_metal/programming_examples/shard_data_rm/kernels/reader_sharded_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/kernels/reader_sharded_rm.cpp
@@ -17,8 +17,8 @@ void kernel_main() {
     const uint32_t current_core = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
-    const InterleavedAddrGen<src_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
+    constexpr auto s0_args = TensorAccessorArgs<1>();
+    const auto s0 = TensorAccessor(s0_args, src_addr, stick_size);
     uint32_t stick_id = start_id;
     cb_reserve_back(cb_id_in0, shard_height);
     uint32_t l1_write_addr = get_write_ptr(cb_id_in0);

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -63,7 +64,6 @@ int main() {
     uint32_t src_addr = src_buffer->address();
 
     // configure and create circular buffers with the same address on each of the designated cores
-    bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     uint32_t input_cb_index = CBIndex::c_0;
     CircularBufferConfig input_cb_config =
         CircularBufferConfig(shard_size * input_unit_size, {{input_cb_index, cb_data_format}})
@@ -71,7 +71,8 @@ int main() {
     tt_metal::CreateCircularBuffer(program, cores, input_cb_config);
 
     // create data movement kernel to shard data
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index, (std::uint32_t)src_is_dram};
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index};
+    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "shard_data_rm/kernels/reader_sharded_rm.cpp",

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -72,7 +72,7 @@ int main() {
 
     // create data movement kernel to shard data
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index};
-    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     auto reader_id = tt_metal::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "shard_data_rm/kernels/reader_sharded_rm.cpp",

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     //  easy. But may not be the most efficient way to do it in all cases.
     constexpr auto a_args = TensorAccessorArgs<2>();
     const auto a = TensorAccessor(a_args, a_addr, tile_size_bytes);
-    constexpr auto b_args = TensorAccessorArgs<2 + a_args.compile_time_args_skip()>();
+    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
     const auto b = TensorAccessor(b_args, b_addr, tile_size_bytes);
 
     // Calculate the range of tiles this core should process

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -27,16 +27,10 @@ void kernel_main() {
     //  Setting the page size to be tile_size_bytes works because we set it up
     //  explicitly in host code. This is usually a good idea as it makes coding
     //  easy. But may not be the most efficient way to do it in all cases.
-    const InterleavedAddrGenFast<true> a = {
-        .bank_base_address = a_addr,           // The base address of the buffer
-        .page_size = tile_size_bytes,          // The size of a buffer page
-        .data_format = DataFormat::Float16_b,  // The data format of the buffer
-    };
-    const InterleavedAddrGenFast<true> b = {
-        .bank_base_address = b_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto a_args = TensorAccessorArgs<2>();
+    const auto a = TensorAccessor(a_args, a_addr, tile_size_bytes);
+    constexpr auto b_args = TensorAccessorArgs<2 + a_args.compile_time_args_skip()>();
+    const auto b = TensorAccessor(b_args, b_addr, tile_size_bytes);
 
     // Calculate the range of tiles this core should process
     const uint32_t end_tile_id = start_tile_id + n_tiles;

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -15,11 +15,8 @@ void kernel_main() {
 
     // Address generator for the output buffer. This is faster than doing plain
     // DRAM writes.
-    const InterleavedAddrGenFast<true> c = {
-        .bank_base_address = c_addr,
-        .page_size = tile_size_bytes,
-        .data_format = DataFormat::Float16_b,
-    };
+    constexpr auto c_args = TensorAccessorArgs<1>();
+    const auto c = TensorAccessor(c_args, c_addr, tile_size_bytes);
 
     // Calculate the range of tiles this core should process
     const uint32_t end_tile_id = start_tile_id + n_tiles;

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -157,10 +157,10 @@ int main(int argc, char** argv) {
     // result into a third circular buffer. `tile_write` reads tiles from the
     // third circular buffer and writes them to the output buffer C.
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1};
-    TensorAccessorArgs(*a).append_args(reader_compile_time_args);
-    TensorAccessorArgs(*b).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*a).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*b).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)tt::CBIndex::c_2};
-    TensorAccessorArgs(*c).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*c).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_compile_time_args = {
         (std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1, (std::uint32_t)tt::CBIndex::c_2};
 

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -156,7 +157,10 @@ int main(int argc, char** argv) {
     // result into a third circular buffer. `tile_write` reads tiles from the
     // third circular buffer and writes them to the output buffer C.
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1};
+    TensorAccessorArgs(*a).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*b).append_args(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)tt::CBIndex::c_2};
+    TensorAccessorArgs(*c).append_args(writer_compile_time_args);
     std::vector<uint32_t> compute_compile_time_args = {
         (std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1, (std::uint32_t)tt::CBIndex::c_2};
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -68,7 +68,6 @@ target_sources(
         core/tensor/serialization.cpp
         core/tensor/storage.cpp
         core/tensor/tensor.cpp
-        core/tensor/tensor_accessor_args.cpp
         core/tensor/tensor_attributes.cpp
         core/tensor/tensor_impl.cpp
         core/tensor/tensor_ops.cpp

--- a/ttnn/api/ttnn/tensor/tensor_accessor_args.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_accessor_args.hpp
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#include <tt-metalium/tensor_accessor_args.hpp>

--- a/ttnn/api/ttnn/tensor/tensor_accessor_args.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_accessor_args.hpp
@@ -4,28 +4,4 @@
 
 #pragma once
 
-#include <tt-metalium/buffer.hpp>
-#include <hostdevcommon/tensor_accessor/arg_config.hpp>
-
-#include <cstdint>
-#include <vector>
-
-namespace tt::tt_metal {
-
-class TensorAccessorArgs {
-public:
-    explicit TensorAccessorArgs(
-        const Buffer& buffer, tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
-
-    void append_args(std::vector<uint32_t>& compile_time_args) const;
-    void append_args(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
-
-    std::vector<uint32_t> get_compile_time_args() const;
-    std::vector<uint32_t> get_common_runtime_args() const;
-
-private:
-    const Buffer* buffer_ = nullptr;
-    tensor_accessor::ArgsConfig args_config_ = tensor_accessor::ArgConfig::None;
-};
-
-}  // namespace tt::tt_metal
+#include <tt-metalium/tensor_accessor_args.hpp>

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_naive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_naive_reader.cpp
@@ -8,8 +8,8 @@
 // Simple kernel that copies [start_page, end_page) pages from src to dst.
 void kernel_main() {
     auto args_src = TensorAccessorArgs<0, 0>();
-    constexpr uint32_t base_idx_cta = args_src.compile_time_args_skip();
-    constexpr uint32_t base_idx_crta = args_src.runtime_args_skip();
+    constexpr uint32_t base_idx_cta = args_src.next_compile_time_args_offset();
+    constexpr uint32_t base_idx_crta = args_src.next_common_runtime_args_offset();
 
     constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
     constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_naive_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_naive_writer.cpp
@@ -8,8 +8,8 @@
 // Simple kernel that copies [start_page, end_page) pages from dst to dst.
 void kernel_main() {
     auto args_dst = TensorAccessorArgs<0, 0>();
-    constexpr uint32_t base_idx_cta = args_dst.compile_time_args_skip();
-    constexpr uint32_t base_idx_crta = args_dst.runtime_args_skip();
+    constexpr uint32_t base_idx_cta = args_dst.next_compile_time_args_offset();
+    constexpr uint32_t base_idx_crta = args_dst.next_common_runtime_args_offset();
 
     constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
     constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory.cpp
@@ -4,7 +4,7 @@
 
 #include "nd_reshard_program_factory.hpp"
 
-#include "ttnn/tensor/tensor_accessor_args.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_program.cpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/kernel.hpp>
-#include <ttnn/tensor/tensor_accessor_args.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_program.cpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/fabric.hpp>
-#include <ttnn/tensor/tensor_accessor_args.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "ttnn/tensor/tensor_accessor_args.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::reduction::detail {
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -172,10 +172,10 @@ operation::ProgramWithCallbacks reduce_nc_factory(
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> reader_compile_time_args = {input_granularity, shard_factor, num_cores_to_be_used};
-    TensorAccessorArgs(*input.buffer()).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {shard_factor, num_cores_to_be_used};
-    TensorAccessorArgs(*output.buffer()).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
     const auto reader_kernel_file =
         "ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reader_reduce_nc.cpp";

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -137,7 +137,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
             tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
     } else {
         std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, chunk_size, packed_scaler_value};
-        TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
         reader_kernel_id = tt_metal::CreateKernel(
             program,
@@ -161,7 +161,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
             WriterDataMovementConfig(writer_ct_args));
     } else {
         std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-        TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
         writer_kernel_id = tt_metal::CreateKernel(
             program,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "ttnn/tensor/tensor_accessor_args.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 using namespace tt::constants;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
-#include "ttnn/tensor/tensor_accessor_args.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 using namespace tt::constants;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -79,10 +79,10 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
     tt_metal::Buffer* src_buffer = a.buffer();
     std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
-    TensorAccessorArgs(*src_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     tt_metal::Buffer* dst_buffer = output.buffer();
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> reduce_defines = reduce_op_utils::get_defines(reduce_op, ReduceOpDim::W);
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -81,10 +81,10 @@ operation::ProgramWithCallbacks reduce_single_core_hw(
     bfloat16 bfloat_scaler_value = bfloat16(scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
     std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
-    TensorAccessorArgs(*src0_buffer).append_args(reader_compile_time_args);
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_args(writer_compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "ttnn/tensor/tensor_accessor_args.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 using namespace tt::constants;


### PR DESCRIPTION
### Ticket

### Problem description
We're working towards deprecating InterleavedAddrGen in favor of the universal TensorAccessor which can handle both interleaved and sharded tensors. This pull request updates the documentation to always use TensorAccessor

### What's changed
Moved TensorAccessorArgs to Metal, so TensorAccessor can be easily set up there
Update all documentation and examples to remove usages of InterleavedAddrGen in favor of TensorAccessor

TensorAccessorArgs API changes:
 - Renamed `append_args`-> `append_to`
 - Renamed `compile_time_args_skip` -> `num_compile_time_args`
 - Renamed `runtime_args_skip` -> `num_common_runtime_args `
 - Added `next_compile_time_args_offset`
 - Added `next_common_runtime_args_offset`

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16482427186)
- [x] New/Existing tests provide coverage for changes