### PR TITLE
Add conv3d stride

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -25,7 +25,9 @@ from tests.ttnn.unit_tests.operations.conv.test_conv3d import (
 @pytest.mark.parametrize("H", [4, 6])
 @pytest.mark.parametrize("W", [5, 7])
 @pytest.mark.parametrize("kernel_size", [(3, 3, 3), (1, 1, 1)], ids=["kernel_333", "kernel_111"])
-@pytest.mark.parametrize("stride", [(1, 1, 1), (2, 2, 2)], ids=["stride_111", "stride_222"])
+@pytest.mark.parametrize(
+    "stride", [(1, 1, 1), (2, 2, 2), (1, 3, 5), (3, 2, 1)], ids=["stride_111", "stride_222", "stride_135", "stride_321"]
+)
 @pytest.mark.parametrize("padding", [(0, 0, 0), (0, 1, 1)], ids=["padding_000", "padding_011"])
 @pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
 def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, padding_mode):

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -25,7 +25,7 @@ from tests.ttnn.unit_tests.operations.conv.test_conv3d import (
 @pytest.mark.parametrize("H", [4, 6])
 @pytest.mark.parametrize("W", [5, 7])
 @pytest.mark.parametrize("kernel_size", [(3, 3, 3), (1, 1, 1)], ids=["kernel_333", "kernel_111"])
-@pytest.mark.parametrize("stride", [(1, 1, 1)], ids=["stride_111"])
+@pytest.mark.parametrize("stride", [(1, 1, 1), (2, 2, 2)], ids=["stride_111", "stride_222"])
 @pytest.mark.parametrize("padding", [(0, 0, 0), (0, 1, 1)], ids=["padding_000", "padding_011"])
 @pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
 def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, padding_mode):

--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -10,8 +10,8 @@ import torch.nn as nn
 from tests.ttnn.utils_for_testing import check_with_pcc
 
 
-def _out_size(in_size, pad, k):
-    return in_size + 2 * pad - (k - 1)
+def _out_size(in_size, pad, stride, k):
+    return (in_size + 2 * pad - k) // stride + 1
 
 
 ALIGNMENT = 32  # Valid L1 alignment for Wormhole and Blackhole
@@ -100,9 +100,9 @@ def setup_conv3d_test(input_shape, out_channels, kernel_size, stride, padding, p
 
     # Define input dimensions
     N, C, D, H, W = input_shape
-    D_out = _out_size(D, padding[0], kernel_size[0])
-    H_out = _out_size(H, padding[1], kernel_size[1])
-    W_out = _out_size(W, padding[2], kernel_size[2])
+    D_out = _out_size(D, padding[0], stride[0], kernel_size[0])
+    H_out = _out_size(H, padding[1], stride[1], kernel_size[1])
+    W_out = _out_size(W, padding[2], stride[2], kernel_size[2])
 
     # Create input tensor and PyTorch Conv3d module
     input_tensor = torch.randn(N, C, D, H, W, dtype=torch.float32)
@@ -170,15 +170,15 @@ def run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padd
 
 
 @pytest.mark.parametrize("B", [1])
-@pytest.mark.parametrize("C_in", [12, 64])
-@pytest.mark.parametrize("C_out", [64])
-@pytest.mark.parametrize("T", [8, 11])
-@pytest.mark.parametrize("H", [10, 13])
-@pytest.mark.parametrize("W", [9, 12])
-@pytest.mark.parametrize("kernel_size", [(3, 3, 3), (1, 1, 1)], ids=["kernel_333", "kernel_111"])
-@pytest.mark.parametrize("stride", [(1, 1, 1)], ids=["stride_111"])
-@pytest.mark.parametrize("padding", [(0, 1, 1)], ids=["padding_011"])
-@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
+@pytest.mark.parametrize("C_in", [7])
+@pytest.mark.parametrize("C_out", [32])
+@pytest.mark.parametrize("T", [3])
+@pytest.mark.parametrize("H", [256])
+@pytest.mark.parametrize("W", [256])
+@pytest.mark.parametrize("kernel_size", [(3, 3, 3)])
+@pytest.mark.parametrize("stride", [(1, 5, 8)])
+@pytest.mark.parametrize("padding", [(0, 1, 1)])
+@pytest.mark.parametrize("padding_mode", ["zeros"])
 def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, padding_mode):
     input_shape = (B, C_in, T, H, W)
     out_channels = C_out

--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -170,15 +170,15 @@ def run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padd
 
 
 @pytest.mark.parametrize("B", [1])
-@pytest.mark.parametrize("C_in", [7])
-@pytest.mark.parametrize("C_out", [32])
-@pytest.mark.parametrize("T", [3])
-@pytest.mark.parametrize("H", [256])
-@pytest.mark.parametrize("W", [256])
-@pytest.mark.parametrize("kernel_size", [(3, 3, 3)])
-@pytest.mark.parametrize("stride", [(1, 5, 8)])
-@pytest.mark.parametrize("padding", [(0, 1, 1)])
-@pytest.mark.parametrize("padding_mode", ["zeros"])
+@pytest.mark.parametrize("C_in", [12, 64])
+@pytest.mark.parametrize("C_out", [64])
+@pytest.mark.parametrize("T", [8, 11])
+@pytest.mark.parametrize("H", [10, 13])
+@pytest.mark.parametrize("W", [9, 12])
+@pytest.mark.parametrize("kernel_size", [(3, 3, 3), (1, 1, 1)], ids=["kernel_333", "kernel_111"])
+@pytest.mark.parametrize("stride", [(1, 1, 1), (2, 2, 2)], ids=["stride_111", "stride_222"])
+@pytest.mark.parametrize("padding", [(0, 1, 1)], ids=["padding_011"])
+@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
 def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, padding_mode):
     input_shape = (B, C_in, T, H, W)
     out_channels = C_out

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "conv3d_device_operation.hpp"
+#include <array>
+#include <cstdint>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/constants.hpp>
@@ -21,10 +23,11 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_output_dims(
     uint32_t H_in,
     uint32_t W_in,
     const std::array<uint32_t, 3>& padding,
+    const std::array<uint32_t, 3>& stride,
     const std::array<uint32_t, 3>& kernel_size) {
-    uint32_t T_out = T_in + 2 * padding[0] - (kernel_size[0] - 1);
-    uint32_t H_out = H_in + 2 * padding[1] - (kernel_size[1] - 1);
-    uint32_t W_out = W_in + 2 * padding[2] - (kernel_size[2] - 1);
+    uint32_t T_out = (T_in + 2 * padding[0] - kernel_size[0]) / stride[0] + 1;
+    uint32_t H_out = (H_in + 2 * padding[1] - kernel_size[1]) / stride[1] + 1;
+    uint32_t W_out = (W_in + 2 * padding[2] - kernel_size[2]) / stride[2] + 1;
     return {T_out, H_out, W_out};
 }
 }  // namespace detail
@@ -66,13 +69,6 @@ void Conv3dOp::validate(
             bias_tensor.logical_shape().size());
     }
 
-    // Add assertions for strides and groups
-    TT_FATAL(
-        config.stride[0] == 1 && config.stride[1] == 1 && config.stride[2] == 1,
-        "Strides must be (1,1,1). got ({}, {}, {})",
-        config.stride[0],
-        config.stride[1],
-        config.stride[2]);
     TT_FATAL(config.groups == 1, "Groups must be 1. got {}", config.groups);
     // assert padding on T is zero
     TT_FATAL(
@@ -169,7 +165,8 @@ std::vector<TensorSpec> Conv3dOp::compute_output_specs(const std::vector<Tensor>
     uint32_t W_in = input_tensor_a_shape[3];
     uint32_t C_out = config.output_channels;
 
-    auto [T_out, H_out, W_out] = detail::compute_output_dims(T_in, H_in, W_in, config.padding, config.kernel_size);
+    auto [T_out, H_out, W_out] =
+        detail::compute_output_dims(T_in, H_in, W_in, config.padding, config.stride, config.kernel_size);
 
     ttnn::Shape output_shape({N, T_out, H_out, W_out, C_out});
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -21,6 +21,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_output_dims(
     uint32_t H_in,
     uint32_t W_in,
     const std::array<uint32_t, 3>& padding,
+    const std::array<uint32_t, 3>& stride,
     const std::array<uint32_t, 3>& kernel_size);
 }  // namespace detail
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -274,10 +274,7 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
         in0_block_w,
         out_subblock_h,
         out_subblock_w,
-        semaphore_id,
-        config.stride[0],
-        config.stride[1],
-        config.stride[2]};
+        semaphore_id};
 
     auto compute_kernels_id = CreateKernel(
         program,
@@ -436,15 +433,6 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
         uint32_t w_out_block_end = std::min(w_out_block_start + w_out_per_core, W_out_blocks);
 
         // Calculate actual indices
-        uint32_t t_in_start = t_out_block_start * config.T_out_block * config.stride[0];
-        uint32_t t_in_end = std::min(t_out_block_end * config.T_out_block * config.stride[0], T_in + config.padding[0]);
-
-        uint32_t h_in_start = h_out_block_start * config.H_out_block * config.stride[1];
-        uint32_t h_in_end = std::min(h_out_block_end * config.H_out_block * config.stride[1], H_in + config.padding[1]);
-
-        uint32_t w_in_start = w_out_block_start * config.W_out_block * config.stride[2];
-        uint32_t w_in_end = std::min(w_out_block_end * config.W_out_block * config.stride[2], W_in + config.padding[2]);
-
         uint32_t t_out_start = t_out_block_start * config.T_out_block;
         uint32_t t_out_end = std::min(t_out_block_end * config.T_out_block, T_out);
 
@@ -509,12 +497,12 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
             c_in_block_end,
             c_out_block_start,
             c_out_block_end,
-            t_in_start,
-            t_in_end,
-            h_in_start,
-            h_in_end,
-            w_in_start,
-            w_in_end,
+            t_out_start,
+            t_out_end,
+            h_out_start,
+            h_out_end,
+            w_out_start,
+            w_out_end,
         };
 
         compute_args_per_core[core_id] = {
@@ -522,12 +510,12 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
             c_in_block_end,
             c_out_block_start,
             c_out_block_end,
-            t_in_start,
-            t_in_end,
-            h_in_start,
-            h_in_end,
-            w_in_start,
-            w_in_end,
+            t_out_start,
+            t_out_end,
+            h_out_start,
+            h_out_end,
+            w_out_start,
+            w_out_end,
             (uint32_t)is_reducer};
 
         writer_args_per_core[core_id] = {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/constants.hpp>
 #include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include <algorithm>
 
 namespace ttnn::operations::experimental::conv3d::detail {
@@ -436,13 +437,13 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
 
         // Calculate actual indices
         uint32_t t_in_start = t_out_block_start * config.T_out_block * config.stride[0];
-        uint32_t t_in_end = std::min(t_out_block_end * config.T_out_block * config.stride[0], T_in);
+        uint32_t t_in_end = std::min(t_out_block_end * config.T_out_block * config.stride[0], T_in + config.padding[0]);
 
         uint32_t h_in_start = h_out_block_start * config.H_out_block * config.stride[1];
-        uint32_t h_in_end = std::min(h_out_block_end * config.H_out_block * config.stride[1], H_in);
+        uint32_t h_in_end = std::min(h_out_block_end * config.H_out_block * config.stride[1], H_in + config.padding[1]);
 
         uint32_t w_in_start = w_out_block_start * config.W_out_block * config.stride[2];
-        uint32_t w_in_end = std::min(w_out_block_end * config.W_out_block * config.stride[2], W_in);
+        uint32_t w_in_end = std::min(w_out_block_end * config.W_out_block * config.stride[2], W_in + config.padding[2]);
 
         uint32_t t_out_start = t_out_block_start * config.T_out_block;
         uint32_t t_out_end = std::min(t_out_block_end * config.T_out_block, T_out);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -155,6 +155,10 @@ void MAIN {
 
     constexpr uint32_t semaphore_id = get_compile_time_arg_val(25);
 
+    constexpr uint32_t stride_t = get_compile_time_arg_val(26);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(27);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(28);
+
     constexpr uint32_t patch_tiles = matmul_M_t * matmul_K_t;
     constexpr uint32_t weight_tiles = matmul_K_t * matmul_N_t;
     constexpr uint32_t output_tiles = matmul_M_t * matmul_N_t;
@@ -176,6 +180,10 @@ void MAIN {
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_workers = get_arg_val<uint32_t>(argidx++);
 
+    constexpr uint32_t T_strided_block_size = T_block_size * stride_t;
+    constexpr uint32_t H_strided_block_size = H_block_size * stride_h;
+    constexpr uint32_t W_strided_block_size = W_block_size * stride_w;
+
     for (uint32_t c_in_block = c_in_block_start; c_in_block < c_in_block_end; c_in_block++) {
         // Process only assigned C_out blocks
         for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
@@ -189,9 +197,9 @@ void MAIN {
             }
 
             // 3D blocking loops over assigned ranges:
-            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
-                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
-                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_block_size) {
+            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_strided_block_size) {
+                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_strided_block_size) {
+                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_strided_block_size) {
                         // Tilize row-major patches
                         uint32_t patch_rows_left = num_patches;
                         tilize_init(cb_vol2col_rm, matmul_K_t, cb_vol2col_tiled);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -155,10 +155,6 @@ void MAIN {
 
     constexpr uint32_t semaphore_id = get_compile_time_arg_val(25);
 
-    constexpr uint32_t stride_t = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(27);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(28);
-
     constexpr uint32_t patch_tiles = matmul_M_t * matmul_K_t;
     constexpr uint32_t weight_tiles = matmul_K_t * matmul_N_t;
     constexpr uint32_t output_tiles = matmul_M_t * matmul_N_t;
@@ -180,10 +176,6 @@ void MAIN {
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_workers = get_arg_val<uint32_t>(argidx++);
 
-    constexpr uint32_t T_strided_block_size = T_block_size * stride_t;
-    constexpr uint32_t H_strided_block_size = H_block_size * stride_h;
-    constexpr uint32_t W_strided_block_size = W_block_size * stride_w;
-
     for (uint32_t c_in_block = c_in_block_start; c_in_block < c_in_block_end; c_in_block++) {
         // Process only assigned C_out blocks
         for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
@@ -197,9 +189,9 @@ void MAIN {
             }
 
             // 3D blocking loops over assigned ranges:
-            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_strided_block_size) {
-                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_strided_block_size) {
-                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_strided_block_size) {
+            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
+                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
+                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_block_size) {
                         // Tilize row-major patches
                         uint32_t patch_rows_left = num_patches;
                         tilize_init(cb_vol2col_rm, matmul_K_t, cb_vol2col_tiled);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -82,30 +82,32 @@ void kernel_main() {
     constexpr uint32_t num_patches = T_block_size * H_block_size * W_block_size;
     constexpr uint32_t H_in_W_in = H_in * W_in;
 
-    constexpr uint32_t T_strided_block_size = T_block_size * stride_t;
-    constexpr uint32_t H_strided_block_size = H_block_size * stride_h;
-    constexpr uint32_t W_strided_block_size = W_block_size * stride_w;
-
     for (uint32_t c_in_block = c_in_block_start; c_in_block < c_in_block_end; c_in_block++) {
         const uint32_t c_in_offset_bytes = c_in_block * C_in_block_bytes;
         // Iterate only over assigned C_out blocks
         for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
             // 3D blocking loops over assigned ranges:
-            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_strided_block_size) {
-                const uint32_t t_block_end = std::min(t_block + T_strided_block_size, t_out_end);
+            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
+                const uint32_t t_block_end = std::min(t_block + T_block_size, t_out_end);
+                const uint32_t t_block_s_start = t_block * stride_t;
+                const uint32_t t_block_end_s = t_block_end * stride_t;
 
-                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_strided_block_size) {
-                    const uint32_t h_block_end = std::min(h_block + H_strided_block_size, h_out_end);
+                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
+                    const uint32_t h_block_end = std::min(h_block + H_block_size, h_out_end);
+                    const uint32_t h_block_s_start = h_block * stride_h;
+                    const uint32_t h_block_end_s = h_block_end * stride_h;
 
-                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_strided_block_size) {
-                        const uint32_t w_block_end = std::min(w_block + W_strided_block_size, w_out_end);
+                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_block_size) {
+                        const uint32_t w_block_end = std::min(w_block + W_block_size, w_out_end);
+                        const uint32_t w_block_s_start = w_block * stride_w;
+                        const uint32_t w_block_end_s = w_block_end * stride_w;
                         // Now iterate through the sub-tile
                         cb_reserve_back(cb_vol2col, num_patches);
                         const uint32_t cb_write_ptr = get_write_ptr(cb_vol2col);
                         uint32_t cb_write_addr = cb_write_ptr;
-                        for (uint32_t t = t_block; t < t_block_end; t += stride_t) {
-                            for (uint32_t h = h_block; h < h_block_end; h += stride_h) {
-                                for (uint32_t w = w_block; w < w_block_end; w += stride_w) {
+                        for (uint32_t t = t_block_s_start; t < t_block_end_s; t += stride_t) {
+                            for (uint32_t h = h_block_s_start; h < h_block_end_s; h += stride_h) {
+                                for (uint32_t w = w_block_s_start; w < w_block_end_s; w += stride_w) {
                                     // For each output coordinate (t, h, w),
                                     // gather the kT*kH*kW patch around (t,h,w).
                                     for (uint32_t kt = 0; kt < kT; kt++) {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -58,6 +58,9 @@ void kernel_main() {
     constexpr uint32_t out_row_size_bytes = get_compile_time_arg_val(22);
     constexpr bool is_padding_zeros = get_compile_time_arg_val(23) == 1;
     constexpr uint32_t semaphore_id = get_compile_time_arg_val(24);
+    constexpr uint32_t stride_t = get_compile_time_arg_val(25);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(26);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
     // Load input/output addresses and range parameters
     uint32_t argidx = 0;
     const uint32_t in_addr = get_arg_val<uint32_t>(argidx++);
@@ -79,26 +82,30 @@ void kernel_main() {
     constexpr uint32_t num_patches = T_block_size * H_block_size * W_block_size;
     constexpr uint32_t H_in_W_in = H_in * W_in;
 
+    constexpr uint32_t T_strided_block_size = T_block_size * stride_t;
+    constexpr uint32_t H_strided_block_size = H_block_size * stride_h;
+    constexpr uint32_t W_strided_block_size = W_block_size * stride_w;
+
     for (uint32_t c_in_block = c_in_block_start; c_in_block < c_in_block_end; c_in_block++) {
         const uint32_t c_in_offset_bytes = c_in_block * C_in_block_bytes;
         // Iterate only over assigned C_out blocks
         for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
             // 3D blocking loops over assigned ranges:
-            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
-                const uint32_t t_block_end = std::min(t_block + T_block_size, t_out_end);
+            for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_strided_block_size) {
+                const uint32_t t_block_end = std::min(t_block + T_strided_block_size, t_out_end);
 
-                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
-                    const uint32_t h_block_end = std::min(h_block + H_block_size, h_out_end);
+                for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_strided_block_size) {
+                    const uint32_t h_block_end = std::min(h_block + H_strided_block_size, h_out_end);
 
-                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_block_size) {
-                        const uint32_t w_block_end = std::min(w_block + W_block_size, w_out_end);
+                    for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_strided_block_size) {
+                        const uint32_t w_block_end = std::min(w_block + W_strided_block_size, w_out_end);
                         // Now iterate through the sub-tile
                         cb_reserve_back(cb_vol2col, num_patches);
                         const uint32_t cb_write_ptr = get_write_ptr(cb_vol2col);
                         uint32_t cb_write_addr = cb_write_ptr;
-                        for (uint32_t t = t_block; t < t_block_end; ++t) {
-                            for (uint32_t h = h_block; h < h_block_end; ++h) {
-                                for (uint32_t w = w_block; w < w_block_end; ++w) {
+                        for (uint32_t t = t_block; t < t_block_end; t += stride_t) {
+                            for (uint32_t h = h_block; h < h_block_end; h += stride_h) {
+                                for (uint32_t w = w_block; w < w_block_end; w += stride_w) {
                                     // For each output coordinate (t, h, w),
                                     // gather the kT*kH*kW patch around (t,h,w).
                                     for (uint32_t kt = 0; kt < kT; kt++) {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -90,24 +90,24 @@ void kernel_main() {
             for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
                 const uint32_t t_block_end = std::min(t_block + T_block_size, t_out_end);
                 const uint32_t t_block_s_start = t_block * stride_t;
-                const uint32_t t_block_end_s = t_block_end * stride_t;
+                const uint32_t t_block_s_end = t_block_end * stride_t;
 
                 for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
                     const uint32_t h_block_end = std::min(h_block + H_block_size, h_out_end);
                     const uint32_t h_block_s_start = h_block * stride_h;
-                    const uint32_t h_block_end_s = h_block_end * stride_h;
+                    const uint32_t h_block_s_end = h_block_end * stride_h;
 
                     for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_block_size) {
                         const uint32_t w_block_end = std::min(w_block + W_block_size, w_out_end);
                         const uint32_t w_block_s_start = w_block * stride_w;
-                        const uint32_t w_block_end_s = w_block_end * stride_w;
+                        const uint32_t w_block_s_end = w_block_end * stride_w;
                         // Now iterate through the sub-tile
                         cb_reserve_back(cb_vol2col, num_patches);
                         const uint32_t cb_write_ptr = get_write_ptr(cb_vol2col);
                         uint32_t cb_write_addr = cb_write_ptr;
-                        for (uint32_t t = t_block_s_start; t < t_block_end_s; t += stride_t) {
-                            for (uint32_t h = h_block_s_start; h < h_block_end_s; h += stride_h) {
-                                for (uint32_t w = w_block_s_start; w < w_block_end_s; w += stride_w) {
+                        for (uint32_t t = t_block_s_start; t < t_block_s_end; t += stride_t) {
+                            for (uint32_t h = h_block_s_start; h < h_block_s_end; h += stride_h) {
+                                for (uint32_t w = w_block_s_start; w < w_block_s_end; w += stride_w) {
                                     // For each output coordinate (t, h, w),
                                     // gather the kT*kH*kW patch around (t,h,w).
                                     for (uint32_t kt = 0; kt < kT; kt++) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24634

### Problem description
Conv3d doesn't support arbitrary strides

### What's changed
- introduced stride to calculation for output dimensions
- introduced strided access in reader kernel

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16518266996)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/16517410464)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI  [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16590183279)