### PR TITLE
Make big-mesh dual-rank test regressions run again

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -44,7 +44,7 @@ run_t3000_ttmetal_tests() {
 }
 
 run_t3000_dual_rank_big_mesh_tests() {
-  tt-run --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml --mpi-args "--allow-run-as-root --tag-output" build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter="*BigMeshDualRankTestT3K*"
+  tt-run --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml --mpi-args "--allow-run-as-root --tag-output" build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter="*BigMeshDualRankTest2x4*"
 }
 
 run_t3000_ttfabric_tests() {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -96,12 +96,6 @@ void MetalContext::initialize(
     // Initialize inspector
     inspector_data_ = Inspector::initialize();
 
-    // If a custom fabric mesh graph descriptor is specified as an RT Option, use it by default
-    // to initialize the control plane.
-    if (rtoptions_.is_custom_fabric_mesh_graph_desc_path_specified()) {
-        custom_mesh_graph_desc_path_ = rtoptions_.get_custom_fabric_mesh_graph_desc_path();
-    }
-
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
     dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs);
@@ -232,6 +226,12 @@ MetalContext& MetalContext::instance() {
 }
 
 MetalContext::MetalContext() {
+    // If a custom fabric mesh graph descriptor is specified as an RT Option, use it by default
+    // to initialize the control plane.
+    if (rtoptions_.is_custom_fabric_mesh_graph_desc_path_specified()) {
+        custom_mesh_graph_desc_path_ = rtoptions_.get_custom_fabric_mesh_graph_desc_path();
+    }
+
     bool is_base_routing_fw_enabled =
         Cluster::is_base_routing_fw_enabled(Cluster::get_cluster_type_from_cluster_desc(rtoptions_));
     hal_ = std::make_unique<Hal>(get_platform_architecture(rtoptions_), is_base_routing_fw_enabled);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
It seems with the recent renaming of the Google C++ Test Suites now cause the tests no longer to be run in regression. 😱 

### What's changed
- Update to re-enable the test suites to run in regression.
- This also coincided with recent changes (yesterday) to how custom mesh graph descriptor was being handled. This also fixes a bug where `custom_mesh_graph_desc_path_` is populated too late and is now fixed to populate on `MetalContext` construction.

### Checklist
- [x] All Post Commit: https://github.com/tenstorrent/tt-metal/actions/runs/16511016457
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/16511008778