### PR TITLE
Global and local embeddings

### DIFF
--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -93,6 +93,9 @@ class Attention(LightweightModule):
         self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
 
         self.transformation_mats = transformation_mats
+        self.is_sliding = (
+            configuration.layer_types[layer_num] == "sliding_window" if configuration.layer_types else False
+        )
 
         self.model_config = configuration.get_model_config()
         self.ccl_topology = configuration.ccl_topology()
@@ -866,6 +869,9 @@ class Attention(LightweightModule):
         chunk_start_idx=None,
         kv_cache=None,
     ):
+        if isinstance(rot_mats, dict) and "local" in rot_mats and "global" in rot_mats:
+            rot_mats = rot_mats["local"] if self.is_sliding else rot_mats["global"]
+
         if mode == "prefill":
             return self.forward_prefill(
                 x,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1455,8 +1455,11 @@ class ModelArgs:
                     )
                     self.hidden_dim = padded_hidden_dim
 
+        self.layer_types = text_config.get("layer_types", None)
+
         # RoPE params
         self.rope_theta = text_config.get("rope_theta")
+        self.rope_theta_local = text_config.get("rope_local_base_freq", None)
         # If use_scaled_rope is not present, assume setting rope_scaling means use scaled rope
         # If it is present and is set to false, do not use scaled rope
         # Setting self.rope_scaling_factor to None is our way of saying do not use scaled rope

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional
+
 import torch
 
 import ttnn
@@ -24,8 +26,8 @@ class RotarySetup(LightweightModule):
         head_dim: int,
         max_seq_len: int,
         rope_theta: float,
-        scale_factor: float,  # use None to disable rope scaling
-        orig_context_len: int,  # only used if scaling enabled
+        scale_factor: Optional[float] = None,  # use None to disable rope scaling
+        orig_context_len: Optional[int] = None,  # only used if scaling enabled
         datatype=ttnn.bfloat16,
     ):
         super().__init__()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22809

### Problem description
Gemma3 uses both global and local embeddings, and `tt_transformers` supports only global.

### What's changed
I tried to keep the change the least invasive possible.
But now it feels like a borderline hack, and I would appreciate input on that.

Gemma3 has both embeddings in the Decoder forward function as arguments - [modeling_gemma3.py#L371](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma3/modeling_gemma3.py#L371)
But I would like us to try and avoid polluting the API (and all the tests).

This change should follow up https://github.com/tenstorrent/tt-metal/issues/25321.

Let me know what you think! I wanted to reach out before adding additional tests, etc.
Thank you!

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) - TO DO
- [ ] [T3K Unit and Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16589664130)
- [ ] [New tests] - TO DO