### PR TITLE
#0: SDPA Const Max Optimization For Prefill (can work for decode as well)

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -154,6 +154,88 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
     cb_push_back(reduce_cb, rows);
 }
 
+template <uint32_t in0_cb, uint32_t rows, uint32_t cols, uint32_t scale_fp32>
+void sub_exp_block_bcast_cols_inplace_constant_offset(uint32_t constant_offset_cb, uint32_t reduce_cb) {
+    // Precondition: in0_cb has rows*cols produced
+    // Precondition: constant_offset_cb has 1 produced
+    // Postcondition: in0_cb has rows*cols produced
+    // Postcondition: constant_offset_cb has 1 produced
+
+    sub_bcast_cols_init_short(in0_cb, constant_offset_cb);
+    exp_tile_init<true, true, scale_fp32>();
+    cb_wait_front(in0_cb, rows * cols);
+    cb_wait_front(constant_offset_cb, 1);
+    cb_reserve_back(reduce_cb, rows);
+
+    constexpr uint32_t dst_tiles = SUB_EXP_GRANULARITY;
+    constexpr uint32_t granularity = cols >> LOG2_SUB_EXP_GRANULARITY;
+    uint32_t in0_index = 0;
+    for (uint32_t i = 0; i < rows; ++i) {
+        for (uint32_t u = 0; u < granularity; u++) {
+            tile_regs_acquire();
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                sub_tiles_bcast_cols(in0_cb, constant_offset_cb, in0_index, 0, j);
+                exp_tile<true, true>(j);
+                in0_index++;
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                pack_tile(j, in0_cb);
+            }
+
+            // While we have results in DST, take advantage of L1 accumulation
+            // to reduce row x cols tiles to rows x 1 tiles.
+            if (u > 0) {
+                // If on the same row, keep accumulating
+                PACK((llk_pack_reconfig_l1_acc(1)));
+            }
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                pack_tile<true>(j, reduce_cb, i);
+                if (u == 0 && j == 0) {
+                    // If this was the first tile of a row, start accumulating
+                    PACK((llk_pack_reconfig_l1_acc(1)));
+                }
+            }
+            tile_regs_release();
+            PACK((llk_pack_reconfig_l1_acc(0)));
+        }
+    }
+    cb_pop_front(in0_cb, rows * cols);
+    cb_reserve_back(in0_cb, rows * cols);
+    cb_push_back(in0_cb, rows * cols);
+    cb_push_back(reduce_cb, rows);
+}
+
+template <uint32_t scale_fp32>
+void compute_exp_correction_factor(
+    uint32_t constant_offset_cb, uint32_t curr_max_cb, uint32_t out_cb, uint32_t num_tiles) {
+    // Compute exp(constant_offset - curr_max) * scale for final correction
+    // This corrects for using constant offset instead of actual max during computation
+
+    sub_tiles_init(constant_offset_cb, curr_max_cb);
+    exp_tile_init<EXP_APPROX_MODE, false>();
+    cb_wait_front(constant_offset_cb, 1);
+    cb_wait_front(curr_max_cb, num_tiles);
+    cb_reserve_back(out_cb, num_tiles);
+
+    // Convert scale_fp32 to bf16 scale
+    constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
+
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        acquire_dst();
+
+        sub_tiles(constant_offset_cb, curr_max_cb, 0, i, 0);
+
+        exp_tile<EXP_APPROX_MODE, false, true, true>(0, static_cast<int>(VectorMode::C), scale_bf16);
+
+        pack_tile(0, out_cb);
+        cb_push_back(out_cb, 1);
+        release_dst();
+    }
+}
+
 template <uint32_t rows, uint32_t cols>
 void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, bool pack_accumulate = false) {
     // Precondition: in0_cb has rows*cols produced

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -101,7 +101,7 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
 }
 
 template <uint32_t in0_cb, uint32_t rows, uint32_t cols, uint32_t scale_fp32>
-void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
+void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, bool is_constant_cb) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
@@ -120,61 +120,8 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
         for (uint32_t u = 0; u < granularity; u++) {
             tile_regs_acquire();
             for (uint32_t j = 0; j < dst_tiles; ++j) {
-                sub_tiles_bcast_cols(in0_cb, in1_cb, in0_index, i, j);
-                exp_tile<true, true>(j);
-                in0_index++;
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-
-            for (uint32_t j = 0; j < dst_tiles; ++j) {
-                pack_tile(j, in0_cb);
-            }
-
-            // While we have results in DST, take advantage of L1 accumulation
-            // to reduce row x cols tiles to rows x 1 tiles.
-            if (u > 0) {
-                // If on the same row, keep accumulating
-                PACK((llk_pack_reconfig_l1_acc(1)));
-            }
-            for (uint32_t j = 0; j < dst_tiles; ++j) {
-                pack_tile<true>(j, reduce_cb, i);
-                if (u == 0 && j == 0) {
-                    // If this was the first tile of a row, start accumulating
-                    PACK((llk_pack_reconfig_l1_acc(1)));
-                }
-            }
-            tile_regs_release();
-            PACK((llk_pack_reconfig_l1_acc(0)));
-        }
-    }
-    cb_pop_front(in0_cb, rows * cols);
-    cb_reserve_back(in0_cb, rows * cols);
-    cb_push_back(in0_cb, rows * cols);
-    cb_push_back(reduce_cb, rows);
-}
-
-template <uint32_t in0_cb, uint32_t rows, uint32_t cols, uint32_t scale_fp32>
-void sub_exp_block_bcast_cols_inplace_constant_offset(uint32_t constant_offset_cb, uint32_t reduce_cb) {
-    // Precondition: in0_cb has rows*cols produced
-    // Precondition: constant_offset_cb has 1 produced
-    // Postcondition: in0_cb has rows*cols produced
-    // Postcondition: constant_offset_cb has 1 produced
-
-    sub_bcast_cols_init_short(in0_cb, constant_offset_cb);
-    exp_tile_init<true, true, scale_fp32>();
-    cb_wait_front(in0_cb, rows * cols);
-    cb_wait_front(constant_offset_cb, 1);
-    cb_reserve_back(reduce_cb, rows);
-
-    constexpr uint32_t dst_tiles = SUB_EXP_GRANULARITY;
-    constexpr uint32_t granularity = cols >> LOG2_SUB_EXP_GRANULARITY;
-    uint32_t in0_index = 0;
-    for (uint32_t i = 0; i < rows; ++i) {
-        for (uint32_t u = 0; u < granularity; u++) {
-            tile_regs_acquire();
-            for (uint32_t j = 0; j < dst_tiles; ++j) {
-                sub_tiles_bcast_cols(in0_cb, constant_offset_cb, in0_index, 0, j);
+                uint32_t tile_index_1 = is_constant_cb ? 0 : i;
+                sub_tiles_bcast_cols(in0_cb, in1_cb, in0_index, tile_index_1, j);
                 exp_tile<true, true>(j);
                 in0_index++;
             }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -200,8 +200,8 @@ void MAIN {
                      * Partial reduce_sum is used to push the final row_reduction within a tile
                      * outside of the loop over K chunks.
                      */
-                    sub_exp_block_bcast_cols_inplace_constant_offset<cb_qk_im, Sq_chunk_t, Sk_chunk_t, scale_fp32>(
-                        cb_constant_offset_in, alias_cur_sum);
+                    sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, Sk_chunk_t, scale_fp32>(
+                        cb_constant_offset_in, alias_cur_sum, true);
 
                     cb_wait_front(cb_qk_im, qk_chunk_tiles);
                     /* OUT_IM = QK @ V_CHUNK */

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -265,8 +265,7 @@ void MAIN {
                  * Apply constant offset correction: multiply by exp(44.25 - curr_max) * scale
                  * This corrects for using constant offset instead of actual max during computation
                  */
-                compute_exp_correction_factor<scale_fp32>(
-                    cb_constant_offset_in, alias_prev_max, cb_exp_max_diff, Sq_chunk_t);
+                sub_exp_block<scale_fp32>(cb_constant_offset_in, alias_prev_max, cb_exp_max_diff, Sq_chunk_t, true);
                 mul_tiles_bcast_cols_inplace(alias_prev_sum, cb_exp_max_diff, Sq_chunk_t);
                 mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(alias_mm2_prev_out, cb_exp_max_diff);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -21,12 +21,13 @@ void kernel_main() {
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(10);
     constexpr uint32_t k_num_chunks = get_compile_time_arg_val(11);
     constexpr uint32_t identity_scalar_packed = get_compile_time_arg_val(12);
-    constexpr uint32_t scale_val = get_compile_time_arg_val(13);
-    constexpr uint32_t num_cores = get_compile_time_arg_val(14);
-    constexpr uint32_t is_causal = get_compile_time_arg_val(15) == 1;
-    constexpr uint32_t use_provided_mask = get_compile_time_arg_val(16) == 1;
-    constexpr uint32_t use_padded_mask = get_compile_time_arg_val(17) == 1;
-    constexpr uint32_t is_chunked = get_compile_time_arg_val(18) == 1;
+    constexpr uint32_t constant_offset_scalar_packed = get_compile_time_arg_val(13);
+    constexpr uint32_t scale_val = get_compile_time_arg_val(14);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(15);
+    constexpr uint32_t is_causal = get_compile_time_arg_val(16) == 1;
+    constexpr uint32_t use_provided_mask = get_compile_time_arg_val(17) == 1;
+    constexpr uint32_t use_padded_mask = get_compile_time_arg_val(18) == 1;
+    constexpr uint32_t is_chunked = get_compile_time_arg_val(19) == 1;
 
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
@@ -59,9 +60,11 @@ void kernel_main() {
     uint32_t barrier_count = 0;
 
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
+    constexpr uint32_t cb_constant_offset_in = tt::CBIndex::c_4;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_7;
 
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
+    generate_bcast_col_scalar(cb_constant_offset_in, constant_offset_scalar_packed);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -320,6 +320,11 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     class bfloat16 bfloat_identity_scalar(1.0f);
     uint32_t packed_identity_scalar = pack_two_bfloat16_into_uint32({bfloat_identity_scalar, bfloat_identity_scalar});
 
+    // Constant offset for SDPA optimization (44.25)
+    class bfloat16 bfloat_constant_offset_scalar(44.25f);
+    uint32_t packed_constant_offset_scalar =
+        pack_two_bfloat16_into_uint32({bfloat_constant_offset_scalar, bfloat_constant_offset_scalar});
+
     union {
         float f;
         uint32_t u;
@@ -364,6 +369,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         Sk_chunk_t,
         k_num_chunks,
         packed_identity_scalar,
+        packed_constant_offset_scalar,
         scale_union.u,
         num_cores,
         (std::uint32_t)is_causal,
@@ -508,6 +514,10 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     auto c_in5_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_5, scalar_df}})
                             .set_page_size(tt::CBIndex::c_5, scalar_tile_size);
     auto cb_in5_id = CreateCircularBuffer(program, core_grid, c_in5_config);
+    // constant offset input (44.25)
+    auto c_in4_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_4, scalar_df}})
+                            .set_page_size(tt::CBIndex::c_4, scalar_tile_size);
+    auto cb_in4_id = CreateCircularBuffer(program, core_grid, c_in4_config);
     // identity column input
     auto c_in7_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_7, scalar_df}})
                             .set_page_size(tt::CBIndex::c_7, scalar_tile_size);


### PR DESCRIPTION
### Problem description
Currently, in order to maintain the correct online softmax output we have to multiply the intermediate outputs cb_out_acc_im with the cb_exp_max_diff=exp(prev_max - cur_max) for every k chunk we have. From my understanding this ultimately cancels out the previous max factor multiplied and replaces the factor with the most updated max factor. And we have to do this for both the overall exp sum cb_prev_sum and the accumulate outputs. But I believe there is a better way to maintain correctness in the output without actually doing these steps since in our flash attention report we mention exp is one of the largest ops taking up 25% of runtime….

At first I think these steps are needed was because on a hardware level doing exp(x - max(x)) @ V is significantly different from performing (exp(x) @ V) * e^(-max(x)) because of numerical overflow such that we would get extremely large values close to +inf prior to doing the matmul and would give incorrect values, so we must subtract by the updated or current max first so that the exp exponent must always maintain something stable before doing the matmul 

But if that is the sole reason, I believe it is possible to instead of doing this multiplication with cb_exp_max_diff for every chunk, we can safely omit this step and replace the QK -= cb_cur_max and QK = exp(QK) step with exp(x-44.25) (Essentially wherever exp(x-curr_max), we replace curr_max with a constant with a restriction on x to prevent overflow) while still keeping track of curr_max, the reason for 44.25 (half of 88.5) is such that for the operating range of x (from -88.5 to 88.5) that we care about, it still ensures stability, then we only do one multiplication at the very end of the compute kernel with exp(44.25- curr_max) (essentially a one time cb_exp_max_diff ). Mathematically the outputs and the softmax sum are still being scaled by the curr_max and it should not change the distribution of softmax. So it should ultimately be equivalent to the original implementation while saving the cb_prev_sum *= cb_exp_max_diff step and the cb_out_accumulate_im *= cb_exp_max_diff steps so both these steps are only done once, at least for fast-approx mode...

### What's changed
- Instead of subtracting by `curr_max` we subtract by 44.25, but we still keep track of curr_max
- we omit the exp(prev_max - curr_max) calculation and we perform exp(44.25 - curr_max) and this is multiplied at the end of the kernel to the output logits and the sum.
- Upsides:
   - up to 10-11% savings in kernel duration depending on the k chunk sizes
- Downsides:
   - there is potentially a precision issue where we are clipping a certain range of logits, but this can be further investigated as to how we can mitigate this if we have more information about the distribution of the logits prior to exp

Some perf numbers reported here in this [sheet](https://docs.google.com/spreadsheets/d/1XPAlkTKcP68SAhKQ7tcT8b6KkS2m3rTP3IMa275QmIE/edit?gid=1374507100#gid=1374507100)