### PR TITLE
Workaround for debug_tools flakiness

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <functional>
-#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <variant>
@@ -154,17 +153,16 @@ static void RunTest(
 
     // Run the kernel, don't expect an issue here.
     log_info(LogTest, "Running args that shouldn't assert...");
-    // TODO: #24887, ND issue with this test - only run once below when issue is fixed
-    fixture->RunProgram(device, program);
-    fixture->RunProgram(device, program);
-    fixture->RunProgram(device, program);
+    // TODO: #24887, ND issue with this test - remove the sleep below when issue is fixed
+    fixture->RunProgram(device, program, true);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
     log_info(LogTest, "Args did not assert!");
 
     // Write runtime args that should trip an assert.
     const std::vector<uint32_t> unsafe_args = {3, 3, static_cast<uint32_t>(assert_type)};
     SetRuntimeArgs(program, assert_kernel, logical_core, unsafe_args);
 
-    // Run the kerel, expect an exit due to the assert.
+    // Run the kernel, expect an exit due to the assert.
     log_info(LogTest, "Running args that should assert...");
     fixture->RunProgram(device, program);
 
@@ -216,13 +214,11 @@ static void RunTest(
             kernel);
     }
 
-    log_info(LogTest, "Expected error: {}", expected);
     std::string exception = "";
     do {
         exception = MetalContext::instance().watcher_server()->exception_message();
     } while (exception == "");
-    log_info(LogTest, "Reported error: {}", exception);
-    EXPECT_TRUE(expected == MetalContext::instance().watcher_server()->exception_message());
+    EXPECT_EQ(expected, MetalContext::instance().watcher_server()->exception_message());
 }
 }
 


### PR DESCRIPTION
### Ticket
#25697 #25785

### Problem description
This is a workaround for the ND failure in debug_tools test.  The problem is still to be root-caused.

The test flow is `repeat { good_kernel bad_kernel check_watcher_exception }`

My suspicion is there's too little time between two runs of bad_kernel and somehow watcher reads a stale assertion before the bad kernel starts.  This may explain why the kernel is blank in the mailbox and later changed to the bad kernel when checked again.

### What's changed

Added a delay in the test flow. It now passes 1000 runs of TestWatcherAssertBrisc (usually breaks within 50 iterations).

This PR only affects debug_tools unit test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16509733681) CI passes (tg-demo should be unrelated)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16509802001) CI with demo tests passes (whisper performance should be unrelated)