### PR TITLE
#25203: Add fabric node ID querying on `MeshDeviceView`

### DIFF
--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -66,36 +66,39 @@ TEST(BigMeshDualRankTest2x4, SystemMeshShape) {
     auto& control_plane = MetalContext::instance().get_control_plane();
     auto rank = control_plane.get_local_host_rank_id_binding();
 
-    auto physical_device_ids = system_mesh.get_mapped_devices(MeshShape(2, 4));
+    auto mapped_devices = system_mesh.get_mapped_devices(MeshShape(2, 4));
+    const MeshContainer<MaybeRemote<int>> physical_device_ids(MeshShape(2, 4), std::move(mapped_devices.device_ids));
+    const MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids(
+        MeshShape(2, 4), std::move(mapped_devices.fabric_node_ids));
     if (rank == HostRankId{0}) {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_remote());
     } else {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_local());
     }
 
     // Check fabric node IDs are set for all devices, globally.
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 0)).fabric_node_id.chip_id, 0);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 1)).fabric_node_id.chip_id, 1);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 2)).fabric_node_id.chip_id, 2);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 3)).fabric_node_id.chip_id, 3);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 0)).fabric_node_id.chip_id, 4);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 1)).fabric_node_id.chip_id, 5);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 2)).fabric_node_id.chip_id, 6);
-    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 3)).fabric_node_id.chip_id, 7);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(0, 0)).chip_id, 0);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(0, 1)).chip_id, 1);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(0, 2)).chip_id, 2);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(0, 3)).chip_id, 3);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(1, 0)).chip_id, 4);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(1, 1)).chip_id, 5);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(1, 2)).chip_id, 6);
+    EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(1, 3)).chip_id, 7);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -66,26 +66,36 @@ TEST(BigMeshDualRankTest2x4, SystemMeshShape) {
     auto& control_plane = MetalContext::instance().get_control_plane();
     auto rank = control_plane.get_local_host_rank_id_binding();
 
-    auto physical_device_ids = system_mesh.get_mapped_physical_device_ids(MeshShape(2, 4));
+    auto physical_device_ids = system_mesh.get_mapped_devices(MeshShape(2, 4));
     if (rank == HostRankId{0}) {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_remote());
     } else {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_local());
     }
+
+    // Check fabric node IDs are set for all devices, globally.
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 0)).fabric_node_id.chip_id, 0);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 1)).fabric_node_id.chip_id, 1);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 2)).fabric_node_id.chip_id, 2);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(0, 3)).fabric_node_id.chip_id, 3);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 0)).fabric_node_id.chip_id, 4);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 1)).fabric_node_id.chip_id, 5);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 2)).fabric_node_id.chip_id, 6);
+    EXPECT_EQ(physical_device_ids.at(MeshCoordinate(1, 3)).fabric_node_id.chip_id, 7);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -65,18 +65,20 @@ TEST_F(MeshDevice2x4Test, MemoryAllocationStatistics) {
 }
 
 TEST_F(MeshDevice2x4Test, ViewIs2D) {
-    std::vector<IDevice*> devices = mesh_device_->get_devices();
+    std::vector<IDevice*> devices;
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
+    for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
+        devices.push_back(mesh_device_->get_view().get_device(coord));
+        fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
+    }
 
-    MeshContainer<IDevice*> container_1d(MeshShape(8), devices);
-    MeshDeviceView view_1d(container_1d);
+    MeshDeviceView view_1d(MeshShape(8), devices, fabric_node_ids);
     EXPECT_FALSE(view_1d.is_mesh_2d());
 
-    MeshContainer<IDevice*> container_2d(MeshShape(2, 4), devices);
-    MeshDeviceView view_2d(container_2d);
+    MeshDeviceView view_2d(MeshShape(2, 4), devices, fabric_node_ids);
     EXPECT_TRUE(view_2d.is_mesh_2d());
 
-    MeshContainer<IDevice*> container_3d(MeshShape(2, 2, 2), devices);
-    MeshDeviceView view_3d(container_3d);
+    MeshDeviceView view_3d(MeshShape(2, 2, 2), devices, fabric_node_ids);
     EXPECT_FALSE(view_3d.is_mesh_2d());
 }
 

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -89,7 +89,7 @@ TEST_P(MeshConfigurationTest, GetPhysicalDeviceIds) {
     const auto& shape = GetParam();
 
     auto& system_mesh = SystemMesh::instance();
-    EXPECT_THAT(system_mesh.get_mapped_physical_device_ids(shape).values(), SizeIs(shape.mesh_size()));
+    EXPECT_THAT(system_mesh.get_mapped_devices(shape).values(), SizeIs(shape.mesh_size()));
 }
 
 // Test all possible mesh configurations on T3000
@@ -148,18 +148,18 @@ TEST_F(MeshDeviceReshapeTest, InvalidRequestedShape) {
     auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
 
     // Shape too big.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(9)));
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 5)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(9)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(2, 5)));
 
     // Invalid offset.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(1, 8), /*offset=*/MeshCoordinate(0, 1)));
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 3), /*offset=*/MeshCoordinate(1, 1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(1, 8), /*offset=*/MeshCoordinate(0, 1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(2, 3), /*offset=*/MeshCoordinate(1, 1)));
 
     // Offset dimensionality mismatch.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 3), /*offset=*/MeshCoordinate(1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(2, 3), /*offset=*/MeshCoordinate(1)));
 
     // Mismatch system mesh shape.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(8), /*offset=*/MeshCoordinate(1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(8), /*offset=*/MeshCoordinate(1)));
 }
 
 TEST_F(MeshDeviceReshapeTest, InvalidReshapeDimensions) {
@@ -242,7 +242,11 @@ TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
     auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
 
     // Fetch the device ids for a physically connected 2x2 mesh.
-    auto physical_device_ids = extract_locals(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 2)).values());
+    std::vector<chip_id_t> physical_device_ids;
+    for (const auto& [_, system_device] : system_mesh.get_mapped_devices(MeshShape(2, 2))) {
+        TT_FATAL(system_device.device_id.is_local(), "Device is not local");
+        physical_device_ids.push_back(*system_device.device_id);
+    }
 
     // Supply the physical device ids to the mesh constructor that we know we know is 2x2 physically connected.
     // We will create a 1x4 mesh and then reshape it to 2x2.

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -89,7 +89,7 @@ TEST_P(MeshConfigurationTest, GetPhysicalDeviceIds) {
     const auto& shape = GetParam();
 
     auto& system_mesh = SystemMesh::instance();
-    EXPECT_THAT(system_mesh.get_mapped_devices(shape).values(), SizeIs(shape.mesh_size()));
+    EXPECT_THAT(system_mesh.get_mapped_devices(shape).device_ids, SizeIs(shape.mesh_size()));
 }
 
 // Test all possible mesh configurations on T3000
@@ -243,9 +243,9 @@ TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
 
     // Fetch the device ids for a physically connected 2x2 mesh.
     std::vector<chip_id_t> physical_device_ids;
-    for (const auto& [_, system_device] : system_mesh.get_mapped_devices(MeshShape(2, 2))) {
-        TT_FATAL(system_device.device_id.is_local(), "Device is not local");
-        physical_device_ids.push_back(*system_device.device_id);
+    for (const auto device_id : system_mesh.get_mapped_devices(MeshShape(2, 2)).device_ids) {
+        TT_FATAL(device_id.is_local(), "Device is not local");
+        physical_device_ids.push_back(*device_id);
     }
 
     // Supply the physical device ids to the mesh constructor that we know we know is 2x2 physically connected.

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -85,7 +85,7 @@ TEST_P(MeshConfigurationTest, MeshConfigurations) {
     mesh->close();
 }
 
-TEST_P(MeshConfigurationTest, GetPhysicalDeviceIds) {
+TEST_P(MeshConfigurationTest, GetMappedDevices) {
     const auto& shape = GetParam();
 
     auto& system_mesh = SystemMesh::instance();

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -149,15 +149,11 @@ public:
 
         auto mapped_devices = SystemMesh::instance().get_mapped_devices(cluster_shape);
 
-        std::vector<int> physical_device_ids;
-        for (const auto maybe_remote_device_id : mapped_devices.device_ids) {
-            TT_FATAL(maybe_remote_device_id.is_local(), "Device is not local");
-            physical_device_ids.push_back(*maybe_remote_device_id);
-        }
-
+        const std::vector<int> physical_device_ids = extract_locals(mapped_devices.device_ids);
+        TT_FATAL(physical_device_ids.size() == cluster_shape.mesh_size(), "Some of the devices are remote");
         physical_devices_ = tt::tt_metal::detail::CreateDevices(physical_device_ids);
 
-        std::vector<IDevice*> devices = {};
+        std::vector<IDevice*> devices;
         devices.reserve(physical_device_ids.size());
         for (auto device_id : physical_device_ids) {
             devices.push_back(physical_devices_.at(device_id));

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -72,8 +72,6 @@ private:
     class ScopedDevices {
     private:
         std::vector<MaybeRemote<IDevice*>> devices_;
-
-        std::vector<IDevice*> local_devices_;
         std::map<chip_id_t, IDevice*> opened_local_devices_;
 
     public:

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/maybe_remote.hpp>
+#include <tt-metalium/routing_table_generator.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -44,11 +45,15 @@ public:
     using DeviceView = std::vector<IDevice*>;
     using DeviceViews = std::vector<std::vector<IDevice*>>;
 
-    // // Create a view of a sub-region of the mesh defined by `range`.
-    // MeshDeviceView(const std::vector<IDevice*>& devices, const MeshCoordinateRange& range);
-    explicit MeshDeviceView(const MeshContainer<IDevice*>& devices);
-    explicit MeshDeviceView(const MeshContainer<MaybeRemote<IDevice*>>& devices);
-    explicit MeshDeviceView(const MeshDevice& mesh_device);
+    // Constructors for MeshDeviceView for fully and partially local meshes.
+    explicit MeshDeviceView(
+        const MeshShape& shape,
+        const std::vector<IDevice*>& devices,
+        const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids);
+    explicit MeshDeviceView(
+        const MeshShape& shape,
+        const std::vector<MaybeRemote<IDevice*>>& devices,
+        const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids);
 
     // Get devices spanning the region defined by `range` in row-major order with start/end coordinates inclusive
     [[nodiscard]] DeviceView get_devices(const MeshCoordinateRange& range) const;
@@ -60,21 +65,20 @@ public:
     [[nodiscard]] size_t size() const noexcept;
     [[nodiscard]] const MeshShape& shape() const noexcept;
     [[nodiscard]] bool contains(const MeshCoordinate& coord) const noexcept;
-    [[nodiscard]] IDevice* get_device(const MeshCoordinate& coord) const;
-    [[nodiscard]] const IDevice* at(const MeshCoordinate& coord) const noexcept;
 
-    bool operator==(const MeshDeviceView& other) const;
+    // Returns `IDevice*` instance for `coord`.
+    // In multi-host context, throws if `coord` is querying a remote device.
+    [[nodiscard]] IDevice* get_device(const MeshCoordinate& coord) const;
+
+    // Returns `tt::tt_fabric::FabricNodeId` for `coord`.
+    // In multi-host context, fabric node IDs are always available, even for remote devices.
+    [[nodiscard]] tt::tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
 
     auto begin() const { return devices_.values().begin(); }
     auto end() const { return devices_.values().end(); }
 
-    [[nodiscard]] bool contains_device(chip_id_t device_id) const;
-
     // Throws if no device corresponds to `device_id`.
     [[nodiscard]] MeshCoordinate find_device(chip_id_t device_id) const;
-
-    // Throws if the `coord` is out of bounds of this view.
-    [[nodiscard]] chip_id_t find_device_id(const MeshCoordinate& coord) const;
 
     // TODO: #17477 - Remove the methods that assume 2D mesh.
     [[nodiscard]] bool is_mesh_2d() const;
@@ -97,8 +101,10 @@ public:
     // TODO: #17477 - Remove the methods that assume 2D mesh.
     [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(
         size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset);
+    [[nodiscard]] std::vector<MeshCoordinate> get_line_coordinates() const;
     [[nodiscard]] static std::vector<MeshCoordinate> get_ring_coordinates(
         const Shape2D& ring_shape, const Shape2D& mesh_shape);
+    [[nodiscard]] std::vector<MeshCoordinate> get_ring_coordinates() const;
     [[nodiscard]] std::vector<IDevice*> get_ring_devices() const;
     [[nodiscard]] std::vector<IDevice*> get_line_devices() const;
 
@@ -112,6 +118,8 @@ public:
 private:
     bool fully_local_ = true;
     DistributedMeshContainer<IDevice*> devices_;
+    MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids_;
+
     std::unordered_map<chip_id_t, MeshCoordinate> device_coordinates_;
 
     // Set if the view is 2D to enable row/col APIs, otherwise nullopt.

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -40,16 +40,18 @@ public:
     // Returns the local shape of the system mesh; this is the local mesh shape in distributed context
     const MeshShape& local_shape() const;
 
-    struct SystemMeshDevice {
+    // Wrapper structure with device IDs and fabric node IDs ordered in row-major order according to the requested
+    // `shape`.
+    struct MappedDevices {
         // Device ID is set for host-local devices only.
-        MaybeRemote<int> device_id;
+        std::vector<MaybeRemote<int>> device_ids;
 
         // Fabric node ID is set for host-local and host-remote devices globally.
-        tt::tt_fabric::FabricNodeId fabric_node_id;
+        std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     };
 
     // Returns devices that should be mapped to a MeshDevice according to the shape and offset.
-    MeshContainer<SystemMeshDevice> get_mapped_devices(
+    MappedDevices get_mapped_devices(
         const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
 };
 

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/maybe_remote.hpp>
+#include <tt-metalium/routing_table_generator.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -39,8 +40,16 @@ public:
     // Returns the local shape of the system mesh; this is the local mesh shape in distributed context
     const MeshShape& local_shape() const;
 
-    // Returns the physical device IDs mapped to a MeshDevice
-    DistributedMeshContainer<int> get_mapped_physical_device_ids(
+    struct SystemMeshDevice {
+        // Device ID is set for host-local devices only.
+        MaybeRemote<int> device_id;
+
+        // Fabric node ID is set for host-local and host-remote devices globally.
+        tt::tt_fabric::FabricNodeId fabric_node_id;
+    };
+
+    // Returns devices that should be mapped to a MeshDevice according to the shape and offset.
+    MeshContainer<SystemMeshDevice> get_mapped_devices(
         const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
 };
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -32,6 +32,7 @@
 #include "mesh_config.hpp"
 #include "mesh_trace.hpp"
 #include "profiler_types.hpp"
+#include "routing_table_generator.hpp"
 #include "shape_base.hpp"
 #include <tt_stl/span.hpp>
 #include <tt_stl/strong_type.hpp>
@@ -118,23 +119,6 @@ decltype(auto) validate_and_get_reference_value(
 }
 
 }  // namespace
-
-MeshDevice::ScopedDevices::ScopedDevices(
-    size_t l1_small_size,
-    size_t trace_region_size,
-    size_t num_command_queues,
-    size_t worker_l1_size,
-    const DispatchCoreConfig& dispatch_core_config,
-    const MeshDeviceConfig& config) :
-    ScopedDevices(
-        config.physical_device_ids().empty()
-            ? SystemMesh::instance().get_mapped_physical_device_ids(config.mesh_shape(), config.offset()).values()
-            : wrap_to_maybe_remote(config.physical_device_ids()),
-        l1_small_size,
-        trace_region_size,
-        num_command_queues,
-        worker_l1_size,
-        dispatch_core_config) {}
 
 MeshDevice::ScopedDevices::ScopedDevices(
     const std::vector<MaybeRemote<int>>& device_ids,
@@ -229,14 +213,44 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     size_t worker_l1_size) {
-    auto scoped_devices = std::make_shared<ScopedDevices>(
-        l1_small_size, trace_region_size, num_command_queues, worker_l1_size, dispatch_core_config, config);
+    std::shared_ptr<ScopedDevices> scoped_devices;
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
+    if (config.physical_device_ids().empty()) {
+        auto system_devices = SystemMesh::instance().get_mapped_devices(config.mesh_shape(), config.offset());
+        std::vector<MaybeRemote<int>> device_ids;
+        std::transform(
+            system_devices.values().begin(),
+            system_devices.values().end(),
+            std::back_inserter(device_ids),
+            [](const auto& d) { return d.device_id; });
+        std::transform(
+            system_devices.values().begin(),
+            system_devices.values().end(),
+            std::back_inserter(fabric_node_ids),
+            [](const auto& d) { return d.fabric_node_id; });
+        scoped_devices = std::make_shared<ScopedDevices>(
+            device_ids, l1_small_size, trace_region_size, num_command_queues, worker_l1_size, dispatch_core_config);
+    } else {
+        // Initialize fabric node ids manually.
+        // TODO: #22087 - Remove this code path.
+        for (int i = 0; i < config.physical_device_ids().size(); i++) {
+            fabric_node_ids.push_back(tt::tt_fabric::FabricNodeId(tt::tt_fabric::MeshId(0), i));
+        }
+        scoped_devices = std::make_shared<ScopedDevices>(
+            wrap_to_maybe_remote(config.physical_device_ids()),
+            l1_small_size,
+            trace_region_size,
+            num_command_queues,
+            worker_l1_size,
+            dispatch_core_config);
+    }
+
     auto local_root_devices = scoped_devices->local_root_devices();
 
-    DistributedMeshContainer<IDevice*> global_devices(config.mesh_shape(), scoped_devices->root_devices());
-
     auto mesh_device = std::make_shared<MeshDevice>(
-        std::move(scoped_devices), std::make_unique<MeshDeviceView>(global_devices), std::shared_ptr<MeshDevice>());
+        std::move(scoped_devices),
+        std::make_unique<MeshDeviceView>(config.mesh_shape(), scoped_devices->root_devices(), fabric_node_ids),
+        std::shared_ptr<MeshDevice>());
 
     mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
     // TODO #20966: Remove these calls
@@ -268,9 +282,14 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
         num_command_queues,
         worker_l1_size,
         dispatch_core_config);
-    MeshContainer<IDevice*> devices(MeshShape(1, device_ids.size()), scoped_devices->local_root_devices());
     auto mesh_device = std::make_shared<MeshDevice>(
-        std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::shared_ptr<MeshDevice>());
+        std::move(scoped_devices),
+        std::make_unique<MeshDeviceView>(
+            MeshShape(1, device_ids.size()),
+            scoped_devices->local_root_devices(),
+            std::vector<tt::tt_fabric::FabricNodeId>(
+                device_ids.size(), tt::tt_fabric::FabricNodeId(tt::tt_fabric::MeshId(0), /*chip_id=*/0))),
+        std::shared_ptr<MeshDevice>());
 
     auto submeshes = mesh_device->create_submeshes(MeshShape(1, 1));
     TT_FATAL(
@@ -345,11 +364,23 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
     }
     auto end_coordinate = MeshCoordinate(end_coords);
 
-    MeshContainer<IDevice*> submesh_devices_container(
-        submesh_shape, view_->get_devices(MeshCoordinateRange{offset_coord, end_coordinate}));
-
+    // Create mesh device view for the submesh.
+    std::vector<MaybeRemote<IDevice*>> submesh_devices;
+    std::vector<tt::tt_fabric::FabricNodeId> submesh_fabric_node_ids;
+    const MeshCoordinateRange submesh_range(offset_coord, end_coordinate);
+    for (const auto& coord : submesh_range) {
+        if (view_->is_local(coord)) {
+            submesh_devices.push_back(MaybeRemote<IDevice*>::local(view_->get_device(coord)));
+        } else {
+            submesh_devices.push_back(MaybeRemote<IDevice*>::remote());
+        }
+        submesh_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
+    }
     auto submesh = std::make_shared<MeshDevice>(
-        scoped_devices_, std::make_unique<MeshDeviceView>(submesh_devices_container), shared_from_this());
+        scoped_devices_,
+        std::make_unique<MeshDeviceView>(submesh_shape, submesh_devices, submesh_fabric_node_ids),
+        shared_from_this());
+
     const auto& allocator_config = reference_device()->allocator()->get_config();
     submesh->initialize(
         num_hw_cqs(),
@@ -455,8 +486,11 @@ const MeshShape& MeshDevice::shape() const { return view_->shape(); }
 
 bool MeshDevice::is_local(const MeshCoordinate& coord) const { return view_->is_local(coord); }
 
-std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_shape) const {
+void MeshDevice::reshape(const MeshShape& new_shape) {
     TT_FATAL(view_->fully_local(), "Cannot reshape a mesh that is partially distributed");
+    TT_FATAL(
+        new_shape.mesh_size() == this->num_devices(),
+        "New shape must have the same number of devices as current shape");
 
     // MeshDeviceView requires devices to be provided as a 1D array in row-major order for the target mesh shape.
     // The physical connectivity between devices must be preserved when reshaping.
@@ -481,41 +515,37 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
 
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
     // However, going from a Line mesh to an MxN mesh is not always possible.
+    std::vector<IDevice*> new_device_order;
+    std::vector<tt::tt_fabric::FabricNodeId> new_fabric_node_ids;
+    new_device_order.reserve(num_devices());
+    new_fabric_node_ids.reserve(num_devices());
     if (new_shape.is_line_topology()) {
-        return view_->get_line_devices();
-    }
+        auto line_coords = view_->get_line_coordinates();
+        for (const auto& coord : line_coords) {
+            new_device_order.push_back(this->get_device(coord));
+            new_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
+        }
+    } else {
+        auto new_mapped_devices = SystemMesh::instance().get_mapped_devices(new_shape);
 
-    auto new_physical_device_ids =
-        extract_locals(SystemMesh::instance().get_mapped_physical_device_ids(new_shape).values());
+        for (const auto& [_, system_device] : new_mapped_devices) {
+            if (physical_device_id_to_linearized_index.find(*system_device.device_id) ==
+                physical_device_id_to_linearized_index.end()) {
+                TT_THROW(
+                    "User has requested a reshape of the MeshDevice to shape: {}, but it is not possible to form a "
+                    "physically connected mesh grid with the opened devices from the original shape: {}.",
+                    new_shape,
+                    view_->shape());
+            }
+        }
 
-    for (size_t i = 0; i < new_physical_device_ids.size(); i++) {
-        if (physical_device_id_to_linearized_index.find(new_physical_device_ids[i]) ==
-            physical_device_id_to_linearized_index.end()) {
-            TT_THROW(
-                "User has requested a reshape of the MeshDevice to shape: {}, but it is not possible to form a "
-                "physically connected mesh grid with the opened devices from the original shape: {}.",
-                new_shape,
-                view_->shape());
+        for (const auto& [_, system_device] : new_mapped_devices) {
+            new_device_order.push_back(get_device(*system_device.device_id));
+            new_fabric_node_ids.push_back(system_device.fabric_node_id);
         }
     }
 
-    std::vector<IDevice*> new_device_order;
-    new_device_order.reserve(new_physical_device_ids.size());
-    for (size_t i = 0; i < new_physical_device_ids.size(); i++) {
-        new_device_order.push_back(this->get_device(new_physical_device_ids[i]));
-    }
-    return new_device_order;
-}
-
-void MeshDevice::reshape(const MeshShape& new_shape) {
-    TT_FATAL(view_->fully_local(), "Cannot reshape a mesh that is partially distributed");
-
-    TT_FATAL(
-        new_shape.mesh_size() == this->num_devices(),
-        "New shape must have the same number of devices as current shape");
-
-    MeshContainer<IDevice*> devices(new_shape, this->get_row_major_devices(new_shape));
-    auto new_view = std::make_unique<MeshDeviceView>(devices);
+    auto new_view = std::make_unique<MeshDeviceView>(new_shape, new_device_order, new_fabric_node_ids);
     view_ = std::move(new_view);
 }
 

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -34,21 +34,24 @@ std::vector<IDevice*> get_devices_from_coordinates(
 
 }  // namespace
 
-MeshDeviceView::MeshDeviceView(const MeshDevice& mesh_device) :
-    MeshDeviceView(MeshContainer<IDevice*>(MeshShape(mesh_device.shape()), mesh_device.get_devices())) {}
+MeshDeviceView::MeshDeviceView(
+    const MeshShape& shape,
+    const std::vector<IDevice*>& devices,
+    const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
+    MeshDeviceView(shape, wrap_to_maybe_remote(devices), fabric_node_ids) {}
 
-MeshDeviceView::MeshDeviceView(const MeshContainer<IDevice*>& devices) :
-    MeshDeviceView(MeshContainer<MaybeRemote<IDevice*>>(devices.shape(), wrap_to_maybe_remote(devices.values()))) {}
-
-MeshDeviceView::MeshDeviceView(const MeshContainer<MaybeRemote<IDevice*>>& devices) : devices_(devices.shape()) {
+MeshDeviceView::MeshDeviceView(
+    const MeshShape& shape,
+    const std::vector<MaybeRemote<IDevice*>>& devices,
+    const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
+    devices_(shape, devices), fabric_node_ids_(shape, fabric_node_ids) {
     if (devices_.shape().dims() == 2) {
         shape_2d_ = Shape2D(devices_.shape()[0], devices_.shape()[1]);
     }
 
-    // Copy the MaybeRemote values and build coordinate map
+    // Build coordinate map.
     bool all_local = true;
-    for (const auto& [coord, maybe_device] : devices) {
-        devices_.at(coord) = maybe_device;
+    for (const auto& [coord, maybe_device] : devices_) {
         all_local &= maybe_device.is_local();
         maybe_device.if_local([this, &coord](const auto& device) { device_coordinates_.emplace(device->id(), coord); });
     }
@@ -128,17 +131,10 @@ IDevice* MeshDeviceView::get_device(const MeshCoordinate& coord) const {
     TT_FATAL(maybe_device.is_local(), "Cannot get device for remote device at coordinate {}", coord);
     return *maybe_device;
 }
-const IDevice* MeshDeviceView::at(const MeshCoordinate& coord) const noexcept {
-    if (!contains(coord)) {
-        return nullptr;
-    }
-    const auto& maybe_device = devices_.at(coord);
-    return maybe_device.is_local() ? *maybe_device : nullptr;
-}
 
-bool MeshDeviceView::operator==(const MeshDeviceView& other) const {
-    return devices_ == other.devices_ && device_coordinates_ == other.device_coordinates_ &&
-           shape_2d_ == other.shape_2d_;
+tt::tt_fabric::FabricNodeId MeshDeviceView::get_fabric_node_id(const MeshCoordinate& coord) const {
+    TT_FATAL(contains(coord), "Coordinate {} not found in mesh {}", coord, devices_.shape());
+    return fabric_node_ids_.at(coord);
 }
 
 size_t MeshDeviceView::num_rows() const {
@@ -151,21 +147,10 @@ size_t MeshDeviceView::num_cols() const {
 }
 size_t MeshDeviceView::num_devices() const { return devices_.shape().mesh_size(); }
 
-bool MeshDeviceView::contains_device(chip_id_t device_id) const {
-    return device_coordinates_.find(device_id) != device_coordinates_.end();
-}
-
 MeshCoordinate MeshDeviceView::find_device(chip_id_t device_id) const {
     auto it = device_coordinates_.find(device_id);
     TT_FATAL(it != device_coordinates_.end(), "Device not found in mesh: {}", device_id);
     return it->second;
-}
-
-chip_id_t MeshDeviceView::find_device_id(const MeshCoordinate& coord) const {
-    TT_FATAL(contains(coord), "Coordinate {} not found in mesh {}", coord, devices_.shape());
-    auto& maybe_device = devices_.at(coord);
-    TT_FATAL(maybe_device.is_local(), "Cannot get device ID for remote device at coordinate {}", coord);
-    return (*maybe_device)->id();
 }
 
 bool MeshDeviceView::is_mesh_2d() const { return shape_2d_.has_value(); }
@@ -236,17 +221,22 @@ std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& 
     return boundary_coords;
 }
 
-std::vector<IDevice*> MeshDeviceView::get_line_devices() const {
+std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates() const {
     TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
-    auto boundary_coords =
-        get_line_coordinates(devices_.shape().mesh_size(), *shape_2d_, /*mesh_offset=*/Shape2D(0, 0));
-    return get_devices_from_coordinates(*this, boundary_coords);
+    return get_line_coordinates(devices_.shape().mesh_size(), *shape_2d_, /*mesh_offset=*/Shape2D(0, 0));
+}
+
+std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    return get_ring_coordinates(*shape_2d_, *shape_2d_);
+}
+
+std::vector<IDevice*> MeshDeviceView::get_line_devices() const {
+    return get_devices_from_coordinates(*this, get_line_coordinates());
 }
 
 std::vector<IDevice*> MeshDeviceView::get_ring_devices() const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
-    auto boundary_coords = get_ring_coordinates(*shape_2d_, *shape_2d_);
-    return get_devices_from_coordinates(*this, boundary_coords);
+    return get_devices_from_coordinates(*this, get_ring_coordinates());
 }
 
 MeshDeviceView::DeviceView MeshDeviceView::get_devices() const { return extract_locals(devices_.values()); }

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -27,49 +27,71 @@
 #include <tt-metalium/control_plane.hpp>
 
 namespace tt::tt_metal::distributed {
+namespace {
 
+// Initializes a mesh container with SystemMeshDevice objects, with configured fabric node IDs.
+MeshContainer<SystemMesh::SystemMeshDevice> make_system_mesh_devices(
+    const tt::tt_fabric::MeshId mesh_id, const MeshShape& shape) {
+    std::vector<SystemMesh::SystemMeshDevice> system_mesh_devices;
+    system_mesh_devices.reserve(shape.mesh_size());
+    for (int linear_index = 0; linear_index < shape.mesh_size(); ++linear_index) {
+        system_mesh_devices.push_back(SystemMesh::SystemMeshDevice{
+            .device_id = MaybeRemote<int>::remote(),
+            .fabric_node_id = tt::tt_fabric::FabricNodeId(mesh_id, linear_index)});
+    }
+    return MeshContainer<SystemMesh::SystemMeshDevice>(shape, std::move(system_mesh_devices));
+}
+
+}  // namespace
 class SystemMesh::Impl {
 private:
+    tt::tt_fabric::MeshId mesh_id_;
     DistributedCoordinateTranslator coordinate_translator_;
+    MeshContainer<SystemMesh::SystemMeshDevice> system_mesh_devices_;
 
-    DistributedMeshContainer<PhysicalMeshCoordinate> physical_coordinates_;
-
-    MaybeRemoteDeviceId get_maybe_remote_device_id(const MeshCoordinate& coord) const;
+    SystemMesh::SystemMeshDevice get_system_mesh_device(const MeshCoordinate& coord) const;
 
 public:
     Impl();
 
     const DistributedCoordinateTranslator& coordinate_translator() const;
 
-    DistributedMeshContainer<chip_id_t> get_mapped_physical_device_ids(
+    MeshContainer<SystemMesh::SystemMeshDevice> get_mapped_physical_device_ids(
         const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
-    chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
 };
 
-MaybeRemoteDeviceId SystemMesh::Impl::get_maybe_remote_device_id(const MeshCoordinate& coord) const {
-    return physical_coordinates_.at(coord).when(
-        [&](const auto& physical_coord) {
-            auto physical_device_id = get_physical_device_id(coord);
-            log_debug(LogDistributed, "Mesh coordinate: {} is local, Physical device ID: {}", coord, physical_device_id);
-            return MaybeRemoteDeviceId::local(physical_device_id);
-        },
-        [&]() {
-            log_debug(LogDistributed, "Mesh coordinate: {} is remote", coord);
-            return MaybeRemoteDeviceId::remote();
-        });
+SystemMesh::SystemMeshDevice SystemMesh::Impl::get_system_mesh_device(const MeshCoordinate& coord) const {
+    auto system_mesh_device = system_mesh_devices_.at(coord);
+    if (system_mesh_device.device_id.is_local()) {
+        log_debug(
+            LogDistributed,
+            "Mesh coordinate: {} is local, Physical device ID: {}, Fabric node ID: {}",
+            coord,
+            system_mesh_device.device_id.local(),
+            system_mesh_device.fabric_node_id);
+    } else {
+        log_debug(
+            LogDistributed,
+            "Mesh coordinate: {} is remote, Fabric node ID: {}",
+            coord,
+            system_mesh_device.fabric_node_id);
+    }
+
+    return system_mesh_device;
 }
 
 // Implementation of public methods
 SystemMesh::Impl::Impl() :
+    mesh_id_(MetalContext::instance().get_control_plane().get_local_mesh_id_bindings()[0]),
     coordinate_translator_(
         MetalContext::instance().get_control_plane().get_physical_mesh_shape(
-            MetalContext::instance().get_control_plane().get_local_mesh_id_bindings()[0],
+            mesh_id_,  //
             tt::tt_fabric::MeshScope::GLOBAL),
         MetalContext::instance().get_control_plane().get_physical_mesh_shape(
-            MetalContext::instance().get_control_plane().get_local_mesh_id_bindings()[0],
+            mesh_id_,  //
             tt::tt_fabric::MeshScope::LOCAL),
         MetalContext::instance().get_control_plane().get_local_mesh_offset()),
-    physical_coordinates_(coordinate_translator_.global_shape()) {
+    system_mesh_devices_(make_system_mesh_devices(mesh_id_, coordinate_translator_.global_shape())) {
     log_debug(
         LogDistributed,
         "SystemMesh: Global shape: {}, Local shape: {}, Local offset: {}",
@@ -85,7 +107,15 @@ SystemMesh::Impl::Impl() :
         local_physical_translation_map.shape(),
         coordinate_translator_.local_shape());
 
+    // Populate chip IDs for host-local devices.
     for (const auto& local_coord : MeshCoordinateRange(coordinate_translator_.local_shape())) {
+        TT_FATAL(
+            local_physical_translation_map.at(local_coord).mesh_id() == mesh_id_,
+            "Mesh id mismatch for coordinate {}: {} != {}",
+            local_coord,
+            local_physical_translation_map.at(local_coord).mesh_id(),
+            mesh_id_);
+
         const auto global_coord = coordinate_translator_.local_to_global(local_coord);
         log_debug(
             LogDistributed,
@@ -93,8 +123,8 @@ SystemMesh::Impl::Impl() :
             global_coord,
             local_physical_translation_map.at(local_coord),
             local_coord);
-        physical_coordinates_.at(global_coord) =
-            MaybeRemote<PhysicalMeshCoordinate>::local(local_physical_translation_map.at(local_coord));
+        system_mesh_devices_.at(global_coord).device_id =
+            MaybeRemote<int>::local(local_physical_translation_map.at(local_coord).chip_id());
     }
 }
 
@@ -102,19 +132,9 @@ const DistributedCoordinateTranslator& SystemMesh::Impl::coordinate_translator()
     return coordinate_translator_;
 }
 
-chip_id_t SystemMesh::Impl::get_physical_device_id(const MeshCoordinate& coord) const {
-    TT_FATAL(physical_coordinates_.is_local_at(coord), "Coordinate {} is not in the local mesh", coord);
-
-    const auto& maybe_physical = physical_coordinates_.at(coord);
-    auto physical_device_id = maybe_physical->chip_id();
-    log_debug(LogDistributed, "Global coordinate: {} mapped to physical device ID: {}",
-              coord, physical_device_id);
-    return physical_device_id;
-}
-
-DistributedMeshContainer<int> SystemMesh::Impl::get_mapped_physical_device_ids(
+MeshContainer<SystemMesh::SystemMeshDevice> SystemMesh::Impl::get_mapped_physical_device_ids(
     const MeshShape& shape, const std::optional<MeshCoordinate>& offset) const {
-    std::vector<MaybeRemoteDeviceId> physical_device_ids;
+    std::vector<SystemMesh::SystemMeshDevice> system_mesh_devices;
 
     const MeshShape& system_shape = coordinate_translator_.global_shape();
     TT_FATAL(
@@ -152,9 +172,9 @@ DistributedMeshContainer<int> SystemMesh::Impl::get_mapped_physical_device_ids(
         auto line_length = shape.mesh_size();
         for (const auto& logical_coordinate :
              MeshDeviceView::get_line_coordinates(line_length, system_mesh_2d, system_offset_2d)) {
-            physical_device_ids.push_back(get_maybe_remote_device_id(logical_coordinate));
+            system_mesh_devices.push_back(get_system_mesh_device(logical_coordinate));
         }
-        return DistributedMeshContainer<int>(shape, std::move(physical_device_ids));
+        return MeshContainer<SystemMesh::SystemMeshDevice>(shape, std::move(system_mesh_devices));
     }
 
     TT_FATAL(
@@ -193,7 +213,7 @@ DistributedMeshContainer<int> SystemMesh::Impl::get_mapped_physical_device_ids(
 
     MeshCoordinateRange system_range(system_offset, MeshCoordinate(end_coord));
 
-    // Iterate over the system mesh and map the logical coordinates to physical device IDs.
+    // Iterate over the system mesh and map the logical coordinates to system mesh devices.
     bool is_rotated = rotations > 0;  // Track if we rotated the mesh.
     if (is_rotated) {
         TT_FATAL(rotations == 1 and system_shape.dims() == 2, "Mesh rotation is only supported for 2D meshes");
@@ -202,16 +222,16 @@ DistributedMeshContainer<int> SystemMesh::Impl::get_mapped_physical_device_ids(
         for (int i = 0; i < shape[0]; i++) {
             for (int j = 0; j < shape[1]; j++) {
                 auto system_coord = MeshCoordinate(j, i);
-                physical_device_ids.push_back(get_maybe_remote_device_id(system_coord));
+                system_mesh_devices.push_back(get_system_mesh_device(system_coord));
             }
         }
     } else {
         for (const auto& system_coord : system_range) {
-            physical_device_ids.push_back(get_maybe_remote_device_id(system_coord));
+            system_mesh_devices.push_back(get_system_mesh_device(system_coord));
         }
     }
 
-    return DistributedMeshContainer<int>(shape, std::move(physical_device_ids));
+    return MeshContainer<SystemMesh::SystemMeshDevice>(shape, std::move(system_mesh_devices));
 }
 
 SystemMesh::SystemMesh() : pimpl_(std::make_unique<Impl>()) {}
@@ -224,7 +244,7 @@ SystemMesh& SystemMesh::instance() {
 const MeshShape& SystemMesh::shape() const { return pimpl_->coordinate_translator().global_shape(); }
 const MeshShape& SystemMesh::local_shape() const { return pimpl_->coordinate_translator().local_shape(); }
 
-DistributedMeshContainer<chip_id_t> SystemMesh::get_mapped_physical_device_ids(
+MeshContainer<SystemMesh::SystemMeshDevice> SystemMesh::get_mapped_devices(
     const MeshShape& shape, const std::optional<MeshCoordinate>& offset) const {
     return pimpl_->get_mapped_physical_device_ids(shape, offset);
 }

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -72,14 +72,14 @@ MappedDevice SystemMesh::Impl::get_system_mapped_device(const MeshCoordinate& co
             LogDistributed,
             "Mesh coordinate: {} is local, Physical device ID: {}, Fabric node ID: {}",
             coord,
-            *system_mesh_device.device_id,
-            system_mesh_device.fabric_node_id);
+            *system_mapped_device.device_id,
+            system_mapped_device.fabric_node_id);
     } else {
         log_debug(
             LogDistributed,
             "Mesh coordinate: {} is remote, Fabric node ID: {}",
             coord,
-            system_mesh_device.fabric_node_id);
+            system_mapped_device.fabric_node_id);
     }
 
     return system_mapped_device;

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -133,16 +133,10 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
 std::vector<int> get_t3k_physical_device_ids_ring() {
     using namespace tt::tt_metal::distributed;
     auto& instance = SystemMesh::instance();
+    TT_FATAL(instance.shape() == instance.local_shape(), "System mesh must be fully local");
     auto num_devices = instance.shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
-
-    auto maybe_remote_device_ids = instance.get_mapped_devices(MeshShape(1, 8)).device_ids;
-    std::vector<int> physical_device_ids;
-    for (const auto maybe_remote_device_id : maybe_remote_device_ids) {
-        TT_FATAL(maybe_remote_device_id.is_local(), "Device is not local");
-        physical_device_ids.push_back(*maybe_remote_device_id);
-    }
-    return physical_device_ids;
+    return extract_locals(instance.get_mapped_devices(MeshShape(1, 8)).device_ids);
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -136,7 +136,12 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     auto num_devices = instance.shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
 
-    auto physical_device_ids = extract_locals(instance.get_mapped_physical_device_ids(MeshShape(1, 8)).values());
+    auto system_devices = instance.get_mapped_devices(MeshShape(1, 8));
+    std::vector<int> physical_device_ids;
+    for (const auto& device : system_devices.values()) {
+        TT_FATAL(device.device_id.is_local(), "Device is not local");
+        physical_device_ids.push_back(*device.device_id);
+    }
     return physical_device_ids;
 }
 

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -136,11 +136,11 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     auto num_devices = instance.shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
 
-    auto system_devices = instance.get_mapped_devices(MeshShape(1, 8));
+    auto maybe_remote_device_ids = instance.get_mapped_devices(MeshShape(1, 8)).device_ids;
     std::vector<int> physical_device_ids;
-    for (const auto& device : system_devices.values()) {
-        TT_FATAL(device.device_id.is_local(), "Device is not local");
-        physical_device_ids.push_back(*device.device_id);
+    for (const auto maybe_remote_device_id : maybe_remote_device_ids) {
+        TT_FATAL(maybe_remote_device_id.is_local(), "Device is not local");
+        physical_device_ids.push_back(*maybe_remote_device_id);
     }
     return physical_device_ids;
 }

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -125,7 +125,9 @@ SenderRecieverConfig get_device_sender_receiver_config_in_ring(
         } else {
             new_col = line_index % ring_size;
         }
-        return mesh_view.find_device_id(MeshCoordinate(new_row, new_col));
+        auto* device = mesh_view.get_device(MeshCoordinate(new_row, new_col));
+        TT_FATAL(device != nullptr, "Device not found at coordinate {}", MeshCoordinate(new_row, new_col));
+        return device->id();
     };
 
     bool is_last_chip_in_clockwise_direction = config.device_index == (ring_size - 1);


### PR DESCRIPTION
### Ticket
#25203

### Problem description
Need to be able to query `FabricNodeId` off `MeshDeviceView`

### What's changed
* Extended `SystemMesh` to return pairs of `MaybeRemote<int>` chip IDs and `FabricNodeId` for every global device.
* Added plumbing through to `MeshDeviceView`

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16502761772) - known failures + fixed debug build in https://github.com/tenstorrent/tt-metal/pull/25702/commits/022915618aafb9eb2bf91e1e759ca2cf9deca150
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16482837427)
- [X] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/16506027311)
- [X] New/Existing tests provide coverage for changes