### PR TITLE
Fix non-determinism of pow function (disable stochastic rounding)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -236,6 +236,36 @@ def test_binary_sfpu_accuracy(device, dtype):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
+def test_pow_determinism(device, dtype):
+    torch.manual_seed(0)
+
+    torch_dtype = getattr(torch, dtype)
+    ttnn_dtype = getattr(ttnn, dtype)
+
+    shape = [512, 512]
+
+    torch_a = torch.randn(shape, dtype=torch_dtype)
+    torch_b = torch.randn(shape, dtype=torch_dtype)
+
+    # Run the operations twice, and check that results are the same
+    # This ensures that, by default, ttnn.pow is deterministic (expected behavior from MLIR)
+
+    ttnn_a = ttnn.from_torch(torch_a, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_b = ttnn.from_torch(torch_b, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # First round
+    ttnn_result_1 = ttnn.pow(ttnn_a, ttnn_b)
+    ttnn_result_1_torch = ttnn.to_torch(ttnn_result_1)
+
+    # Second round
+    ttnn_result_2 = ttnn.pow(ttnn_a, ttnn_b)
+    ttnn_result_2_torch = ttnn.to_torch(ttnn_result_2)
+
+    mask = torch.isnan(ttnn_result_1_torch) | torch.isnan(ttnn_result_2_torch)
+    assert torch.equal(ttnn_result_1_torch[~mask], ttnn_result_2_torch[~mask])
+
+
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 def test_binary_sfpu_accuracy_pos(device, dtype):
     if ttnn.get_arch_name() == "blackhole":
         pytest.skip("Blackhole implementation of pow is stil legacy and inaccurate")

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -123,8 +123,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif, 0);
     d2 = d1 * d2;
     zif = _float_to_int32_positive_(d2 * d3);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

Following the new pow implementation in #25025, some [MLIR tests have been failing](https://github.com/tenstorrent/tt-mlir/actions/runs/16561428849/job/46832850493?pr=4226#step:19:278) due to `pow` not producing the same output on successive calls with the same inputs. 
This non-determinism has been caused by missing arguments to the `int32_to_float` function in the pow approximation: it uses stochastic rounding by default. 

### What's changed

This PR sets the default parameter of `int32_to_float` to round-to-nearest-tie-to-event. 
It also tests for determinism (i.e. consecutive calls to pow on the same input should produce the same results)

Both the execution time and the accuracy (beyond float32 rounding) are the same.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/16572978864/job/46875466293
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [X] New/Existing tests provide coverage for changes