### PR TITLE
Adding feature to selectively run paged cache op on subset of available mesh devices 

### DIFF
--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -894,10 +894,12 @@ class MLA1D(AbstractModule):
         ttnn.deallocate(tt_kv_rope)
 
         # Update KVPE Cache
+        mesh_coords = {*[ttnn.MeshCoordinate(0, x) for x in range(cfg["mesh_shape"][1])]}
         ttnn.experimental.paged_update_cache(
             kvpe_cache,
             tt_kvpe,
             update_idxs_tensor=position_idxs,
+            mesh_coords=mesh_coords,
         )
 
         # FlashMLA

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -894,12 +894,10 @@ class MLA1D(AbstractModule):
         ttnn.deallocate(tt_kv_rope)
 
         # Update KVPE Cache
-        mesh_coords = {*[ttnn.MeshCoordinate(0, x) for x in range(cfg["mesh_shape"][1])]}
         ttnn.experimental.paged_update_cache(
             kvpe_cache,
             tt_kvpe,
             update_idxs_tensor=position_idxs,
-            mesh_coords=mesh_coords,
         )
 
         # FlashMLA

--- a/tests/ttnn/unit_tests/operations/test_paged_cache_mask.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_cache_mask.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_paged_cache_mask.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_cache_mask.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 import ttnn
-import numpy as np
 from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
 from models.utility_functions import nearest_y
@@ -14,8 +13,9 @@ from models.utility_functions import nearest_y
 def get_random_devices(mesh_shape: list[int]) -> set[ttnn.MeshCoordinate]:
     """Get a set of random device coordinates based on the mesh shape."""
     assert len(mesh_shape) == 2, "Mesh shape must be a 2D shape."
+    mesh_shape = torch.tensor(mesh_shape)
 
-    num_devices = torch.randint(1, np.prod(mesh_shape) + 1, (1,)).item()
+    num_devices = torch.randint(1, torch.prod(mesh_shape) + 1, (1,)).item()
     device_coords = set()
     while len(device_coords) < num_devices:
         coord = (torch.randint(0, mesh_shape[0], (1,)).item(), torch.randint(0, mesh_shape[1], (1,)).item())

--- a/tests/ttnn/unit_tests/operations/test_paged_cache_mask.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_cache_mask.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import numpy as np
+from loguru import logger
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
+from models.utility_functions import nearest_y
+
+
+def get_random_devices(mesh_shape: list[int]) -> set[ttnn.MeshCoordinate]:
+    """Get a set of random device coordinates based on the mesh shape."""
+    assert len(mesh_shape) == 2, "Mesh shape must be a 2D shape."
+
+    num_devices = torch.randint(1, np.prod(mesh_shape) + 1, (1,)).item()
+    device_coords = set()
+    while len(device_coords) < num_devices:
+        coord = (torch.randint(0, mesh_shape[0], (1,)).item(), torch.randint(0, mesh_shape[1], (1,)).item())
+        device_coords.add(coord)
+
+    return {ttnn.MeshCoordinate(*coord) for coord in device_coords}
+
+
+def run_test_update_cache(mesh_device: ttnn.MeshDevice, cache_shape: list[int], dtype: ttnn.DataType) -> None:
+    """Test the paged cache update operation on a mesh device, with only using select devices.
+
+    ┌─────┬─────┬─────┬─────┐
+    │  x  │     │  x  │     │
+    │(0,0)│(0,1)│(0,2)│(0,3)│
+    ├─────┼─────┼─────┼─────┤
+    │     │  x  │     │  x  │
+    │(1,0)│(1,1)│(1,2)│(1,3)│
+    └─────┴─────┴─────┴─────┘
+
+    Legend:
+    - Each square represents a device in the mesh
+    - (row,col) shows the mesh coordinate
+    - 'x' marks devices that perform the update operation
+    - Empty squares are idle devices (no update performed)
+
+    Args:
+        mesh_device (ttnn.MeshDevice): The mesh device to run the test on.
+            Must be a 2D mesh with shape accessible via mesh_device.shape.
+        cache_shape (list[int]): Shape of the cache tensor as [bsz, nh, seq_len, dim].
+            - bsz: Batch size, must be divisible by mesh_device.shape[1]
+            - nh: Number of heads, must be ≤ 32 due to operation limitations
+            - seq_len: Sequence length for the cache
+            - dim: Head dimension
+        dtype (ttnn.DataType): Data type for the tensors (e.g., ttnn.bfloat16).
+
+    Returns:
+        None.
+    Raises:
+        AssertionError: If batch size is not divisible by mesh width, if number
+                       of heads exceeds 32, or if output PCC is below threshold.
+
+    Note:
+        - The cache is replicated across mesh dimension 0 and sharded across mesh dimension 1
+        - Input tensor replicated across mesh dimension 0 and sharded across mesh dimension 1
+        - Only devices specified in randomly generated mesh_coords perform updates
+    """
+
+    # Setup and validation
+    mesh_shape = list(mesh_device.shape)
+    bsz, nh, seq_len, dim = cache_shape
+    assert bsz % mesh_shape[1] == 0, "Batch size must be divisible by mesh width"
+    assert nh <= 32, "Number of heads must be ≤ 32"
+    bsz_per_device = bsz // mesh_shape[1]
+
+    # Create torch tensors
+    cache = torch.zeros(cache_shape).bfloat16().float()
+    inp = torch.ones((1, bsz, nh, dim)).bfloat16().float()
+    update_idxs = torch.randint(0, seq_len, (bsz,), dtype=torch.int32)
+    mesh_coords = get_random_devices(mesh_shape)
+
+    # TTNN cache setup
+    tt_cache = ttnn.from_torch(
+        cache,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 0), mesh_shape=mesh_shape),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # TTNN input setup with sharding config
+    grid_size = mesh_device.compute_with_storage_grid_size()
+    inp_mem_cfg = ttnn.create_sharded_memory_config(
+        shape=(nearest_y(nh, ttnn.TILE_SIZE), dim),
+        core_grid=ttnn.num_cores_to_corerangeset(bsz_per_device, grid_size, row_wise=True),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    tt_inp = ttnn.from_torch(
+        inp,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 1), mesh_shape=mesh_shape),
+        memory_config=inp_mem_cfg,
+    )
+
+    tt_update_idxs = ttnn.from_torch(
+        update_idxs,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 0), mesh_shape=mesh_shape),
+    )
+
+    # TTNN operation
+    ttnn.experimental.paged_update_cache(tt_cache, tt_inp, update_idxs_tensor=tt_update_idxs, mesh_coords=mesh_coords)
+
+    # Convert back and reshape
+    tt_out_torch = ttnn.to_torch(
+        tt_cache, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+    )  # Returned in row-major order
+    tt_out_torch = tt_out_torch.unsqueeze(0).reshape(mesh_shape[0], *cache_shape)
+
+    # Torch reference implementation
+    cache = cache.unsqueeze(0).repeat(mesh_shape[0], 1, 1, 1, 1)
+    inp = inp.repeat(mesh_shape[0], 1, 1, 1)
+
+    for coord in mesh_coords:
+        coord = list(coord)
+        row, col = coord[0], coord[1]
+        col_slice = slice(col * bsz_per_device, (col + 1) * bsz_per_device)
+        inp_to_use = inp[row, col_slice]
+        idxs_to_use = update_idxs[col_slice]
+
+        for i in range(bsz_per_device):
+            idx = idxs_to_use[i].item()
+            b_idx = col * bsz_per_device + i
+            cache[row, b_idx, :, idx] = inp_to_use[i]
+
+    # Validation
+    out_pass, out_pcc = comp_equal(tt_out_torch, cache)
+    logger.info(f"Output PCC: {out_pcc}")
+    assert out_pass, f"Output mismatch: PCC {out_pcc} < 1.0"
+
+
+@pytest.mark.parametrize("mesh_device", [pytest.param((1, 2), id="1x2_grid")], indirect=True)
+@pytest.mark.parametrize("cache_shape", [(32, 1, 32, 128)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_update_cache(mesh_device, cache_shape, dtype, reset_seeds):
+    run_test_update_cache(mesh_device, cache_shape, dtype)

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -260,8 +260,8 @@ operation::MeshWorkloadWithCallbacks PagedUpdateCacheDeviceOperation::create_mes
 
             // Create the program for the coordinate
             const ttnn::MeshCoordinateRange program_range(coord, coord);
-            auto program_with_callbacks =
-                PagedUpdateCacheDeviceOperation::create_program_(input_tensors, optional_input_tensors, output_tensors);
+            auto program_with_callbacks = PagedUpdateCacheDeviceOperation::create_program_at(
+                {0, 0}, input_tensors, optional_input_tensors, output_tensors);
             workload_with_callbacks.workload.add_program(program_range, std::move(program_with_callbacks.program));
             if (program_with_callbacks.override_runtime_arguments_callback.has_value()) {
                 workload_with_callbacks.per_program_callbacks.emplace(
@@ -272,7 +272,8 @@ operation::MeshWorkloadWithCallbacks PagedUpdateCacheDeviceOperation::create_mes
     return workload_with_callbacks;
 }
 
-operation::ProgramWithCallbacks PagedUpdateCacheDeviceOperation::create_program_(
+operation::ProgramWithCallbacks PagedUpdateCacheDeviceOperation::create_program_at(
+    const ttnn::MeshCoordinate& _,
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
     std::vector<Tensor>& output_tensors) const {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
@@ -42,7 +42,8 @@ struct PagedUpdateCacheDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program_(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
+        const ttnn::MeshCoordinate& _,  // Unused
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
@@ -26,6 +26,8 @@ struct PagedUpdateCacheDeviceOperation {
     const PagedUpdateCacheOpType op_type;
     const ttnn::DeviceComputeKernelConfig compute_kernel_config;
     const bool share_cache;
+    const std::optional<std::set<ttnn::MeshCoordinate>>
+        mesh_coords;  // Optional mesh coordinates to use for the operation
 
     PagedUpdateCacheOpParallelizationStrategy get_parallelization_strategy(
         const std::vector<Tensor>& input_tensors) const;
@@ -40,8 +42,7 @@ struct PagedUpdateCacheDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
-        const ttnn::MeshCoordinate& coord,
+    tt::tt_metal::operation::ProgramWithCallbacks create_program_(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
@@ -58,9 +59,5 @@ struct PagedUpdateCacheDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
 };
-
-tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_programs(
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const std::function<tt::tt_metal::operation::ProgramWithCallbacks(const ttnn::MeshCoordinate&)>& create_program);
 
 }  // namespace ttnn::operations::experimental::paged_cache

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
@@ -35,7 +35,13 @@ struct PagedUpdateCacheDeviceOperation {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
 
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
+        const ttnn::MeshCoordinate& coord,
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
@@ -52,5 +58,9 @@ struct PagedUpdateCacheDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
 };
+
+tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_programs(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::function<tt::tt_metal::operation::ProgramWithCallbacks(const ttnn::MeshCoordinate&)>& create_program);
 
 }  // namespace ttnn::operations::experimental::paged_cache

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
@@ -20,7 +20,8 @@ ttnn::Tensor PagedUpdateCacheOperation::invoke(
     const std::optional<bool> share_cache = std::nullopt,
     const std::optional<const Tensor>& page_table = std::nullopt,
     const uint32_t batch_offset = 0,
-    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords = std::nullopt) {
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
     const bool share_cache_arg = share_cache.has_value() ? share_cache.value() : false;
     tt::tt_metal::operation::run(
@@ -31,7 +32,8 @@ ttnn::Tensor PagedUpdateCacheOperation::invoke(
             batch_offset,                    // .batch_offset
             PagedUpdateCacheOpType::UPDATE,  // .op_type
             kernel_config_val,               // .compute_kernel_config
-            share_cache_arg                  // .share_cache
+            share_cache_arg,                 // .share_cache
+            mesh_coords,                     // .mesh_coords
         },
         {cache_tensor, input_tensor},
         {update_idxs_tensor, page_table});  // Optional inputs for UPDATE
@@ -74,7 +76,8 @@ ttnn::Tensor PagedFillCacheOperation::invoke(
     const Tensor& page_table,
     const std::optional<const Tensor>& batch_idx_tensor,
     const uint32_t batch_idx_fallback,
-    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords = std::nullopt) {
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
 
     std::vector<std::optional<const Tensor>> optional_inputs_for_run;
@@ -86,7 +89,8 @@ ttnn::Tensor PagedFillCacheOperation::invoke(
             0,                             // .batch_offset (0 for fill)
             PagedUpdateCacheOpType::FILL,  // .op_type
             kernel_config_val,             // .compute_kernel_config
-            false  // .share_cache (false for fill, can be made a param if needed for future FILL variants)
+            false,        // .share_cache (false for fill, can be made a param if needed for future FILL variants)
+            mesh_coords,  // .mesh_coords (optional, can be used to restrict operation to specific mesh coordinates)
         },
         {cache_tensor, input_tensor, page_table},  // Mandatory inputs for FILL
         {std::nullopt, std::nullopt});

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
@@ -51,7 +51,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> PagedFusedUpdateCacheOperation::invoke(
     const std::optional<bool> share_cache = std::nullopt,
     const std::optional<const Tensor>& page_table = std::nullopt,
     const uint32_t batch_offset = 0,
-    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords = std::nullopt) {
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor1.device()->arch(), compute_kernel_config);
     const bool share_cache_arg = share_cache.has_value() ? share_cache.value() : false;
     tt::tt_metal::operation::run(
@@ -62,7 +63,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> PagedFusedUpdateCacheOperation::invoke(
             batch_offset,                          // .batch_offset
             PagedUpdateCacheOpType::FUSED_UPDATE,  // .op_type
             kernel_config_val,                     // .compute_kernel_config
-            share_cache_arg                        // .share_cache
+            share_cache_arg,                       // .share_cache
+            mesh_coords,                           // .mesh_coords
         },
         {cache_tensor1, input_tensor1, cache_tensor2, input_tensor2},
         {update_idxs_tensor, page_table});  // Optional inputs for FUSED_UPDATE

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
@@ -19,7 +19,8 @@ struct PagedUpdateCacheOperation {
         std::optional<bool> share_cache,
         const std::optional<const Tensor>& page_table,
         uint32_t batch_offset,
-        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);
+        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+        std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords);
 };
 
 struct PagedFusedUpdateCacheOperation {
@@ -43,7 +44,8 @@ struct PagedFillCacheOperation {
         const Tensor& page_table,
         const std::optional<const Tensor>& batch_idx_tensor,
         uint32_t batch_idx_fallback,
-        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);
+        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+        std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords);
 };
 
 }  // namespace operations::experimental::paged_cache

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
@@ -34,7 +34,8 @@ struct PagedFusedUpdateCacheOperation {
         std::optional<bool> share_cache,
         const std::optional<const Tensor>& page_table,
         uint32_t batch_offset,
-        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);
+        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+        std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords);
 };
 
 struct PagedFillCacheOperation {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
@@ -31,7 +31,8 @@ void bind_experimental_paged_cache_operations(py::module& module) {
                const std::optional<bool> share_cache,
                const std::optional<const ttnn::Tensor>& page_table,
                const uint32_t batch_offset,
-               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+               std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords) {
                 return self(
                     cache_tensor,
                     input_tensor,
@@ -40,7 +41,8 @@ void bind_experimental_paged_cache_operations(py::module& module) {
                     share_cache,
                     page_table,
                     batch_offset,
-                    compute_kernel_config);
+                    compute_kernel_config,
+                    mesh_coords);
             },
             py::arg("cache_tensor").noconvert(),
             py::arg("input_tensor").noconvert(),
@@ -51,6 +53,7 @@ void bind_experimental_paged_cache_operations(py::module& module) {
             py::arg("page_table").noconvert() = std::nullopt,
             py::arg("batch_offset") = 0,
             py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("mesh_coords").noconvert() = std::nullopt,
         });
 
     auto paged_fused_update_cache_doc =
@@ -141,8 +144,16 @@ void bind_experimental_paged_cache_operations(py::module& module) {
                const ttnn::Tensor& page_table,
                std::optional<const ttnn::Tensor> batch_idx_tensor,
                const uint32_t batch_idx,
-               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-                return self(cache_tensor, input_tensor, page_table, batch_idx_tensor, batch_idx, compute_kernel_config);
+               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+               std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords) {
+                return self(
+                    cache_tensor,
+                    input_tensor,
+                    page_table,
+                    batch_idx_tensor,
+                    batch_idx,
+                    compute_kernel_config,
+                    mesh_coords);
             },
             py::arg("cache_tensor").noconvert(),
             py::arg("input_tensor").noconvert(),
@@ -151,6 +162,7 @@ void bind_experimental_paged_cache_operations(py::module& module) {
             py::arg("batch_idx_tensor").noconvert() = std::nullopt,
             py::arg("batch_idx") = 0,
             py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("mesh_coords").noconvert() = std::nullopt,
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
@@ -74,6 +74,7 @@ void bind_experimental_paged_cache_operations(py::module& module) {
                 page_table (ttnn.Tensor, optional): The page table for managing memory regions during updates. Defaults to None.
                 batch_offset (int): Offset for batching updates. Defaults to 0.
                 compute_kernel_config (DeviceComputeKernelConfig, Optional): Optional configuration for the device compute kernel. Defaults to None.
+                mesh_coords (Set[MeshCoordinate], optional): Set of mesh coordinates to execute on.
 
             Returns:
                 ttnn.Tensor, ttnn.Tensor: Tensors representing the updated cache states.
@@ -95,7 +96,8 @@ void bind_experimental_paged_cache_operations(py::module& module) {
                const std::optional<bool> share_cache,
                const std::optional<const ttnn::Tensor>& page_table,
                const uint32_t batch_offset,
-               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+               std::optional<const std::set<ttnn::MeshCoordinate>> mesh_coords) {
                 return self(
                     cache_tensor1,
                     input_tensor1,
@@ -106,7 +108,8 @@ void bind_experimental_paged_cache_operations(py::module& module) {
                     share_cache,
                     page_table,
                     batch_offset,
-                    compute_kernel_config);
+                    compute_kernel_config,
+                    mesh_coords);
             },
             py::arg("cache_tensor1").noconvert(),
             py::arg("input_tensor1").noconvert(),
@@ -119,6 +122,7 @@ void bind_experimental_paged_cache_operations(py::module& module) {
             py::arg("page_table").noconvert() = std::nullopt,
             py::arg("batch_offset") = 0,
             py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("mesh_coords").noconvert() = std::nullopt,
         });
 
     auto paged_fill_cache_doc =
@@ -130,6 +134,7 @@ void bind_experimental_paged_cache_operations(py::module& module) {
         page_table shape: [batch_size, max_num_blocks_per_seq]
         batch_idx_tensor (optional) shape: [1] (scalar uint32 tensor)
         batch_idx (scalar, defaults to 0) is used if batch_idx_tensor is not provided.
+        mesh_coords (optional) is a set of MeshCoordinate objects that specify the mesh coordinates to execute on.
         )doc";
 
     using PagedFillCacheType = decltype(ttnn::experimental::paged_fill_cache);


### PR DESCRIPTION
### Ticket
- #23022 

### Problem description
For the 1xTG DeepSeekV3 functional bring-up, we need to add support to only run paged update cache on a specified row of  the mesh_device, as the layers are sharded across the rows. So for eg, when running layer i + 1 on row i + 1, we do not want the cache to change on row i.

### What's changed
- Uplifting paged cache ops to go through the `create_program_at` infra
- Adding a `mesh_coords` parameter to select which devices to run the op on

### TODOs
- [x] Create unit tests
- [x] Add unit tests to some pipeline


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16527878433) CI passes