### PR TITLE
Rewrite host-device bandwidth benchmark to use MeshDevice.

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -66,8 +66,6 @@ std::shared_ptr<MeshBuffer> create_buffer(int page_size, int transfer_size, std:
     ReplicatedBufferConfig mesh_buffer_config{transfer_size};
     DeviceLocalBufferConfig device_local_config{.page_size = page_size, .buffer_type = TARGET_BUFFER_TYPE};
 
-    TT_ASSERT(mesh_buffer_config.compute_datum_size_bytes() == sizeof(DataType));
-
     return MeshBuffer::create(mesh_buffer_config, device_local_config, device.get());
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
 #include <chrono>
 #include <fmt/base.h>
 #include <fmt/format.h>
@@ -55,7 +54,7 @@ static const auto PAGE_SIZE_ARGS = benchmark::CreateRange(32, 32 * KB, 2);
 static const std::vector<int64_t> TRANSFER_SIZE_ARGS{32 * KB, 512 * MB};
 static const auto BENCHMARK_ARGS = {PAGE_SIZE_ARGS, TRANSFER_SIZE_ARGS};
 
-static std::map<int, std::shared_ptr<MeshDevice>> DEVICES;
+static std::map<int, std::shared_ptr<MeshDevice>> devices;
 
 // Create a buffer of total transfer_size big that is paged with page_size
 std::shared_ptr<MeshBuffer> create_buffer(int page_size, int transfer_size, std::shared_ptr<MeshDevice> device) {
@@ -72,7 +71,7 @@ std::shared_ptr<MeshBuffer> create_buffer(int page_size, int transfer_size, std:
 static void BM_write(benchmark::State& state) {
     auto page_size = state.range(0);
     auto transfer_size = state.range(1);
-    auto mesh_device = DEVICES[state.range(2)];
+    auto mesh_device = devices[state.range(2)];
 
     auto random_buffer_seed = std::chrono::system_clock::now().time_since_epoch().count();
     auto host_buffer = create_random_vector_of_bfloat16(transfer_size, 1000, random_buffer_seed);
@@ -89,7 +88,7 @@ static void BM_write(benchmark::State& state) {
 static void BM_read(benchmark::State& state) {
     auto page_size = state.range(0);
     auto transfer_size = state.range(1);
-    auto mesh_device = DEVICES[state.range(2)];
+    auto mesh_device = devices[state.range(2)];
 
     auto device_buffer = create_buffer(page_size, transfer_size, mesh_device);
     std::vector<uint32_t> host_buffer;
@@ -117,7 +116,7 @@ int main(int argc, char** argv) {
         log_info(LogTest, "Device 1 is not available");
     }
 
-    DEVICES = MeshDevice::create_unit_meshes(device_ids);
+    devices = MeshDevice::create_unit_meshes(device_ids);
 
     auto benchmark_args = {
         PAGE_SIZE_ARGS, TRANSFER_SIZE_ARGS, std::vector<int64_t>(device_ids.begin(), device_ids.end())};
@@ -128,7 +127,7 @@ int main(int argc, char** argv) {
 
     benchmark::RunSpecifiedBenchmarks();
     // closes all opened devices.
-    DEVICES.clear();
+    devices.clear();
     benchmark::Shutdown();
 
     return 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -34,7 +34,7 @@ using namespace tt::tt_metal::distributed;
 ////////////////////////////////////////////////////////////////////////////////
 // This test measures the bandwidth of host-to-device data transfer and
 // device-to-host data transfer. It uses EnqueueWriteMeshBuffer and
-// EnqueueReadMeshBuffer APIs to transfer the data. The device memory object
+// ReadShard APIs to transfer the data. The device memory object
 // (mesh buffer) will be in DRAM.
 //
 // Benchmark Matrix:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -102,21 +102,6 @@ static void BM_read(benchmark::State& state) {
     state.SetBytesProcessed(transfer_size * state.iterations());
 }
 
-std::vector<chip_id_t> setup_device_pool() {
-    auto available_device_ids = MetalContext::instance().get_cluster().all_chip_ids();
-    TT_ASSERT(available_device_ids.contains(0));
-
-    std::vector<chip_id_t> device_ids = {0};
-    log_info(tt::LogTest, "Device 1 available, enable testing on device 1 assuming it's a remote device");
-    if (available_device_ids.contains(1)) {
-        device_ids.push_back(1);
-    }
-
-    DevicePool::initialize(device_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{});
-
-    return device_ids;
-}
-
 int main(int argc, char** argv) {
     benchmark::Initialize(&argc, argv);
 


### PR DESCRIPTION
### Ticket
#25132

### Problem description
The bandwidth benchmark test was not using meshdevice and meshbuffer.

### What's changed
Converted benchmark to use Mesh Device and Mesh Buffer.

Here's the performance numbers:

| Page Size | Transfer Size | Device Number | Write MiB/s | Read MiB/s |
|-----------|---------------|--------------|--------------|--------------|
| 32 | 32768 | 0 | 252.951 | 447.104 |
| 64 | 32768 | 0 | 253.212 | 497.138 |
| 128 | 32768 | 0 | 253.515 | 497.512 |
| 256 | 32768 | 0 | 254.263 | 497.873 |
| 512 | 32768 | 0 | 254.023 | 495.969 |
| 1024 | 32768 | 0 | 255.494 | 496.820 |
| 2048 | 32768 | 0 | 256.980 | 495.945 |
| 4096 | 32768 | 0 | 257.591 | 495.433 |
| 8192 | 32768 | 0 | 257.296 | 492.421 |
| 16384 | 32768 | 0 | 256.930 | 492.276 |
| 32768 | 32768 | 0 | 257.355 | 491.970 |
| 32 | 536870912 | 0 | 499.903 | 544.700 |
| 64 | 536870912 | 0 | 997.741 | 936.472 |
| 128 | 536870912 | 0 | 1988.386 | 1785.198 |
| 256 | 536870912 | 0 | 3942.656 | 3060.294 |
| 512 | 536870912 | 0 | 7532.760 | 5257.074 |
| 1024 | 536870912 | 0 | 12179.352 | 7447.398 |
| 2048 | 536870912 | 0 | 14373.224 | 8989.978 |
| 4096 | 536870912 | 0 | 14313.984 | 10930.688 |
| 8192 | 536870912 | 0 | 14083.226 | 11613.056 |
| 16384 | 536870912 | 0 | 13981.056 | 11717.632 |
| 32768 | 536870912 | 0 | 13698.816 | 11793.152 |
| 32 | 32768 | 1 | 250.832 | 403.663 |
| 64 | 32768 | 1 | 251.056 | 492.426 |
| 128 | 32768 | 1 | 251.099 | 492.184 |
| 256 | 32768 | 1 | 250.028 | 493.856 |
| 512 | 32768 | 1 | 249.965 | 496.915 |
| 1024 | 32768 | 1 | 250.155 | 492.212 |
| 2048 | 32768 | 1 | 251.299 | 495.309 |
| 4096 | 32768 | 1 | 252.305 | 499.438 |
| 8192 | 32768 | 1 | 251.007 | 500.089 |
| 16384 | 32768 | 1 | 250.104 | 499.835 |
| 32768 | 32768 | 1 | 250.053 | 499.600 |
| 32 | 536870912 | 1 | 526.688 | 496.309 |
| 64 | 536870912 | 1 | 1050.176 | 867.491 |
| 128 | 536870912 | 1 | 2092.522 | 1650.982 |
| 256 | 536870912 | 1 | 4140.481 | 2955.469 |
| 512 | 536870912 | 1 | 8148.837 | 3711.938 |
| 1024 | 536870912 | 1 | 8547.021 | 3693.978 |
| 2048 | 536870912 | 1 | 8493.402 | 3535.262 |
| 4096 | 536870912 | 1 | 8431.514 | 3523.046 |
| 8192 | 536870912 | 1 | 8460.362 | 3535.511 |
| 16384 | 536870912 | 1 | 8561.715 | 3524.382 |
| 32768 | 536870912 | 1 | 8566.220 | 3536.013 |

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/16510321636))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes