### PR TITLE
[Minimal reduce-scatter] Remove hashing on global sems 

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -71,9 +71,9 @@ class TT_CCL:
 
                 if mode == "prefill":
                     if self.use_ring_rs_prefill:
-                        # current ring implementation of reduce scatter expects 3 semaphores per link (12 total), where AG and old RS use same addresses on all links
+                        # current ring implementation of reduce scatter expects 3 semaphores
                         self.reduce_semaphore_handles[i].append(
-                            [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(12)]
+                            [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(3)]
                         )
 
                     else:
@@ -881,14 +881,11 @@ class TT_CCL:
         )
         persistent_buffers_list = list(persistent_buffers.values()) if persistent_buffers else None
         num_links = 4
-        num_semaphores = 3
         ttnn_tensor_out = ttnn.experimental.reduce_scatter_minimal_async(
             input_tensor=input_tensor_mesh,
             persistent_output_buffers=persistent_buffers_list,
             dim=dim,
-            multi_device_global_semaphore=self.reduce_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]][
-                :num_semaphores
-            ],
+            multi_device_global_semaphore=self.reduce_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
             num_links=num_links,
             memory_config=memory_config,
             topology=ttnn.Topology.Ring,

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -881,7 +881,7 @@ class TT_CCL:
         )
         persistent_buffers_list = list(persistent_buffers.values()) if persistent_buffers else None
         num_links = 4
-        num_semaphores = 3 * num_links
+        num_semaphores = 3
         ttnn_tensor_out = ttnn.experimental.reduce_scatter_minimal_async(
             input_tensor=input_tensor_mesh,
             persistent_output_buffers=persistent_buffers_list,

--- a/models/experimental/stable_diffusion_35_large/tt/parallel_config.py
+++ b/models/experimental/stable_diffusion_35_large/tt/parallel_config.py
@@ -148,7 +148,7 @@ class StableDiffusionParallelManager:
         self._init_subdevice()
 
         # SD35-specific semaphores
-        semaphore_names = [("ping_pong", 4), ("ring_sdpa", 2), ("rs_ping_pong", 3 * 2 * num_links)]
+        semaphore_names = [("ping_pong", 4), ("ring_sdpa", 2), ("rs_ping_pong", 3 * 2)]
         self._init_semaphores(semaphore_names)
         self.ping_pong_idx = 0
         self.rs_ping_pong_idx = 0
@@ -288,7 +288,7 @@ class StableDiffusionParallelManager:
 
     def get_rs_ping_pong_semaphore(self, cfg_index):
         cur_idx = self.rs_ping_pong_idx
-        n_sems = 3 * self.num_links
+        n_sems = 3
         self.rs_ping_pong_idx = (cur_idx + 1) % 2
         return self.cfg_semaphores[cfg_index]["rs_ping_pong"][cur_idx * n_sems : (cur_idx + 1) * n_sems]
 

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -11,11 +11,9 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from models.utility_functions import skip_for_blackhole
 
 
-def create_global_semaphores(mesh_device, num_devices, cores, initial_value, num_links):
+def create_global_semaphores(mesh_device, cores, initial_value):
     # create global semaphore handles
-    ccl_semaphore_handles = [
-        ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(3 * num_links)
-    ]
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(3)]
     return ccl_semaphore_handles
 
 
@@ -66,10 +64,7 @@ def run_reduce_scatter_impl(
     t3k_mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [
-        create_global_semaphores(t3k_mesh_device, num_devices, ccl_sub_device_crs, 0, num_links)
-        for _ in range(num_iters)
-    ]
+    ccl_semaphore_handles = [create_global_semaphores(t3k_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
 
     barrier_semaphore_handles = [
         ttnn.create_global_semaphore(t3k_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)

--- a/tests/ttnn/unit_tests/operations/ccl/test_ag_rs_llama_prefill_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ag_rs_llama_prefill_TG.py
@@ -411,11 +411,7 @@ def run_reduce_scatter_on_TG(
     mesh_device.load_sub_device_manager(sub_device_manager)
     mesh_device.set_sub_device_stall_group(sub_device_stall_group)
     # create global semaphore handles
-    from_remote_semaphore_handles = []
-    for _ in range(num_links):
-        from_remote_semaphore_handles.append(ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0))
-        from_remote_semaphore_handles.append(ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0))
-        from_remote_semaphore_handles.append(ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0))
+    from_remote_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(3)]
 
     ##
     ## Compute golden

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py
@@ -13,7 +13,7 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_gather import is_unsupported_
 from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
 
-def create_global_semaphores(mesh_device, num_devices, cores, initial_value):
+def create_global_semaphores(mesh_device, cores, initial_value):
     # create global semaphore handles
     ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(3)]
     return ccl_semaphore_handles
@@ -67,9 +67,7 @@ def run_reduce_scatter_impl(
     t3k_mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [
-        create_global_semaphores(t3k_mesh_device, num_devices, ccl_sub_device_crs, 0) for _ in range(num_iters)
-    ]
+    ccl_semaphore_handles = [create_global_semaphores(t3k_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
 
     ### Create persistent output buffers
     logger.info("Creating persistent buffers")

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -108,11 +108,11 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
     }
 
     // Each direction has a ready semaphore and there's a global sync semaphore, per link.
-    const auto num_directions_per_link = 3;
+    const auto num_expected_semaphores = 3;
     TT_FATAL(
-        semaphore.size() == num_directions_per_link,
+        semaphore.size() == num_expected_semaphores,
         "Error, semaphore size should be {} but has {}",
-        num_directions_per_link,
+        num_expected_semaphores,
         semaphore.size());
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -108,10 +108,11 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
     }
 
     // Each direction has a ready semaphore and there's a global sync semaphore, per link.
+    const auto num_directions_per_link = 3;
     TT_FATAL(
-        semaphore.size() == num_links * 3,
+        semaphore.size() == num_directions_per_link,
         "Error, semaphore size should be {} but has {}",
-        num_links * 3,
+        num_directions_per_link,
         semaphore.size());
 }
 
@@ -210,12 +211,6 @@ tt::tt_metal::operation::ProgramWithCallbacks ReduceScatterMinimalAsync::create_
 
 tt::tt_metal::operation::Hash ReduceScatterMinimalAsync::compute_program_hash(
     const std::vector<Tensor>& input_tensors) const {
-    log_trace(tt::LogOp, "compute_program_hash is called");
-    auto input_shape = input_tensors[0].padded_shape();
-    auto input_memory_layout = input_tensors[0].layout();
-    auto input_dtype = input_tensors[0].dtype();
-    auto input_memory_config = input_tensors[0].memory_config();
-    uint32_t semaphore_address = this->semaphore.at(0).address();
     return tt::tt_metal::operation::hash_operation<ReduceScatterMinimalAsync>(
         this->dim,
         this->num_links,
@@ -223,15 +218,12 @@ tt::tt_metal::operation::Hash ReduceScatterMinimalAsync::compute_program_hash(
         this->output_mem_config,
         this->topology,
         this->barrier_semaphore.has_value(),
+        this->sub_device_id,
         this->cluster_axis,
         this->chunks_per_sync,
         this->num_workers_per_link,
         this->num_buffers_per_channel,
-        input_shape,
-        input_memory_layout,
-        input_dtype,
-        input_memory_config,
-        semaphore_address);
+        input_tensors);
 }
 
 namespace operations {


### PR DESCRIPTION
### Problem description
`reduce_scatter_minimal_async` used to hash on semaphore addresses, leading to many program cache entries. This made trace capture difficult, in the case where in trace capture the program is called with a different global sem than in the compile stage. In addition, the number of global sems used by this op was unnecessarily tied to the number of links.

### What's changed
- remove hashing on global sems
- reduce number of global sems used
- update usage in tests & models

### Checklist
- [x] TG demo https://github.com/tenstorrent/tt-metal/actions/runs/16576533952
- [x] TG frequent https://github.com/tenstorrent/tt-metal/actions/runs/16569440658
- [x] TG nightly https://github.com/tenstorrent/tt-metal/actions/runs/16569442636
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/16569438752
- [x] T3K frequent https://github.com/tenstorrent/tt-metal/actions/runs/16569445634