### PR TITLE
Add real io test and dequantisation support

### DIFF
--- a/models/demos/deepseek_v3/tt/expert.py
+++ b/models/demos/deepseek_v3/tt/expert.py
@@ -59,13 +59,22 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
             end_expert = start_expert + num_experts_per_device
             expert_indices = range(start_expert, end_expert)
 
-            # TODO: check for quantized weights
             # Process each weight type
             for weight_key in weight_key_to_expert.keys():
                 # Collect tensors for this weight type and device
-                weight_tensors = [
-                    state_dict[f"experts.{expert_idx}.{weight_key}.weight"] for expert_idx in expert_indices
-                ]
+                weight_tensors = []
+                for expert_idx in expert_indices:
+                    weight_tensor = state_dict[f"experts.{expert_idx}.{weight_key}.weight"]
+                    inv_scale_key = f"experts.{expert_idx}.{weight_key}.weight_scale_inv"
+                    if inv_scale_key in state_dict:
+                        # Dequantize the tensor before using it
+                        inv_scale_tensor = state_dict[inv_scale_key]
+                        weight_tensor = dequantize(
+                            weight_tensor, inv_scale_tensor, hf_config.quantization_config["weight_block_size"]
+                        )
+
+                    weight_tensors.append(weight_tensor)
+
                 # Stack and permute, then add to the corresponding weight group
                 weight_groups[weight_key].append(torch.stack(weight_tensors, dim=0).permute(0, 2, 1))
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes