### PR TITLE
add pack_untilize LLK to untilize op

### DIFF
--- a/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
@@ -89,9 +89,9 @@ def test_device_perf_wh_bare_metal(
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, model_config_str, samples",
     (
-        ("prefill", 1, 128, 0, "BFLOAT16-DRAM", 2005),
-        ("prefill", 1, 1024, 0, "BFLOAT16-DRAM", 2895),
-        ("prefill", 1, 2048, 0, "BFLOAT16-DRAM", 2684),
+        ("prefill", 1, 128, 0, "BFLOAT16-DRAM", 2115),
+        ("prefill", 1, 1024, 0, "BFLOAT16-DRAM", 3120),
+        ("prefill", 1, 2048, 0, "BFLOAT16-DRAM", 2870),
         ("decode", 32, 1, 128, "BFLOAT16-L1_SHARDED", 629),
         ("decode", 32, 1, 1024, "BFLOAT16-L1_SHARDED", 572),
         ("decode", 32, 1, 2047, "BFLOAT16-L1_SHARDED", 533),

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -444,3 +444,13 @@ def test_untilize_with_unpad_int32(shape, device):
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, end_shape)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[32, 1024], [64, 512]])
+def test_untilize_int32_t(shape, device):
+    torch.manual_seed(2005)
+    input_a = torch.randint(1, 64, shape, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.int32)
+    output_tensor = ttnn.untilize(input_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(input_a, output_tensor)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -435,7 +435,7 @@ def test_to_layout_wh2(shape, input_layout, output_layout, device):
     assert_with_pcc(input_a, output_tensor)
 
 
-@pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64]])
+@pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64], [64, 512]])
 def test_untilize_with_unpad_int32(shape, device):
     torch.manual_seed(2005)
     end_shape = [x - 1 for x in shape]
@@ -446,7 +446,7 @@ def test_untilize_with_unpad_int32(shape, device):
     assert_with_pcc(input_a, output_tensor)
 
 
-@pytest.mark.parametrize("shape", [[32, 1024], [64, 512]])
+@pytest.mark.parametrize("shape", [[3072, 1024], [2048, 512]])
 def test_untilize_int32_t(shape, device):
     torch.manual_seed(2005)
     input_a = torch.randint(1, 64, shape, dtype=torch.int32)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -435,7 +435,7 @@ def test_to_layout_wh2(shape, input_layout, output_layout, device):
     assert_with_pcc(input_a, output_tensor)
 
 
-@pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64], [64, 512]])
+@pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64], [64, 512], [10, 1024, 2048]])
 def test_untilize_with_unpad_int32(shape, device):
     torch.manual_seed(2005)
     end_shape = [x - 1 for x in shape]
@@ -446,7 +446,7 @@ def test_untilize_with_unpad_int32(shape, device):
     assert_with_pcc(input_a, output_tensor)
 
 
-@pytest.mark.parametrize("shape", [[3072, 1024], [2048, 512]])
+@pytest.mark.parametrize("shape", [[3072, 1024], [2, 2048, 512]])
 def test_untilize_int32_t(shape, device):
     torch.manual_seed(2005)
     input_a = torch.randint(1, 64, shape, dtype=torch.int32)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -436,21 +436,23 @@ def test_to_layout_wh2(shape, input_layout, output_layout, device):
 
 
 @pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64], [64, 512], [10, 1024, 2048]])
-def test_untilize_with_unpad_int32(shape, device):
+@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
+def test_untilize_with_unpad_int32(shape, dtype, device):
     torch.manual_seed(2005)
     end_shape = [x - 1 for x in shape]
     input_a = torch.randint(1, 64, shape, dtype=torch.int32)
-    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.int32)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, end_shape)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[3072, 1024], [2, 2048, 512]])
-def test_untilize_int32_t(shape, device):
+@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
+def test_untilize_int32_t(shape, dtype, device):
     torch.manual_seed(2005)
     input_a = torch.randint(1, 64, shape, dtype=torch.int32)
-    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.int32)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
     output_tensor = ttnn.untilize(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/common.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+// Helper constexpr function to compute num_blocks_per_col for pack untilize kernels
+constexpr uint32_t compute_num_blocks_per_column(uint32_t per_core_block_tile_cnt, uint32_t max_bct) {
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -7,6 +7,18 @@
 #include "compute_kernel_api/untilize.h"
 #include "compute_kernel_api/pack_untilize.h"
 
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
 namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
@@ -14,19 +26,22 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
 
+    // Compute optimal num_blocks_per_col and block_ct_dim
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(per_core_block_tile_cnt);
+    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
     compute_kernel_hw_startup(src_cb_id, out_cb_id);
-    pack_untilize_init<per_core_block_tile_cnt>(src_cb_id, out_cb_id);
+    pack_untilize_init<block_ct_dim, full_ct_dim>(src_cb_id, out_cb_id);
 
-    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(src_cb_id, per_core_block_tile_cnt);
-        cb_reserve_back(out_cb_id, per_core_block_tile_cnt);
-
-        pack_untilize_block<per_core_block_tile_cnt>(src_cb_id, 1, out_cb_id);
-
-        cb_push_back(out_cb_id, per_core_block_tile_cnt);
-        cb_pop_front(src_cb_id, per_core_block_tile_cnt);
+    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
+        cb_reserve_back(out_cb_id, full_ct_dim);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            cb_wait_front(src_cb_id, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(src_cb_id, 1, out_cb_id, b);
+            cb_pop_front(src_cb_id, block_ct_dim);
+        }
+        cb_push_back(out_cb_id, full_ct_dim);
     }
-
     pack_untilize_uninit(out_cb_id);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -8,9 +8,7 @@
 #include "compute_kernel_api/pack_untilize.h"
 
 // Helper constexpr function to compute num_blocks_per_col
-constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
-    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
-
+constexpr uint32_t compute_num_blocks_per_column(uint32_t per_core_block_tile_cnt, uint32_t max_bct) {
     for (uint32_t bct = max_bct; bct >= 1; --bct) {
         if (per_core_block_tile_cnt % bct == 0) {
             return per_core_block_tile_cnt / bct;
@@ -21,13 +19,18 @@ constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) 
 }
 namespace NAMESPACE {
 void MAIN {
+#ifdef DST_ACCUM_MODE
+    constexpr uint32_t max_bct = 4;
+#else
+    constexpr uint32_t max_bct = 8;
+#endif
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
 
     // Compute optimal num_blocks_per_col and block_ct_dim
-    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(per_core_block_tile_cnt);
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_column(per_core_block_tile_cnt, max_bct);
     constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
     constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
     compute_kernel_hw_startup(src_cb_id, out_cb_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -6,17 +6,8 @@
 
 #include "compute_kernel_api/untilize.h"
 #include "compute_kernel_api/pack_untilize.h"
+#include "common.cpp"
 
-// Helper constexpr function to compute num_blocks_per_col
-constexpr uint32_t compute_num_blocks_per_column(uint32_t per_core_block_tile_cnt, uint32_t max_bct) {
-    for (uint32_t bct = max_bct; bct >= 1; --bct) {
-        if (per_core_block_tile_cnt % bct == 0) {
-            return per_core_block_tile_cnt / bct;
-        }
-    }
-
-    return 1;
-}
 namespace NAMESPACE {
 void MAIN {
 #ifdef DST_ACCUM_MODE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize_variable_num_blocks.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-//
+// //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
@@ -7,27 +7,45 @@
 #include "compute_kernel_api/untilize.h"
 #include "compute_kernel_api/pack_untilize.h"
 
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks(uint32_t per_core_block_tile_cnt, uint32_t max_bct) {
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
 namespace NAMESPACE {
 void MAIN {
+#ifdef DST_ACCUM_MODE
+    constexpr uint32_t max_bct = 4;
+#else
+    constexpr uint32_t max_bct = 8;
+#endif
     const uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);
 
+    // Compute optimal num_blocks_per_col and block_ct_dim
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks(per_core_block_tile_cnt, max_bct);
+    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
     compute_kernel_hw_startup(src_cb_id, out_cb_id);
-    pack_untilize_init<per_core_block_tile_cnt>(src_cb_id, out_cb_id);
+    pack_untilize_init<block_ct_dim, full_ct_dim>(src_cb_id, out_cb_id);
 
-    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(src_cb_id, per_core_block_tile_cnt);
-        cb_reserve_back(out_cb_id, per_core_block_tile_cnt);
-
-        pack_untilize_block<per_core_block_tile_cnt>(src_cb_id, 1, out_cb_id);
-
-        cb_push_back(out_cb_id, per_core_block_tile_cnt);
-        cb_pop_front(src_cb_id, per_core_block_tile_cnt);
+    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
+        cb_reserve_back(out_cb_id, full_ct_dim);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            cb_wait_front(src_cb_id, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(src_cb_id, 1, out_cb_id, b);
+            cb_pop_front(src_cb_id, block_ct_dim);
+        }
+        cb_push_back(out_cb_id, full_ct_dim);
     }
-
     pack_untilize_uninit(out_cb_id);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize_variable_num_blocks.cpp
@@ -6,17 +6,8 @@
 
 #include "compute_kernel_api/untilize.h"
 #include "compute_kernel_api/pack_untilize.h"
+#include "common.cpp"
 
-// Helper constexpr function to compute num_blocks_per_col
-constexpr uint32_t compute_num_blocks(uint32_t per_core_block_tile_cnt, uint32_t max_bct) {
-    for (uint32_t bct = max_bct; bct >= 1; --bct) {
-        if (per_core_block_tile_cnt % bct == 0) {
-            return per_core_block_tile_cnt / bct;
-        }
-    }
-
-    return 1;
-}
 namespace NAMESPACE {
 void MAIN {
 #ifdef DST_ACCUM_MODE
@@ -31,7 +22,7 @@ void MAIN {
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);
 
     // Compute optimal num_blocks_per_col and block_ct_dim
-    constexpr uint32_t num_blocks_per_col = compute_num_blocks(per_core_block_tile_cnt, max_bct);
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_column(per_core_block_tile_cnt, max_bct);
     constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
     constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
     compute_kernel_hw_startup(src_cb_id, out_cb_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
@@ -34,6 +34,7 @@ void MAIN {
     constexpr uint32_t num_blocks_per_col = compute_num_blocks(per_core_block_tile_cnt, max_bct);
     constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
     constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
+    compute_kernel_hw_startup(src_cb_id, out_cb_id);
     pack_untilize_init<block_ct_dim, full_ct_dim>(src_cb_id, out_cb_id);
 
     for (uint32_t r = 0; r < per_core_block_cnt; ++r) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
@@ -5,7 +5,20 @@
 #include <cstdint>
 
 #include "compute_kernel_api/untilize.h"
+#include "compute_kernel_api/pack_untilize.h"
 
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
 namespace NAMESPACE {
 void MAIN {
     const uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
@@ -14,17 +27,21 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);
 
-    compute_kernel_hw_startup(src_cb_id, out_cb_id);
-    untilize_init(src_cb_id);
+    // Compute optimal num_blocks_per_col and block_ct_dim
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(per_core_block_tile_cnt);
+    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
+    pack_untilize_init<block_ct_dim, full_ct_dim>(src_cb_id, out_cb_id);
 
-    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(src_cb_id, per_core_block_tile_cnt);
-        cb_reserve_back(out_cb_id, per_core_block_tile_cnt);
-
-        untilize_block(src_cb_id, per_core_block_tile_cnt, out_cb_id);
-
-        cb_push_back(out_cb_id, per_core_block_tile_cnt);
-        cb_pop_front(src_cb_id, per_core_block_tile_cnt);
+    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
+        cb_reserve_back(out_cb_id, full_ct_dim);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            cb_wait_front(src_cb_id, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(src_cb_id, 1, out_cb_id, b);
+            cb_pop_front(src_cb_id, block_ct_dim);
+        }
+        cb_push_back(out_cb_id, full_ct_dim);
     }
+    pack_untilize_uninit(out_cb_id);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
@@ -5,47 +5,26 @@
 #include <cstdint>
 
 #include "compute_kernel_api/untilize.h"
-#include "compute_kernel_api/pack_untilize.h"
 
-// Helper constexpr function to compute num_blocks_per_col
-constexpr uint32_t compute_num_blocks(uint32_t per_core_block_tile_cnt, uint32_t max_bct) {
-    for (uint32_t bct = max_bct; bct >= 1; --bct) {
-        if (per_core_block_tile_cnt % bct == 0) {
-            return per_core_block_tile_cnt / bct;
-        }
-    }
-
-    return 1;
-}
 namespace NAMESPACE {
 void MAIN {
-#ifdef DST_ACCUM_MODE
-    constexpr uint32_t max_bct = 4;
-#else
-    constexpr uint32_t max_bct = 8;
-#endif
     const uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);
 
-    // Compute optimal num_blocks_per_col and block_ct_dim
-    constexpr uint32_t num_blocks_per_col = compute_num_blocks(per_core_block_tile_cnt, max_bct);
-    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
-    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
     compute_kernel_hw_startup(src_cb_id, out_cb_id);
-    pack_untilize_init<block_ct_dim, full_ct_dim>(src_cb_id, out_cb_id);
+    untilize_init(src_cb_id);
 
-    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
-        cb_reserve_back(out_cb_id, full_ct_dim);
-        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
-            cb_wait_front(src_cb_id, block_ct_dim);
-            pack_untilize_block<block_ct_dim, full_ct_dim>(src_cb_id, 1, out_cb_id, b);
-            cb_pop_front(src_cb_id, block_ct_dim);
-        }
-        cb_push_back(out_cb_id, full_ct_dim);
+    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+        cb_wait_front(src_cb_id, per_core_block_tile_cnt);
+        cb_reserve_back(out_cb_id, per_core_block_tile_cnt);
+
+        untilize_block(src_cb_id, per_core_block_tile_cnt, out_cb_id);
+
+        cb_push_back(out_cb_id, per_core_block_tile_cnt);
+        cb_pop_front(src_cb_id, per_core_block_tile_cnt);
     }
-    pack_untilize_uninit(out_cb_id);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -142,7 +142,7 @@ operation::ProgramWithCallbacks untilize_multi_core_sub_core_grids(
     if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
     }
@@ -333,7 +333,7 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
     if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
     }
@@ -815,7 +815,7 @@ operation::ProgramWithCallbacks untilize_multi_core_input_and_output_shard_type_
     if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
         compute_kernel =
@@ -1444,7 +1444,7 @@ operation::ProgramWithCallbacks untilize_single_core(
     if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -142,13 +142,6 @@ operation::ProgramWithCallbacks untilize_multi_core_sub_core_grids(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    } else {
-        log_debug(tt::LogOp, "Using fast pack untilize.");
-    }
 
     auto untilize_kernel_id = CreateKernel(
         program,
@@ -338,13 +331,6 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    } else {
-        log_debug(tt::LogOp, "Using fast pack untilize.");
-    }
 
     if (core_range.ranges().size() > 0) {
         auto untilize_kernel_id = CreateKernel(
@@ -1454,10 +1440,6 @@ operation::ProgramWithCallbacks untilize_single_core(
     }
 
     // Untilized writer
-    std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
-    }
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
@@ -1466,15 +1448,12 @@ operation::ProgramWithCallbacks untilize_single_core(
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_compute_defines));
 
     // Compute file path
+    std::map<std::string, std::string> compute_kernel_defines;
+    if (a.dtype() == DataType::INT32) {
+        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+    }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    } else {
-        log_debug(tt::LogOp, "Using fast pack untilize.");
-    }
 
     // Compute compile-time args
     uint32_t num_blocks = num_columns_of_blocks * num_blocks_per_column_row * num_blocks_across_height;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -358,7 +358,10 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
             program,
             compute_kernel,
             core_range_cliff,
-            ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args_cliff});
+            ComputeConfig{
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = compute_args_cliff,
+                .defines = compute_kernel_defines});
     }
 
     uint32_t ncores_full = ncores;
@@ -1109,7 +1112,8 @@ operation::ProgramWithCallbacks untilize_multi_core(
 
     // Compute kernel file
     std::string compute_kernel;
-    if (num_tiles_per_input_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
+        (a.dtype() == DataType::FLOAT32 && num_tiles_per_input_block > MAX_PACK_UNTILIZE_WIDTH)) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel = std::string(
             "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
@@ -1150,7 +1154,10 @@ operation::ProgramWithCallbacks untilize_multi_core(
             program,
             compute_kernel,
             cliff_compute_core_range,
-            ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_compile_time_args_cliff});
+            ComputeConfig{
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = compute_compile_time_args_cliff,
+                .defines = compute_kernel_defines});
     }
 
     // Run-time arg assignment

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -137,12 +137,13 @@ operation::ProgramWithCallbacks untilize_multi_core_sub_core_grids(
         (uint32_t)src0_cb_index,
         (uint32_t)output_cb_index};
     std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32) {
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         compute_kernel_defines["DST_ACCUM_MODE"] = "1";
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
+        (a.dtype() == DataType::FLOAT32 && ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
@@ -333,12 +334,13 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
         (uint32_t)output_cb_index};
 
     std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32) {
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         compute_kernel_defines["DST_ACCUM_MODE"] = "1";
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
+        (a.dtype() == DataType::FLOAT32 && ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
@@ -823,11 +825,12 @@ operation::ProgramWithCallbacks untilize_multi_core_input_and_output_shard_type_
 
     // Compute kernel
     std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32) {
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         compute_kernel_defines["DST_ACCUM_MODE"] = "1";
     }
     std::string compute_kernel;
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
+        (a.dtype() == DataType::FLOAT32 && num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
@@ -1128,7 +1131,7 @@ operation::ProgramWithCallbacks untilize_multi_core(
     // Note: This condition is always true for sharded input
     KernelHandle untilize_kernel_id = 0;
     std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32) {
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         compute_kernel_defines["DST_ACCUM_MODE"] = "1";
     }
     if (full_compute_core_range.ranges().size() > 0) {
@@ -1469,12 +1472,13 @@ operation::ProgramWithCallbacks untilize_single_core(
 
     // Compute file path
     std::map<std::string, std::string> compute_kernel_defines;
-    if (a.dtype() == DataType::INT32) {
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         compute_kernel_defines["DST_ACCUM_MODE"] = "1";
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
+        (a.dtype() == DataType::FLOAT32 && num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -142,6 +142,13 @@ operation::ProgramWithCallbacks untilize_multi_core_sub_core_grids(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+        log_debug(tt::LogOp, "Using slow untilize.");
+        compute_kernel =
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+    } else {
+        log_debug(tt::LogOp, "Using fast pack untilize.");
+    }
 
     auto untilize_kernel_id = CreateKernel(
         program,
@@ -331,7 +338,13 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+        log_debug(tt::LogOp, "Using slow untilize.");
+        compute_kernel =
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+    } else {
+        log_debug(tt::LogOp, "Using fast pack untilize.");
+    }
     if (core_range.ranges().size() > 0) {
         auto untilize_kernel_id = CreateKernel(
             program,
@@ -811,10 +824,10 @@ operation::ProgramWithCallbacks untilize_multi_core_input_and_output_shard_type_
         compute_kernel_defines["DST_ACCUM_MODE"] = "1";
     }
     std::string compute_kernel;
-    if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
-            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
         compute_kernel =
@@ -1454,6 +1467,13 @@ operation::ProgramWithCallbacks untilize_single_core(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+        log_debug(tt::LogOp, "Using slow untilize.");
+        compute_kernel =
+            std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+    } else {
+        log_debug(tt::LogOp, "Using fast pack untilize.");
+    }
 
     // Compute compile-time args
     uint32_t num_blocks = num_columns_of_blocks * num_blocks_per_column_row * num_blocks_across_height;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -1474,7 +1474,7 @@ operation::ProgramWithCallbacks untilize_single_core(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
+    if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -174,12 +174,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp";
-    } else {
-        log_debug(tt::LogOp, "Using fast pack untilize.");
-    }
 
     auto untilize_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -775,9 +769,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (num_tiles_per_row > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp";
-    }
 
     if (core_range.size() > 0) {
         auto tilize_kernel_id = CreateKernel(
@@ -1035,11 +1026,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
         // Use copy compute kernel just for a potential data type conversion.
         compute_kernel = "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp";
         compute_args[0] = (uint32_t)num_input_tiles;  // per_core_tile_cnt
-    } else if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp";
-    } else {
-        log_debug(tt::LogOp, "Using fast pack untilize.");
     }
 
     auto untilize_kernel_id = CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -172,7 +172,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     if (num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp";
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
     }
@@ -768,7 +768,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     if (num_tiles_per_row > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
-        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp";
     }
 
     if (core_range.size() > 0) {
@@ -1023,7 +1023,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
         compute_args[0] = (uint32_t)num_input_tiles;  // per_core_tile_cnt
     } else if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
-        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+        compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp";
     } else {
         log_debug(tt::LogOp, "Using fast pack untilize.");
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/25528

### Problem description
Replace current untilize compute kernel with the newest pack_untilize LLK in untilize and untilize with unpadding ops

### What's changed
- This adds support for uint32 and int32 data types for untilize when the row width is greater than 8 tiles
- it also improves the performance of the op. Below is a plot for the performance improvement for the untilize test (the y axis represents the ratio of the latency after over the latency before)
<img width="516" height="241" alt="Untilize_llk_perf" src="https://github.com/user-attachments/assets/cfb4a7ac-d494-47f5-ba6b-e3ffd11674fd" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16453006538
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16506905242
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes