### PR TITLE
Parallelize profiler data processing in DumpMeshDeviceProfileResults

### DIFF
--- a/tests/scripts/test_moreh_microbenchmark.py
+++ b/tests/scripts/test_moreh_microbenchmark.py
@@ -1070,6 +1070,7 @@ def test_dram_read_remote_cb_sync(
         ("blackhole", 800, 6, 6, np.array([[2304, 1536, 1024], [1536, 1536, 768]]), np.array([[1536, 1536, 768]])),
     ],
 )
+@pytest.mark.skip()
 def test_matmul_l1(arch, freq, r, c, test_vector_global, test_vector_local):
     file_name = PROFILER_LOGS_DIR / "moreh_old_Matmul_SRAM.csv"
     header = ["M", "N", "K", "Cycles", "Time (ms)", "TFLOPS"]

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -6,7 +6,7 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerDumpState { NORMAL, FORCE_UMD_READ, ONLY_DISPATCH_CORES, LAST_FD_DUMP };
+enum class ProfilerDumpState { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_DUMP };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
 enum class ProfilerDataBufferSource { L1, DRAM };
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -834,11 +834,6 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
         tt::llrt::internal_::wait_until_cores_done(dev_id, RUN_MSG_GO, dispatch_cores, 0);
     }
 
-    for (const chip_id_t device_id : devices_to_close) {
-        IDevice* device = tt::DevicePool::instance().get_active_device(device_id);
-        detail::DumpDeviceProfileResults(device, ProfilerDumpState::ONLY_DISPATCH_CORES);
-    }
-
     // Process registered termination signals from topology
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
@@ -870,6 +865,11 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
             tt_metal::detail::WriteToDeviceL1(
                 dev, master_router_logical_core, termination_signal_address, termination_signal, CoreType::ETH);
         }
+    }
+
+    for (const chip_id_t device_id : devices_to_close) {
+        IDevice* device = tt::DevicePool::instance().get_active_device(device_id);
+        detail::DumpDeviceProfileResults(device, ProfilerDumpState::ONLY_DISPATCH_CORES);
     }
 
     detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -757,12 +757,6 @@ void dumpDeviceResultsToCSV(
         return;
     }
 
-    std::string concatenated_data_points = "";
-
-    // This is a rough estimate of the number of characters per data point based on observing the CSV output
-    constexpr uint32_t approximate_num_chars_per_data_point = 100;
-    concatenated_data_points.reserve(device_data_points.size() * approximate_num_chars_per_data_point);
-
     for (const DeviceProfilerDataPoint& data_point : device_data_points) {
         std::string meta_data_str = "";
         if (!data_point.meta_data.is_null()) {
@@ -770,7 +764,7 @@ void dumpDeviceResultsToCSV(
             std::replace(meta_data_str.begin(), meta_data_str.end(), ',', ';');
         }
 
-        concatenated_data_points += fmt::format(
+        log_file_ofs << fmt::format(
             "{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
             data_point.device_id,
             data_point.core_x,
@@ -786,8 +780,6 @@ void dumpDeviceResultsToCSV(
             data_point.source_file,
             meta_data_str);
     }
-
-    log_file_ofs << concatenated_data_points << std::flush;
 
     log_file_ofs.close();
 }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1418,11 +1418,12 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
 DeviceProfiler::~DeviceProfiler() {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    dumpDeviceResults();
+    auto t = std::thread([this]() { dumpDeviceResults(); });
     pushTracyDeviceResults();
     for (auto& tracyCtx : device_tracy_contexts) {
         TracyTTDestroy(tracyCtx.second);
     }
+    t.join();
 #endif
 }
 
@@ -1537,7 +1538,7 @@ bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
          ((old_info.device_time / old_info.frequency) < (new_info.device_time / new_info.frequency))));
 }
 
-void DeviceProfiler::dumpDeviceResults() {
+void DeviceProfiler::dumpDeviceResults() const {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1389,60 +1389,6 @@ void DeviceProfiler::setDeviceArchitecture(tt::ARCH device_arch) {
 #endif
 }
 
-uint32_t DeviceProfiler::hash32CT(const char* str, size_t n, uint32_t basis) {
-    return n == 0 ? basis : hash32CT(str + 1, n - 1, (basis ^ str[0]) * UINT32_C(16777619));
-}
-
-uint16_t DeviceProfiler::hash16CT(const std::string& str) {
-    uint32_t res = hash32CT(str.c_str(), str.length());
-    return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
-}
-
-void DeviceProfiler::populateZoneSrcLocations(
-    const std::string& new_log_name, const std::string& log_name, const bool push_new) {
-    std::ifstream log_file_read(new_log_name);
-    std::string line;
-    while (std::getline(log_file_read, line)) {
-        std::string delimiter = "'#pragma message: ";
-        int delimiter_index = line.find(delimiter) + delimiter.length();
-        std::string zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
-
-        uint16_t hash_16bit = hash16CT(zone_src_location);
-
-        auto did_insert = zone_src_locations.insert(zone_src_location);
-        if (did_insert.second && (hash_to_zone_src_locations.find(hash_16bit) != hash_to_zone_src_locations.end())) {
-            TT_THROW("Source location hashes are colliding, two different locations are having the same hash");
-        }
-
-        std::stringstream ss(zone_src_location);
-        std::string zone_name;
-        std::string source_file;
-        std::string line_num_str;
-        std::getline(ss, zone_name, ',');
-        std::getline(ss, source_file, ',');
-        std::getline(ss, line_num_str, ',');
-
-        ZoneDetails details(zone_name, source_file, std::stoull(line_num_str));
-
-        auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
-        if (ret.second && push_new) {
-            std::ofstream log_file_write(log_name, std::ios::app);
-            log_file_write << line << std::endl;
-            log_file_write.close();
-        }
-    }
-    log_file_read.close();
-}
-
-void DeviceProfiler::generateZoneSourceLocationsHashes() {
-    // Load existing zones from previous runs
-    populateZoneSrcLocations(tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG);
-
-    // Load new zones from the current run
-    populateZoneSrcLocations(
-        tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG, true);
-}
-
 void DeviceProfiler::readResults(
     IDevice* device,
     const std::vector<CoreCoord>& virtual_cores,
@@ -1491,8 +1437,6 @@ void DeviceProfiler::processResults(
     ZoneName(zone_name.c_str(), zone_name.size());
 
     device_core_frequency = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
-
-    generateZoneSourceLocationsHashes();
 
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1400,7 +1400,7 @@ void DeviceProfiler::readResults(
 
     const chip_id_t device_id = device->id();
     const std::string zone_name = fmt::format(
-        "{}-{}-{}", "readResults", device_id, magic_enum::enum_name(state), magic_enum::enum_name(data_source));
+        "{}-{}-{}-{}", "readResults", device_id, magic_enum::enum_name(state), magic_enum::enum_name(data_source));
     ZoneName(zone_name.c_str(), zone_name.size());
 
     TT_ASSERT(doAllDispatchCoresComeAfterNonDispatchCores(device, virtual_cores));

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1464,11 +1464,6 @@ void DeviceProfiler::dumpResults(
 
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
 
-    FabricRoutingLookup routing_lookup;
-    if (state == ProfilerDumpState::NORMAL && rtoptions.get_profiler_noc_events_enabled()) {
-        routing_lookup = FabricRoutingLookup(device);
-    }
-
     if (rtoptions.get_profiler_noc_events_enabled()) {
         log_warning(
             tt::LogAlways, "Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
@@ -1538,14 +1533,14 @@ void DeviceProfiler::dumpResults(
         }
     }
 
-    // if defined, used profiler_noc_events_report_path to write json log. otherwise use output_dir
-    std::string rpt_path = rtoptions.get_profiler_noc_events_report_path();
-    if (rpt_path.empty()) {
-        rpt_path = output_dir.string();
-    }
-
     // serialize noc traces only in normal state, to avoid overwriting individual trace files
     if (state == ProfilerDumpState::NORMAL && rtoptions.get_profiler_noc_events_enabled()) {
+        // if defined, used profiler_noc_events_report_path to write json log. otherwise use output_dir
+        std::string rpt_path = rtoptions.get_profiler_noc_events_report_path();
+        if (rpt_path.empty()) {
+            rpt_path = output_dir.string();
+        }
+        FabricRoutingLookup routing_lookup(device);
         serializeJsonNocTraces(noc_trace_json_log, rpt_path, device_id, routing_lookup);
         dumpClusterCoordinatesAsJson(std::filesystem::path(rpt_path) / "cluster_coordinates.json");
     }

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -136,8 +136,11 @@ struct DeviceProfilerDataPoint {
 
 class DeviceProfiler {
 private:
-    // Device corresponding to this profiler object
-    const IDevice* device = nullptr;
+    // Device architecture
+    tt::ARCH device_arch;
+
+    // Device ID
+    chip_id_t device_id;
 
     // Device frequency
     int device_core_frequency;
@@ -302,7 +305,9 @@ public:
         ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
         const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
-    void dumpRoutingInfo();
+    void dumpRoutingInfo() const;
+
+    void dumpClusterCoordinates() const;
 
     // Push device results to tracy
     void pushTracyDeviceResults();

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -154,6 +154,9 @@ private:
     // Output dir for device Profile Logs
     std::filesystem::path output_dir;
 
+    // Hash to zone source locations
+    std::unordered_map<uint16_t, ZoneDetails> hash_to_zone_src_locations;
+
     // Device-Core tracy context
     std::unordered_map<std::pair<uint16_t, CoreCoord>, TracyTTCtx, pair_hash<uint16_t, CoreCoord>>
         device_tracy_contexts;
@@ -248,9 +251,6 @@ public:
     DeviceProfiler() = delete;
 
     ~DeviceProfiler();
-
-    // Hash to zone source locations
-    std::unordered_map<uint16_t, ZoneDetails> hash_to_zone_src_locations;
 
     // Device-core Syncdata
     std::map<CoreCoord, SyncInfo> device_core_sync_info;

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -161,6 +161,9 @@ private:
     // Storage for all core's control buffers
     std::unordered_map<CoreCoord, std::vector<uint32_t>> core_control_buffers;
 
+    // Storage for all core's L1 data buffers
+    std::unordered_map<CoreCoord, std::vector<uint32_t>> core_l1_data_buffers;
+
     // 32bit FNV-1a hashing
     uint32_t hash32CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261));
 
@@ -201,11 +204,7 @@ private:
     void resetControlBufferForCore(IDevice* device, const CoreCoord& virtual_core, ProfilerDumpState state);
 
     // Read all L1 data buffers
-    void readL1DataBuffers(
-        IDevice* device,
-        const std::vector<CoreCoord>& virtual_cores,
-        ProfilerDumpState state,
-        std::unordered_map<CoreCoord, std::vector<uint32_t>>& core_l1_data_buffers);
+    void readL1DataBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores, ProfilerDumpState state);
 
     // Read L1 data buffer for a single core
     void readL1DataBufferForCore(
@@ -280,7 +279,6 @@ private:
         IDevice* device,
         const CoreCoord& worker_core,
         ProfilerDumpState state,
-        const std::vector<uint32_t>& data_buffer,
         ProfilerDataBufferSource data_source,
         const std::optional<ProfilerOptionalMetadata>& metadata,
         std::ofstream& log_file_ofs,
@@ -330,8 +328,16 @@ public:
     // Change the output dir of device profile logs
     void setOutputDir(const std::string& new_output_dir);
 
-    // Traverse all cores on the device and dump the device profile results
-    void dumpResults(
+    // Traverse all cores on the device and read the device profile results
+    void readResults(
+        IDevice* device,
+        const std::vector<CoreCoord>& virtual_cores,
+        ProfilerDumpState state = ProfilerDumpState::NORMAL,
+        ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
+        const std::optional<ProfilerOptionalMetadata>& metadata = {});
+
+    // Process the device profile results previously read
+    void processResults(
         IDevice* device,
         const std::vector<CoreCoord>& virtual_cores,
         ProfilerDumpState state = ProfilerDumpState::NORMAL,

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -183,28 +183,23 @@ private:
     std::vector<std::unordered_map<RuntimeID, nlohmann::json::array_t>> noc_trace_data;
 
     // Read all control buffers
-    void readControlBuffers(
-        IDevice* device, const std::vector<CoreCoord>& virtual_cores, ProfilerDumpState state);
+    void readControlBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores);
 
     // Read control buffer for a single core
-    void readControlBufferForCore(IDevice* device, const CoreCoord& virtual_core, ProfilerDumpState state);
+    void readControlBufferForCore(IDevice* device, const CoreCoord& virtual_core);
 
     // Reset all control buffers
-    void resetControlBuffers(
-        IDevice* device, const std::vector<CoreCoord>& virtual_cores, ProfilerDumpState state);
+    void resetControlBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores);
 
     // Read all L1 data buffers
-    void readL1DataBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores, ProfilerDumpState state);
+    void readL1DataBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores);
 
     // Read L1 data buffer for a single core
     void readL1DataBufferForCore(
-        IDevice* device,
-        const CoreCoord& virtual_core,
-        ProfilerDumpState state,
-        std::vector<uint32_t>& core_l1_data_buffer);
+        IDevice* device, const CoreCoord& virtual_core, std::vector<uint32_t>& core_l1_data_buffer);
 
     // Read device profiler buffer
-    void readProfilerBuffer(IDevice* device, ProfilerDumpState state);
+    void readProfilerBuffer(IDevice* device);
 
     // Read data from profiler buffer using fast dispatch
     void issueFastDispatchReadFromProfilerBuffer(IDevice* device);
@@ -224,7 +219,6 @@ private:
     void readRiscProfilerResults(
         IDevice* device,
         const CoreCoord& worker_core,
-        ProfilerDumpState state,
         ProfilerDataBufferSource data_source,
         const std::optional<ProfilerOptionalMetadata>& metadata);
 
@@ -326,14 +320,9 @@ public:
     bool isLastFDDumpDone() const;
 };
 
-bool useFastDispatchForControlBuffers(const IDevice* device, ProfilerDumpState state);
+bool useFastDispatch(IDevice* device);
 
-void writeToCoreControlBuffer(
-    IDevice* device, const CoreCoord& virtual_core, ProfilerDumpState state, const std::vector<uint32_t>& data);
-
-bool onlyProfileDispatchCores(ProfilerDumpState state);
-
-bool isGalaxyMMIODevice(const IDevice* device);
+void writeToCoreControlBuffer(IDevice* device, const CoreCoord& virtual_core, const std::vector<uint32_t>& data);
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -137,12 +137,6 @@ private:
     std::unordered_map<std::pair<uint16_t, CoreCoord>, TracyTTCtx, pair_hash<uint16_t, CoreCoord>>
         device_tracy_contexts;
 
-    // Hash to zone source locations
-    std::unordered_map<uint16_t, ZoneDetails> hash_to_zone_src_locations;
-
-    // Zone sourece locations
-    std::unordered_set<std::string> zone_src_locations;
-
     // Iterator on the current zone being processed
     std::unordered_set<tracy::TTDeviceEvent>::iterator current_zone_it;
 
@@ -172,9 +166,6 @@ private:
 
     void populateZoneSrcLocations(
         const std::string& new_log_name, const std::string& log_name = "", bool push_new = false);
-
-    // Iterate through all zone source locations and generate hash
-    void generateZoneSourceLocationsHashes();
 
     // serialize all noc trace data into per-op json trace files
     void serializeJsonNocTraces(
@@ -296,6 +287,9 @@ public:
     DeviceProfiler() = delete;
 
     ~DeviceProfiler();
+
+    // Hash to zone source locations
+    std::unordered_map<uint16_t, ZoneDetails> hash_to_zone_src_locations;
 
     // Device-core Syncdata
     std::map<CoreCoord, SyncInfo> device_core_sync_info;

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -243,7 +243,7 @@ private:
     void updateTracyContext(std::pair<uint32_t, CoreCoord> device_core);
 
     // Dump device results to files
-    void dumpDeviceResults();
+    void dumpDeviceResults() const;
 
 public:
     DeviceProfiler(const IDevice* device, bool new_logs);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -158,15 +158,6 @@ private:
     // Storage for all core's L1 data buffers
     std::unordered_map<CoreCoord, std::vector<uint32_t>> core_l1_data_buffers;
 
-    // 32bit FNV-1a hashing
-    uint32_t hash32CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261));
-
-    // XORe'd 16-bit FNV-1a hashing functions
-    uint16_t hash16CT(const std::string& str);
-
-    void populateZoneSrcLocations(
-        const std::string& new_log_name, const std::string& log_name = "", bool push_new = false);
-
     // serialize all noc trace data into per-op json trace files
     void serializeJsonNocTraces(
         const nlohmann::ordered_json& noc_trace_json_log,

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -18,7 +18,6 @@
 #include <filesystem>
 #include <limits>
 #include <map>
-#include <mutex>
 #include <optional>
 #include <ostream>
 #include <set>

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -83,7 +83,6 @@ std::unordered_map<chip_id_t, uint64_t> smallestHostime;
 
 std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::vector<std::pair<uint64_t, uint64_t>>>>
     deviceDeviceTimePair;
-std::mutex device_mutex;
 
 bool do_sync_on_close = true;
 std::unordered_set<chip_id_t> sync_set_devices;
@@ -702,10 +701,9 @@ void DumpDeviceProfileResults(
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    std::scoped_lock<std::mutex> lock(device_mutex);
-
-    auto profiler_it = tt_metal_device_profiler_map.find(device->id());
-    if (getDeviceProfilerState() && profiler_it != tt_metal_device_profiler_map.end()) {
+    if (getDeviceProfilerState()) {
+        auto profiler_it = tt_metal_device_profiler_map.find(device->id());
+        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
         DeviceProfiler& profiler = profiler_it->second;
         if (state != ProfilerDumpState::ONLY_DISPATCH_CORES) {
             if (tt::DevicePool::instance().is_dispatch_firmware_active() && !isGalaxyMMIODevice(device)) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -877,17 +877,20 @@ void DumpMeshDeviceProfileResults(
     ZoneScoped;
 
     if (getDeviceProfilerState()) {
-        auto profiler_it = detail::tt_metal_device_profiler_map.find(mesh_device.id());
-        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
-        DeviceProfiler& profiler = profiler_it->second;
-
         if (useFastDispatch(&mesh_device)) {
-            if (profiler.isLastFDDumpDone() && state == ProfilerDumpState::LAST_FD_DUMP) {
-                ZoneScopedN("Skipping! Last FD dispatch is done");
-                return;
-            } else if (state == ProfilerDumpState::LAST_FD_DUMP) {
-                profiler.setLastFDDumpAsDone();
+            for (IDevice* device : mesh_device.get_devices()) {
+                auto profiler_it = detail::tt_metal_device_profiler_map.find(device->id());
+                TT_ASSERT(profiler_it != detail::tt_metal_device_profiler_map.end());
+                DeviceProfiler& profiler = profiler_it->second;
+
+                if (profiler.isLastFDDumpDone() && state == ProfilerDumpState::LAST_FD_DUMP) {
+                    ZoneScopedN("Skipping! Last FD dispatch is done");
+                    return;
+                } else if (state == ProfilerDumpState::LAST_FD_DUMP) {
+                    profiler.setLastFDDumpAsDone();
+                }
             }
+
             mesh_device.mesh_command_queue().finish();
         }
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -836,7 +836,6 @@ void DumpDeviceProfileResults(
             not tt::tt_metal::MetalContext::instance().dprint_server(),
             "Debug print server is running, cannot dump device profiler data");
 
-        profiler.setDeviceArchitecture(device->arch());
         profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
         profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -963,8 +963,16 @@ void DumpMeshDeviceProfileResults(
         for (IDevice* device : mesh_device.get_devices()) {
             const std::vector<CoreCoord> virtual_cores = detail::getVirtualCoresForProfiling(device, state);
             detail::ReadDeviceProfilerResults(device, virtual_cores, state, metadata);
-            detail::ProcessDeviceProfilerResults(device, virtual_cores, state, metadata);
         }
+
+        for (IDevice* device : mesh_device.get_devices()) {
+            mesh_device.enqueue_to_thread_pool([device, state, &metadata]() {
+                const std::vector<CoreCoord> virtual_cores = detail::getVirtualCoresForProfiling(device, state);
+                detail::ProcessDeviceProfilerResults(device, virtual_cores, state, metadata);
+            });
+        }
+
+        mesh_device.wait_for_thread_pool();
     }
 #endif
 }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -740,6 +740,7 @@ void InitDeviceProfiler(IDevice* device) {
 
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
             profiler.dumpRoutingInfo();
+            profiler.dumpClusterCoordinates();
         }
     }
 #endif

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -832,7 +832,9 @@ void DumpDeviceProfileResults(
             } else if (state == ProfilerDumpState::LAST_FD_DUMP) {
                 profiler.setLastFDDumpAsDone();
             }
-            Finish(device->command_queue());
+            for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
+                Finish(device->command_queue(cq_id));
+            }
         }
 
         const std::vector<CoreCoord> virtual_cores = getVirtualCoresForProfiling(device, state);
@@ -891,7 +893,9 @@ void DumpMeshDeviceProfileResults(
                 }
             }
 
-            mesh_device.mesh_command_queue().finish();
+            for (uint8_t cq_id = 0; cq_id < mesh_device.num_hw_cqs(); ++cq_id) {
+                mesh_device.mesh_command_queue(cq_id).finish();
+            }
         }
 
         for (IDevice* device : mesh_device.get_devices()) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -61,18 +61,6 @@ namespace tt {
 
 namespace tt_metal {
 
-void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice& mesh_device,
-    ProfilerDumpState state,
-    const std::optional<ProfilerOptionalMetadata>& metadata) {
-#if defined(TRACY_ENABLE)
-    ZoneScoped;
-    for (IDevice* device : mesh_device.get_devices()) {
-        detail::DumpDeviceProfileResults(device, state, metadata);
-    }
-#endif
-}
-
 namespace detail {
 
 std::unordered_map<chip_id_t, DeviceProfiler> tt_metal_device_profiler_map;
@@ -99,7 +87,7 @@ void setControlBuffer(IDevice* device, std::vector<uint32_t>& control_buffer) {
 
         control_buffer[kernel_profiler::FLAT_ID] = core.second;
 
-        writeToCoreControlBuffer(device, curr_core, ProfilerDumpState::NORMAL, control_buffer);
+        writeToCoreControlBuffer(device, curr_core, control_buffer);
     }
 #endif
 }
@@ -166,9 +154,9 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     tt_metal::detail::WaitProgramDone(device, sync_program, false);
     std::vector<CoreCoord> cores = {core};
     tt_metal_device_profiler_map.at(device_id).readResults(
-        device, cores, ProfilerDumpState::FORCE_UMD_READ, ProfilerDataBufferSource::L1);
+        device, cores, ProfilerDumpState::NORMAL, ProfilerDataBufferSource::L1);
     tt_metal_device_profiler_map.at(device_id).processResults(
-        device, cores, ProfilerDumpState::FORCE_UMD_READ, ProfilerDataBufferSource::L1);
+        device, cores, ProfilerDumpState::NORMAL, ProfilerDataBufferSource::L1);
 
     log_info(tt::LogMetal, "SYNC PROGRAM FINISH IS DONE ON {}", device_id);
     if ((smallestHostime[device_id] == 0) || (smallestHostime[device_id] > hostStartTime)) {
@@ -319,10 +307,8 @@ void peekDeviceData(IDevice* device, std::vector<CoreCoord>& worker_cores) {
     if (device_profiler_it != tt_metal_device_profiler_map.end()) {
         DeviceProfiler& device_profiler = device_profiler_it->second;
         device_profiler.device_sync_new_events.clear();
-        device_profiler.readResults(
-            device, worker_cores, ProfilerDumpState::FORCE_UMD_READ, ProfilerDataBufferSource::L1);
-        device_profiler.processResults(
-            device, worker_cores, ProfilerDumpState::FORCE_UMD_READ, ProfilerDataBufferSource::L1);
+        device_profiler.readResults(device, worker_cores, ProfilerDumpState::NORMAL, ProfilerDataBufferSource::L1);
+        device_profiler.processResults(device, worker_cores, ProfilerDumpState::NORMAL, ProfilerDataBufferSource::L1);
         for (auto& event : device_profiler.device_events) {
             const ZoneDetails zone_details = device_profiler.getZoneDetails(event.timer_id);
             if (zone_details.zone_name_keyword_flags[static_cast<uint16_t>(ZoneDetails::ZoneNameKeyword::SYNC_ZONE)]) {
@@ -562,6 +548,9 @@ void ProfilerSync(ProfilerSyncState state) {
     if (!getDeviceProfilerState()) {
         return;
     }
+    TT_ASSERT(
+        !tt::DevicePool::instance().is_dispatch_firmware_active(),
+        "Profiler sync is not supported with fast dispatch enabled!");
     static chip_id_t first_connected_device_id = -1;
     if (state == ProfilerSyncState::INIT) {
         do_sync_on_close = true;
@@ -765,7 +754,17 @@ bool areAllCoresDispatchCores(IDevice* device, const std::vector<CoreCoord>& vir
     return true;
 }
 
-void DumpDeviceProfileResults(
+bool skipReadingDeviceProfilerResults(const ProfilerDumpState state) {
+    return !tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores() &&
+           state == ProfilerDumpState::ONLY_DISPATCH_CORES;
+}
+
+bool onlyProfileDispatchCores(const ProfilerDumpState state) {
+    return tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores() &&
+           state == ProfilerDumpState::ONLY_DISPATCH_CORES;
+}
+
+void ReadDeviceProfilerResults(
     IDevice* device,
     const std::vector<CoreCoord>& virtual_cores,
     ProfilerDumpState state,
@@ -777,22 +776,12 @@ void DumpDeviceProfileResults(
         auto profiler_it = tt_metal_device_profiler_map.find(device->id());
         TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
         DeviceProfiler& profiler = profiler_it->second;
-        if (state != ProfilerDumpState::ONLY_DISPATCH_CORES) {
-            if (tt::DevicePool::instance().is_dispatch_firmware_active() && !isGalaxyMMIODevice(device)) {
-                if (profiler.isLastFDDumpDone() && state == ProfilerDumpState::LAST_FD_DUMP) {
-                    ZoneScopedN("Skipping! Last FD dispatch is done");
-                    return;
-                } else if (state == ProfilerDumpState::LAST_FD_DUMP) {
-                    profiler.setLastFDDumpAsDone();
-                }
 
-                if (auto mesh_device = device->get_mesh_device()) {
-                    mesh_device->mesh_command_queue().finish();
-                } else {
-                    Finish(device->command_queue());
-                }
-            }
-        } else if (onlyProfileDispatchCores(state)) {
+        if (skipReadingDeviceProfilerResults(state)) {
+            return;
+        }
+
+        if (onlyProfileDispatchCores(state)) {
             TT_ASSERT(areAllCoresDispatchCores(device, virtual_cores));
 
             constexpr uint8_t maxLoopCount = 10;
@@ -827,16 +816,35 @@ void DumpDeviceProfileResults(
                     log_warning(tt::LogMetal, "{}", msg);
                 }
             }
-        } else {
-            return;
         }
 
         TT_FATAL(
-            not tt::tt_metal::MetalContext::instance().dprint_server(),
-            "Debug print server is running, cannot dump device profiler data");
+            !tt::tt_metal::MetalContext::instance().dprint_server(),
+            "Debug print server is running, cannot read device profiler data");
 
         profiler.hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
         profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
+    }
+#endif
+}
+
+void ProcessDeviceProfilerResults(
+    IDevice* device,
+    const std::vector<CoreCoord>& virtual_cores,
+    ProfilerDumpState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
+#if defined(TRACY_ENABLE)
+    ZoneScoped;
+
+    if (getDeviceProfilerState()) {
+        auto profiler_it = tt_metal_device_profiler_map.find(device->id());
+        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
+        DeviceProfiler& profiler = profiler_it->second;
+
+        if (skipReadingDeviceProfilerResults(state)) {
+            return;
+        }
+
         profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {
             profiler.pushTracyDeviceResults();
@@ -844,11 +852,8 @@ void DumpDeviceProfileResults(
     }
 #endif
 }
-void DumpDeviceProfileResults(
-    IDevice* device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
-#if defined(TRACY_ENABLE)
-    ZoneScoped;
 
+std::vector<CoreCoord> getVirtualCoresForProfiling(const IDevice* device, const ProfilerDumpState state) {
     std::vector<CoreCoord> virtual_cores;
 
     const chip_id_t device_id = device->id();
@@ -876,7 +881,33 @@ void DumpDeviceProfileResults(
         }
     }
 
-    DumpDeviceProfileResults(device, virtual_cores, state, metadata);
+    return virtual_cores;
+}
+
+void DumpDeviceProfileResults(
+    IDevice* device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
+#if defined(TRACY_ENABLE)
+    ZoneScoped;
+
+    if (getDeviceProfilerState()) {
+        auto profiler_it = tt_metal_device_profiler_map.find(device->id());
+        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
+        DeviceProfiler& profiler = profiler_it->second;
+
+        if (useFastDispatch(device)) {
+            if (profiler.isLastFDDumpDone() && state == ProfilerDumpState::LAST_FD_DUMP) {
+                ZoneScopedN("Skipping! Last FD dispatch is done");
+                return;
+            } else if (state == ProfilerDumpState::LAST_FD_DUMP) {
+                profiler.setLastFDDumpAsDone();
+            }
+            Finish(device->command_queue());
+        }
+
+        const std::vector<CoreCoord> virtual_cores = getVirtualCoresForProfiling(device, state);
+        ReadDeviceProfilerResults(device, virtual_cores, state, metadata);
+        ProcessDeviceProfilerResults(device, virtual_cores, state, metadata);
+    }
 #endif
 }
 
@@ -906,6 +937,37 @@ uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, 
 }
 
 }  // namespace detail
+
+void DumpMeshDeviceProfileResults(
+    distributed::MeshDevice& mesh_device,
+    ProfilerDumpState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
+#if defined(TRACY_ENABLE)
+    ZoneScoped;
+
+    if (getDeviceProfilerState()) {
+        auto profiler_it = detail::tt_metal_device_profiler_map.find(mesh_device.id());
+        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
+        DeviceProfiler& profiler = profiler_it->second;
+
+        if (useFastDispatch(&mesh_device)) {
+            if (profiler.isLastFDDumpDone() && state == ProfilerDumpState::LAST_FD_DUMP) {
+                ZoneScopedN("Skipping! Last FD dispatch is done");
+                return;
+            } else if (state == ProfilerDumpState::LAST_FD_DUMP) {
+                profiler.setLastFDDumpAsDone();
+            }
+            mesh_device.mesh_command_queue().finish();
+        }
+
+        for (IDevice* device : mesh_device.get_devices()) {
+            const std::vector<CoreCoord> virtual_cores = detail::getVirtualCoresForProfiling(device, state);
+            detail::ReadDeviceProfilerResults(device, virtual_cores, state, metadata);
+            detail::ProcessDeviceProfilerResults(device, virtual_cores, state, metadata);
+        }
+    }
+#endif
+}
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -733,8 +733,6 @@ void InitDeviceProfiler(IDevice* device) {
         profiler.profile_buffer_bank_size_bytes = bank_size_bytes;
         profiler.profile_buffer.resize(profiler.profile_buffer_bank_size_bytes * num_dram_banks / sizeof(uint32_t));
 
-        profiler.hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
-
         std::vector<uint32_t> control_buffer(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE, 0);
         control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS] =
             MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::PROFILER);
@@ -836,6 +834,7 @@ void DumpDeviceProfileResults(
             not tt::tt_metal::MetalContext::instance().dprint_server(),
             "Debug print server is running, cannot dump device profiler data");
 
+        profiler.hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
         profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
         profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -621,74 +621,6 @@ void ClearProfilerControlBuffer(IDevice* device) {
 #endif
 }
 
-uint32_t hash32CT(const char* str, size_t n, uint32_t basis) {
-    return n == 0 ? basis : hash32CT(str + 1, n - 1, (basis ^ str[0]) * UINT32_C(16777619));
-}
-
-uint16_t hash16CT(const std::string& str) {
-    uint32_t res = hash32CT(str.c_str(), str.length(), UINT32_C(2166136261));
-    return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
-}
-
-void populateZoneSrcLocations(
-    const std::string& new_log_name,
-    const std::string& log_name,
-    const bool push_new,
-    std::unordered_map<uint16_t, ZoneDetails>& hash_to_zone_src_locations,
-    std::unordered_set<std::string>& zone_src_locations) {
-    std::ifstream log_file_read(new_log_name);
-    std::string line;
-    while (std::getline(log_file_read, line)) {
-        std::string delimiter = "'#pragma message: ";
-        int delimiter_index = line.find(delimiter) + delimiter.length();
-        std::string zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
-
-        uint16_t hash_16bit = hash16CT(zone_src_location);
-
-        auto did_insert = zone_src_locations.insert(zone_src_location);
-        if (did_insert.second && (hash_to_zone_src_locations.find(hash_16bit) != hash_to_zone_src_locations.end())) {
-            TT_THROW("Source location hashes are colliding, two different locations are having the same hash");
-        }
-
-        std::stringstream ss(zone_src_location);
-        std::string zone_name;
-        std::string source_file;
-        std::string line_num_str;
-        std::getline(ss, zone_name, ',');
-        std::getline(ss, source_file, ',');
-        std::getline(ss, line_num_str, ',');
-
-        ZoneDetails details(zone_name, source_file, std::stoull(line_num_str));
-
-        auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
-        if (ret.second && push_new) {
-            std::ofstream log_file_write(log_name, std::ios::app);
-            log_file_write << line << std::endl;
-            log_file_write.close();
-        }
-    }
-    log_file_read.close();
-}
-
-std::unordered_map<uint16_t, ZoneDetails> generateZoneSourceLocationsHashes() {
-    std::unordered_map<uint16_t, ZoneDetails> hash_to_zone_src_locations;
-    std::unordered_set<std::string> zone_src_locations;
-
-    // Load existing zones from previous runs
-    populateZoneSrcLocations(
-        tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG, "", false, hash_to_zone_src_locations, zone_src_locations);
-
-    // Load new zones from the current run
-    populateZoneSrcLocations(
-        tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG,
-        tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG,
-        true,
-        hash_to_zone_src_locations,
-        zone_src_locations);
-
-    return hash_to_zone_src_locations;
-}
-
 void InitDeviceProfiler(IDevice* device) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
@@ -822,7 +754,6 @@ void ReadDeviceProfilerResults(
             !tt::tt_metal::MetalContext::instance().dprint_server(),
             "Debug print server is running, cannot read device profiler data");
 
-        profiler.hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
         profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
     }
 #endif


### PR DESCRIPTION
#14897 

### Key changes
This change modifies `DumpMeshDeviceProfileResults` to process profiler data that has been read from the mesh device in parallel with the number of additional threads being the number of devices in the mesh device. In order to support parallelization, profiling data is now written to the output file(s) when the `DeviceProfiler` destructors run.

### Other minor changes
 - In the `DeviceProfiler` destructor, writing data to output file(s) and pushing data to the Tracy GUI happen in parallel
 - The logic in the profiler to determine when to use slow dispatch vs. fast dispatch to read data from the device has been simplified
 - `ProfilerDumpState::FORCE_UMD_READ` enum has been removed as it is no longer needed with the above logic simplification
 - In `DevicePool::close_devices()`, the `ONLY_DISPATCH_CORES` dump happens after fabric teardown

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16576600627)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16576606030)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16576610681)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16576617187)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16576621624)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/16576627083)
- [x] [TG Model Perf] (https://github.com/tenstorrent/tt-metal/actions/runs/16576693092)
- [x] [Metal Microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/16576667888)
- [x] New/Existing tests provide coverage for changes