### PR TITLE
Fix resnet50 upstream test import

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -200,6 +200,7 @@ jobs:
       - get-image-tags
       - build-images
     strategy:
+      fail-fast: false
       matrix:
         bh-card:
           - P100

--- a/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_functional_resnet50_batch32.py
+++ b/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_functional_resnet50_batch32.py
@@ -5,7 +5,7 @@
 import pytest
 
 import ttnn
-from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import run_resnet_50
+from models.demos.wormhole.resnet50.tests.test_resnet50_functional import run_resnet_50
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)


### PR DESCRIPTION
### Ticket
None

### Problem description
Upstream tests broken after clean up of `integration_tests` dir:
```
ModuleNotFoundError: No module named 'tests.ttnn.integration_tests.resnet'
```

### What's changed
Update the test file to the correct import path
Run both p100 and p150 upstream tests fully (fail-fast: false)

### Checklist
- [x] upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/16506958195