### PR TITLE
Add Fabric 1D ring support for all_to_all_dispatch

### DIFF
--- a/tests/ttnn/multidevice_perf_tests/test_all_to_all_dispatch_perf.py
+++ b/tests/ttnn/multidevice_perf_tests/test_all_to_all_dispatch_perf.py
@@ -12,10 +12,10 @@ from models.perf.device_perf_utils import run_device_perf_detailed
 @pytest.mark.parametrize(
     "warmup_iters, arch_type, stage, perf_target_max_us, perf_target_min_us",
     [
-        (5, "6U", "decode", 31, 24),
+        (5, "6U", "decode", 24, 20),
         (5, "TG", "decode", 61, 52),
         (5, "T3K", "decode", 38, 32),  # huge variance among machines for T3K
-        (1, "6U", "prefill", 2000, 1400),
+        (1, "6U", "prefill", 1600, 1300),
         (1, "TG", "prefill", 2700, 2000),
         (1, "T3K", "prefill", 4300, 3800),
     ],

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py
@@ -25,6 +25,7 @@ from tracy import signpost
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_2D},
     ],
+    ids=["fabric_1d", "fabric_1d_ring", "fabric_2d"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [False])
@@ -114,6 +115,7 @@ def test_all_to_all_dispatch_no_trace(
             "trace_region_size": 500000,
         },
     ],
+    ids=["fabric_1d", "fabric_1d_ring", "fabric_2d"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [True])
@@ -194,6 +196,7 @@ def test_all_to_all_dispatch_trace(
             "trace_region_size": 500000,
         }
     ],
+    ids=["fabric_1d_ring"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [True])
@@ -273,6 +276,7 @@ def test_decode_perf(
             "trace_region_size": 500000,
         }
     ],
+    ids=["fabric_1d_ring"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [True])

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py
@@ -22,6 +22,7 @@ from tracy import signpost
     "device_params",
     [
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_2D},
     ],
     indirect=True,
@@ -104,7 +105,12 @@ def test_all_to_all_dispatch_no_trace(
         },
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "trace_region_size": 500000,
+        },
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
             "trace_region_size": 500000,
         },
     ],
@@ -184,7 +190,7 @@ def test_all_to_all_dispatch_trace(
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
             "trace_region_size": 500000,
         }
     ],
@@ -263,7 +269,7 @@ def test_decode_perf(
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
             "trace_region_size": 500000,
         }
     ],

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -270,7 +270,7 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     };
     for (auto& neighbor : neighbors) {
         auto neighbor_coordinate = mesh_view.find_device(neighbor->id());
-        uint32_t link_id = common::select_link(mesh_view, mesh_coordinate, neighbor_coordinate, num_links, topology);
+        uint32_t link_id = 0;
         const auto neighbor_fabric_id = get_fabric_node_id_from_physical_chip_id(neighbor->id());
         append_fabric_connection_rt_args(
             fabric_node_id, neighbor_fabric_id, link_id, program, sender_core, writer_runtime_args);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -74,8 +74,6 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         operation_attributes.cross_device_semaphore.has_value(),
         "Cross device semaphore must be specified at the moment");
-
-    TT_FATAL(operation_attributes.topology == tt::tt_fabric::Topology::Linear, "Topology must be linear at the moment");
 }
 
 void AllToAllDispatchDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -120,7 +120,7 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
     const auto& output_tensor = tensor_return_value.at(0);
     const auto& metadata_tensor = tensor_return_value.at(1);
     auto num_links = operation_attributes.num_links;
-    auto topology = operation_attributes.topology;
+    auto topology = tt::tt_fabric::get_fabric_topology();
 
     auto mesh_device = input_tensor.mesh_device();
     const auto& mesh_view = mesh_device->get_view();
@@ -342,7 +342,7 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
         tokens_per_device,
 
         num_links,
-        (uint32_t)tt::tt_fabric::get_fabric_topology(),
+        (uint32_t)topology,
 
         src_mesh_id,
         (uint32_t)src_chip_id,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.hpp
@@ -16,13 +16,6 @@ std::pair<std::vector<tt::tt_metal::IDevice*>, std::array<bool, 4>> get_neighbor
     tt::tt_fabric::Topology topology,
     std::optional<uint32_t> axis);
 
-uint32_t select_link(
-    const distributed::MeshDeviceView& mesh_view,
-    const distributed::MeshCoordinate& src,
-    const distributed::MeshCoordinate& dst,
-    uint32_t num_links,
-    tt::tt_fabric::Topology topology);
-
 // Utilities to code-gen variadic length containers for kernels
 template <typename T>
 std::string stringify(const T& vec) {

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -126,8 +126,8 @@ uint32_t get_route(uint32_t linearized_src_mesh_coord, uint32_t linearized_dest_
             return src_row < dest_row ? eth_chan_directions::SOUTH : eth_chan_directions::NORTH;
         } else {
             // with wrap around, we can go either North or South. Choose the shorter route
-            uint32_t north_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, true);
-            uint32_t south_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, false);
+            uint32_t north_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, false);
+            uint32_t south_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, true);
             return north_distance < south_distance ? eth_chan_directions::NORTH : eth_chan_directions::SOUTH;
         }
     } else {
@@ -137,8 +137,8 @@ uint32_t get_route(uint32_t linearized_src_mesh_coord, uint32_t linearized_dest_
             return src_row < dest_row ? eth_chan_directions::SOUTH : eth_chan_directions::NORTH;
         } else {
             // with wrap around, we can go either North or South. Choose the shorter route
-            uint32_t north_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, true);
-            uint32_t south_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, false);
+            uint32_t north_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, false);
+            uint32_t south_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, true);
             return north_distance < south_distance ? eth_chan_directions::NORTH : eth_chan_directions::SOUTH;
         }
     }

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -78,7 +78,7 @@ std::pair<uint32_t, uint32_t> get_mesh_coords(uint32_t linearized_mesh_coord) {
 }
 
 template <tt::tt_fabric::Topology Topology>
-uint32_t distance(uint32_t position_1, uint32_t position_2, uint32_t axis_size) {
+uint32_t topological_distance(uint32_t position_1, uint32_t position_2, uint32_t axis_size) {
     if (position_1 == position_2) {
         return 0;
     }
@@ -90,11 +90,21 @@ uint32_t distance(uint32_t position_1, uint32_t position_2, uint32_t axis_size) 
     }
 }
 
+template <uint32_t AxisSize>
+uint32_t directional_wrap_distance(uint32_t position_1, uint32_t position_2, bool is_forward) {
+    if (is_forward) {
+        return (position_2 - position_1 + AxisSize) % AxisSize;
+    } else {
+        return (position_1 - position_2 + AxisSize) % AxisSize;
+    }
+}
+
 template <tt::tt_fabric::Topology Topology, uint32_t MeshRows, uint32_t MeshCols>
 uint32_t manhattan_distance(uint32_t linearized_src_mesh_coord, uint32_t linearized_dest_mesh_coord) {
     auto [src_row, src_col] = get_mesh_coords<MeshRows, MeshCols>(linearized_src_mesh_coord);
     auto [dest_row, dest_col] = get_mesh_coords<MeshRows, MeshCols>(linearized_dest_mesh_coord);
-    return distance<Topology>(src_row, dest_row, MeshRows) + distance<Topology>(src_col, dest_col, MeshCols);
+    return topological_distance<Topology>(src_row, dest_row, MeshRows) +
+           topological_distance<Topology>(src_col, dest_col, MeshCols);
 }
 
 template <tt::tt_fabric::Topology Topology, uint32_t MeshRows, uint32_t MeshCols>
@@ -107,8 +117,8 @@ uint32_t get_route(uint32_t linearized_src_mesh_coord, uint32_t linearized_dest_
             return src_col < dest_col ? eth_chan_directions::EAST : eth_chan_directions::WEST;
         } else {
             // with wrap around, we can go either East or West. Choose the shorter route
-            uint32_t east_distance = distance<tt::tt_fabric::Topology::Mesh>(src_col, dest_col, MeshCols);
-            uint32_t west_distance = distance<tt::tt_fabric::Topology::Mesh>(src_col, dest_col, MeshCols);
+            uint32_t east_distance = directional_wrap_distance<MeshCols>(src_col, dest_col, true);
+            uint32_t west_distance = directional_wrap_distance<MeshCols>(src_col, dest_col, false);
             return east_distance < west_distance ? eth_chan_directions::EAST : eth_chan_directions::WEST;
         }
     } else if (src_col == dest_col) {
@@ -116,8 +126,8 @@ uint32_t get_route(uint32_t linearized_src_mesh_coord, uint32_t linearized_dest_
             return src_row < dest_row ? eth_chan_directions::SOUTH : eth_chan_directions::NORTH;
         } else {
             // with wrap around, we can go either North or South. Choose the shorter route
-            uint32_t north_distance = distance<tt::tt_fabric::Topology::Mesh>(src_row, dest_row, MeshRows);
-            uint32_t south_distance = distance<tt::tt_fabric::Topology::Mesh>(src_row, dest_row, MeshRows);
+            uint32_t north_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, true);
+            uint32_t south_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, false);
             return north_distance < south_distance ? eth_chan_directions::NORTH : eth_chan_directions::SOUTH;
         }
     } else {
@@ -127,8 +137,8 @@ uint32_t get_route(uint32_t linearized_src_mesh_coord, uint32_t linearized_dest_
             return src_row < dest_row ? eth_chan_directions::SOUTH : eth_chan_directions::NORTH;
         } else {
             // with wrap around, we can go either North or South. Choose the shorter route
-            uint32_t north_distance = distance<tt::tt_fabric::Topology::Mesh>(src_row, dest_row, MeshRows);
-            uint32_t south_distance = distance<tt::tt_fabric::Topology::Mesh>(src_row, dest_row, MeshRows);
+            uint32_t north_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, true);
+            uint32_t south_distance = directional_wrap_distance<MeshRows>(src_row, dest_row, false);
             return north_distance < south_distance ? eth_chan_directions::NORTH : eth_chan_directions::SOUTH;
         }
     }


### PR DESCRIPTION
### Ticket
#24407

### Problem description
Ring support would add a performance improvement for 1D Fabric Ring topology, so we need it.

### What's changed

- Add some fixes to routing functions
- Delete dead code that affects a2a combine along the way
- TODO: deprecate topology flag in the op as we are moving towards queueing it up directly in the program factory. Since RING is a strict improvement here, there's no need to run the line algorithm on a ring topology.
- Decode B=8/device, S=1 performance: 26.9 us to 22.4 us
- Prefill B=8/device, S=127 performance: 1587 us to 1480 us


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16630511030
- [ ] [Galaxy frequent](https://github.com/tenstorrent/tt-metal/actions/runs/16630507344) CI passes (if applicable)
- [ ] (For runtime and ops writers) [T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/16630502492)