### PR TITLE
Run blackhole post-commit on p150b CIv2 runners by default. Run p100 1x nightly.

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -40,20 +40,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  ttnn-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150b"]') }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.card_type }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   blackhole-llmbox-demo-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -4,14 +4,10 @@ on:
   workflow_call:
     inputs:
       runner-label:
-          description: 'Optional: BH'
+          description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only), ["BH-LLMBox"] (4xP150 only, needs boolean enable-llmbox-tests)'
           required: false
           type: string
-          default: 'BH'
-      enable-ttnn-unit-tests:
-          description: 'Enable ttnn unit tests'
-          default: false
-          type: boolean
+          default: '["P150"]'
       enable-watcher:
           description: 'Enable watcher in BH Post commit'
           default: false
@@ -23,10 +19,10 @@ on:
   workflow_dispatch:
     inputs:
       runner-label:
-          description: 'Optional: BH'
-          required: true
-          type: string
-          default: 'BH'
+        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only), ["BH-LLMBox"] (4xP150 only, needs boolean enable-llmbox-tests)'
+        required: false
+        type: string
+        default: '["P150"]'
       build-type:
         description: 'Build type for the workflow'
         required: false
@@ -38,10 +34,6 @@ on:
           - RelWithDebInfo
           - ASan
           - TSan
-      enable-ttnn-unit-tests:
-        description: 'Enable ttnn unit tests'
-        default: false
-        type: boolean
       enable-watcher:
         description: 'Enable watcher in BH Post commit'
         default: false
@@ -52,11 +44,12 @@ on:
         type: boolean
   schedule:
     - cron: "0 */4 * * *"
+    - cron: "0 0 * * *"  # Every day at 0:00 UTC
   # Pause this since not enough runners to support every commit to main
   # push:
   #  branches: ["main"]
 
-run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled) ' || 'Blackhole post-commit tests') }}
+run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled) ' || ((github.event_name == 'schedule' && github.event.schedule == '0 0 * * *') && 'Blackhole post-commit tests (P100 nightly) ' || 'Blackhole post-commit tests') }}
 
 permissions:
   actions: read
@@ -76,22 +69,47 @@ jobs:
       civ2-viommu-matrix: ${{ steps.set-matrix.outputs.civ2-viommu-matrix }}
     steps:
       - id: set-matrix
+        shell: bash
         run: |
-          if [ "${{ inputs.enable-llmbox-tests }}" = "true" ]; then
-            if [ "${{ inputs.runner-label }}" != "BH-LLMBox" ]; then
-              echo "::warning::LLMBox tests are enabled but runner-label is not set to BH-LLMBox. Current value: ${{ inputs.runner-label }}"
+          # Store runner-label with fallback in a variable for reuse
+          runner_label='${{ inputs.runner-label || '["P150"]' }}'
+
+          # Check if this is a scheduled P100-only run at midnight UTC (daily)
+          if [[ "${{ github.event_name }}" = "schedule" && "${{ github.event.schedule }}" = "0 0 * * *" ]]; then
+            matrix='["P100"]'
+            civ2_matrix='["P100"]'
+            civ2_viommu_matrix='["P100"]'
+          elif [ "${{ inputs.enable-llmbox-tests }}" = "true" ]; then
+            if [[ "$runner_label" != *"BH-LLMBox"* ]]; then
+              echo "::warning::LLMBox tests are enabled but runner-label does not contain BH-LLMBox. Current value: $runner_label"
             fi
             matrix='["BH-LLMBox"]'
             civ2_matrix='["BH-LLMBox"]'
             civ2_viommu_matrix='["BH-LLMBox"]'
           else
-            matrix='["P100", "P150"]'
-            civ2_matrix='["P100", "P150b"]'
-            civ2_viommu_matrix='["P100", "P150b-viommu"]'
+            matrix="$runner_label"
+            civ2_matrix="$runner_label"
+            civ2_viommu_matrix="$runner_label"
+
+            # Transform P150 to P150b for civ2_matrix (only if P150 exists, not P150b)
+            if [[ "$runner_label" == *"P150"* && "$runner_label" != *"P150b"* ]]; then
+              civ2_matrix=$(echo "$runner_label" | sed 's/"P150"/"P150b"/g')
+            fi
+
+            # Transform P150 to P150b-viommu for civ2_viommu_matrix (only if P150 exists, not P150b)
+            if [[ "$runner_label" == *"P150"* && "$runner_label" != *"P150b"* ]]; then
+              civ2_viommu_matrix=$(echo "$runner_label" | sed 's/"P150"/"P150b-viommu"/g')
+            fi
           fi
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
           echo "civ2-matrix=$civ2_matrix" >> $GITHUB_OUTPUT
           echo "civ2-viommu-matrix=$civ2_viommu_matrix" >> $GITHUB_OUTPUT
+
+          # Print matrices
+          echo "Final matrix values:"
+          echo "matrix: $matrix"
+          echo "civ2_matrix: $civ2_matrix"
+          echo "civ2_viommu_matrix: $civ2_viommu_matrix"
 
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
@@ -114,55 +132,75 @@ jobs:
       tracy: true
       version: "22.04"
   run-profiler-regression:
-    needs: build-artifact-profiler
+    needs: [build-artifact-profiler, generate-matrix]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: "blackhole"
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   umd-unit-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   sd-unit-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   fd-unit-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
       timeout: 40
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   # FD C++ Unit Tests
   cpp-unit-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/cpp-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
@@ -198,13 +236,16 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   ttnn-unit-tests:
-    needs: build-artifact
-    if: ${{ inputs.enable-ttnn-unit-tests }}
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -44,7 +44,7 @@ on:
         type: boolean
   schedule:
     - cron: "0 */4 * * *"
-    - cron: "0 0 * * *"  # Every day at 0:00 UTC
+    - cron: "0 7 * * *"  # Every day at 7:00 UTC
   # Pause this since not enough runners to support every commit to main
   # push:
   #  branches: ["main"]
@@ -74,8 +74,8 @@ jobs:
           # Store runner-label with fallback in a variable for reuse
           runner_label='${{ inputs.runner-label || '["P150"]' }}'
 
-          # Check if this is a scheduled P100-only run at midnight UTC (daily)
-          if [[ "${{ github.event_name }}" = "schedule" && "${{ github.event.schedule }}" = "0 0 * * *" ]]; then
+          # Check if this is a scheduled P100-only run at 7:00 UTC (daily)
+          if [[ "${{ github.event_name }}" = "schedule" && "${{ github.event.schedule }}" = "0 7 * * *" ]]; then
             matrix='["P100"]'
             civ2_matrix='["P100"]'
             civ2_viommu_matrix='["P100"]'

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -46,8 +46,8 @@ on:
     - cron: "0 */4 * * *"
     - cron: "0 7 * * *"  # Every day at 7:00 UTC
   # Pause this since not enough runners to support every commit to main
-  push:
-   branches: ["williamly/bh-in-apc"]
+  # push:
+  #  branches: ["main"]
 
 run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -49,7 +49,7 @@ on:
   # push:
   #  branches: ["main"]
 
-run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled) ' || ((github.event_name == 'schedule' && github.event.schedule == '0 0 * * *') && 'Blackhole post-commit tests (P100 nightly) ' || 'Blackhole post-commit tests') }}
+run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)' || (github.event_name == 'schedule' && github.event.schedule == '0 0 * * *') && 'Blackhole post-commit tests (P100 nightly)' || 'Blackhole post-commit tests') }}
 
 permissions:
   actions: read

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -49,7 +49,7 @@ on:
   # push:
   #  branches: ["main"]
 
-run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 0 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
+run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 
 permissions:
   actions: read

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -46,8 +46,8 @@ on:
     - cron: "0 */4 * * *"
     - cron: "0 7 * * *"  # Every day at 7:00 UTC
   # Pause this since not enough runners to support every commit to main
-  # push:
-  #  branches: ["main"]
+  push:
+   branches: ["williamly/bh-in-apc"]
 
 run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -49,7 +49,7 @@ on:
   # push:
   #  branches: ["main"]
 
-run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)' || (github.event_name == 'schedule' && github.event.schedule == '0 0 * * *') && 'Blackhole post-commit tests (P100 nightly)' || 'Blackhole post-commit tests') }}
+run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 0 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 
 permissions:
   actions: read

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -257,7 +257,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: >-
       ${{
         (startsWith(inputs.runner-label, 'tt-beta-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)))
-        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        || (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     steps:

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -44,7 +44,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -313,11 +313,7 @@ jobs:
 
           # Trigger workflow with appropriate inputs
           echo "Triggering $WORKFLOW..."
-          if [ "$WORKFLOW" = "blackhole-post-commit.yaml" ]; then
-            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" -f enable-ttnn-unit-tests=true --repo "${{ github.repository }}"
-          else
-            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
-          fi
+          gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
 
           # Wait for the new run to appear and ensure it's created after trigger time
           run_id=""

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -29,8 +29,8 @@ jobs:
     runs-on: >-
       ${{
         contains('P150b, N150, N300', inputs.runner-label) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || (inputs.runner-label == 'config-tg' || inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)
+        || (inputs.runner-label == 'config-tg' || inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -26,12 +26,12 @@ on:
 jobs:
   ttnn:
     name: ttnn stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on:
-      - "in-service"
-      - "${{ inputs.runner-label }}"
-      - "${{ (inputs.runner-label == 'config-tg' || inputs.runner-label == 'topology-6u') && 'bare-metal' || 'cloud-virtual-machine' }}"
-
-
+    runs-on: >-
+      ${{
+        contains('P150b, N150, N300', inputs.runner-label) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        || (inputs.runner-label == 'config-tg' || inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label)
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)
+      }}
     container:
       image: ${{ inputs.docker-image }}
       env:

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -23,10 +23,11 @@ on:
 jobs:
   umd-unit-tests:
     name: UMD tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on:
-      - ${{ inputs.runner-label }}
-      - cloud-virtual-machine
-      - in-service
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+      }}
     container:
       image: ${{ inputs.docker-image }}
       env:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21401

### Problem description
We have more capacity in CIv2 than CIv1 for blackhole now, so we should be running the tests on p150 CIv2 runners.
However, we don't want to stop testing p100 which is CIv1 only.

### What's changed

- Move ttnn unit tests from BH nightly to BH post commit.
- Run on p150b CIv2 runners by default for BH post commit (both schedule + dispatch)
- Run blackhole post commit with p100 on a 1x/night schedule

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16606512967
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16606403238
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/16605355247