### PR TITLE
set dtype torch.bfloat16 for input tensor

### DIFF
--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -157,7 +157,9 @@ def test_attention_inference(
 
     for i in range(generation_length):
         # 70B attention block typically sees tensors with mean 0 and std 0.03 - 0.05 in layer 1
-        pt_attention_input = torch.randn(batch_size, seq_len, model_args.dim)  # Qwen2.5 0.5B sees 0.1 to 2.1
+        pt_attention_input = torch.randn(
+            batch_size, seq_len, model_args.dim, dtype=torch.bfloat16
+        )  # Qwen2.5 0.5B sees 0.1 to 2.1
 
         tt_attention_input = pt_attention_input.clone()
 

--- a/models/tt_transformers/tests/test_attention_prefill.py
+++ b/models/tt_transformers/tests/test_attention_prefill.py
@@ -134,7 +134,7 @@ def test_attention_inference(
         paged_attention_config=paged_attention_config,
     )
 
-    pt_attention_input = (torch.rand(batch_size, max_seq_len, model_args.dim) * 2) - 1
+    pt_attention_input = (torch.rand(batch_size, max_seq_len, model_args.dim, dtype=torch.bfloat16) * 2) - 1
     tt_attention_input = pt_attention_input.clone()
     attention_input = model_args.prepare_residual_tensor_prefill(
         tt_attention_input,

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -156,7 +156,7 @@ def test_decoder_inference(
         logger.info(f"[Decoder] Generating token {i}")
 
         # input = torch.randn(1, 32, 4096)
-        pt_decode_input = (torch.rand(batch_size, seqlen, model_args.dim) * 2) - 1
+        pt_decode_input = (torch.rand(batch_size, seqlen, model_args.dim, dtype=torch.bfloat16) * 2) - 1
         tt_decode_input = pt_decode_input.clone()
 
         decode_input = model_args.prepare_residual_tensor_decode(

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -141,7 +141,7 @@ def test_decoder_inference(
 
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
-        pt_decode_input = (torch.rand(batch_size, max_seq_len, model_args.dim) * 2) - 1
+        pt_decode_input = (torch.rand(batch_size, max_seq_len, model_args.dim, dtype=torch.bfloat16) * 2) - 1
         tt_decode_input = pt_decode_input.clone()
         decode_input = model_args.prepare_residual_tensor_prefill(
             tt_decode_input,

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -59,7 +59,7 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc)
         dtype=dtype,
         model_config=model_args.get_model_config(),
     )
-    torch_input = torch.randn(1, 1, seq_len, model_args.dim)
+    torch_input = torch.randn(1, 1, seq_len, model_args.dim, dtype=torch.bfloat16)
     reference_output = reference_model(torch_input)
     tt_input = ttnn.from_torch(
         torch_input,


### PR DESCRIPTION
### Ticket
None

### Problem description
dtype mismatch creates issue "expected m1 and m2 to have the same dtype, but got: float != c10::BFloat16"

### What's changed
Set input tensot dtype to torch.bfloat16

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes