### PR TITLE
EnqueueWaitForEvent Test Migration to use TT-Mesh APIs, Test Fixture Cleanup

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -1415,7 +1415,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteComman
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToDramBank0) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
     distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -1425,7 +1425,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToDramBank0) {
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllDramBanks) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     auto device = mesh_device->get_devices()[0];
     TestBufferConfig config = {
         .num_pages = uint32_t(device->allocator()->get_num_banks(BufferType::DRAM)),
@@ -1440,7 +1440,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllDramBanks) {
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     auto device = mesh_device->get_devices()[0];
     constexpr uint32_t num_round_robins = 2;
     TestBufferConfig config = {
@@ -1456,7 +1456,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileAcrossAllDramBanksT
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, Sending131072Pages) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     // Was a failing case where we used to accidentally program cb num pages to be total
     // pages instead of cb num pages.
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
@@ -1469,7 +1469,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, Sending131072Pages) {
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDram) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
     distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
@@ -1480,7 +1480,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDra
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDram2) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
@@ -1492,7 +1492,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDra
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     auto device = mesh_device->get_devices()[0];
     uint32_t page_size = 2048;
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
@@ -1994,7 +1994,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestLargeBuffer4096BPageSize) {
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToL1Bank0) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
     distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
     distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -2004,7 +2004,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToL1Bank0) {
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllL1Banks) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
     TestBufferConfig config = {
         .num_pages = uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -2019,7 +2019,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllL1Banks) {
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
     TestBufferConfig config = {
         .num_pages = 2 * uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -2034,7 +2034,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRo
 }
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) {
-    auto mesh_device = this->devices_[0];
+    auto mesh_device = this->device_;
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
     distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -6,8 +6,7 @@
 #include <fmt/base.h>
 #include <stdint.h>
 #include <sys/types.h>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/event.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <functional>
@@ -35,9 +34,9 @@ using std::vector;
 
 namespace local_test_functions {
 
-void FinishAllCqs(vector<std::reference_wrapper<CommandQueue>>& cqs) {
+void FinishAllCqs(vector<std::reference_wrapper<distributed::MeshCommandQueue>>& cqs) {
     for (uint i = 0; i < cqs.size(); i++) {
-        Finish(cqs[i]);
+        distributed::Finish(cqs[i]);
     }
 }
 }  // namespace local_test_functions
@@ -46,29 +45,29 @@ namespace basic_tests {
 
 // Simplest test to record Event per CQ and wait from host, and verify populated Event struct is correct (many events,
 // wrap issue queue)
-TEST_F(MultiCommandQueueMultiDeviceEventFixture, TestEventsEventSynchronizeSanity) {
-    for (IDevice* device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", device->id());
-        vector<std::reference_wrapper<CommandQueue>> cqs = {device->command_queue(0), device->command_queue(1)};
+TEST_F(UnitMeshMultiCQMultDeviceEventFixture, TestEventsEventSynchronizeSanity) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
         vector<uint32_t> cmds_issued_per_cq = {0, 0};
 
         TT_ASSERT(cqs.size() == 2);
         const int num_cmds_per_cq = 1;
 
         auto start = std::chrono::system_clock::now();
-        std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
+        std::unordered_map<uint, std::vector<distributed::MeshEvent>> sync_events;
         const size_t num_events = 10;
 
         for (size_t j = 0; j < num_events; j++) {
             for (uint i = 0; i < cqs.size(); i++) {
                 log_debug(
                     tt::LogTest, "j : {} Recording and Host Syncing on event for CQ ID: {}", j, cqs[i].get().id());
-                auto event = sync_events[i].emplace_back(std::make_shared<Event>());
-                EnqueueRecordEvent(cqs[i], event);
-                EventSynchronize(event);
+                auto event = sync_events[i].emplace_back(distributed::EnqueueRecordEventToHost(cqs[i]));
+                distributed::EventSynchronize(event);
                 // Can check events fields after prev sync w/ async CQ.
-                EXPECT_EQ(event->cq_id, cqs[i].get().id());
-                EXPECT_EQ(event->event_id, cmds_issued_per_cq[i] + 1);
+                EXPECT_EQ(event.mesh_cq_id(), cqs[i].get().id());
+                EXPECT_EQ(event.id(), cmds_issued_per_cq[i] + 1);
                 cmds_issued_per_cq[i] += num_cmds_per_cq;
             }
         }
@@ -76,7 +75,7 @@ TEST_F(MultiCommandQueueMultiDeviceEventFixture, TestEventsEventSynchronizeSanit
         // Sync on earlier events again per CQ just to show it works.
         for (uint i = 0; i < cqs.size(); i++) {
             for (size_t j = 0; j < num_events; j++) {
-                EventSynchronize(sync_events.at(i)[j]);
+                distributed::EventSynchronize(sync_events.at(i)[j]);
             }
         }
 
@@ -86,404 +85,350 @@ TEST_F(MultiCommandQueueMultiDeviceEventFixture, TestEventsEventSynchronizeSanit
     }
 }
 
-// Simplest test to record Event per CQ and wait from host, and verify populated Event struct is correct (many events,
-// wrap issue queue)
-TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsEventSynchronizeSanity) {
-    vector<std::reference_wrapper<CommandQueue>> cqs = {
-        this->device_->command_queue(0), this->device_->command_queue(1)};
-    vector<uint32_t> cmds_issued_per_cq = {0, 0};
-
-    TT_ASSERT(cqs.size() == 2);
-    const int num_cmds_per_cq = 1;
-
-    auto start = std::chrono::system_clock::now();
-    std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
-    const size_t num_events = 10;
-
-    for (size_t j = 0; j < num_events; j++) {
-        for (uint i = 0; i < cqs.size(); i++) {
-            log_debug(tt::LogTest, "j : {} Recording and Host Syncing on event for CQ ID: {}", j, cqs[i].get().id());
-            auto event = sync_events[i].emplace_back(std::make_shared<Event>());
-            EnqueueRecordEvent(cqs[i], event);
-            EventSynchronize(event);
-            // Can check events fields after prev sync w/ async CQ.
-            EXPECT_EQ(event->cq_id, cqs[i].get().id());
-            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i] + 1);
-            cmds_issued_per_cq[i] += num_cmds_per_cq;
-        }
-    }
-
-    // Sync on earlier events again per CQ just to show it works.
-    for (uint i = 0; i < cqs.size(); i++) {
-        for (size_t j = 0; j < num_events; j++) {
-            EventSynchronize(sync_events.at(i)[j]);
-        }
-    }
-
-    local_test_functions::FinishAllCqs(cqs);
-    std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
-}
-
 // Simplest test to record and wait-for-events on same CQ.
-TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsEnqueueWaitForEventSanity) {
-    vector<std::reference_wrapper<CommandQueue>> cqs = {
-        this->device_->command_queue(0), this->device_->command_queue(1)};
-    vector<uint32_t> events_issued_per_cq = {0, 0};
-    size_t num_events = 10;
+TEST_F(UnitMeshMultiCQMultDeviceEventFixture, TestEventsEnqueueWaitForEventSanity) {
+    for (auto& mesh_device : devices_) {
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+        vector<uint32_t> events_issued_per_cq = {0, 0};
+        size_t num_events = 10;
 
-    TT_ASSERT(cqs.size() == 2);
-    const int num_events_per_cq = 1;
+        TT_ASSERT(cqs.size() == 2);
+        const int num_events_per_cq = 1;
 
-    auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::system_clock::now();
 
-    for (size_t j = 0; j < num_events; j++) {
-        for (uint i = 0; i < cqs.size(); i++) {
-            log_debug(tt::LogTest, "j : {} Recording and Device Syncing on event for CQ ID: {}", j, cqs[i].get().id());
-            auto event = std::make_shared<Event>();
-            EnqueueRecordEvent(cqs[i], event);
-            EXPECT_EQ(event->cq_id, cqs[i].get().id());
-            EXPECT_EQ(event->event_id, events_issued_per_cq[i] + 1);
-            EnqueueWaitForEvent(cqs[i], event);
-            events_issued_per_cq[i] += num_events_per_cq;
+        for (size_t j = 0; j < num_events; j++) {
+            for (uint i = 0; i < cqs.size(); i++) {
+                log_debug(
+                    tt::LogTest, "j : {} Recording and Device Syncing on event for CQ ID: {}", j, cqs[i].get().id());
+                auto event = distributed::EnqueueRecordEvent(cqs[i]);
+                EXPECT_EQ(event.mesh_cq_id(), cqs[i].get().id());
+                EXPECT_EQ(event.id(), events_issued_per_cq[i] + 1);
+                distributed::EnqueueWaitForEvent(cqs[i], event);
+                events_issued_per_cq[i] += num_events_per_cq;
+            }
         }
+        local_test_functions::FinishAllCqs(cqs);
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
     }
-    local_test_functions::FinishAllCqs(cqs);
-    std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Record event on one CQ, wait-for-that-event on another CQ. Then do the flip. Occasionally insert
 // syncs from Host per CQ, and verify completion queues per CQ are correct.
-TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsEnqueueWaitForEventCrossCQs) {
-    vector<std::reference_wrapper<CommandQueue>> cqs = {
-        this->device_->command_queue(0), this->device_->command_queue(1)};
-    vector<uint32_t> cmds_issued_per_cq = {0, 0};
-    const size_t num_events_per_cq = 10;
+TEST_F(UnitMeshMultiCQMultDeviceEventFixture, TestEventsEnqueueWaitForEventCrossCQs) {
+    for (auto& mesh_device : devices_) {
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+        vector<uint32_t> cmds_issued_per_cq = {0, 0};
+        const size_t num_events_per_cq = 10;
 
-    // Currently hardcoded for 2 CQ. For 3+ CQ, can extend to record for CQ0, Wait for CQ1,CQ2,etc.
-    TT_ASSERT(cqs.size() == 2);
-    const int num_cmds_per_cq = 1;
-    vector<uint32_t> expected_event_id = {0, 0};
+        // Currently hardcoded for 2 CQ. For 3+ CQ, can extend to record for CQ0, Wait for CQ1,CQ2,etc.
+        TT_ASSERT(cqs.size() == 2);
+        const int num_cmds_per_cq = 1;
+        vector<uint32_t> expected_event_id = {0, 0};
 
-    auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::system_clock::now();
 
-    // Store completion queue base address from initial rdptr, for later readback.
-    vector<uint32_t> completion_queue_base;
-    completion_queue_base.reserve(cqs.size());
-    for (uint i = 0; i < cqs.size(); i++) {
-        completion_queue_base.push_back(this->device_->sysmem_manager().get_completion_queue_read_ptr(i));
-    }
+        // Issue a number of Event Record/Waits per CQ, with Record/Wait on alternate CQs
+        for (size_t j = 0; j < num_events_per_cq; j++) {
+            for (uint i = 0; i < cqs.size(); i++) {
+                auto cq_idx_record = i;
+                auto cq_idx_wait = (i + 1) % cqs.size();
+                log_debug(
+                    tt::LogTest,
+                    "j : {} Recording event on CQ ID: {} and Device Syncing on CQ ID: {}",
+                    j,
+                    cqs[cq_idx_record].get().id(),
+                    cqs[cq_idx_wait].get().id());
+                auto event = distributed::EnqueueRecordEvent(cqs[cq_idx_record]);
+                EXPECT_EQ(event.mesh_cq_id(), cqs[cq_idx_record].get().id());
+                EXPECT_EQ(event.id(), cmds_issued_per_cq[i] + 1);
+                distributed::EnqueueWaitForEvent(cqs[cq_idx_wait], event);
 
-    // Issue a number of Event Record/Waits per CQ, with Record/Wait on alternate CQs
-    for (size_t j = 0; j < num_events_per_cq; j++) {
-        for (uint i = 0; i < cqs.size(); i++) {
-            auto cq_idx_record = i;
-            auto cq_idx_wait = (i + 1) % cqs.size();
-            auto event = std::make_shared<Event>();
-            log_debug(
-                tt::LogTest,
-                "j : {} Recording event on CQ ID: {} and Device Syncing on CQ ID: {}",
-                j,
-                cqs[cq_idx_record].get().id(),
-                cqs[cq_idx_wait].get().id());
-            EnqueueRecordEvent(cqs[cq_idx_record], event);
-            EXPECT_EQ(event->cq_id, cqs[cq_idx_record].get().id());
-            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i] + 1);
-            EnqueueWaitForEvent(cqs[cq_idx_wait], event);
-
-            // Occasionally do host wait for extra coverage from both CQs.
-            if (j > 0 && ((j % 3) == 0)) {
-                EventSynchronize(event);
+                // Note: Removed host sync here since EnqueueRecordEvent creates device-only events
+                // that don't notify the host. Host sync would require EnqueueRecordEventToHost.
+                cmds_issued_per_cq[cq_idx_record] += num_cmds_per_cq;
+                // cmds_issued_per_cq[cq_idx_wait] += num_cmds_per_cq; // wait_for_event no longer records an event on
+                // host
             }
-            cmds_issued_per_cq[cq_idx_record] += num_cmds_per_cq;
-            // cmds_issued_per_cq[cq_idx_wait] += num_cmds_per_cq; // wait_for_event no longer records an event on host
         }
+
+        local_test_functions::FinishAllCqs(cqs);
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
     }
-
-    local_test_functions::FinishAllCqs(cqs);
-
-    // Check that completion queue per device is correct. Ensure expected event_ids seen in order.
-    chip_id_t mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
-    uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
-    constexpr uint32_t completion_queue_event_alignment = 32;
-    uint32_t event;
-    // Iterate through all CQs, and verify that the events returned by EnqueueRecordEvent are in order.
-    for (uint cq_id = 0; cq_id < cqs.size(); cq_id++) {
-        for (size_t i = 0; i < num_cmds_per_cq * num_events_per_cq; i++) {
-            uint32_t host_addr =
-                completion_queue_base[cq_id] + i * DispatchSettings::TRANSFER_PAGE_SIZE + sizeof(CQDispatchCmd);
-            tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                &event, 4, host_addr, mmio_device_id, channel);
-            log_debug(
-                tt::LogTest,
-                "Checking completion queue. cq_id: {} i: {} host_addr: {}. Got event_id: {}",
-                cq_id,
-                i,
-                host_addr,
-                event);
-            EXPECT_EQ(event, ++expected_event_id[cq_id]);
-        }
-    }
-
-    std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Simple 2CQ test to mix reads, writes, record-event, wait-for-event in a basic way. It's simple because
 // the write, record-event, wait-event, read-event are all on the same CQ, but cover both CQ's.
-TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitForEventSameCQ) {
-    TestBufferConfig config = {.num_pages = 1, .page_size = 256, .buftype = BufferType::DRAM};
-    vector<std::reference_wrapper<CommandQueue>> cqs = {
-        this->device_->command_queue(0), this->device_->command_queue(1)};
-    vector<uint32_t> cmds_issued_per_cq = {0, 0};
+TEST_F(UnitMeshMultiCQMultDeviceEventFixture, TestEventsReadWriteWithWaitForEventSameCQ) {
+    for (auto& mesh_device : devices_) {
+        TestBufferConfig config = {.num_pages = 1, .page_size = 256, .buftype = BufferType::DRAM};
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+        vector<uint32_t> cmds_issued_per_cq = {0, 0};
 
-    size_t buf_size = config.num_pages * config.page_size;
+        size_t buf_size = config.num_pages * config.page_size;
 
-    size_t num_buffers_per_cq = 10;
-    bool pass = true;
+        size_t num_buffers_per_cq = 10;
+        bool pass = true;
 
-    auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::system_clock::now();
 
-    std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
+        std::unordered_map<uint, std::vector<distributed::MeshEvent>> sync_events;
 
-    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
-        vector<std::shared_ptr<Buffer>> buffers;
-        vector<vector<uint32_t>> srcs;
-        for (uint i = 0; i < cqs.size(); i++) {
-            uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
-            buffers.push_back(Buffer::create(this->device_, buf_size, config.page_size, config.buftype));
-            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
-            log_debug(tt::LogTest, "buf_idx: {} Doing Write to cq_id: {} of data: {}", buf_idx, i, srcs[i]);
-            EnqueueWriteBuffer(cqs[i], *buffers[i], srcs[i], false);
-            auto event = sync_events[i].emplace_back(std::make_shared<Event>());
-            EnqueueRecordEvent(cqs[i], event);
+        for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+            vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
+            vector<vector<uint32_t>> srcs;
+            for (uint i = 0; i < cqs.size(); i++) {
+                uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+                // Create MeshBuffer with proper config
+                distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+                distributed::DeviceLocalBufferConfig device_local_config{
+                    .page_size = config.page_size, .buffer_type = config.buftype};
+                buffers.push_back(
+                    distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
+                srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+                log_debug(tt::LogTest, "buf_idx: {} Doing Write to cq_id: {} of data: {}", buf_idx, i, srcs[i]);
+
+                distributed::WriteShard(cqs[i], buffers[i], srcs[i], distributed::MeshCoordinate(0, 0), false);
+                auto event = sync_events[i].emplace_back(distributed::EnqueueRecordEvent(cqs[i]));
+            }
+
+            for (uint i = 0; i < cqs.size(); i++) {
+                auto event = sync_events[i][buf_idx];
+                distributed::EnqueueWaitForEvent(cqs[i], event);
+                vector<uint32_t> result;
+                distributed::ReadShard(cqs[i], result, buffers[i], zero_coord_, true);  // Blocking.
+                bool local_pass = (srcs[i] == result);
+                log_debug(
+                    tt::LogTest,
+                    "Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}",
+                    buf_idx,
+                    i,
+                    local_pass,
+                    srcs[i],
+                    result);
+                pass &= local_pass;
+            }
         }
 
-        for (uint i = 0; i < cqs.size(); i++) {
-            auto event = sync_events[i][buf_idx];
-            EnqueueWaitForEvent(cqs[i], event);
-            vector<uint32_t> result;
-            EnqueueReadBuffer(cqs[i], *buffers[i], result, true);  // Blocking.
-            bool local_pass = (srcs[i] == result);
-            log_debug(
-                tt::LogTest,
-                "Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}",
-                buf_idx,
-                i,
-                local_pass,
-                srcs[i],
-                result);
-            pass &= local_pass;
-        }
+        local_test_functions::FinishAllCqs(cqs);
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+        EXPECT_TRUE(pass);
     }
-
-    local_test_functions::FinishAllCqs(cqs);
-    std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
-    EXPECT_TRUE(pass);
 }
 
 // More interesting test where Blocking ReadBuffer, Non-Blocking WriteBuffer are on alternate CQs,
 // ordered via events. Do many loops, occasionally increasing size of buffers (page size, num pages).
 // Ensure read back data is correct, data is different for each write.
-TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
+TEST_F(UnitMeshMultiCQMultDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::GRAYSKULL) {
         GTEST_SKIP() << "Skipping for GS due to readback mismatch under debug Github issue #6281 ";
     }
 
-    TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
-    vector<std::reference_wrapper<CommandQueue>> cqs = {
-        this->device_->command_queue(0), this->device_->command_queue(1)};
-    vector<uint32_t> cmds_issued_per_cq = {0, 0};
+    for (auto& mesh_device : devices_) {
+        TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+        vector<uint32_t> cmds_issued_per_cq = {0, 0};
 
-    size_t num_buffers_per_cq = 50;
-    bool pass = true;
+        size_t num_buffers_per_cq = 50;
+        bool pass = true;
 
-    auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::system_clock::now();
 
-    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
-        // Increase number of pages and page size every 10 buffers, to change async timing betwen CQs.
-        if (buf_idx > 0 && ((buf_idx % 10) == 0)) {
-            config.page_size *= 2;
-            config.num_pages *= 2;
+        for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+            // Increase number of pages and page size every 10 buffers, to change async timing betwen CQs.
+            if (buf_idx > 0 && ((buf_idx % 10) == 0)) {
+                config.page_size *= 2;
+                config.num_pages *= 2;
+            }
+
+            vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
+            vector<vector<uint32_t>> srcs;
+            size_t buf_size = config.num_pages * config.page_size;
+
+            for (uint i = 0; i < cqs.size(); i++) {
+                uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+                auto& cq_write = cqs[i];
+                auto& cq_read = cqs[(i + 1) % cqs.size()];
+                vector<uint32_t> result;
+
+                // Create MeshBuffer with proper config
+                distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+                distributed::DeviceLocalBufferConfig device_local_config{
+                    .page_size = config.page_size, .buffer_type = config.buftype};
+                buffers.push_back(
+                    distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
+                srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+
+                // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
+                log_debug(
+                    tt::LogTest,
+                    "buf_idx: {} Doing Write (page_size: {} num_pages: {}) to cq_id: {}",
+                    buf_idx,
+                    config.page_size,
+                    config.num_pages,
+                    cq_write.get().id());
+
+                distributed::WriteShard(cq_write, buffers[i], srcs[i], zero_coord_, false);
+                auto event = distributed::EnqueueRecordEvent(cq_write);
+                distributed::EnqueueWaitForEvent(cq_read, event);
+                distributed::ReadShard(cq_read, result, buffers[i], zero_coord_, true);
+                bool local_pass = (srcs[i] == result);
+                log_debug(
+                    tt::LogTest,
+                    "Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}",
+                    buf_idx,
+                    i,
+                    local_pass,
+                    srcs[i],
+                    result);
+                pass &= local_pass;
+            }
         }
 
-        vector<std::shared_ptr<Buffer>> buffers;
-        vector<vector<uint32_t>> srcs;
-        size_t buf_size = config.num_pages * config.page_size;
+        local_test_functions::FinishAllCqs(cqs);
 
-        for (uint i = 0; i < cqs.size(); i++) {
-            uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
-            auto& cq_write = cqs[i];
-            auto& cq_read = cqs[(i + 1) % cqs.size()];
-            auto event = std::make_shared<Event>();
-            vector<uint32_t> result;
-
-            buffers.push_back(Buffer::create(this->device_, buf_size, config.page_size, config.buftype));
-            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
-
-            // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
-            log_debug(
-                tt::LogTest,
-                "buf_idx: {} Doing Write (page_size: {} num_pages: {}) to cq_id: {}",
-                buf_idx,
-                config.page_size,
-                config.num_pages,
-                cq_write.get().id());
-            EnqueueWriteBuffer(cq_write, *buffers[i], srcs[i], false);
-            EnqueueRecordEvent(cq_write, event);
-            EnqueueWaitForEvent(cq_read, event);
-            EnqueueReadBuffer(cq_read, *buffers[i], result, true);
-            bool local_pass = (srcs[i] == result);
-            log_debug(
-                tt::LogTest,
-                "Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}",
-                buf_idx,
-                i,
-                local_pass,
-                srcs[i],
-                result);
-            pass &= local_pass;
-        }
+        auto end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = (end - start);
+        log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+        EXPECT_TRUE(pass);
     }
-
-    local_test_functions::FinishAllCqs(cqs);
-
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds = (end - start);
-    log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
-    EXPECT_TRUE(pass);
 }
 
 // 2 CQs with single Buffer, and a loop where each iteration has non-blocking Write to Buffer via CQ0 and non-blocking
 // Read to Bufffer via CQ1. Ping-Pongs between Writes and Reads to same buffer. Use events to synchronze read after
 // write and write after read before checking correct data read at the end after all cmds finished on device.
-TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
+TEST_F(UnitMeshMultiCQMultDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::GRAYSKULL) {
         GTEST_SKIP() << "Skipping for GS due to readback mismatch under debug Github issue #6281 ";
     }
 
-    TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
-    vector<std::reference_wrapper<CommandQueue>> cqs = {
-        this->device_->command_queue(0), this->device_->command_queue(1)};
-    size_t buf_size = config.num_pages * config.page_size;
+    for (auto& mesh_device : devices_) {
+        TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+        size_t buf_size = config.num_pages * config.page_size;
 
-    bool pass = true;
+        bool pass = true;
 
-    // Some configuration, eventually refactor and spawn more tests.
-    int num_buffers = 20;
-    int num_wr_rd_per_buf = 5;
-    bool use_events = true;  // Set to false to see failures.
+        // Some configuration, eventually refactor and spawn more tests.
+        int num_buffers = 20;
+        int num_wr_rd_per_buf = 5;
+        bool use_events = true;  // Set to false to see failures.
 
-    TT_ASSERT(cqs.size() == 2);
+        TT_ASSERT(cqs.size() == 2);
 
-    auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::system_clock::now();
 
-    // Repeat test starting with different CQ ID. Could have placed this loop lower down.
-    for (uint cq_idx = 0; cq_idx < cqs.size(); cq_idx++) {
-        auto& cq_write = cqs[cq_idx];
-        auto& cq_read = cqs[(cq_idx + 1) % cqs.size()];
+        // Repeat test starting with different CQ ID. Could have placed this loop lower down.
+        for (uint cq_idx = 0; cq_idx < cqs.size(); cq_idx++) {
+            auto& cq_write = cqs[cq_idx];
+            auto& cq_read = cqs[(cq_idx + 1) % cqs.size()];
 
-        // Another loop for increased testing. Repeat test multiple times for different buffers.
-        for (int i = 0; i < num_buffers; i++) {
-            vector<vector<uint32_t>> write_data;
-            vector<vector<uint32_t>> read_results;
-            vector<std::shared_ptr<Buffer>> buffers;
+            // Another loop for increased testing. Repeat test multiple times for different buffers.
+            for (int i = 0; i < num_buffers; i++) {
+                vector<vector<uint32_t>> write_data;
+                vector<vector<uint32_t>> read_results;
+                vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
 
-            buffers.push_back(Buffer::create(this->device_, buf_size, config.page_size, config.buftype));
+                // Create MeshBuffer with proper config
+                distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+                distributed::DeviceLocalBufferConfig device_local_config{
+                    .page_size = config.page_size, .buffer_type = config.buftype};
+                buffers.push_back(
+                    distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
 
-            // Number of write-read combos per buffer. Fewer make RAW race without events easier to hit.
-            for (uint j = 0; j < num_wr_rd_per_buf; j++) {
-                // 2 Events to synchronize delaying the read after write, and delaying the next write after read.
-                auto event_sync_read_after_write = std::make_shared<Event>();
-                auto event_sync_write_after_read = std::make_shared<Event>();
+                // Number of write-read combos per buffer. Fewer make RAW race without events easier to hit.
+                for (uint j = 0; j < num_wr_rd_per_buf; j++) {
+                    // Add entry in resutls vector, and construct write data, unique per loop
+                    read_results.emplace_back();
+                    write_data.push_back(generate_arange_vector(buffers.back()->size(), j * 100));
 
-                // Add entry in resutls vector, and construct write data, unique per loop
-                read_results.emplace_back();
-                write_data.push_back(generate_arange_vector(buffers.back()->size(), j * 100));
-
-                // Issue non-blocking write via first CQ and record event to synchronize with read on other CQ.
-                log_debug(
-                    tt::LogTest,
-                    "cq_idx: {} Doing Write j: {} (page_size: {} num_pages: {}) to cq_id: {} write_data: {}",
-                    cq_idx,
-                    j,
-                    config.page_size,
-                    config.num_pages,
-                    cq_write.get().id(),
-                    write_data.back());
-                EnqueueWriteBuffer(cq_write, *buffers.back(), write_data.back(), false);
-                if (use_events) {
-                    EnqueueRecordEvent(cq_write, event_sync_read_after_write);
-                }
-
-                // Issue wait for write to complete, and non-blocking read from the second CQ.
-                if (use_events) {
-                    EnqueueWaitForEvent(cq_read, event_sync_read_after_write);
-                }
-                EnqueueReadBuffer(cq_read, *buffers.back(), read_results.back(), false);
-                log_debug(
-                    tt::LogTest,
-                    "cq_idx: {} Issued Read for j: {} to cq_id: {} got data: {}",
-                    cq_idx,
-                    j,
-                    cq_read.get().id(),
-                    read_results.back());  // Data not ready since non-blocking.
-
-                // If more loops, Record Event on second CQ and wait for it to complete on first CQ before next loop's
-                // write.
-                if (use_events && j < num_wr_rd_per_buf - 1) {
-                    EnqueueRecordEvent(cq_read, event_sync_write_after_read);
-                    EnqueueWaitForEvent(cq_write, event_sync_write_after_read);
-                }
-            }
-
-            // Basically like Finish, but use host sync on event to ensure all read cmds are finished.
-            if (use_events) {
-                auto event_done_reads = std::make_shared<Event>();
-                EnqueueRecordEvent(cq_read, event_done_reads);
-                EventSynchronize(event_done_reads);
-            }
-
-            TT_ASSERT(write_data.size() == read_results.size());
-            TT_ASSERT(write_data.size() == num_wr_rd_per_buf);
-
-            for (uint j = 0; j < num_wr_rd_per_buf; j++) {
-                // Make copy of read results, helpful for comparison without events, since vector may be updated between
-                // comparison and debug log.
-                auto read_results_snapshot = read_results[j];
-                bool local_pass = write_data[j] == read_results_snapshot;
-                if (!local_pass) {
-                    log_warning(
+                    // Issue non-blocking write via first CQ and record event to synchronize with read on other CQ.
+                    log_debug(
                         tt::LogTest,
-                        "cq_idx: {} Checking j: {} local_pass: {} write_data: {} read_results: {}",
+                        "cq_idx: {} Doing Write j: {} (page_size: {} num_pages: {}) to cq_id: {} write_data: {}",
                         cq_idx,
                         j,
-                        local_pass,
-                        write_data[j],
-                        read_results_snapshot);
+                        config.page_size,
+                        config.num_pages,
+                        cq_write.get().id(),
+                        write_data.back());
+
+                    distributed::WriteShard(cq_write, buffers.back(), write_data.back(), zero_coord_, false);
+                    if (use_events) {
+                        distributed::MeshEvent event_sync_read_after_write = distributed::EnqueueRecordEvent(cq_write);
+
+                        // Issue wait for write to complete, and non-blocking read from the second CQ.
+                        distributed::EnqueueWaitForEvent(cq_read, event_sync_read_after_write);
+                    }
+                    distributed::ReadShard(cq_read, read_results.back(), buffers.back(), zero_coord_, false);
+                    log_debug(
+                        tt::LogTest,
+                        "cq_idx: {} Issued Read for j: {} to cq_id: {} got data: {}",
+                        cq_idx,
+                        j,
+                        cq_read.get().id(),
+                        read_results.back());  // Data not ready since non-blocking.
+
+                    // If more loops, Record Event on second CQ and wait for it to complete on first CQ before next
+                    // loop's write.
+                    if (use_events && j < num_wr_rd_per_buf - 1) {
+                        distributed::MeshEvent event_sync_write_after_read = distributed::EnqueueRecordEvent(cq_read);
+                        distributed::EnqueueWaitForEvent(cq_write, event_sync_write_after_read);
+                    }
                 }
-                pass &= local_pass;
-            }
 
-            // Before starting test with another buffer, drain CQs. Without this, see segfaults after
-            // adding num_buffers loop.
-            local_test_functions::FinishAllCqs(cqs);
+                // Basically like Finish, but use host sync on event to ensure all read cmds are finished.
+                if (use_events) {
+                    auto event_done_reads = distributed::EnqueueRecordEventToHost(cq_read);
+                    distributed::EventSynchronize(event_done_reads);
+                }
 
-        }  // num_buffers
+                TT_ASSERT(write_data.size() == read_results.size());
+                TT_ASSERT(write_data.size() == num_wr_rd_per_buf);
 
-    }  // cqs
+                for (uint j = 0; j < num_wr_rd_per_buf; j++) {
+                    // Make copy of read results, helpful for comparison without events, since vector may be updated
+                    // between comparison and debug log.
+                    auto read_results_snapshot = read_results[j];
+                    bool local_pass = write_data[j] == read_results_snapshot;
+                    if (!local_pass) {
+                        log_warning(
+                            tt::LogTest,
+                            "cq_idx: {} Checking j: {} local_pass: {} write_data: {} read_results: {}",
+                            cq_idx,
+                            j,
+                            local_pass,
+                            write_data[j],
+                            read_results_snapshot);
+                    }
+                    pass &= local_pass;
+                }
 
-    local_test_functions::FinishAllCqs(cqs);
+                // Before starting test with another buffer, drain CQs. Without this, see segfaults after
+                // adding num_buffers loop.
+                local_test_functions::FinishAllCqs(cqs);
 
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds = (end - start);
-    log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+            }  // num_buffers
 
-    EXPECT_TRUE(pass);
+        }  // cqs
+
+        local_test_functions::FinishAllCqs(cqs);
+
+        auto end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = (end - start);
+        log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+
+        EXPECT_TRUE(pass);
+    }
 }
 
 }  // end namespace basic_tests

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1747,20 +1747,16 @@ TEST_F(UnitMeshCQFixture, TestLogicalCoordinatesCompute) {
 
 // Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
 TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TestLogicalCoordinatesDataMovement) {
-    for (const auto& device : devices_) {
-        local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC, 1);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC, 1);
-    }
+    local_test_functions::test_my_coordinates(device_, tt::RISCV::BRISC);
+    local_test_functions::test_my_coordinates(device_, tt::RISCV::BRISC, 1);
+    local_test_functions::test_my_coordinates(device_, tt::RISCV::NCRISC);
+    local_test_functions::test_my_coordinates(device_, tt::RISCV::NCRISC, 1);
 }
 
 // Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
 TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
-    for (const auto& device : devices_) {
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
-    }
+    local_test_functions::test_my_coordinates(device_, tt::RISCV::COMPUTE);
+    local_test_functions::test_my_coordinates(device_, tt::RISCV::COMPUTE, 1);
 }
 
 }  // end namespace multicore_tests
@@ -1783,9 +1779,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
     log_info(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
-    auto device = this->devices_.at(0);
-
-    CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+    CoreCoord worker_grid_size = device_->compute_with_storage_grid_size();
     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     CoreRangeSet cr_set({cr});
 
@@ -1995,11 +1989,11 @@ TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
         }
     }
 
-    for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
+    for (uint8_t cq_id = 0; cq_id < device_->num_hw_cqs(); ++cq_id) {
         log_info(tt::LogTest, "Running {} MeshWorkloads on cq {} for cache warmup.", workloads.size(), (uint32_t)cq_id);
         // This loop caches program and runs
         for (distributed::MeshWorkload& wl : workloads) {
-            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), wl, false);
+            distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), wl, false);
         }
 
         // This loops assumes already cached
@@ -2025,12 +2019,12 @@ TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
                     NUM_ITERATIONS);
             }
             for (distributed::MeshWorkload& wl : workloads) {
-                EnqueueMeshWorkload(device->mesh_command_queue(), wl, false);
+                EnqueueMeshWorkload(device_->mesh_command_queue(), wl, false);
             }
         }
 
         log_info(tt::LogTest, "Calling Finish.");
-        Finish(device->mesh_command_queue(cq_id));
+        Finish(device_->mesh_command_queue(cq_id));
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -286,11 +286,12 @@ protected:
     }
 
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+    distributed::MeshCoordinate zero_coord_ = distributed::MeshCoordinate::zero_coordinate(2);
+    distributed::MeshCoordinateRange device_range_ = distributed::MeshCoordinateRange(zero_coord_, zero_coord_);
 };
 
 class UnitMeshMultiCQMultiDeviceBufferFixture : public UnitMeshMultiCQMultiDeviceFixture {};
-
-class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
+class UnitMeshMultiCQMultDeviceEventFixture : public UnitMeshMultiCQMultiDeviceFixture {};
 
 class DISABLED_MultiCQMultiDeviceOnFabricFixture : public UnitMeshMultiCQMultiDeviceFixture,
                                                    public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -151,11 +151,9 @@ protected:
 
 class UnitMeshMultiCQSingleDeviceProgramFixture : public UnitMeshMultiCQSingleDeviceFixture {};
 
-<<<<<<< HEAD
 class UnitMeshMultiCQSingleDeviceBufferFixture : public UnitMeshMultiCQSingleDeviceFixture {};
-=======
+
 class UnitMeshMultiCQSingleDeviceEventFixture : public UnitMeshMultiCQSingleDeviceFixture {};
->>>>>>> 0cbe6cec94 (changed SingleDevice fixture to properly have a single device)
 
 class UnitMeshMultiCQSingleDeviceTraceFixture : public UnitMeshMultiCQSingleDeviceFixture {
 protected:

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -103,16 +103,11 @@ protected:
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         const chip_id_t device_id = 0;
-        const DispatchCoreType dispatch_core_type = this->get_dispatch_core_type();
 
-        this->create_devices();
+        this->create_device(device_id, DEFAULT_TRACE_REGION_SIZE);
     }
 
-    void TearDown() override {
-        for (auto& device : devices_) {
-            device.reset();
-        }
-    }
+    void TearDown() override { device_.reset(); }
 
     bool validate_dispatch_mode() {
         this->slow_dispatch_ = false;
@@ -137,28 +132,17 @@ protected:
         return dispatch_core_type;
     }
 
-    void create_devices(std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+    void create_device(const chip_id_t device_id, const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
-        const chip_id_t mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
-        std::vector<chip_id_t> chip_ids;
-        auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
-        if (enable_remote_chip or
-            tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
-            for (chip_id_t id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
-                chip_ids.push_back(id);
-            }
-        } else {
-            chip_ids.push_back(mmio_device_id);
-        }
+        std::vector<chip_id_t> chip_id = {device_id};
+
         auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
-            chip_ids, DEFAULT_L1_SMALL_SIZE, trace_region_size, 2, dispatch_core_config);
-        for (const auto& [id, device] : reserved_devices) {
-            this->devices_.push_back(device);
-        }
+            chip_id, DEFAULT_L1_SMALL_SIZE, trace_region_size, 2, dispatch_core_config);
+        this->device_ = reserved_devices[device_id];
     }
 
-    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+    std::shared_ptr<distributed::MeshDevice> device_;
     tt::ARCH arch_;
     uint8_t num_cqs_;
     distributed::MeshCoordinate zero_coord_ = distributed::MeshCoordinate::zero_coordinate(2);
@@ -167,7 +151,11 @@ protected:
 
 class UnitMeshMultiCQSingleDeviceProgramFixture : public UnitMeshMultiCQSingleDeviceFixture {};
 
+<<<<<<< HEAD
 class UnitMeshMultiCQSingleDeviceBufferFixture : public UnitMeshMultiCQSingleDeviceFixture {};
+=======
+class UnitMeshMultiCQSingleDeviceEventFixture : public UnitMeshMultiCQSingleDeviceFixture {};
+>>>>>>> 0cbe6cec94 (changed SingleDevice fixture to properly have a single device)
 
 class UnitMeshMultiCQSingleDeviceTraceFixture : public UnitMeshMultiCQSingleDeviceFixture {
 protected:
@@ -181,8 +169,8 @@ protected:
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     }
 
-    void CreateDevices(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
-        this->create_devices(trace_region_size);
+    void CreateDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+        this->create_device(0 /* device_id */, trace_region_size);
     }
 };
 
@@ -291,8 +279,8 @@ protected:
 };
 
 class UnitMeshMultiCQMultiDeviceBufferFixture : public UnitMeshMultiCQMultiDeviceFixture {};
-class UnitMeshMultiCQMultDeviceEventFixture : public UnitMeshMultiCQMultiDeviceFixture {};
 
+class UnitMeshMultiCQMultDeviceEventFixture : public UnitMeshMultiCQMultiDeviceFixture {};
 class DISABLED_MultiCQMultiDeviceOnFabricFixture : public UnitMeshMultiCQMultiDeviceFixture,
                                                    public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
 private:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22835)

### Problem description
This PR is another one of many to migrate test code to use TT-Mesh APIs instead of legacy APIs.

### What's changed
Migrated the tests in `tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp`
`UnitMeshMultiCQSingleDeviceFixture` used to support MultiDevice. Now only supports a single device as described by the fixture name. Some old fixtures were also removed.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16577544495) CI passes
- [ ] New/Existing tests provide coverage for changes