### PR TITLE
Revert reset control plane to avoid double init

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -411,14 +411,6 @@ void MetalContext::set_fabric_config(
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch config, not through this function exposed in the detail API.
     force_reinit_ = true;
 
-    // Reset control plane when switching from DISABLED to enabled or between different configs
-    // This ensures the correct mesh graph descriptor is used for the new fabric config
-    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED &&
-        fabric_config != tt_fabric::FabricConfig::DISABLED) {
-        log_info(tt::LogMetal, "Resetting control plane for new fabric config: {}", fabric_config);
-        control_plane_.reset();
-    }
-
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED || fabric_config == tt_fabric::FabricConfig::DISABLED) {
         this->fabric_config_ = fabric_config;
         this->fabric_reliability_mode_ = reliability_mode;


### PR DESCRIPTION
### Problem description
previous change broke the t3k unit test, revert changes to fix it.

### What's changed
previously control plane is reset to null when set fabric config, to allow 6U to set control plane based on correct fabric topology. but it introduces sea faults due to double initialization for control plane.


### Checklist
- [ ] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/16498039353
- [x] T3K unit test https://github.com/tenstorrent/tt-metal/actions/runs/16498055200
