### PR TITLE
#0: Add multiprocess send recv op tests and add to ci

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -27,6 +27,7 @@ jobs:
           { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k big-mesh multiprocess tests", arch: wormhole_b0, cmd: run_t3000_dual_rank_big_mesh_tests, timeout: 20, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 10, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 5, owner_id: U013121KDH9}, #Austin Ho
           { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -124,6 +124,22 @@ run_t3000_tt_metal_multiprocess_tests() {
   fi
 }
 
+run_t3000_ttnn_multiprocess_tests() {
+   # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_ttnn_multiprocess_tests"
+  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/unit_tests_ttnn_multihost_ccl_ops ; fail+=$?
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_ttnn_multiprocess_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_falcon7b_tests() {
   # Record the start time
   fail=0

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -108,36 +108,12 @@ run_t3000_ttnn_tests() {
 }
 
 run_t3000_tt_metal_multiprocess_tests() {
-   # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_tt_metal_multiprocess_tests"
   tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
   tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_tt_metal_multiprocess_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
 }
 
 run_t3000_ttnn_multiprocess_tests() {
-   # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_ttnn_multiprocess_tests"
-  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/unit_tests_ttnn_multihost_ccl_ops ; fail+=$?
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_ttnn_multiprocess_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/unit_tests_ttnn_multihost_ccl_ops
 }
 
 run_t3000_falcon7b_tests() {

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -124,6 +124,16 @@ target_sources(
 )
 setup_ttnn_test_target(unit_tests_ttnn_ccl_ops)
 
+# unit_tests_ttnn_multihost_ccl_ops
+add_executable(unit_tests_ttnn_multihost_ccl_ops)
+target_sources(
+    unit_tests_ttnn_multihost_ccl_ops
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+        multihost_ccl/test_send_recv_ops.cpp
+)
+setup_ttnn_test_target(unit_tests_ttnn_multihost_ccl_ops)
+
 # unit_tests_ttnn_fabric_edm
 
 add_executable(unit_tests_ttnn_fabric_edm)

--- a/tests/ttnn/unit_tests/gtests/multihost_ccl/test_send_recv_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/multihost_ccl/test_send_recv_ops.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+
+#include "ttnn/operations/experimental/ccl/send_recv_async/send_async/send_async.hpp"
+#include "ttnn/operations/experimental/ccl/send_recv_async/recv_async/recv_async.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
+
+#include "tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp"
+#include <tt-metalium/mesh_socket.hpp>
+#include <tt-metalium/distributed_context.hpp>
+#include "tests/ttnn/unit_tests/gtests/ccl/send_recv_op_utils.hpp"
+
+namespace tt::tt_metal {
+
+class MeshDeviceDual2x4SendRecvFixture : public tt::tt_fabric::fabric_router_tests::MeshDeviceDual2x4Fixture,
+                                         public testing::WithParamInterface<SocketTestArgs> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    MeshDeviceDual2x4SendRecvTests, MeshDeviceDual2x4SendRecvFixture, ::testing::ValuesIn(get_socket_test_args()));
+
+class MeshDeviceSplit2x2SendRecvFixture : public tt::tt_fabric::fabric_router_tests::MeshDeviceSplit2x2Fixture,
+                                          public testing::WithParamInterface<SocketTestArgs> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    MeshDeviceSplit2x2SendRecvTests, MeshDeviceSplit2x2SendRecvFixture, ::testing::ValuesIn(get_socket_test_args()));
+
+class MeshDeviceSplit1x2SendRecvFixture : public tt::tt_fabric::fabric_router_tests::MeshDeviceSplit1x2Fixture,
+                                          public testing::WithParamInterface<SocketTestArgs> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    MeshDeviceSplit1x2SendRecvTests, MeshDeviceSplit1x2SendRecvFixture, ::testing::ValuesIn(get_socket_test_args()));
+
+class MeshDeviceNanoExabox2x4SendRecvFixture
+    : public tt::tt_fabric::fabric_router_tests::MeshDeviceNanoExabox2x4Fixture,
+      public testing::WithParamInterface<SocketTestArgs> {};
+INSTANTIATE_TEST_SUITE_P(
+    MeshDeviceNanoExabox2x4SendRecvTests,
+    MeshDeviceNanoExabox2x4SendRecvFixture,
+    ::testing::ValuesIn(get_socket_test_args()));
+
+template <typename T>
+void test_send_recv_async_(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
+    const TensorSpec& tensor_spec,
+    BufferType socket_buffer_type,
+    distributed::multihost::Rank sender_rank,
+    distributed::multihost::Rank receiver_rank,
+    uint32_t seed) {
+    auto tag = tt::tt_metal::distributed::multihost::Tag{0};
+    auto sender_logical_coord = CoreCoord(0, 0);
+    auto recv_logical_coord = CoreCoord(0, 1);
+    uint32_t socket_fifo_size = 10 * 1024;
+    auto mesh_shape = mesh_device->shape();
+    std::vector<distributed::SocketConnection> forward_socket_connections;
+    forward_socket_connections.reserve(mesh_shape.mesh_size());
+    std::vector<distributed::SocketConnection> backward_socket_connections;
+    backward_socket_connections.reserve(mesh_shape.mesh_size());
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_shape)) {
+        forward_socket_connections.push_back({
+            .sender_core = {coord, sender_logical_coord},
+            .receiver_core = {coord, recv_logical_coord},
+        });
+        backward_socket_connections.push_back({
+            .sender_core = {coord, sender_logical_coord},
+            .receiver_core = {coord, recv_logical_coord},
+        });
+    }
+
+    distributed::SocketMemoryConfig socket_mem_config = {
+        .socket_storage_type = socket_buffer_type,
+        .fifo_size = socket_fifo_size,
+    };
+
+    distributed::SocketConfig forward_socket_config = {
+        .socket_connection_config = forward_socket_connections,
+        .socket_mem_config = socket_mem_config,
+        .sender_rank = sender_rank,
+        .receiver_rank = receiver_rank};
+    distributed::SocketConfig backward_socket_config = {
+        .socket_connection_config = backward_socket_connections,
+        .socket_mem_config = socket_mem_config,
+        .sender_rank = receiver_rank,
+        .receiver_rank = sender_rank};
+    auto forward_socket = distributed::MeshSocket(mesh_device, forward_socket_config);
+    auto backward_socket = distributed::MeshSocket(mesh_device, backward_socket_config);
+    const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    const auto& input_shape = tensor_spec.logical_shape();
+    const auto& memory_config = tensor_spec.memory_config();
+    uint32_t num_elems = input_shape.volume();
+    auto layout = tensor_spec.layout();
+    auto dtype = tensor_spec.data_type();
+    if (*(distributed_context->rank()) == *sender_rank) {
+        const Tensor input_tensor =
+            ttnn::distributed::distribute_tensor(
+                ttnn::experimental::view(ttnn::arange(seed, seed + num_elems, 1, dtype), input_shape).to_layout(layout),
+                *ttnn::distributed::replicate_tensor_to_mesh_mapper(*mesh_device),
+                std::nullopt)
+                .to_device(mesh_device.get(), memory_config);
+        ttnn::experimental::send_async(input_tensor, forward_socket);
+        distributed::Synchronize(mesh_device.get(), std::nullopt);
+        auto composer = ttnn::distributed::concat_mesh_to_tensor_composer(*mesh_device, /*dim=*/0);
+        auto input_data = ttnn::distributed::aggregate_tensor(input_tensor, *composer).to_vector<T>();
+        // Send test results to the receiver host
+        distributed_context->send(
+            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(input_data.data()), input_data.size() * sizeof(T)),
+            receiver_rank,  // send to receiver host
+            tag             // exchange test results over tag 0
+        );
+        auto output_tensor = tt::tt_metal::allocate_tensor_on_device(
+            TensorSpec(input_shape, tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(layout), memory_config)),
+            mesh_device.get());
+        ttnn::experimental::recv_async(output_tensor, backward_socket);
+        distributed::Synchronize(mesh_device.get(), std::nullopt);
+        auto output_data = ttnn::distributed::aggregate_tensor(output_tensor, *composer).to_vector<T>();
+        std::vector<T> inc_output_data(output_data.size());
+        distributed_context->recv(
+            tt::stl::Span<std::byte>(
+                reinterpret_cast<std::byte*>(inc_output_data.data()), inc_output_data.size() * sizeof(T)),
+            receiver_rank,  // recv from receiver host
+            tag             // exchange test results over tag 0
+        );
+        EXPECT_EQ(output_data, inc_output_data);
+    } else {
+        auto output_tensor = tt::tt_metal::allocate_tensor_on_device(
+            TensorSpec(input_shape, tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(layout), memory_config)),
+            mesh_device.get());
+        ttnn::experimental::recv_async(output_tensor, forward_socket);
+        distributed::Synchronize(mesh_device.get(), std::nullopt);
+        auto composer = ttnn::distributed::concat_mesh_to_tensor_composer(*mesh_device, /*dim=*/0);
+        auto output_data = ttnn::distributed::aggregate_tensor(output_tensor, *composer).to_vector<T>();
+        std::vector<T> input_data(output_data.size());
+        distributed_context->recv(
+            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(input_data.data()), input_data.size() * sizeof(T)),
+            sender_rank,  // recv from sender host
+            tag           // exchange test results over tag 0
+        );
+        EXPECT_EQ(input_data, output_data);
+        auto inc_output_tensor = ttnn::add(output_tensor, 1);
+        ttnn::experimental::send_async(inc_output_tensor, backward_socket);
+        distributed::Synchronize(mesh_device.get(), std::nullopt);
+        auto inc_output_data = ttnn::distributed::aggregate_tensor(inc_output_tensor, *composer).to_vector<T>();
+        distributed_context->send(
+            tt::stl::Span<std::byte>(
+                reinterpret_cast<std::byte*>(inc_output_data.data()), inc_output_data.size() * sizeof(T)),
+            sender_rank,  // send to sender host
+            tag           // exchange test results over tag 0
+        );
+    }
+}
+
+void test_send_recv_async(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
+    const TensorSpec& tensor_spec,
+    BufferType socket_buffer_type,
+    distributed::multihost::Rank sender_rank,
+    distributed::multihost::Rank receiver_rank,
+    uint32_t seed) {
+    switch (tensor_spec.data_type()) {
+        case tt::tt_metal::DataType::BFLOAT16:
+            test_send_recv_async_<bfloat16>(
+                mesh_device, tensor_spec, socket_buffer_type, sender_rank, receiver_rank, seed);
+            break;
+        case tt::tt_metal::DataType::UINT32:
+            test_send_recv_async_<uint32_t>(
+                mesh_device, tensor_spec, socket_buffer_type, sender_rank, receiver_rank, seed);
+            break;
+        default: GTEST_SKIP() << "Unsupported data type: " << tensor_spec.data_type(); break;
+    }
+}
+
+TEST_P(MeshDeviceDual2x4SendRecvFixture, SendRecvAsync) {
+    auto [tensor_spec, socket_buffer_type] = GetParam();
+    for (uint32_t i = 0; i < 10; i++) {
+        test_send_recv_async(
+            mesh_device_,
+            tensor_spec,
+            socket_buffer_type,
+            distributed::multihost::Rank{0},
+            distributed::multihost::Rank{1},
+            i);
+        test_send_recv_async(
+            mesh_device_,
+            tensor_spec,
+            socket_buffer_type,
+            distributed::multihost::Rank{1},
+            distributed::multihost::Rank{0},
+            i);
+    }
+}
+
+TEST_P(MeshDeviceSplit2x2SendRecvFixture, SendRecvAsync) {
+    auto [tensor_spec, socket_buffer_type] = GetParam();
+    for (uint32_t i = 0; i < 10; i++) {
+        test_send_recv_async(
+            mesh_device_,
+            tensor_spec,
+            socket_buffer_type,
+            distributed::multihost::Rank{0},
+            distributed::multihost::Rank{1},
+            i);
+        test_send_recv_async(
+            mesh_device_,
+            tensor_spec,
+            socket_buffer_type,
+            distributed::multihost::Rank{1},
+            distributed::multihost::Rank{0},
+            i);
+    }
+}
+
+TEST_P(MeshDeviceSplit1x2SendRecvFixture, MultiSendRecvAsync) {
+    constexpr distributed::multihost::Rank receiver_rank = distributed::multihost::Rank{0};
+    auto [tensor_spec, socket_buffer_type] = GetParam();
+    const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    auto rank = *(distributed_context->rank());
+    for (uint32_t i = 0; i < 10; i++) {
+        if (rank == *receiver_rank || rank == 1) {
+            test_send_recv_async(
+                mesh_device_, tensor_spec, socket_buffer_type, distributed::multihost::Rank{1}, receiver_rank, i);
+        }
+        if (rank == *receiver_rank || rank == 2) {
+            test_send_recv_async(
+                mesh_device_, tensor_spec, socket_buffer_type, distributed::multihost::Rank{2}, receiver_rank, i);
+        }
+        if (rank == *receiver_rank || rank == 3) {
+            test_send_recv_async(
+                mesh_device_, tensor_spec, socket_buffer_type, distributed::multihost::Rank{3}, receiver_rank, i);
+        }
+    }
+}
+
+TEST_P(MeshDeviceNanoExabox2x4SendRecvFixture, MultiSendRecvAsync) {
+    constexpr distributed::multihost::Rank receiver_rank = distributed::multihost::Rank{1};
+    auto [tensor_spec, socket_buffer_type] = GetParam();
+    const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    auto rank = *(distributed_context->rank());
+    for (uint32_t i = 0; i < 10; i++) {
+        for (uint32_t r = 0; r < *(distributed_context->size()); r++) {
+            if (r == *receiver_rank) {
+                continue;
+            }
+            if (rank == *receiver_rank || rank == r) {
+                test_send_recv_async(
+                    mesh_device_, tensor_spec, socket_buffer_type, distributed::multihost::Rank{r}, receiver_rank, i);
+            }
+        }
+    }
+}
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to add tests for send recv ops with multiprocessor to verify functionality.

### What's changed
Add multiprocessor/multihost send recv ops and add the 2x2 multiprocess configuration to CI.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/16530864271/job/46756076524