### PR TITLE
Migrating EnqueueWaitForEvent Tests to TT-Mesh APIs

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -261,6 +261,7 @@ run_t3000_tteager_tests() {
   pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_moe_ccl_end_to_end.py ; fail+=$?
 
   # distributed layernorm

--- a/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_6U.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_6U.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+import ttnn
+
+# Import the test function from the t3000 file
+from tests.ttnn.unit_tests.operations.ccl.test_mesh_partition_t3000 import (
+    run_mesh_partition_test,
+)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 18432,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [True, False])
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
+)
+@pytest.mark.parametrize("per_device_output_shape, dim", [((1, 1, 8, 7168), 2)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("cluster_axis", [0, 1, None])
+@pytest.mark.parametrize("mesh_axes", [[0, 1]])
+@pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+def test_mesh_partition_rm(
+    mesh_device,
+    mesh_shape,
+    trace_mode,
+    per_device_output_shape,
+    dtype,
+    layout,
+    dim,
+    cluster_axis,
+    mesh_axes,
+    input_memory_config,
+    output_memory_config,
+):
+    num_iters = 2
+    warmup_iters = 0
+
+    run_mesh_partition_test(
+        mesh_device,
+        per_device_output_shape,
+        dim,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        dtype,
+        layout,
+        cluster_axis,
+        mesh_axes,
+        mesh_shape,
+        input_memory_config,
+        output_memory_config,
+        scheme="random",
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+from models.utility_functions import skip_for_grayskull
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from tracy import signpost
+
+
+def gen_tensor(dim, per_device_output_shape, mesh_axes, mesh_shape, cluster_axis, scheme="random"):
+    factor = 0
+
+    if cluster_axis is None:
+        # Linearized grid case - treat all devices as a single linear sequence
+        total_devices = mesh_shape[0] * mesh_shape[1]
+
+        # Create output tensors for each device in the linearized grid
+        single_device_output_tensors = []
+        for device_idx in range(total_devices):
+            if scheme == "random":
+                single_device_output_tensors.append(torch.rand(per_device_output_shape))
+            elif scheme == "sequential":
+                single_device_output_tensors.append(torch.ones(per_device_output_shape) * factor)
+                factor += 1
+            else:
+                raise ValueError(f"Invalid scheme: {scheme}")
+
+        # Create input tensor by concatenating all slices along dim
+        torch_input_tensor = torch.cat(single_device_output_tensors, dim=dim)
+
+        # For output tensor, we need to arrange slices according to mesh layout
+        # First, arrange them in rows and columns according to mesh_shape
+        output_tensors_2d = []
+        device_idx = 0
+        for row in range(mesh_shape[0]):
+            row_tensors = []
+            for col in range(mesh_shape[1]):
+                row_tensors.append(single_device_output_tensors[device_idx])
+                device_idx += 1
+            # Concatenate along mesh_axes[1] (column dimension)
+            row_tensor = torch.cat(row_tensors, dim=mesh_axes[1])
+            output_tensors_2d.append(row_tensor)
+
+        # Concatenate rows along mesh_axes[0] (row dimension)
+        torch_output_tensor = torch.cat(output_tensors_2d, dim=mesh_axes[0])
+
+        # Create input tensor with same structure as output for mesh mapping
+        input_tensors_2d = []
+        for row in range(mesh_shape[0]):
+            row_tensors = []
+            for col in range(mesh_shape[1]):
+                row_tensors.append(torch_input_tensor)
+            row_tensor = torch.cat(row_tensors, dim=mesh_axes[1])
+            input_tensors_2d.append(row_tensor)
+        torch_input_tensor = torch.cat(input_tensors_2d, dim=mesh_axes[0])
+
+        return torch_input_tensor, torch_output_tensor
+
+    # Original logic for when cluster_axis is specified
+    non_cluster_axes = [i for i in range(len(mesh_axes)) if i != cluster_axis]
+
+    torch_input_tensor = None
+    for axis in non_cluster_axes:
+        per_axis_tensor = None
+        temp_per_axis_tensors = []
+        temp_per_axis_output_tensors = []
+        for _ in range(mesh_shape[axis]):
+            single_device_output_tensors = []
+            for _ in range(mesh_shape[cluster_axis]):
+                if scheme == "random":
+                    single_device_output_tensors.append(torch.rand(per_device_output_shape))
+                elif scheme == "sequential":
+                    single_device_output_tensors.append(torch.ones(per_device_output_shape) * factor)
+                    factor += 1
+                else:
+                    raise ValueError(f"Invalid scheme: {scheme}")
+            single_device_input_tensor = torch.cat(single_device_output_tensors, dim=dim)
+            cluster_axis_tensors = []
+            for _ in range(mesh_shape[cluster_axis]):
+                cluster_axis_tensors.append(single_device_input_tensor)
+
+            cluster_axis_tensor = torch.cat(cluster_axis_tensors, dim=mesh_axes[cluster_axis])
+            cluster_axis_output_tensor = torch.cat(single_device_output_tensors, dim=mesh_axes[cluster_axis])
+
+            temp_per_axis_tensors.append(cluster_axis_tensor)
+            temp_per_axis_output_tensors.append(cluster_axis_output_tensor)
+        per_axis_tensor = torch.cat(temp_per_axis_tensors, dim=axis)
+        per_axis_output_tensor = torch.cat(temp_per_axis_output_tensors, dim=axis)
+
+        if torch_input_tensor is None:
+            torch_input_tensor = per_axis_tensor
+            torch_output_tensor = per_axis_output_tensor
+        else:
+            torch_input_tensor = torch.cat([torch_input_tensor, per_axis_tensor], dim=axis)
+            torch_output_tensor = torch.cat([torch_output_tensor, per_axis_output_tensor], dim=axis)
+
+    return torch_input_tensor, torch_output_tensor
+
+
+def run_mesh_partition_test(
+    mesh_device,
+    per_device_output_shape,
+    dim,
+    num_iters,
+    warmup_iters,
+    trace_mode,
+    dtype,
+    layout,
+    cluster_axis,
+    mesh_axes,
+    mesh_shape,
+    input_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    output_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    scheme="random",
+    profiler=BenchmarkProfiler(),
+):
+    mesh_device.enable_program_cache()
+    torch.manual_seed(2005)
+
+    output_tensor_goldens_list = []
+    tt_input_tensors_list = []
+    for it in range(num_iters):
+        input, output = gen_tensor(dim, per_device_output_shape, mesh_axes, mesh_shape, cluster_axis, scheme=scheme)
+
+        output_tensor_goldens_list.append(output)
+
+        tt_input = ttnn.from_torch(
+            input,
+            device=mesh_device,
+            layout=layout,
+            dtype=dtype,
+            memory_config=input_memory_config,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=mesh_axes, mesh_shape=mesh_shape),
+        )
+        if it == 0:
+            logger.info(f"input shape {input.shape}")
+            logger.info(f"tt_input per-device shape {tt_input.shape}")
+        tt_input_tensors_list.append(tt_input)
+
+    tt_out_tensor_list = []
+
+    def run_op(n_iters, store_all_results=True):
+        tt_output_list = []
+        for i in range(n_iters):
+            buffer_index = 0 if trace_mode else i
+            tt_out_tensor = ttnn.mesh_partition(
+                tt_input_tensors_list[buffer_index],
+                dim,
+                cluster_axis=cluster_axis,
+                memory_config=output_memory_config,
+            )
+            if not trace_mode:
+                ttnn.synchronize_device(mesh_device)
+            if store_all_results:
+                tt_output_list.append(tt_out_tensor)
+        if store_all_results:
+            return tt_output_list
+        else:
+            return [tt_out_tensor]
+
+    if trace_mode:
+        # compile run:
+        logger.info("Compiling model")
+        tt_out_tensor_list = run_op(1, store_all_results=False)
+
+        logger.info("Capturing Warmup")
+        logger.info("Warmup iteration: ", warmup_iters)
+        if warmup_iters > 0:
+            trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            run_op(warmup_iters, store_all_results=False)
+            ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+
+        logger.info("Capturing Trace")
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tt_outs = run_op(num_iters, store_all_results=False)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        logger.info("Starting Trace perf test...")
+        profiler.start("reduce-scatter-trace-warmup")
+        if warmup_iters > 0:
+            ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+            ttnn.release_trace(mesh_device, trace_id_warmup)
+            ttnn.synchronize_device(mesh_device)
+        profiler.end("reduce-scatter-trace-warmup")
+
+        signpost("start")
+        profiler.start("reduce-scatter-trace")
+        ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.synchronize_device(mesh_device)
+        profiler.end("reduce-scatter-trace")
+        signpost("stop")
+
+        time_taken = profiler.get_duration("reduce-scatter-trace") - profiler.get_duration(
+            "reduce-scatter-trace-warmup"
+        )
+        logger.info(f"Time taken e2e: {time_taken} s")
+    else:
+        signpost("start")
+        tt_out_tensor_list = run_op(num_iters, store_all_results=True)
+        signpost("stop")
+
+    passed = True
+    first_failed_tensor_index = None
+    failed_indices = []
+    expected_pcc = 0.999 if dtype == ttnn.bfloat8_b else 1.0
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_torch_tensor = ttnn.to_torch(
+            tt_out_tensor_list[tensor_index],
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=mesh_axes),
+        )
+        if tensor_index == 0:
+            logger.info(f"tt_output per-device shape {tt_out_tensor_list[tensor_index].shape}")
+            logger.info(f"golden shape {output_tensor_goldens_list[tensor_index].shape}")
+            logger.info(f"tt_torch_tensor shape {tt_torch_tensor.shape}")
+        eq, output_results = comp_pcc(tt_torch_tensor, output_tensor_goldens_list[tensor_index], expected_pcc)
+        logger.info(f"Output tensor {tensor_index} has result {output_results}")
+        if not eq:
+            passed = False
+            first_failed_tensor_index = tensor_index
+            failed_indices = torch.where(tt_torch_tensor != output_tensor_goldens_list[tensor_index])
+            break
+
+    logger.info(f"Device has {mesh_device.num_program_cache_entries()} program cache entries")
+    assert (
+        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
+    ), f"Device {mesh_device.id} has {mesh_device.num_program_cache_entries()} program cache entries"
+
+    if not passed:
+        logger.info(f"Failed indices: {failed_indices}")
+        assert eq, f"{first_failed_tensor_index} FAILED: {output_results}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 10000,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [True])
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device", [pytest.param((2, 4), (2, 4), id="2x4_grid")], indirect=["mesh_device"]
+)
+@pytest.mark.parametrize("per_device_output_shape", [(1, 1, 32, 32)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("cluster_axis", [0, 1, None])
+@pytest.mark.parametrize("mesh_axes", [[0, 1]])
+@pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+def test_mesh_partition(
+    mesh_device,
+    mesh_shape,
+    trace_mode,
+    per_device_output_shape,
+    dtype,
+    layout,
+    dim,
+    cluster_axis,
+    mesh_axes,
+    input_memory_config,
+    output_memory_config,
+):
+    num_iters = 2
+    warmup_iters = 0
+
+    run_mesh_partition_test(
+        mesh_device,
+        per_device_output_shape,
+        dim,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        dtype,
+        layout,
+        cluster_axis,
+        mesh_axes,
+        mesh_shape,
+        input_memory_config,
+        output_memory_config,
+        scheme="random",
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 16384,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [True, False])
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device", [pytest.param((2, 4), (2, 4), id="2x4_grid")], indirect=["mesh_device"]
+)
+@pytest.mark.parametrize("per_device_output_shape, dim", [((16, 1, 1, 7168), 0), ((1, 1, 8, 7168), 2)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("cluster_axis", [0, 1, None])
+@pytest.mark.parametrize("mesh_axes", [[0, 1]])
+@pytest.mark.parametrize("input_memory_config", [ttnn.L1_MEMORY_CONFIG])
+@pytest.mark.parametrize("output_memory_config", [ttnn.L1_MEMORY_CONFIG])
+def test_mesh_partition_rm(
+    mesh_device,
+    mesh_shape,
+    trace_mode,
+    per_device_output_shape,
+    dtype,
+    layout,
+    dim,
+    cluster_axis,
+    mesh_axes,
+    input_memory_config,
+    output_memory_config,
+):
+    num_iters = 2
+    warmup_iters = 0
+
+    run_mesh_partition_test(
+        mesh_device,
+        per_device_output_shape,
+        dim,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        dtype,
+        layout,
+        cluster_axis,
+        mesh_axes,
+        mesh_shape,
+        input_memory_config,
+        output_memory_config,
+        scheme="random",
+    )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -315,6 +315,7 @@ set(CCL_TTNN_SRCS_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_gather/all_gather_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/barrier/barrier_${PY_BINDING}.cpp
 )

--- a/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
@@ -30,6 +30,9 @@ target_sources(
         all_to_all_dispatch/all_to_all_dispatch.cpp
         all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
         all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+        mesh_partition/mesh_partition.cpp
+        mesh_partition/device/mesh_partition_device_operation.cpp
+        mesh_partition/device/mesh_partition_program_factory.cpp
         reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
         reduce_scatter/device/reduce_scatter_op.cpp
         reduce_scatter/reduce_scatter.cpp

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/operations/ccl/all_gather/all_gather_pybind.hpp"
 #include "ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp"
+#include "ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.hpp"
 #include "ttnn/operations/ccl/barrier/barrier_pybind.hpp"
 #include "ttnn/operations/ccl/all_to_all_combine/all_to_all_combine_pybind.hpp"
 #include "ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_pybind.hpp"
@@ -45,6 +46,7 @@ void py_module(py::module& module) {
     ccl::py_bind_common(module);
     ccl::py_bind_all_gather(module);
     ccl::py_bind_reduce_scatter(module);
+    ccl::py_bind_mesh_partition(module);
     ccl::py_bind_barrier(module);
     ccl::py_bind_all_to_all_combine(module);
     ccl::py_bind_all_to_all_dispatch(module);

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <utility>
+
+#include "ttnn/tensor/types.hpp"
+#include "mesh_partition_device_operation.hpp"
+#include "cpp/ttnn/operations/data_movement/common/common.hpp"
+#include <tt-metalium/work_split.hpp>
+
+namespace ttnn::operations::ccl {
+
+namespace detail {
+uint32_t get_cluster_axis_size(const ttnn::Tensor& input_tensor, const std::optional<uint32_t>& cluster_axis) {
+    auto mesh_device = input_tensor.mesh_device();
+    const auto& mesh_view = mesh_device->get_view();
+    return cluster_axis.has_value() ? ((cluster_axis.value() == 0) ? mesh_view.num_rows() : mesh_view.num_cols())
+                                    : mesh_view.num_devices();
+}
+}  // namespace detail
+
+MeshPartitionDeviceOperation::program_factory_t MeshPartitionDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return MeshPartition{};
+}
+
+void MeshPartitionDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto input_tensor = tensor_args.input_tensor;
+    uint32_t rank = input_tensor.logical_shape().rank();
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    if (tensor_args.optional_output_tensor.has_value()) {
+        TT_FATAL(
+            tensor_args.optional_output_tensor.value().tensor_spec() == output_spec,
+            "Output tensor spec must match computed output spec");
+    }
+    const auto& output_shape = output_spec.logical_shape();
+    const auto& input_shape = input_tensor.logical_shape();
+
+    TT_FATAL(
+        !(operation_attributes.cluster_axis.has_value() && operation_attributes.cluster_axis.value() > 1),
+        "Only support cluster axis of None, 0 or 1");
+
+    TT_FATAL(operation_attributes.dim < rank, "dim must be less than the rank of the input tensor");
+
+    const uint32_t cluster_axis_size = detail::get_cluster_axis_size(input_tensor, operation_attributes.cluster_axis);
+
+    TT_FATAL(
+        cluster_axis_size > 1,
+        "Partition has only been tested with mesh axis size > 1, but has {} devices",
+        cluster_axis_size);
+    TT_FATAL(
+        input_shape[operation_attributes.dim] % cluster_axis_size == 0,
+        "input shape {} must be divisible by cluster axis size {}",
+        input_tensor.logical_shape(),
+        cluster_axis_size);
+
+    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+        TT_FATAL(
+            output_shape == output_spec.padded_shape(),
+            "output shape {} must be equal to padded shape {} for tiled inputs",
+            output_shape,
+            output_spec.padded_shape());
+    }
+}
+
+void MeshPartitionDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+
+MeshPartitionDeviceOperation::spec_return_value_t MeshPartitionDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto input_tensor = tensor_args.input_tensor;
+    auto output_shape = input_tensor.logical_shape();
+
+    const uint32_t cluster_axis_size = detail::get_cluster_axis_size(input_tensor, operation_attributes.cluster_axis);
+
+    output_shape[operation_attributes.dim] = output_shape[operation_attributes.dim] / cluster_axis_size;
+    return {TensorSpec(
+        Shape(output_shape),
+        tt::tt_metal::TensorLayout(
+            input_tensor.dtype(),
+            tt::tt_metal::PageConfig(input_tensor.layout()),
+            operation_attributes.output_mem_config))};
+}
+
+MeshPartitionDeviceOperation::tensor_return_value_t MeshPartitionDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
+
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+
+    auto tensor = create_device_tensor(output_spec, tensor_args.input_tensor.device());
+    return tensor;
+}
+
+std::tuple<MeshPartitionDeviceOperation::operation_attributes_t, MeshPartitionDeviceOperation::tensor_args_t>
+MeshPartitionDeviceOperation::invoke(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor) {
+    return {
+        operation_attributes_t{
+            .dim = (dim < 0 ? uint32_t(input_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
+            .cluster_axis = cluster_axis,
+            .output_mem_config = memory_config,
+        },
+        tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor}};
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+#include <optional>
+
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/decorators.hpp"
+#include "ttnn/global_semaphore.hpp"
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+#include "ttnn/operations/data_movement/slice/device/slice_op.hpp"
+
+namespace ttnn::operations::ccl {
+
+struct MeshPartitionDeviceOperation {
+    struct operation_attributes_t {
+        uint32_t dim;
+        std::optional<uint32_t> cluster_axis;
+        const MemoryConfig output_mem_config;
+    };
+    struct tensor_args_t {
+        const ttnn::Tensor input_tensor;
+        const std::optional<ttnn::Tensor> optional_output_tensor;
+    };
+
+    using spec_return_value_t = ttnn::TensorSpec;
+
+    using tensor_return_value_t = ttnn::Tensor;
+
+    struct MeshPartition {
+        using OverrideRuntimeArgsCallback = std::function<void(
+            const void*,
+            tt::tt_metal::Program&,  // ‼  no const, exact type
+            const std::vector<tt::tt_metal::Tensor>&,
+            const std::vector<std::optional<const tt::tt_metal::Tensor>>&,
+            const std::vector<tt::tt_metal::Tensor>&)>;
+
+        // -- shared variables --------------------------------------------
+        struct shared_variables_t {
+            OverrideRuntimeArgsCallback override_runtime_arguments_callback;
+            ttnn::operations::data_movement::SliceDeviceOperation slice_op;
+        };
+        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate& mesh_coordinate,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<MeshPartition>;
+
+    // Mandatory methods
+
+    // Select the program factory based on the operation attributes and tensor args
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    // Validate the operation when it creates a program.
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    // Empty as there doesn't seem to be any complicated hashing requirement
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    // Compute the output shapes based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    // Create the output tensors based on the operation attributes and tensor args
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const ttnn::Tensor& input_tensor,
+        int32_t dim,
+        std::optional<uint32_t> cluster_axis,
+        const ttnn::MemoryConfig& memory_config,
+        const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt);
+};
+
+namespace detail {
+uint32_t get_cluster_axis_size(const ttnn::Tensor& input_tensor, const std::optional<uint32_t>& cluster_axis);
+}
+
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
+constexpr auto mesh_partition =
+    ttnn::register_operation<"ttnn::prim::mesh_partition", ttnn::operations::ccl::MeshPartitionDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mesh_partition_device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <vector>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/device_pool.hpp>
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "cpp/ttnn/operations/ccl/sharding_addrgen_helper.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/erisc_datamover_builder.hpp>
+#include "cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/fabric.hpp>
+#include "ttnn/operations/data_movement/slice/device/slice_op.hpp"
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+
+namespace ttnn::operations::ccl {
+namespace detail {
+uint32_t get_cluster_axis_index(
+    const ttnn::MeshDeviceView& mesh_view,
+    const ttnn::MeshCoordinate& mesh_coordinate,
+    const MeshPartitionDeviceOperation::operation_attributes_t& operation_attributes) {
+    return operation_attributes.cluster_axis.has_value()
+               ? ((operation_attributes.cluster_axis.value() == 0) ? mesh_coordinate[0] : mesh_coordinate[1])
+               : common::get_linearized_index(mesh_coordinate, mesh_view);
+}
+}  // namespace detail
+
+MeshPartitionDeviceOperation::MeshPartition::cached_mesh_workload_t
+MeshPartitionDeviceOperation::MeshPartition::create_mesh_workload(
+    const operation_attributes_t& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    for (const auto& coord : tensor_coords.coords()) {
+        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
+        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
+        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+    }
+    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
+}
+
+ttnn::device_operation::CachedProgram<MeshPartitionDeviceOperation::MeshPartition::shared_variables_t>
+MeshPartitionDeviceOperation::MeshPartition::create_at(
+    const operation_attributes_t& operation_attributes,
+    const ttnn::MeshCoordinate& mesh_coordinate,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& input_tensor = tensor_args.input_tensor;
+
+    const uint32_t cluster_size = detail::get_cluster_axis_size(input_tensor, operation_attributes.cluster_axis);
+    uint32_t cluster_index =
+        detail::get_cluster_axis_index(input_tensor.mesh_device()->get_view(), mesh_coordinate, operation_attributes);
+    TT_FATAL(
+        cluster_index < cluster_size,
+        "cluster_index ({}) must be less than cluster_size ({})",
+        cluster_index,
+        cluster_size);
+
+    auto input_shape = input_tensor.logical_shape();
+    uint32_t dim = operation_attributes.dim;
+    uint32_t rank = input_shape.size();
+    auto partitioned_dim_size = input_shape[dim] / cluster_size;
+    uint64_t begin_pos = static_cast<uint64_t>(cluster_index) * partitioned_dim_size;
+    TT_FATAL(
+        begin_pos <= std::numeric_limits<uint32_t>::max() - partitioned_dim_size,
+        "Integer overflow: cluster_index ({}) * partitioned_dim_size ({}) = {} exceeds uint32_t max",
+        cluster_index,
+        partitioned_dim_size,
+        begin_pos);
+
+    auto begins = ttnn::Shape(std::vector<uint32_t>(rank, 0));
+    auto ends = input_shape;
+    auto strides = ttnn::Shape(std::vector<uint32_t>(rank, 1));
+
+    begins[dim] = static_cast<uint32_t>(begin_pos);
+    ends[dim] = begins[dim] + partitioned_dim_size;
+
+    TT_FATAL(
+        ends[dim] <= input_shape[dim],
+        "Slice bounds error: ends[{}] ({}) exceeds input_shape[{}] ({})",
+        dim,
+        ends[dim],
+        dim,
+        input_shape[dim]);
+
+    log_debug(
+        tt::LogOp,
+        "Slice at ({}, {}) will have begins {}, ends {}, step {}",
+        mesh_coordinate[0],
+        mesh_coordinate[1],
+        begins,
+        ends,
+        strides);
+
+    auto slice_op = ttnn::operations::data_movement::SliceDeviceOperation{
+        .slice_start = begins,
+        .slice_end = ends,
+        .step = strides,
+        .output_mem_config = operation_attributes.output_mem_config};
+
+    auto input_tensors = std::vector<ttnn::Tensor>{tensor_args.input_tensor};
+    auto output_tensors = std::vector<ttnn::Tensor>{tensor_return_value};
+    auto optional_output_tensors = std::vector<std::optional<ttnn::Tensor>>{std::nullopt};
+    slice_op.validate_with_output_tensors(input_tensors, optional_output_tensors);
+
+    auto cached_program = slice_op.create_program(input_tensors, output_tensors);
+    TT_FATAL(
+        cached_program.override_runtime_arguments_callback.has_value(),
+        "override_runtime_arguments_callback is not set for program at mesh coordinate ({}, {})",
+        mesh_coordinate[0],
+        mesh_coordinate[1]);
+
+    // -- building the return value -----------------------------------
+    shared_variables_t vars{
+        // if the optional holds a callback, move it; otherwise construct an empty
+        // std::function (== "no-op")
+        .override_runtime_arguments_callback = cached_program.override_runtime_arguments_callback.value_or(
+            OverrideRuntimeArgsCallback{}),  //   ^ empty functor
+        .slice_op = slice_op};
+
+    return {std::move(cached_program.program), std::move(vars)};
+}
+
+void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    std::vector<tt::tt_metal::Tensor> input_tensors{tensor_args.input_tensor};
+    std::vector<std::optional<const tt::tt_metal::Tensor>> input_tensor_options{};
+    std::vector<tt::tt_metal::Tensor> output_tensors{tensor_return_value};
+    for (auto& [range, program] : cached_workload.workload.get_programs()) {
+        const auto& shared_variables = cached_workload.shared_variables.at(range);
+        shared_variables.override_runtime_arguments_callback(
+            (const void*)&shared_variables.slice_op, program, input_tensors, input_tensor_options, output_tensors);
+    }
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/common/queue_id.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include "mesh_partition.hpp"
+#include "device/mesh_partition_device_operation.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include <tt-metalium/sub_device.hpp>
+
+namespace ttnn::operations::ccl {
+
+ttnn::Tensor ExecuteMeshPartition::invoke(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<ttnn::MemoryConfig>& memory_config) {
+    if (detail::get_cluster_axis_size(input_tensor, cluster_axis) == 1) {
+        return input_tensor;
+    }
+
+    return ttnn::prim::mesh_partition(
+        input_tensor, dim, cluster_axis, memory_config.value_or(input_tensor.memory_config()));
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/global_semaphore.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+
+namespace ttnn {
+namespace operations::ccl {
+
+struct ExecuteMeshPartition {
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const ttnn::Tensor& input_tensor,
+        int32_t dim,
+        std::optional<uint32_t> cluster_axis,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+};
+
+}  // namespace operations::ccl
+
+constexpr auto mesh_partition =
+    ttnn::register_operation<"ttnn::mesh_partition", ttnn::operations::ccl::ExecuteMeshPartition>();  // namespace
+                                                                                                      // ttnn
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mesh_partition_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn-pybind/decorators.hpp"
+#include "mesh_partition.hpp"
+
+namespace ttnn::operations::ccl {
+
+void py_bind_mesh_partition(py::module& module) {
+    auto doc =
+        R"doc(mesh_partition(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+
+            Partitions the input tensor across the mesh such that each device has the i/num_devices-th partition of the input tensor along the specified dimension. This is the inverse of all_gather
+
+            Args:
+                input_tensor (ttnn.Tensor): the input tensor.
+                dim (number): the dimension to partition along
+                cluster_axis (number): the cluster axis on the mesh.
+
+            Keyword Args:
+                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+                queue_id (int, optional): command queue id. Defaults to `0`.
+
+           Returns:
+               ttnn.Tensor: the output tensor.
+
+            Example:
+
+                >>> tensor = ttnn.experimental.mesh_partition(
+                                tt_input_tensors_list[i],
+                                dim,
+                                cluster_axis=1,
+                                memory_config=output_mem_config))doc";
+
+    using OperationType = decltype(ttnn::mesh_partition);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::mesh_partition,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               int32_t dim,
+               std::optional<uint32_t> cluster_axis,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               QueueId queue_id) { return self(queue_id, input_tensor, dim, cluster_axis, memory_config); },
+            py::arg("input_tensor").noconvert(),
+            py::arg("dim"),
+            py::arg("cluster_axis") = std::nullopt,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId,
+
+        });
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::ccl {
+
+void py_bind_mesh_partition(pybind11::module& module);
+
+}  // namespace ttnn::operations::ccl


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22835)

### Problem description
This PR migrates tests 

### What's changed
Migrated all tests to use TT-Mesh APIs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] New/Existing tests provide coverage for changes