### PR TITLE
Support for creating metamodules in the deepseek module framework

### DIFF
--- a/models/demos/deepseek_v3/tt/decoder_layer.py
+++ b/models/demos/deepseek_v3/tt/decoder_layer.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import torch
+from transformers.configuration_utils import PretrainedConfig
+
+import ttnn
+from models.demos.deepseek_v3.tt.mla_1d import MLA1D
+from models.demos.deepseek_v3.tt.mlp.non_expert import NonExpert
+from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
+from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
+from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.run_config import (
+    ModelPrefillConfig,
+    ModelState,
+    RunDecodeConfig,
+    RunPrefillConfig,
+    WeightConfig,
+)
+
+
+class DecoderLayer(AbstractModule):
+    """
+    x += attn(attn_norm(x))
+    x += ffn(ffn_norm(x))
+    """
+
+    @classmethod
+    def convert_weights(
+        cls,
+        hf_config: PretrainedConfig,
+        state_dict: dict[str, torch.Tensor],
+        output_path: Path,
+        mesh_device: ttnn.MeshDevice,
+        mesh_row: ttnn.MeshDevice,
+    ) -> WeightConfig:
+        cls.validate_mesh_devices(mesh_device, mesh_row)
+        return {
+            "mla_norm": DistributedRMSNorm.convert_weights(
+                hf_config, sub_state_dict(state_dict, "input_layernorm."), output_path / "mla_norm", mesh_row
+            ),
+            "mla": MLA1D.convert_weights(
+                hf_config, sub_state_dict(state_dict, "self_attn."), output_path / "mla", mesh_row
+            ),
+            "mlp_norm": DistributedRMSNorm.convert_weights(
+                hf_config, sub_state_dict(state_dict, "post_attention_layernorm."), output_path / "mlp_norm", mesh_row
+            ),
+            "mlp": NonExpert.convert_weights(
+                hf_config, sub_state_dict(state_dict, "mlp."), output_path / "mlp", mesh_row
+            ),
+        }
+
+    @classmethod
+    def prefill_model_config(
+        cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice, mesh_row: ttnn.MeshDevice
+    ) -> ModelPrefillConfig:
+        cls.validate_mesh_devices(mesh_device, mesh_row)
+        return {
+            "mla_norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_row),
+            "mla": MLA1D.prefill_model_config(hf_config, mesh_row),
+            "mlp_norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_row),
+            "mlp": NonExpert.prefill_model_config(hf_config, mesh_row),
+        }
+
+    @classmethod
+    def decode_model_config(
+        cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice, mesh_row: ttnn.MeshDevice
+    ) -> ModeldecodeConfig:
+        cls.validate_mesh_devices(mesh_device, mesh_row)
+        return {
+            "mla_norm": DistributedRMSNorm.decode_model_config(hf_config, mesh_row),
+            "mla": MLA1D.decode_model_config(hf_config, mesh_row),
+            "mlp_norm": DistributedRMSNorm.decode_model_config(hf_config, mesh_row),
+            "mlp": NonExpert.decode_model_config(hf_config, mesh_row),
+        }
+
+    @classmethod
+    def create_state(
+        cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice, mesh_row: ttnn.MeshDevice
+    ) -> ModelState:
+        cls.validate_mesh_devices(mesh_device, mesh_row)
+        return {
+            "mla_norm": DistributedRMSNorm.create_state(hf_config, mesh_row),
+            "mla": MLA1D.create_state(hf_config, mesh_row),
+            "mlp_norm": DistributedRMSNorm.create_state(hf_config, mesh_row),
+            "mlp": NonExpert.create_state(hf_config, mesh_row),
+        }
+
+    @classmethod
+    def validate_mesh_devices(cls, mesh_device: ttnn.MeshDevice, mesh_row: ttnn.MeshDevice) -> None:
+        assert tuple(mesh_device.shape) == (4, 8), "decoder layer runs on a full galaxy"
+        assert tuple(mesh_row.shape) == (1, 8), "the mesh row that the norms and MLP are supposed to run on must be 1x8"
+        assert set(mesh_row.get_device_ids()).issubset(
+            mesh_device.get_device_ids()
+        ), "the mesh row must be a subdevice of the mesh device"
+
+    @classmethod
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
+        raise NotImplementedError("TODO")
+
+    @classmethod
+    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
+        raise NotImplementedError("TODO")

--- a/models/demos/deepseek_v3/utils/abstract_module.py
+++ b/models/demos/deepseek_v3/utils/abstract_module.py
@@ -9,6 +9,7 @@ import torch
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from models.demos.deepseek_v3.utils.config_helpers import get_state_dicts
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -20,8 +21,8 @@ from models.demos.deepseek_v3.utils.run_config import (
 )
 
 
-class AbstractModule(ABC):  # TODO: update the doc
-    """Abstract base class for Deepseek submodules.
+class AbstractModule(ABC):
+    f"""Abstract base class for Deepseek submodules.
 
     This class defines the common interface for submodules. The modules are not instantiated directly, but rather
     used as a namespace for the methods that define the model's behavior in prefill and decode. This is to make it easy
@@ -33,6 +34,10 @@ class AbstractModule(ABC):  # TODO: update the doc
     - `prefill_model_config` - generates the model configuration for prefill mode.
     - `decode_model_config` - generates the model configuration for decode mode.
     - `convert_weights` - converts PyTorch weights to TTNN format and saves them to the specified path.
+      The weights are in a form of a list of PyTorch state dictionaries. For submodules that can act as a collection
+      of layers, for example MLP, the length of the list is expected to be the same as the dimension 0 of the mesh device.
+      Use `{get_state_dicts.__module__}` for a convenient way to concatenate the weights from the state dictionaries into
+      a single PyTorch tensor.
     - `create_state` (optional) - creates a new state for the module, which is used to store persistent model state.
 
     Typical usage by a caller would be:
@@ -49,7 +54,9 @@ class AbstractModule(ABC):  # TODO: update the doc
     dictionaries, where the keys are operator names. In `ModelPrefillConfig` and `ModelDecodeConfig`, the
     operator-specific configurations are dataclasses that inherit from `OpConfigBase`. They behave exactly like
     dictionaries, in that they can be string-addressed, but with the added benefit of restricting the keys to only
-    the ones allowed by the operators.
+    the ones allowed by the operators. They are meant to be serializable into e.g. json, so they should not contain any
+    runtime-dependent data. Importantly, this excludes the mesh device and any objects that hold references to
+    the constructs on the device.
 
     The `OpConfigBase` dataclasses are meant to provide a clear interface for the operator arguments. They are designed
     to be kwargs-destructured into the operator calls, e.g. `ttnn.linear(x, **cfg["w1"])`. This allows for a clean and
@@ -151,17 +158,19 @@ class AbstractModule(ABC):  # TODO: update the doc
     def convert_weights(
         cls,
         hf_config: PretrainedConfig,
-        state_dict: dict[str, torch.Tensor],
+        state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
         """Convert PyTorch weights to TTNN format for 1D tensor parallelism.
-        Subclasses must implement this method to convert the PyTorch state dict to a TTNN-compatible format and
+        Subclasses must implement this method to convert a tuple of PyTorch state dicts to a TTNN-compatible format and
         return a (nested) dictionary of paths created from the `ttnn.Tensor`s saved using `save_and_get_path`.
 
         Args:
             hf_config: HuggingFace model configuration object
-            state_dict: PyTorch state dict for this layer
+            state_dicts: Tuple of PyTorch state dicts for the layers of this submodule. This is assumed to have
+                         the same length as the dimension 0 of the mesh device. If there is a None instead of a dict,
+                         this is supposed to be filled with padding.
             output_path: Path to save converted weights
             mesh_device: TTNN mesh device
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -3,8 +3,7 @@
 
 import math
 from itertools import takewhile
-from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 import torch
 from loguru import logger
@@ -495,12 +494,56 @@ def dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: Seque
     return tensor
 
 
-def sub_state_dict(state_dict, prefix):
+def get_state_dicts(
+    key: Any,
+    dicts: Sequence[dict[str, torch.Tensor] | None],
+    concat_dim: int = 0,
+    shape: Sequence[int] | None = None,
+    concat: bool = False,
+) -> torch.Tensor:
+    """Get a weight from a list of state dictionaries and combine them into a single tensor.
+
+    Args:
+        key (str): The key to look for in the dictionaries.
+        dicts (Sequence[dict[str, torch.Tensor]]): A sequence of state dicts
+        dim (int, optional): The dimension along which to combine the tensors. Defaults to 0.
+        concat (bool, optional): Whether to concatenate the tensors or stack them. Defaults to False.
+    Returns:
+        torch.Tensor: The combined tensor.
+    """
+    if not dicts:
+        return torch.empty()
+
+    expected_shape = (
+        next(map(lambda d: d[key].shape, filter(lambda d: d is not None, dicts)), None) if shape is None else shape
+    )
+    assert expected_shape is not None, "At least one dictionary must be non-empty, or a shape must be provided"
+
+    assert all(key in d for d in dicts if d is not None), f"Key {key} not found in all dictionaries"
+    assert all(
+        d[key].shape == expected_shape for d in dicts if d is not None
+    ), f"Key {key} must have the value shaped as {expected_shape} in all dictionaries"
+
+    tensors = [torch.zeros(expected_shape) if d is None else d[key] for d in dicts]
+
+    if concat:
+        return torch.concat(tensors, dim=concat_dim)
+    return torch.stack(tensors, dim=concat_dim)
+
+
+def sub_state_dict(state_dict: dict[str, torch.Tensor], prefix: str):
     """Get a subset of the state dict with a given prefix."""
     return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
 
 
-def save_and_get_path(path: Path, tensor: ttnn.Tensor) -> str:
+def sub_state_dicts(
+    state_dicts: Sequence[dict[str, torch.Tensor] | None], prefix: str
+) -> tuple[dict[str, torch.Tensor] | None, ...]:
+    """Get a subset of the state dict with a given prefix."""
+    return tuple(None if d is None else sub_state_dict(d, prefix) for d in state_dicts)
+
+
+def save_and_get_path(path, tensor):
     """Save a tensor to a file and return the path."""
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -15,7 +15,7 @@ MESH_DEVICE_STATE_DICT_KEY = "mesh_device"
 WeightConfig = dict[str, "WeightConfig | str"]
 
 _PRIMITIVE_COPYABLE_TYPES = bool | int | float | complex | str | bytes | None | Enum
-# In general, we require ModelConfig to be deepcopyable
+# In general, we require ModelConfig to be serializable (NOTE: mesh device and classes that hold references to the objects on it are NOT serializable).
 ModelPrefillConfig = dict[str, "ModelPrefillConfig | _PRIMITIVE_COPYABLE_TYPES"] | OpConfigBase
 ModelDecodeConfig = dict[str, "ModelDecodeConfig | _PRIMITIVE_COPYABLE_TYPES"] | OpConfigBase
 


### PR DESCRIPTION
### !!!!!! Notice for Module writers !!!!!!
This PR introduces a somewhat significant conceptual change to our deepseek bringup. Please read this description carefully, as it is the provisional documentation for the new change. Please also migrate your code to the new API. While this is an annoying change, it is a necessary one to be able to execute the DeepSeek on a single Galaxy machine. Hopefully, with the convenience functions, this will be as painless as possible.

### Background of the issue
Yesterday we noticed that the current architectural design of the deepseek bringup assumed greater support from the submesh system than actually exists. Namely, the assumption was that it's possible to transfer tensors between the submeshes, which is not true. 

### The solution (architectural view)
Thus, the new architectural design assumes that decoder blocks in deepseek will be grouped up into metablocks, calling metalayers underneath. For example, blocks 3, 18, 33, 48 might have their weights bunched up together. The idea is that a single activation will be put on a single row of a galaxy, with the shards on the other devices begin filled with garbage. The row that the activation will be put on will directly correspond to the layer that we actually want to call. For example, if the activation is put on the last row of a galaxy and the metablock contains blocks 9, 12, 14, 18, the activation will be passed through the layer 18. This design also allows for later model execution pipelining.

### The solution (API view)
At the level of a module such as RMSNorm or MLA, all that changes is that `AbstractModule.convert_weights` now takes in a list of dictionaries instead of a dictionary. These dictionaries correspond to the layers that a given metalayer is supposed to handle. For the sake of testing, the only assumption here is that the number of rows of the mesh_device is the same as the number of dictionaries given in the argument.

For the sake of the change being minimally invasive to implement, the API provides a number of convenience functions in utils.config_helpers to handle sharding the weights in a form of a list of dictionaries. Firstly, `get_multidict_key` allows for extracting a key from a list of dictionaries, to get a list of tensors. Second, a new `shard_torch_tensor` function provides a more powerful interface for converting a list of tensors into per-device shards. The resulting shards are flattened and placed in a row-wise order on the device using `from_torch_sharded` or `save_sharded_tensor`. I highly recommend reading the documentation for `shard_torch_tensor`, as it is quite expansive.

For example, to shard something like an MLP weight, one would use:
```python
weights_list = get_multidict_key(state_dicts, "w1") # List of (hidden_size, intermediate_size)
tensor_shards = shard_torch_tensor(weights_list, (-1, 0), (mesh_device.shape[1], None)) # (32, hidden_size, intermediate_size // 8)
return save_sharded_tensor(dir/"w1.tensor", tensor_shards, ...)
```

### Consequences to the codebase
- The changes to README.md and AbstractModule documentation are missing for now, will be updated later in the week.
- This change does not break any existing tests, but it is important for the Module writers to migrate to the new API as this is what the DecoderBlock module will need to function properly.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes