### PR TITLE
Conv2d check for input_channel alignment in input

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -200,16 +200,6 @@ class TtResnetBlock2D(nn.Module):
         if hidden_states.memory_config().memory_layout != self.conv1_config.shard_layout:
             hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
 
-        if C == 1920 and H == 32:
-            mem_cfg = ttnn.create_sharded_memory_config(
-                shape=(204, 256),
-                core_grid=ttnn.CoreGrid(x=8, y=8),
-                strategy=ttnn.ShardStrategy.BLOCK,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
-            )
-            hidden_states = ttnn.to_memory_config(hidden_states, mem_cfg)
-
         if self.split_conv:
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
             hidden_states, [C, H, W], [self.tt_conv1_weights, self.tt_conv1_bias] = split_conv2d(

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -208,12 +208,13 @@ def run_conv(
             mesh_mapper=weight_mesh_mapper,
         )
 
+    requires_device_placement = input_dtype == ttnn.bfloat8_b or sharded_cfg is not None
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         input_dtype,
         mesh_mapper=input_mesh_mapper,
         layout=input_layout,
-        device=device if input_dtype == ttnn.bfloat8_b else None,
+        device=device if requires_device_placement else None,
     )
 
     if sharded_cfg:
@@ -3974,7 +3975,6 @@ def test_conv_single_core(
         config_override = None,
     )
 
-@pytest.mark.skip("Bug id TBD")
 @pytest.mark.parametrize(
     "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, shard_layout, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader, act_db, w_db",
     (


### PR DESCRIPTION
For sharded inputs add a check to ensure that the
input_channel alignment is correct and trigger a reshard if it is not.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16571157147)
- [x] [Model perf regression](https://github.com/tenstorrent/tt-metal/actions/runs/16570269019)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16570261465) 
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/16573626019)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16569125410)