### PR TITLE
Change get_mem_reader call to reflect lens changes

### DIFF
--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -130,7 +130,7 @@ class DispatcherData:
             pass
 
     def get_core_data(self, location: OnChipCoordinate, risc_name: str) -> DispatcherCoreData:
-        loc_mem_reader = ELF.get_mem_reader(location._device._context, location._device._id, location)
+        loc_mem_reader = ELF.get_mem_reader(location)
         if location._device.get_block_type(location) == "functional_workers":
             # For tensix, use the brisc elf
             fw_elf = self._brisc_elf


### PR DESCRIPTION
Changed arguments in `ELF.get_mem_reader` call to reflect changes made in `tt-exalens`.