### PR TITLE
sfpi v6.14.0

### DIFF
--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,13 +1,13 @@
 # set SFPI release version information
 
-sfpi_version=v6.13.0
+sfpi_version=v6.14.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi-\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_aarch64_Linux_txz_md5=6f680d44ba3155860b6acbafdd068397
-sfpi_aarch64_Linux_deb_md5=cacca03723888fb3ddfa9d9e1f879fb6
-sfpi_aarch64_Linux_rpm_md5=84aeeca966d608a561b0cbbc11430b41
-sfpi_x86_64_Linux_txz_md5=e5ee5a36037a0199e67141ae01003123
-sfpi_x86_64_Linux_deb_md5=0d282c8ca6c0403a9b6da4f7aedb16d6
-sfpi_x86_64_Linux_rpm_md5=9878daa5c0159e5e27e7910b947fa7e7
+sfpi_aarch64_Linux_txz_md5=2359e09b55d08e31c8588b789eb8275b
+sfpi_aarch64_Linux_deb_md5=43f596487fd54d0c6fa7d24e35a8ee10
+sfpi_aarch64_Linux_rpm_md5=0a4cf2aab711364c762443eb56c0ecc3
+sfpi_x86_64_Linux_txz_md5=919b5d0bb149ae52558f6df4c7eae8e8
+sfpi_x86_64_Linux_deb_md5=c32dcf27c013b1118235270d9ca5cbad
+sfpi_x86_64_Linux_rpm_md5=c35e9c1492127da9ea352fe99afd6c11


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25598

### Problem description
Internal compiler error in replay optimization pass.

### What's changed
Fixed compiler

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes