### PR TITLE
#25734: add n300 DataParallel Support for SentenceBERT

### DIFF
--- a/models/demos/sentence_bert/README.md
+++ b/models/demos/sentence_bert/README.md
@@ -38,16 +38,30 @@ pytest --disable-warnings models/demos/sentence_bert/tests/pcc/test_ttnn_sentenc
 
 ###  Performant Model with Trace+2CQ
 > **Note:** SentenceBERT uses BERT-base as its backbone model.
+
+#### Single Device (BS=8):
+
 - End-to-end performance with mean-pooling post-processing is **408 sentences per second**
 
-
-Use the following command to run the performant Model with Trace+2CQs (without mean-pooling):
+Use the following command to run the performant Model with Trace+2CQs:
 
 ```
-pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py
+pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py::test_e2e_performant_sentencebert
+```
+
+#### Multi Device (DP=2, N300):
+
+- End-to-end performance with mean-pooling post-processing is **757 sentences per second**
+
+Use the following command to run the performant Model with Trace+2CQs:
+
+```
+pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py::test_e2e_performant_sentencebert_dp
 ```
 
 ### Performant Demo with Trace+2CQ
+
+#### Single Device (BS=8):
 
 Use the following command to run the performant Demo with Trace+2CQs:
 
@@ -55,11 +69,23 @@ Use the following command to run the performant Demo with Trace+2CQs:
 pytest --disable-warnings models/demos/sentence_bert/demo/demo.py::test_sentence_bert_demo_inference
 ```
 
+#### Multi Device (DP=2, N300):
+
+Use the following command to run the performant Demo with Trace+2CQs:
+
+```
+pytest --disable-warnings models/demos/sentence_bert/demo/demo.py::test_sentence_bert_demo_inference_dp
+```
+
+
 ### Performant Interactive Demo with Trace+2CQ
+
 - This script demonstrates a simple semantic search using a Turkish Sentence-BERT model. It loads a knowledge base from a text file (`knowledge_base.txt`), encodes all entries, and waits for user input. For each query, it returns the most semantically similar entry from the knowledge base using cosine similarity.
 - Run the interactive demo using the command below. For every user input, the top-matching knowledge base entry along with its similarity score will be displayed.
 - Type `exit` to quit the interactive demo.
 - Modify the `knowledge_base.txt` file to customize the knowledge base with your own turkish input sentences.
+
+#### Single Device (BS=8):
 
 Use the following command to run the performant interactive Demo with Trace+2CQs:
 
@@ -67,13 +93,31 @@ Use the following command to run the performant interactive Demo with Trace+2CQs
 pytest --disable-warnings models/demos/sentence_bert/demo/interactive_demo.py::test_interactive_demo_inference
 ```
 
+#### Multi Device (DP=2, N300):
+
+Use the following command to run the performant interactive Demo with Trace+2CQs:
+
+```
+pytest --disable-warnings models/demos/sentence_bert/demo/interactive_demo.py::test_interactive_demo_inference_dp
+```
+
 ### Performant Dataset evaluation with Trace+2CQ
 
 - dataset source: [STSb Turkish](https://github.com/emrecncelik/sts-benchmark-tr) (Semantic textual similarity dataset for the Turkish language)
 - Adjust the `num_samples` parameter to control the number of dataset samples used during evaluation.
 
+#### Single Device (BS=8):
+
 Use the following command to run the performant dataset evaluation with Trace+2CQs:
 
 ```
 pytest --disable-warnings models/demos/sentence_bert/demo/dataset_evaluation.py::test_sentence_bert_eval
+```
+
+#### Multi Device (DP=2, N300):
+
+Use the following command to run the performant dataset evaluation with Trace+2CQs:
+
+```
+pytest --disable-warnings models/demos/sentence_bert/demo/dataset_evaluation.py::test_sentence_bert_eval_dp
 ```

--- a/models/demos/sentence_bert/demo/dataset_evaluation.py
+++ b/models/demos/sentence_bert/demo/dataset_evaluation.py
@@ -33,16 +33,8 @@ def load_sts_tr(split="test"):
     return Dataset.from_pandas(df)
 
 
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
-)
-@pytest.mark.parametrize(
-    "model_name, sequence_length,batch_size,num_samples",
-    [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384, 8, 4)],
-)
-def test_sentence_bert_eval(
-    device, model_name, sequence_length, batch_size, num_samples, model_location_generator, start=0, end=7
-):
+def run_sentence_bert_eval(device, model_name, sequence_length, batch_size, num_samples, model_location_generator):
+    batch_size = batch_size * device.get_num_devices()
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
     config = transformers.BertConfig.from_pretrained(model_name)
     dataset = load_sts_tr("test")
@@ -89,7 +81,9 @@ def test_sentence_bert_eval(
             )
             ttnn_module._capture_sentencebert_trace_2cqs()
         ttnn_out = ttnn_module.run(input_ids, token_type_ids, position_ids, extended_mask, attention_mask)
-        ttnn_sentence_embeddings = ttnn.to_torch(ttnn_out, dtype=torch.float32)
+        ttnn_sentence_embeddings = ttnn.to_torch(
+            ttnn_out, dtype=torch.float32, mesh_composer=ttnn_module.runner_infra.output_mesh_composer
+        )
         sim1 = F.cosine_similarity(reference_sentence_embeddings[:1], reference_sentence_embeddings[-1:]).item()
         sim2 = F.cosine_similarity(ttnn_sentence_embeddings[:1], ttnn_sentence_embeddings[-1:]).item()
         ref_pred_score, ttnn_pred_score = (sim1 + 1) * 2.5, (sim2 + 1) * 2.5  # scale from [-1, 1] to [0, 5]
@@ -103,3 +97,31 @@ def test_sentence_bert_eval(
         f"Cosine Pearson correlation and Spearman correlation for reference model: {pearson1:.4f}, {spearman1:.4f}"
     )
     logger.info(f"Cosine Pearson correlation and Spearman correlation for ttnn model: {pearson2:.4f}, {spearman2:.4f}")
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "model_name, sequence_length,batch_size,num_samples",
+    [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384, 8, 4)],
+)
+def test_sentence_bert_eval(device, model_name, sequence_length, batch_size, num_samples, model_location_generator):
+    return run_sentence_bert_eval(
+        device, model_name, sequence_length, batch_size, num_samples, model_location_generator
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "model_name, sequence_length,device_batch_size,num_samples",
+    [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384, 8, 4)],
+)
+def test_sentence_bert_eval_dp(
+    mesh_device, model_name, sequence_length, device_batch_size, num_samples, model_location_generator
+):
+    return run_sentence_bert_eval(
+        mesh_device, model_name, sequence_length, device_batch_size, num_samples, model_location_generator
+    )

--- a/models/demos/sentence_bert/demo/demo.py
+++ b/models/demos/sentence_bert/demo/demo.py
@@ -14,33 +14,27 @@ from models.demos.sentence_bert.common import load_torch_model
 from models.demos.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
 from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerformantRunner
 
-
-@pytest.mark.parametrize(
-    "inputs",
+inputs = [
     [
-        [
-            [  # input sentences (turkish)
-                "Yarın tatil yapacağım, ailemle beraber doğada vakit geçireceğiz, yürüyüşler yapıp, keşifler yapacağız, çok keyifli bir tatil olacak.",
-                "Yarın tatilde olacağım, ailemle birlikte şehir dışına çıkacağız, doğal güzellikleri keşfedecek ve eğlenceli zaman geçireceğiz.",
-                "Yarın tatil planım var, ailemle doğa yürüyüşlerine çıkıp, yeni yerler keşfedeceğiz, harika bir tatil olacak.",
-                "Yarın tatil için yola çıkacağız, ailemle birlikte sakin bir yerlerde vakit geçirip, doğa aktiviteleri yapacağız.",
-                "Yarın tatilde olacağım, ailemle birlikte doğal alanlarda gezi yapıp, yeni yerler keşfedeceğiz, eğlenceli bir tatil geçireceğiz.",
-                "Yarın tatilde olacağım, ailemle birlikte şehir dışında birkaç gün geçirip, doğa ile iç içe olacağız.",
-                "Yarın tatil için yola çıkıyoruz, ailemle birlikte doğada keşif yapıp, eğlenceli etkinliklere katılacağız.",
-                "Yarın tatilde olacağım, ailemle doğada yürüyüş yapıp, yeni yerler keşfederek harika bir zaman geçireceğiz.",
-            ],
-        ]
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
-)
-@pytest.mark.parametrize("model_name, sequence_length", [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384)])
-def test_sentence_bert_demo_inference(device, inputs, model_name, sequence_length, model_location_generator):
+        "Yarın tatil yapacağım, ailemle beraber doğada vakit geçireceğiz, yürüyüşler yapıp, keşifler yapacağız, çok keyifli bir tatil olacak.",
+        "Yarın tatilde olacağım, ailemle birlikte şehir dışına çıkacağız, doğal güzellikleri keşfedecek ve eğlenceli zaman geçireceğiz.",
+        "Yarın tatil planım var, ailemle doğa yürüyüşlerine çıkıp, yeni yerler keşfedeceğiz, harika bir tatil olacak.",
+        "Yarın tatil için yola çıkacağız, ailemle birlikte sakin bir yerlerde vakit geçirip, doğa aktiviteleri yapacağız.",
+        "Yarın tatilde olacağım, ailemle birlikte doğal alanlarda gezi yapıp, yeni yerler keşfedeceğiz, eğlenceli bir tatil geçireceğiz.",
+        "Yarın tatilde olacağım, ailemle birlikte şehir dışında birkaç gün geçirip, doğa ile iç içe olacağız.",
+        "Yarın tatil için yola çıkıyoruz, ailemle birlikte doğada keşif yapıp, eğlenceli etkinliklere katılacağız.",
+        "Yarın tatilde olacağım, ailemle doğada yürüyüş yapıp, yeni yerler keşfederek harika bir zaman geçireceğiz.",
+    ]
+]
+
+
+def run_sentence_bert_demo_inference(device, inputs, model_name, sequence_length, model_location_generator):
+    inputs = inputs * device.get_num_devices()
+    transformers_model = transformers.AutoModel.from_pretrained(model_name).eval()
     config = transformers.BertConfig.from_pretrained(model_name)
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
     encoded_input = tokenizer(
-        inputs[0], padding="max_length", max_length=sequence_length, truncation=True, return_tensors="pt"
+        inputs, padding="max_length", max_length=sequence_length, truncation=True, return_tensors="pt"
     )
     input_ids = encoded_input["input_ids"]
     attention_mask = encoded_input["attention_mask"]
@@ -69,7 +63,9 @@ def test_sentence_bert_demo_inference(device, inputs, model_name, sequence_lengt
     )
     ttnn_module._capture_sentencebert_trace_2cqs()
     ttnn_out = ttnn_module.run(input_ids, token_type_ids, position_ids, extended_mask, attention_mask)
-    ttnn_sentence_embeddings = ttnn.to_torch(ttnn_out, dtype=torch.float32)
+    ttnn_sentence_embeddings = ttnn.to_torch(
+        ttnn_out, dtype=torch.float32, mesh_composer=ttnn_module.runner_infra.output_mesh_composer
+    )
     cosine_sim_matrix1 = cosine_similarity(Reference_sentence_embeddings.detach().squeeze().cpu().numpy())
     upper_triangle1 = np.triu(cosine_sim_matrix1, k=1)
     similarities1 = upper_triangle1[upper_triangle1 != 0]
@@ -80,3 +76,27 @@ def test_sentence_bert_demo_inference(device, inputs, model_name, sequence_lengt
     mean_similarity2 = similarities2.mean()
     logger.info(f"Mean Cosine Similarity for Reference Model: {mean_similarity1}")
     logger.info(f"Mean Cosine Similarity for TTNN Model:: {mean_similarity2}")
+    similarity_diff = abs(mean_similarity1 - mean_similarity2)
+    tolerance = 0.02  # 2% tolerance
+    assert (
+        similarity_diff < tolerance
+    ), f"Cosine similarities differ by {similarity_diff:.4f}, which exceeds tolerance of {tolerance}"
+    logger.info(f"Cosine similarities are close (difference: {similarity_diff:.4f})")
+
+
+@pytest.mark.parametrize("inputs", inputs)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize("model_name, sequence_length", [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384)])
+def test_sentence_bert_demo_inference(device, inputs, model_name, sequence_length, model_location_generator):
+    return run_sentence_bert_demo_inference(device, inputs, model_name, sequence_length, model_location_generator)
+
+
+@pytest.mark.parametrize("inputs", inputs)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize("model_name, sequence_length", [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384)])
+def test_sentence_bert_demo_inference_dp(mesh_device, inputs, model_name, sequence_length, model_location_generator):
+    return run_sentence_bert_demo_inference(mesh_device, inputs, model_name, sequence_length, model_location_generator)

--- a/models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py
+++ b/models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py
@@ -12,17 +12,7 @@ from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerf
 from models.utility_functions import run_for_wormhole_b0
 
 
-@run_for_wormhole_b0()
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
-)
-@pytest.mark.parametrize(
-    "act_dtype, weight_dtype",
-    ((ttnn.bfloat16, ttnn.bfloat8_b),),
-)
-@pytest.mark.parametrize("batch_size, sequence_length", [(8, 384)])
-@pytest.mark.models_performance_bare_metal
-def test_e2e_performant_sentencebert(
+def run_e2e_performant_sentencebert(
     device, batch_size, sequence_length, act_dtype, weight_dtype, model_location_generator
 ):
     performant_runner = SentenceBERTPerformantRunner(
@@ -45,5 +35,41 @@ def test_e2e_performant_sentencebert(
 
     inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
     logger.info(
-        f"ttnn_sentencebert_batch_size: {batch_size}, One inference iteration time (sec): {inference_time_avg}, Sentence per sec: {round(batch_size/inference_time_avg)}"
+        f"ttnn_sentencebert_batch_size: {batch_size}, One inference iteration time (sec): {inference_time_avg}, Sentence per sec: {round(batch_size * device.get_num_devices()/inference_time_avg)}"
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype",
+    ((ttnn.bfloat16, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize("batch_size, sequence_length", [(8, 384)])
+def test_e2e_performant_sentencebert(
+    device, batch_size, sequence_length, act_dtype, weight_dtype, model_location_generator
+):
+    return run_e2e_performant_sentencebert(
+        device, batch_size, sequence_length, act_dtype, weight_dtype, model_location_generator
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype",
+    ((ttnn.bfloat16, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize("device_batch_size, sequence_length", [(8, 384)])
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+def test_e2e_performant_sentencebert_dp(
+    mesh_device, device_batch_size, sequence_length, act_dtype, weight_dtype, model_location_generator
+):
+    return run_e2e_performant_sentencebert(
+        mesh_device, device_batch_size, sequence_length, act_dtype, weight_dtype, model_location_generator
     )

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -34,10 +34,12 @@ run_segformer_func() {
 run_sentencebert_func() {
 
   #SentenceBERT Demo
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/sentence_bert/demo/demo.py::test_sentence_bert_demo_inference --timeout 600; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/sentence_bert/demo/demo.py --timeout 600; fail+=$?
 
   #SentenceBERT eval
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/sentence_bert/demo/dataset_evaluation.py::test_sentence_bert_eval --timeout 600; fail+=$?
+  # comment out SentenceBERT eval from CI tests for now unitl dataset_evaluation test is available in CIv2 (issue: #25866)
+
+  #WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/sentence_bert/demo/dataset_evaluation.py--timeout 600; fail+=$?
 
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue - [here](https://github.com/tenstorrent/tt-metal/issues/25734)

### Problem description
Added n300 DataParallel Support for SentenceBERT

### What's changed
Added (n300) DP functionality for e2e perf, demo, interactive demo and dataset evaluation scripts.


### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16647365337) - Passes
- [x] [Single-Card Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16635987751/attempts/1)  (SB model passes)
- [x] [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/16635989196) - Passes


### e2e Performant Model Details:
- Single Device - 408 FPS
- Multi-Device (n300) - 757 FPS
