### PR TITLE
Add PERF.md to Llama-3.3-70B on Galaxy and clean references to FAKE_DEVICE

### DIFF
--- a/models/demos/llama3_subdevices/PERF.md
+++ b/models/demos/llama3_subdevices/PERF.md
@@ -1,0 +1,80 @@
+# Llama-3.3-70B on Galaxy Performance
+
+This file contains the measured performance of Llama-3.3-70B on Galaxy systems, coupled with the run commands we have used to generate these numbers.
+
+Please note that using more recent versions of the software stack (TT-Metal and vLLM) might lead to different performance numbers.
+
+
+## 25 July 2025
+
+TT-Metal: [633160e](https://github.com/tenstorrent/tt-metal/commit/633160efc176b71dc35b6d15be0e9421b986493d)
+vLLM: [0c0ee9e](https://github.com/tenstorrent/vllm/commit/0c0ee9e6d81bbb26d44229992ad2273e8ea1052b)
+TT-Inference-server: [3380ea0](https://github.com/tenstorrent/tt-inference-server/commit/3380ea073e53f20ea782626f42c406e5cf4260c8)
+
+
+### TT-Metal runs
+
+```
+pytest models/demos/llama3_subdevices/demo/text_demo.py -k performance-batch-1
+```
+To run different sequence lengths you can use the following configurations:
+- performance-long-4k-b1
+- performance-long-8k-b1
+- performance-long-32k-b1
+- performance-long-64k-b1
+- performance-long-128k-b1
+
+All of the above will run for batch 1. To run a different batch size just add the override flag to the run command `--batch_size <NUMBER>`.
+
+Similarly, if you want to run a different input prompt file with different length you can use the override `--input_prompts “models/demos/llama3_subdevices/demo/sample_prompts/input_data_long_1k.json”` (this example will run the 1K prompts instead).
+
+| Input length | Output length | Batch  | TTFT (per user)   | Token/s/u (avg of all decoded tokens)                                        |
+|--------------|---------------|--------|-------------------|------------------------------------------------------------------------------|
+| 128          | 128           | 1, 32  | 59.64 ms          | 14.01 ms, 71.38 t/s/u (128th token=117 prefill + 11 decode) <br> 14.28 ms, 70.01 t/s/u |
+| 1K           | 128           | 1      | 160.86 ms         | 16.53 ms, 60.48 t/s/u                                                     |
+| 1K           | 128           | 32     | 161.66 ms         | 17.58 ms, 56.89 t/s/u                                                     |
+| 4K           | 128           | 1      | 625.08 ms         | 18.5 ms, 54.07 t/s/u                                                      |
+| 4K           | 128           | 32     | 626.85 ms         | 22.43 ms, 44.58 t/s/u                                                     |
+| 8K           | 128           | 1      | 1,382.3 ms        | 21.41 ms, 46.72 t/s/u                                                     |
+| 16K          | 128           | 1      | 3,403.12 ms       | 27.49 ms, 36.38 t/s/u                                                     |
+| 32K          | 128           | 1      | 9,482.38 ms       | 38.17 ms, 26.2 t/s/u                                                      |
+| 64K          | 128           | 1      | 29,697.47 ms      | 60.87 ms, 16.43 t/s/u                                                     |
+| 128K         | 128           | 1      | 102,310.21 ms     | 91.25 ms, 10.96 t/s/u                                                     |
+
+### vLLM Runs
+
+For vLLM runs, you'll need to install [Tenstorrent's vLLM fork](https://github.com/tenstorrent/vllm/blob/dev/tt_metal/README.md).
+
+vLLM offline run command:
+```
+VLLM_RPC_TIMEOUT=100000 TT_LLAMA_TEXT_VER=llama3_subdevices python examples/offline_inference_tt.py  --model meta-llama/Llama-3.3-70B-Instruct --override_tt_config '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 95693824}' --greedy_sampling --num_repeat_prompts 2 --num_scheduler_steps 30 --async_engine --measure_perf
+```
+
+vLLM server run command:
+```
+TT_LLAMA_TEXT_VER=llama3_subdevices VLLM_RPC_TIMEOUT=900000 python examples/server_example_tt.py --model "meta-llama/Llama-3.3-70B-Instruct" --override_tt_config '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 95693824}' --num_scheduler_steps 30
+```
+
+To send requests to vLLM the server, you will need [TT-Inference-Server](https://github.com/tenstorrent/tt-inference-server/tree/dev).
+```
+export HF_MODEL_REPO_ID='meta-llama/Llama-3.3-70B-Instruct'
+
+cd tt-inference-server/vllm-tt-metal-llama3/src
+python example_requests_client.py --num_concurrent 32 --prompt_json_path "vllm_server_prompts.json"
+```
+
+**Note:** Please send the request twice, to warmup the cache and get accurate performance numbers.
+**Note:** The file containing server prompts can be found in tt-metal at `models/demos/llama3_subdevices/demo/sample_prompts/vllm_server_prompts.json `.
+
+| Command      | Input length | Output length | Batch  | TTFT (per user)   | Token/s/u (avg of all decoded tokens) |
+|--------------|--------------|---------------|--------|-------------------|---------------------------------------|
+| vLLM Offline | 128          | 128           | 32     | 69.14 ms          | 14.92 ms, 67.03 t/s/u                 |
+| vLLM server  | 128          | 128           | 32     | 74.91 ms          | 15.12 ms, 66.15 t/s/u                 |
+
+
+To Run the TT-Inference-Server release tests (Benchmark and eval), you can run:
+```
+python run.py --model Llama-3.3-70B-Instruct --device galaxy --workflow release
+```
+
+Please refer to the [TT-Inference-Server](https://github.com/tenstorrent/tt-inference-server/tree/dev) repo for more information.

--- a/models/demos/llama3_subdevices/PERF.md
+++ b/models/demos/llama3_subdevices/PERF.md
@@ -30,8 +30,8 @@ Similarly, if you want to run a different input prompt file with different lengt
 
 | Input length | Output length | Batch  | TTFT (per user)   | Token/s/u (avg of all decoded tokens)                                        |
 |--------------|---------------|--------|-------------------|------------------------------------------------------------------------------|
-| 128          | 128           | 1, 32  | 59.64 ms          | 14.01 ms, 71.38 t/s/u (128th token=117 prefill + 11 decode) <br> 14.28 ms, 70.01 t/s/u |
-| 1K           | 128           | 1      | 160.86 ms         | 16.53 ms, 60.48 t/s/u                                                     |
+| 128          | 128           | 1, 32  | 59.64 ms          | 14.01 ms, 71.38 t/s/u (measured at 128th token=117 prefill + 11 decode) <br> 14.28 ms, 70.01 t/s/u (avg) |
+| 1K           | 128           | 1      | 160.86 ms         | 16.53 ms, 60.48 t/s/u                                                    |
 | 1K           | 128           | 32     | 161.66 ms         | 17.58 ms, 56.89 t/s/u                                                     |
 | 4K           | 128           | 1      | 625.08 ms         | 18.5 ms, 54.07 t/s/u                                                      |
 | 4K           | 128           | 32     | 626.85 ms         | 22.43 ms, 44.58 t/s/u                                                     |

--- a/models/demos/llama3_subdevices/PERF.md
+++ b/models/demos/llama3_subdevices/PERF.md
@@ -7,9 +7,9 @@ Please note that using more recent versions of the software stack (TT-Metal and 
 
 ## 25 July 2025
 
-TT-Metal: [633160e](https://github.com/tenstorrent/tt-metal/commit/633160efc176b71dc35b6d15be0e9421b986493d)
-vLLM: [0c0ee9e](https://github.com/tenstorrent/vllm/commit/0c0ee9e6d81bbb26d44229992ad2273e8ea1052b)
-TT-Inference-server: [3380ea0](https://github.com/tenstorrent/tt-inference-server/commit/3380ea073e53f20ea782626f42c406e5cf4260c8)
+- TT-Metal: [633160e](https://github.com/tenstorrent/tt-metal/commit/633160efc176b71dc35b6d15be0e9421b986493d)
+- vLLM: [0c0ee9e](https://github.com/tenstorrent/vllm/commit/0c0ee9e6d81bbb26d44229992ad2273e8ea1052b)
+- TT-Inference-server: [3380ea0](https://github.com/tenstorrent/tt-inference-server/commit/3380ea073e53f20ea782626f42c406e5cf4260c8)
 
 
 ### TT-Metal runs

--- a/models/demos/llama3_subdevices/README.md
+++ b/models/demos/llama3_subdevices/README.md
@@ -36,8 +36,7 @@ Note: If you downloaded your weights directly from `huggingface`, they will be `
 
 ```
 export LLAMA_DIR=<path_to_Llama-3.3-70B-instruct>
-export TT_METAL_ENABLE_ERISC_IRAM=1
-export FAKE_DEVICE=TG
+export MESH_DEVICE=TG
 ```
 
 Note: if using HuggingFace weights (`.safetensors` format), please use `HF_MODEL=meta-llama/Llama-3.3-70B-Instruct` or `HF_MODEL=<PATH_TO_HF_WEIGHTS>` instead of `LLAMA_DIR`.

--- a/models/demos/llama3_subdevices/README.md
+++ b/models/demos/llama3_subdevices/README.md
@@ -36,7 +36,6 @@ Note: If you downloaded your weights directly from `huggingface`, they will be `
 
 ```
 export LLAMA_DIR=<path_to_Llama-3.3-70B-instruct>
-export MESH_DEVICE=TG
 ```
 
 Note: if using HuggingFace weights (`.safetensors` format), please use `HF_MODEL=meta-llama/Llama-3.3-70B-Instruct` or `HF_MODEL=<PATH_TO_HF_WEIGHTS>` instead of `LLAMA_DIR`.

--- a/models/demos/llama3_subdevices/README.md
+++ b/models/demos/llama3_subdevices/README.md
@@ -166,12 +166,16 @@ It supports the following parameters:
 - **optimizations (str)**: Optimization level (performance, accuracy)
 
 
-### Mixing topologies in prefill ccl ops
+### Mixing topologies in prefill ccl ops [Debug-Only]
+Please note that using line topology on a galaxy system might affect model accuracy. This functionality is for debug purposes only!
+
 When running `text_demo.py` on a machine with torus, all ops will by default use ring topology. To use line implementation of ops you can set enviroment variables:
+
 - LINE_RS = 1: to use line for all ReduceScatter ops
 - LINE_AG = 1: use line for all AllGather ops
 
 To use line for only some of the AG ops, you can set USE_LINE_AG set in `llama_ccl.py`, for example to use line for all RS and just QKV AG, and ring for the rest of AG set:
+
 - LINE_RS = 1
 - LINE_AG = 0
 - USE_LINE_AG = {"QKV"}

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -602,7 +602,6 @@ def run_llama3_demo(
 # sampling_params (dict): Sampling parameters for decoding (temperature, top_p). If temperature is set to 0, argmax (greedy decode) is used.
 #
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
-# FAKE_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export FAKE_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
     "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos",
     [
@@ -757,7 +756,7 @@ def test_llama_demo(
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
     # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
     if galaxy_type != "6U" and galaxy_type != "4U":
         raise Exception("Not running on TG nor on 6U, you must run on those systems for this test")

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -755,11 +755,11 @@ def test_llama_demo(
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
-    # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
-        pytest.skip("TG only supports batch 1 and 32")
+    # TODO: Remove this once all batch sizes are supported on Galaxy
+    if batch_size not in [1, 32]:
+        pytest.skip("Galaxy only supports batch 1 and 32")
     if galaxy_type != "6U" and galaxy_type != "4U":
-        raise Exception("Not running on TG nor on 6U, you must run on those systems for this test")
+        raise Exception("Not running on Galaxy 4U nor on 6U, you must run on those systems for this test")
 
     if paged_attention:
         paged_attention_config = PagedAttentionConfig(

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -424,9 +424,7 @@ def run_llama3_decode_performance(
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )
@@ -462,9 +460,9 @@ def test_llama_decode_performance(
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
-    # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
-        pytest.skip("TG only supports batch 1 and 32")
+    # TODO: Remove this once all batch sizes are supported on Galaxy
+    if batch_size not in [1, 32]:
+        pytest.skip("Galaxy only supports batch 1 and 32")
 
     if paged_attention:
         paged_attention_config = PagedAttentionConfig(

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -425,7 +425,7 @@ def run_llama3_decode_performance(
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,
@@ -463,7 +463,7 @@ def test_llama_decode_performance(
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
     # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
     if paged_attention:

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -190,7 +190,6 @@ def create_tt_model(
 # stop_at_eos (bool): Whether to stop decoding when the model generates an EoS token
 #
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
-# MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
     "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, prefill_profile, num_layers, print_outputs",
     [

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -108,7 +108,7 @@ def test_llama_demo(
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
     # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
     if paged_attention:
@@ -374,7 +374,7 @@ def load_perf_targets(galaxy_type):
 @pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run FAKE_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
+# Run MESH_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
 # Copy the printed kernel_duration_per_instance_averaged_dict and dispatch_duration_per_instance_averaged_dict dictionaries
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?
@@ -780,7 +780,7 @@ def test_llama_TG_perf_device(
 @pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run FAKE_DEVICE=TG TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
+# Run MESH_DEVICE=TG TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
 # Copy the printed dispatch_duration_per_instance_averaged_dict dictionary
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from loguru import logger
-import os
 import math
 import ttnn
 import json
@@ -107,9 +106,9 @@ def test_llama_demo(
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
-    # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
-        pytest.skip("TG only supports batch 1 and 32")
+    # TODO: Remove this once all batch sizes are supported on Galaxy
+    if batch_size not in [1, 32]:
+        pytest.skip("Galaxy only supports batch 1 and 32")
 
     if paged_attention:
         paged_attention_config = PagedAttentionConfig(
@@ -374,7 +373,7 @@ def load_perf_targets(galaxy_type):
 @pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run MESH_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
+# Run pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
 # Copy the printed kernel_duration_per_instance_averaged_dict and dispatch_duration_per_instance_averaged_dict dictionaries
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?
@@ -780,7 +779,7 @@ def test_llama_TG_perf_device(
 @pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run MESH_DEVICE=TG TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
+# Run TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
 # Copy the printed dispatch_duration_per_instance_averaged_dict dictionary
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -33,9 +33,7 @@ from tqdm import tqdm
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -34,7 +34,7 @@ from tqdm import tqdm
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -29,7 +29,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_common import (
     precompute_freqs,
@@ -28,9 +27,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -20,7 +20,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
 from models.demos.llama3_subdevices.tt.llama_decoder import TtTransformerBlock
@@ -19,9 +18,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/test_llama_embedding.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_embedding.py
@@ -23,7 +23,7 @@ from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_embedding.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_embedding.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_embedding import TtLlamaEmbedding
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
@@ -22,9 +21,7 @@ from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/test_lm_head.py
+++ b/models/demos/llama3_subdevices/tests/test_lm_head.py
@@ -33,7 +33,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_lm_head.py
+++ b/models/demos/llama3_subdevices/tests/test_lm_head.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.lm_head import LMHead
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
@@ -32,9 +31,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/test_prefill_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_prefill_device_perf.py
@@ -158,7 +158,7 @@ def is_collective_op(op_code):
 
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run MESH_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device
+# Run pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device
 # Copy the printed kernel_duration_per_instance_averaged_dict and dispatch_duration_per_instance_averaged_dict dictionaries
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?

--- a/models/demos/llama3_subdevices/tests/test_prefill_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_prefill_device_perf.py
@@ -158,7 +158,7 @@ def is_collective_op(op_code):
 
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run FAKE_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device
+# Run MESH_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device
 # Copy the printed kernel_duration_per_instance_averaged_dict and dispatch_duration_per_instance_averaged_dict dictionaries
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_attention import TtLlamaAttention
 from models.demos.llama3_subdevices.tt.llama_rope import TtLlamaRotarySetup
@@ -38,9 +37,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -39,7 +39,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -29,7 +29,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_attention import TtLlamaAttention
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
@@ -28,9 +27,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
@@ -29,7 +29,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_common import (
     get_prefill_rot_mat,
@@ -28,9 +27,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -25,7 +25,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_mlp import TtLlamaMLP
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
@@ -24,9 +23,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
@@ -25,7 +25,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.llama_mlp import TtLlamaMLP
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
@@ -24,9 +23,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
@@ -25,7 +25,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
@@ -4,7 +4,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.common.rmsnorm import RMSNorm as TtRMSNorm
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
@@ -24,9 +23,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_sampling.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_sampling.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import os
 import ttnn
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
 from models.utility_functions import (
@@ -190,9 +189,7 @@ def reference_sampling(input_tensor, sampling_params, num_devices, padded_vocab_
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_sampling.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_sampling.py
@@ -191,7 +191,7 @@ def reference_sampling(input_tensor, sampling_params, num_devices, padded_vocab_
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -991,6 +991,8 @@ class TtModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
             self.qkv_size = self.head_dim * (2 * self.n_kv_heads + self.n_heads)
+            print(self.n_kv_heads)
+            print(self.cluster_shape)
             self.min_kv_prefill_shard_seqlen = (self.tile_size * 8 * 8) / (self.n_kv_heads // self.cluster_shape[1])
             self.model_config["XQKV_PREFILL_PROGCFG"] = (
                 lambda seq_len: self.matmul_1d_config(

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -991,8 +991,6 @@ class TtModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
             self.qkv_size = self.head_dim * (2 * self.n_kv_heads + self.n_heads)
-            print(self.n_kv_heads)
-            print(self.cluster_shape)
             self.min_kv_prefill_shard_seqlen = (self.tile_size * 8 * 8) / (self.n_kv_heads // self.cluster_shape[1])
             self.model_config["XQKV_PREFILL_PROGCFG"] = (
                 lambda seq_len: self.matmul_1d_config(


### PR DESCRIPTION
Changes introduced:
- Adds PERF.md to Llama-3.3-70B on Galaxy
- clean references to FAKE_DEVICE in Galaxy code to avoid confusion
- Updates Llama-3.3-70B on Galaxy Readme

- [x] [APC pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16620637806) 
- [x] [TG Unit](https://github.com/tenstorrent/tt-metal/actions/runs/16620645465) 
- [x] [TG Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16620647149) 