### PR TITLE
#25898: SDXL: call to_mem_config() with L1 memory before convs that would call reshard, which ends up as s2i and i2s with DRAM memory.

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -49,7 +49,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 248_163_368
+    expected_device_perf_cycles_per_iteration = 245_115_735
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -220,6 +220,20 @@ class TtResnetBlock2D(nn.Module):
                 groups=self.groups,
             )
         else:
+            # Workaround for #25898
+            # Conv calls to_mem_cfg, which doesn't call reshard but calls s2i -> i2s with dram mem config.
+            # Do that here, as s2i -> i2s with L1 mem config is faster than dram mem config.
+            if (
+                self.conv1_config.shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+                and hidden_states.memory_config().memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+            ):
+                if hidden_states.memory_config().shard_spec.shape[1] % 32 != 0 or (
+                    H == 64
+                    and W == 64
+                    and self.conv1_params["input_channels"] == 1280
+                    and self.conv1_params["output_channels"] == 640
+                ):
+                    hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
             [hidden_states, [H, W], [self.tt_conv1_weights, self.tt_conv1_bias]] = ttnn.conv2d(
                 input_tensor=hidden_states,
                 weight_tensor=self.tt_conv1_weights,
@@ -284,6 +298,15 @@ class TtResnetBlock2D(nn.Module):
 
         hidden_states = ttnn.silu(hidden_states)
 
+        # Workaround for #25898
+        # Conv calls to_mem_cfg, which doesn't call reshard but calls s2i -> i2s with dram mem config.
+        # Do that here, as s2i -> i2s with L1 mem config is faster than dram mem config.
+        if (
+            self.conv2_config.shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+            and hidden_states.memory_config().memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        ):
+            if hidden_states.memory_config().shard_spec.shape[1] % 32 != 0:
+                hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
         [hidden_states, [H, W], [self.tt_conv2_weights, self.tt_conv2_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_conv2_weights,


### PR DESCRIPTION
### Ticket
#25898

### Problem description
Bunch of convs in SDXL are using reshard_if_not_optimal, which in turn calls to_mem_config() which in turn calls s2i and i2s with DRAM config, as that reshard isn't working atm. Call to_mem_config() before the conv does it, and use L1 memory instead. ~0.3s speedup on image gen.

### Checklist
- [x] [Device performance regression][(https://github.com/tenstorrent/tt-metal/actions/runs/16597995599) 
- [x] [Frequent model tests] (https://github.com/tenstorrent/tt-metal/actions/runs/16597978472) SDXL tests passing, unrelated failures