### PR TITLE
Llama70b - Update perf unit tests

### DIFF
--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
@@ -485,7 +485,7 @@ def test_llama_tg_RowMajorPagedUpdateCacheDeviceOperation(
 )
 @pytest.mark.parametrize("datatype", (ttnn.bfloat16,))
 @pytest.mark.parametrize("pcc", (0.9997,))
-def test_llama_tg_RotaryEmbeddingLlamaFusedQK(
+def test_llama_tg_TileLayoutRotaryEmbeddingLlamaFusedQK(
     batch,
     seq_len,
     n_heads,
@@ -514,7 +514,7 @@ def test_llama_tg_RotaryEmbeddingLlamaFusedQK(
 )
 @pytest.mark.parametrize("datatype", (ttnn.bfloat16,))
 @pytest.mark.parametrize("pcc", (0.9997,))
-def test_llama_tg_RowMajorRotaryEmbeddingLlamaFusedQK(
+def test_llama_tg_RotaryEmbeddingLlamaFusedQK(
     batch,
     seq_len,
     n_heads,


### PR DESCRIPTION
### Problem description
Perf unit tests do not reflect op configuration inside decoder.
### What's changed
Perf Unit test for LlamaRotaryEmbeddingFusedQK is now using RowMajor implementation instead of TileLayout one.
Since script is using test_llama_tg_RotaryEmbeddingLlamaFusedQK for running unit test, function names are just renamed so RowMajor one is hit now.
### Checklist
- [ ] [TG Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/16494429327)
- [ ] [Galaxy Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/16494433329)