### PR TITLE
#25469: Multi-host aware device reshapes

### DIFF
--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -71,23 +71,23 @@ TEST(BigMeshDualRankTest2x4, SystemMeshShape) {
     const MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids(
         MeshShape(2, 4), std::move(mapped_devices.fabric_node_ids));
     if (rank == HostRankId{0}) {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_remote());
     } else {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_local());
     }
 
     // Check fabric node IDs are set for all devices, globally.

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -71,23 +71,23 @@ TEST(BigMeshDualRankTest2x4, SystemMeshShape) {
     const MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids(
         MeshShape(2, 4), std::move(mapped_devices.fabric_node_ids));
     if (rank == HostRankId{0}) {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_remote());
     } else {
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).device_id.is_remote());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).device_id.is_local());
-        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).device_id.is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 1)).is_remote());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 2)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 3)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 2)).is_local());
+        EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 3)).is_local());
     }
 
     // Check fabric node IDs are set for all devices, globally.

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -246,7 +246,7 @@ class MeshEndToEnd2x4TraceTests : public MeshDeviceFixtureBase {
 protected:
     MeshEndToEnd2x4TraceTests() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape = MeshShape{2, 4},
             .num_cqs = 2,
             .trace_region_size = 3072,  // 1024 per workload necessary
         }) {}

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -65,10 +65,10 @@ TEST_F(MeshDevice2x4Test, MemoryAllocationStatistics) {
 }
 
 TEST_F(MeshDevice2x4Test, ViewIs2D) {
-    std::vector<MaybeRemote<IDevice*>> devices;
+    std::vector<IDevice*> devices;
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-        devices.push_back(MaybeRemote<IDevice*>::local(mesh_device_->get_view().get_device(coord)));
+        devices.push_back(mesh_device_->get_view().get_device(coord));
         fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
     }
 

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -65,10 +65,10 @@ TEST_F(MeshDevice2x4Test, MemoryAllocationStatistics) {
 }
 
 TEST_F(MeshDevice2x4Test, ViewIs2D) {
-    std::vector<IDevice*> devices;
+    std::vector<MaybeRemote<IDevice*>> devices;
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-        devices.push_back(mesh_device_->get_view().get_device(coord));
+        devices.push_back(MaybeRemote<IDevice*>::local(mesh_device_->get_view().get_device(coord)));
         fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
     }
 
@@ -143,7 +143,7 @@ TEST_F(MeshDeviceTest, CheckFabricNodeIds) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     EXPECT_EQ(mesh_device_->shape().dims(), 2);
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-        tt_fabric::FabricNodeId fabric_node_id = mesh_device_->get_device_fabric_node_id(coord);
+        tt_fabric::FabricNodeId fabric_node_id = mesh_device_->get_fabric_node_id(coord);
         EXPECT_EQ(
             control_plane.get_fabric_node_id_from_physical_chip_id(mesh_device_->get_device(coord)->id()),
             fabric_node_id);

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/maybe_remote.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "umd/device/types/arch.h"
@@ -30,6 +31,7 @@
 namespace tt::tt_metal::distributed {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::SizeIs;
 
 std::vector<chip_id_t> get_physical_device_ids(const MeshDevice& mesh) {
@@ -40,28 +42,6 @@ std::vector<chip_id_t> get_physical_device_ids(const MeshDevice& mesh) {
     return device_ids;
 }
 
-class T3KReshapeTestFixture : public ::testing::Test {
-private:
-    inline static ARCH arch = tt::ARCH::Invalid;
-    inline static size_t num_devices = 0;
-
-public:
-    static void SetUpTestSuite() {
-        arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        num_devices = tt::tt_metal::GetNumAvailableDevices();
-    }
-
-    void SetUp() override {
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (slow_dispatch) {
-            GTEST_SKIP() << "Skipping Multi-Device test suite, since it can only be run in Fast Dispatch Mode.";
-        }
-        if (num_devices != 8 or arch != tt::ARCH::WORMHOLE_B0) {
-            GTEST_SKIP() << "Skipping T3K Multi-Device test suite on non T3K machine.";
-        }
-    }
-};
-
 std::vector<MeshShape> get_mesh_shapes() {
     static tt::stl::Indestructible<std::vector<MeshShape>> kMeshShapes(std::vector<MeshShape>{
         MeshShape{1, 1}, MeshShape{1, 2}, MeshShape{1, 3}, MeshShape{1, 4}, MeshShape{1, 5}, MeshShape{1, 6},
@@ -71,32 +51,37 @@ std::vector<MeshShape> get_mesh_shapes() {
     return kMeshShapes.get();
 }
 
-class MeshConfigurationTest : public T3KReshapeTestFixture, public ::testing::WithParamInterface<MeshShape> {};
+class MeshConfigurationTest : public MeshDeviceFixtureBase, public ::testing::WithParamInterface<MeshShape> {
+public:
+    MeshConfigurationTest() :
+        MeshDeviceFixtureBase(Config{
+            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape_to_open = GetParam(),
+        }) {}
+};
 
-TEST_P(MeshConfigurationTest, MeshConfigurations) {
-    const auto& shape = GetParam();
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(shape),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
-    EXPECT_EQ(mesh->shape(), shape);
-    mesh->close();
-}
+TEST_P(MeshConfigurationTest, MeshConfigurations) { EXPECT_EQ(mesh_device_->shape(), GetParam()); }
 
 TEST_P(MeshConfigurationTest, GetMappedDevices) {
     const auto& shape = GetParam();
 
     auto& system_mesh = SystemMesh::instance();
     EXPECT_THAT(system_mesh.get_mapped_devices(shape).device_ids, SizeIs(shape.mesh_size()));
+    EXPECT_THAT(system_mesh.get_mapped_devices(shape).fabric_node_ids, SizeIs(shape.mesh_size()));
 }
 
 // Test all possible mesh configurations on T3000
 INSTANTIATE_TEST_SUITE_P(AllMeshShapes, MeshConfigurationTest, ::testing::ValuesIn(get_mesh_shapes()));
 
-class MeshDeviceReshapeRoundtripTest : public T3KReshapeTestFixture,
-                                       public ::testing::WithParamInterface<std::tuple<MeshShape, MeshShape>> {};
+class MeshDeviceReshapeRoundtripTest : public MeshDeviceFixtureBase,
+                                       public ::testing::WithParamInterface<std::tuple<MeshShape, MeshShape>> {
+public:
+    MeshDeviceReshapeRoundtripTest() :
+        MeshDeviceFixtureBase(Config{
+            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape_to_open = std::get<0>(GetParam()),
+        }) {}
+};
 
 TEST_P(MeshDeviceReshapeRoundtripTest, ReshapeBetweenConfigurations) {
     const auto& [old_shape, new_shape] = GetParam();
@@ -108,29 +93,22 @@ TEST_P(MeshDeviceReshapeRoundtripTest, ReshapeBetweenConfigurations) {
         GTEST_SKIP() << "Either old or new shape is in line configuration; we test this in From1x4To2x2Invalid";
     }
 
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(old_shape),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
+    EXPECT_EQ(mesh_device_->shape(), old_shape);
 
-    EXPECT_EQ(mesh->shape(), old_shape);
-
-    auto original_order = mesh->get_device_ids();
+    auto original_order = mesh_device_->get_device_ids();
 
     // Attempt reshape
-    mesh->reshape(new_shape);
+    mesh_device_->reshape(new_shape);
 
     // Verify new shape
-    EXPECT_EQ(mesh->shape(), new_shape);
+    EXPECT_EQ(mesh_device_->shape(), new_shape);
 
     // Verify device ordering is preserved
     if (old_shape == new_shape) {
-        EXPECT_EQ(mesh->get_device_ids(), original_order)
+        EXPECT_EQ(mesh_device_->get_device_ids(), original_order)
             << "Device ordering is preserved " << MeshShape(old_shape) << " -> " << new_shape;
     } else {
-        EXPECT_NE(mesh->get_device_ids(), original_order)
+        EXPECT_NE(mesh_device_->get_device_ids(), original_order)
             << "Device ordering is not preserved " << MeshShape(old_shape) << " -> " << new_shape;
     }
 }
@@ -141,10 +119,16 @@ INSTANTIATE_TEST_SUITE_P(
     MeshDeviceReshapeRoundtripTest,
     ::testing::Combine(::testing::ValuesIn(get_mesh_shapes()), ::testing::ValuesIn(get_mesh_shapes())));
 
-// Base class for non-parameterized tests
-using MeshDeviceReshapeTest = T3KReshapeTestFixture;
+class MeshDevice1x8ReshapeTest : public MeshDeviceFixtureBase {
+public:
+    MeshDevice1x8ReshapeTest() :
+        MeshDeviceFixtureBase(Config{
+            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape_to_open = MeshShape{1, 8},
+        }) {}
+};
 
-TEST_F(MeshDeviceReshapeTest, InvalidRequestedShape) {
+TEST_F(MeshDevice1x8ReshapeTest, InvalidRequestedShape) {
     auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
 
     // Shape too big.
@@ -162,36 +146,22 @@ TEST_F(MeshDeviceReshapeTest, InvalidRequestedShape) {
     EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(8), /*offset=*/MeshCoordinate(1)));
 }
 
-TEST_F(MeshDeviceReshapeTest, InvalidReshapeDimensions) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(MeshShape(1, 8)),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
-
+TEST_F(MeshDevice1x8ReshapeTest, InvalidReshapeDimensions) {
     // Test reshaping to dimensions that don't match total device count
-    EXPECT_THROW(mesh->reshape(MeshShape(3, 3)), std::runtime_error);  // 9 devices != 8
-    EXPECT_THROW(mesh->reshape(MeshShape(1, 9)), std::runtime_error);  // 9 devices != 8
+    EXPECT_THROW(mesh_device_->reshape(MeshShape(3, 3)), std::runtime_error);  // 9 devices != 8
+    EXPECT_THROW(mesh_device_->reshape(MeshShape(1, 9)), std::runtime_error);  // 9 devices != 8
 
     // Verify original shape is preserved after failed reshapes
-    EXPECT_EQ(mesh->shape(), MeshShape(1, 8));
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(1, 8));
 }
 
-TEST_F(MeshDeviceReshapeTest, From1x8To2x4ThenBackTo1x8) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(MeshShape(1, 8)),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
+TEST_F(MeshDevice1x8ReshapeTest, From1x8To2x4ThenBackTo1x8) {
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(1, 8));
+    auto original_order = mesh_device_->get_device_ids();
 
-    EXPECT_EQ(mesh->shape(), MeshShape(1, 8));
-    auto original_order = mesh->get_device_ids();
+    mesh_device_->reshape(MeshShape(2, 4));
 
-    mesh->reshape(MeshShape(2, 4));
-
-    EXPECT_EQ(mesh->shape(), MeshShape(2, 4));
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
     std::vector<chip_id_t> expected_physical_device_id_order = {
         original_order[0],
         original_order[1],
@@ -203,91 +173,102 @@ TEST_F(MeshDeviceReshapeTest, From1x8To2x4ThenBackTo1x8) {
         original_order[4],
     };
 
-    auto new_order = mesh->get_device_ids();
+    auto new_order = mesh_device_->get_device_ids();
     EXPECT_EQ(new_order, expected_physical_device_id_order);
 
-    mesh->reshape(MeshShape(1, 8));
-    EXPECT_EQ(mesh->get_device_ids(), original_order);
+    mesh_device_->reshape(MeshShape(1, 8));
+    EXPECT_EQ(mesh_device_->get_device_ids(), original_order);
 }
 
-TEST_F(MeshDeviceReshapeTest, InvalidTotalDeviceCount) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(MeshShape(1, 8)),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
-
+TEST_F(MeshDevice1x8ReshapeTest, InvalidTotalDeviceCount) {
     // Test reshaping to dimensions that don't match total device count
-    EXPECT_THROW(mesh->reshape(MeshShape(3, 3)), std::runtime_error);  // 9 devices != 8
-    EXPECT_THROW(mesh->reshape(MeshShape(1, 9)), std::runtime_error);  // 9 devices != 8
+    EXPECT_THROW(mesh_device_->reshape(MeshShape(3, 3)), std::runtime_error);  // 9 devices != 8
+    EXPECT_THROW(mesh_device_->reshape(MeshShape(1, 9)), std::runtime_error);  // 9 devices != 8
 
     // Verify original shape is preserved after failed reshapes
-    EXPECT_EQ(mesh->shape(), MeshShape(1, 8));
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(1, 8));
 }
 
-TEST_F(MeshDeviceReshapeTest, From1x4To2x2Invalid) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(MeshShape(1, 4)),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
+class MeshDevice1x4ReshapeTest : public MeshDeviceFixtureBase {
+public:
+    MeshDevice1x4ReshapeTest() :
+        MeshDeviceFixtureBase(Config{
+            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape_to_open = MeshShape{1, 4},
+        }) {}
+};
 
+TEST_F(MeshDevice1x4ReshapeTest, From1x4To2x2Invalid) {
     // This is an invalid reshape because the 1x4 mesh does not fully cover the 2x2 mesh
-    EXPECT_THROW(mesh->reshape(MeshShape(2, 2)), std::runtime_error);
+    EXPECT_THROW(mesh_device_->reshape(MeshShape(2, 2)), std::runtime_error);
 }
 
-TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
-    auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
+class MeshDevice2x2ReshapeTest : public MeshDeviceFixtureBase {
+public:
+    MeshDevice2x2ReshapeTest() :
+        MeshDeviceFixtureBase(Config{
+            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape_to_open = MeshShape{2, 2},
+        }) {}
+};
 
+TEST_F(MeshDevice2x2ReshapeTest, From1x4To2x2Valid) {
     // Fetch the device ids for a physically connected 2x2 mesh.
-    std::vector<chip_id_t> physical_device_ids;
-    for (const auto device_id : system_mesh.get_mapped_devices(MeshShape(2, 2)).device_ids) {
-        TT_FATAL(device_id.is_local(), "Device is not local");
-        physical_device_ids.push_back(*device_id);
-    }
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 2));
+    std::vector<chip_id_t> physical_device_ids = mesh_device_->get_device_ids();
 
     // Supply the physical device ids to the mesh constructor that we know we know is 2x2 physically connected.
     // We will create a 1x4 mesh and then reshape it to 2x2.
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    mesh_device_.reset();
+    mesh_device_ = tt::tt_metal::distributed::MeshDevice::create(
         MeshDeviceConfig(MeshShape(1, 4), /*offset=*/std::nullopt, /*physical_device_ids=*/physical_device_ids),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
         tt::tt_metal::DispatchCoreType::WORKER);
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(1, 4));
 
-    mesh->reshape(MeshShape(2, 2));
-    EXPECT_EQ(mesh->shape(), MeshShape(2, 2));
-    auto new_layout = mesh->get_device_ids();
-    for (auto physical_device_id : physical_device_ids) {
-        EXPECT_TRUE(std::find(new_layout.begin(), new_layout.end(), physical_device_id) != new_layout.end());
-    }
+    mesh_device_->reshape(MeshShape(2, 2));
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 2));
+
+    EXPECT_THAT(
+        mesh_device_->get_device_ids(),
+        ElementsAre(physical_device_ids[0], physical_device_ids[1], physical_device_ids[2], physical_device_ids[3]));
 }
 
-TEST_F(MeshDeviceReshapeTest, From2x2To1x4) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig(MeshShape(2, 2)),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
+class MeshDevice2x2WithOffsetReshapeTest : public MeshDeviceFixtureBase,
+                                           public testing::WithParamInterface<MeshCoordinate> {
+public:
+    MeshDevice2x2WithOffsetReshapeTest() :
+        MeshDeviceFixtureBase(Config{
+            .system_mesh_shape = MeshShape{2, 4},
+            .mesh_shape_to_open = MeshShape{2, 2},
+            .mesh_offset_to_open = GetParam(),
+        }) {}
+};
 
-    auto mesh_2x2_device_ids = mesh->get_device_ids();
+TEST_P(MeshDevice2x2WithOffsetReshapeTest, From2x2To1x4ThenBackTo2x2) {
+    auto mesh_2x2_device_ids = mesh_device_->get_device_ids();
 
-    mesh->reshape(MeshShape(1, 4));
-    EXPECT_EQ(mesh->shape(), MeshShape(1, 4));
+    mesh_device_->reshape(MeshShape(1, 4));
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(1, 4));
 
-    auto mesh_1x4_device_ids = mesh->get_device_ids();
-    std::vector<chip_id_t> expected_1x4_device_ids = {
-        mesh_2x2_device_ids[0],
-        mesh_2x2_device_ids[1],
-        mesh_2x2_device_ids[3],
-        mesh_2x2_device_ids[2],
-    };
+    EXPECT_THAT(
+        mesh_device_->get_device_ids(),
+        ElementsAre(mesh_2x2_device_ids[0], mesh_2x2_device_ids[1], mesh_2x2_device_ids[3], mesh_2x2_device_ids[2]));
 
-    EXPECT_EQ(mesh_1x4_device_ids, expected_1x4_device_ids);
+    mesh_device_->reshape(MeshShape(2, 2));
+    EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 2));
+
+    EXPECT_THAT(
+        mesh_device_->get_device_ids(),
+        ElementsAre(mesh_2x2_device_ids[0], mesh_2x2_device_ids[1], mesh_2x2_device_ids[2], mesh_2x2_device_ids[3]));
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    AllMeshOffsets,
+    MeshDevice2x2WithOffsetReshapeTest,
+    testing::Values(MeshCoordinate(0, 0), MeshCoordinate(0, 1), MeshCoordinate(0, 2)));
 
 }  // namespace
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -55,8 +55,7 @@ class MeshConfigurationTest : public MeshDeviceFixtureBase, public ::testing::Wi
 public:
     MeshConfigurationTest() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .mesh_shape_to_open = GetParam(),
+            .mesh_shape = GetParam(),
         }) {}
 };
 
@@ -78,8 +77,7 @@ class MeshDeviceReshapeRoundtripTest : public MeshDeviceFixtureBase,
 public:
     MeshDeviceReshapeRoundtripTest() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .mesh_shape_to_open = std::get<0>(GetParam()),
+            .mesh_shape = std::get<0>(GetParam()),
         }) {}
 };
 
@@ -123,8 +121,7 @@ class MeshDevice1x8ReshapeTest : public MeshDeviceFixtureBase {
 public:
     MeshDevice1x8ReshapeTest() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .mesh_shape_to_open = MeshShape{1, 8},
+            .mesh_shape = MeshShape{1, 8},
         }) {}
 };
 
@@ -193,8 +190,7 @@ class MeshDevice1x4ReshapeTest : public MeshDeviceFixtureBase {
 public:
     MeshDevice1x4ReshapeTest() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .mesh_shape_to_open = MeshShape{1, 4},
+            .mesh_shape = MeshShape{1, 4},
         }) {}
 };
 
@@ -207,8 +203,7 @@ class MeshDevice2x2ReshapeTest : public MeshDeviceFixtureBase {
 public:
     MeshDevice2x2ReshapeTest() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .mesh_shape_to_open = MeshShape{2, 2},
+            .mesh_shape = MeshShape{2, 2},
         }) {}
 };
 
@@ -241,9 +236,8 @@ class MeshDevice2x2WithOffsetReshapeTest : public MeshDeviceFixtureBase,
 public:
     MeshDevice2x2WithOffsetReshapeTest() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .mesh_shape_to_open = MeshShape{2, 2},
-            .mesh_offset_to_open = GetParam(),
+            .mesh_shape = MeshShape{2, 2},
+            .mesh_offset = GetParam(),
         }) {}
 };
 

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -91,13 +91,13 @@ protected:
 class MeshTraceTest2x4 : public MeshDeviceFixtureBase {
 protected:
     MeshTraceTest2x4() :
-        MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}, .trace_region_size = (64 << 20)}) {}
+        MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 4}, .trace_region_size = (64 << 20)}) {}
 };
 
 class MeshTraceTest4x8 : public MeshDeviceFixtureBase {
 protected:
     MeshTraceTest4x8() :
-        MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{4, 8}, .trace_region_size = (64 << 20)}) {}
+        MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{4, 8}, .trace_region_size = (64 << 20)}) {}
 };
 
 TEST_F(MeshTraceTestSuite, Sanity) {

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -109,8 +109,7 @@ void test_socket_send_recv(
                     src_vec,
                     connection.sender_core.device_coord);
 
-                auto sender_fabric_node_id =
-                    mesh_device_->get_device_fabric_node_id(connection.sender_core.device_coord);
+                auto sender_fabric_node_id = mesh_device_->get_fabric_node_id(connection.sender_core.device_coord);
                 auto recv_fabric_node_id =
                     socket.get_fabric_node_id(SocketEndpoint::RECEIVER, connection.receiver_core.device_coord);
 
@@ -169,8 +168,7 @@ void test_socket_send_recv(
             for (const auto& connection : socket.get_config().socket_connection_config) {
                 auto sender_fabric_node_id =
                     socket.get_fabric_node_id(SocketEndpoint::SENDER, connection.sender_core.device_coord);
-                auto recv_fabric_node_id =
-                    mesh_device_->get_device_fabric_node_id(connection.receiver_core.device_coord);
+                auto recv_fabric_node_id = mesh_device_->get_fabric_node_id(connection.receiver_core.device_coord);
 
                 auto recv_program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -93,13 +93,10 @@ protected:
     using MeshShape = ::tt::tt_metal::distributed::MeshShape;
 
     struct Config {
-        // If specified, the associated tests will run only if SystemMesh shape matches the specified shape.
-        std::optional<tt::tt_metal::distributed::MeshShape> system_mesh_shape;
-
         // If specified, the fixture will open a mesh device with the specified shape and offset.
         // Otherwise, SystemMesh shape with zero offset will be used.
-        std::optional<tt::tt_metal::distributed::MeshShape> mesh_shape_to_open;
-        std::optional<tt::tt_metal::distributed::MeshCoordinate> mesh_offset_to_open;
+        std::optional<tt::tt_metal::distributed::MeshShape> mesh_shape;
+        std::optional<tt::tt_metal::distributed::MeshCoordinate> mesh_offset;
 
         // If specified, the associated tests will run only if the machine architecture matches the specified
         // architecture.
@@ -130,12 +127,13 @@ protected:
         }
 
         const auto system_mesh_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
-        if (config_.system_mesh_shape.has_value() && *config_.system_mesh_shape != system_mesh_shape) {
+        if (config_.mesh_shape.has_value() && config_.mesh_shape->mesh_size() > system_mesh_shape.mesh_size()) {
             GTEST_SKIP() << fmt::format(
-                "Skipping MeshDevice test suite on a machine with SystemMesh {} that does not match the requested mesh "
+                "Skipping MeshDevice test suite on a machine with SystemMesh {} that is smaller than the requested "
+                "mesh "
                 "shape {}",
                 system_mesh_shape,
-                *config_.system_mesh_shape);
+                *config_.mesh_shape);
         }
 
         // Use ethernet dispatch for more than 1 CQ on T3K/N300
@@ -149,7 +147,7 @@ protected:
             tt_fabric::SetFabricConfig(config_.fabric_config);
         }
         mesh_device_ = MeshDevice::create(
-            MeshDeviceConfig(config_.mesh_shape_to_open.value_or(system_mesh_shape), config_.mesh_offset_to_open),
+            MeshDeviceConfig(config_.mesh_shape.value_or(system_mesh_shape), config_.mesh_offset),
             config_.l1_small_size,
             config_.trace_region_size,
             config_.num_cqs,
@@ -192,24 +190,24 @@ protected:
 // what is specified.
 class MeshDevice2x4Fixture : public MeshDeviceFixtureBase {
 protected:
-    MeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}}) {}
+    MeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 4}}) {}
 };
 
 class MeshDevice4x8Fixture : public MeshDeviceFixtureBase {
 protected:
-    MeshDevice4x8Fixture() : MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{4, 8}}) {}
+    MeshDevice4x8Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{4, 8}}) {}
 };
 
 class MultiCQMeshDevice2x4Fixture : public MeshDeviceFixtureBase {
 protected:
-    MultiCQMeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}, .num_cqs = 2}) {}
+    MultiCQMeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 4}, .num_cqs = 2}) {}
 };
 
 class MeshDevice2x4Fabric1DFixture : public MeshDeviceFixtureBase {
 protected:
     MeshDevice2x4Fabric1DFixture() :
-        MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_1D}) {}
+        MeshDeviceFixtureBase(
+            Config{.mesh_shape = MeshShape{2, 4}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_1D}) {}
 };
 
 class GenericMeshDeviceFabric2DFixture : public MeshDeviceFixtureBase {
@@ -222,9 +220,8 @@ class MeshDevice2x4Fabric2DFixture : public MeshDeviceFixtureBase {
 protected:
     MeshDevice2x4Fabric2DFixture() :
         MeshDeviceFixtureBase(Config{
-            .system_mesh_shape = MeshShape{2, 4},
-            .num_cqs = 1,
-            .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {}
+            .mesh_shape = MeshShape{2, 4}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {
+    }
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -271,7 +271,7 @@ public:
     std::vector<IDevice*> get_devices() const;
     IDevice* get_device(chip_id_t physical_device_id) const;
     IDevice* get_device(const MeshCoordinate& coord) const;
-    tt_fabric::FabricNodeId get_device_fabric_node_id(const MeshCoordinate& coord) const;
+    tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
 
     DeviceIds get_device_ids() const;
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -119,6 +119,18 @@ decltype(auto) validate_and_get_reference_value(
     return reference_value;
 }
 
+// Returns offset of the mesh device view in the system mesh.
+MeshCoordinate compute_system_mesh_offset(const MeshDeviceView& view) {
+    const auto origin_fabric_node_id = view.get_fabric_node_id(MeshCoordinate::zero_coordinate(view.shape().dims()));
+    const auto system_mesh_shape = SystemMesh::instance().shape();
+    for (const auto& coord : MeshCoordinateRange(system_mesh_shape)) {
+        if (coord.to_linear_index(system_mesh_shape) == origin_fabric_node_id.chip_id) {
+            return coord;
+        }
+    }
+    TT_THROW("Failed to find offset for mesh device view");
+}
+
 }  // namespace
 
 MeshDevice::ScopedDevices::ScopedDevices(
@@ -287,7 +299,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     auto mesh_device = std::make_shared<MeshDevice>(
         std::move(scoped_devices),
         std::make_unique<MeshDeviceView>(
-            MeshShape(1, device_ids.size()), extract_locals(scoped_devices->root_devices()), fabric_node_ids),
+            MeshShape(1, device_ids.size()), scoped_devices->root_devices(), fabric_node_ids),
         std::shared_ptr<MeshDevice>());
 
     auto submeshes = mesh_device->create_submeshes(MeshShape(1, 1));
@@ -448,9 +460,8 @@ IDevice* MeshDevice::get_device(size_t row_idx, size_t col_idx) const {
 
 IDevice* MeshDevice::get_device(const MeshCoordinate& coord) const { return view_->get_device(coord); }
 
-tt_fabric::FabricNodeId MeshDevice::get_device_fabric_node_id(const MeshCoordinate& coord) const {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    return control_plane.get_fabric_node_id_from_physical_chip_id(view_->get_device(coord)->id());
+tt_fabric::FabricNodeId MeshDevice::get_fabric_node_id(const MeshCoordinate& coord) const {
+    return view_->get_fabric_node_id(coord);
 }
 
 MeshCommandQueue& MeshDevice::mesh_command_queue(std::size_t cq_id) const {
@@ -486,10 +497,8 @@ const MeshShape& MeshDevice::shape() const { return view_->shape(); }
 bool MeshDevice::is_local(const MeshCoordinate& coord) const { return view_->is_local(coord); }
 
 void MeshDevice::reshape(const MeshShape& new_shape) {
-    TT_FATAL(view_->fully_local(), "Cannot reshape a mesh that is partially distributed");
-    TT_FATAL(
-        new_shape.mesh_size() == this->num_devices(),
-        "New shape must have the same number of devices as current shape");
+    const auto num_devices = view_->shape().mesh_size();
+    TT_FATAL(new_shape.mesh_size() == num_devices, "New shape must have the same number of devices as current shape");
 
     // MeshDeviceView requires devices to be provided as a 1D array in row-major order for the target mesh shape.
     // The physical connectivity between devices must be preserved when reshaping.
@@ -507,41 +516,44 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
     // For a 2x2 mesh shape:
     // - Preserves original 2x2 physical connectivity
     // - Row-major order will be: [0,1,3,2]
-    std::unordered_map<chip_id_t, size_t> physical_device_id_to_linearized_index;
-    for (size_t i = 0; i < this->num_devices(); i++) {
-        physical_device_id_to_linearized_index[this->get_devices()[i]->id()] = i;
+    std::unordered_set<tt::tt_fabric::FabricNodeId> current_fabric_nodes;
+    for (const auto& coord : MeshCoordinateRange(view_->shape())) {
+        current_fabric_nodes.insert(view_->get_fabric_node_id(coord));
     }
 
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
     // However, going from a Line mesh to an MxN mesh is not always possible.
-    std::vector<IDevice*> new_device_order;
+    std::vector<MaybeRemote<IDevice*>> new_device_order;
     std::vector<tt::tt_fabric::FabricNodeId> new_fabric_node_ids;
-    new_device_order.reserve(num_devices());
-    new_fabric_node_ids.reserve(num_devices());
+    new_device_order.reserve(num_devices);
+    new_fabric_node_ids.reserve(num_devices);
     if (new_shape.is_line_topology()) {
         auto line_coords = view_->get_line_coordinates();
         for (const auto& coord : line_coords) {
-            new_device_order.push_back(this->get_device(coord));
+            new_device_order.push_back(
+                view_->is_local(coord) ? MaybeRemote<IDevice*>::local(this->get_device(coord))
+                                       : MaybeRemote<IDevice*>::remote());
             new_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
         }
     } else {
-        auto new_mapped_devices = SystemMesh::instance().get_mapped_devices(new_shape);
-        new_fabric_node_ids = std::move(new_mapped_devices.fabric_node_ids);
-
-        for (const auto maybe_remote_device_id : new_mapped_devices.device_ids) {
-            TT_FATAL(maybe_remote_device_id.is_local(), "Device is not local");
-            if (physical_device_id_to_linearized_index.find(*maybe_remote_device_id) ==
-                physical_device_id_to_linearized_index.end()) {
-                TT_THROW(
-                    "User has requested a reshape of the MeshDevice to shape: {}, but it is not possible to form a "
-                    "physically connected mesh grid with the opened devices from the original shape: {}.",
-                    new_shape,
-                    view_->shape());
-            }
-            new_device_order.push_back(get_device(*maybe_remote_device_id));
+        // Do our best at requesting a new set of mapped devices from system mesh, starting at the offset of the first
+        // device in the original mesh.
+        auto new_mapped_devices =
+            SystemMesh::instance().get_mapped_devices(new_shape, compute_system_mesh_offset(*view_));
+        for (int i = 0; i < new_mapped_devices.device_ids.size(); i++) {
+            TT_FATAL(
+                current_fabric_nodes.contains(new_mapped_devices.fabric_node_ids[i]),
+                "User has requested a reshape of the MeshDevice to shape: {}, but it is not possible to form a "
+                "physically connected mesh grid with the opened devices from the original shape: {}.",
+                new_shape,
+                view_->shape());
+            new_device_order.push_back(
+                new_mapped_devices.device_ids[i].is_local()
+                    ? MaybeRemote<IDevice*>::local(get_device(*new_mapped_devices.device_ids[i]))
+                    : MaybeRemote<IDevice*>::remote());
         }
+        new_fabric_node_ids = std::move(new_mapped_devices.fabric_node_ids);
     }
-
     auto new_view = std::make_unique<MeshDeviceView>(new_shape, new_device_order, new_fabric_node_ids);
     view_ = std::move(new_view);
 }

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -244,7 +244,7 @@ void write_socket_configs(
                 const auto& [sender_core, recv_core] = connection;
                 TT_FATAL(sender_core.device_coord == device_coord, "Internal Error: Sender cores incorrectly grouped.");
                 auto [downstream_mesh_id, downstream_chip_id] = get_sender_receiver_chip_fabric_encoding(
-                    mesh_device->get_device_fabric_node_id(sender_core.device_coord),
+                    mesh_device->get_fabric_node_id(sender_core.device_coord),
                     tt_fabric::FabricNodeId(
                         tt_fabric::MeshId{peer_descriptor.mesh_ids[conn_idx]}, peer_descriptor.chip_ids[conn_idx]),
                     fabric_config,
@@ -278,7 +278,7 @@ void write_socket_configs(
                 auto [upstream_mesh_id, upstream_chip_id] = get_sender_receiver_chip_fabric_encoding(
                     tt_fabric::FabricNodeId(
                         tt_fabric::MeshId{peer_descriptor.mesh_ids[conn_idx]}, peer_descriptor.chip_ids[conn_idx]),
-                    mesh_device->get_device_fabric_node_id(recv_core.device_coord),
+                    mesh_device->get_fabric_node_id(recv_core.device_coord),
                     fabric_config,
                     SocketEndpoint::RECEIVER);
                 auto sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core.core_coord);
@@ -317,7 +317,7 @@ SocketPeerDescriptor generate_local_endpoint_descriptor(
     auto device = socket_endpoint.get_config_buffer()->device();
     for (const auto& [sender_core, recv_core] : config.socket_connection_config) {
         const auto& device_coord = is_sender ? sender_core.device_coord : recv_core.device_coord;
-        auto fabric_node_id = device->get_device_fabric_node_id(device_coord);
+        auto fabric_node_id = device->get_fabric_node_id(device_coord);
         local_endpoint_desc.mesh_ids.push_back(*fabric_node_id.mesh_id);
         local_endpoint_desc.chip_ids.push_back(fabric_node_id.chip_id);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_program.cpp
@@ -38,7 +38,7 @@ tt::tt_metal::operation::ProgramWithCallbacks recv_async_multicore(
         if (socket_mesh_device->get_device(connection.receiver_core.device_coord)->id() == target_device->id()) {
             receiver_core_coord = connection.receiver_core.core_coord;
             receiver_fabric_node_id =
-                output_tensor.mesh_device()->get_device_fabric_node_id(connection.sender_core.device_coord);
+                output_tensor.mesh_device()->get_fabric_node_id(connection.sender_core.device_coord);
             sender_fabric_node_id = mesh_socket.get_fabric_node_id(
                 tt::tt_metal::distributed::SocketEndpoint::SENDER, connection.sender_core.device_coord);
             break;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_program.cpp
@@ -36,8 +36,7 @@ tt::tt_metal::operation::ProgramWithCallbacks send_async_multicore(
         if (socket_mesh_device->get_device(connection.sender_core.device_coord)->id() == target_device->id()) {
             sender_core_coord = connection.sender_core.core_coord;
             receiver_core_coord = connection.receiver_core.core_coord;
-            sender_fabric_node_id =
-                input_tensor.mesh_device()->get_device_fabric_node_id(connection.sender_core.device_coord);
+            sender_fabric_node_id = input_tensor.mesh_device()->get_fabric_node_id(connection.sender_core.device_coord);
             receiver_fabric_node_id = mesh_socket.get_fabric_node_id(
                 tt::tt_metal::distributed::SocketEndpoint::RECEIVER, connection.receiver_core.device_coord);
             break;


### PR DESCRIPTION
### Ticket
#25469

### Problem description
Relax the requirement that re-shapes can only be done on fully local meshes.

### What's changed
* The key piece of this PR is relying on `FabricNodeId` to validate that we get the same set of devices from `SystemMesh`.
* Fixed issue of re-shaping `MeshDevice` opened at particular offsets within `SystemMesh`. See the added tests for the illustration.
* Get rid of `T3KReshapeTestFixture` and use the standard solution.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16656262867)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16656265125)
- [x] New/Existing tests provide coverage for changes