### PR TITLE
Enable weight cache loading for experts

### DIFF
--- a/.github/workflows/tg-deepseek-tests-impl.yaml
+++ b/.github/workflows/tg-deepseek-tests-impl.yaml
@@ -69,7 +69,7 @@ jobs:
 
           pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           pytest models/demos/deepseek_v3/tests/test_embedding_1d.py --timeout 10 || fail=1
-          pytest models/demos/deepseek_v3/tests/test_expert.py --timeout 15 || fail=1
+          pytest models/demos/deepseek_v3/tests/test_moe_experts.py --timeout 15 || fail=1
           pytest models/demos/deepseek_v3/tests/test_mla_1d.py --timeout 10 || fail=1
           pytest models/demos/deepseek_v3/tests/test_mlp_1d.py --timeout 5 || fail=1
           pytest models/demos/deepseek_v3/tests/test_rms_norm.py --timeout 5 || fail=1

--- a/.github/workflows/tg-deepseek-tests-impl.yaml
+++ b/.github/workflows/tg-deepseek-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 30, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "Galaxy DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 50, owner_id: U03HY7MK4BT}, # Mark O'Connor
         ]
     runs-on:
       - arch-wormhole_b0
@@ -69,7 +69,7 @@ jobs:
 
           pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           pytest models/demos/deepseek_v3/tests/test_embedding_1d.py --timeout 10 || fail=1
-          pytest models/demos/deepseek_v3/tests/test_expert.py --timeout 5 || fail=1
+          pytest models/demos/deepseek_v3/tests/test_expert.py --timeout 15 || fail=1
           pytest models/demos/deepseek_v3/tests/test_mla_1d.py --timeout 10 || fail=1
           pytest models/demos/deepseek_v3/tests/test_mlp_1d.py --timeout 5 || fail=1
           pytest models/demos/deepseek_v3/tests/test_rms_norm.py --timeout 5 || fail=1

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -66,6 +66,11 @@ def model_path():
     return Path(os.getenv("HF_MODEL", "models/demos/deepseek_v3/reference"))
 
 
+@pytest.fixture(scope="session")
+def tensor_cache_path():
+    return Path(os.getenv("DEEPSEEK_V3_CACHE", "/proj_sw/user_dev/deepseek-v3-cache/tensors_cache"))
+
+
 @pytest.fixture
 def reference_io(request):
     param = getattr(request, "param", None)

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -45,7 +45,7 @@ class DeepseekV3MoE_Experts(nn.Module):
 
 
 @pytest.fixture
-def reference_model(hf_config: Any | torch.Any):
+def reference_model(hf_config: Any):
     """Get the actual DeepSeek MLP model using local implementation."""
     torch.manual_seed(0)
     return DeepseekV3MoE_Experts(hf_config).eval()

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -55,7 +55,7 @@ def reference_model(hf_config: Any | torch.Any):
     "mode,seq_len",
     [
         ("decode", 128),
-        ("prefill", 2048),
+        ("prefill", 1024),
     ],
 )
 def test_forward_pass(


### PR DESCRIPTION
### Problem description
`test_expert.py `is timing out in CI due to longer runtime as we generate ttnn tensors for each experts everytime.

❗ This PR is just a proposal, we need to adopt a common api for caching and loading ttnn tensors.❗

This pull request introduces several updates to `test_experts.py` adding caching mechanisms, and enhancing logging for tensor operations. Below is a breakdown of the most important changes:

### Test Configuration Updates:
* Increased the timeout for the "Galaxy DeepSeek tests" job from 30 to 50 mins in `.github/workflows/tg-deepseek-tests-impl.yaml` to accommodate longer test runs.
* Adjusted the timeout for the `test_expert.py` test from 5 to 15 min to prevent premature test failures.
* Reduced the sequence length for the "prefill" mode in `test_forward_pass` from 2048 to 1024 to fix following ttnn error
```
if ttnn.is_tensor_storage_on_device(tensor):
      tensor = ttnn.from_device(tensor, cq_id=cq_id)
   
>    tensor = tensor.to_torch(mesh_composer=mesh_composer)
E    ValueError: cannot create std::vector larger than max_size()

ttnn/ttnn/operations/core.py:376: ValueError
```

### Caching Mechanisms:
* Introduced a new `tensor_cache_path` fixture in `models/demos/deepseek_v3/conftest.py` to enable caching of tensors for reuse, reducing redundant computations.
* Updated `test_forward_pass` in `test_moe_experts.py` to use the new `tensor_cache_path` for weight conversion, replacing the previous `tmp_path`.

### Logging Enhancements:
* Added logging using `loguru` in `models/demos/deepseek_v3/tt/expert.py` to provide better visibility into tensor caching operations, including whether tensors are being saved or reused from the cache. [[1]](diffhunk://#diff-8b5ab71b988ce8d735bdd366fa3804407cde6e4de36ce482fcbd29e9c5231210R9) [[2]](diffhunk://#diff-8b5ab71b988ce8d735bdd366fa3804407cde6e4de36ce482fcbd29e9c5231210L72-R91)

### Code Improvements:
* Ensured that the `reference_model` in `test_moe_experts.py` is set to evaluation mode and initialized with a fixed random seed for deterministic testing.
* Wrapped the forward pass of the `reference_model` in a `torch.no_grad()` block to prevent unnecessary gradient computations during tests.


### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes