### PR TITLE
add (experimental) lightweight/basic bandwidth telemetry to fabric.

### DIFF
--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -32,8 +32,10 @@ jobs:
       matrix:
         test-group: [
           {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*" },
+          {name: fabric 1D unit tests with BW telemetry, cmd: TT_METAL_FABRIC_TELEMETRY=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*" --gtest_also_run_disabled_tests },
           {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
           {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
+          {name: fabric 2D fixture unit tests with BW telemetry, cmd: TT_METAL_FABRIC_TELEMETRY=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
           {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
           {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },
           # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -61,6 +61,8 @@ run_t3000_ttfabric_tests() {
   #TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 
   # these tests cover mux fixture as well
+  TT_METAL_FABRIC_TELEMETRY=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+  TT_METAL_FABRIC_TELEMETRY=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
 

--- a/tests/tt_metal/microbenchmarks/ethernet/post_processing/visualize_bw.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/post_processing/visualize_bw.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#!/usr/bin/env python3
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.patches import FancyBboxPatch
+from matplotlib.collections import LineCollection
+import argparse
+import sys
+
+
+def load_data(topology_file, bandwidth_file):
+    """Load and validate the CSV files."""
+    try:
+        # Load topology data
+        topology_df = pd.read_csv(topology_file)
+        required_topo_cols = ["MeshRow", "MeshCol", "ConnectedMeshRow", "ConnectedMeshCol", "EthernetChannel"]
+        if not all(col in topology_df.columns for col in required_topo_cols):
+            raise ValueError(f"Topology file missing required columns: {required_topo_cols}")
+
+        # Load bandwidth data
+        bandwidth_df = pd.read_csv(bandwidth_file)
+        required_bw_cols = ["MeshRow", "MeshCol", "EthernetChannel", "BandwidthGB_s", "PacketsPerSecond"]
+        if not all(col in bandwidth_df.columns for col in required_bw_cols):
+            raise ValueError(f"Bandwidth file missing required columns: {required_bw_cols}")
+
+        return topology_df, bandwidth_df
+    except Exception as e:
+        print(f"Error loading data: {e}")
+        sys.exit(1)
+
+
+def get_mesh_extent(topology_df):
+    """Determine the mesh grid dimensions."""
+    all_rows = pd.concat([topology_df["MeshRow"], topology_df["ConnectedMeshRow"]])
+    all_cols = pd.concat([topology_df["MeshCol"], topology_df["ConnectedMeshCol"]])
+
+    # min_row, max_row = all_rows.min(), all_rows.max()
+    # min_col, max_col = all_cols.min(), all_cols.max()
+    min_row, max_row = 0, all_rows.max()
+    min_col, max_col = 0, all_cols.max()
+
+    return min_row, max_row, min_col, max_col
+
+
+def create_bandwidth_lookup(bandwidth_df):
+    """Create a lookup dictionary for bandwidth data."""
+    lookup = {}
+    for _, row in bandwidth_df.iterrows():
+        key = (row["MeshRow"], row["MeshCol"], row["EthernetChannel"])
+        lookup[key] = {"bandwidth": row["BandwidthGB_s"], "packets": row["PacketsPerSecond"]}
+    return lookup
+
+
+def get_connection_bandwidth(topology_row, bw_lookup):
+    """Get bandwidth for a specific connection."""
+    key = (topology_row["MeshRow"], topology_row["MeshCol"], topology_row["EthernetChannel"])
+    if key in bw_lookup:
+        return bw_lookup[key]["bandwidth"]
+    return None
+
+
+def visualize_mesh_topology(topology_df, bandwidth_df, output_file=None):
+    """Create the main visualization."""
+    # Get mesh dimensions
+    min_row, max_row, min_col, max_col = get_mesh_extent(topology_df)
+
+    # Create bandwidth lookup
+    bw_lookup = create_bandwidth_lookup(bandwidth_df)
+
+    # Set up the plot
+    fig, ax = plt.subplots(figsize=(12, 8))
+
+    # Create grid
+    rows = max_row - min_row + 1
+    cols = max_col - min_col + 1
+
+    # Draw mesh nodes
+    for r in range(min_row, max_row + 1):
+        for c in range(min_col, max_col + 1):
+            # Position on plot (flip y-axis for intuitive row/col display)
+            x, y = c, max_row - r
+
+            # Draw node as a square
+            rect = FancyBboxPatch(
+                (x - 0.3, y - 0.3),
+                0.6,
+                0.6,
+                boxstyle="round,pad=0.05",
+                facecolor="lightblue",
+                edgecolor="black",
+                linewidth=1,
+            )
+            ax.add_patch(rect)
+
+            # Add node label
+            ax.text(x, y, f"({r},{c})", ha="center", va="center", fontsize=8, fontweight="bold")
+
+    # Process connections and collect bandwidth data
+    connections = []
+    bandwidths = []
+
+    # Group connections by source-destination pairs to calculate offsets for multiple channels
+    connection_groups = {}
+
+    for _, row in topology_df.iterrows():
+        src_r, src_c = row["MeshRow"], row["MeshCol"]
+        dst_r, dst_c = row["ConnectedMeshRow"], row["ConnectedMeshCol"]
+        channel = row["EthernetChannel"]
+
+        # Get bandwidth
+        bandwidth = get_connection_bandwidth(row, bw_lookup)
+
+        # Group key for counting multiple channels between same nodes (directional)
+        key = (src_r, src_c, dst_r, dst_c)
+        if key not in connection_groups:
+            connection_groups[key] = []
+
+        connection_groups[key].append({"channel": channel, "bandwidth": bandwidth, "row_data": row})
+
+    # Detect bidirectional connections for offset calculation
+    bidirectional_pairs = set()
+    for src_r, src_c, dst_r, dst_c in connection_groups.keys():
+        reverse_key = (dst_r, dst_c, src_r, src_c)
+        if reverse_key in connection_groups:
+            # Create a normalized pair key (smaller coordinates first)
+            pair_key = tuple(sorted([(src_r, src_c), (dst_r, dst_c)]))
+            bidirectional_pairs.add(pair_key)
+
+    # Draw individual connections with offsets for multiple channels
+    for (src_r, src_c, dst_r, dst_c), channels in connection_groups.items():
+        # Calculate base positions (flip y for display)
+        x1, y1 = src_c, max_row - src_r
+        x2, y2 = dst_c, max_row - dst_r
+
+        # Check if this connection is bidirectional
+        pair_key = tuple(sorted([(src_r, src_c), (dst_r, dst_c)]))
+        is_bidirectional = pair_key in bidirectional_pairs
+
+        # Calculate line direction vector
+        dx, dy = x2 - x1, y2 - y1
+        length = np.sqrt(dx**2 + dy**2) if dx != 0 or dy != 0 else 1
+
+        # Perpendicular unit vector for offsets
+        perp_x, perp_y = -dy / length, dx / length
+
+        # Apply bidirectional offset if needed
+        bidirectional_offset = 0
+        if is_bidirectional:
+            # Determine which direction this is (use coordinate comparison for consistency)
+            is_forward = (src_r, src_c) < (dst_r, dst_c)
+            bidirectional_offset = 0.02 if is_forward else -0.08
+
+        # Calculate offsets for multiple channels within the same direction
+        num_channels = len(channels)
+        # Always apply channel spacing to avoid overlaps
+        channel_spacing = 0.04
+        # Start from a base offset to ensure separation from the center line
+        channel_base_offset = 0.02
+
+        # Draw each channel as a separate line
+        for i, ch in enumerate(channels):
+            # Calculate offset positions for multiple channels
+            if ch["bandwidth"] is None:
+                continue
+
+            # Combine bidirectional offset with multi-channel offset
+            total_offset = bidirectional_offset
+
+            # Apply channel offset (starts from base offset to avoid center line)
+            channel_offset = channel_base_offset + (i * channel_spacing)
+            # If bidirectional, apply channel offset in the appropriate direction
+            if is_bidirectional:
+                # Forward direction: positive offset, Backward direction: negative offset
+                is_forward = (src_r, src_c) < (dst_r, dst_c)
+                channel_offset = channel_offset if is_forward else -channel_offset
+
+            total_offset += channel_offset
+
+            # Apply the combined offset
+            line_x1 = x1 + total_offset * perp_x
+            line_y1 = y1 + total_offset * perp_y
+            line_x2 = x2 + total_offset * perp_x
+            line_y2 = y2 + total_offset * perp_y
+
+            # Store connection for line collection
+            connections.append([(line_x1, line_y1), (line_x2, line_y2)])
+
+            # Store bandwidth for heatmap coloring
+            bandwidths.append(ch["bandwidth"])
+
+            # Add direction arrow for bidirectional connections
+            if is_bidirectional:
+                # Calculate arrow position (closer to destination)
+                arrow_ratio = 0.75
+                arrow_x = line_x1 + arrow_ratio * (line_x2 - line_x1)
+                arrow_y = line_y1 + arrow_ratio * (line_y2 - line_y1)
+
+                # Arrow direction
+                arrow_dx = (line_x2 - line_x1) * 0.1
+                arrow_dy = (line_y2 - line_y1) * 0.1
+
+                ax.annotate(
+                    "",
+                    xy=(arrow_x + arrow_dx, arrow_y + arrow_dy),
+                    xytext=(arrow_x, arrow_y),
+                    arrowprops=dict(arrowstyle="->", color="black", lw=1.5),
+                )
+
+            # Create individual annotation for this channel
+            label = f"Ch{ch['channel']}: {ch['bandwidth']:.2f}GB/s"
+
+            # Position annotation at midpoint of this specific line
+            mid_x = (line_x1 + line_x2) / 2
+            mid_y = (line_y1 + line_y2) / 2
+
+            # Check if this is a vertical or horizontal line for special handling
+            is_vertical = abs(x2 - x1) < 0.1
+            is_horizontal = abs(y2 - y1) < 0.1
+
+            offset_x = 0
+            offset_y = 0
+            rotation = 0
+            # Calculate annotation positioning and rotation
+            if is_vertical:
+                # For vertical lines, spread annotations vertically to avoid overlap
+                vertical_spacing = 0.4  # Increased spacing for better readability
+                # Center the annotations around the midpoint
+                total_vertical_span = (num_channels - 1) * vertical_spacing
+                vertical_offset = (i * vertical_spacing) - (total_vertical_span / 2)
+
+                # Add horizontal offset based on direction for bidirectional connections
+                # if is_bidirectional:
+                is_forward = (src_r, src_c) < (dst_r, dst_c)
+                horizontal_offset = -0.05 if is_forward else 0.05
+                # else:
+                #     horizontal_offset = 0.2
+
+                offset_x = 0  # horizontal_offset
+                offset_y = vertical_offset + horizontal_offset
+            else:
+                offset_y = i * 0.1
+
+            ax.annotate(
+                label,
+                (mid_x + offset_x, mid_y + offset_y),
+                fontsize=7,
+                ha="center",
+                va="center",
+                rotation=rotation,
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", alpha=0.8),
+            )
+
+    # Apply heatmap coloring to connections
+    if bandwidths and max(bandwidths) > 0:
+        # Normalize bandwidths for colormap
+        norm_bw = np.array(bandwidths)
+        norm_bw = norm_bw / max(norm_bw) if max(norm_bw) > 0 else norm_bw
+
+        # Create line collection with heatmap colors
+        lc = LineCollection(connections, linewidths=2, cmap="viridis", alpha=0.7)
+        lc.set_array(norm_bw)
+        line_collection = ax.add_collection(lc)
+
+        # Add colorbar
+        cbar = plt.colorbar(line_collection, ax=ax, shrink=0.8)
+        cbar.set_label("Normalized Bandwidth (GB/s)", rotation=270, labelpad=15)
+    else:
+        # Draw connections without heatmap if no bandwidth data
+        for connection in connections:
+            ax.plot(
+                [connection[0][0], connection[1][0]], [connection[0][1], connection[1][1]], "k-", linewidth=2, alpha=0.5
+            )
+
+    # Set plot properties
+    ax.set_xlim(min_col - 0.5, max_col + 0.5)
+    ax.set_ylim(-0.5, rows - 0.5)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.3)
+    ax.set_xlabel("Mesh Column")
+    ax.set_ylabel("Mesh Row (flipped for display)")
+    ax.set_title("Mesh Topology with Bandwidth Visualization")
+
+    # Set integer ticks
+    ax.set_xticks(range(min_col, max_col + 1))
+    ax.set_yticks(range(rows))
+    ax.set_yticklabels(range(max_row, min_row - 1, -1))
+
+    plt.tight_layout()
+
+    if output_file:
+        plt.savefig(output_file, dpi=300, bbox_inches="tight")
+        print(f"Visualization saved to {output_file}")
+
+    plt.show()
+
+
+def print_summary_stats(topology_df, bandwidth_df):
+    """Print summary statistics about the data."""
+    print("\n=== Data Summary ===")
+    print(f"Topology connections: {len(topology_df)}")
+    print(f"Bandwidth measurements: {len(bandwidth_df)}")
+
+    # Bandwidth stats
+    if not bandwidth_df.empty:
+        bw_stats = bandwidth_df["BandwidthGB_s"].describe()
+        print(f"\nBandwidth Statistics (GB/s):")
+        print(f"  Min: {bw_stats['min']:.2f}")
+        print(f"  Max: {bw_stats['max']:.2f}")
+        print(f"  Mean: {bw_stats['mean']:.2f}")
+        print(f"  Std: {bw_stats['std']:.2f}")
+
+    # Coverage analysis
+    bw_lookup = create_bandwidth_lookup(bandwidth_df)
+    covered_connections = 0
+    total_connections = len(topology_df)
+
+    for _, row in topology_df.iterrows():
+        key = (row["MeshRow"], row["MeshCol"], row["EthernetChannel"])
+        if key in bw_lookup:
+            covered_connections += 1
+
+    coverage_pct = (covered_connections / total_connections) * 100 if total_connections > 0 else 0
+    print(f"\nBandwidth Coverage: {covered_connections}/{total_connections} ({coverage_pct:.1f}%)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize mesh topology with bandwidth data")
+    parser.add_argument("topology_file", help="CSV file with mesh topology connections")
+    parser.add_argument("bandwidth_file", help="CSV file with bandwidth measurements")
+    parser.add_argument("-o", "--output", help="Output file for saving the plot (optional)")
+
+    args = parser.parse_args()
+
+    # Load data
+    topology_df, bandwidth_df = load_data(args.topology_file, args.bandwidth_file)
+
+    # Print summary
+    print_summary_stats(topology_df, bandwidth_df)
+
+    # Create visualization
+    visualize_mesh_topology(topology_df, bandwidth_df, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2710,28 +2710,6 @@ tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_helper(FabricTestM
     }
 }
 
-// Clears the L1 buffer on every active ethernet core where telemetry data is buffered
-void clear_fabric_telemetry_data(MeshDeviceView* mesh_device) {
-    constexpr size_t telemetry_struct_size_bytes = 24;
-    const auto telemetry_buffer_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
-    std::vector<uint32_t> clearing_data_vec(telemetry_struct_size_bytes / sizeof(uint32_t), 0);
-    for (const auto& device : mesh_device->get_devices()) {
-        auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-        for (const auto& eth_logical_core : device->get_active_ethernet_cores(true)) {
-            // Clear the telemetry data
-            log_info(
-                tt::LogMetal,
-                "Clearing telemetry data for device {}, ethernet core {}",
-                device->id(),
-                eth_logical_core);
-            // tt::tt_metal::detail::WriteToDeviceL1(
-            //     device, eth_logical_core, telemetry_buffer_address, clearing_data_vec, CoreType::ETH);
-        }
-    }
-    log_info(tt::LogMetal, "Done clearing telemetry data");
-}
-
-
 // Reads back and report the bandwidth telemetry data from active Ethernet core L1.
 void read_fabric_telemetry_data(MeshDeviceView* mesh_device) {
     constexpr size_t telemetry_struct_size_bytes = 24;
@@ -3032,10 +3010,6 @@ void Run1DFabricPacketSendTest(
             false,
             is_6u_galaxy,
             edm_buffer_config);
-    }
-
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_fabric_telemetry()) {
-        clear_fabric_telemetry_data(test_fixture->view_.get());
     }
 
     // Other boiler plate setup

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2710,6 +2710,233 @@ tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_helper(FabricTestM
     }
 }
 
+// Clears the L1 buffer on every active ethernet core where telemetry data is buffered
+void clear_fabric_telemetry_data(MeshDeviceView* mesh_device) {
+    constexpr size_t telemetry_struct_size_bytes = 24;
+    const auto telemetry_buffer_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
+    std::vector<uint32_t> clearing_data_vec(telemetry_struct_size_bytes / sizeof(uint32_t), 0);
+    for (const auto& device : mesh_device->get_devices()) {
+        auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
+        for (const auto& eth_logical_core : device->get_active_ethernet_cores(true)) {
+            // Clear the telemetry data
+            log_info(
+                tt::LogMetal,
+                "Clearing telemetry data for device {}, ethernet core {}",
+                device->id(),
+                eth_logical_core);
+            // tt::tt_metal::detail::WriteToDeviceL1(
+            //     device, eth_logical_core, telemetry_buffer_address, clearing_data_vec, CoreType::ETH);
+        }
+    }
+    log_info(tt::LogMetal, "Done clearing telemetry data");
+}
+
+
+// Reads back and report the bandwidth telemetry data from active Ethernet core L1.
+void read_fabric_telemetry_data(MeshDeviceView* mesh_device) {
+    constexpr size_t telemetry_struct_size_bytes = 24;
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto telemetry_buffer_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
+
+    // Convert raw data to telemetry struct
+    struct RiscTimestamp {
+        union {
+            uint64_t full;
+            struct {
+                uint32_t lo;
+                uint32_t hi;
+            };
+        };
+    };
+    struct LowResolutionBandwidthTelemetry {
+        RiscTimestamp timestamp_start;
+        RiscTimestamp timestamp_end;
+        uint32_t num_words_sent;
+        uint32_t num_packets_sent;
+    };
+    // host copy buffer to hold the readback telemetry data
+    std::vector<uint32_t> telemetry_raw_data(telemetry_struct_size_bytes / sizeof(uint32_t));
+
+    // Clear the telemetry data on the fabric core
+    std::vector<uint32_t> clearing_data_vec(telemetry_struct_size_bytes / sizeof(uint32_t), 0);
+
+    // Store telemetry data for CSV generation
+    struct TelemetryEntry {
+        ttnn::MeshCoordinate mesh_coord;
+        uint32_t eth_channel;
+        double bandwidth_gbps;
+        double packets_per_second;
+        ttnn::MeshCoordinate connected_mesh_coord;
+        uint32_t connected_eth_channel;
+    };
+    std::vector<TelemetryEntry> telemetry_entries;
+
+    for (const auto& device : mesh_device->get_devices()) {
+        log_info(tt::LogMetal, "Reading telemetry data for device {}", device->id());
+        auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
+        auto device_mesh_coord = mesh_device->find_device(device->id());
+
+        for (const auto& eth_logical_core : control_plane.get_active_ethernet_cores(device->id())) {
+            // for (const auto& eth_logical_core : device->get_active_ethernet_cores(true)) {
+            log_info(
+                tt::LogMetal, "Reading telemetry data for device {}, ethernet core {}", device->id(), eth_logical_core);
+            // Read the telemetry struct from L1
+            tt::tt_metal::detail::ReadFromDeviceL1(
+                device,
+                eth_logical_core,
+                telemetry_buffer_address,
+                telemetry_struct_size_bytes,
+                telemetry_raw_data,
+                CoreType::ETH);
+
+            LowResolutionBandwidthTelemetry telemetry_data;
+            std::memcpy(&telemetry_data, telemetry_raw_data.data(), telemetry_struct_size_bytes);
+
+            // Calculate bandwidth
+            uint32_t total_eth_words = telemetry_data.num_words_sent;
+            uint32_t total_bytes = total_eth_words << 4;
+
+            uint32_t total_packets = telemetry_data.num_packets_sent;
+            // I stored the cycles elapsed directly from device side since for much of the time, the fabric could just
+            // be idle, and that shouldn't count towards the bandwidth.
+            uint64_t total_cycles = telemetry_data.timestamp_start.full;
+
+            if (total_eth_words == 0 || total_packets == 0 || total_cycles == 0) {
+                log_warning(
+                    tt::LogTest,
+                    "Invalid telemetry data for device {}, ethernet channel {}",
+                    device->id(),
+                    eth_logical_core);
+                continue;
+            }
+            if (telemetry_data.timestamp_end.full != 0) {
+                log_warning(
+                    tt::LogMetal,
+                    "Telemetry data for device {}, ethernet channel {} is corrupted. Ignoring data",
+                    device->id(),
+                    eth_logical_core);
+                continue;
+            }
+
+            tt::tt_metal::detail::WriteToDeviceL1(
+                device, eth_logical_core, telemetry_buffer_address, clearing_data_vec, CoreType::ETH);
+
+            double bandwidth_gbps = 0.0;
+            double packets_per_second = 0.0;
+
+            TT_FATAL(total_cycles > 0, "Total cycles is 0");
+
+            // Convert cycles to seconds (assuming 1GHz clock)
+            double total_nanoseconds = static_cast<double>(total_cycles);
+            // Convert words to bytes (4 bytes per word)
+            double total_bytes_double = static_cast<double>(total_bytes);
+            bandwidth_gbps = total_bytes_double / total_nanoseconds;
+            packets_per_second = static_cast<double>(total_packets) / (total_nanoseconds / 1e9);
+
+            log_info(
+                tt::LogMetal,
+                "Fabric Telemetry - Device: {}, Ethernet Channel: {}, "
+                "Total Words: {}, Total Packets: {}, Total Cycles: {}, Bandwidth: {:.2f} GB/s, Packets/s: {:.2f}",
+                device->id(),
+                eth_logical_core,
+                total_eth_words,
+                total_packets,
+                total_cycles,
+                bandwidth_gbps,
+                packets_per_second);
+
+            // Store telemetry data for CSV generation
+            // Find ethernet channel for this core
+            uint32_t eth_channel = 0;
+            if (soc_desc.logical_eth_core_to_chan_map.find(eth_logical_core) !=
+                soc_desc.logical_eth_core_to_chan_map.end()) {
+                eth_channel = soc_desc.logical_eth_core_to_chan_map.at(eth_logical_core);
+            }
+
+            // Get connectivity info
+            auto [connected_chip_id, connected_eth_core] = device->get_connected_ethernet_core(eth_logical_core);
+            auto connected_mesh_coord = mesh_device->find_device(connected_chip_id);
+
+            auto connected_soc_desc =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(connected_chip_id);
+            uint32_t connected_eth_channel = 0;
+            if (connected_soc_desc.logical_eth_core_to_chan_map.find(connected_eth_core) !=
+                connected_soc_desc.logical_eth_core_to_chan_map.end()) {
+                connected_eth_channel = connected_soc_desc.logical_eth_core_to_chan_map.at(connected_eth_core);
+            }
+
+            telemetry_entries.push_back(
+                {device_mesh_coord,
+                 eth_channel,
+                 bandwidth_gbps,
+                 packets_per_second,
+                 connected_mesh_coord,
+                 connected_eth_channel});
+        }
+    }
+
+    // Generate CSV tables from stored telemetry data
+    const size_t num_rows = mesh_device->num_rows();
+    const size_t num_cols = mesh_device->num_cols();
+
+    // Build CSV tables as single strings
+    std::string connectivity_table = "=== CHIP CONNECTIVITY TABLE (CSV) ===\n";
+    connectivity_table += "MeshRow,MeshCol,ConnectedMeshRow,ConnectedMeshCol,EthernetChannel\n";
+
+    std::string bandwidth_table = "=== BANDWIDTH TABLE (CSV) ===\n";
+    bandwidth_table += "MeshRow,MeshCol,EthernetChannel,BandwidthGB_s,PacketsPerSecond\n";
+
+    // Enumerate all ethernet connections from mesh device
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    for (size_t row = 0; row < num_rows; row++) {
+        for (size_t col = 0; col < num_cols; col++) {
+            ttnn::MeshCoordinate current_coord(row, col);
+
+            // Get the physical chip ID for this mesh coordinate
+            IDevice* device = mesh_device->get_device(current_coord);
+            chip_id_t chip_id = device->id();
+
+            // Get all ethernet connections for this chip
+            const auto& connected_chips_and_cores = cluster.get_ethernet_cores_grouped_by_connected_chips(chip_id);
+            const auto& soc_desc = cluster.get_soc_desc(chip_id);
+
+            // Add entry for each ethernet connection
+            for (const auto& [connected_chip_id, local_eth_cores] : connected_chips_and_cores) {
+                // Find the mesh coordinate of the connected chip
+                ttnn::MeshCoordinate connected_coord = mesh_device->find_device(connected_chip_id);
+
+                for (const auto& eth_core : local_eth_cores) {
+                    // Get the ethernet channel for this core
+                    auto eth_channel_iter = soc_desc.logical_eth_core_to_chan_map.find(eth_core);
+                    TT_FATAL(
+                        eth_channel_iter != soc_desc.logical_eth_core_to_chan_map.end(),
+                        "Ethernet channel not found for core {}",
+                        eth_core);
+                    uint32_t eth_channel = eth_channel_iter->second;
+                    connectivity_table +=
+                        fmt::format("{},{},{},{},{}\n", row, col, connected_coord[0], connected_coord[1], eth_channel);
+                }
+            }
+        }
+    }
+
+    // Add entries for each telemetry data point
+    for (const auto& entry : telemetry_entries) {
+        bandwidth_table += fmt::format(
+            "{},{},{},{:.2f},{:.2f}\n",
+            entry.mesh_coord[0],
+            entry.mesh_coord[1],
+            entry.eth_channel,
+            entry.bandwidth_gbps,
+            entry.packets_per_second);
+    }
+
+    // Output complete tables as single log messages
+    log_info(tt::LogMetal, "");
+    log_info(tt::LogMetal, "{}", connectivity_table);
+    log_info(tt::LogMetal, "{}", bandwidth_table);
+}
+
 template <typename FABRIC_DEVICE_FIXTURE = Fabric1DFixture>
 void Run1DFabricPacketSendTest(
     std::unique_ptr<Fabric1DFixture>& test_fixture,
@@ -2805,6 +3032,10 @@ void Run1DFabricPacketSendTest(
             false,
             is_6u_galaxy,
             edm_buffer_config);
+    }
+
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_fabric_telemetry()) {
+        clear_fabric_telemetry_data(test_fixture->view_.get());
     }
 
     // Other boiler plate setup
@@ -3147,6 +3378,13 @@ void Run1DFabricPacketSendTest(
             tt_metal::detail::ReadDeviceProfilerResults(d);
         }
     }
+
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_fabric_telemetry()) {
+        log_info(tt::LogMetal, "Reading fabric telemetry data");
+        log_info(tt::LogMetal, "--------------------------------");
+        read_fabric_telemetry_data(test_fixture->view_.get());
+    }
+
     log_trace(tt::LogTest, "Finished");
 }
 
@@ -3714,6 +3952,12 @@ void Run1DFullMeshFabricPacketSendTest(
         device_programs,
         worker_cores_vec_per_axis_per_device,
         global_semaphore_addrs_per_axis);
+
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_fabric_telemetry()) {
+        log_info(tt::LogMetal, "Reading fabric telemetry data");
+        log_info(tt::LogMetal, "--------------------------------");
+        read_fabric_telemetry_data(test_fixture_->view_.get());
+    }
 }
 
 void RunWriteThroughputStabilityTestWithPersistentFabric(

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -145,6 +145,9 @@ struct FabricEriscDatamoverConfig {
     std::size_t edm_local_sync_address = 0;
     std::size_t edm_status_address = 0;
 
+    // Performance telemetry buffer address (16B aligned)
+    std::size_t perf_telemetry_buffer_address = 0;
+
     // Debug and Counters
     static constexpr std::size_t receiver_channel_counters_size_bytes =
         (((tt::tt_fabric::receiver_channel_counters_l1_size - 1) / field_size) + 1) * field_size;
@@ -392,6 +395,9 @@ public:
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc);
 
     [[nodiscard]] std::vector<uint32_t> get_compile_time_args(uint32_t risc_id) const;
+
+    // Helper for `get_compile_time_args`
+    void get_telemetry_compile_time_args(std::vector<uint32_t>& ct_args) const;
 
     [[nodiscard]] std::vector<uint32_t> get_runtime_args() const;
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -8,6 +8,7 @@
 #include "dataflow_api.h"
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp"
 
 #include <array>
 #include <utility>
@@ -360,7 +361,23 @@ static_assert(
     "Special marker 1 not found. This implies some arguments were misaligned between host and device. Double check the "
     "CT args.");
 
-constexpr size_t TO_SENDER_CREDIT_COUNTERS_START_IDX = SPECIAL_MARKER_1_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+///////////////////////////////////////////////
+// Telemetry
+constexpr size_t PERF_TELEMETRY_MODE_IDX = SPECIAL_MARKER_1_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+constexpr PerfTelemetryRecorderType perf_telemetry_mode =
+    static_cast<PerfTelemetryRecorderType>(get_compile_time_arg_val(PERF_TELEMETRY_MODE_IDX));
+
+constexpr size_t PERF_TELEMETRY_BUFFER_ADDR_IDX = PERF_TELEMETRY_MODE_IDX + 1;
+constexpr size_t perf_telemetry_buffer_addr = get_compile_time_arg_val(PERF_TELEMETRY_BUFFER_ADDR_IDX);
+
+constexpr size_t SPECIAL_MARKER_2_IDX = PERF_TELEMETRY_BUFFER_ADDR_IDX + 1;
+constexpr size_t SPECIAL_MARKER_2 = 0x20c0ffee;
+static_assert(
+    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_2_IDX) == SPECIAL_MARKER_2,
+    "Special marker 2 not found. This implies some arguments were misaligned between host and device. Double check the "
+    "CT args.");
+
+constexpr size_t TO_SENDER_CREDIT_COUNTERS_START_IDX = SPECIAL_MARKER_2_IDX + SPECIAL_MARKER_CHECK_ENABLED;
 
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> to_sender_remote_ack_counter_addrs =
     conditional_get_next_n_args<multi_txq_enabled, size_t, TO_SENDER_CREDIT_COUNTERS_START_IDX, NUM_SENDER_CHANNELS>();
@@ -407,15 +424,15 @@ static_assert(
     !multi_txq_enabled || counter_credit_addresses_are_valid(local_receiver_completion_counter_ptrs),
     "local_receiver_completion_counter_ptrs must be valid");
 
-constexpr size_t SPECIAL_MARKER_2_IDX =
+constexpr size_t SPECIAL_MARKER_3_IDX =
     TO_SENDER_CREDIT_COUNTERS_START_IDX + (multi_txq_enabled ? 2 * (NUM_SENDER_CHANNELS + NUM_RECEIVER_CHANNELS) : 0);
-constexpr size_t SPECIAL_MARKER_2 = 0x20c0ffee;
+constexpr size_t SPECIAL_MARKER_3 = 0x30c0ffee;
 static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_2_IDX) == SPECIAL_MARKER_2,
+    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_3_IDX) == SPECIAL_MARKER_3,
     "Special marker 2 not found. This implies some arguments were misaligned between host and device. Double check the "
     "CT args.");
 
-constexpr size_t HOST_SIGNAL_ARGS_START_IDX = SPECIAL_MARKER_2_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+constexpr size_t HOST_SIGNAL_ARGS_START_IDX = SPECIAL_MARKER_3_IDX + SPECIAL_MARKER_CHECK_ENABLED;
 // static_assert(HOST_SIGNAL_ARGS_START_IDX == 56, "HOST_SIGNAL_ARGS_START_IDX must be 56");
 // TODO: Add type safe getter
 constexpr bool is_local_handshake_master =

--- a/tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/hw/inc/ethernet/tt_eth_api.h"
+#include "tt_metal/hw/inc/risc_attribs.h"
+
+#include <cstdint>
+#include <cstddef>  // Define FORCE_INLINE if not already defined
+#ifndef FORCE_INLINE
+#define FORCE_INLINE __attribute__((always_inline)) inline
+#endif
+
+/**
+ * @brief Timestamp structure with 64-bit value accessible as full or split into high/low 32-bit parts
+ */
+struct RiscTimestamp {
+    union {
+        uint64_t full;
+        struct {
+            uint32_t lo;
+            uint32_t hi;
+        };
+    };
+};
+
+/**
+ * @brief Enumeration of performance telemetry recorder types
+ */
+enum class PerfTelemetryRecorderType : uint8_t {
+    NONE = 0,
+    LOW_RESOLUTION_BANDWIDTH = 1,
+};
+
+/**
+ * @brief Low resolution bandwidth telemetry data structure
+ *
+ * This is expected to be dumped after completing the inner loop
+ * and is expected to be stored in local memory.
+ */
+struct LowResolutionBandwidthTelemetry {
+    RiscTimestamp timestamp_start;
+    RiscTimestamp timestamp_end;
+    uint32_t num_words_sent;
+    uint32_t num_packets_sent;
+};
+
+/**
+ * @brief L1 buffer wrapper for storing telemetry data
+ */
+struct L1PerfTelemetrySingleBuffer {
+    volatile tt_l1_ptr uint32_t* buffer_ptr;
+
+    /**
+     * @brief Constructs a telemetry buffer with the given pointer
+     * @param ptr Pointer to the L1 memory buffer, must be 16-byte aligned
+     */
+    L1PerfTelemetrySingleBuffer(uint32_t* ptr) : buffer_ptr(ptr) {}
+
+    /**
+     * @brief Returns the buffer pointer
+     * @return Pointer to the L1 telemetry buffer
+     */
+    FORCE_INLINE volatile tt_l1_ptr uint32_t* get_ptr() const { return buffer_ptr; }
+};
+
+/**
+ * @brief Default template function to check if an event was captured in the last capture window
+ *        This helper is useful for filtering out idle time from reported data.
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ * @return Always returns false for default case
+ */
+template <typename PERF_TELEMETRY_COLLECTOR>
+bool captured_an_event(PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector) {
+    return false;
+}
+
+/**
+ * @brief Specialized function to check if a bandwidth telemetry event was captured
+ * @param perf_telemetry_collector Reference to the bandwidth telemetry collector
+ * @return True if packets were sent, false otherwise
+ */
+template <>
+bool captured_an_event<LowResolutionBandwidthTelemetry>(LowResolutionBandwidthTelemetry& perf_telemetry_collector) {
+    return perf_telemetry_collector.num_packets_sent > 0;
+}
+
+/**
+ * @brief Default template function to open a performance recording window.
+ *        Does nothing.
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ */
+template <typename PERF_TELEMETRY_COLLECTOR>
+FORCE_INLINE void open_perf_recording_window(PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector) {
+    // do nothing as default behaviour
+}
+
+/**
+ * @brief Specialized function to open a bandwidth telemetry recording window
+ * @param perf_telemetry_collector Reference to the bandwidth telemetry collector
+ */
+template <>
+FORCE_INLINE void open_perf_recording_window<LowResolutionBandwidthTelemetry>(
+    LowResolutionBandwidthTelemetry& perf_telemetry_collector) {
+    perf_telemetry_collector.timestamp_start.full = eth_read_wall_clock();
+    perf_telemetry_collector.num_words_sent = 0;
+    perf_telemetry_collector.num_packets_sent = 0;
+}
+
+/**
+ * @brief Default template function to close a performance recording window
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ */
+template <typename PERF_TELEMETRY_COLLECTOR>
+FORCE_INLINE void close_perf_recording_window(PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector) {
+    // do nothing as default behaviour
+}
+
+/**
+ * @brief Specialized function to close a bandwidth telemetry recording window
+ * @param perf_telemetry_collector Reference to the bandwidth telemetry collector
+ */
+template <>
+FORCE_INLINE void close_perf_recording_window<LowResolutionBandwidthTelemetry>(
+    LowResolutionBandwidthTelemetry& perf_telemetry_collector) {
+    perf_telemetry_collector.timestamp_end.full = eth_read_wall_clock();
+}
+
+/**
+ * @brief Default template function to clear a telemetry buffer
+ * @param buffer Reference to the telemetry buffer
+ */
+template <typename BUFFER_TYPE>
+FORCE_INLINE void clear_telemetry_buffer(BUFFER_TYPE& buffer) {
+    // do nothing as default behaviour
+}
+
+/**
+ * @brief Specialized function to clear an L1 telemetry buffer
+ * @param buffer Reference to the L1 telemetry buffer
+ */
+template <>
+FORCE_INLINE void clear_telemetry_buffer<L1PerfTelemetrySingleBuffer>(L1PerfTelemetrySingleBuffer& buffer) {
+    volatile tt_l1_ptr auto* buffer_ptr = buffer.get_ptr();
+    constexpr size_t num_words_to_clear = sizeof(LowResolutionBandwidthTelemetry) / sizeof(size_t);
+    static_assert(sizeof(LowResolutionBandwidthTelemetry) > sizeof(size_t), "L1PerfTelemetrySingleBuffer is too small");
+    for (size_t i = 0; i < num_words_to_clear; i++) {
+        buffer_ptr[i] = 0;
+    }
+}
+
+/**
+ * @brief Default template function to write performance recording window results
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ * @param buffer Reference to the telemetry buffer
+ */
+template <typename PERF_TELEMETRY_COLLECTOR, typename BUFFER_TYPE>
+FORCE_INLINE void write_perf_recording_window_results(
+    PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector, BUFFER_TYPE& buffer) {
+    // do nothing as default behaviour
+}
+
+/**
+ * @brief Specialized function to write bandwidth telemetry results to L1 buffer
+ * @param perf_telemetry_collector Reference to the bandwidth telemetry collector
+ * @param buffer Reference to the L1 telemetry buffer
+ */
+template <>
+FORCE_INLINE void write_perf_recording_window_results<LowResolutionBandwidthTelemetry, L1PerfTelemetrySingleBuffer>(
+    LowResolutionBandwidthTelemetry& perf_telemetry_collector, L1PerfTelemetrySingleBuffer& buffer) {
+    volatile tt_l1_ptr auto* buffer_ptr = buffer.get_ptr();
+    auto num_words_sent_l1_copy = buffer_ptr[4];
+    auto num_packets_sent_l1_copy = buffer_ptr[5];
+    uint64_t total_cycles = (static_cast<uint64_t>(buffer_ptr[1]) << 32) | buffer_ptr[0];
+    auto added_cycles =
+        total_cycles + (perf_telemetry_collector.timestamp_end.full - perf_telemetry_collector.timestamp_start.full);
+
+    // For the time being, this telemetry mode records elapsed elapsed (busy) cycles, not start/end, because
+    // we want to exclude large idle times from the bandwidth calculation
+    buffer_ptr[0] = added_cycles & 0xFFFFFFFF;
+    buffer_ptr[1] = added_cycles >> 32;
+    // Skip end timstamp
+    buffer_ptr[4] = num_words_sent_l1_copy + perf_telemetry_collector.num_words_sent;
+    buffer_ptr[5] = num_packets_sent_l1_copy + perf_telemetry_collector.num_packets_sent;
+}
+
+/**
+ * @brief Default template function to record a packet send event
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ * @param channel_idx Sender channel index of the channel (unused in this implementation)
+ * @param packet_size_bytes Size of the packet in bytes
+ */
+template <typename PERF_TELEMETRY_COLLECTOR>
+FORCE_INLINE void record_packet_send(
+    PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector, size_t channel_idx, size_t packet_size_bytes) {
+    // do nothing as default behaviour
+}
+
+/**
+ * @brief Specialized function to record a packet send event for bandwidth telemetry
+ * @param perf_telemetry_collector Reference to the bandwidth telemetry collector
+ * @param channel_idx Sender channel index of the channel (unused in this implementation)
+ * @param packet_size_bytes Size of the packet in bytes
+ */
+template <>
+FORCE_INLINE void record_packet_send<LowResolutionBandwidthTelemetry>(
+    LowResolutionBandwidthTelemetry& perf_telemetry_collector, size_t channel_idx, size_t packet_size_bytes) {
+    // do nothing as default behaviour
+    perf_telemetry_collector.num_packets_sent++;
+    perf_telemetry_collector.num_words_sent += bytes_to_eth_words_truncated(packet_size_bytes);
+}
+
+/**
+ * @brief Default template function to record packet receiver forward event
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ * @param channel_idx receiver channel index the event is captured from
+ * @param packet_size_bytes Size of the packet in bytes
+ */
+template <typename PERF_TELEMETRY_COLLECTOR>
+FORCE_INLINE void record_packet_receiver_forward(
+    PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector, size_t channel_idx, size_t packet_size_bytes) {}
+
+/**
+ * @brief Default template function to record packet receiver write to NOC event
+ * @param perf_telemetry_collector Reference to the telemetry collector
+ * @param channel_idx receiver channel index the event is captured from
+ * @param packet_size_bytes Size of the packet in bytes
+ */
+template <typename PERF_TELEMETRY_COLLECTOR>
+FORCE_INLINE void record_packet_receiver_write_to_noc(
+    PERF_TELEMETRY_COLLECTOR& perf_telemetry_collector, size_t channel_idx, size_t packet_size_bytes) {}
+
+/**
+ * @brief Template function to build a performance telemetry recorder for NONE type
+ * @return Always returns false for NONE type
+ */
+template <PerfTelemetryRecorderType PERF_TELEMETRY_RECORDER_TYPE>
+std::enable_if_t<PERF_TELEMETRY_RECORDER_TYPE == PerfTelemetryRecorderType::NONE, bool>
+build_perf_telemetry_recorder() {
+    return false;
+}
+
+/**
+ * @brief Template function to build a low resolution bandwidth telemetry recorder
+ * @return Initialized LowResolutionBandwidthTelemetry structure
+ */
+template <PerfTelemetryRecorderType PERF_TELEMETRY_RECORDER_TYPE>
+std::enable_if_t<
+    PERF_TELEMETRY_RECORDER_TYPE == PerfTelemetryRecorderType::LOW_RESOLUTION_BANDWIDTH,
+    LowResolutionBandwidthTelemetry>
+build_perf_telemetry_recorder() {
+    auto local_perf_telemetry_recorder = LowResolutionBandwidthTelemetry();
+    local_perf_telemetry_recorder.timestamp_start.full = 0;
+    local_perf_telemetry_recorder.timestamp_end.full = 0;
+    local_perf_telemetry_recorder.num_words_sent = 0;
+    local_perf_telemetry_recorder.num_packets_sent = 0;
+    return local_perf_telemetry_recorder;
+}
+
+/**
+ * @brief Builds a performance telemetry buffer and initializes it
+ * @param perf_telemetry_buffer_addr Pointer to the telemetry buffer address
+ * @return Initialized L1PerfTelemetrySingleBuffer with cleared contents
+ */
+L1PerfTelemetrySingleBuffer build_perf_telemetry_buffer(uint32_t* perf_telemetry_buffer_addr) {
+    auto local_perf_telemetry_buffer = L1PerfTelemetrySingleBuffer(perf_telemetry_buffer_addr);
+    clear_telemetry_buffer(local_perf_telemetry_buffer);
+    return local_perf_telemetry_buffer;
+}

--- a/tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp
@@ -8,10 +8,7 @@
 #include "tt_metal/hw/inc/risc_attribs.h"
 
 #include <cstdint>
-#include <cstddef>  // Define FORCE_INLINE if not already defined
-#ifndef FORCE_INLINE
-#define FORCE_INLINE __attribute__((always_inline)) inline
-#endif
+#include <cstddef>
 
 /**
  * @brief Timestamp structure with 64-bit value accessible as full or split into high/low 32-bit parts

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -22,6 +22,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_tmp_utils.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp"
 
 #include "noc_overlay_parameters.h"
 #include "tt_metal/hw/inc/utils/utils.h"
@@ -254,6 +255,14 @@ write to the same receiver channel.
 // Data structures, types, enums, and constants
 ////////////////////////////////////////////////
 
+static constexpr bool PERF_TELEMETRY_DISABLED = perf_telemetry_mode == PerfTelemetryRecorderType::NONE;
+static constexpr bool PERF_TELEMETRY_LOW_RESOLUTION_BANDWIDTH =
+    perf_telemetry_mode == PerfTelemetryRecorderType::LOW_RESOLUTION_BANDWIDTH;
+using PerfTelemetryRecorder = std::conditional_t<
+    PERF_TELEMETRY_LOW_RESOLUTION_BANDWIDTH,
+    LowResolutionBandwidthTelemetry,
+    std::conditional_t<PERF_TELEMETRY_DISABLED, bool, std::nullptr_t>>;
+
 // Defined here because sender_channel_0_free_slots_stream_id does not come from
 // 1d_fabric_constants.hpp
 static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_free_slots_stream_ids = {
@@ -385,7 +394,8 @@ FORCE_INLINE void send_next_data(
     tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>& sender_buffer_channel,
     tt::tt_fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>& sender_worker_interface,
     OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS>& outbound_to_receiver_channel_pointers,
-    tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& receiver_buffer_channel) {
+    tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& receiver_buffer_channel,
+    PerfTelemetryRecorder& perf_telemetry_recorder) {
     auto& remote_receiver_buffer_index = outbound_to_receiver_channel_pointers.remote_receiver_buffer_index;
     auto& remote_receiver_num_free_slots = outbound_to_receiver_channel_pointers.num_free_slots;
     auto& local_sender_write_counter = sender_worker_interface.local_write_counter;
@@ -431,6 +441,9 @@ FORCE_INLINE void send_next_data(
     remote_receiver_num_free_slots--;
     // update the remote reg
     static constexpr uint32_t packets_to_forward = 1;
+
+    record_packet_send(perf_telemetry_recorder, sender_channel_index, payload_size_bytes);
+
     while (internal_::eth_txq_is_busy(sender_txq_id)) {
     };
     remote_update_ptr_val<to_receiver_pkts_sent_id, sender_txq_id>(packets_to_forward);
@@ -1178,7 +1191,8 @@ void run_sender_channel_step_impl(
     PacketHeaderRecorder& packet_header_recorder,
     bool& channel_connection_established,
     uint32_t sender_channel_free_slots_stream_id,
-    SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits) {
+    SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits,
+    PerfTelemetryRecorder& perf_telemetry_recorder) {
     // If the receiver has space, and we have one or more packets unsent from producer, then send one
     // TODO: convert to loop to send multiple packets back to back (or support sending multiple packets in one shot)
     //       when moving to stream regs to manage rd/wr ptrs
@@ -1206,7 +1220,8 @@ void run_sender_channel_step_impl(
             local_sender_channel,
             local_sender_channel_worker_interface,
             outbound_to_receiver_channel_pointers,
-            remote_receiver_channel);
+            remote_receiver_channel,
+            perf_telemetry_recorder);
         increment_local_update_ptr_val(sender_channel_free_slots_stream_id, 1);
     }
 
@@ -1295,7 +1310,8 @@ FORCE_INLINE void run_sender_channel_step(
     std::array<PacketHeaderRecorder, MAX_NUM_SENDER_CHANNELS>& sender_channel_packet_recorders,
     std::array<bool, NUM_SENDER_CHANNELS>& channel_connection_established,
     std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids_ordered,
-    std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>& sender_channel_from_receiver_credits) {
+    std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>& sender_channel_from_receiver_credits,
+    PerfTelemetryRecorder& perf_telemetry_recorder) {
     if constexpr (is_sender_channel_serviced[sender_channel_index]) {
         run_sender_channel_step_impl<
             enable_packet_header_recording,
@@ -1310,7 +1326,8 @@ FORCE_INLINE void run_sender_channel_step(
             sender_channel_packet_recorders[sender_channel_index],
             channel_connection_established[sender_channel_index],
             local_sender_channel_free_slots_stream_ids_ordered[sender_channel_index],
-            sender_channel_from_receiver_credits[sender_channel_index]);
+            sender_channel_from_receiver_credits[sender_channel_index],
+            perf_telemetry_recorder);
     }
 }
 
@@ -1487,6 +1504,17 @@ FORCE_INLINE void run_receiver_channel_step(
     }
 }
 
+bool any_sender_channels_active(
+    const std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
+    for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
+        if (get_ptr_val(local_sender_channel_free_slots_stream_ids[i]) !=
+            static_cast<int32_t>(SENDER_NUM_BUFFERS_ARRAY[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /*
  * Main control loop for fabric EDM. Run indefinitely until a termination signal is received
  *
@@ -1544,6 +1572,10 @@ void run_fabric_edm_main_loop(
     std::array<bool, NUM_SENDER_CHANNELS> channel_connection_established =
         initialize_array<NUM_SENDER_CHANNELS, bool, false>();
 
+    PerfTelemetryRecorder inner_loop_perf_telemetry_collector = build_perf_telemetry_recorder<perf_telemetry_mode>();
+    auto local_perf_telemetry_buffer =
+        build_perf_telemetry_buffer(reinterpret_cast<uint32_t*>(perf_telemetry_buffer_addr));
+
     auto receiver_channel_response_credit_senders =
         init_receiver_channel_response_credit_senders<NUM_RECEIVER_CHANNELS>();
     auto sender_channel_from_receiver_credits =
@@ -1554,6 +1586,9 @@ void run_fabric_edm_main_loop(
 
     while (!got_immediate_termination_signal(termination_signal_ptr)) {
         did_something = false;
+
+        open_perf_recording_window(inner_loop_perf_telemetry_collector);
+
         for (size_t i = 0; i < iterations_between_ctx_switch_and_teardown_checks; i++) {
             invalidate_l1_cache();
             // Capture these to see if we made progress
@@ -1568,7 +1603,8 @@ void run_fabric_edm_main_loop(
                 sender_channel_packet_recorders,
                 channel_connection_established,
                 local_sender_channel_free_slots_stream_ids_ordered,
-                sender_channel_from_receiver_credits);
+                sender_channel_from_receiver_credits,
+                inner_loop_perf_telemetry_collector);
             if constexpr (!dateline_connection) {
                 run_receiver_channel_step<0>(
                     local_receiver_channels,
@@ -1597,7 +1633,8 @@ void run_fabric_edm_main_loop(
                     sender_channel_packet_recorders,
                     channel_connection_established,
                     local_sender_channel_free_slots_stream_ids_ordered,
-                    sender_channel_from_receiver_credits);
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector);
             }
             if constexpr (is_2d_fabric) {
                 run_sender_channel_step<enable_packet_header_recording, VC0_RECEIVER_CHANNEL, 2>(
@@ -1608,7 +1645,8 @@ void run_fabric_edm_main_loop(
                     sender_channel_packet_recorders,
                     channel_connection_established,
                     local_sender_channel_free_slots_stream_ids_ordered,
-                    sender_channel_from_receiver_credits);
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector);
                 run_sender_channel_step<enable_packet_header_recording, VC0_RECEIVER_CHANNEL, 3>(
                     local_sender_channels,
                     local_sender_channel_worker_interfaces,
@@ -1617,7 +1655,8 @@ void run_fabric_edm_main_loop(
                     sender_channel_packet_recorders,
                     channel_connection_established,
                     local_sender_channel_free_slots_stream_ids_ordered,
-                    sender_channel_from_receiver_credits);
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector);
             }
             if constexpr (enable_ring_support && !dateline_connection && !skip_sender_vc1_channel_connection) {
                 run_sender_channel_step<enable_packet_header_recording, VC1_RECEIVER_CHANNEL, NUM_SENDER_CHANNELS - 1>(
@@ -1628,7 +1667,8 @@ void run_fabric_edm_main_loop(
                     sender_channel_packet_recorders,
                     channel_connection_established,
                     local_sender_channel_free_slots_stream_ids_ordered,
-                    sender_channel_from_receiver_credits);
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector);
             }
         }
 
@@ -1648,6 +1688,14 @@ void run_fabric_edm_main_loop(
                     did_nothing_count = 0;
                     run_routing_without_noc_sync();
                 }
+            }
+        }
+
+        close_perf_recording_window(inner_loop_perf_telemetry_collector);
+        if constexpr (perf_telemetry_mode != PerfTelemetryRecorderType::NONE) {
+            if (captured_an_event(inner_loop_perf_telemetry_collector) ||
+                any_sender_channels_active(local_sender_channel_free_slots_stream_ids_ordered)) {
+                write_perf_recording_window_results(inner_loop_perf_telemetry_collector, local_perf_telemetry_buffer);
             }
         }
     }

--- a/tt_metal/hw/inc/ethernet/tt_eth_api.h
+++ b/tt_metal/hw/inc/ethernet/tt_eth_api.h
@@ -13,6 +13,15 @@
 #define ETH_READ_REG(addr) (*((volatile uint32_t*)((addr))))
 
 #define ETH_WORD_SIZE_BYTES 16
+#define BYTES_TO_ETH_WORD_SHIFT 4
+
+// Doesn't round up/ceil, just truncates for perf where we don't care about the remainder
+// and we know the input is already a multiple of ETH_WORD_SIZE_BYTES
+inline uint32_t bytes_to_eth_words_truncated(uint32_t num_bytes) { return num_bytes >> BYTES_TO_ETH_WORD_SHIFT; }
+
+inline uint32_t bytes_to_eth_words(uint32_t num_bytes) {
+    return (num_bytes + (ETH_WORD_SIZE_BYTES - 1)) >> BYTES_TO_ETH_WORD_SHIFT;
+}
 
 inline void eth_txq_reg_write(uint32_t qnum, uint32_t offset, uint32_t val) {
     ETH_WRITE_REG(ETH_TXQ0_REGS_START + (qnum * ETH_TXQ_REGS_SIZE) + offset, val);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -239,6 +239,8 @@ RunTimeOptions::RunTimeOptions() {
         }
     }
 
+    enable_fabric_telemetry = (getenv("TT_METAL_FABRIC_TELEMETRY") != nullptr);
+
     if (getenv("TT_METAL_FORCE_REINIT")) {
         force_context_reinit = true;
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -239,7 +239,9 @@ RunTimeOptions::RunTimeOptions() {
         }
     }
 
-    enable_fabric_telemetry = (getenv("TT_METAL_FABRIC_TELEMETRY") != nullptr);
+    if (getenv("TT_METAL_FABRIC_TELEMETRY")) {
+        enable_fabric_telemetry = true;
+    }
 
     if (getenv("TT_METAL_FORCE_REINIT")) {
         force_context_reinit = true;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -472,6 +472,8 @@ public:
     // If true, the fabric (routers) will collect coarse grain telemetry data in software. This flag's state does not
     // affect the ability to capture Ethernet Subsystem register-read-based telemetry data.
     // This BW telemetry is coarse grain and records the total time that the reouter has unsent and inflight packets.
+    //
+    // NOTE: Enabling this option will lead to a 0-2% performance degradation for fabric traffic.
     inline bool get_enable_fabric_telemetry() const { return enable_fabric_telemetry; }
     inline void set_enable_fabric_telemetry(bool enable) { enable_fabric_telemetry = enable; }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -469,6 +469,9 @@ public:
 
     inline bool get_log_kernels_compilation_commands() const { return log_kernels_compilation_commands; }
 
+    // If true, the fabric (routers) will collect coarse grain telemetry data in software. This flag's state does not
+    // affect the ability to capture Ethernet Subsystem register-read-based telemetry data.
+    // This BW telemetry is coarse grain and records the total time that the reouter has unsent and inflight packets.
     inline bool get_enable_fabric_telemetry() const { return enable_fabric_telemetry; }
     inline void set_enable_fabric_telemetry(bool enable) { enable_fabric_telemetry = enable; }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -199,6 +199,9 @@ class RunTimeOptions {
     // Log kernels compilation commands
     bool log_kernels_compilation_commands = false;
 
+    // Enable fabric performance telemetry
+    bool enable_fabric_telemetry = false;
+
 public:
     RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
@@ -465,6 +468,9 @@ public:
     inline std::string get_custom_fabric_mesh_graph_desc_path() const { return custom_fabric_mesh_graph_desc_path; }
 
     inline bool get_log_kernels_compilation_commands() const { return log_kernels_compilation_commands; }
+
+    inline bool get_enable_fabric_telemetry() const { return enable_fabric_telemetry; }
+    inline void set_enable_fabric_telemetry(bool enable) { enable_fabric_telemetry = enable; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.


### PR DESCRIPTION
This PR adds an opt-in, experimental bandwidth telemetry feature to TT-Fabric router. The approach here is minimal and future work will provide more resolution/granularity to the reporting.

The current BW telemetry behaviour is reported once for the entire workload. It works by timestamping windows where we either send messages or have unsent/unacknowledged messages in our sender channel. For windows where no traffic is recorded, the interval is omitted. This is to avoid reported bandwidth artificially being lowered due to long idle times in the test.

Results are currently dumped in L1 at the first unreserved address (this is subject to change) and take the following structure (also subject to change):

```
struct results {
  uint64_t elapsed_cycles;
  uint64_t zero;
  // eth words are 16B, this lets us have longer capture windows without needing a uin64_t to manage overflow
  uint32_t num_eth_words_sent; 
  uint32_t num_packets_sent;
}
```

Future iterations will add more functionality:
- Finer grain telemetry
  - Host polling rate dictates resolution of these bandwidth measurements, as opposed to one number for a full run
  - Will move it closer to "real-time" reporting from the  
- Per (sender/receiver) channel reporting

## Usage

To enable the telemetry, specifiy environment variable `TT_METAL_FABRIC_TELEMETRY=1`. This flag will only enable the telemetry on device side, and will not (currently) enable automatic reporting by host of telemetry data.

As a rough prototype, the fabric bandwidth tests have implemented a basic read-back function.

## Limitation
Because this current implementation strictly accumulates into a fixed set of counters, with no ability to swap out data, there is an integer overflow concern. Because of this, results are only considered valid if the test runtime is less than about 10s of runtime. This is fine for our intended uses cases. This will be lifted in the future as we enable multiple buffer slots for results that can be round-robin read by host and cycled through by the router.

## Overheads

Overhead data is still being collected but ranges depending on the fabric and type of traffic pattern. So far I have observed a 0-1% overhead. However, further testing may reveal higher max overheads. This is another reason the feature is opt-in for the time-being.

## Outcomes

Based on the existing telemetry in this change, we are already able to start plotting useful information for benchmarking and system-level performance analysis.

For example, this is a line fabric running on the inner 4 devices of a t3k with traffic being sent in both directions. We see that the middle hop it "hot" and the end hops are cooler (about half bandwidth), due to the current fairness policy implemented in the router.

<img width="1309" height="770" alt="image" src="https://github.com/user-attachments/assets/187387ab-b8c0-4a92-9598-df3ec1ab1e5e" />

Here's another example with a full T3K where all rows and columns are sending data left/right/up/down. Note that the labels/lines may not exactly line up - the image is really more for illustrative purposes. Also note that the labels specify "Gbps" but the actual unit of the numbers are  "GB/s". This issue is resolved in this set of changes.
<img width="1394" height="828" alt="image" src="https://github.com/user-attachments/assets/c2147218-3ad9-40ca-9824-6a0e52f08e2b" />

The images above are not intended to represent a productized visualizer but are more of a quick visualization aid. They are generated by the `visualize_bw.py` script in this change.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/16686836591
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16506442679
- [x] Microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/16506444544
- [x] New tests in t3k unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/16510001431 