### PR TITLE
add fabric APIs that hide and workaround Blackhole DRAM arbiter bug

### DIFF
--- a/tt_metal/fabric/hw/inc/linear/addrgen_api.h
+++ b/tt_metal/fabric/hw/inc/linear/addrgen_api.h
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/hw/inc/dataflow_api_addrgen.h"
+#include "tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
+
+namespace tt::tt_fabric {
+
+namespace linear {
+
+namespace addrgen_detail {
+
+template <bool DRAM>
+uint32_t get_page_size(const InterleavedAddrGen<DRAM>& s) {
+    return s.aligned_page_size;
+}
+
+template <bool DRAM>
+uint32_t get_page_size(const InterleavedAddrGenFast<DRAM>& s) {
+    return s.page_size;
+}
+}  // namespace addrgen_detail
+
+template <typename AddrGenType>
+FORCE_INLINE void to_noc_unicast_write(
+    volatile PACKET_HEADER_TYPE* pkt_hdr, const uint32_t id, const AddrGenType& d, uint32_t offset = 0) {
+    pkt_hdr->noc_send_type = NOC_FUSED_UNICAST_ATOMIC_INC;
+
+    pkt_hdr->command_fields.unicast_write.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
+    pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d);
+}
+
+template <typename AddrGenType>
+FORCE_INLINE void to_noc_fused_unicast_write_atomic_inc(
+    volatile PACKET_HEADER_TYPE* pkt_hdr,
+    const NocUnicastAtomicIncCommandHeader& atomic_inc_spec,
+    const uint32_t id,
+    const AddrGenType& d,
+    uint32_t offset = 0) {
+    pkt_hdr->noc_send_type = NOC_FUSED_UNICAST_ATOMIC_INC;
+
+    pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d, offset, edm_to_local_chip_noc);
+
+    pkt_hdr->command_fields.unicast_seminc_fused.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
+    pkt_hdr->command_fields.unicast_seminc_fused.semaphore_noc_address = atomic_inc_spec.noc_address;
+    pkt_hdr->command_fields.unicast_seminc_fused.val = atomic_inc_spec.val;
+    pkt_hdr->command_fields.unicast_seminc_fused.wrap = atomic_inc_spec.wrap;
+    pkt_hdr->command_fields.unicast_seminc_fused.flush = atomic_inc_spec.flush;
+}
+
+template <typename AddrGenType>
+FORCE_INLINE void to_noc_unicast_scatter_write(
+    volatile PACKET_HEADER_TYPE* pkt_hdr,
+    const uint32_t id0,
+    const uint32_t id1,
+    const AddrGenType& d,
+    uint32_t offset0 = 0,
+    uint32_t offset1 = 0) {
+    pkt_hdr->noc_send_type = NOC_UNICAST_SCATTER_WRITE;
+    pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d) * 2;
+
+    pkt_hdr->command_fields.unicast_scatter_write.noc_address[0] = d.get_noc_addr(id0, offset0, edm_to_local_chip_noc);
+    pkt_hdr->command_fields.unicast_scatter_write.noc_address[1] = d.get_noc_addr(id1, offset1, edm_to_local_chip_noc);
+    pkt_hdr->command_fields.unicast_scatter_write.chunk_size[0] = addrgen_detail::get_page_size(d);
+    pkt_hdr->command_fields.unicast_scatter_write.chunk_size[1] = addrgen_detail::get_page_size(d);
+}
+
+}  // namespace linear
+
+};  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/linear/addrgen_api.h
+++ b/tt_metal/fabric/hw/inc/linear/addrgen_api.h
@@ -28,7 +28,7 @@ uint32_t get_page_size(const InterleavedAddrGenFast<DRAM>& s) {
 template <typename AddrGenType>
 FORCE_INLINE void to_noc_unicast_write(
     volatile PACKET_HEADER_TYPE* pkt_hdr, const uint32_t id, const AddrGenType& d, uint32_t offset = 0) {
-    pkt_hdr->noc_send_type = NOC_FUSED_UNICAST_ATOMIC_INC;
+    pkt_hdr->noc_send_type = NOC_UNICAST_WRITE;
 
     pkt_hdr->command_fields.unicast_write.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
     pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d);

--- a/tt_metal/fabric/hw/inc/linear/addrgen_api.h
+++ b/tt_metal/fabric/hw/inc/linear/addrgen_api.h
@@ -25,13 +25,30 @@ uint32_t get_page_size(const InterleavedAddrGenFast<DRAM>& s) {
 }
 }  // namespace addrgen_detail
 
+// Placeholder max page size for the addrgen until the page size is properly visible by the worker
+// https://github.com/tenstorrent/tt-metal/issues/25966
+static constexpr uint32_t max_fabric_addrgen_page_size = 2048;
+
+FORCE_INLINE void validate_max_page_size(uint32_t page_size) {
+    ASSERT((page_size > max_fabric_addrgen_page_size));
+    if ((page_size > max_fabric_addrgen_page_size)) {
+        WAYPOINT("HUNG");
+        // hang to promopt investigation
+        while (1) {
+        }
+    }
+}
+
 template <typename AddrGenType>
 FORCE_INLINE void to_noc_unicast_write(
     volatile PACKET_HEADER_TYPE* pkt_hdr, const uint32_t id, const AddrGenType& d, uint32_t offset = 0) {
     pkt_hdr->noc_send_type = NOC_UNICAST_WRITE;
 
     pkt_hdr->command_fields.unicast_write.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
-    pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d);
+    auto page_size = addrgen_detail::get_page_size(d);
+    pkt_hdr->payload_size_bytes = page_size;
+
+    validate_max_page_size(page_size);
 }
 
 template <typename AddrGenType>
@@ -43,13 +60,16 @@ FORCE_INLINE void to_noc_fused_unicast_write_atomic_inc(
     uint32_t offset = 0) {
     pkt_hdr->noc_send_type = NOC_FUSED_UNICAST_ATOMIC_INC;
 
-    pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d, offset, edm_to_local_chip_noc);
+    auto page_size = addrgen_detail::get_page_size(d, offset, edm_to_local_chip_noc);
+    pkt_hdr->payload_size_bytes = page_size;
 
     pkt_hdr->command_fields.unicast_seminc_fused.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
     pkt_hdr->command_fields.unicast_seminc_fused.semaphore_noc_address = atomic_inc_spec.noc_address;
     pkt_hdr->command_fields.unicast_seminc_fused.val = atomic_inc_spec.val;
     pkt_hdr->command_fields.unicast_seminc_fused.wrap = atomic_inc_spec.wrap;
     pkt_hdr->command_fields.unicast_seminc_fused.flush = atomic_inc_spec.flush;
+
+    validate_max_page_size(page_size);
 }
 
 template <typename AddrGenType>
@@ -61,12 +81,16 @@ FORCE_INLINE void to_noc_unicast_scatter_write(
     uint32_t offset0 = 0,
     uint32_t offset1 = 0) {
     pkt_hdr->noc_send_type = NOC_UNICAST_SCATTER_WRITE;
-    pkt_hdr->payload_size_bytes = addrgen_detail::get_page_size(d) * 2;
+
+    auto page_size = addrgen_detail::get_page_size(d);
+    auto payload_size = page_size * 2;
+    pkt_hdr->payload_size_bytes = payload_size;
 
     pkt_hdr->command_fields.unicast_scatter_write.noc_address[0] = d.get_noc_addr(id0, offset0, edm_to_local_chip_noc);
     pkt_hdr->command_fields.unicast_scatter_write.noc_address[1] = d.get_noc_addr(id1, offset1, edm_to_local_chip_noc);
-    pkt_hdr->command_fields.unicast_scatter_write.chunk_size[0] = addrgen_detail::get_page_size(d);
-    pkt_hdr->command_fields.unicast_scatter_write.chunk_size[1] = addrgen_detail::get_page_size(d);
+    pkt_hdr->command_fields.unicast_scatter_write.chunk_size[0] = page_size;
+
+    validate_max_page_size(payload_size);
 }
 
 }  // namespace linear


### PR DESCRIPTION
Issue https://github.com/tenstorrent/tt-metal/issues/25348

There is a dram arbiter bug on Blackhole that can cause noc hang by dropping and backing up a noc when there are noc reads/writes to the same DRAM noc endpoint. As a workaround, each noc is assigned different noc endpoints (cores) to access each given DRAM bank. This bank lookup is handled automatically for address generators. However, this is a problem for TT-Fabric.

When TT-Fabric is given a noc address, it doesn't necessarily know if it is a DRAM address. It must assume the noc coordinate system that was used for the address. To avoid this bug it needs to detect a DRAM noc endpoint, and then do a remapping to the new noc endpoint for the noc used by fabric to perform the DRAM write.

To avoid accidental usability errors, new APIs were added that are more reflective of the dataflow addrgen APIs. This is slightly innefficient because an address would be regenerated for each direction on fabric in the case of a multi-cast. However, upon completion of the API cleanup and updates [here](https://github.com/tenstorrent/tt-metal/issues/24850), the number of address lookups would be reduced back to one.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/16679805788
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16679802089