### PR TITLE
detect dtype and set for input tensor

### DIFF
--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -8,6 +8,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.tt_transformers.tests.test_utils import get_ref_model_dype
 from models.tt_transformers.tt.attention import Attention
 from models.tt_transformers.tt.common import PagedAttentionConfig, precompute_freqs
 from models.tt_transformers.tt.model_config import ModelArgs
@@ -157,7 +158,9 @@ def test_attention_inference(
 
     for i in range(generation_length):
         # 70B attention block typically sees tensors with mean 0 and std 0.03 - 0.05 in layer 1
-        pt_attention_input = torch.randn(batch_size, seq_len, model_args.dim)  # Qwen2.5 0.5B sees 0.1 to 2.1
+        pt_attention_input = torch.randn(
+            batch_size, seq_len, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+        )  # Qwen2.5 0.5B sees 0.1 to 2.1
 
         tt_attention_input = pt_attention_input.clone()
 

--- a/models/tt_transformers/tests/test_attention_prefill.py
+++ b/models/tt_transformers/tests/test_attention_prefill.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import precompute_freqs_cis
+from models.tt_transformers.tests.test_utils import get_ref_model_dype
 from models.tt_transformers.tt.attention import Attention
 from models.tt_transformers.tt.common import PagedAttentionConfig, get_prefill_rot_mat, get_rot_transformation_mat
 from models.tt_transformers.tt.model_config import ModelArgs
@@ -134,7 +135,12 @@ def test_attention_inference(
         paged_attention_config=paged_attention_config,
     )
 
-    pt_attention_input = (torch.rand(batch_size, max_seq_len, model_args.dim) * 2) - 1
+    pt_attention_input = (
+        torch.rand(
+            batch_size, max_seq_len, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+        )
+        * 2
+    ) - 1
     tt_attention_input = pt_attention_input.clone()
     attention_input = model_args.prepare_residual_tensor_prefill(
         tt_attention_input,

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -8,6 +8,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.tt_transformers.tests.test_utils import get_ref_model_dype
 from models.tt_transformers.tt.common import PagedAttentionConfig, precompute_freqs
 from models.tt_transformers.tt.decoder import TransformerBlock
 from models.tt_transformers.tt.model_config import ModelArgs
@@ -156,7 +157,12 @@ def test_decoder_inference(
         logger.info(f"[Decoder] Generating token {i}")
 
         # input = torch.randn(1, 32, 4096)
-        pt_decode_input = (torch.rand(batch_size, seqlen, model_args.dim) * 2) - 1
+        pt_decode_input = (
+            torch.rand(
+                batch_size, seqlen, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+            )
+            * 2
+        ) - 1
         tt_decode_input = pt_decode_input.clone()
 
         decode_input = model_args.prepare_residual_tensor_decode(

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import precompute_freqs_cis
+from models.tt_transformers.tests.test_utils import get_ref_model_dype
 from models.tt_transformers.tt.common import PagedAttentionConfig, get_prefill_rot_mat, get_rot_transformation_mat
 from models.tt_transformers.tt.decoder import TransformerBlock
 from models.tt_transformers.tt.model_config import ModelArgs
@@ -141,7 +142,15 @@ def test_decoder_inference(
 
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
-        pt_decode_input = (torch.rand(batch_size, max_seq_len, model_args.dim) * 2) - 1
+        pt_decode_input = (
+            torch.rand(
+                batch_size,
+                max_seq_len,
+                model_args.dim,
+                dtype=get_ref_model_dype(reference_model, model_args.model_name),
+            )
+            * 2
+        ) - 1
         tt_decode_input = pt_decode_input.clone()
         decode_input = model_args.prepare_residual_tensor_prefill(
             tt_decode_input,

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.tt_transformers.tests.test_utils import get_ref_model_dype
 from models.tt_transformers.tt.mlp import MLP
 from models.tt_transformers.tt.model_config import ModelArgs
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
@@ -59,7 +60,10 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc)
         dtype=dtype,
         model_config=model_args.get_model_config(),
     )
-    torch_input = torch.randn(1, 1, seq_len, model_args.dim)
+
+    torch_input = torch.randn(
+        1, 1, seq_len, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+    )
     reference_output = reference_model(torch_input)
     tt_input = ttnn.from_torch(
         torch_input,

--- a/models/tt_transformers/tests/test_utils.py
+++ b/models/tt_transformers/tests/test_utils.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from models.tt_transformers.tt.model_config import HfAttentionWrapper
+
+
+def _extract_dtype_from_state_dict(model):
+    """Helper to extract dtype from model's state_dict."""
+    try:
+        state_dict = model.state_dict()
+        for key, param in state_dict.items():
+            if "weight" in key:
+                print(f"get_ref_model_dype: key={key}, dtype={param.dtype}")
+                return param.dtype
+    except Exception as e:
+        pass
+    return None
+
+
+def get_ref_model_dype(ref_model, model_name):
+    default_dype = torch.float32
+
+    if ref_model is None and model_name is None:
+        return default_dype
+
+    try:
+        models_to_check = []
+        if isinstance(ref_model, HfAttentionWrapper):
+            # HfAttentionWrapper is a wrapper around a HuggingFace model
+            models_to_check = [ref_model.model, ref_model.attention, ref_model.decoder]
+        else:
+            models_to_check = [ref_model]
+
+        # Try all models until one works
+        for model in models_to_check:
+            if model is not None:
+                dtype = _extract_dtype_from_state_dict(model)
+                if dtype is not None:
+                    return dtype
+
+    except Exception as e:
+        pass
+
+    # try hardcoded dtypes
+    if model_name and isinstance(model_name, str):
+        model_name_lower = model_name.lower()
+        if "mistral-7b" in model_name_lower:
+            return torch.bfloat16
+        if "llama" in model_name_lower:
+            return torch.bfloat16
+
+    return default_dype


### PR DESCRIPTION
### Ticket
None

### Problem description
dtype mismatch creates issue "expected m1 and m2 to have the same dtype, but got: float != c10::BFloat16"

### What's changed
Try to get dtype from reference_model state dict, if that does not work try known-to-work-hard-coded-values for models to find expected dtype of the input tensor.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes