### PR TITLE
#25869: add DP(N300) and dataset eval support for swin_v2

### DIFF
--- a/models/experimental/classification_eval/README.md
+++ b/models/experimental/classification_eval/README.md
@@ -11,6 +11,8 @@
 | MobileNetV2  | (224, 224) | 10          | 512     | 68.36%                 | 70.62%                 |
 | VoVNet       | (224, 224) | 1          | 512     | 72.85%                 | 78.12%                 |
 | EfficientNetB0| (224, 224) | 1          | 512     | 75.39%         | 76.76%         |
+| SwinV2       | (512, 512) | 1          | 512     | 75.59%                 | 81.05%                 |
+
 ***Note:*** The accuracy is for the selected random samples from the validation dataset.
 
 Where,
@@ -18,6 +20,19 @@ Where,
 - **Torch Accuracy** refers to the ratio of correct predictions made by torch model to the total number of predictions, calculated by comparing Torch outputs against the ground truth data(Labels given in validation dataset).
 
 ## To run the test of ttnn vs ground truth, please follow the following commands:
+
+ **SwinV2:** <br>
+**_For 512x512,_**<br>
+
+**_Single-Device (BS-1):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval[1-512-tt_model-device_params0]
+ ```
+
+**_Multi-Device (DP-2,N300):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval_dp[wormhole_b0-1-512-tt_model-device_params0]
+ ```
 
 **Vit:** <br>
 **_For 224x224,_**<br>
@@ -110,11 +125,26 @@ Where,
 
 **EfficientNetB0:** <br>
 **_For 224x224,_**<br>
+
 **_Single-Device (BS-1):_**<br>
  ```sh
  pytest models/experimental/classification_eval/classification_eval.py::test_efficientnetb0_image_classification_eval[1-224-torch_model-device_params0]
  ```
- **_Multi-Device (DP-2,N300):_**<br>
+
+**_Multi-Device (DP-2,N300):_**<br>
  ```sh
  pytest models/experimental/classification_eval/classification_eval.py::test_efficientnetb0_image_classification_eval_dp[wormhole_b0-1-224-torch_model-device_params0]
+ ```
+
+**SwinV2:** <br>
+**_For 512x512,_**<br>
+
+**_Single-Device (BS-1):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval[1-512-torch_model-device_params0]
+ ```
+
+**_Multi-Device (DP-2,N300):_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval_dp[wormhole_b0-1-512-torch_model-device_params0]
  ```

--- a/models/experimental/swin_v2/README.md
+++ b/models/experimental/swin_v2/README.md
@@ -1,7 +1,7 @@
 # Swin_V2
 
 ## Platforms:
-Wormhole N150, N300
+Wormhole (n150, n300)
 
 ## Introduction
 Swin Transformer v2 builds upon the original Swin Transformer to tackle key challenges in large-scale vision models, including training stability, handling high-resolution inputs, and the scarcity of labeled data. It introduces advanced techniques such as residual-post-norm with cosine attention, log-spaced continuous position bias, and SimMIM-based self-supervised pretraining. The core idea of the Swin Transformer is to integrate essential visual priors—like hierarchy, locality, and translation invariance—into the standard Transformer encoder. This combination leverages the strong modeling capabilities of Transformers while making the architecture more effective and adaptable for a wide range of vision tasks.
@@ -19,21 +19,59 @@ Swin Transformer v2 builds upon the original Swin Transformer to tackle key chal
   pytest models/experimental/swin_v2/tests/pcc/test_ttnn_swin_v2_s.py
   ```
 
-### Model performant running with Trace+2CQ
+### Performant Model with Trace+2CQ
+
+#### Single Device (BS=1):
+
 - For `512x512` resolution, end-2-end perf is `7` FPS
 
     ```sh
-    pytest models/experimental/swin_v2/tests/perf/test_e2e_performant.py
+    pytest models/experimental/swin_v2/tests/perf/test_e2e_performant.py::test_e2e_performant
+    ```
+#### Multi Device (DP=2, N300):
+
+- For `512x512` resolution, end-2-end perf is `14` FPS
+
+    ```sh
+    pytest models/experimental/swin_v2/tests/perf/test_e2e_performant.py::test_e2e_performant_dp
     ```
 
-### Performant Demo on ImageNet:
+### Performant Demo with Trace+2CQ
 - Make sure your HuggingFace token is set ([See Prerequisites](#prerequisites) for instructions).
+
+#### Single Device (BS=1):
 - Use the following command to run the demo using `Imagenet-1K` dataset:
 
   ```bash
-  pytest models/experimental/swin_v2/demo/demo.py
+  pytest models/experimental/swin_v2/demo/demo.py::test_swin_v2_trace_2cqs_inference
   ```
 
+#### Multi Device (DP=2, N300):
+- Use the following command to run the demo using `Imagenet-1K` dataset:
+
+  ```bash
+  pytest models/experimental/swin_v2/demo/demo.py::test_swin_v2_trace_2cqs_inference_dp
+  ```
+
+## Testing
+
+### Performant Data Evaluation with Trace+2CQ
+
+#### Single Device (BS=1):
+
+- Use the following command to run the performant data evaluation with Trace+2CQs:
+
+  ```
+  pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval
+  ```
+
+#### Multi Device (DP=2, N300):
+
+- Use the following command to run the performant data evaluation with Trace+2CQs:
+
+  ```
+  pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval_dp
+  ```
 ## Details
 - Entry point for the model is `models/experimental/swin_v2/tt/tt_swin_transformer.py`
 - Batch Size: `1` (Single Device).

--- a/models/experimental/swin_v2/demo/demo.py
+++ b/models/experimental/swin_v2/demo/demo.py
@@ -14,25 +14,9 @@ from models.experimental.swin_v2.common import SWIN_V2_L1_SMALL_SIZE
 from loguru import logger
 
 
-@run_for_wormhole_b0()
-@pytest.mark.parametrize(
-    "device_params",
-    [{"l1_small_size": SWIN_V2_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype",
-    ((1, ttnn.bfloat16, ttnn.bfloat16),),
-)
-@pytest.mark.parametrize(
-    "resolution",
-    [
-        (512, 512),
-    ],
-)
-def test_run_swin_v2_trace_2cqs_inference(
+def run_swin_v2_trace_2cqs_inference(
     device,
-    batch_size,
+    device_batch_size,
     act_dtype,
     weight_dtype,
     model_location_generator,
@@ -41,10 +25,12 @@ def test_run_swin_v2_trace_2cqs_inference(
     iterations=100,
 ):
     disable_persistent_kernel_cache()
+    batch_size = device.get_num_devices() * device_batch_size
+    iterations = iterations // batch_size
     with torch.no_grad():
         swin_v2_trace_2cq = SwinV2PerformantRunner(
             device,
-            batch_size,
+            device_batch_size,
             act_dtype,
             weight_dtype,
             resolution=resolution,
@@ -70,7 +56,7 @@ def test_run_swin_v2_trace_2cqs_inference(
             torch_input_tensor = input_tensors_all[iter]
             labels = input_labels_all[iter]
             output = swin_v2_trace_2cq.run(torch_input_tensor)
-            output = ttnn.to_torch(output).to(torch.float)
+            output = ttnn.to_torch(output, mesh_composer=swin_v2_trace_2cq.runner_infra.output_composer).to(torch.float)
             prediction = output.argmax(dim=-1)
             for i in range(batch_size):
                 predictions.append(imagenet_label_dict[prediction[i].item()])
@@ -83,3 +69,79 @@ def test_run_swin_v2_trace_2cqs_inference(
         accuracy = correct / (batch_size * iterations)
         logger.info(f"=============")
         logger.info(f"Accuracy for  batch size: {batch_size} over {iterations} iterations is: {accuracy}")
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": SWIN_V2_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "iterations,batch_size, act_dtype, weight_dtype",
+    ((100, 1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+def test_swin_v2_trace_2cqs_inference(
+    device,
+    batch_size,
+    iterations,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+    imagenet_label_dict,
+):
+    return run_swin_v2_trace_2cqs_inference(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        model_location_generator,
+        resolution,
+        imagenet_label_dict,
+        iterations,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": SWIN_V2_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "iterations,device_batch_size, act_dtype, weight_dtype",
+    ((100, 1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+def test_swin_v2_trace_2cqs_inference_dp(
+    mesh_device,
+    device_batch_size,
+    iterations,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+    imagenet_label_dict,
+):
+    return run_swin_v2_trace_2cqs_inference(
+        mesh_device,
+        device_batch_size,
+        act_dtype,
+        weight_dtype,
+        model_location_generator,
+        resolution,
+        imagenet_label_dict,
+        iterations,
+    )

--- a/models/experimental/swin_v2/runner/performant_runner_infra.py
+++ b/models/experimental/swin_v2/runner/performant_runner_infra.py
@@ -6,7 +6,11 @@
 import torch
 from loguru import logger
 import ttnn
-from models.experimental.swin_v2.tt.model_preprocessing import create_swinv2_model_parameters, preprocess_attn_mask
+from models.experimental.swin_v2.tt.model_preprocessing import (
+    create_swinv2_model_parameters,
+    preprocess_attn_mask,
+    get_mesh_mappers,
+)
 from models.experimental.swin_v2.reference.swin_transformer import SwinTransformer
 
 from models.experimental.swin_v2.tt.tt_swin_transformer import TtSwinTransformer
@@ -25,13 +29,16 @@ class SwinV2PerformanceRunnerInfra:
         model_location_generator=None,
         resolution=(512, 512),
         torch_input_tensor=None,
+        channels=3,
     ):
         torch.manual_seed(0)
         self.resolution = resolution
         self.pcc_passed = False
         self.pcc_message = "Did you forget to call validate()?"
         self.device = device
-        self.batch_size = batch_size
+        self.channels = channels
+        self.num_devices = self.device.get_num_devices()
+        self.batch_size = batch_size * self.num_devices
         self.act_dtype = act_dtype
         self.weight_dtype = weight_dtype
         self.model_location_generator = model_location_generator
@@ -43,14 +50,16 @@ class SwinV2PerformanceRunnerInfra:
         self.torch_model = load_torch_model(torch_model=torch_model, model_location_generator=model_location_generator)
 
         self.torch_input_tensor = (
-            torch.randn((1, 3, 512, 512), dtype=torch.float32)
+            torch.randn((self.batch_size, channels, resolution[0], resolution[1]), dtype=torch.float32)
             if self.torch_input_tensor is None
             else self.torch_input_tensor
         )
-
+        self.inputs_mesh_mapper, self.weight_mapper, self.output_composer = get_mesh_mappers(self.device)
         self.parameters = create_swinv2_model_parameters(self.torch_model, device=self.device)
 
-        attn_mask_tuple = preprocess_attn_mask([1, 3, 512, 512], [4, 4], [8, 8], [3, 3], device)
+        attn_mask_tuple = preprocess_attn_mask(
+            [self.batch_size, self.channels, resolution[0], resolution[1]], [4, 4], [8, 8], [3, 3], device
+        )
         self.ttnn_swin_model = TtSwinTransformer(
             self.device,
             self.parameters,
@@ -68,22 +77,29 @@ class SwinV2PerformanceRunnerInfra:
         if is_wormhole_b0():
             core_grid = ttnn.CoreGrid(y=8, x=8)
         else:
-            exit("Unsupported device")
+            raise RuntimeError("Unsupported device: Only Wormhole B0 is currently supported.")
 
+        num_devices = device.get_num_devices()
         torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
+
         n, c, h, w = torch_input_tensor.shape
         if c < min_channels:
             c = min_channels
         elif c % min_channels != 0:
             c = ((c // min_channels) + 1) * min_channels
 
+        assert n % self.num_devices == 0, f"n isn't evenly divided by the available number of devices"
+        n = n // self.num_devices if n // self.num_devices != 0 else n
+
         input_mem_config = ttnn.create_sharded_memory_config(
             [n, c, h, w],
             ttnn.CoreGrid(x=8, y=8),
             ttnn.ShardStrategy.HEIGHT,
         )
-        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-
+        input_tensor = [torch_input_tensor[i].unsqueeze(0) for i in range(torch_input_tensor.shape[0])]
+        tt_inputs_host = ttnn.from_host_shards(
+            [ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) for t in input_tensor], device.shape
+        )
         return tt_inputs_host, input_mem_config
 
     def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
@@ -111,7 +127,7 @@ class SwinV2PerformanceRunnerInfra:
     def validate(self, output_tensor=None, torch_output_tensor=None):
         ttnn_output_tensor = self.output_tensor if output_tensor is None else output_tensor
         torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
-        output_tensor = ttnn.to_torch(ttnn_output_tensor)
+        output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=self.output_composer)
         self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor, output_tensor, pcc=0.98)
 
         logger.info(

--- a/models/experimental/swin_v2/tests/perf/test_e2e_performant.py
+++ b/models/experimental/swin_v2/tests/perf/test_e2e_performant.py
@@ -9,7 +9,45 @@ from loguru import logger
 import ttnn
 from models.experimental.swin_v2.runner.performant_runner import SwinV2PerformantRunner
 from models.utility_functions import run_for_wormhole_b0
-from models.experimental.swin_v2.common import SWIN_V2_L1_SMALL_SIZE
+
+
+def run_e2e_performant(
+    device,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+    channels=3,
+):
+    total_batch_size = batch_size * device.get_num_devices()
+    performant_runner = SwinV2PerformantRunner(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=None,
+    )
+    performant_runner._capture_swinv2_trace_2cqs()
+    inference_times = []
+    iterations_count = 10
+    for i in range(iterations_count):
+        input_shape = (total_batch_size, channels, resolution[0], resolution[1])
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+        t0 = time.time()
+        _ = performant_runner.run(torch_input_tensor)
+        if i + 1 == iterations_count:
+            ttnn.synchronize_device(device)
+        t1 = time.time()
+        inference_times.append(t1 - t0)
+
+    performant_runner.release()
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    logger.info(
+        f"ttnn_swin_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(total_batch_size/inference_time_avg)}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -22,12 +60,9 @@ from models.experimental.swin_v2.common import SWIN_V2_L1_SMALL_SIZE
         (512, 512),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "device_params",
-    [{"l1_small_size": SWIN_V2_L1_SMALL_SIZE, "trace_region_size": 18776064, "num_command_queues": 2}],
-    indirect=True,
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 19193856, "num_command_queues": 2}], indirect=True
 )
 def test_e2e_performant(
     device,
@@ -37,28 +72,45 @@ def test_e2e_performant(
     model_location_generator,
     resolution,
 ):
-    performant_runner = SwinV2PerformantRunner(
+    return run_e2e_performant(
         device,
         batch_size,
         act_dtype,
         weight_dtype,
-        resolution=resolution,
-        model_location_generator=model_location_generator,
+        model_location_generator,
+        resolution,
     )
-    performant_runner._capture_swinv2_trace_2cqs()
 
-    inference_times = []
-    for _ in range(10):
-        input_shape = (1, 3, 512, 512)
-        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-        t0 = time.time()
-        _ = performant_runner.run(torch_input_tensor)
-        t1 = time.time()
-        inference_times.append(t1 - t0)
 
-    performant_runner.release()
-
-    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
-    logger.info(
-        f"ttnn_swin_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+@pytest.mark.parametrize(
+    "device_batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (512, 512),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 19193856, "num_command_queues": 2}], indirect=True
+)
+def test_e2e_performant_dp(
+    mesh_device,
+    device_batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    return run_e2e_performant(
+        mesh_device,
+        device_batch_size,
+        act_dtype,
+        weight_dtype,
+        model_location_generator,
+        resolution,
     )

--- a/models/experimental/swin_v2/tt/model_preprocessing.py
+++ b/models/experimental/swin_v2/tt/model_preprocessing.py
@@ -88,12 +88,6 @@ def create_custom_preprocessor(device):
 
 
 def create_swinv2_model_parameters(torch_model, device):
-    # model = models.swin_v2_s(weights="IMAGENET1K_V1")
-    # state_dict = model.state_dict()
-
-    # torch_model.load_state_dict(state_dict)
-    # torch_model.eval()
-
     parameters = preprocess_model_parameters(
         initialize_model=lambda: torch_model, custom_preprocessor=create_custom_preprocessor(device), device=device
     )
@@ -140,3 +134,15 @@ def preprocess_attn_mask(input_shape, patch_size, window_size, shift_size, devic
         attn_mask_tuple += (attn_mask,)
 
     return attn_mask_tuple
+
+
+def get_mesh_mappers(device):
+    if device.get_num_devices() > 1:
+        inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+        weights_mesh_mapper = None
+        output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+    else:
+        inputs_mesh_mapper = None
+        weights_mesh_mapper = None
+        output_mesh_composer = None
+    return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer

--- a/models/experimental/swin_v2/tt/tt_swin_transformer.py
+++ b/models/experimental/swin_v2/tt/tt_swin_transformer.py
@@ -70,7 +70,7 @@ class TtSwinTransformer:
             nchw = ttnn.pad(x, ((0, 0), (0, channel_padding_needed), (0, 0), (0, 0)), value=0.0)
         else:
             nchw = x
-        nhwc = ttnn.permute(nchw, (0, 2, 3, 1))  # , memory_config=ttnn.L1_MEMORY_CONFIG)
+        nhwc = ttnn.permute(nchw, (0, 2, 3, 1))
         ttnn.deallocate(nchw)
         ttnn.deallocate(x)
         nhwc = ttnn.reallocate(nhwc)


### PR DESCRIPTION
### Ticket
Link to Github Issue - [here](https://github.com/tenstorrent/tt-metal/issues/25869)

### Problem description
added DP(N300) support and dataset eval for swin_v2

### What's changed
Modified e2e performant, demo , dataset eval scripts to enable multi-device functionality(n300).

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17031284855) - Passed
- [x] [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/17031288392/job/48281134395#step:8:511) - swin_v2 passed

### e2e Perf Details:
- Single Device: 7 FPS
- Multi-Device (n300): 14 FPS


Note: This PR depends on the following to be merged first:
~~1. Swin_v2 Demo - https://github.com/tenstorrent/tt-metal/pull/24290~~
~~2. Swin_v2 trace - https://github.com/tenstorrent/tt-metal/pull/24291~~
~~3. Swin_v2 eval - https://github.com/tenstorrent/tt-metal/pull/24459~~ (these changes are also included in the current PR(25880) )