### PR TITLE
Adding paged support for FlashMLA decode

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -171,16 +171,16 @@ def run_flash_mla_decode_impl(
     num_iters = 5
 
     # Log the test parameters
-    logger.info(f"Running FlashMLA Decode with parameters: ")
-    logger.info(f"Batch: {batch}")
-    logger.info(f"Sequence Length: {seq_len}")
-    logger.info(f"Number of Heads (Q): {nh}")
-    logger.info(f"Number of Heads (KV): {nkv}")
-    logger.info(f"KV LoRA Rank: {kv_lora_rank}")
-    logger.info(f"Dimensionality of RoPE: {d_rope}")
-    logger.info(f"Number of Cores for Q Sharding: {q_num_cores}")
-    logger.info(f"Query Data Type: {q_dtype}")
-    logger.info(f"Key-Value Data Type: {dtype}")
+    logger.debug(f"Running FlashMLA Decode with parameters: ")
+    logger.debug(f"Batch: {batch}")
+    logger.debug(f"Sequence Length: {seq_len}")
+    logger.debug(f"Number of Heads (Q): {nh}")
+    logger.debug(f"Number of Heads (KV): {nkv}")
+    logger.debug(f"KV LoRA Rank: {kv_lora_rank}")
+    logger.debug(f"Dimensionality of RoPE: {d_rope}")
+    logger.debug(f"Number of Cores for Q Sharding: {q_num_cores}")
+    logger.debug(f"Query Data Type: {q_dtype}")
+    logger.debug(f"Key-Value Data Type: {dtype}")
 
     # Paged attention configuration
     paged_attention_cfg = None
@@ -350,7 +350,7 @@ def run_flash_mla_decode_impl(
 
     tt_outs = []
     for i in range(num_iters):  # Check for program cache
-        logger.info(f"Running FlashMLA Decode operation iteration {i + 1}/{num_iters}")
+        logger.debug(f"Running FlashMLA Decode operation iteration {i + 1}/{num_iters}")
         tt_out = run_op()
         tt_outs.append(tt_out)
 
@@ -384,7 +384,7 @@ def run_flash_mla_decode_impl(
         tt_out_torch = ttnn.to_torch(tt_out)[..., :nh, :].permute(1, 2, 0, 3)  # (S, B, H, D) -> (B, H, S, D)
 
         out_pass, out_pcc = comp_pcc(tt_out_torch, out_t, pcc_threshold)
-        logger.info(f"Output PCC: {out_pcc}")
+        logger.debug(f"Output PCC: {out_pcc}")
 
     assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -16,6 +16,10 @@ import ttnn
 from loguru import logger
 import pytest
 
+from models.tt_transformers.tt.common import (
+    PagedAttentionConfig,
+)
+
 
 def scaled_dot_product_attention_reference(Q, K, V, start_indices, padded_layer_len, scale, is_causal=True):
     b, nh, _, _ = Q.shape  # b, nh, 1, d
@@ -47,6 +51,96 @@ def scaled_dot_product_attention_reference(Q, K, V, start_indices, padded_layer_
     return out
 
 
+def page_table_setup(batch_size: int, config: PagedAttentionConfig) -> torch.Tensor:
+    """
+    Setup the page-related tensors for the attention cache.
+    Args:
+        batch_size: The number of batches.
+        config: PagedAttentionConfig object containing configuration parameters.
+    Returns:
+        page_table: The page table tensor.
+    """
+    block_size, max_num_blocks = config.block_size, config.max_num_blocks
+    assert (
+        max_num_blocks % batch_size == 0
+    ), f"max_num_blocks {max_num_blocks} must be divisible by batch_size {batch_size}."
+
+    page_table = torch.randperm(max_num_blocks, dtype=torch.int32)
+    page_table = page_table.reshape(batch_size, max_num_blocks // batch_size)
+
+    return page_table
+
+
+def to_paged_cache(
+    cache: torch.Tensor,
+    mapping: torch.Tensor,
+    config: PagedAttentionConfig,
+) -> torch.Tensor:
+    """
+    Convert a cache tensor to a paged cache using the provided mapping.
+    Args:
+        cache: The original cache tensor.
+        mapping: The mapping tensor that defines how to convert the cache.
+        config: PagedAttentionConfig object containing configuration parameters.
+    Returns:
+        paged_cache: The converted paged cache tensor.
+    """
+    batch_size, nh, seq_len, dim = cache.shape
+
+    block_size, max_num_blocks = config.block_size, config.max_num_blocks
+    assert (
+        max_num_blocks % batch_size == 0
+    ), f"max_num_blocks {max_num_blocks} must be divisible by batch_size {batch_size}."
+    assert seq_len == block_size * (
+        max_num_blocks // batch_size
+    ), f"Sequence length {seq_len} must equal effective paged seq_len {block_size * (max_num_blocks // batch_size)}."
+
+    paged_cache = cache.reshape(batch_size, nh, -1, block_size, dim)  # (B, H, num_blocks // B, block_size, D)
+    paged_cache = paged_cache.transpose(1, 2)  # (B, num_blocks // B, H, block_size, D)
+    paged_cache = paged_cache.reshape(max_num_blocks, nh, block_size, dim)  # (num_blocks, H, block_size, D)
+
+    # Get the reverse mapping to reorder the paged cache, so that paged cache + mapping = original cache
+    # So, paged_cache = original_cache + inverse mapping
+    inverse_mapping = torch.argsort(mapping.view(-1))
+    paged_cache = paged_cache[inverse_mapping]
+
+    return paged_cache
+
+
+def from_paged_cache(
+    paged_cache: torch.Tensor,
+    mapping: torch.Tensor,
+    config: PagedAttentionConfig,
+) -> torch.Tensor:
+    """
+    Convert a paged cache back to the original cache format using the provided mapping.
+    Args:
+        paged_cache: The paged cache tensor.
+        mapping: The mapping tensor that defines how to convert the paged cache.
+        config: PagedAttentionConfig object containing configuration parameters.
+    Returns:
+        cache: The converted cache tensor.
+    """
+    max_num_blocks, nh, block_size, dim = paged_cache.shape  # (max_num_blocks, H, block_size, D)
+    assert (
+        block_size == config.block_size
+    ), f"block_size {block_size} must match the paged attention config block size {config.block_size}."
+    assert (
+        max_num_blocks == config.max_num_blocks
+    ), f"max_num_blocks {max_num_blocks} must match the paged attention config max_num_blocks {config.max_num_blocks}."
+
+    batch, num_blocks_per_batch = mapping.shape
+
+    # Use the mapping to get the original order, paged_cache + mapping = original cache
+    cache = paged_cache[mapping.view(-1)]
+
+    cache = cache.reshape(batch, num_blocks_per_batch, nh, block_size, dim)  # (B, num_blocks // B, H, block_size, D)
+    cache = cache.transpose(1, 2)  # (B, H, num_blocks // B, block_size, D)
+    cache = cache.reshape(batch, nh, -1, dim)  # (B, H, seq_len, D)
+
+    return cache
+
+
 def run_flash_mla_decode_impl(
     device,
     batch,
@@ -58,6 +152,7 @@ def run_flash_mla_decode_impl(
     q_num_cores,
     q_dtype,
     dtype,
+    paged_attention_cfg=None,
 ):
     # Can't run too many iters, or run out of L1
     num_iters = 5
@@ -84,6 +179,23 @@ def run_flash_mla_decode_impl(
     ######################
     ### TT Setup
     #######################
+
+    # Page-related setup
+    tt_k_torch = k
+    page_table = None
+    if paged_attention_cfg:
+        page_table = page_table_setup(batch, paged_attention_cfg)
+        tt_k_torch = to_paged_cache(
+            k,
+            page_table,
+            paged_attention_cfg,
+        )
+        tt_k_torch_og = from_paged_cache(
+            tt_k_torch,
+            page_table,
+            paged_attention_cfg,
+        )
+        assert torch.all(tt_k_torch_og == k), "Paged cache conversion for K failed."
 
     q_chunk_size = 0  # Not used in decode
     k_chunk_size = 128
@@ -158,7 +270,7 @@ def run_flash_mla_decode_impl(
         memory_config=q_mem_config,
     )
     tt_k = ttnn.from_torch(
-        k,
+        tt_k_torch,
         device=device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
@@ -243,7 +355,7 @@ def run_flash_mla_decode_impl(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope, number of cores to shard q on
     [
-        (2, 1024, 128, 1, 512, 64, 8),  # DeepSeek V3 TG full DP
+        (4, 1024, 128, 1, 512, 64, 64),  # DeepSeek V3 TG full DP
         (2, 1024, 128, 1, 256, 64, 16),
         (2, 1024, 128, 1, 256, 64, 32),
         (2, 1024, 128, 1, 256, 64, 64),
@@ -266,6 +378,13 @@ def run_flash_mla_decode_impl(
         (ttnn.bfloat8_b, ttnn.bfloat4_b),
     ],
 )
+@pytest.mark.parametrize(
+    "use_paged_attention",
+    [
+        False,
+        # True,
+    ],
+)
 def test_flash_mla_decode(
     device,
     batch,
@@ -277,9 +396,22 @@ def test_flash_mla_decode(
     q_num_cores,
     q_dtype,
     dtype,
+    use_paged_attention,
     function_level_defaults,
     reset_seeds,
 ):
+    # Paged attention configuration
+    paged_attention_cfg = None
+    if use_paged_attention:
+        block_size = ttnn.TILE_SIZE
+        assert seq_len % block_size == 0, f"Sequence length must be a multiple of {block_size=} for paged attention."
+
+        max_num_blocks = seq_len // block_size * batch
+        paged_attention_cfg = PagedAttentionConfig(
+            block_size=block_size,
+            max_num_blocks=max_num_blocks,
+        )
+
     run_flash_mla_decode_impl(
         device,
         batch,
@@ -291,6 +423,7 @@ def test_flash_mla_decode(
         q_num_cores,
         q_dtype,
         dtype,
+        paged_attention_cfg=paged_attention_cfg,
     )
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -165,6 +165,7 @@ def run_flash_mla_decode_impl(
     q_dtype,
     dtype,
     use_paged_attention=False,
+    block_size=ttnn.TILE_SIZE,
 ):
     # Can't run too many iters, or run out of L1
     num_iters = 5
@@ -184,7 +185,6 @@ def run_flash_mla_decode_impl(
     # Paged attention configuration
     paged_attention_cfg = None
     if use_paged_attention:
-        block_size = ttnn.TILE_SIZE
         assert seq_len % block_size == 0, f"Sequence length must be a multiple of {block_size=} for paged attention."
 
         max_num_blocks = seq_len // block_size * batch
@@ -374,7 +374,7 @@ def run_flash_mla_decode_impl(
 
         start_indices = [x + 1 for x in start_indices]
 
-    pcc_threshold = 0.99
+    pcc_threshold = 0.999
     if dtype == ttnn.bfloat4_b:
         pcc_threshold = 0.91
     if dtype == ttnn.bfloat8_b:
@@ -429,6 +429,13 @@ def run_flash_mla_decode_impl(
         True,
     ],
 )
+@pytest.mark.parametrize(
+    "block_size",
+    [
+        32,
+        128,
+    ],
+)
 def test_flash_mla_decode(
     device,
     batch,
@@ -441,6 +448,7 @@ def test_flash_mla_decode(
     q_dtype,
     dtype,
     use_paged_attention,
+    block_size,
     function_level_defaults,
     reset_seeds,
 ):
@@ -456,6 +464,7 @@ def test_flash_mla_decode(
         q_dtype,
         dtype,
         use_paged_attention,
+        block_size,
     )
 
 
@@ -525,6 +534,13 @@ def test_flash_mla_decode(
         True,
     ],
 )
+@pytest.mark.parametrize(
+    "block_size",
+    [
+        32,
+        128,
+    ],
+)
 def test_flash_mla_decode_stress(
     device,
     batch,
@@ -537,6 +553,7 @@ def test_flash_mla_decode_stress(
     q_dtype,
     dtype,
     use_paged_attention,
+    block_size,
     function_level_defaults,
     reset_seeds,
 ):
@@ -569,4 +586,5 @@ def test_flash_mla_decode_stress(
         q_dtype,
         dtype,
         use_paged_attention,
+        block_size,
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -99,8 +99,20 @@ def to_paged_cache(
     paged_cache = paged_cache.transpose(1, 2)  # (B, num_blocks // B, H, block_size, D)
     paged_cache = paged_cache.reshape(max_num_blocks, nh, block_size, dim)  # (num_blocks, H, block_size, D)
 
-    # Get the reverse mapping to reorder the paged cache, so that paged cache + mapping = original cache
-    # So, paged_cache = original_cache + inverse mapping
+    """
+    Get the reverse mapping to reorder the paged cache,
+    so that paged cache + mapping = original cache
+    and paged_cache = original_cache + inverse mapping
+
+    For example:
+        cache = [0, 1, 2, 3]
+        mapping = [1, 3, 0, 2]
+        inverse_mapping (argsort) = [2, 0, 3, 1]
+    Then,
+        paged_cache = cache[inverse_mapping] = [2, 0, 3, 1]
+        paged_cache[mapping] = cache = [0, 1, 2, 3]
+    """
+
     inverse_mapping = torch.argsort(mapping.view(-1))
     paged_cache = paged_cache[inverse_mapping]
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -454,6 +454,10 @@ void read_kv_mask_chunks(
                 }
                 v_tile_id += (DHt - vDHt);  // Skip the padding!
             }
+
+            // ASSUMPTION: We don't support different V chunk size than K chunk size
+            // Execept for FlashMLA, however, V is a subset of K, so we still need to strid with k_chunk_tiles
+            v_start_tile_id += k_chunk_tiles;
         }
         noc_async_read_barrier();
         cb_push_back(cb_v_in, v_chunk_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -382,7 +382,6 @@ void read_kv_mask_chunks(
     uint32_t k_chunk_start,
     uint32_t k_chunk_end,
     uint32_t k_start_tile_id,
-    uint32_t v_start_tile_id,
     uint32_t mask_start_tile_id,
     uint32_t Sk_chunk_t,
     uint32_t k_chunk_tiles,
@@ -415,7 +414,6 @@ void read_kv_mask_chunks(
         }
         noc_async_read_barrier();
         cb_push_back(cb_k_in, k_chunk_tiles);
-        k_start_tile_id += k_chunk_tiles;
 
         if constexpr (use_attention_mask) {
             mask_start_tile_id = read_mask_chunk<cb_mask_in, mask_tile_bytes, barrier_threshold, PNHt>(
@@ -441,7 +439,7 @@ void read_kv_mask_chunks(
             cb_reserve_back(cb_v_in, v_chunk_tiles);
             uint32_t v_write_ptr = get_write_ptr(cb_v_in);
             barrier_count = 0;
-            uint32_t v_tile_id = v_start_tile_id;
+            uint32_t v_tile_id = k_start_tile_id;
             for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
                 for (uint32_t col = 0; col < vDHt; ++col) {
                     noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
@@ -454,12 +452,11 @@ void read_kv_mask_chunks(
                 }
                 v_tile_id += (DHt - vDHt);  // Skip the padding!
             }
-
-            // ASSUMPTION: We don't support different V chunk size than K chunk size
-            // Execept for FlashMLA, however, V is a subset of K, so we still need to strid with k_chunk_tiles
-            v_start_tile_id += k_chunk_tiles;
         }
         noc_async_read_barrier();
         cb_push_back(cb_v_in, v_chunk_tiles);
+
+        // Update the starting tile id for next iteration
+        k_start_tile_id += k_chunk_tiles;
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -307,16 +307,11 @@ void kernel_main() {
         } else {
             // Offset for current batch
             const uint32_t k_batch_offset = ((cur_batch / q_heads_parallel_factor) % Bkv) * num_kv_heads * St * DHt;
-            const uint32_t v_batch_offset =
-                ((cur_batch / q_heads_parallel_factor) % Bkv) * num_kv_heads * St * DHt;  // Use K's head dim
             const uint32_t k_head_offset = cur_head * St * DHt;
-            const uint32_t v_head_offset = cur_head * St * DHt;  // Use K's head dim
 
             // Then, read K, V, Mask k_chunk_tiles at a time
             const uint32_t k_chunk_offset = k_chunk_start * Sk_chunk_t_dynamic * DHt;
-            const uint32_t v_chunk_offset = k_chunk_start * Sk_chunk_t_dynamic * DHt;
             uint32_t k_start_tile_id = k_batch_offset + k_head_offset + k_chunk_offset;
-            uint32_t v_start_tile_id = v_batch_offset + v_head_offset + v_chunk_offset;
 
             read_kv_mask_chunks<
                 DHt,
@@ -332,7 +327,6 @@ void kernel_main() {
                 k_chunk_start,
                 k_chunk_end,
                 k_start_tile_id,
-                v_start_tile_id,
                 mask_start_tile_id,
                 Sk_chunk_t_dynamic,
                 k_chunk_tiles,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -206,7 +206,7 @@ void kernel_main() {
             .bank_base_address = page_table_addr, .page_size = page_table_page_size};
         cb_reserve_back(cb_id_page_table, 1);
         uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
-        uint64_t page_table_noc_addr = get_noc_addr(cur_batch, page_table_gen);
+        uint64_t page_table_noc_addr = get_noc_addr((cur_batch / q_heads_parallel_factor), page_table_gen);
         noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_page_size);
         noc_async_read_barrier();
         cb_push_back(cb_id_page_table, 1);
@@ -275,6 +275,7 @@ void kernel_main() {
                                 barrier_count = 0;
                             }
                         }
+                        physical_v_tile_id += (DHt - vDHt);
                     }
                     noc_async_read_barrier();
                     cb_push_back(cb_v_in, v_chunk_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -222,11 +222,13 @@ void kernel_main() {
         if constexpr (is_paged_attention) {
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
                 const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t_dynamic;
+                uint64_t k_base_read_ptr;
                 {
                     // Read K chunk in row-major order (to simplify page mapping). Write tiles to CB in transposed
                     // order.
                     cb_reserve_back(cb_k_in, k_chunk_tiles);
                     uint32_t k_write_ptr = get_write_ptr(cb_k_in);
+                    k_base_read_ptr = get_noc_addr(k_write_ptr);
                     barrier_count = 0;
                     for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
                         uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
@@ -255,28 +257,48 @@ void kernel_main() {
                 }
 
                 {
-                    // Read V chunk in row major order, write in row-major order
-                    cb_reserve_back(cb_v_in, v_chunk_tiles);
-                    uint32_t v_write_ptr = get_write_ptr(cb_v_in);
-                    barrier_count = 0;
+                    if constexpr (reuse_k) {
+                        // Read V chunk (tranpose of K), from K's L1 buffer
+                        cb_reserve_back(cb_v_in, v_chunk_tiles);
+                        uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+                        uint64_t k_read_ptr = k_base_read_ptr;
 
-                    for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
-                        uint32_t virtual_v_tile_row_num = k_chunk_start_row_num + row;
-                        uint32_t physical_v_tile_id =
-                            virtual_seq_tile_id_to_physical_tile_id<num_kv_heads, block_size_t, DHt /* Use K's head dim */>(
-                                virtual_v_tile_row_num, cur_head, page_table_ptr);
-                        for (uint32_t col = 0; col < vDHt; ++col) {
-                            noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
-                            physical_v_tile_id += 1;
-                            v_write_ptr += v_tile_bytes;
+                        for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {  // Row of V
+                            k_read_ptr = k_base_read_ptr + row * k_tile_bytes;     // Increment across K's Col
 
-                            if (++barrier_count == barrier_threshold) {
-                                noc_async_read_barrier();
-                                barrier_count = 0;
+                            for (uint32_t col = 0; col < vDHt; ++col) {  // Col of V
+                                noc_async_read(k_read_ptr, v_write_ptr, v_tile_bytes);
+
+                                v_write_ptr += v_tile_bytes;
+                                k_read_ptr += Sk_chunk_t_dynamic * k_tile_bytes;  // Strid across K's width
                             }
                         }
-                        physical_v_tile_id += (DHt - vDHt);
+                    } else {
+                        // Read V chunk in row major order, write in row-major order
+                        cb_reserve_back(cb_v_in, v_chunk_tiles);
+                        uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+                        barrier_count = 0;
+
+                        for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
+                            uint32_t virtual_v_tile_row_num = k_chunk_start_row_num + row;
+                            uint32_t physical_v_tile_id = virtual_seq_tile_id_to_physical_tile_id<
+                                num_kv_heads,
+                                block_size_t,
+                                DHt /* Use K's head dim */>(virtual_v_tile_row_num, cur_head, page_table_ptr);
+                            for (uint32_t col = 0; col < vDHt; ++col) {
+                                noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
+                                physical_v_tile_id += 1;
+                                v_write_ptr += v_tile_bytes;
+
+                                if (++barrier_count == barrier_threshold) {
+                                    noc_async_read_barrier();
+                                    barrier_count = 0;
+                                }
+                            }
+                            physical_v_tile_id += (DHt - vDHt);  // Skip the padding!
+                        }
                     }
+
                     noc_async_read_barrier();
                     cb_push_back(cb_v_in, v_chunk_tiles);
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -19,7 +19,6 @@ void ScaledDotProductAttentionDecode::validate(
     if (use_mla) {
         TT_FATAL(input_tensors.size() == 2, "Must have 2 input tensors and mask");
         TT_FATAL(this->head_dim_v.has_value(), "Must provide head_dim_v for multi-latent attention decode");
-        TT_FATAL(!this->paged_attention, "Paged attention is untested for multi-latent attention decode!");
         TT_FATAL(this->is_causal, "Multi-latent attention decode only tested for causal!");
     } else {
         TT_FATAL(input_tensors.size() == 3, "Must have 3 input tensors and mask");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -275,4 +275,85 @@ ttnn::Tensor ExecuteFlashMultiLatentAttentionDecode::invoke(
         compute_kernel_config);
 }
 
+ttnn::Tensor ExecutePagedFlashMultiLatentAttentionDecode::invoke(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const uint32_t head_dim_v,
+    const ttnn::Tensor& page_table_tensor,
+    const bool is_causal,
+    const std::optional<const Tensor>& attn_mask,
+    const std::optional<const Tensor>& cur_pos_tensor,
+    std::optional<float> scale,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<SDPAProgramConfig> program_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
+                    ? input_tensor_q.device()->arch()
+                    : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    uint32_t s = input_tensor_k.logical_shape()[-2];
+
+    // Use k_chunk_size as override; if k_chunk_size == 0, figure it out in kernels
+    // uint32_t k_chunk_size = get_chunk_size(s);
+    uint32_t k_chunk_size = 0;
+    if (program_config.has_value() && program_config.value().k_chunk_size > 0) {
+        k_chunk_size = program_config.value().k_chunk_size;
+        // assert chunk size must be power of 2 and multiple of 32
+        TT_FATAL(
+            (k_chunk_size & (k_chunk_size - 1)) == 0,
+            "User provided k_chunk_size must be power of 2, got: {}",
+            k_chunk_size);
+        TT_FATAL(k_chunk_size % 32 == 0, "User provided k_chunk_size must be multiple of 32, got: {}", k_chunk_size);
+    }
+
+    // get chunk size and then pass to sdpa decode as an attribute for prgm cache
+    auto kernel_config_val = init_device_compute_kernel_config(
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+
+    return operation::run(
+               ScaledDotProductAttentionDecode{
+                   .is_causal = is_causal,
+                   .cur_pos = std::vector<uint32_t>(),
+                   .scale = scale,
+                   .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
+                   .program_config = program_config,
+                   .compute_kernel_config = kernel_config_val,
+                   .k_chunk_size = k_chunk_size,
+                   .paged_attention = true,
+                   .use_mla = true,
+                   .head_dim_v = head_dim_v},
+               {input_tensor_q, input_tensor_k},
+               {cur_pos_tensor, page_table_tensor, attn_mask},
+               {},
+               queue_id)
+        .at(0);
+}
+
+ttnn::Tensor ExecutePagedFlashMultiLatentAttentionDecode::invoke(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const uint32_t head_dim_v,
+    const ttnn::Tensor& page_table_tensor,
+    const bool is_causal,
+    const std::optional<const Tensor>& attn_mask,
+    const std::optional<const Tensor>& cur_pos_tensor,
+    std::optional<float> scale,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<SDPAProgramConfig> program_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    return invoke(
+        DefaultQueueId,
+        input_tensor_q,
+        input_tensor_k,
+        head_dim_v,
+        page_table_tensor,
+        is_causal,
+        attn_mask,
+        cur_pos_tensor,
+        scale,
+        memory_config,
+        std::move(program_config),
+        compute_kernel_config);
+}
+
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -98,6 +98,35 @@ struct ExecuteFlashMultiLatentAttentionDecode {
         std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 
+struct ExecutePagedFlashMultiLatentAttentionDecode {
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        uint32_t head_dim_v,
+        const ttnn::Tensor& page_table_tensor,
+        bool is_causal = true,
+        const std::optional<const Tensor>& attn_mask = std::nullopt,
+        const std::optional<const Tensor>& cur_pos_tensor = std::nullopt,
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        uint32_t head_dim_v,
+        const ttnn::Tensor& page_table_tensor,
+        bool is_causal = true,
+        const std::optional<const Tensor>& attn_mask = std::nullopt,
+        const std::optional<const Tensor>& cur_pos_tensor = std::nullopt,
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+};
+
 }  // namespace operations::transformer
 
 namespace transformer {
@@ -113,6 +142,10 @@ constexpr auto paged_scaled_dot_product_attention_decode = ttnn::register_operat
 constexpr auto flash_multi_latent_attention_decode = ttnn::register_operation<
     "ttnn::transformer::flash_multi_latent_attention_decode",
     ttnn::operations::transformer::ExecuteFlashMultiLatentAttentionDecode>();
+
+constexpr auto paged_flash_multi_latent_attention_decode = ttnn::register_operation<
+    "ttnn::transformer::paged_flash_multi_latent_attention_decode",
+    ttnn::operations::transformer::ExecutePagedFlashMultiLatentAttentionDecode>();
 
 }  // namespace transformer
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
@@ -191,5 +191,53 @@ void py_bind_sdpa_decode(py::module& module) {
             py::arg("compute_kernel_config").noconvert() = std::nullopt,
             py::arg("queue_id") = DefaultQueueId,
         });
+
+    using PagedMLAOperationType = decltype(ttnn::transformer::paged_flash_multi_latent_attention_decode);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::transformer::paged_flash_multi_latent_attention_decode,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const PagedMLAOperationType& self,
+               const ttnn::Tensor& input_tensor_q,
+               const ttnn::Tensor& input_tensor_k,
+               const uint32_t head_dim_v,
+               const ttnn::Tensor& page_table_tensor,
+               const bool is_causal,
+               const std::optional<const Tensor>& attn_mask,
+               const std::optional<const Tensor>& cur_pos_tensor,
+               std::optional<float> scale,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<SDPAProgramConfig> program_config,
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+               QueueId queue_id) {
+                return self(
+                    queue_id,
+                    input_tensor_q,
+                    input_tensor_k,
+                    head_dim_v,
+                    page_table_tensor,
+                    is_causal,
+                    attn_mask,
+                    cur_pos_tensor,
+                    scale,
+                    memory_config,
+                    program_config,
+                    compute_kernel_config);
+            },
+            py::arg("input_tensor_q").noconvert(),
+            py::arg("input_tensor_k").noconvert(),
+            py::arg("head_dim_v").noconvert(),
+            py::arg("page_table_tensor").noconvert(),
+            py::kw_only(),
+            py::arg("is_causal").noconvert() = true,
+            py::arg("attn_mask").noconvert() = std::nullopt,
+            py::arg("cur_pos_tensor").noconvert() = std::nullopt,
+            py::arg("scale").noconvert() = std::nullopt,
+            py::arg("memory_config").noconvert() = std::nullopt,
+            py::arg("program_config").noconvert() = std::nullopt,
+            py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId,
+        });
 }
 }  // namespace ttnn::operations::transformer


### PR DESCRIPTION
### Ticket
- #23022 
- #24577 

### Problem description
Currently, the FlashMLA decode op does not have a paged version. This is needed for the eventual vLLM integration of DeepSeekV3.

### What's changed
- Added fixes to the SDPA reader kernel to support reading a dim of `vDHt`
    - Also added support for `reuse_k`
- Made changes to the testing infra to support paged attention testing
    - `page_table_setup`: Provides a `page_table` given the configuration. Randomizes block order (for sake of testing).
    - `to_paged_cache`: Given an existing `cache` and a `mapping`, returns the `paged_cache`, such that `paged_cache[mapping] = cache`
    - `from_paged_cache:` Given an existing `paged_cache` and a `mapping`, returns the `cache`.
 

### SDPA Decode Changes 🚨 
- Removed dependency on `v_start_tile_id` in `read_kv_mask_chunks` and instead only use `k_start_tile_id`
    - Currently, we don't support different K/V chunk sizes, except when we're using FlashMLA. As such, there's no need to have a different `v_start_tile_id`. In the case of FlashMLA, since V is a subset of K, we still want to use `k_start_tile_id` to iterate through the cache.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16501504306) CI passes