### PR TITLE
Revert Go back to hugepages on WH for Merge Gate"

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -190,7 +190,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
+          "N150-viommu",
           "P150b-viommu",
         ]
     uses: ./.github/workflows/basic.yaml
@@ -212,7 +212,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
+          "N150-viommu",
           "P150b-viommu",
         ]
     uses: ./.github/workflows/basic.yaml


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#25564

The issue of merge gate failing on iommu runners has been root caused to a missing tag on a CIv2 node which then fails to set the grub boot args. This has since then been fixed.

https://tenstorrent.slack.com/archives/C074QGD4P5L/p1753300943850089