### PR TITLE
Adding upstream tests for BH-Deskbox and RackBox

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -190,10 +190,10 @@ jobs:
         bh_box:
           - name: BH-LLMBox
             num_devices: 4
+          - name: BH-DeskBox
+            num_devices: 2
           # - name: BH-RackBox
           #   num_devices: 8
-          # - name: BH-DeskBox
-          #   num_devices: 2
     runs-on:
       - ${{ matrix.bh_box.name }}
       - in-service

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -185,14 +185,37 @@ jobs:
     needs:
       - get-image-tags
       - build-images
+    strategy:
+      matrix:
+        bh-box:
+          - BH-LLMBox
+          - BH-RackBox
+          - BH-DeskBox
     runs-on:
-      - BH-LLMBox
+      - ${{ matrix.bh-box }}
       - in-service
       - cloud-virtual-machine
     steps:
+      - name: Set NUM_DEVICES
+        run: |
+          case "${{ matrix.bh-box }}" in
+            BH-LLMBox)
+              echo "NUM_DEVICES=4" >> "$GITHUB_ENV"
+              ;;
+            BH-RackBox)
+              echo "NUM_DEVICES=8" >> "$GITHUB_ENV"
+              ;;
+            BH-DeskBox)
+              echo "NUM_DEVICES=2" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "NUM_DEVICES=1" >> "$GITHUB_ENV"
+              ;;
+          esac
       - name: Run image
         timeout-minutes: 30
         env:
+          NUM_DEVICES: ${{ env.NUM_DEVICES }}
           LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
   test-bh-image:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -206,14 +206,15 @@ jobs:
       - get-image-tags
       - build-images
     strategy:
+      fail-fast: false
       matrix:
         bh-config:
           - runner-label: BH-LLMBox
             image-name: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
-          - runner-label: BH-DeskBox
-            image-name: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
-          - runner-label: BH-RackBox
-            image-name: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
+          # - runner-label: BH-DeskBox
+          #   image-name: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+          # - runner-label: BH-RackBox
+          #   image-name: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
     runs-on:
       - ${{ matrix.bh-config.runner-label }}
       - in-service

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -208,7 +208,7 @@ jobs:
         env:
           NUM_DEVICES: ${{ matrix.bh_box.num_devices }}
           LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }} -e NUM_DEVICES=$NUM_DEVICES
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR=$LLAMA_DIR -e NUM_DEVICES=$NUM_DEVICES ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
   test-bh-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -111,12 +111,14 @@ jobs:
             hw-topology: blackhole_llmbox
             build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+            techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_deskbox
             build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+            techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -199,12 +201,21 @@ jobs:
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
-  test-bh-llmbox-image:
+  test-bh-multicard-image:
     needs:
       - get-image-tags
       - build-images
+    strategy:
+      matrix:
+        bh-config:
+          - runner-label: BH-LLMBox
+            image-name: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
+          - runner-label: BH-DeskBox
+            image-name: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+          - runner-label: BH-RackBox
+            image-name: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
     runs-on:
-      - BH-LLMBox
+      - ${{ matrix.bh-config.runner-label }}
       - in-service
       - cloud-virtual-machine
     steps:
@@ -212,35 +223,7 @@ jobs:
         timeout-minutes: 30
         env:
           LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
-  test-bh-deskbox-image:
-    needs:
-      - get-image-tags
-      - build-images
-    runs-on:
-      - BH-DeskBox
-      - in-service
-      - cloud-virtual-machine
-    steps:
-      - name: Run image
-        timeout-minutes: 30
-        env:
-          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
-  test-bh-rackbox-image:
-    needs:
-      - get-image-tags
-      - build-images
-    runs-on:
-      - BH-RackBox
-      - in-service
-      - cloud-virtual-machine
-    steps:
-      - name: Run image
-        timeout-minutes: 30
-        env:
-          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:
       - get-image-tags
@@ -288,6 +271,7 @@ jobs:
       - get-image-tags
       - test-wh-6u-image
       - test-bh-image
+      - test-bh-multicard-image
     permissions:
       packages: write
       contents: read
@@ -299,6 +283,8 @@ jobs:
           - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -223,7 +223,29 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
+  test-bh-multicard-image-ignore-status:
+    needs:
+      - get-image-tags
+      - build-images
+    strategy:
+      fail-fast: false
+      matrix:
+        bh-config:
+          - runner-label: BH-DeskBox
+            image-name: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+          - runner-label: BH-RackBox
+            image-name: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
+    runs-on:
+      - ${{ matrix.bh-config.runner-label }}
+      - in-service
+      - cloud-virtual-machine
+    steps:
+      - name: Run image
+        timeout-minutes: 30
+        env:
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -223,7 +223,7 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && !contains(runner.name, 'qb') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-multicard-image-ignore-status:
     needs:
@@ -245,7 +245,7 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && !contains(runner.name, 'qb') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -18,6 +18,8 @@ env:
   BLACKHOLE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh
   BLACKHOLE_PROFILER_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-profiler-tests-bh
   BLACKHOLE_LLMBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-llmbox
+  BLACKHOLE_DESKBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-deskbox
+  BLACKHOLE_RACKBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-rackbox
 
 jobs:
   build-artifact:
@@ -46,6 +48,8 @@ jobs:
       bh-image-tag: ${{ steps.set-image-tags.outputs.bh-image-tag }}
       bh-profiler-image-tag: ${{ steps.set-image-tags.outputs.bh-profiler-image-tag }}
       bh-llmbox-image-tag: ${{ steps.set-image-tags.outputs.bh-llmbox-image-tag }}
+      bh-deskbox-image-tag: ${{ steps.set-image-tags.outputs.bh-deskbox-image-tag }}
+      bh-rackbox-image-tag: ${{ steps.set-image-tags.outputs.bh-rackbox-image-tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +66,8 @@ jobs:
           echo "bh-image-tag=${{ env.BLACKHOLE_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
           echo "bh-profiler-image-tag=${{ env.BLACKHOLE_PROFILER_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
           echo "bh-llmbox-image-tag=${{ env.BLACKHOLE_LLMBOX_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
+          echo "bh-deskbox-image-tag=${{ env.BLACKHOLE_DESKBOX_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
+          echo "bh-rackbox-image-tag=${{ env.BLACKHOLE_RACKBOX_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
   build-images:
     needs:
       - build-artifact
@@ -103,6 +109,18 @@ jobs:
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_llmbox
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+            dockerfile: dockerfile/upstream_test_images/Dockerfile
+            test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+            hw-topology: blackhole_deskbox
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
+            dockerfile: dockerfile/upstream_test_images/Dockerfile
+            test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+            hw-topology: blackhole_rackbox
             build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
@@ -185,30 +203,44 @@ jobs:
     needs:
       - get-image-tags
       - build-images
-    strategy:
-      matrix:
-        bh_box:
-          - name: BH-LLMBox
-            num_devices: 4
-          - name: BH-DeskBox
-            num_devices: 2
-          # - name: BH-RackBox
-          #   num_devices: 8
     runs-on:
-      - ${{ matrix.bh_box.name }}
+      - BH-LLMBox
       - in-service
       - cloud-virtual-machine
     steps:
-      - name: Show box config
-        run: |
-          echo "Box: ${{ matrix.bh_box.name }}"
-          echo "NUM_DEVICES: ${{ matrix.bh_box.num_devices }}"
       - name: Run image
         timeout-minutes: 30
         env:
-          NUM_DEVICES: ${{ matrix.bh_box.num_devices }}
           LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR=$LLAMA_DIR -e NUM_DEVICES=$NUM_DEVICES ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
+  test-bh-deskbox-image:
+    needs:
+      - get-image-tags
+      - build-images
+    runs-on:
+      - BH-DeskBox
+      - in-service
+      - cloud-virtual-machine
+    steps:
+      - name: Run image
+        timeout-minutes: 30
+        env:
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+  test-bh-rackbox-image:
+    needs:
+      - get-image-tags
+      - build-images
+    runs-on:
+      - BH-RackBox
+      - in-service
+      - cloud-virtual-machine
+    steps:
+      - name: Run image
+        timeout-minutes: 30
+        env:
+          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-rackbox-image-tag }}
   test-bh-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -187,35 +187,26 @@ jobs:
       - build-images
     strategy:
       matrix:
-        bh-box:
-          - BH-LLMBox
-          - BH-RackBox
-          - BH-DeskBox
+        config:
+          - name: BH-LLMBox
+            num_devices: 4
+          - name: BH-RackBox
+            num_devices: 8
+          - name: BH-DeskBox
+            num_devices: 2
     runs-on:
-      - ${{ matrix.bh-box }}
+      - ${{ matrix.config.name }}
       - in-service
       - cloud-virtual-machine
     steps:
-      - name: Set NUM_DEVICES
+      - name: Show box config
         run: |
-          case "${{ matrix.bh-box }}" in
-            BH-LLMBox)
-              echo "NUM_DEVICES=4" >> "$GITHUB_ENV"
-              ;;
-            BH-RackBox)
-              echo "NUM_DEVICES=8" >> "$GITHUB_ENV"
-              ;;
-            BH-DeskBox)
-              echo "NUM_DEVICES=2" >> "$GITHUB_ENV"
-              ;;
-            *)
-              echo "NUM_DEVICES=1" >> "$GITHUB_ENV"
-              ;;
-          esac
+          echo "Box: ${{ matrix.config.name }}"
+          echo "NUM_DEVICES: ${{ matrix.config.num_devices }}"
       - name: Run image
         timeout-minutes: 30
         env:
-          NUM_DEVICES: ${{ env.NUM_DEVICES }}
+          NUM_DEVICES: ${{ matrix.config.num_devices }}
           LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
   test-bh-image:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -187,28 +187,28 @@ jobs:
       - build-images
     strategy:
       matrix:
-        config:
+        bh_box:
           - name: BH-LLMBox
             num_devices: 4
-          - name: BH-RackBox
-            num_devices: 8
-          - name: BH-DeskBox
-            num_devices: 2
+          # - name: BH-RackBox
+          #   num_devices: 8
+          # - name: BH-DeskBox
+          #   num_devices: 2
     runs-on:
-      - ${{ matrix.config.name }}
+      - ${{ matrix.bh_box.name }}
       - in-service
       - cloud-virtual-machine
     steps:
       - name: Show box config
         run: |
-          echo "Box: ${{ matrix.config.name }}"
-          echo "NUM_DEVICES: ${{ matrix.config.num_devices }}"
+          echo "Box: ${{ matrix.bh_box.name }}"
+          echo "NUM_DEVICES: ${{ matrix.bh_box.num_devices }}"
       - name: Run image
         timeout-minutes: 30
         env:
-          NUM_DEVICES: ${{ matrix.config.num_devices }}
+          NUM_DEVICES: ${{ matrix.bh_box.num_devices }}
           LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci-vm') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }} -e NUM_DEVICES=$NUM_DEVICES
   test-bh-image:
     needs:
       - get-image-tags

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -84,10 +84,20 @@ test_suite_bh_llmbox_llama_demo_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama demo model tests"
     verify_llama_dir_
 
-    echo "Using data_parallel = $NUM_DEVICES"
+    if [[ "$hw_topology" == "blackhole_deskbox" ]]; then
+        local data_parallel_devices="2"
+    elif [[ "$hw_topology" == "blackhole_llmbox" ]]; then
+        local data_parallel_devices="4"
+    elif [[ "$hw_topology" == "blackhole_rackbox" ]]; then
+        local data_parallel_devices="8"
+    else
+        echo "Your blackhole hw topology is not supported to run Llama demo model tests!"
+    fi
 
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel "$NUM_DEVICES"
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$NUM_DEVICES" --max_generated_tokens 220
+    echo "Using data_parallel = $data_parallel_devices for topology: $hw_topology"
+
+    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel "$data_parallel_devices"
+    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$data_parallel_devices" --max_generated_tokens 220
 }
 
 test_suite_bh_llmbox_llama_stress_tests() {
@@ -163,6 +173,14 @@ test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_single_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
+test_suite_bh_llmbox_metal_unit_tests
+test_suite_bh_llmbox_llama_demo_tests"
+
+hw_topology_test_suites["blackhole_deskbox"]="
+test_suite_bh_llmbox_metal_unit_tests
+test_suite_bh_llmbox_llama_demo_tests"
+
+hw_topology_test_suites["blackhole_rackbox"]="
 test_suite_bh_llmbox_metal_unit_tests
 test_suite_bh_llmbox_llama_demo_tests"
 

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -82,19 +82,21 @@ test_suite_bh_llmbox_metal_unit_tests() {
 
 test_suite_bh_llmbox_llama_demo_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama demo model tests"
-
     verify_llama_dir_
 
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4 --max_generated_tokens 220
+    echo "Using data_parallel = $NUM_DEVICES"
+
+    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel "$NUM_DEVICES"
+    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$NUM_DEVICES" --max_generated_tokens 220
 }
 
 test_suite_bh_llmbox_llama_stress_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama stress model tests"
-
     verify_llama_dir_
 
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4 --max_generated_tokens 22000
+    echo "Using data_parallel = $NUM_DEVICES"
+
+    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$NUM_DEVICES" --max_generated_tokens 22000
 }
 
 test_suite_wh_6u_metal_unit_tests() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -185,17 +185,14 @@ test_suite_bh_single_pcie_didt_tests"
 hw_topology_test_suites["blackhole_llmbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests
-test_suite_bh_multi_pcie_llama_stress_tests"
 
 hw_topology_test_suites["blackhole_deskbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests
-test_suite_bh_multi_pcie_llama_stress_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests
-test_suite_bh_multi_pcie_llama_stress_tests"
 
 
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -184,15 +184,15 @@ test_suite_bh_single_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_deskbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -71,7 +71,7 @@ test_suite_bh_single_pcie_llama_demo_tests() {
     pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1
 }
 
-test_suite_bh_llmbox_metal_unit_tests() {
+test_suite_bh_multi_pcie_metal_unit_tests() {
     echo "[upstream-tests] Running BH LLMBox metal unit tests"
 
     ./build/test/tt_metal/tt_fabric/test_system_health
@@ -80,7 +80,7 @@ test_suite_bh_llmbox_metal_unit_tests() {
     ./build/test/tt_metal/unit_tests_eth
 }
 
-test_suite_bh_llmbox_llama_demo_tests() {
+test_suite_bh_multi_pcie_llama_demo_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama demo model tests"
     verify_llama_dir_
 
@@ -173,16 +173,16 @@ test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_single_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
-test_suite_bh_llmbox_metal_unit_tests
-test_suite_bh_llmbox_llama_demo_tests"
+test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_deskbox"]="
-test_suite_bh_llmbox_metal_unit_tests
-test_suite_bh_llmbox_llama_demo_tests"
+test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
-test_suite_bh_llmbox_metal_unit_tests
-test_suite_bh_llmbox_llama_demo_tests"
+test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests
 test_suite_wh_6u_llama_demo_tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -100,13 +100,23 @@ test_suite_bh_multi_pcie_llama_demo_tests() {
     pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$data_parallel_devices" --max_generated_tokens 220
 }
 
-test_suite_bh_llmbox_llama_stress_tests() {
+test_suite_bh_multi_pcie_llama_stress_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama stress model tests"
     verify_llama_dir_
 
-    echo "Using data_parallel = $NUM_DEVICES"
+    if [[ "$hw_topology" == "blackhole_deskbox" ]]; then
+        local data_parallel_devices="2"
+    elif [[ "$hw_topology" == "blackhole_llmbox" ]]; then
+        local data_parallel_devices="4"
+    elif [[ "$hw_topology" == "blackhole_rackbox" ]]; then
+        local data_parallel_devices="8"
+    else
+        echo "Your blackhole hw topology is not supported to run Llama demo stress tests!"
+    fi
 
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$NUM_DEVICES" --max_generated_tokens 22000
+    echo "Using data_parallel = $data_parallel_devices for topology: $hw_topology"
+
+    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel "$data_parallel_devices" --max_generated_tokens 22000
 }
 
 test_suite_wh_6u_metal_unit_tests() {
@@ -174,15 +184,19 @@ test_suite_bh_single_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
+test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_multi_pcie_llama_stress_tests"
 
 hw_topology_test_suites["blackhole_deskbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
+test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_multi_pcie_llama_stress_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
+test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_multi_pcie_llama_stress_tests"
+
 
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests
 test_suite_wh_6u_llama_demo_tests

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -768,12 +768,6 @@ void ControlPlane::trim_ethernet_channels_not_mapped_to_live_routing_planes() {
                         fabric_node_id.chip_id,
                         direction,
                         directional_eth_chans.at(direction).size());
-                    TT_FATAL(
-                        num_available_routing_planes <= 4,
-                        "Expected at most 4 routing planes for M{}D{} in direction {}",
-                        fabric_node_id.mesh_id,
-                        fabric_node_id.chip_id,
-                        direction);
                     bool trim = directional_eth_chans.at(direction).size() > num_available_routing_planes;
                     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
                     if (trim) {


### PR DESCRIPTION
### Tickets
https://github.com/tenstorrent/tt-metal/issues/24014
https://github.com/tenstorrent/tt-metal/issues/24012

### Problem description
Currently only P150x4 is supported in the upstream tests in CI, adding it here so that for desk box and rack box the data parallelism factor is also determined based on device on container creation.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes