### PR TITLE
[skip ci] Disallow workflow dispatch for L2 nightly workflow

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -2,7 +2,7 @@ name: "Nightly tt-metal L2 tests"
 
 on:
   schedule:
-    - cron: "0 22 * * *"
+    - cron: "0 6 * * *"
 
 jobs:
   build-artifact:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -1,12 +1,6 @@
 name: "Nightly tt-metal L2 tests"
 
 on:
-  workflow_dispatch:
-    inputs:
-      timeout:
-        required: false
-        type: number
-        default: 120
   schedule:
     - cron: "0 22 * * *"
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
This is a nightly workflow, it is not all post commit.
These tests comprise 7 hours of runtime, and we were seeing them launches 3 times or more per day.
This is not cool.

### What's changed
- Remove workflow dispatch trigger for this pipeline.
- Move it to run at 10pm/11pm PST.