### PR TITLE
Add test name into artifact name

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -265,7 +265,7 @@ jobs:
         env:
           TRACY_NO_INVARIANT_CHECK: 1
         run: |
-          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_$(date +%Y_%m_%d).csv
+          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${{ replace(matrix.test-info.name, ' ', '-') }}_$(date +%Y_%m_%d).csv
           python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
@@ -280,7 +280,7 @@ jobs:
         if: ${{ !cancelled() && steps.check-device-perf-report.conclusion == 'success' }}
         uses: actions/upload-artifact@v4
         with:
-          name: device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}
+          name: device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${{ replace(matrix.test-info.name, ' ', '-') }}
           path: /work/${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -286,7 +286,7 @@ jobs:
         if: ${{ !cancelled() && steps.check-device-perf-report.conclusion == 'success' }}
         uses: actions/upload-artifact@v4
         with:
-          name: device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${{ replace(matrix.test-info.name, ' ', '-') }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: /work/${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -265,8 +265,7 @@ jobs:
         env:
           TRACY_NO_INVARIANT_CHECK: 1
         run: |
-          CLEAN_NAME=$(echo "${{ matrix.test-info.name }}" | tr ' ' '-')
-          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${{ CLEAN_NAME }}_$(date +%Y_%m_%d).csv
+          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${{ replace(matrix.test-info.name, ' ', '-') }}_$(date +%Y_%m_%d).csv
           python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
@@ -279,13 +278,9 @@ jobs:
       - name: Upload device perf report
         timeout-minutes: 5
         if: ${{ !cancelled() && steps.check-device-perf-report.conclusion == 'success' }}
-        run: |
-          CLEAN_NAME=$(echo "${{ matrix.test-info.name }}" | tr ' ' '-')
-          ARTIFACT_NAME="device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${CLEAN_NAME}"
-          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_ENV"
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifact_name }}
+          name: device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${{ replace(matrix.test-info.name, ' ', '-') }}
           path: /work/${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -265,7 +265,8 @@ jobs:
         env:
           TRACY_NO_INVARIANT_CHECK: 1
         run: |
-          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${{ replace(matrix.test-info.name, ' ', '-') }}_$(date +%Y_%m_%d).csv
+          CLEAN_NAME=$(echo "${{ matrix.test-info.name }}" | tr ' ' '-')
+          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${{ CLEAN_NAME }}_$(date +%Y_%m_%d).csv
           python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
@@ -278,9 +279,13 @@ jobs:
       - name: Upload device perf report
         timeout-minutes: 5
         if: ${{ !cancelled() && steps.check-device-perf-report.conclusion == 'success' }}
+        run: |
+          CLEAN_NAME=$(echo "${{ matrix.test-info.name }}" | tr ' ' '-')
+          ARTIFACT_NAME="device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${CLEAN_NAME}"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_ENV"
         uses: actions/upload-artifact@v4
         with:
-          name: device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${{ replace(matrix.test-info.name, ' ', '-') }}
+          name: ${{ env.artifact_name }}
           path: /work/${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -265,7 +265,8 @@ jobs:
         env:
           TRACY_NO_INVARIANT_CHECK: 1
         run: |
-          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${{ replace(matrix.test-info.name, ' ', '-') }}_$(date +%Y_%m_%d).csv
+          CLEAN_NAME=$(echo "${{ matrix.test-info.name }}" | tr ' ' '-')
+          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_${CLEAN_NAME}_$(date +%Y_%m_%d).csv
           python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
@@ -274,6 +275,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           ls -hal ${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
+
+      - name: Clean test name for artifact
+        run: |
+          CLEAN_NAME=$(echo "${{ matrix.test-info.name }}" | tr ' ' '-')
+          echo "ARTIFACT_NAME=device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}-${CLEAN_NAME}" >> "$GITHUB_ENV"
 
       - name: Upload device perf report
         timeout-minutes: 5


### PR DESCRIPTION
### Problem description
When running the device performance regression workflow with a matrix of test configurations, multiple jobs attempted to upload artifacts with the same name. This resulted in a 409 Conflict error from GitHub Actions: "Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run." 

### What's changed
The artifact upload step was updated to use the replace function on matrix.test-info.name, converting spaces to dashes in the artifact name

This ensures all artifact names are unique and contain no spaces, preventing upload conflicts and improving artifact discoverability and management in the workflow.