### PR TITLE
Conv2d skip_mcast cleanup

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3932,8 +3932,11 @@ def test_conv2d_act_dealloc(
 @pytest.mark.parametrize(
     "output_channels, input_channels, input_height, input_width, shard_layout",
     (
-        (32, 32, 8, 8, WS),
-        (16, 16, 8, 4, BS),
+        (32, 32, 8, 4, HS), # single core HS
+        (32, 32, 8, 8, WS), # single core WS
+        (32, 32, 8, 4, BS), # single core BS
+        (32, 32, 8, 8, BS), # skip act mcast
+        (64, 64, 8, 4, BS), # skip weight mcast
     ),
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -139,7 +139,8 @@ std::vector<CBInfo> get_cb_info(
             .name = Conv2dCb::ACT,
             .num_pages = skip_act_cb_create ? 0 : act_cb_num_tiles,
             .page_size = act_cb_tile_size,
-            .data_format = act_cb_data_format});
+            .data_format = act_cb_data_format,
+            .overlapped_by_cb = skip_act_cb_create ? std::optional<Conv2dCb>(Conv2dCb::ACT_TILIZED) : std::nullopt});
         cb_info.emplace_back(CBInfo{
             .name = Conv2dCb::ACT_SECOND_READER,
             .num_pages = act_block_split_num_tiles,
@@ -177,14 +178,14 @@ std::vector<CBInfo> get_cb_info(
             row_major_act_cb_num_tiles = act_block_num_tiles;
         }
 
-        const bool overlap_act_cb = sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED && conv_input_df == output_df;
+        const bool overlap_act_cb =
+            sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED && conv_input_df == output_df && !skip_act_cb_create;
         cb_info.emplace_back(CBInfo{
             .name = Conv2dCb::ACT_ROW_MAJOR_BFLOAT16,
-            .num_pages = overlap_act_cb && !skip_act_cb_create ? 0 : row_major_act_cb_num_tiles,
+            .num_pages = overlap_act_cb ? 0 : row_major_act_cb_num_tiles,
             .page_size = input_tile_size,
             .data_format = conv_input_df,
-            .overlapped_by_cb =
-                overlap_act_cb && !skip_act_cb_create ? std::optional<Conv2dCb>(Conv2dCb::ACT) : std::nullopt});
+            .overlapped_by_cb = overlap_act_cb ? std::optional<Conv2dCb>(Conv2dCb::ACT) : std::nullopt});
     }
 
     // Output CB

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -135,12 +135,13 @@ std::vector<CBInfo> get_cb_info(
             sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED ? input_tile_size : output_tile_size;
         const tt::DataFormat act_cb_data_format =
             sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED ? conv_input_df : output_df;
+        const bool overlap_act_cb = sharding_scheme != TensorMemoryLayout::HEIGHT_SHARDED && skip_act_cb_create;
         cb_info.emplace_back(CBInfo{
             .name = Conv2dCb::ACT,
-            .num_pages = skip_act_cb_create ? 0 : act_cb_num_tiles,
+            .num_pages = overlap_act_cb ? 0 : act_cb_num_tiles,
             .page_size = act_cb_tile_size,
             .data_format = act_cb_data_format,
-            .overlapped_by_cb = skip_act_cb_create ? std::optional<Conv2dCb>(Conv2dCb::ACT_TILIZED) : std::nullopt});
+            .overlapped_by_cb = overlap_act_cb ? std::optional<Conv2dCb>(Conv2dCb::ACT_TILIZED) : std::nullopt});
         cb_info.emplace_back(CBInfo{
             .name = Conv2dCb::ACT_SECOND_READER,
             .num_pages = act_block_split_num_tiles,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -462,11 +462,7 @@ bool is_1d_deptwise_conv(
     return is_depthwise_conv && is_1d_conv(kernel_width, image_width) && !has_bias;
 }
 
-bool is_singlecore_skip_mcast(
-    const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout) {
-    if (memory_layout != TensorMemoryLayout::BLOCK_SHARDED && memory_layout != TensorMemoryLayout::WIDTH_SHARDED) {
-        return false;
-    }
+bool is_singlecore_skip_mcast(const OptimizedConvParallelizationConfig& parallelization_config) {
     return parallelization_config.num_cores_c * parallelization_config.num_cores_nhw == 1;
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -462,13 +462,15 @@ bool is_1d_deptwise_conv(
     return is_depthwise_conv && is_1d_conv(kernel_width, image_width) && !has_bias;
 }
 
-std::tuple<bool, bool> conv_skip_mcast(
+SkipMcast conv_skip_mcast(
     const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout) {
     if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        return {parallelization_config.num_cores_c == 1, parallelization_config.num_cores_nhw == 1};
+        return SkipMcast{
+            .skip_activation_mcast = parallelization_config.num_cores_c == 1,
+            .skip_weights_mcast = parallelization_config.num_cores_nhw == 1};
     }
     const bool skip_mcast = parallelization_config.num_cores_c * parallelization_config.num_cores_nhw == 1;
-    return {skip_mcast, skip_mcast};
+    return SkipMcast{.skip_activation_mcast = skip_mcast, .skip_weights_mcast = skip_mcast};
 }
 
 template <typename DeviceType>

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -462,8 +462,13 @@ bool is_1d_deptwise_conv(
     return is_depthwise_conv && is_1d_conv(kernel_width, image_width) && !has_bias;
 }
 
-bool is_singlecore_skip_mcast(const OptimizedConvParallelizationConfig& parallelization_config) {
-    return parallelization_config.num_cores_c * parallelization_config.num_cores_nhw == 1;
+std::tuple<bool, bool> conv_skip_mcast(
+    const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout) {
+    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        return {parallelization_config.num_cores_c == 1, parallelization_config.num_cores_nhw == 1};
+    }
+    const bool skip_mcast = parallelization_config.num_cores_c * parallelization_config.num_cores_nhw == 1;
+    return {skip_mcast, skip_mcast};
 }
 
 template <typename DeviceType>

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -53,8 +53,7 @@ bool is_1d_deptwise_conv(
     uint32_t image_width,
     bool has_bias);
 
-bool is_singlecore_skip_mcast(
-    const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout);
+bool is_singlecore_skip_mcast(const OptimizedConvParallelizationConfig& parallelization_config);
 
 sliding_window::ParallelConfig determine_parallel_config(
     TensorMemoryLayout shard_layout,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -53,7 +53,12 @@ bool is_1d_deptwise_conv(
     uint32_t image_width,
     bool has_bias);
 
-std::tuple<bool, bool> conv_skip_mcast(
+struct SkipMcast {
+    bool skip_activation_mcast;
+    bool skip_weights_mcast;
+};
+
+SkipMcast conv_skip_mcast(
     const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout);
 
 sliding_window::ParallelConfig determine_parallel_config(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -53,7 +53,8 @@ bool is_1d_deptwise_conv(
     uint32_t image_width,
     bool has_bias);
 
-bool is_singlecore_skip_mcast(const OptimizedConvParallelizationConfig& parallelization_config);
+std::tuple<bool, bool> conv_skip_mcast(
+    const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout);
 
 sliding_window::ParallelConfig determine_parallel_config(
     TensorMemoryLayout shard_layout,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -243,6 +243,8 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
 
     auto kernel_dims =
         std::array<uint32_t, 2>({sliding_window_config.window_hw.first, sliding_window_config.window_hw.second});
+
+    const std::tuple<bool, bool>& skip_mcast = conv_skip_mcast(parallelization_config, memory_config.memory_layout());
     conv_op_l1_usage l1_usage = calculate_L1_usage(
         compute_kernel_config,
         block_config,
@@ -266,7 +268,8 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             kernel_dims[1],
             sliding_window_config.get_output_shape()[2],
             has_bias),
-        is_singlecore_skip_mcast(parallelization_config));
+        std::get<0>(skip_mcast)  // skip_activation_mcast
+    );
 
     TT_FATAL(
         actual_cb_size == l1_usage.CB_allocation_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -244,7 +244,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
     auto kernel_dims =
         std::array<uint32_t, 2>({sliding_window_config.window_hw.first, sliding_window_config.window_hw.second});
 
-    const std::tuple<bool, bool>& skip_mcast = conv_skip_mcast(parallelization_config, memory_config.memory_layout());
+    const SkipMcast& skip_mcast = conv_skip_mcast(parallelization_config, memory_config.memory_layout());
     conv_op_l1_usage l1_usage = calculate_L1_usage(
         compute_kernel_config,
         block_config,
@@ -268,8 +268,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             kernel_dims[1],
             sliding_window_config.get_output_shape()[2],
             has_bias),
-        std::get<0>(skip_mcast)  // skip_activation_mcast
-    );
+        skip_mcast.skip_activation_mcast);
 
     TT_FATAL(
         actual_cb_size == l1_usage.CB_allocation_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -266,7 +266,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             kernel_dims[1],
             sliding_window_config.get_output_shape()[2],
             has_bias),
-        is_singlecore_skip_mcast(parallelization_config, input_tensor_a.memory_config().memory_layout()));
+        is_singlecore_skip_mcast(parallelization_config));
 
     TT_FATAL(
         actual_cb_size == l1_usage.CB_allocation_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -80,10 +80,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     const uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     const uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
-    const std::tuple<bool, bool>& skip_mcast =
-        conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
-    const bool skip_activation_mcast = std::get<0>(skip_mcast);
-    const bool skip_weights_mcast = std::get<1>(skip_mcast);
+    const SkipMcast& skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
+    const bool skip_activation_mcast = skip_mcast.skip_activation_mcast;
+    const bool skip_weights_mcast = skip_mcast.skip_weights_mcast;
 
     const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -80,7 +80,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     const uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     const uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
-    const bool skip_mcast = is_singlecore_skip_mcast(parallelization_config, a.memory_config().memory_layout());
+    const bool skip_mcast = is_singlecore_skip_mcast(parallelization_config);
 
     const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -553,13 +553,16 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     std::vector<uint32_t> act_mcast_noc_y;
     if (block_sharded) {
         // 2D mcast
-        if (transpose_mcast && !skip_mcast) {
-            mcast_sender_cores = CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1));
-            mcast_receiver_cores = CoreRange(CoreCoord(1, 0), bottom_right_core);
-        } else if (!skip_mcast) {
-            mcast_sender_cores = CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0));
-            mcast_receiver_cores = CoreRange(CoreCoord(0, 1), bottom_right_core);
+        if (!skip_mcast) {
+            if (transpose_mcast) {
+                mcast_sender_cores = CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1));
+                mcast_receiver_cores = CoreRange(CoreCoord(1, 0), bottom_right_core);
+            } else {
+                mcast_sender_cores = CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0));
+                mcast_receiver_cores = CoreRange(CoreCoord(0, 1), bottom_right_core);
+            }
         }
+
         weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
         weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
     } else {
@@ -752,11 +755,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     std::map<std::string, std::string> writer_defines;
     std::map<std::string, std::string> writer_mcast_sender_defines;
     std::map<std::string, std::string> compute_defines;
-    if (total_num_cores == 1) {
-        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
-    }
     if (skip_mcast) {
         reader_defines["SKIP_MCAST"] = "1";
+        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
     }
     if (has_bias) {
         writer_defines["FUSE_BIAS"] = "1";
@@ -857,8 +858,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         bias_ntiles_per_core,
 
         get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
-        skip_mcast ? get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index
-                   : get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
         get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
@@ -965,7 +965,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                     (uint32_t)bottom_core_physical.x,  // act_mcast_sender_noc_x
                 };
                 reader_rt_args.insert(
-                    reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());  // act_mcast_sender_noc_y
+                    reader_rt_args.end(),
+                    act_mcast_noc_y.begin(),
+                    act_mcast_noc_y.end());  // act_mcast_sender_noc_y
             } else {
                 CoreCoord core = {core_x_i, core_y_i};
                 auto core_physical = device->worker_core_from_logical_core(core);
@@ -990,7 +992,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                     (uint32_t)core_physical.y,  // act_mcast_sender_noc_x
                 };
                 reader_rt_args.insert(
-                    reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());  // act_mcast_sender_noc_y
+                    reader_rt_args.end(),
+                    act_mcast_noc_y.begin(),
+                    act_mcast_noc_y.end());  // act_mcast_sender_noc_y
             }
         } else {
             reader_rt_args = {(uint32_t)noop_core};

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -345,7 +345,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     if (output_num_cores == 1) {
         writer_mcast_sender_defines["SKIP_MCAST"] = "1";
     }
-    bool skip_mcast = is_singlecore_skip_mcast(p_config, a.memory_config().memory_layout());
+    bool skip_mcast = is_singlecore_skip_mcast(p_config);
     if (skip_mcast) {
         reader_defines["SKIP_MCAST"] = "1";
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -342,13 +342,15 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     std::map<std::string, std::string> writer_mcast_sender_defines;
     std::map<std::string, std::string> compute_defines;
 
-    compute_defines["WIDTH_SHARDED"] = "1";
-
     const std::tuple<bool, bool>& skip_mcast =
         conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
     const bool skip_activation_mcast = std::get<0>(skip_mcast);
+    const bool skip_weights_mcast = std::get<1>(skip_mcast);
     if (skip_activation_mcast) {
         reader_defines["SKIP_MCAST"] = "1";
+    }
+    if (skip_weights_mcast) {
+        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
     }
     if (has_bias) {
         writer_defines["FUSE_BIAS"] = "1";

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -342,10 +342,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     std::map<std::string, std::string> writer_mcast_sender_defines;
     std::map<std::string, std::string> compute_defines;
 
-    const std::tuple<bool, bool>& skip_mcast =
-        conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
-    const bool skip_activation_mcast = std::get<0>(skip_mcast);
-    const bool skip_weights_mcast = std::get<1>(skip_mcast);
+    const SkipMcast& skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
+    const bool skip_activation_mcast = skip_mcast.skip_activation_mcast;
+    const bool skip_weights_mcast = skip_mcast.skip_weights_mcast;
     if (skip_activation_mcast) {
         reader_defines["SKIP_MCAST"] = "1";
     }


### PR DESCRIPTION
### Ticket

### Problem description
Multiple "skip_mcast" flags in conv program factories.

### What's changed
- Unify "skip_mcast" checks
- added test cases for single core HS, single core WS, single core BS, column BS, row BS

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [relevant jobs passing](https://github.com/tenstorrent/tt-metal/actions/runs/16570124584/job/46860402769)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [relevant jobs passing](https://github.com/tenstorrent/tt-metal/actions/runs/16616351655)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16571792000)