### PR TITLE
#0: [skip ci] I didn't test this out, but let's not send full GitHub Action runner names

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -218,6 +218,11 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         if len(parts) >= 2 and parts[-2] == "runner":
             host_name = "-".join(parts[:-1])
 
+    # Cleanup GitHub-hosted runner names because we're sending the whole thing, which is unnecessary
+    # and clogs up the data with 1000s of hosts
+    if host_name and location == "github":
+        host_name = "GitHub Actions"
+
     os = ubuntu_version
 
     name = github_job["name"]


### PR DESCRIPTION
…ner names

### Ticket

Saw this on superset

### Problem description

<img width="377" height="236" alt="Screenshot 2025-07-23 at 9 04 02 AM" src="https://github.com/user-attachments/assets/50e7800f-64c2-40d8-b4bd-47134bd48eb6" />

<img width="602" height="577" alt="Screenshot 2025-07-23 at 9 04 16 AM" src="https://github.com/user-attachments/assets/9a18675d-132e-43dc-89db-111567d0ac01" />


### What's changed

Just set it to one name for now

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes