### PR TITLE
#0: Make writes to packet header volatile

### DIFF
--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -591,9 +591,17 @@ struct LowLatencyMeshPacketHeader : public PacketHeaderBase<LowLatencyMeshPacket
 };
 
 struct MeshPacketHeader : public PacketHeaderBase<MeshPacketHeader> {
-    uint16_t dst_start_chip_id;
-    uint16_t dst_start_mesh_id;
-    uint16_t mcast_params[4];
+    union {
+        struct {
+            uint16_t dst_start_chip_id;
+            uint16_t dst_start_mesh_id;
+        };
+        uint32_t dst_start_node_id;  // Used for efficiently writing the dst info
+    };
+    union {
+        uint16_t mcast_params[4];  // Array representing the hops in each direction
+        uint64_t mcast_params_64;  // Used for efficiently writing to the mcast_params array
+    };
     uint8_t is_mcast_active;
     uint8_t reserved[7];
     void to_chip_unicast_impl(uint8_t distance_in_hops) {}

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -259,7 +259,7 @@ inline void fabric_async_write_add_header(
 
 template <bool mcast = false>
 void fabric_set_route(
-    low_latency_packet_header_t* packet_header,
+    volatile tt_l1_ptr low_latency_packet_header_t* packet_header,
     eth_chan_directions direction,
     uint32_t start_hop,
     uint32_t num_hops,
@@ -346,13 +346,14 @@ void fabric_set_unicast_route(
     }
 }
 
-void fabric_set_mcast_route(low_latency_packet_header_t* packet_header, eth_chan_directions direction, uint32_t hops) {
+void fabric_set_mcast_route(
+    volatile tt_l1_ptr low_latency_packet_header_t* packet_header, eth_chan_directions direction, uint32_t hops) {
     fabric_set_route<true>(packet_header, (eth_chan_directions)direction, 0, hops);
 }
 
 template <bool mcast = false>
 void fabric_set_route(
-    LowLatencyMeshPacketHeader* packet_header,
+    volatile tt_l1_ptr LowLatencyMeshPacketHeader* packet_header,
     eth_chan_directions direction,
     uint32_t branch_forward,
     uint32_t start_hop,
@@ -383,7 +384,7 @@ void fabric_set_route(
         default: ASSERT(false);
     }
 
-    uint8_t* route_vector = packet_header->route_buffer;
+    volatile tt_l1_ptr uint8_t* route_vector = packet_header->route_buffer;
     uint32_t local_val;
     uint32_t forward_val;
     uint32_t end_hop = start_hop + num_hops;
@@ -408,41 +409,36 @@ void fabric_set_route(
 }
 
 void fabric_set_unicast_route(
-    MeshPacketHeader* packet_header,
+    volatile tt_l1_ptr MeshPacketHeader* packet_header,
     eth_chan_directions outgoing_direction,  // Ignore this: Dynamic Routing does not need outgoing_direction specified
     uint16_t my_dev_id,                      // Ignore this: Dynamic Routing does not need src chip ID
     uint16_t dst_dev_id,
     uint16_t dst_mesh_id,
     uint16_t ew_dim  // Ignore this: Dynamic Routing does not need mesh dimensions
 ) {
-    packet_header->dst_start_chip_id = dst_dev_id;
-    packet_header->dst_start_mesh_id = dst_mesh_id;
-    packet_header->mcast_params[0] = 0;
-    packet_header->mcast_params[1] = 0;
-    packet_header->mcast_params[2] = 0;
-    packet_header->mcast_params[3] = 0;
+    packet_header->dst_start_node_id = ((uint32_t)dst_mesh_id << 16) | (uint32_t)dst_dev_id;
+    // Minimize writes to L1 by doing 1 u64 write (decomposed to 2 u32 writes) instead of 4 u16 writes
+    packet_header->mcast_params_64 = 0;
     packet_header->is_mcast_active = 0;
 }
 
 void fabric_set_mcast_route(
-    MeshPacketHeader* packet_header,
+    volatile tt_l1_ptr MeshPacketHeader* packet_header,
     uint16_t dst_dev_id,
     uint16_t dst_mesh_id,
     uint16_t e_num_hops,
     uint16_t w_num_hops,
     uint16_t n_num_hops,
     uint16_t s_num_hops) {
-    packet_header->dst_start_chip_id = dst_dev_id;
-    packet_header->dst_start_mesh_id = dst_mesh_id;
-    packet_header->mcast_params[0] = e_num_hops;
-    packet_header->mcast_params[1] = w_num_hops;
-    packet_header->mcast_params[2] = n_num_hops;
-    packet_header->mcast_params[3] = s_num_hops;
+    packet_header->dst_start_node_id = ((uint32_t)dst_mesh_id << 16) | (uint32_t)dst_dev_id;
+    // Minimize writes to L1 by doing 1 u64 write (decomposed to 2 u32 writes) instead of 4 u16 writes
+    packet_header->mcast_params_64 = ((uint64_t)s_num_hops << 48) | ((uint64_t)n_num_hops << 32) |
+                                     ((uint64_t)w_num_hops << 16) | ((uint64_t)e_num_hops);
     packet_header->is_mcast_active = 0;
 }
 
 void fabric_set_unicast_route(
-    LowLatencyMeshPacketHeader* packet_header,
+    volatile tt_l1_ptr LowLatencyMeshPacketHeader* packet_header,
     eth_chan_directions outgoing_direction,
     uint16_t my_dev_id,
     uint16_t dst_dev_id,
@@ -483,7 +479,7 @@ void fabric_set_unicast_route(
 }
 
 void fabric_set_mcast_route(
-    LowLatencyMeshPacketHeader* packet_header,
+    volatile tt_l1_ptr LowLatencyMeshPacketHeader* packet_header,
     uint16_t dst_dev_id,   // Ignore this, since Low Latency Mesh Fabric does not support arbitrary 2D Mcasts yet
     uint16_t dst_mesh_id,  // Ignore this, since Low Latency Mesh Fabric is not used for Inter-Mesh Routing
     uint16_t e_num_hops,

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -30,20 +30,10 @@ void fabric_set_unicast_route(volatile tt_l1_ptr PACKET_HEADER_TYPE* fabric_head
 #if defined(DYNAMIC_ROUTING_ENABLED)
     if constexpr (std::is_same_v<SocketT, SocketSenderInterface>) {
         fabric_set_unicast_route(
-            (MeshPacketHeader*)fabric_header_addr,
-            eth_chan_directions::COUNT,
-            0,
-            socket.downstream_chip_id,
-            socket.downstream_mesh_id,
-            0);
+            fabric_header_addr, eth_chan_directions::COUNT, 0, socket.downstream_chip_id, socket.downstream_mesh_id, 0);
     } else if constexpr (std::is_same_v<SocketT, SocketReceiverInterface>) {
         fabric_set_unicast_route(
-            (MeshPacketHeader*)fabric_header_addr,
-            eth_chan_directions::COUNT,
-            0,
-            socket.upstream_chip_id,
-            socket.upstream_mesh_id,
-            0);
+            fabric_header_addr, eth_chan_directions::COUNT, 0, socket.upstream_chip_id, socket.upstream_mesh_id, 0);
     } else {
         static_assert(always_false<SocketT>, "Unsupported socket type passed to set_fabric_unicast_route");
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We were doing writes to L1 for the packet headers and these weren't marked volatile. This could result in reordering/caching, ex if sent over noc the data might not have actually been written to l1 before noc reads it, so wrong data ends up sent over noc.

### What's changed
Make fabric apis that write to packet headers use a volatile pointer.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16489313171
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes