### PR TITLE
Correct End of Page checks in Embedding

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/test_embedding.py
@@ -58,6 +58,42 @@ def test_embedding(
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.parametrize("batch_size", [55, 100, 200])
+@pytest.mark.parametrize("sentence_size", [1, 10, 100])
+@pytest.mark.parametrize("hidden_embedding_dim", [1, 128])  # Bert_Num_Cols_768, Llama_Num_Cols
+@pytest.mark.parametrize(
+    "vocabulary_size", [768]
+)  # Bert_Position_Embeddings_512, Bert_Word_Embeddings_30528, Llama_Position_Embeddings,
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("output_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_embedding_unaligned_RM_pages(
+    device,
+    batch_size,
+    sentence_size,
+    hidden_embedding_dim,
+    vocabulary_size,
+    dtype,
+    input_mem_config,
+    output_mem_config,
+    layout,
+):
+    torch.manual_seed(1234)
+
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    input_tensor = ttnn.to_device(ttnn.from_torch(torch_input_tensor), device, memory_config=input_mem_config)
+    weights = ttnn.to_device(ttnn.from_torch(torch_weights, dtype=dtype), device, memory_config=input_mem_config)
+
+    output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=layout)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor)
+
+
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sentence_size", [384])
 @pytest.mark.parametrize("hidden_embedding_dim", [1024])

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     uint32_t curr_row = batch_offset;  // Number of pages/rows we have read from input so far
     uint32_t offset = weights_offset;  // Which input elem we are on (bytes offset from start of row)
     uint32_t index = index_idx;
-    uint32_t input_size_bytes = input_block_size_bytes / rows_per_block;
+    uint32_t input_elem_size_bytes = input_block_size_bytes / rows_per_block;
 
     bool read_indices = true;
     for (uint32_t i = 0; i < num_rows; ++i) {
@@ -57,7 +57,7 @@ void kernel_main() {
         cb_push_back(cb_id_in0, 1);
 
         index++;
-        uint32_t total_bytes_into_page = offset + index * input_size_bytes;
+        uint32_t total_bytes_into_page = offset + index * input_elem_size_bytes;
         bool end_of_block = index == rows_per_block;
         bool end_of_page = total_bytes_into_page == input_page_size;
         if (end_of_block || end_of_page) {

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     constexpr uint32_t weight_stick_size = get_compile_time_arg_val(6);
     const auto weights = get_interleaved_addr_gen<weight_in_dram, weight_stick_size>(weight_buffer_src_addr);
 
-    constexpr uint32_t rows_per_block = get_compile_time_arg_val(7);
+    constexpr uint32_t rows_per_block = get_compile_time_arg_val(7);  // Input elems per block
     constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(8);
 
     prepare_local_cache(cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
@@ -35,9 +35,10 @@ void kernel_main() {
     uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
-    uint32_t curr_row = batch_offset;
-    uint32_t offset = weights_offset;
+    uint32_t curr_row = batch_offset;  // Number of pages/rows we have read from input so far
+    uint32_t offset = weights_offset;  // Which input elem we are on (bytes offset from start of row)
     uint32_t index = index_idx;
+    uint32_t input_size_bytes = input_block_size_bytes / rows_per_block;
 
     bool read_indices = true;
     for (uint32_t i = 0; i < num_rows; ++i) {
@@ -56,14 +57,17 @@ void kernel_main() {
         cb_push_back(cb_id_in0, 1);
 
         index++;
-        if (index == rows_per_block) {
-            index = 0;
-            read_indices = true;
+        uint32_t total_bytes_into_page = offset + index * input_size_bytes;
+        bool end_of_block = index == rows_per_block;
+        bool end_of_page = total_bytes_into_page == input_page_size;
+        if (end_of_block || end_of_page) {
             offset += input_block_size_bytes;
-            if (offset == input_page_size) {
+            if (end_of_page) {
                 offset = 0;
                 curr_row++;
             }
+            index = 0;
+            read_indices = true;
         }
     }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23481)

### Problem description
Embedding was giving bad pcc for specific shapes, further investigation found it had to do with shapes with large batch dims for the input indices

### What's changed
The RM embedding reader was checking only if it was at the end of a hardware aligned block before checking if it was at the end of a page, so this only worked for block-aligned input tensors. Now the embedding kernel correctly checks if we are at the end of a block OR a page.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16660894070) CI passes
- [ ] [T3K]()
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16579915224) CI passes (if applicable)