### PR TITLE
Add Mesh Graph Descriptor support for P150x8, Add Health Checks for P150x2 and Update TTT for supporting P150x8

### DIFF
--- a/models/tt_transformers/demo/multimodal_demo_chat.py
+++ b/models/tt_transformers/demo/multimodal_demo_chat.py
@@ -25,9 +25,17 @@ from models.tt_transformers.tt.generator import Generator
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "N150x4": (1, 4),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150": (1, 1),
+            "P300": (1, 2),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
     ],
     indirect=True,
 )

--- a/models/tt_transformers/demo/multimodal_demo_text.py
+++ b/models/tt_transformers/demo/multimodal_demo_text.py
@@ -26,9 +26,17 @@ from models.tt_transformers.tt.generator import Generator
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "N150x4": (1, 4),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150": (1, 1),
+            "P300": (1, 2),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
     ],
     indirect=True,
 )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -511,9 +511,17 @@ def prepare_generator_args(
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "N150x4": (1, 4), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "N150x4": (1, 4),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150": (1, 1),
+            "P300": (1, 2),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
     ],
     indirect=True,
 )
@@ -946,7 +954,7 @@ def test_demo_text(
 
     # Benchmark targets
     supported_models = ["Llama-3.2-1B", "Llama-3.2-3B", "Llama-3.1-8B", "Llama-3.2-11B", "Llama-3.1-70B", "Mistral-7B"]
-    supported_devices = ["N150", "P100", "P150", "P300", "N300", "P150x4", "T3K", "TG"]
+    supported_devices = ["N150", "P100", "P150", "P300", "N300", "P150x4", "P150x8", "T3K", "TG"]
 
     tt_device_name = determine_device_name(mesh_device)  # submesh device should not decide performance target
     model_name = model_args[0].base_model_name

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -120,9 +120,17 @@ def prepare_generator_args(
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "N150x4": (1, 4), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "N150x4": (1, 4),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150": (1, 1),
+            "P300": (1, 2),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
     ],
     indirect=True,
 )

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2605,6 +2605,7 @@ def determine_device_name(mesh_device):
             1: "P100" if dram_grid_size and dram_grid_size.x == 7 else "P150",  # P100 DRAM grid is 7x1, P150 is 8x1
             2: "P300",
             4: "P150x4",
+            8: "P150x8",
         }
     elif is_wormhole_b0():
         dict_device_names = {

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -374,10 +374,18 @@ TEST(Cluster, TestMeshFullConnectivity) {
         num_expected_chips = 32;
         num_expected_mmio_chips = 32;
         num_connections_per_side = 4;
+    } else if (cluster_type == tt::tt_metal::ClusterType::P150_X2) {
+        num_expected_chips = 2;
+        num_expected_mmio_chips = 2;
+        num_connections_per_side = 4;
     } else if (cluster_type == tt::tt_metal::ClusterType::P150_X4) {
         num_expected_chips = 4;
         num_expected_mmio_chips = 4;
         num_connections_per_side = 4;
+    } else if (cluster_type == tt::tt_metal::ClusterType::P150_X8) {
+        num_expected_chips = 8;
+        num_expected_mmio_chips = 8;
+        num_connections_per_side = 2;
     } else {
         GTEST_SKIP() << "Mesh check not supported for system type " << enchantum::to_string(cluster_type);
     }

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(
             fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml

--- a/tt_metal/api/tt-metalium/cluster.hpp
+++ b/tt_metal/api/tt-metalium/cluster.hpp
@@ -35,9 +35,10 @@ enum class ClusterType : std::uint8_t {
     P150 = 7,                    // Blackhole single card, ethernet enabled
     P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
     P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
-    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
-    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
-    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
+    P150_X8 = 10,                // 8 Blackhole single card, ethernet connected
+    SIMULATOR_WORMHOLE_B0 = 11,  // Simulator Wormhole B0
+    SIMULATOR_BLACKHOLE = 12,    // Simulator Blackhole
+    N300_2x2 = 13,               // 2 N300 cards, ethernet connected to form 2x2
 };
 
 /**

--- a/tt_metal/api/tt-metalium/cluster.hpp
+++ b/tt_metal/api/tt-metalium/cluster.hpp
@@ -35,10 +35,10 @@ enum class ClusterType : std::uint8_t {
     P150 = 7,                    // Blackhole single card, ethernet enabled
     P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
     P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
-    P150_X8 = 10,                // 8 Blackhole single card, ethernet connected
-    SIMULATOR_WORMHOLE_B0 = 11,  // Simulator Wormhole B0
-    SIMULATOR_BLACKHOLE = 12,    // Simulator Blackhole
-    N300_2x2 = 13,               // 2 N300 cards, ethernet connected to form 2x2
+    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
+    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
+    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
+    P150_X8 = 13,                // 8 Blackhole single card, ethernet connected
 };
 
 /**

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -48,6 +48,7 @@ const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std:
                 {tt::tt_metal::ClusterType::P150, "p150_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::P150_X2, "p150_x2_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::P150_X4, "p150_x4_mesh_graph_descriptor.yaml"},
+                {tt::tt_metal::ClusterType::P150_X8, "p150_x8_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "n150_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "p150_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.yaml"}});

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
@@ -1,0 +1,27 @@
+ChipSpec: {
+  arch: blackhole,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+Board: [
+  { name: P150,
+    type: Mesh,
+    topology: [2, 4]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: P150,
+  device_topology: [2, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -171,6 +171,8 @@ tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
                 cluster_type = tt::tt_metal::ClusterType::P150_X2;
             } else if (cluster_desc->get_all_chips().size() == 4) {
                 cluster_type = tt::tt_metal::ClusterType::P150_X4;
+            } else if (cluster_desc->get_all_chips().size() == 8) {
+                cluster_type = tt::tt_metal::ClusterType::P150_X8;
             }
         } else if (board_type == BoardType::UBB) {
             cluster_type = tt::tt_metal::ClusterType::GALAXY;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -64,6 +64,23 @@ enum class TargetDevice : std::uint8_t {
     Invalid = 0xFF,
 };
 
+enum class ClusterType : std::uint8_t {
+    INVALID = 0,
+    N150 = 1,                    // Production N150
+    N300 = 2,                    // Production N300
+    T3K = 3,                     // Production T3K, built with 4 N300s
+    GALAXY = 4,                  // Production Galaxy, all chips with mmio
+    TG = 5,                      // Will be deprecated
+    P100 = 6,                    // Blackhole single card, ethernet disabled
+    P150 = 7,                    // Blackhole single card, ethernet enabled
+    P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
+    P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
+    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
+    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
+    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
+    P150_X8 = 13,                // 8 Blackhole single card, ethernet connected
+};
+
 enum class EthRouterMode : uint32_t {
     IDLE = 0,
     FABRIC_ROUTER = 1,

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -64,23 +64,6 @@ enum class TargetDevice : std::uint8_t {
     Invalid = 0xFF,
 };
 
-enum class ClusterType : std::uint8_t {
-    INVALID = 0,
-    N150 = 1,                    // Production N150
-    N300 = 2,                    // Production N300
-    T3K = 3,                     // Production T3K, built with 4 N300s
-    GALAXY = 4,                  // Production Galaxy, all chips with mmio
-    TG = 5,                      // Will be deprecated
-    P100 = 6,                    // Blackhole single card, ethernet disabled
-    P150 = 7,                    // Blackhole single card, ethernet enabled
-    P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
-    P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
-    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
-    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
-    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
-    P150_X8 = 13,                // 8 Blackhole single card, ethernet connected
-};
-
 enum class EthRouterMode : uint32_t {
     IDLE = 0,
     FABRIC_ROUTER = 1,

--- a/ttnn/cpp/ttnn-pybind/cluster.cpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.cpp
@@ -68,6 +68,7 @@ void py_cluster_module_types(py::module& module) {
         .value("P150", tt::tt_metal::ClusterType::P150, "Blackhole single card, ethernet enabled")
         .value("P150_X2", tt::tt_metal::ClusterType::P150_X2, "2 Blackhole single card, ethernet connected")
         .value("P150_X4", tt::tt_metal::ClusterType::P150_X4, "4 Blackhole single card, ethernet connected")
+        .value("P150_X8", tt::tt_metal::ClusterType::P150_X8, "8 Blackhole single card, ethernet connected")
         .value("SIMULATOR_WORMHOLE_B0", tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "Simulator Wormhole B0")
         .value("SIMULATOR_BLACKHOLE", tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "Simulator Blackhole")
         .value("N300_2x2", tt::tt_metal::ClusterType::N300_2x2, "2 N300 cards, ethernet connected to form 2x2");


### PR DESCRIPTION
### Problem description
Previously P150x8 Rackbox was not a supported cluster type configuration. This PR adds support for that configuration and provides the mesh device yaml as well as updates fabric tests. This also updates 

### What's changed
- update fabric and health check tests for P150x8
- add mesh graph descriptor for P150x8
- add cluster type for rackbox
- update the simple text demo in TTT to add support for P150x8

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes