### PR TITLE
Add test for submitting CCLs and other work at the same time

### DIFF
--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -349,7 +349,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
             futures.push_back(promise->get_future());
             boost::asio::post(pool, [&, dev_idx, promise]() mutable {
                 auto& single_mesh = single_meshes[dev_idx];
-                // TODO: investigate why other OPs can't be scheduled on a different command queue until CCL is finished
+                // Wait for the CCL operation to finish before enqueueing the dummy ops, because ownership of the workers needs to be transferred between CQs.
                 ttnn::queue_synchronize(single_mesh->mesh_command_queue(ccl_cq_id));
 
                 auto dummy_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
@@ -415,6 +415,202 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
 
     for (auto& single_mesh : single_meshes) {
         ttnn::queue_synchronize(single_mesh->mesh_command_queue(op_cq_id));
+    }
+
+    log_info(tt::LogTest, "Finished");
+}
+
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksMultithreadCQ0) {
+    const size_t dim = 0;
+    const size_t num_links = 1;
+    constexpr auto layout = Layout::TILE;
+    constexpr size_t test_expected_num_devices = 4;
+
+    MeshDevice* mesh_device = this->mesh_device_.get();
+
+    // build a line of devices
+    std::vector<std::shared_ptr<distributed::MeshDevice>> single_meshes = {
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 3)),
+    };
+    std::vector<IDevice*> devices = {
+        single_meshes[0].get(),
+        single_meshes[1].get(),
+        single_meshes[2].get(),
+        single_meshes[3].get(),
+    };
+
+    // https://github.com/tenstorrent/tt-metal/issues/24235
+    for (auto& device : single_meshes) {
+        device->disable_and_clear_program_cache();
+    }
+
+    const size_t num_devices = devices.size();
+    TT_FATAL(
+        test_expected_num_devices == num_devices,
+        "Expected {} devices but got {}",
+        test_expected_num_devices,
+        num_devices);
+
+    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
+
+    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        devices,
+        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        0,                             // initial value
+        tt::tt_metal::BufferType::L1,  // buffer type
+        10                             // attempts
+    );
+
+    const int batch_size = 8;
+    const int sequence_length = 1024;
+    const int embedding_dim = 768;
+
+    const ttnn::Shape input_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const auto num_elems = input_shape.volume();
+
+    uint8_t op_ccl_cq_id = 0;   // device operation, ccl command queue id
+    uint8_t mem_cq_id = 1;   // read/write command queue id
+
+    boost::asio::thread_pool pool(devices.size());
+
+    for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
+        log_info(LogTest, "Running outer loop {}", outer_loop);
+        std::vector<Tensor> device_tensors(devices.size());
+
+        TensorSpec tensor_spec(
+            input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+
+        log_info(LogTest, "Enqueue Operations before AllGather");
+        std::vector<std::future<void>> futures;
+        for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
+            auto promise = std::make_shared<std::promise<void>>();
+            futures.push_back(promise->get_future());
+            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
+                // Generate input data for each device
+                auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
+                for (int j = 0; j < num_elems; j++) {
+                    host_data[j] = bfloat16(static_cast<float>(dev_idx));
+                }
+
+                auto& single_mesh = single_meshes[dev_idx];
+                auto input_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {MeshCoordinate(0, 0)}};
+
+                // TODO (#25340): Switch to use create_device_tensor? (TensorTopology logic should mirror
+                // create_device_tensor)
+                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
+
+                // Enqueue write_buffer to the operation`s command queue and record the event
+                ttnn::write_buffer(ttnn::QueueId(mem_cq_id), input_tensor, {host_data});
+
+                auto operation_event = ttnn::record_event(single_mesh->mesh_command_queue(mem_cq_id));
+                // Enqueue the task waiting for the operation_event to the ccl`s command queue
+                ttnn::wait_for_event(single_mesh->mesh_command_queue(op_ccl_cq_id), operation_event);
+
+                // Enqueue multiple operations to the operation command queue
+                // Set output_tensor into device_tensor for allgather
+                device_tensors[dev_idx] =
+                    ttnn::test_utils::dispatch_ops_to_device(input_tensor, ttnn::QueueId(op_ccl_cq_id));
+
+                promise->set_value();
+            });
+        }
+
+        // Wait for all tasks to complete
+        for (auto& future : futures) {
+            future.wait();
+        }
+        futures.clear();
+
+        log_info(LogTest, "Enqueue AllGather");
+
+        // Enqueue the all_gather_async operation on each device.
+        // It does not support command queue ID as a parameter and internally uses command queue 0.
+        std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
+            multi_device_global_semaphore};
+        const std::vector<Tensor> gathered_tensors = ttnn::experimental::all_gather_async(
+            device_tensors,
+            0,
+            multi_dev_semaphore,
+            1,
+            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            ttnn::ccl::Topology::Linear,
+            SubDeviceId(0));
+
+        log_info(LogTest, "Enqueue dummy ops");
+        for (size_t dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
+            auto promise = std::make_shared<std::promise<void>>();
+            futures.push_back(promise->get_future());
+            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
+                // Enqueue the dummy ops at the same time as the AllGather is running.
+                auto& single_mesh = single_meshes[dev_idx];
+
+                auto dummy_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
+                for (int j = 0; j < num_elems; j++) {
+                    dummy_data[j] = bfloat16(static_cast<float>(dev_idx));
+                }
+                auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
+                auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer, {MeshCoordinate(0, 0)}};
+                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
+                ttnn::write_buffer(ttnn::QueueId(op_ccl_cq_id), dummy_tensor, {dummy_data});
+                ttnn::test_utils::dispatch_ops_to_device(dummy_tensor, ttnn::QueueId(op_ccl_cq_id));
+                promise->set_value();
+            });
+        }
+
+        // Wait for all tasks to complete
+        for (auto& future : futures) {
+            future.wait();
+        }
+        futures.clear();
+
+        for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
+            auto device = devices[dev_idx];
+            auto promise = std::make_shared<std::promise<void>>();
+            futures.push_back(promise->get_future());
+            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+                auto& single_mesh = single_meshes[dev_idx];
+                auto ccl_event = ttnn::record_event(single_mesh->mesh_command_queue(op_ccl_cq_id));
+                // Enqueue the task waiting for the operation_event to the ccl`s command queue
+                ttnn::wait_for_event(single_mesh->mesh_command_queue(mem_cq_id), ccl_event);
+
+                promise->set_value();
+            });
+        }
+
+        // Wait for all tasks to complete
+        for (auto& future : futures) {
+            future.wait();
+        }
+        futures.clear();
+
+        log_info(LogTest, "EnqueueReadBuffer");
+        // Read the values from each device and compare them with the results calculated on the host
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto device_tensor = gathered_tensors[i];
+
+            boost::asio::post(pool, [&, i, device, num_elems, device_tensor]() mutable {
+                auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
+                ttnn::read_buffer(ttnn::QueueId(mem_cq_id), device_tensor, {output_data});
+
+                for (int j = 0; j < device_tensor.physical_volume(); j++) {
+                    int base = j / num_elems;  // dev_idx
+                    ASSERT_EQ(output_data[j].to_float(), (-1.0 * base * 32.0 + 128));
+                }
+                log_info(LogTest, "Device{} Compare Success", device->id());
+            });
+        }
+    }
+
+    pool.join();
+
+    for (auto& single_mesh : single_meshes) {
+        ttnn::queue_synchronize(single_mesh->mesh_command_queue(mem_cq_id));
     }
 
     log_info(tt::LogTest, "Finished");

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -442,11 +442,6 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksMultithreadCQ0) {
         single_meshes[3].get(),
     };
 
-    // https://github.com/tenstorrent/tt-metal/issues/24235
-    for (auto& device : single_meshes) {
-        device->disable_and_clear_program_cache();
-    }
-
     const size_t num_devices = devices.size();
     TT_FATAL(
         test_expected_num_devices == num_devices,


### PR DESCRIPTION
### Ticket
#20802 

### Problem description
Customers want to be able to enqueue a CCL from one thread and ops from other threads to the same CQ.

### What's changed
Add a test that matches the desired behavior:

- enqueue memory operations onto CQ 1
- wait on an event for CQ 1 to finish, then enqueue ops onto CQ 0
- wait for the threads doing that to finish, then enqueue a CCL onto CQ 0
- immediately enqueue some ops onto CQ 0 from multiple threads
- wait for the CCL to finish, then read on CQ 1

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes