### PR TITLE
Int32 support for binary logical AND

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -12,7 +12,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     compare_pcc,
     compare_equal,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -133,9 +133,9 @@ def test_binary_atan2_ttnn(input_shapes, device):
 def test_binary_logical_xor_ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
-    in_data1 = in_data1[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    in_data1 = in_data1[:num_elements].reshape(input_shapes)
     in_data2 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
-    in_data2 = in_data2[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    in_data2 = in_data2[:num_elements].reshape(input_shapes)
 
     input_tensor1 = ttnn.from_torch(
         in_data1,
@@ -154,11 +154,11 @@ def test_binary_logical_xor_ttnn(input_shapes, device):
     )
 
     output_tensor = ttnn.logical_xor(input_tensor1, input_tensor2)
+    output_tensor = ttnn.to_torch(output_tensor)
     golden_function = ttnn.get_golden_function(ttnn.logical_xor)
     golden_tensor = golden_function(in_data1, in_data2)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert torch.equal(output_tensor, golden_tensor)
 
 
 @pytest.mark.parametrize("accurate_mode", [False, True])
@@ -523,14 +523,34 @@ def test_fmod_ttnn(input_shapes, scalar, device):
     ),
 )
 def test_binary_logical_and__ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
-    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
+    in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
+    in_data1 = in_data1[:num_elements].reshape(input_shapes)
+    in_data2 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
+    in_data2 = in_data2[:num_elements].reshape(input_shapes)
+
+    input_tensor1 = ttnn.from_torch(
+        in_data1,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    input_tensor2 = ttnn.from_torch(
+        in_data2,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
     ttnn.logical_and_(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.logical_and_)
     golden_tensor = golden_function(in_data1, in_data2)
 
-    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(input_tensor1, golden_tensor)
+    assert torch.equal(ttnn.to_torch(input_tensor1), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -544,9 +564,9 @@ def test_binary_logical_and__ttnn(input_shapes, device):
 def test_binary_logical_or__ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
-    in_data1 = in_data1[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    in_data1 = in_data1[:num_elements].reshape(input_shapes)
     in_data2 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
-    in_data2 = in_data2[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    in_data2 = in_data2[:num_elements].reshape(input_shapes)
 
     input_tensor1 = ttnn.from_torch(
         in_data1,
@@ -568,8 +588,8 @@ def test_binary_logical_or__ttnn(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.logical_or_)
     golden_tensor = golden_function(in_data1, in_data2)
 
-    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(input_tensor1, golden_tensor)
+    assert torch.equal(ttnn.to_torch(input_tensor1), golden_tensor)
 
 
 @pytest.mark.parametrize(
@@ -583,9 +603,9 @@ def test_binary_logical_or__ttnn(input_shapes, device):
 def test_binary_logical_xor__ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
-    in_data1 = in_data1[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    in_data1 = in_data1[:num_elements].reshape(input_shapes)
     in_data2 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
-    in_data2 = in_data2[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    in_data2 = in_data2[:num_elements].reshape(input_shapes)
 
     input_tensor1 = ttnn.from_torch(
         in_data1,
@@ -607,8 +627,8 @@ def test_binary_logical_xor__ttnn(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.logical_xor_)
     golden_tensor = golden_function(in_data1, in_data2)
 
-    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
-    assert comp_pass
+    assert_with_ulp(input_tensor1, golden_tensor)
+    assert torch.equal(ttnn.to_torch(input_tensor1), golden_tensor)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2060,7 +2060,7 @@ void py_module(py::module& module) {
         R"doc(Computes logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i \, \& \, \mathrm{{input\_tensor\_b}}_i)doc",
         ". ",
-        R"doc(BFLOAT16, BFLOAT8_B)doc",
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc",
         "INT32 for tensor-scalar is supported only when use_legacy= False.");
 
     detail::bind_binary_operation(
@@ -2256,7 +2256,7 @@ void py_module(py::module& module) {
         ttnn::logical_and_,
         R"doc(Computes inplace logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{input\_tensor\_a}}_i \& \mathrm{{input\_tensor\_b}}_i)doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
     detail::bind_binary_gcd_lcm_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -324,10 +324,6 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "sub_binary_tile";
             new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst1));
             break;
-        case BinaryOpType::LOGICAL_AND:
-            op_name = "mul_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
-            break;
         case BinaryOpType::BIAS_GELU:
             new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
             op_name = "add_binary_tile";
@@ -352,6 +348,16 @@ std::map<std::string, std::string> get_defines_fp32(
                 op_name = "sub_int32_tile";
             } else {
                 op_name = "sub_binary_tile";
+            }
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
+            break;
+        case BinaryOpType::LOGICAL_AND:
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "mul_int32_tile";
+            } else {
+                op_name = "mul_binary_tile";
             }
             new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -32,8 +32,8 @@ namespace utils {
         case BinaryOpType::LOGADDEXP2:
         case BinaryOpType::LDEXP:
         case BinaryOpType::SQUARED_DIFFERENCE:
-        case BinaryOpType::LOGICAL_AND:
         case BinaryOpType::BIAS_GELU: return (a == DataType::FLOAT32 && b == DataType::FLOAT32);
+        case BinaryOpType::LOGICAL_AND:
         case BinaryOpType::LOGICAL_OR:
         case BinaryOpType::LOGICAL_XOR:
         case BinaryOpType::GT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -25,8 +25,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LOGADDEXP2:
         case LDEXP:
         case SQUARED_DIFFERENCE:
-        case LOGICAL_AND:
         case BIAS_GELU: return (a == FLOAT32 && b == FLOAT32);
+        case LOGICAL_AND:
         case LOGICAL_OR:
         case LOGICAL_XOR:
         case GT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -178,6 +178,8 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>) : b
             postprocess = unary::UnaryOpType::GELU;
             break;
         case BinaryOpType::LOGICAL_AND:
+            process_lhs = unary::UnaryOpType::NEZ;
+            process_rhs = unary::UnaryOpType::NEZ;
             binary_op = EnumT::MUL;
             postprocess = unary::UnaryOpType::NEZ;
             break;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -68,7 +68,10 @@ struct OpConfig {
         REQUANT,
         DEQUANT,
         MAXIMUM,
-        MINIMUM
+        MINIMUM,
+        LOGICAL_AND,
+        LOGICAL_OR,
+        LOGICAL_XOR,
     };
 
     template <class EnumT>


### PR DESCRIPTION
### Ticket
#22452 

### Problem description
logical AND currently does not support integer datatype

### What's changed
Added int32 support for logical AND in binary and binary_ng infra.
One tile perf [1, 1, 32, 32] = **8487 ns**

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16515356975) - latest run: https://github.com/tenstorrent/tt-metal/actions/runs/16525631675 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16560568262) - same as main
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/16515374056) - same as main
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16515407214) - same as main
- [x] New/Existing tests provide coverage for changes