### PR TITLE
Enable MUX in SD3.5 CCLs

### DIFF
--- a/models/experimental/stable_diffusion_35_large/tests/test_fun_transformer_block.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_fun_transformer_block.py
@@ -45,7 +45,7 @@ TILE_SIZE = 32
     [
         [(2, 4), (2, 0), (1, 0), (4, 1), ttnn.Topology.Linear, 1],
         [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
-        [(8, 4), (2, 0), (4, 0), (4, 1), ttnn.Topology.Linear, 3],
+        [(8, 4), (2, 0), (4, 0), (4, 1), ttnn.Topology.Linear, 4],
         [(8, 4), (2, 1), (8, 0), (2, 1), ttnn.Topology.Linear, 3],
         [(8, 4), (2, 1), (2, 1), (8, 0), ttnn.Topology.Linear, 3],
     ],

--- a/models/experimental/stable_diffusion_35_large/tests/test_fun_transformer_block.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_fun_transformer_block.py
@@ -46,8 +46,8 @@ TILE_SIZE = 32
         [(2, 4), (2, 0), (1, 0), (4, 1), ttnn.Topology.Linear, 1],
         [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
         [(8, 4), (2, 0), (4, 0), (4, 1), ttnn.Topology.Linear, 4],
-        [(8, 4), (2, 1), (8, 0), (2, 1), ttnn.Topology.Linear, 3],
-        [(8, 4), (2, 1), (2, 1), (8, 0), ttnn.Topology.Linear, 3],
+        [(8, 4), (2, 1), (8, 0), (2, 1), ttnn.Topology.Linear, 4],
+        [(8, 4), (2, 1), (2, 1), (8, 0), ttnn.Topology.Linear, 4],
     ],
     ids=[
         "t3k_cfg2_sp1_tp4",

--- a/models/experimental/stable_diffusion_35_large/tests/test_performance.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_performance.py
@@ -11,14 +11,14 @@ from ..tt.parallel_config import StableDiffusionParallelManager
 @pytest.mark.parametrize(
     "model_name, image_w, image_h, guidance_scale, num_inference_steps",
     [
-        ("large", 1024, 1024, 3.5, 28),
+        ("large", 1024, 1024, 3.5, 20),
     ],
 )
 @pytest.mark.parametrize(
     "mesh_device, cfg, sp, tp, topology, num_links",
     [
         [(2, 4), (2, 1), (2, 0), (2, 1), ttnn.Topology.Linear, 1],
-        [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 3],
+        [(4, 8), (2, 1), (4, 0), (4, 1), ttnn.Topology.Linear, 4],
     ],
     ids=[
         "t3k_cfg2_sp2_tp2",
@@ -28,7 +28,7 @@ from ..tt.parallel_config import StableDiffusionParallelManager
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 20000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 8192, "trace_region_size": 25000000}],
     indirect=True,
 )
 def test_sd35_performance(

--- a/models/experimental/stable_diffusion_35_large/tt/fun_attention.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_attention.py
@@ -311,7 +311,7 @@ def sd_joint_attention(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.ulysses_parallel.mesh_axis,
-            chunks_per_sync=40,
+            chunks_per_sync=16,
             num_workers_per_link=3,
             num_buffers_per_channel=2,
         )

--- a/models/experimental/stable_diffusion_35_large/tt/fun_attention.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_attention.py
@@ -311,8 +311,8 @@ def sd_joint_attention(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.ulysses_parallel.mesh_axis,
-            chunks_per_sync=10,
-            num_workers_per_link=2,
+            chunks_per_sync=40,
+            num_workers_per_link=3,
             num_buffers_per_channel=2,
         )
         prompt = unpadded_all_gather_async(

--- a/models/experimental/stable_diffusion_35_large/tt/fun_attention.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_attention.py
@@ -305,23 +305,27 @@ def sd_joint_attention(
     if parallel_manager.is_ulysses_parallel:
         spatial = ttnn.experimental.all_gather_async(
             spatial,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_buffer"),
             dim=3,
-            num_links=parallel_manager.num_links,
-            cluster_axis=parallel_manager.dit_parallel_config.ulysses_parallel.mesh_axis,
-            mesh_device=device,
-            topology=parallel_manager.dit_parallel_config.topology,
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_buffer"),
             multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
+            num_links=parallel_manager.num_links,
+            topology=parallel_manager.dit_parallel_config.topology,
+            cluster_axis=parallel_manager.dit_parallel_config.ulysses_parallel.mesh_axis,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
         prompt = unpadded_all_gather_async(
             prompt,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, "prompt_buffer"),
             dim=3,
-            num_links=parallel_manager.num_links,
-            cluster_axis=parallel_manager.dit_parallel_config.ulysses_parallel.mesh_axis,
-            mesh_device=device,
-            topology=parallel_manager.dit_parallel_config.topology,
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, "prompt_buffer"),
             multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
+            num_links=parallel_manager.num_links,
+            topology=parallel_manager.dit_parallel_config.topology,
+            cluster_axis=parallel_manager.dit_parallel_config.ulysses_parallel.mesh_axis,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
 
     spatial = sd_attention_out_proj(spatial, parameters.spatial)

--- a/models/experimental/stable_diffusion_35_large/tt/fun_feed_forward.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_feed_forward.py
@@ -92,9 +92,9 @@ def sd_feed_forward(
             memory_config=ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            chunks_per_sync=10,
+            chunks_per_sync=2,
             num_workers_per_link=2,
-            num_buffers_per_channel=2,
+            num_buffers_per_channel=8 if is_spatial else 2,
         )
         # Reshape to set padding again
         result_unpadded_shape = list(result.shape)

--- a/models/experimental/stable_diffusion_35_large/tt/fun_feed_forward.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_feed_forward.py
@@ -92,10 +92,9 @@ def sd_feed_forward(
             memory_config=ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            # mesh_device=device,
-            # from_remote_multi_device_global_semaphore=parallel_manager.cfg_semaphores[cfg_index]["rs_from"],
-            # to_remote_multi_device_global_semaphore=parallel_manager.cfg_semaphores[cfg_index]["rs_to"],
-            # math_op=ttnn.ReduceType.Sum,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
         # Reshape to set padding again
         result_unpadded_shape = list(result.shape)

--- a/models/experimental/stable_diffusion_35_large/tt/fun_transformer.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_transformer.py
@@ -170,8 +170,8 @@ def sd_transformer(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis,
-            chunks_per_sync=10,
-            num_workers_per_link=2,
+            chunks_per_sync=16,
+            num_workers_per_link=3,
             num_buffers_per_channel=2,
         )
         spatial = spatial_B1NDt

--- a/models/experimental/stable_diffusion_35_large/tt/fun_transformer.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_transformer.py
@@ -164,26 +164,30 @@ def sd_transformer(
     if parallel_manager.is_sequence_parallel:
         spatial_B1NDt = ttnn.experimental.all_gather_async(
             spatial,
-            dim=-2,
-            cluster_axis=parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis,
-            mesh_device=spatial.device(),
-            topology=parallel_manager.dit_parallel_config.topology,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_seq_gather_buffer"),
+            dim=2,
             multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_seq_gather_buffer"),
             num_links=parallel_manager.num_links,
+            topology=parallel_manager.dit_parallel_config.topology,
+            cluster_axis=parallel_manager.dit_parallel_config.sequence_parallel.mesh_axis,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
         spatial = spatial_B1NDt
 
     if parallel_manager.is_tensor_parallel:
         spatial_B1ND = ttnn.experimental.all_gather_async(
             spatial,
-            dim=-1,
-            cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            mesh_device=spatial.device(),
-            topology=parallel_manager.dit_parallel_config.topology,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_tensor_gather_buffer"),
+            dim=3,
             multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_tensor_gather_buffer"),
             num_links=parallel_manager.num_links,
+            topology=parallel_manager.dit_parallel_config.topology,
+            cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
         spatial = spatial_B1ND
     spatial_B1ND = spatial

--- a/models/experimental/stable_diffusion_35_large/tt/fun_transformer_block.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_transformer_block.py
@@ -177,8 +177,8 @@ def sd_dual_attn_block(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            chunks_per_sync=10,
-            num_workers_per_link=2,
+            chunks_per_sync=40,
+            num_workers_per_link=3,
             num_buffers_per_channel=2,
         )
         prompt_scaled = unpadded_all_gather_async(
@@ -234,8 +234,8 @@ def sd_gated_ff_block(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            chunks_per_sync=10,
-            num_workers_per_link=2,
+            chunks_per_sync=40 if is_spatial else 10,
+            num_workers_per_link=3 if is_spatial else 2,
             num_buffers_per_channel=2,
         )
     result = gate * sd_feed_forward(

--- a/models/experimental/stable_diffusion_35_large/tt/fun_transformer_block.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_transformer_block.py
@@ -177,7 +177,7 @@ def sd_dual_attn_block(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            chunks_per_sync=40,
+            chunks_per_sync=16,
             num_workers_per_link=3,
             num_buffers_per_channel=2,
         )
@@ -234,7 +234,7 @@ def sd_gated_ff_block(
             num_links=parallel_manager.num_links,
             topology=parallel_manager.dit_parallel_config.topology,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            chunks_per_sync=40 if is_spatial else 10,
+            chunks_per_sync=16 if is_spatial else 10,
             num_workers_per_link=3 if is_spatial else 2,
             num_buffers_per_channel=2,
         )

--- a/models/experimental/stable_diffusion_35_large/tt/fun_transformer_block.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_transformer_block.py
@@ -171,23 +171,27 @@ def sd_dual_attn_block(
     if parallel_manager.is_tensor_parallel:
         spatial_scaled = ttnn.experimental.all_gather_async(
             spatial_scaled,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_buffer"),
             dim=3,
-            num_links=parallel_manager.num_links,
-            cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            mesh_device=device,
-            topology=parallel_manager.dit_parallel_config.topology,
             multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, "spatial_buffer"),
+            num_links=parallel_manager.num_links,
+            topology=parallel_manager.dit_parallel_config.topology,
+            cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
         prompt_scaled = unpadded_all_gather_async(
             prompt_scaled,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, "prompt_buffer"),
             dim=3,
+            multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
             num_links=parallel_manager.num_links,
             cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            mesh_device=device,
             topology=parallel_manager.dit_parallel_config.topology,
-            multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, "prompt_buffer"),
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
 
     spatial_attn, prompt_attn = sd_joint_attention(
@@ -224,13 +228,15 @@ def sd_gated_ff_block(
         buffer_name = "spatial_buffer" if is_spatial else "prompt_buffer"
         scaled = unpadded_all_gather_async(
             scaled,
+            persistent_output_buffer=parallel_manager.get_ping_pong_buffer(cfg_index, buffer_name),
             dim=3,
-            num_links=parallel_manager.num_links,
-            cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
-            mesh_device=device,
-            topology=parallel_manager.dit_parallel_config.topology,
             multi_device_global_semaphore=parallel_manager.get_ping_pong_semaphore(cfg_index),
-            persistent_output_tensor=parallel_manager.get_ping_pong_buffer(cfg_index, buffer_name),
+            num_links=parallel_manager.num_links,
+            topology=parallel_manager.dit_parallel_config.topology,
+            cluster_axis=parallel_manager.dit_parallel_config.tensor_parallel.mesh_axis,
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
         )
     result = gate * sd_feed_forward(
         scaled,

--- a/models/experimental/stable_diffusion_35_large/tt/utils.py
+++ b/models/experimental/stable_diffusion_35_large/tt/utils.py
@@ -291,27 +291,31 @@ def silu(x: ttnn.Tensor) -> ttnn.Tensor:
 
 def unpadded_all_gather_async(
     x,
+    persistent_output_buffer,
     dim,
-    cluster_axis,
-    mesh_device,
-    topology,
     multi_device_global_semaphore,
-    memory_config=None,
     num_links=1,
-    persistent_output_tensor=None,
+    memory_config=None,
+    topology=ttnn.Topology.Linear,
+    cluster_axis=None,
+    chunks_per_sync=None,
+    num_workers_per_link=None,
+    num_buffers_per_channel=None,
 ):
     shape = list(x.shape)
 
     x = ttnn.experimental.all_gather_async(
         x,
+        persistent_output_buffer=persistent_output_buffer,
         dim=dim,
-        cluster_axis=cluster_axis,
-        mesh_device=mesh_device,
-        topology=topology,
         multi_device_global_semaphore=multi_device_global_semaphore,
-        memory_config=memory_config,
         num_links=num_links,
-        persistent_output_tensor=persistent_output_tensor,
+        topology=topology,
+        cluster_axis=cluster_axis,
+        memory_config=memory_config,
+        chunks_per_sync=chunks_per_sync,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=num_buffers_per_channel,
     )
 
     shape[dim] = x.shape[dim]


### PR DESCRIPTION
### Problem description
Minimal CCLs merged support for fabric MUX, allowing multiple workers to push data over a link. SD3.5 requires MUX to achieve higher CCL BWs.

### What's changed
Set CCL hyperparameters to enable MUX in SD3.5.