### PR TITLE
#25397: Use pytorch concat in llama prefill / decode processing

### DIFF
--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -236,7 +236,7 @@ class Transformer(LightweightModule):
         """
         Concatenate the output of the devices into a single tensor.
         """
-        torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out)]
+        torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out.cpu())]
         if self.args.is_galaxy:
             row_dim, col_dim = (3, 1)
         else:

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -232,33 +232,34 @@ class Transformer(LightweightModule):
         )
         return tt_tokens, current_pos, tt_rot_mats, page_table
 
+    def concat_device_output(self, tt_out):
+        """
+        Concatenate the output of the devices into a single tensor.
+        """
+        torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out)]
+        if self.args.is_galaxy:
+            row_dim, col_dim = (3, 1)
+        else:
+            row_dim, col_dim = (1, -1)
+
+        rows, cols = self.args.cluster_shape
+        mesh_shape = [torch_out_tensors[i : i + cols] for i in range(0, len(torch_out_tensors), cols)]
+        row_concatenated = [torch.cat(row, dim=col_dim) for row in mesh_shape]
+        return torch.cat(row_concatenated, dim=row_dim)
+
     def process_output_prefill(self, tt_out, last_token_idx):
         """
         Input is ttnn device tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
-        logits = ttnn.to_torch(
-            tt_out,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(
-                self.mesh_device, dims=(3, 1) if self.args.is_galaxy else (1, -1), mesh_shape=self.args.cluster_shape
-            ),
-        )[0, 0, last_token_idx, : self.vocab_size]
-        return logits
+        return self.concat_device_output(tt_out)[0, 0, last_token_idx, : self.vocab_size]
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
         """
         Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
         if is_tokens:
-            tt_out = ttnn.to_torch(
-                tt_out,  # tt_out.cpu(blocking=True, cq_id=1),
-                mesh_composer=ttnn.ConcatMesh2dToTensor(
-                    self.mesh_device,
-                    dims=(3, 1) if self.args.is_galaxy else (1, -1),
-                    mesh_shape=self.args.cluster_shape,
-                ),
-            )[0, 0, :B, 0]
-            return tt_out
+            return self.concat_device_output(tt_out)[0, 0, :B, 0]
 
         if self.args.num_devices > 1:
             tt_out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()


### PR DESCRIPTION
### Ticket
#25397

### Problem description
Llama observed regression due to moving from torch-based concatenation to C++ in TT-NN.

### What's changed
Fallback to torch-based concatenation.



### Checklist
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16483392735)
  - [x] See [llama 70b](https://github.com/tenstorrent/tt-metal/actions/runs/16483392735/job/46603235983):
``` 
Average Time to First Token (TTFT): 170.81ms
Average speed: 65.82ms @ 15.19 tok/s/user (15.19 tok/s throughput)
```
- [x] New/Existing tests provide coverage for changes