### PR TITLE
[skip ci] Restore some workflow dispatch to l2 nightly

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -22,28 +22,26 @@ on:
         required: false
         type: number
         default: 120
+      run_conv_tests:
+        required: false
+        type: boolean
+        default: true
+      run_matmul_tests:
+        required: false
+        type: boolean
+        default: true
+      run_pool_tests:
+        required: false
+        type: boolean
+        default: true
+      run_sdxl_tests:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
-  tt-metal-l2-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group:
-          - name: ttnn nightly conv tests
-            cmd: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
-            owner: U052J2QDDKQ # Pavle Josipovic
-          - name: ttnn nightly matmul tests
-            cmd: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
-            owner: U06Q7ESTFEV # Borys Bradel
-          - name: ttnn nightly pool tests
-            cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
-            owner: U052J2QDDKQ # Pavle Josipovic
-          - name: ttnn nightly sdxl tests
-            cmd:  if [[ "${{ inputs.runner-label }}" == "N300" ]]; then
-                    export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml;
-                  fi;
-                  pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --loop-iter-num=50 -xv -m "not disable_fast_runtime_mode"
-            owner: U07N3CUUN05 # Iva Potkonjak
+  ttnn-conv-tests:
+    if: ${{ inputs.run_conv_tests }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
@@ -60,7 +58,7 @@ jobs:
       run:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
-    name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
+    name: ttnn nightly conv tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
         ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
@@ -73,9 +71,9 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: ${{ matrix.test-group.name }} tests
+      - name: ttnn nightly conv tests
         timeout-minutes: ${{ inputs.timeout }}
-        run: ${{ matrix.test-group.cmd }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -86,6 +84,154 @@ jobs:
         if: ${{ failure() && github.event_name == 'schedule' }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: ${{ matrix.test-group.owner }}
+          owner: U052J2QDDKQ # Pavle Josipovic
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
+  ttnn-matmul-tests:
+    if: ${{ inputs.run_matmul_tests }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        HF_HOME: /mnt/MLPerf/tt_dnn-models/hf_home
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -v /mnt/MLPerf:/mnt/MLPerf:ro"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: ttnn nightly matmul tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+      }}
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ttnn nightly matmul tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U06Q7ESTFEV # Borys Bradel
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
+  ttnn-pool-tests:
+    if: ${{ inputs.run_pool_tests }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        HF_HOME: /mnt/MLPerf/tt_dnn-models/hf_home
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -v /mnt/MLPerf:/mnt/MLPerf:ro"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: ttnn nightly pool tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+      }}
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ttnn nightly pool tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U052J2QDDKQ # Pavle Josipovic
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
+  ttnn-sdxl-tests:
+    if: ${{ inputs.run_sdxl_tests }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        HF_HOME: /mnt/MLPerf/tt_dnn-models/hf_home
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -v /mnt/MLPerf:/mnt/MLPerf:ro"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: ttnn nightly sdxl tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+      }}
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ttnn nightly sdxl tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: |
+          if [[ "${{ inputs.runner-label }}" == "N300" ]]; then
+            export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+          fi
+          pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --loop-iter-num=50 -xv -m "not disable_fast_runtime_mode"
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U07N3CUUN05 # Iva Potkonjak
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -3,6 +3,33 @@ name: "Nightly tt-metal L2 tests"
 on:
   schedule:
     - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      run_conv_tests:
+        description: 'Run TTNN nightly conv tests'
+        required: false
+        type: boolean
+        default: false
+      run_matmul_tests:
+        description: 'Run TTNN nightly matmul tests'
+        required: false
+        type: boolean
+        default: false
+      run_pool_tests:
+        description: 'Run TTNN nightly pool tests'
+        required: false
+        type: boolean
+        default: false
+      run_sdxl_tests:
+        description: 'Run TTNN nightly SDXL tests'
+        required: false
+        type: boolean
+        default: false
+      timeout:
+        description: 'Test timeout in minutes'
+        required: false
+        type: number
+        default: 120
 
 jobs:
   build-artifact:
@@ -33,6 +60,11 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      # Test group selection - default to all enabled for scheduled runs
+      run_conv_tests: ${{ github.event_name == 'schedule' || inputs.run_conv_tests }}
+      run_matmul_tests: ${{ github.event_name == 'schedule' || inputs.run_matmul_tests }}
+      run_pool_tests: ${{ github.event_name == 'schedule' || inputs.run_pool_tests }}
+      run_sdxl_tests: ${{ github.event_name == 'schedule' || inputs.run_sdxl_tests }}
   didt-tests:
     needs: build-artifact
     secrets: inherit


### PR DESCRIPTION
### Ticket
NA

### Problem description
I removed workflow dispatch launch of L2 Nightly without giving teams another way to easily dispatch subtests.

### What's changed
- Reenable workflow dispatch with boolean selectors so that people can launch subsets of the workflow.

This is good because conv/pool teams can launch their tests to verify fixes without launching the whole nightly run.

### Checklist