### PR TITLE
Update small Llama perf numbers

### DIFF
--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -19,10 +19,10 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models excep
 | Llama-3.2-1B      | T3K         | 77        | 96        | 119.8         | 32        |
 | Llama-3.2-1B      | TG          | 77        | 96        | 51.0          |           |
 | Llama-3.2-3B      | N150        | 87        | 97        | 54.0          | 55        |
-| Llama-3.2-3B      | N300        | 88        | 97        | 68.0          | 39        |
+| Llama-3.2-3B      | N300        | 87        | 97        | 68.0          | 39        |
 | Llama-3.2-3B      | T3K         | 88        | 97        | 68.5          | 52        |
 | Llama-3.2-3B      | TG          | 87        | 97        | 33.5          |           |
-| Llama-3.1-8B      | N150        | 89        | 98        | 28.3          | 104       |
+| Llama-3.1-8B      | N150        | 88        | 98        | 28.3          | 104       |
 | Llama-3.1-8B      | N300        | 89        | 97        | 44.2          | 67        |
 | Llama-3.1-8B      | T3K         | 88        | 97        | 64.3          | 53        |
 | Llama-3.1-8B      | T3K  (DP=4) |           |           | 39.6          | 58        |

--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -22,7 +22,7 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models excep
 | Llama-3.2-3B      | N300        | 87        | 97        | 68.0          | 39        |
 | Llama-3.2-3B      | T3K         | 88        | 97        | 68.5          | 52        |
 | Llama-3.2-3B      | TG          | 87        | 97        | 33.5          |           |
-| Llama-3.1-8B      | N150        | 88        | 98        | 28.3          | 104       |
+| Llama-3.1-8B      | N150        | 88        | 97        | 28.3          | 104       |
 | Llama-3.1-8B      | N300        | 89        | 97        | 44.2          | 67        |
 | Llama-3.1-8B      | T3K         | 88        | 97        | 64.3          | 53        |
 | Llama-3.1-8B      | T3K  (DP=4) |           |           | 39.6          | 58        |
@@ -59,7 +59,7 @@ Llama 3 models test as insensitive to attention precision and so we use bfp8 att
 | Llama-3.2-1B      | T3K         | 85        | 98        | 120.5         | 28        |
 | Llama-3.2-1B      | TG          | 85        | 98        | 48.4          |           |
 | Llama-3.2-3B      | N150        | 92        | 99        | 47.6          | 63        |
-| Llama-3.2-3B      | N300        | 93        | 100        | 63.5          | 41        |
+| Llama-3.2-3B      | N300        | 93        | 99        | 63.5          | 41        |
 | Llama-3.2-3B      | T3K         | 93        | 99        | 67.9          | 69        |
 | Llama-3.2-3B      | TG          | 92        | 99        | 33.6          |           |
 | Llama-3.1-8B      | N150        | 94        | 100       | 25.2          | 138       |

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1078,7 +1078,7 @@ def test_demo_text(
             }
             ci_target_decode_tok_s_u = {
                 # N150 targets - higher is better
-                "N150_Llama-3.2-1B": 58,
+                "N150_Llama-3.2-1B": 65,
                 "N150_Llama-3.2-3B": 35,
                 "N150_Llama-3.1-8B": 21,
                 "N150_Mistral-7B": 23,


### PR DESCRIPTION
A recent commit that improve SDPA op: https://github.com/tenstorrent/tt-metal/commit/124e0f31723ebcbcad8b0d9cdd8072ed6dbc8864 had some effects on smaller Llama models.

This PR updates the target perf and the accuracy for those models affected.

- [x] [Single-device demo](https://github.com/tenstorrent/tt-metal/actions/runs/16594103843)
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/16594136523)