### PR TITLE
#25417: Improve accuracy of exp2

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -5,19 +5,7 @@
 import torch
 import pytest
 import ttnn
-import matplotlib.pyplot as plt
-import os
 from tests.ttnn.utils_for_testing import assert_with_ulp
-
-
-def compare_tensors(input_tensor, calculated_tensor, expected_tensor):
-    mismatch_indices = torch.nonzero(calculated_tensor != expected_tensor)
-    for idx in mismatch_indices:
-        idx_tuple = tuple(idx.tolist())
-        print(f"Input tensor value: {input_tensor[idx_tuple]}")
-        print(f"  Calculated tensor value: {calculated_tensor[idx_tuple]}")
-        print(f"  Expected tensor value: {expected_tensor[idx_tuple]}")
-        print("=" * 50)
 
 
 @pytest.mark.parametrize(
@@ -33,7 +21,7 @@ def compare_tensors(input_tensor, calculated_tensor, expected_tensor):
     [
         (-5, 5),
         (-100, 100),
-        (-126, 126),
+        (-126, 126),  # Overflow from 128(inf), Underflow till -127(<0)
     ],
 )
 def test_exp2_ULP(input_shapes, low, high, device):
@@ -54,57 +42,46 @@ def test_exp2_ULP(input_shapes, low, high, device):
 
     tt_result = ttnn.exp2(tt_in)
     result = ttnn.to_torch(tt_result)
-    print(golden, result)
-    assert_with_ulp(golden, result, 0)
+    assert_with_ulp(golden, result)
 
 
 @pytest.mark.parametrize(
-    "low, high, step",
-    [
-        (-127.0, -120.1, 0.1),
-        (-120.0, -110.1, 0.1),
-        (-110.0, -100.1, 0.1),
-        (-100.0, -90.1, 0.1),
-        (-90.0, -80.1, 0.1),
-        (-80.0, -70.1, 0.1),
-        (-70.0, -60.1, 0.1),
-        (-60.0, -50.1, 0.1),
-        (-50.0, -40.1, 0.1),
-        (-40.0, -30.1, 0.1),
-        (-30.0, -20.1, 0.1),
-        (-20.0, -10.1, 0.1),
-        (-10.0, 0.1, 0.1),
-        (0.0, 10.1, 0.1),
-        (10.0, 20.1, 0.1),
-        (20.0, 30.1, 0.1),
-        (30.0, 40.1, 0.1),
-        (40.0, 50.1, 0.1),
-        (50.0, 60.1, 0.1),
-        (60.0, 70.1, 0.1),
-        (70.0, 80.1, 0.1),
-        (80.0, 90.1, 0.1),
-        (90.0, 100.1, 0.1),
-        (100.0, 110.1, 0.1),
-        (110.0, 120.1, 0.1),
-        (120.0, 127.1, 0.1),
-    ],
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
 )
-def test_exp2(low, high, step, device):
-    ttnn.set_printoptions(profile="full")
+def test_exp2_optional(input_shapes, device):
+    low = -100
+    high = 100
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
 
-    input_tensor = torch.arange(low, high, step, dtype=torch.bfloat16)  # to detect fractional differences
+    output_tensor = torch.rand(input_shapes).bfloat16() * (high - low) + low
+
+    golden_function = ttnn.get_golden_function(ttnn.exp2)
+    golden = golden_function(torch_input, device=device)
+
+    cq_id = 0
 
     tt_in = ttnn.from_torch(
-        input_tensor,
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.from_torch(
+        output_tensor,
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    golden_function = ttnn.get_golden_function(ttnn.exp2)
-    golden = golden_function(input_tensor, device=device)
-
-    tt_result = ttnn.exp2(tt_in)
-    result = ttnn.to_torch(tt_result)
-    assert_with_ulp(golden, result, 0)
+    ttnn.exp2(tt_in, output_tensor=tt_out, queue_id=cq_id)
+    result = ttnn.to_torch(tt_out)
+    assert_with_ulp(golden, result)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import matplotlib.pyplot as plt
+import os
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def compare_tensors(input_tensor, calculated_tensor, expected_tensor):
+    mismatch_indices = torch.nonzero(calculated_tensor != expected_tensor)
+    for idx in mismatch_indices:
+        idx_tuple = tuple(idx.tolist())
+        print(f"Input tensor value: {input_tensor[idx_tuple]}")
+        print(f"  Calculated tensor value: {calculated_tensor[idx_tuple]}")
+        print(f"  Expected tensor value: {expected_tensor[idx_tuple]}")
+        print("=" * 50)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-5, 5),
+        (-100, 100),
+        (-126, 126),
+    ],
+)
+def test_exp2_ULP(input_shapes, low, high, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.exp2)
+    golden = golden_function(torch_input, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.exp2(tt_in)
+    result = ttnn.to_torch(tt_result)
+    print(golden, result)
+    assert_with_ulp(golden, result, 0)
+
+
+@pytest.mark.parametrize(
+    "low, high, step",
+    [
+        (-127.0, -120.1, 0.1),
+        (-120.0, -110.1, 0.1),
+        (-110.0, -100.1, 0.1),
+        (-100.0, -90.1, 0.1),
+        (-90.0, -80.1, 0.1),
+        (-80.0, -70.1, 0.1),
+        (-70.0, -60.1, 0.1),
+        (-60.0, -50.1, 0.1),
+        (-50.0, -40.1, 0.1),
+        (-40.0, -30.1, 0.1),
+        (-30.0, -20.1, 0.1),
+        (-20.0, -10.1, 0.1),
+        (-10.0, 0.1, 0.1),
+        (0.0, 10.1, 0.1),
+        (10.0, 20.1, 0.1),
+        (20.0, 30.1, 0.1),
+        (30.0, 40.1, 0.1),
+        (40.0, 50.1, 0.1),
+        (50.0, 60.1, 0.1),
+        (60.0, 70.1, 0.1),
+        (70.0, 80.1, 0.1),
+        (80.0, 90.1, 0.1),
+        (90.0, 100.1, 0.1),
+        (100.0, 110.1, 0.1),
+        (110.0, 120.1, 0.1),
+        (120.0, 127.1, 0.1),
+    ],
+)
+def test_exp2(low, high, step, device):
+    ttnn.set_printoptions(profile="full")
+
+    input_tensor = torch.arange(low, high, step, dtype=torch.bfloat16)  # to detect fractional differences
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.exp2)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.exp2(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_with_ulp(golden, result, 0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
 @pytest.mark.parametrize(
@@ -85,3 +85,39 @@ def test_exp2_optional(input_shapes, device):
     ttnn.exp2(tt_in, output_tensor=tt_out, queue_id=cq_id)
     result = ttnn.to_torch(tt_out)
     assert_with_ulp(golden, result)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-127, -1),  # Max ATOL Delta: 0.001953125, Max RTOL Delta: 1.0
+        (-3.3e38, -1),  # Max ATOL Delta: 0.0, Max RTOL Delta: nan
+    ],
+)
+def test_exp2_atol(input_shapes, low, high, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.exp2)
+    golden = golden_function(torch_input, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.exp2(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_allclose(tt_result, golden, rtol=1, atol=1e-3)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -9,22 +9,14 @@ from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
 @pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 2, 64, 120])),
-        (torch.Size([1, 3, 320, 320])),
-    ),
-)
-@pytest.mark.parametrize(
     "low, high",
     [
-        (-5, 5),
-        (-100, 100),
-        (-126, 126),  # Overflow from 128(inf), Underflow till -127(<0)
+        (-5, 5),  # Check for smaller range
+        (-126, 127),  # Exp2 Working range - Overflow from 128(inf), Underflow till -127(<0)
     ],
 )
-def test_exp2_ULP(input_shapes, low, high, device):
+def test_exp2_ULP(low, high, device):
+    input_shapes = torch.Size([1, 3, 320, 320])
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -42,7 +34,7 @@ def test_exp2_ULP(input_shapes, low, high, device):
 
     tt_result = ttnn.exp2(tt_in)
     result = ttnn.to_torch(tt_result)
-    assert_with_ulp(golden, result)
+    assert_with_ulp(golden, result, 2)
 
 
 @pytest.mark.parametrize(
@@ -54,8 +46,8 @@ def test_exp2_ULP(input_shapes, low, high, device):
     ),
 )
 def test_exp2_optional(input_shapes, device):
-    low = -100
-    high = 100
+    low = -126
+    high = 127
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -84,7 +76,7 @@ def test_exp2_optional(input_shapes, device):
 
     ttnn.exp2(tt_in, output_tensor=tt_out, queue_id=cq_id)
     result = ttnn.to_torch(tt_out)
-    assert_with_ulp(golden, result)
+    assert_with_ulp(golden, result, 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -36,7 +36,7 @@ def test_exp2_arange_masking(device):
 
     tt_result = ttnn.exp2(tt_in)
     result = ttnn.to_torch(tt_result)
-    assert_with_ulp(golden, result, 2)
+    assert_with_ulp(golden, result, 1)
 
 
 @pytest.mark.parametrize(
@@ -62,7 +62,7 @@ def test_exp2_arange(low, high, step, device):
 
     tt_result = ttnn.exp2(tt_in)
     result = ttnn.to_torch(tt_result)
-    assert_with_ulp(golden, result, 2)
+    assert_with_ulp(golden, result, 1)
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ def test_exp2_ULP(low, high, device):
 
     tt_result = ttnn.exp2(tt_in)
     result = ttnn.to_torch(tt_result)
-    assert_with_ulp(golden, result, 2)
+    assert_with_ulp(golden, result, 1)
 
 
 @pytest.mark.parametrize(
@@ -133,7 +133,7 @@ def test_exp2_optional(input_shapes, device):
 
     ttnn.exp2(tt_in, output_tensor=tt_out, queue_id=cq_id)
     result = ttnn.to_torch(tt_out)
-    assert_with_ulp(golden, result, 2)
+    assert_with_ulp(golden, result, 1)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1088,6 +1088,25 @@ def test_unary_frac_ttnn_opt(input_shapes, device):
 @pytest.mark.parametrize(
     "input_shapes",
     (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_exp2_ttnn(input_shapes, device):
+    in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.exp2(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.exp2)
+    golden_tensor = golden_function(in_data)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
         (torch.Size([100])),
         (torch.Size([64, 32])),
         (torch.Size([3, 128, 32])),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -404,26 +404,6 @@ def test_unary_exp_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_exp2_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-
-    cq_id = 0
-    ttnn.exp2(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.exp2(in_data)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 def test_unary_expm1_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,14 +9,38 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_exp2() {
-    _calculate_exp2_<APPROXIMATION_MODE, ITERATIONS>();
+sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
+    sfpi::vFloat y = 0.0f;
+    v_if(val > -127.f) {
+        val = val * 0.6931471805f;
+        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
+        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
+
+        sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+        d2 = d1 * d2;
+        zif = sfpu::_float_to_int32_(d2 * d3);
+
+        zii = sfpi::reinterpret<sfpi::vInt>(
+            sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
+
+        y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    }
+    v_endif;
+    return y;
 }
 
-template <bool APPROXIMATION_MODE>
-inline void exp2_init() {
-    _init_exp2_<APPROXIMATION_MODE>();
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_exp2() {
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat v = dst_reg[0];
+        vFloat exp = _sfpu_exp2_21f_(v);
+        dst_reg[0] = exp;
+        dst_reg++;
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -45,9 +45,9 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_exp2() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        dst_reg[0] = _sfpu_exp2_21f_(v);
-        dst_reg++;
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = _sfpu_exp2_21f_(v);
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -6,8 +6,7 @@
 
 #include "sfpu/ckernel_sfpu_exp2.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 /**
  * This function implements binary exponentiation using a polynomial approximation algorithm
@@ -23,9 +22,13 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
-        sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif, 0);
+        constexpr float CONST_D1 = 0.40196114e-7f;
+        constexpr int CONST_D2 = 0xf94ee7;
+        constexpr int CONST_D3 = 0x560;
+
+        sfpi::vFloat d1 = sfpi::vFloat(CONST_D1);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(CONST_D2) + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(CONST_D3) + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 
@@ -43,11 +46,9 @@ inline void calculate_exp2() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        vFloat exp = _sfpu_exp2_21f_(v);
-        dst_reg[0] = exp;
+        dst_reg[0] = _sfpu_exp2_21f_(v);
         dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,6 +9,13 @@
 namespace ckernel {
 namespace sfpu {
 
+/**
+ * This function implements binary exponentiation using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ **/
+
 sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     v_if(val > -127.f) {
@@ -17,8 +24,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
         sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -12,8 +12,7 @@ namespace sfpu {
 sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     v_if(val > -127.f) {
-        val = val * 0.6931471805f;
-        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -22,13 +22,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
-        constexpr float CONST_D1 = 0.40196114e-7f;
-        constexpr int CONST_D2 = 0xf94ee7;
-        constexpr int CONST_D3 = 0x560;
-
-        sfpi::vFloat d1 = sfpi::vFloat(CONST_D1);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(CONST_D2) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(CONST_D3) + zif, 0);
+        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm1) + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm2) + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 
@@ -49,6 +45,13 @@ inline void calculate_exp2() {
         sfpi::dst_reg[0] = _sfpu_exp2_21f_(v);
         sfpi::dst_reg++;
     }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void exp2_init() {
+    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
+    sfpi::vConstIntPrgm1 = 0xf94ee7;
+    sfpi::vConstIntPrgm2 = 0x560;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -51,7 +51,7 @@ template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
     sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
     sfpi::vConstIntPrgm1 = 0xf94ee7;
-    sfpi::vConstIntPrgm2 = 0x560;
+    sfpi::vConstIntPrgm2 = 0x560e;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -24,8 +24,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
         sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm1) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm2) + zif, 0);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -17,10 +17,10 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_exp2<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -14,7 +14,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_exp2_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -14,7 +14,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_exp2_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,14 +9,38 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_exp2() {
-    _calculate_exp2_<APPROXIMATION_MODE, ITERATIONS>();
+sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
+    sfpi::vFloat y = 0.0f;
+    v_if(val > -127.f) {
+        val = val * 0.6931471805f;
+        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
+        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
+
+        sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+        d2 = d1 * d2;
+        zif = sfpu::_float_to_int32_(d2 * d3);
+
+        zii = sfpi::reinterpret<sfpi::vInt>(
+            sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
+
+        y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    }
+    v_endif;
+    return y;
 }
 
-template <bool APPROXIMATION_MODE>
-inline void exp2_init() {
-    _init_exp2_<APPROXIMATION_MODE>();
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_exp2() {
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat v = dst_reg[0];
+        vFloat exp = _sfpu_exp2_21f_(v);
+        dst_reg[0] = exp;
+        dst_reg++;
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -45,9 +45,9 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_exp2() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        dst_reg[0] = _sfpu_exp2_21f_(v);
-        dst_reg++;
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = _sfpu_exp2_21f_(v);
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -6,8 +6,7 @@
 
 #include "sfpu/ckernel_sfpu_exp2.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 /**
  * This function implements binary exponentiation using a polynomial approximation algorithm
@@ -23,9 +22,13 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
-        sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif, 0);
+        constexpr float CONST_D1 = 0.40196114e-7f;
+        constexpr int CONST_D2 = 0xf94ee7;
+        constexpr int CONST_D3 = 0x560;
+
+        sfpi::vFloat d1 = sfpi::vFloat(CONST_D1);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(CONST_D2) + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(CONST_D3) + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 
@@ -43,11 +46,9 @@ inline void calculate_exp2() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        vFloat exp = _sfpu_exp2_21f_(v);
-        dst_reg[0] = exp;
+        dst_reg[0] = _sfpu_exp2_21f_(v);
         dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,6 +9,13 @@
 namespace ckernel {
 namespace sfpu {
 
+/**
+ * This function implements binary exponentiation using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ **/
+
 sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     v_if(val > -127.f) {
@@ -17,8 +24,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
         sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -12,8 +12,7 @@ namespace sfpu {
 sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     v_if(val > -127.f) {
-        val = val * 0.6931471805f;
-        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -22,13 +22,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
-        constexpr float CONST_D1 = 0.40196114e-7f;
-        constexpr int CONST_D2 = 0xf94ee7;
-        constexpr int CONST_D3 = 0x560;
-
-        sfpi::vFloat d1 = sfpi::vFloat(CONST_D1);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(CONST_D2) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(CONST_D3) + zif, 0);
+        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm1) + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm2) + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 
@@ -49,6 +45,13 @@ inline void calculate_exp2() {
         sfpi::dst_reg[0] = _sfpu_exp2_21f_(v);
         sfpi::dst_reg++;
     }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void exp2_init() {
+    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
+    sfpi::vConstIntPrgm1 = 0xf94ee7;
+    sfpi::vConstIntPrgm2 = 0x560;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -51,7 +51,7 @@ template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
     sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
     sfpi::vConstIntPrgm1 = 0xf94ee7;
-    sfpi::vConstIntPrgm2 = 0x560;
+    sfpi::vConstIntPrgm2 = 0x560e;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -24,8 +24,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
         sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm1) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(sfpi::vConstIntPrgm2) + zif, 0);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
         d2 = d1 * d2;
         zif = sfpu::_float_to_int32_(d2 * d3);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -17,10 +17,10 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_exp2<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -14,7 +14,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_exp2_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -14,7 +14,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_exp2_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -377,7 +377,7 @@ ALWI void max_tile_init() { MATH((llk_math_eltwise_unary_sfpu_max_init<APPROX>()
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
  // clang-format on
-ALWI void exp2_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_exp2<true>(idst))); }
+ALWI void exp2_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_exp2<true, DST_ACCUM_MODE>(idst))); }
 
 /**
  * Please refer to documentation for any_init.


### PR DESCRIPTION
### Ticket
#25417, #13002

### Problem description
Improve accuracy of exp2

### What's changed

- This implementation follows that of pwr_21f (Section 5) from [Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]](https://www.researchgate.net/publication/361844431_Simple_Multiple_Precision_Algorithms_for_Exponential_Functions_Tips_Tricks_IEEE_Signal_Processing_Magazine_394_130-137) paper from 2022 by Moroz et al.
- ULP Values and graphs are as mentioned [here](https://github.com/tenstorrent/tt-metal/issues/25417#issuecomment-3126583356)

### Checklist
- [x] [Galaxy Quick](https://github.com/tenstorrent/tt-metal/actions/runs/16757880234) : PASSED
- [x] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/16757884922) : PASSED
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16823801073) : PASSED
- [x] [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16757836403) : Failed as in main branch
- [x] [(TG) TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16757828606) : PASSED
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/16757886511) : Failed as in main branch
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16757870386) : Failed as in main branch
- [x] [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16757868261) : Failed as in main branch
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/16757838135) : Failed as in main branch
- [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16792876269) : PASSED
- [x] New/Existing tests provide coverage for changes

