### PR TITLE
chore: set llk uplift PR as draft before checks have finished

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -213,7 +213,7 @@ jobs:
           delete-branch: true
           body-path: pr_body.md
           add-paths: ${{ env.SUBMODULE_PATH }}
-          draft: ${{ github.event_name == 'repository_dispatch' || inputs.draft }}
+          draft: ${{ github.event_name == 'repository_dispatch' || inputs.draft == true }}
           labels: |
             llk-update
             automated

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -43,7 +43,6 @@ env:
   SUBMODULE_PATH: tt_metal/third_party/tt_llk
   WORKFLOW_TIMEOUT: 240
   MAX_RETRIES: 3
-  IS_DRAFT_PR: true
 
 permissions:
   contents: write
@@ -214,7 +213,7 @@ jobs:
           delete-branch: true
           body-path: pr_body.md
           add-paths: ${{ env.SUBMODULE_PATH }}
-          draft: ${{ inputs.draft || env.IS_DRAFT_PR }}
+          draft: ${{ github.event_name == 'repository_dispatch' || inputs.draft }}
           labels: |
             llk-update
             automated

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -43,6 +43,7 @@ env:
   SUBMODULE_PATH: tt_metal/third_party/tt_llk
   WORKFLOW_TIMEOUT: 240
   MAX_RETRIES: 3
+  IS_DRAFT_PR: true
 
 permissions:
   contents: write
@@ -213,7 +214,7 @@ jobs:
           delete-branch: true
           body-path: pr_body.md
           add-paths: ${{ env.SUBMODULE_PATH }}
-          draft: ${{ inputs.draft == true || format('{0}', inputs.draft) == 'true' }}
+          draft: ${{ inputs.draft || env.IS_DRAFT_PR }}
           labels: |
             llk-update
             automated


### PR DESCRIPTION
### Ticket
None

### Problem description
We figured out we were not passing any information when performing repository dispatch, causing uplift PRs to always be marked as ready, even before post-commit checks have finished successfully. 

### What's changed
This PR fixes an issue where uplift PRs triggered via repository dispatch events were not being created as drafts, causing them to be marked as ready before post-commit checks completed.
- Updates the draft condition logic in the GitHub workflow to properly handle repository dispatch events
- Ensures uplift PRs are created as drafts when triggered automatically, allowing post-commit checks to complete before marking them as ready