### PR TITLE
[tt_transfromers] Propagate unmapped weights hf->meta

### DIFF
--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -134,16 +134,21 @@ def map_hf_to_meta_keys(loaded_weights):
         prefix = next((p for p in _get_known_prefixes_mapping().keys() if key.startswith(p)), "")
         key = key.replace(prefix, _get_known_prefixes_mapping().get(prefix, ""), 1)
 
+        new_key = key
         if key in hf_to_meta:
             # Direct match for top-level keys
-            meta_state_dict[hf_to_meta[key]] = tensor
-        elif "model.layers." in key:
+            new_key = hf_to_meta[key]
+        elif key.startswith("model.layers."):
             # Extract layer number and form a template key
             parts = key.split(".")
             layer_num = parts[2]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
             template_key = "model.layers.{layer}." + ".".join(parts[3:])
             if template_key in hf_to_meta:
-                meta_state_dict[hf_to_meta[template_key].format(layer=layer_num)] = tensor
+                new_key = hf_to_meta[template_key].format(layer=layer_num)
+            else:
+                new_key = key[len("model.") :]  # Remove "model." prefix
+
+        meta_state_dict[new_key] = tensor
 
     return meta_state_dict
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22799

### Problem description
Gemma3 Decoder tries loading weights that don't exist in Meta state_dict as they are not in the map

### What's changed
For weights that don't exist in Meta implementation, just propagate them without `model.` prefix.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16589238684)
- [x] [T3K Unit and Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16570175274) (Failures are the same as on main)
- [x] [Single card demo](https://github.com/tenstorrent/tt-metal/actions/runs/16598668447) (Failures are the same as on main)