### PR TITLE
[skip ci] Optimize models-post-commit utilization

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -64,7 +64,9 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          source tests/scripts/run_python_model_tests.sh && run_python_model_tests_${{ inputs.arch }}
+          source tests/scripts/run_python_model_tests.sh
+          run_python_model_tests_${{ inputs.arch }}
+          run_python_model_tests_slow_runtime_mode_${{ inputs.arch }}
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
@@ -75,53 +77,4 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           path: generated/test_reports/
-          prefix: "test_reports_"
-
-  models-tests-slow-runtime-mode:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          {name: model},
-        ]
-    name: models slow dispatch
-    runs-on:
-      - ${{ inputs.runner-label }}
-      - in-service
-      - cloud-virtual-machine
-    container:
-      image: ${{ inputs.docker-image }}
-      env:
-        ARCH_NAME: ${{ inputs.arch }}
-        LOGURU_LEVEL: INFO
-        PYTHONPATH: /work
-        SLOW_RUNTIME_MODE: true
-      volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
-    defaults:
-      run:
-        shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
-    steps:
-      - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
-        timeout-minutes: 10
-        with:
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          enable-watcher: ${{ inputs.enable-watcher }}
-      - name: ${{ matrix.test-group.name }} slow runtime mode tests
-        timeout-minutes: ${{ inputs.timeout }}
-        run: |
-          source tests/scripts/run_python_model_tests.sh && run_python_model_tests_slow_runtime_mode_${{ inputs.arch }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U06CXU895AP # Michael Chiou
-      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
-        if: ${{ !cancelled() }}
-        with:
           prefix: "test_reports_"


### PR DESCRIPTION
### Ticket
NA

### Problem description
Models Post Commit runs two tests. The second is 45 seconds. When ran in isolation - this job is very wasteful of resources due to machine setup/teardown.

### What's changed
- Merge two jobs into one (This ends up being 4 jobs into 2, because of N150 and N300).
- Eliminate non functional SLOW_RUNTIME_MODE variable.

### Checklist
- [x] [Models post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16571984122) CI passes