### PR TITLE
enable int32 for repeat and add int32 to repeat tests

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/repeat/repeat.py
+++ b/tests/sweep_framework/sweeps/data_movement/repeat/repeat.py
@@ -15,7 +15,7 @@ from functools import reduce
 
 TIMEOUT = 15
 
-dtypes = [ttnn.bfloat16]
+dtypes = [ttnn.bfloat16, ttnn.int32]
 shapes = [(1, 2, 4, 4), (1, 1, 1, 1)] + [(1, 2, 2 * j, 4 * j) for j in range(2, 12)]
 repeat_specs = [(2, 2, 2, 2), (1, 2, 1, 1)] + [(1, 3, 2 * j, 4 * j) for j in range(2, 12)]
 

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -14,7 +14,13 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 layouts = [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT]
 
-dtypes = [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16), (torch.bfloat16, ttnn.bfloat8_b)]
+dtypes = [
+    (torch.float32, ttnn.float32),
+    (torch.bfloat16, ttnn.bfloat16),
+    (torch.bfloat16, ttnn.bfloat8_b),
+    (torch.int32, ttnn.int32),
+    (torch.int32, ttnn.uint32),
+]
 shapes = [(1,), (2,), (2, 3), (4, 16, 3, 1), (4, 3, 1, 2, 2)]
 repeat_shapes = [
     (1,),

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -20,8 +20,9 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
     TT_FATAL(
         input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "Can only work with bfloat16/float32 or uint32 tensors");
+            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32 or
+            input_tensor_a.dtype() == tt::tt_metal::DataType::INT32,
+        "Can only work with bfloat16/float32 or uint32/int32 tensors");
     // is this relevant?
     TT_FATAL(
         this->m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -19,10 +19,9 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "This function is for RM->RM");
     TT_FATAL(
         input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::INT32,
-        "Can only work with bfloat16/float32 or uint32/int32 tensors");
+        "Can only work with bfloat16/float32 or int32 tensors");
     // is this relevant?
     TT_FATAL(
         this->m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25695)

### Problem description
Repeat should support int32

### What's changed
Repeat already does support int32, just needed to enable it through removing fatal condition in repeat_device_op

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16482157976) CI passes
- [ ] [single-card device perf](https://github.com/tenstorrent/tt-metal/actions/runs/16482169179)
- [ ] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16482179200)