### PR TITLE
`llama3_subdevices/text_demo.py`: fixed broken `stop_at_eos` flag

### DIFF
--- a/models/demos/llama3_subdevices/README.md
+++ b/models/demos/llama3_subdevices/README.md
@@ -83,7 +83,7 @@ This would run the same test as 64K but with a 128K input prompt instead.
 - **paged_attention (bool)**: Whether to use paged attention (required for long contexts and vLLM compatibility). On by default.
 - **page_params (dict)**: Parameters for paged attention `{block_size, max_num_blocks}`.
 - **sampling_params (dict)**: Sampling parameters for decoding `{temperature, top_p}`. If `temperature = 0`, it uses greedy decoding.
-- **stop_at_eos (bool)**: Whether to stop decoding when the model generates an end-of-sequence (EoS) token.
+- **stop_at_eos (bool)**: Whether to stop decoding when the model generates an end-of-sequence (EoS) token. This is currently hard set to False in `text_demo.py` for testing purposes.
 - **apc_test**: [Dev Flag] Runs a specific internal CI test.
 - **pcc_check**: [Dev Flag] Enables PCC comparison. To be used by specific internal CI tests.
 - **prefill-only profile**: [Dev Flag] Runs prefill only. To be used when measuring prefill OP performance.

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -498,6 +498,8 @@ def test_demo_text(
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
     sampling_params = request.config.getoption("--sampling_params") or sampling_params
+
+    stop_at_eos = False # Default to False
     if request.config.getoption("--stop_at_eos") in [
         0,
         1,
@@ -530,7 +532,6 @@ def test_demo_text(
     os.chmod(output_directory, 0o755)
     output_filename = f"{output_directory}/demo_user_output_{timestamp}.txt"
 
-    stop_at_eos = False  # Default to False
     if not stop_at_eos:
         logger.info(f"The decode generation will only stop at the max_generated_tokens limit == {max_generated_tokens}")
 

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -530,7 +530,7 @@ def test_demo_text(
     os.chmod(output_directory, 0o755)
     output_filename = f"{output_directory}/demo_user_output_{timestamp}.txt"
 
-    stop_at_eos = False
+    stop_at_eos = False  # Default to False
     if not stop_at_eos:
         logger.info(f"The decode generation will only stop at the max_generated_tokens limit == {max_generated_tokens}")
 
@@ -958,8 +958,9 @@ def test_demo_text(
             current_pos += 1
             iteration += 1
 
-            # Upper limit of generated tokens for each user
-            users_decoding = iteration < max_generated_tokens
+            # Upper limit of generated tokens for each user; if users_decoding is already False (say by hitting eos), then we don't need to check the max_generated_tokens.
+            if users_decoding:
+                users_decoding = iteration < max_generated_tokens
 
             # Final print
             if not users_decoding and not pcc_check:

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -499,7 +499,7 @@ def test_demo_text(
     page_params = request.config.getoption("--page_params") or page_params
     sampling_params = request.config.getoption("--sampling_params") or sampling_params
 
-    stop_at_eos = False # Default to False
+    stop_at_eos = False  # Default to False
     if request.config.getoption("--stop_at_eos") in [
         0,
         1,


### PR DESCRIPTION
### Ticket
This fixes #25825, where the `--stop_at_eos` flag is broken due to it being reset before the decode loop break

### Problem description
<img width="1634" height="1788" alt="image" src="https://github.com/user-attachments/assets/8797551c-9e27-4717-b26e-108b53ecf866" />
Illustrates how the `users_decoding` flag is being overwritten before being able to break the decode loop. Hence, even if an `eos` token has been generated, the decode loop will continue to run.

### What's changed
I wrapped the existing line
```
users_decoding = iteration < max_generated_tokens
```
in an if statement to only update `users_decoding` to the boolean statement if it is currently True.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes