### PR TITLE
remove incorrect hardcoding of mesh shape from minimal reduce-scatter

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -261,10 +261,7 @@ Tensor reduce_scatter_minimal_async_impl(
     if (num_devices == 2) {
         ccl_topology = ttnn::ccl::Topology::Linear;
     }
-    uint32_t ring_size = num_devices;
-    if (cluster_axis.has_value()) {
-        ring_size = (cluster_axis.value() == 0) ? 8 : 4;
-    }
+
     log_debug(tt::LogOp, "DEBUG: creating line_fabric with num devices: {}, num links: {}", devices.size(), num_links);
     log_debug(tt::LogOp, "DEBUG: line_fabric is created");
 
@@ -282,7 +279,7 @@ Tensor reduce_scatter_minimal_async_impl(
                    devices,
                    dim,
                    num_links,
-                   ring_size,
+                   num_devices,
                    memory_config.value_or(input_tensor.memory_config()),
                    ccl_topology,
                    multi_device_global_semaphore,


### PR DESCRIPTION
### Problem description
Quite a few tests are failing due to a bug introduced in https://github.com/tenstorrent/tt-metal/pull/25010 where the mesh shape was hardcoded to 8x4. 

https://github.com/tenstorrent/tt-metal/actions/runs/16481756837/job/46597973535

### What's changed
Remove this and use the previously implemented, correct calculation of ring_size based on mesh shape and cluster axis.

### Checklist
- [ ] TG nightly https://github.com/tenstorrent/tt-metal/actions/runs/16502433854
- [x] T3K frequent https://github.com/tenstorrent/tt-metal/actions/runs/16502476338
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/16502480565