### PR TITLE
Migrating Read/Write Buffer Tests to Mesh APIs

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -28,7 +28,6 @@ namespace tt::tt_metal {
 class CommandQueueFixture : public DispatchFixture {
 protected:
     tt::tt_metal::IDevice* device_;
-
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -272,7 +272,8 @@ protected:
         this->create_devices(90000000);
     }
 };
-class UnitMeshCQSingleCardBufferFixture : virtual public UnitMeshCQSingleCardFixture {};
+
+using UnitMeshCQSingleCardBufferFixture = UnitMeshCQSingleCardFixture;
 
 class CommandQueueSingleCardBufferFixture : public CommandQueueSingleCardFixture {};
 

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -28,6 +28,7 @@ namespace tt::tt_metal {
 class CommandQueueFixture : public DispatchFixture {
 protected:
     tt::tt_metal::IDevice* device_;
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -272,6 +272,7 @@ protected:
         this->create_devices(90000000);
     }
 };
+class UnitMeshCQSingleCardBufferFixture : virtual public UnitMeshCQSingleCardFixture {};
 
 class CommandQueueSingleCardBufferFixture : public CommandQueueSingleCardFixture {};
 

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -377,6 +377,8 @@ class CommandQueueMultiDeviceProgramFixture : public CommandQueueMultiDeviceFixt
 
 class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixture {};
 
+class UnitMeshCQMultiDeviceBufferFixture : public UnitMeshCQMultiDeviceFixture {};
+
 class DISABLED_CQMultiDeviceOnFabricFixture
     : public UnitMeshCQMultiDeviceFixture,
       public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -294,14 +294,14 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             if (config.sharding_args.has_value()) {
                 distributed::DeviceLocalBufferConfig dram_config{
                     .page_size = config.page_size,
-                    .buffer_type = tt_metal::BufferType::DRAM,
+                    .buffer_type = config.buftype,
                     .sharding_args = config.sharding_args.value(),
                     .bottom_up = false};
                 bufa = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
             } else {
                 distributed::DeviceLocalBufferConfig dram_config{
                     .page_size = config.page_size,
-                    .buffer_type = tt_metal::BufferType::DRAM,
+                    .buffer_type = config.buftype,
                     .bottom_up = false,
                 };
                 bufa = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
@@ -626,14 +626,17 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, Sending131072Pages) {
 }
 
 TEST_F(UnitMeshCQSingleCardBufferFixture, TestPageLargerThanAndUnalignedToTransferPage) {
+    std::cout << "beginning TestPageLargerThanAndUnalignedToTransferPage" << std::endl;
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
+        std::cout << "iteration: " << num_round_robins << std::endl;
         TestBufferConfig config = {
             .num_pages = num_round_robins * (mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = DispatchSettings::TRANSFER_PAGE_SIZE + 32,
             .buftype = BufferType::DRAM};
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             mesh_device, mesh_device->mesh_command_queue(), config);
+        std::cout << "end of iteration: " << num_round_robins << std::endl;
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -305,7 +305,7 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     bool pass = true;
     uint32_t num_pages_left = config.num_pages_total;
 
-    std::vector<std::shared_ptr<Buffer>> buffers;
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
     std::vector<std::vector<uint32_t>> srcs;
     std::vector<std::vector<uint32_t>> dsts;
     while (num_pages_left) {
@@ -1813,27 +1813,27 @@ namespace stress_tests {
 
 // TODO: Add stress test that vary page size
 
-TEST_F(CommandQueueSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsBlocking) {
+TEST_F(UnitMeshCQSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsBlocking) {
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
-    for (IDevice* device : devices_) {
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+    for (const auto& mesh_device : devices_) {
+        log_info(tt::LogTest, "Running on Device {}", mesh_device->id());
         EXPECT_TRUE(local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(
-            device, device->command_queue(), config));
+            mesh_device, mesh_device->mesh_command_queue(), config));
     }
 }
 
-TEST_F(CommandQueueSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {
+TEST_F(UnitMeshCQSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
-    for (IDevice* device : devices_) {
-        if (not device->is_mmio_capable()) {
+    for (const auto& mesh_device : devices_) {
+        if (not mesh_device->get_devices()[0]->is_mmio_capable()) {
             continue;
         }
         EXPECT_TRUE(local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(
-            device, device->command_queue(), config));
+            mesh_device, mesh_device->mesh_command_queue(), config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -334,9 +334,6 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             }
 
             EXPECT_EQ(src, result);
-
-            bufa->deallocate();
-            bufa = nullptr;
         }
     }
 }
@@ -619,14 +616,14 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRou
     }
 }
 
-// TEST_F(UnitMeshCQSingleCardBufferFixture, Sending131072Pages) {
-//     for (const auto& mesh_device : devices_) {
-//         TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
-//         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
-//         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(mesh_device,
-//         mesh_device->mesh_command_queue(), config);
-//     }
-// }
+TEST_F(UnitMeshCQSingleCardBufferFixture, Sending131072Pages) {
+    for (const auto& mesh_device : devices_) {
+        TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
+        local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
+            mesh_device, mesh_device->mesh_command_queue(), config);
+    }
+}
 
 TEST_F(UnitMeshCQSingleCardBufferFixture, TestPageLargerThanAndUnalignedToTransferPage) {
     constexpr uint32_t num_round_robins = 2;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -2080,6 +2080,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRou
         auto device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
+
         TestBufferConfig config = {
             .num_pages = 2 * uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
             .page_size = 2048,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -279,7 +279,6 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     uint32_t cq_size = device->sysmem_manager().get_cq_size();
     uint32_t cq_start =
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-
     auto device_coord = distributed::MeshCoordinate(0, 0);
 
     std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -144,12 +144,6 @@ vector<uint32_t> generate_arange_vector(uint32_t size_bytes) {
     return src;
 }
 
-void clear_buffer(CommandQueue& cq, Buffer& buffer) {
-    TT_FATAL(buffer.size() % sizeof(uint32_t) == 0, "Error");
-    vector<uint32_t> zeroes(buffer.size() / sizeof(uint32_t), 0);
-    EnqueueWriteBuffer(cq, buffer, zeroes, true);
-}
-
 void clear_buffer(distributed::MeshCommandQueue& cq, std::shared_ptr<distributed::MeshBuffer> buffer) {
     TT_FATAL(buffer->size() % sizeof(uint32_t) == 0, "Error");
     vector<uint32_t> zeroes(buffer->size() / sizeof(uint32_t), 0);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -277,7 +277,6 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     uint16_t channel =
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
 
-    std::cout << "got channel" << std::endl;
 
     chip_id_t mmio_device_id =
         tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -167,6 +167,8 @@ protected:
 
 class UnitMeshMultiCQSingleDeviceProgramFixture : public UnitMeshMultiCQSingleDeviceFixture {};
 
+class UnitMeshMultiCQSingleDeviceBufferFixture : public UnitMeshMultiCQSingleDeviceFixture {};
+
 class UnitMeshMultiCQSingleDeviceTraceFixture : public UnitMeshMultiCQSingleDeviceFixture {
 protected:
     void SetUp() override {
@@ -287,6 +289,8 @@ protected:
 
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
 };
+
+class UnitMeshMultiCQMultiDeviceBufferFixture : public UnitMeshMultiCQMultiDeviceFixture {};
 
 class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiDeviceFixture {};
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -485,7 +485,7 @@ void FDMeshCommandQueue::read_shard_from_device(
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
     auto device_buffer = buffer.get_device_buffer(device_coord);
-    auto shard_view = device_buffer->view(BufferRegion(0, device_buffer->size()));
+    auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
 
     auto device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/22835)
### Problem description
tt-metal tests need to be migrated to use Mesh APIs, including EnqueueRead/WriteBuffer. 

### What's changed
- Both single and multi command queue `Mesh` buffer fixtures have been added to `command_queue_fixture.hpp` and `multi_command_queue_fixture.hpp` which are derived from `Mesh` test fixtures I wrote in an earlier PR. 
- All mentions of `EnqueueWriteBuffer` and `EnqueueReadBuffer` have been migrated to `distributed::WriteShard` and `distributed::ReadShard` respectively
- Some helper functions were written to migrate other functions including `WriteToBuffer`, `ReadFromBuffer`, `EnqueueWriteSubBuffer`, and `EnqueueReadSubBuffer` to Mesh API
- A line in `fd_mesh_command_queue.cpp` to enable reading from a given region of a `MeshBuffer`, which is necessary for SubBuffer tests


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16575224001) CI passes
- [ ] [T3K Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/16503198456)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes