### PR TITLE
Use paged attention in MLA decode

### DIFF
--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -27,9 +27,11 @@ from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
     ModelPrefillConfig,
+    RunDecodeConfig,
     RunPrefillConfig,
     WeightConfig,
 )
+from models.tt_transformers.tt.common import PagedAttentionConfig
 from models.utility_functions import nearest_y
 
 
@@ -805,11 +807,131 @@ class MLA1D(AbstractModule):
         }
 
     @classmethod
+    def get_valid_paged_config(
+        cls, max_seq_len: int, batch_size: int, dp_factor: int, block_size: int = ttnn.TILE_SIZE
+    ) -> PagedAttentionConfig:
+        """Get a valid paged attention configuration for MLA1D.
+
+        This function also calculates max_num_blocks such that each user will have max_seq_len available.
+        For DP, the max_num_blocks is divided by the batch size of the DP shard, not the total batch size.
+
+        Args:
+            max_seq_len: Maximum sequence length
+            batch_size: Batch size for the model
+            block_size: Block size for paged attention (default is TILE_SIZE)
+
+        Returns:
+            A PagedAttentionConfig object with valid parameters
+        """
+        assert max_seq_len % block_size == 0, f"max_seq_len {max_seq_len} must be divisible by block_size {block_size}."
+        assert (
+            block_size % ttnn.TILE_SIZE == 0
+        ), f"block_size {block_size} must be a multiple of TILE_SIZE {ttnn.TILE_SIZE}."
+
+        batch_per_shard = even_int_div(batch_size, dp_factor)
+        max_num_blocks = (
+            max_seq_len * batch_per_shard
+        ) // block_size  # Such that each user will have max_seq_len available
+
+        return PagedAttentionConfig(
+            block_size=block_size,
+            max_num_blocks=max_num_blocks,
+        )
+
+    @classmethod
+    def create_page_table(
+        cls,
+        batch_size: int,
+        dp_factor: int,
+        config: PagedAttentionConfig,
+        mesh_device: ttnn.MeshDevice,
+    ) -> ttnn.Tensor:
+        """Helper funtion to create the page table for MLA1D.
+
+        When doing DP, this function replicates the page table across DP shards.
+        Assumptions:
+            - If user X on DP shard 1 is on position N, with page id P,
+                and if user X on DP shard 2 is also on position N, it will also be on page id P.
+                As such, the max_num_blocks is only cut by the batch size of the DP shard, not the total batch size.
+
+        Args:
+            batch_size: Batch size for the model
+            dp_factor: Data parallelism factor, indicating how many DP shards are present
+            config: PagedAttentionConfig containing page table configuration
+            mesh_device: TTNN mesh device
+
+        Returns:
+            A tensor representing the page table
+        """
+        assert cls.is_device_supported(
+            mesh_device
+        ), f"Mesh device shape {mesh_device.shape} must be supported by MLA1D."
+
+        max_num_blocks = config.max_num_blocks
+        batch_per_shard = even_int_div(batch_size, dp_factor)
+
+        page_table = torch.randperm(max_num_blocks, dtype=torch.int32)  # Randperm not necessary, but more rigourous
+        page_table = page_table.reshape(batch_per_shard, even_int_div(max_num_blocks, batch_per_shard))
+
+        tt_page_table = ttnn.from_torch(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+        return tt_page_table, page_table
+
+    @classmethod
+    def from_paged_cache(
+        cls,
+        paged_cache: torch.Tensor,
+        mapping: torch.Tensor,
+        dp_factor: int,
+    ) -> torch.Tensor:
+        """
+        Convert a set of concatenated paged cache back to the original cache format using the provided mapping.
+
+        Args:
+            paged_cache: The paged cache tensor, concatenation of all the DP shards.
+                Each paged_cache shard will have a certain number of max_num_blocks. The max_num_blocks is spread
+                across the batch size of that shard, ie batch_size // dp_factor.
+            mapping: The mapping tensor that defines how to convert the paged cache.
+                The mapping tensor is of shape (batch_per_shard, num_blocks_per_batch) and contains the indices to reorder
+                the paged cache back to the original order.
+            dp_factor: The data parallelism factor, which indicates how many DP shards are present.
+        Returns:
+            cache: The converted cache tensor.
+        """
+        paged_cache = paged_cache.reshape(dp_factor, -1, *paged_cache.shape[1:])
+
+        max_num_blocks, nh, block_size, dim = paged_cache.shape[1:]
+        batch_per_shard, num_blocks_per_batch = mapping.shape
+
+        caches = []
+        for idx, paged_cache_ in enumerate(paged_cache):  # Loop through each DP shard
+            # Use the mapping to get the original order, paged_cache + mapping = original cache
+            cache = paged_cache_[mapping.view(-1)]
+
+            cache = cache.reshape(
+                batch_per_shard, num_blocks_per_batch, nh, block_size, dim
+            )  # (B, num_blocks // B, H, block_size, D)
+            cache = cache.transpose(1, 2)  # (B, H, num_blocks // B, block_size, D)
+            cache = cache.reshape(batch_per_shard, nh, -1, dim)  # (B, H, seq_len, D)
+
+            caches.append(cache)
+
+        return torch.concat(caches, dim=0)
+
+    @classmethod
     def create_state(
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        use_dp_cache: bool,
+        dp_factor: int,
+        paged_config: PagedAttentionConfig,
     ) -> Any:
         kv_lora_rank = hf_config.kv_lora_rank
         qk_rope_head_dim = hf_config.qk_rope_head_dim
@@ -822,16 +944,24 @@ class MLA1D(AbstractModule):
 
         mesh_shape = list(mesh_device.shape)
 
-        cache = torch.zeros(
-            (
-                even_int_div(
-                    MLA1D.MAX_BATCH_SIZE, (mesh_shape[1] if use_dp_cache else 1)
-                ),  # Prefill does not support DP yet
-                1,  # 1 latent kv heads
-                max_seq_len,
-                kvpe_dim,
+        if paged_config:
+            cache = torch.zeros(
+                (
+                    paged_config.max_num_blocks,
+                    1,  # 1 latent kv heads
+                    paged_config.block_size,
+                    kvpe_dim,
+                )
             )
-        )
+        else:
+            cache = torch.zeros(
+                (
+                    even_int_div(MLA1D.MAX_BATCH_SIZE, dp_factor),  # Prefill does not support DP yet
+                    1,  # 1 latent kv heads
+                    max_seq_len,
+                    kvpe_dim,
+                )
+            )
 
         tt_cache = ttnn.as_tensor(
             cache,
@@ -847,15 +977,16 @@ class MLA1D(AbstractModule):
 
     @classmethod
     def forward_decode(
-        self, x: ttnn.Tensor, position_idxs: [int], rope_tensors: dict, cfg: RunPrefillConfig
+        self, x: ttnn.Tensor, cfg: RunDecodeConfig, position_idxs: [int], rope_tensors: dict, page_table: ttnn.Tensor
     ) -> ttnn.Tensor:
         """Forward pass of MLA1D in decode mode.
 
         Args:
             x: Input tensor of shape (batch_size, seq_len, dim)
+            cfg: RunConfig containing weights and op configurations
             position_idxs: List of position indices for the current batch
             rope_tensors: Dictionary containing RoPE tensors
-            cfg: RunConfig containing weights and op configurations
+            page_table: Page table tensor for paged attention
         Returns:
             Output tensor after MLA1D computation
 
@@ -944,6 +1075,7 @@ class MLA1D(AbstractModule):
         tt_kv_rope = ttnn.permute(tt_kv_rope, (0, 2, 1, 3))  # [1, bsz, 1, qk_rope_head_dim]
         tt_kv_rope = ttnn.to_memory_config(tt_kv_rope, **cfg["kv_rope_reshard"])
         # TODO: Use DP tensors
+        # Currently, not using DP tensors because sub-tile RS is not supported
         tt_kv_rope = ttnn.experimental.rotary_embedding_llama(
             tt_kv_rope,
             rope_tensors["cos_matrix"],
@@ -972,13 +1104,15 @@ class MLA1D(AbstractModule):
             kvpe_cache,
             tt_kvpe,
             update_idxs_tensor=position_idxs,
+            page_table=page_table,
         )
 
         # FlashMLA
         tt_q = ttnn.to_memory_config(tt_q, **cfg["flash_mla_reshard"])
-        attn_out = ttnn.transformer.flash_multi_latent_attention_decode(
+        attn_out = ttnn.transformer.paged_flash_multi_latent_attention_decode(
             tt_q,
             kvpe_cache,
+            page_table_tensor=page_table,
             cur_pos_tensor=position_idxs,
             **cfg["flash_mla"],
         )  #  [1, bsz_local, num_heads, kv_lora_rank]
@@ -1010,16 +1144,16 @@ class MLA1D(AbstractModule):
         return out
 
     @classmethod
-    def forward_prefill(self, x: ttnn.Tensor, user_id: int, rope_tensors: dict, cfg: RunPrefillConfig) -> ttnn.Tensor:
+    def forward_prefill(self, x: ttnn.Tensor, cfg: RunPrefillConfig, user_id: int, rope_tensors: dict) -> ttnn.Tensor:
         """Forward pass of the MLP.
 
         Prefill mode we reshape to respect cfg["max_rows"] and generate program configs from the seq-len lambda.
 
         Args:
             x: Input tensor
+            cfg: RunConfig containing weights and op configurations
             user_id: Batch index for cache updates
             rope_tensors: Dictionary containing RoPE tensors
-            cfg: RunConfig containing weights and op configurations
 
         Returns:
             Output tensor after MLP computation

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -956,7 +956,7 @@ class MLA1D(AbstractModule):
         else:
             cache = torch.zeros(
                 (
-                    even_int_div(MLA1D.MAX_BATCH_SIZE, dp_factor),  # Prefill does not support DP yet
+                    even_int_div(MLA1D.MAX_BATCH_SIZE, dp_factor),
                     1,  # 1 latent kv heads
                     max_seq_len,
                     kvpe_dim,


### PR DESCRIPTION
### Ticket
- #23022 

### Problem description
Currently, the MLA module does not use paged attention.

### What's changed
- Enable paged attention in MLA decode
- Add certain helper funcs, tied to the MLA module, to make it easier to work with page tables and paged caches
  - `get_valid_paged_config`: Generates a valid paged config, making sure each user can accommodate the `max_seq_len`
  - `create_page_table`: Creates a TT and Torch page table, with support for DP
  - `from_paged_cache`: Converts a paged TT cache (torch tensor) to a valid cache that can be compared with the reference cache. Supports DP

### ⚠️ TODOs ⚠️ 
- [x] Wait for the [MLA refactor PR](https://github.com/tenstorrent/tt-metal/pull/25892) to be merged

### Checklist
- [ ] New/Existing tests provide coverage for changes