### PR TITLE
Revert "set dtype torch.bfloat16 for input tensor (#25834)"

### DIFF
--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -157,9 +157,7 @@ def test_attention_inference(
 
     for i in range(generation_length):
         # 70B attention block typically sees tensors with mean 0 and std 0.03 - 0.05 in layer 1
-        pt_attention_input = torch.randn(
-            batch_size, seq_len, model_args.dim, dtype=torch.bfloat16
-        )  # Qwen2.5 0.5B sees 0.1 to 2.1
+        pt_attention_input = torch.randn(batch_size, seq_len, model_args.dim)  # Qwen2.5 0.5B sees 0.1 to 2.1
 
         tt_attention_input = pt_attention_input.clone()
 

--- a/models/tt_transformers/tests/test_attention_prefill.py
+++ b/models/tt_transformers/tests/test_attention_prefill.py
@@ -134,7 +134,7 @@ def test_attention_inference(
         paged_attention_config=paged_attention_config,
     )
 
-    pt_attention_input = (torch.rand(batch_size, max_seq_len, model_args.dim, dtype=torch.bfloat16) * 2) - 1
+    pt_attention_input = (torch.rand(batch_size, max_seq_len, model_args.dim) * 2) - 1
     tt_attention_input = pt_attention_input.clone()
     attention_input = model_args.prepare_residual_tensor_prefill(
         tt_attention_input,

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -156,7 +156,7 @@ def test_decoder_inference(
         logger.info(f"[Decoder] Generating token {i}")
 
         # input = torch.randn(1, 32, 4096)
-        pt_decode_input = (torch.rand(batch_size, seqlen, model_args.dim, dtype=torch.bfloat16) * 2) - 1
+        pt_decode_input = (torch.rand(batch_size, seqlen, model_args.dim) * 2) - 1
         tt_decode_input = pt_decode_input.clone()
 
         decode_input = model_args.prepare_residual_tensor_decode(

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -141,7 +141,7 @@ def test_decoder_inference(
 
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
-        pt_decode_input = (torch.rand(batch_size, max_seq_len, model_args.dim, dtype=torch.bfloat16) * 2) - 1
+        pt_decode_input = (torch.rand(batch_size, max_seq_len, model_args.dim) * 2) - 1
         tt_decode_input = pt_decode_input.clone()
         decode_input = model_args.prepare_residual_tensor_prefill(
             tt_decode_input,

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -59,7 +59,7 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc)
         dtype=dtype,
         model_config=model_args.get_model_config(),
     )
-    torch_input = torch.randn(1, 1, seq_len, model_args.dim, dtype=torch.bfloat16)
+    torch_input = torch.randn(1, 1, seq_len, model_args.dim)
     reference_output = reference_model(torch_input)
     tt_input = ttnn.from_torch(
         torch_input,


### PR DESCRIPTION
This reverts commit c2668a69fb6667b9a15651f7df7f7f4f5abbcdb1.

### Problem description
tt-llama3.2-1B is consistently failing on main in (Single-card) Frequent model and ttnn tests pipeline with error: `RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != float`


### What's changed
Revert commit c2668a69fb6667b9a15651f7df7f7f4f5abbcdb1