### PR TITLE
Reenable cache for yolov4

### DIFF
--- a/models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py
+++ b/models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py
@@ -28,8 +28,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 def run_yolov4(device, model_location_generator, use_pretrained_weight, resolution):
     torch.manual_seed(0)
 
-    # https://github.com/tenstorrent/tt-metal/issues/23192
-    device.disable_and_clear_program_cache()
     if use_pretrained_weight:
         torch_model = load_torch_model(model_location_generator)
     else:

--- a/models/demos/yolov9c/tests/perf/test_perf.py
+++ b/models/demos/yolov9c/tests/perf/test_perf.py
@@ -56,8 +56,6 @@ def dealloc_output(output_tensor):
 def test_perf(device, model_task, use_weights_from_ultralytics):
     disable_persistent_kernel_cache()
     enable_segment = model_task == "segment"
-    # https://github.com/tenstorrent/tt-metal/issues/23288
-    device.disable_and_clear_program_cache()
 
     torch_input, ttnn_input = create_yolov9c_input_tensors(device, model=True)
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23192)

### Problem description
During the first pr that activated the cache by default, this was a problem but now I can't reproduce it anymore

### What's changed
Multiple fixes in the cache

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes