### PR TITLE
[skip ci] Optimize slow dispatch CI

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -34,19 +34,22 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        test-group: [
-          {name: All C++, cmd: ./tests/scripts/run_cpp_unit_tests.sh},
-          {name: api, cmd: "./build/test/tt_metal/unit_tests_api"},
-          {name: data_movement, cmd: "./build/test/tt_metal/unit_tests_data_movement"},
-          {name: debug_tools, cmd: "./build/test/tt_metal/unit_tests_debug_tools"},
-          {name: device, cmd: "./build/test/tt_metal/unit_tests_device"},
-          {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
-          {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth"},
-          {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
-          {name: sfpi, cmd: "./build/test/tt_metal/unit_tests_sfpi"},
-          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=MeshDeviceSuite.*"},
-          {name: FD2, cmd: ./tests/scripts/run_cpp_fd2_tests.sh},
-        ]
+        test-group:
+          - name: All C++ and API tests
+            cmd: |
+              ./tests/scripts/run_cpp_unit_tests.sh
+              ./build/test/tt_metal/unit_tests_api
+          - name: data_movement
+            cmd: ./build/test/tt_metal/unit_tests_data_movement
+          - name: debug_tools and device and dispatch
+            cmd: |
+              ./build/test/tt_metal/unit_tests_debug_tools
+              ./build/test/tt_metal/unit_tests_device
+              ./build/test/tt_metal/unit_tests_dispatch
+          - name: llk
+            cmd: ./build/test/tt_metal/unit_tests_llk
+          - name: FD2
+            cmd: ./tests/scripts/run_cpp_fd2_tests.sh
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
       ${{


### PR DESCRIPTION
### Ticket
NA

### Problem description
Since we moved to CIv2, the initialize containers step and setup job step can take 5 minutes. So test jobs that run for 5 seconda are extremely wasteful from an efficiency standpoint. Also there were three jobs in SD tests that verified nothing.
(Almost every test in "eth" was skipped except for two tests ... I don't think its worth keeping that job around for 1 second of test coverage).

### What's changed
- Remove three workflows where almost nothing was being tested.
- Group other fast tests into the same job.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16542815518) CI passes
- [x] New/Existing tests provide coverage for changes