### PR TITLE
Rename profiler-related functions, variables, comments and documentation from 'Dump' to 'Read' across the entire codebase

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -58,8 +58,8 @@ DeviceOperation
 DeviceStorage
 DeviceZoneScopedN
 DstMode
-DumpDeviceProfileResults
-DumpMeshDeviceProfileResults
+ReadDeviceProfilerResults
+ReadMeshDeviceProfilerResults
 ENDL
 ETH
 EltwiseUnary

--- a/docs/source/tt-metalium/tools/device_program_profiler.rst
+++ b/docs/source/tt-metalium/tools/device_program_profiler.rst
@@ -49,7 +49,7 @@ The host code of the ``full_buffer`` example is in ``{$TT_METAL_HOME}/tt_metal/p
 On top of tt_metal's program dispatch API calls, two additional steps specific to this example are taken, which are:
 
 1. Setting ``LOOP_COUNT`` and ``LOOP_SIZE`` defines for the kernels
-2. Calling DumpDeviceProfileResults after the call to Finish to collect the device side profiling data
+2. Calling ReadDeviceProfilerResults after the call to Finish to collect the device side profiling data
 
 The kernel code for full buffer is in ``{$TT_METAL_HOME}/tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer.cpp`` and demonstrated below:
 

--- a/docs/source/tt-metalium/tools/index.rst
+++ b/docs/source/tt-metalium/tools/index.rst
@@ -24,7 +24,7 @@ debug.
 
     tracy_profiler
 
-Tracy profiler is for profiling device-side RISCV code and host-side python and C++ code,
+Tracy profiler is for profiling device-side RISCV code and host-side python and C++ code.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/DumpMeshDeviceProfileResults.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/DumpMeshDeviceProfileResults.rst
@@ -1,6 +1,0 @@
-.. _DumpMeshDeviceProfileResults:
-
-DumpMeshDeviceProfileResults
-============================
-
-.. doxygenfunction:: tt::tt_metal::DumpMeshDeviceProfileResults

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/ReadMeshDeviceProfilerResults.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/ReadMeshDeviceProfilerResults.rst
@@ -1,0 +1,6 @@
+.. _ReadMeshDeviceProfilerResults:
+
+ReadMeshDeviceProfilerResults
+==============================
+
+.. doxygenfunction:: tt::tt_metal::ReadMeshDeviceProfilerResults

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/profiler.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/profiler.rst
@@ -2,4 +2,4 @@ Profiler
 ========
 
 .. toctree::
-  DumpMeshDeviceProfileResults
+  ReadMeshDeviceProfilerResults

--- a/docs/source/ttnn/ttnn/profiling_ttnn_operations.rst
+++ b/docs/source/ttnn/ttnn/profiling_ttnn_operations.rst
@@ -31,8 +31,8 @@ Instructions on using the performance report with `TT-NN Visualizer <https://git
   the same pytest run. Only the host times for the second run of the layer should be analyzed as the first run was populating the cache and will have much higher times for host side.
 
 - The first 1000 ops for each device is automatically collected by pytest fixtures at the end of your test.
-  If your test has more than 1000 ops, ``ttl.device.DumpDeviceProfiler(device)`` should be called at every n number of layers that total to less than 1000 ops in order to avoid dropping profiling data of new ops.
-  For example for resnet with around 120 ops for a single inference layer, if the test calls the layer more than 8 times, ``ttl.device.DumpDeviceProfiler(device)`` should be called at least every eighth layer run.
+  If your test has more than 1000 ops, ``ttl.device.ReadDeviceProfiler(device)`` should be called at every n number of layers that total to less than 1000 ops in order to avoid dropping profiling data of new ops.
+  For example for resnet with around 120 ops for a single inference layer, if the test calls the layer more than 8 times, ``ttl.device.ReadDeviceProfiler(device)`` should be called at least every eighth layer run.
   If profiling data is dropped, you will receive warning messages in the execution log mentioning which RISC of what core of what device dropped profiling data. Note that dispatch
   cores fill up their profiling buffers faster and if only those cores are giving warnings your OP analysis is not affected.
 

--- a/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
+++ b/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
@@ -12,10 +12,10 @@ from sklearn.metrics import top_k_accuracy_score
 import ttnn
 from models.demos.falcon7b_common.tests.test_utils import (
     concat_device_out_layer_present,
-    dump_device_profiler,
     get_num_devices,
     get_rand_falcon_inputs,
     load_hf_model,
+    read_device_profiler,
 )
 from models.demos.falcon7b_common.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b_common.tt.falcon_common import PytorchFalconCausalLM
@@ -227,8 +227,8 @@ def run_test_FalconCausalLM_end_to_end(
         ttnn.synchronize_device(mesh_device)
         profiler.end("first_model_run_with_compile", force_enable=e2e_perf)
 
-        # Dump device profiler data before second run to avoid exceeding profiler memory limits when using tracy
-        dump_device_profiler(mesh_device)
+        # Read device profiler data before second run to avoid exceeding profiler memory limits when using tracy
+        read_device_profiler(mesh_device)
 
         del tt_out
         del tt_layer_past

--- a/models/demos/falcon7b_common/tests/test_utils.py
+++ b/models/demos/falcon7b_common/tests/test_utils.py
@@ -305,6 +305,6 @@ def get_num_devices(device):
         raise ValueError(f"Unrecognized device type {type(device)}")
 
 
-def dump_device_profiler(device):
+def read_device_profiler(device):
     # device is either a ttnn.MeshDevice or a ttnn.Device
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)

--- a/models/demos/falcon7b_common/tt/falcon_model.py
+++ b/models/demos/falcon7b_common/tt/falcon_model.py
@@ -11,8 +11,8 @@ from tqdm import tqdm
 import ttnn
 from models.demos.falcon7b_common.tests.test_utils import (
     create_prefill_attn_mask_for_sharded_softmax,
-    dump_device_profiler,
     get_num_devices,
+    read_device_profiler,
     tt_from_torch,
 )
 from models.demos.falcon7b_common.tt.falcon_decoder import TtFalconDecoderLayer
@@ -271,7 +271,7 @@ class TtFalconModelShared(torch.nn.Module):
             layer_output = layer_output[0]
 
             if device_perf_run and idx % 8 == 0:
-                dump_device_profiler(self.mesh_device)
+                read_device_profiler(self.mesh_device)
 
         # apply final norm layer
         layer_output = layernorm(

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
@@ -47,7 +47,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     op_event = ttnn.record_event(device, 0)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     profiler.start("cache")
     ttnn.wait_for_event(1, op_event)
@@ -61,7 +61,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     test_infra.output_tensor.deallocate(force=True)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("cache")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     # Capture
     ttnn.wait_for_event(1, op_event)
@@ -78,7 +78,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     reshard_out = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
     assert trace_input_addr == reshard_out.buffer_address()
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     for iter in range(0, num_warmup_iterations):
         ttnn.wait_for_event(1, op_event)
@@ -88,7 +88,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
         reshard_out = ttnn.reshard(tt_image_res, input_mem_config, reshard_out)
         op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
-        ttnn.DumpDeviceProfiler(device)
+        ttnn.ReadDeviceProfiler(device)
 
     ttnn.synchronize_device(device)
     if use_signpost:
@@ -109,7 +109,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     profiler.end(f"run")
     if use_signpost:
         signpost(header="stop")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     ttnn.release_trace(device, tid)
 

--- a/models/demos/llama3_70b_galaxy/demo/demo_performance.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_performance.py
@@ -315,9 +315,9 @@ def run_llama3_decode_performance(
     ttnn.synchronize_device(mesh_device)
 
     # When getting dispatch device perf, pushing weights fills up profiler buffers.
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
-    # Sync after dump or execute trace will launch on devices with huge skew
+    # Sync after profiler read or execute trace will launch on devices with huge skew
     ttnn.synchronize_device(mesh_device)
 
     # Start decoding

--- a/models/demos/qwen/tests/test_qwen_perf.py
+++ b/models/demos/qwen/tests/test_qwen_perf.py
@@ -92,7 +92,7 @@ def test_qwen_model_perf(mesh_device, kv_cache_len, expected_compile_time, reset
     profiler.print()
     compile_and_iter_time = profiler.get("model_run_for_inference_0")
 
-    ttnn.DumpDeviceProfiler(mesh_device)
+    ttnn.ReadDeviceProfiler(mesh_device)
 
     if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs only
         signpost("Model perf run")

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -176,7 +176,7 @@ def run_test_FalconCausalLM_end_to_end(
         signpost("WARMUP_RUNS")
 
     for _ in range(warmup_iterations):
-        ttnn.DumpDeviceProfiler(mesh_device)
+        ttnn.ReadDeviceProfiler(mesh_device)
         if llm_mode == "prefill":
             model_inputs = torch.split(model_input, 1)
             tt_inputs, tt_attention_mask = zip(
@@ -220,7 +220,7 @@ def run_test_FalconCausalLM_end_to_end(
     ttnn.synchronize_device(mesh_device)
 
     # Run for perf iteration - profiler enabled
-    ttnn.DumpDeviceProfiler(mesh_device)
+    ttnn.ReadDeviceProfiler(mesh_device)
     profiler.enable()
     enable_persistent_kernel_cache()
     logger.info(f"Enable profiler and enable binary and compile cache")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -103,7 +103,7 @@ def test_mixtral_model_perf(
     profiler.print(units="ms")
     compile_and_iter_time = profiler.get("e2e_decode_compile")
 
-    ttnn.DumpDeviceProfiler(t3k_mesh_device)
+    ttnn.ReadDeviceProfiler(t3k_mesh_device)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("Model perf run")
@@ -240,8 +240,8 @@ def test_mixtral_model_with_prefill_perf(
     profiler.print(units="ms")
     prefill_warmup_time = profiler.get("e2e_prefill_warmup")
 
-    # Profiler dump, ready for real run
-    ttnn.DumpDeviceProfiler(t3k_mesh_device)
+    # Profiler read, ready for real run
+    ttnn.ReadDeviceProfiler(t3k_mesh_device)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("prefill perf run")
@@ -253,8 +253,8 @@ def test_mixtral_model_with_prefill_perf(
     profiler.print(units="ms")
     prefill_time = profiler.get("e2e_prefill_1_user")
 
-    # profile dump
-    ttnn.DumpDeviceProfiler(t3k_mesh_device)
+    # profile read
+    ttnn.ReadDeviceProfiler(t3k_mesh_device)
 
     # Decode (Run 1 warmup iteration before running 1 perf iteration)
     generation_start_pos = prefill_seqlen
@@ -269,8 +269,8 @@ def test_mixtral_model_with_prefill_perf(
     profiler.print(units="ms")
     decode_warmup_time = profiler.get("e2e_decode_warmup")
 
-    # Profiler dump, ready for real run
-    ttnn.DumpDeviceProfiler(t3k_mesh_device)
+    # Profiler read, ready for real run
+    ttnn.ReadDeviceProfiler(t3k_mesh_device)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("decode perf run")

--- a/models/demos/vit/tests/vit_performant.py
+++ b/models/demos/vit/tests/vit_performant.py
@@ -31,7 +31,7 @@ def run_trace_2cq_model(device, batch_size=8, model_location_generator=None):
     op_event = ttnn.record_event(device, 0)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     profiler.start("cache")
     ttnn.wait_for_event(1, op_event)
@@ -45,7 +45,7 @@ def run_trace_2cq_model(device, batch_size=8, model_location_generator=None):
     test_infra.output_tensor.deallocate(force=True)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("cache")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     # Capture
     ttnn.wait_for_event(1, op_event)
@@ -62,7 +62,7 @@ def run_trace_2cq_model(device, batch_size=8, model_location_generator=None):
     reshard_out = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
     assert trace_input_addr == reshard_out.buffer_address()
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     for iter in range(0, 2):
         ttnn.wait_for_event(1, op_event)
@@ -72,7 +72,7 @@ def run_trace_2cq_model(device, batch_size=8, model_location_generator=None):
         reshard_out = ttnn.reshard(tt_image_res, input_mem_config, reshard_out)
         op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
-        ttnn.DumpDeviceProfiler(device)
+        ttnn.ReadDeviceProfiler(device)
 
     ttnn.synchronize_device(device)
     if use_signpost:
@@ -93,6 +93,6 @@ def run_trace_2cq_model(device, batch_size=8, model_location_generator=None):
     profiler.end(f"run")
     if use_signpost:
         signpost(header="stop")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     ttnn.release_trace(device, tid)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -418,7 +418,7 @@ class UNet2DConditionModel:
         down_block_res_samples = (sample_copied_to_dram,)
         output_channel = block_out_channels[0]
         for i, (down_block_type, down_block) in enumerate(zip(self.down_block_types, self.down_blocks)):
-            ttnn.DumpDeviceProfiler(self.device)
+            ttnn.ReadDeviceProfiler(self.device)
             logger.info(f"Down block {i}")
             input_channel = output_channel
             output_channel = block_out_channels[i]
@@ -503,7 +503,7 @@ class UNet2DConditionModel:
         only_cross_attention = list(reversed(only_cross_attention))
         output_channel = reversed_block_out_channels[0]
         for i, (up_block_type, up_block) in enumerate(zip(self.up_block_types, self.up_blocks)):
-            ttnn.DumpDeviceProfiler(self.device)
+            ttnn.ReadDeviceProfiler(self.device)
             logger.info(f"Up block {i}")
             is_final_block = i == len(block_out_channels) - 1
 

--- a/models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+++ b/models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
@@ -110,7 +110,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     profiler.end(f"run")
     if use_signpost:
         signpost(header="stop")
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     ttnn.release_trace(device, trace_id)
 

--- a/models/demos/yolov8s/runner/yolov8s_performant.py
+++ b/models/demos/yolov8s/runner/yolov8s_performant.py
@@ -118,7 +118,7 @@ def run_yolov8s_trace_2cqs_inference(
     test_infra.run()
     test_infra.validate()
     test_infra.dealloc_output()
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     # Optimized run
     ttnn.wait_for_event(1, op_event)
@@ -129,7 +129,7 @@ def run_yolov8s_trace_2cqs_inference(
     op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     # Capture
     ttnn.wait_for_event(1, op_event)
@@ -145,7 +145,7 @@ def run_yolov8s_trace_2cqs_inference(
     input_tensor = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
     assert trace_input_addr == input_tensor.buffer_address()
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     # More optimized run with caching
     if use_signpost:

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -58,7 +58,7 @@ def run_unet_model(batch, groups, device, iterations=1):
             memory_config=unet_shallow_ttnn.UNet.input_sharded_memory_config,
         )
         ttnn_model(ttnn_input, move_input_tensor_to_device=False, deallocate_input_activation=True).cpu()
-        ttnn.DumpDeviceProfiler(device)
+        ttnn.ReadDeviceProfiler(device)
 
 
 @pytest.mark.parametrize("batch", [1])

--- a/models/experimental/grok/tests/test_grok_perf.py
+++ b/models/experimental/grok/tests/test_grok_perf.py
@@ -98,7 +98,7 @@ def test_grok_model_perf(
     profiler.print(units="ms")
     compile_and_iter_time = profiler.get("model_run_for_inference_0")
 
-    ttnn.DumpDeviceProfiler(t3k_mesh_device)
+    ttnn.ReadDeviceProfiler(t3k_mesh_device)
 
     if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs only
         signpost("Model perf run")

--- a/models/experimental/stable_diffusion_35_large/tests/test_transformer.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_transformer.py
@@ -145,7 +145,7 @@ def test_transformer(
     #     )
     # profiler.end(f"run")
     # devices = mesh_device.get_devices()
-    # ttnn.DumpDeviceProfiler(devices[0])
+    # ttnn.ReadDeviceProfiler(devices[0])
     # total_time = profiler.get("run")
     # avg_time = total_time / num_measurement_iterations
     # print(f" TOTAL TIME: {total_time} AVG TIME: {avg_time}\n")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -147,7 +147,7 @@ def run_unet_model(
     ttnn.deallocate(ttnn_timestep_tensor)
     ttnn.deallocate(ttnn_encoder_tensor)
 
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
 
     _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
     logger.info(f"PCC of first iteration is: {pcc_message}")
@@ -175,7 +175,7 @@ def run_unet_model(
         ttnn.deallocate(ttnn_timestep_tensor)
         ttnn.deallocate(ttnn_encoder_tensor)
 
-        ttnn.DumpDeviceProfiler(device)
+        ttnn.ReadDeviceProfiler(device)
 
     del unet
     gc.collect()

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
@@ -75,7 +75,7 @@ class TtCrossAttnDownBlock2D(nn.Module):
             residual = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
             output_states = output_states + (residual,)
 
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         if self.downsamplers is not None:
             hidden_states, [C, H, W] = self.downsamplers.forward(hidden_states, [B, C, H, W])

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -85,7 +85,7 @@ class TtCrossAttnUpBlock2D(nn.Module):
                 hidden_states, [B, C, H, W], encoder_hidden_states=encoder_hidden_states, attention_mask=attention_mask
             )
 
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         if self.upsamplers is not None:
             hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -208,7 +208,7 @@ class TtUNet2DConditionModel(nn.Module):
 
         temb = ttnn.typecast(temb, dtype=ttnn.bfloat16)
 
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
         for i, down_block in enumerate(self.down_blocks):
             if i == 0:
                 sample, [C, H, W], block_residuals = down_block.forward(sample, [B, C, H, W], temb=temb)
@@ -218,12 +218,12 @@ class TtUNet2DConditionModel(nn.Module):
                 )
 
             residuals += block_residuals
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         sample, [C, H, W] = self.mid_block.forward(
             sample, [B, C, H, W], temb=temb, encoder_hidden_states=encoder_hidden_states
         )
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         encoder_hidden_states = ttnn.to_memory_config(encoder_hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         for i, up_block in enumerate(self.up_blocks):
@@ -246,7 +246,7 @@ class TtUNet2DConditionModel(nn.Module):
                     encoder_hidden_states=encoder_hidden_states,
                 )
 
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         sample = ttnn.to_layout(sample, ttnn.ROW_MAJOR_LAYOUT)
 

--- a/models/experimental/swin_s/tt/tt_swin_transformer.py
+++ b/models/experimental/swin_s/tt/tt_swin_transformer.py
@@ -87,11 +87,11 @@ class TtSwinTransformer:
             if i_stage % 2 == 0:
                 for j in range(len(self.layers[i_stage])):
                     output_tensor = self.layers[i_stage][j](output_tensor)
-                ttnn.DumpDeviceProfiler(self.device)
+                ttnn.ReadDeviceProfiler(self.device)
             else:
                 output_tensor = self.layers[i_stage](output_tensor)
 
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
         if self.norm_layer is None:
             output_tensor = ttnn.layer_norm(
                 output_tensor,

--- a/models/experimental/swin_v2/tt/tt_mlp.py
+++ b/models/experimental/swin_v2/tt/tt_mlp.py
@@ -265,5 +265,5 @@ class TtMLP:
                 ),
             )
         x = ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat16)
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
         return x

--- a/models/experimental/swin_v2/tt/tt_shifted_window_attention_v2.py
+++ b/models/experimental/swin_v2/tt/tt_shifted_window_attention_v2.py
@@ -156,5 +156,5 @@ class TtShiftedWindowAttentionV2:
         x = ttnn.reshape(x, (B, H, W, C), memory_config=ttnn.L1_MEMORY_CONFIG)
 
         x = x[:, :H, :W, :]
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
         return x

--- a/models/experimental/yolov12x/tt/yolov12x.py
+++ b/models/experimental/yolov12x/tt/yolov12x.py
@@ -186,7 +186,7 @@ class YoloV12x:
         x = self.a2c2f_2(x, i=10)  # 8
         x8 = x
         x8 = ttnn.to_memory_config(x8, ttnn.DRAM_MEMORY_CONFIG)
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         x = interleaved_to_sharded(x)
         x = ttnn.upsample(x, scale_factor=2)  # 9
@@ -223,7 +223,7 @@ class YoloV12x:
             x11 = ttnn.to_layout(x11, ttnn.ROW_MAJOR_LAYOUT)
         x = concat(-1, False, x, x11)  # 16
         ttnn.deallocate(x11)
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
         x = self.a2c2f_5(x, i=19)  # 17
         x17 = x
         x17 = ttnn.to_memory_config(x17, ttnn.DRAM_MEMORY_CONFIG)
@@ -235,7 +235,7 @@ class YoloV12x:
         x20 = x
         x14 = ttnn.to_memory_config(x14, ttnn.L1_MEMORY_CONFIG)
         x17 = ttnn.to_memory_config(x17, ttnn.L1_MEMORY_CONFIG)
-        ttnn.DumpDeviceProfiler(self.device)
+        ttnn.ReadDeviceProfiler(self.device)
 
         x = self.detect(x14, x17, x20)  # 21
         return x

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -85,4 +85,4 @@ def test_all_gather_async(
         num_workers_per_link=num_workers_per_link,
         num_buffers_per_channel=num_buffers_per_channel,
     )
-    ttnn.DumpDeviceProfiler(submesh_device)
+    ttnn.ReadDeviceProfiler(submesh_device)

--- a/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
@@ -93,4 +93,4 @@ def test_reduce_scatter_async(
         num_workers_per_link=num_workers_per_link,
         num_buffers_per_channel=num_buffers_per_channel,
     )
-    ttnn.DumpDeviceProfiler(submesh_device)
+    ttnn.ReadDeviceProfiler(submesh_device)

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -52,7 +52,7 @@ def gather_single_test_perf(device, test_passed):
     if device.get_num_devices() > 1:
         logger.error("Multi-device perf is not supported. Failing.")
         return None
-    ttnn.DumpDeviceProfiler(device)
+    ttnn.ReadDeviceProfiler(device)
     opPerfData = get_device_data_generate_report(
         PROFILER_LOGS_DIR, None, None, None, export_csv=False, cleanup_device_log=True
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -1050,4 +1050,4 @@ def test_sdpa_benchmark(device):
                             )
                             logger.error(f"Error: {e}")
 
-                ttnn.DumpDeviceProfiler(device)
+                ttnn.ReadDeviceProfiler(device)

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -437,7 +437,7 @@ def test_noc_event_profiler_linked_multicast_hang():
     testCommand = "build/test/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency"
     # note: this runs a long series repeated multicasts from worker {1,1} to grid {2,2},{3,3}
     # note: -m6 is multicast test mode, -link activates linked multicast
-    testCommandArgs = "-tx 3 -ty 3 -sx 2 -sy 2 -rx 1 -ry 1 -m 6 -link -profdump"
+    testCommandArgs = "-tx 3 -ty 3 -sx 2 -sy 2 -rx 1 -ry 1 -m 6 -link -profread"
     clear_profiler_runtime_artifacts()
     nocEventProfilerEnv = "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1"
     profilerRun = os.system(f"cd {TT_METAL_HOME} && {nocEventProfilerEnv} {testCommand} {testCommandArgs}")

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -511,7 +511,7 @@ void RunTestUnicastRaw(
     fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
 
     if (enable_fabric_tracing) {
-        tt_metal::detail::DumpDeviceProfileResults(sender_device);
+        tt_metal::detail::ReadDeviceProfilerResults(sender_device);
     }
 
     // Validate the status and packets processed by sender and receiver
@@ -1498,7 +1498,7 @@ void RunTestChipMCast1D(
     log_info(tt::LogTest, "All Receivers Finished");
 
     if (enable_fabric_tracing) {
-        tt_metal::detail::DumpDeviceProfileResults(sender_device);
+        tt_metal::detail::ReadDeviceProfilerResults(sender_device);
     }
 
     // Validate the status and packets processed by sender and receiver

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -209,7 +209,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicPrograms) {
         device->reset_sub_device_stall_group();
     }
     Synchronize(device);
-    detail::DumpDeviceProfileResults(device);
+    detail::ReadDeviceProfilerResults(device);
 }
 
 TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicProgramsReuse) {
@@ -250,7 +250,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicProgramsReuse) {
         device->reset_sub_device_stall_group();
     }
     Synchronize(device);
-    detail::DumpDeviceProfileResults(device);
+    detail::ReadDeviceProfilerResults(device);
 }
 
 TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthPrograms) {
@@ -279,7 +279,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthProgra
         device->reset_sub_device_stall_group();
     }
     Synchronize(device);
-    detail::DumpDeviceProfileResults(device);
+    detail::ReadDeviceProfilerResults(device);
 }
 
 // Ensure each core in the sub device aware of their own logical coordinate. Same binary used in multiple sub devices.

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -86,7 +86,7 @@ TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms
         ReplayTrace(device, device->command_queue().id(), tid_3, false);
     }
     Synchronize(device);
-    detail::DumpDeviceProfileResults(device);
+    detail::ReadDeviceProfilerResults(device);
 }
 
 TEST_F(CommandQueueSingleCardTraceFixture, TensixActiveEthTestSubDeviceTraceBasicEthPrograms) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -916,7 +916,7 @@ int main(int argc, char** argv) {
             }
             Finish(device->command_queue());
             for (auto& program : programs) {
-                tt_metal::detail::DumpDeviceProfileResults(device);
+                tt_metal::detail::ReadDeviceProfilerResults(device);
             }
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -910,7 +910,7 @@ int main(int argc, char** argv) {
             }
             Finish(device->command_queue());
             for (auto& program : programs) {
-                tt_metal::detail::DumpDeviceProfileResults(device);
+                tt_metal::detail::ReadDeviceProfilerResults(device);
             }
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -616,7 +616,7 @@ int main(int argc, char** argv) {
                 EnqueueProgram(device->command_queue(), program, false);
                 Finish(device->command_queue());
                 log_debug(LogTest, "EnqueProgram done");
-                tt_metal::detail::DumpDeviceProfileResults(device);
+                tt_metal::detail::ReadDeviceProfilerResults(device);
 
                 if (single_core) {
                     uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(device, program);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -458,7 +458,7 @@ int main(int argc, char** argv) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
             Finish(device->command_queue());
-            tt_metal::detail::DumpDeviceProfileResults(device);
+            tt_metal::detail::ReadDeviceProfilerResults(device);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -644,7 +644,7 @@ int main(int argc, char** argv) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
             Finish(device->command_queue());
-            tt_metal::detail::DumpDeviceProfileResults(device);
+            tt_metal::detail::ReadDeviceProfilerResults(device);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -81,7 +81,7 @@ bool hammer_pcie_g = false;
 bool hammer_pcie_type_g = false;
 bool test_write = false;
 bool linked = false;
-bool dump_profiler_results = false;
+bool read_profiler_results = false;
 uint32_t nop_count_g = 0;
 
 void init(int argc, char** argv) {
@@ -123,7 +123,7 @@ void init(int argc, char** argv) {
         log_info(LogTest, " -hpt:hammer hugepage PCIe hammer type: 0:32bit writes 1:128bit non-temporal writes");
         log_info(LogTest, "  -psrta: pass page size as a runtime argument (default compile time define)");
         log_info(LogTest, " -nop: time loop of <n> nops");
-        log_info(LogTest, "-profdump: dump profiler results before closing device");
+        log_info(LogTest, "-profread: read profiler results before closing device");
         exit(0);
     }
 
@@ -162,7 +162,7 @@ void init(int argc, char** argv) {
 
     linked = test_args::has_command_option(input_args, "-link");
 
-    dump_profiler_results = test_args::has_command_option(input_args, "-profdump");
+    read_profiler_results = test_args::has_command_option(input_args, "-profread");
 
     worker_g = CoreRange({core_x, core_y}, {core_x, core_y});
     src_worker_g = {src_core_x, src_core_y};
@@ -492,8 +492,8 @@ int main(int argc, char** argv) {
             log_info(LogTest, "BW: {} GB/s", ss.str());
         }
 
-        if (dump_profiler_results) {
-            tt_metal::detail::DumpDeviceProfileResults(device);
+        if (read_profiler_results) {
+            tt_metal::detail::ReadDeviceProfilerResults(device);
         }
 
         pass &= tt_metal::CloseDevice(device);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -582,8 +582,8 @@ void run(
     }
 
     for (const auto& link : device_helper.unique_links) {
-        // Only dump profile results from sender
-        tt_metal::detail::DumpDeviceProfileResults(device_helper.devices.at(link.sender.chip));
+        // Only read profiler results from sender
+        tt_metal::detail::ReadDeviceProfilerResults(device_helper.devices.at(link.sender.chip));
 
         switch (params.benchmark_type) {
             case BenchmarkType::EthOnlyUniDir:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -175,8 +175,8 @@ void run(
         tt_metal::Finish(device0->command_queue());
         tt_metal::Finish(device1->command_queue());
     }
-    tt::tt_metal::detail::DumpDeviceProfileResults(device0);
-    tt::tt_metal::detail::DumpDeviceProfileResults(device1);
+    tt::tt_metal::detail::ReadDeviceProfilerResults(device0);
+    tt::tt_metal::detail::ReadDeviceProfilerResults(device1);
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -344,7 +344,7 @@ void build_and_run_roundtrip_latency_test(
     }
 
     for (auto [device_ptr, program_ptr] : device_program_map) {
-        tt::tt_metal::detail::DumpDeviceProfileResults(device_ptr);
+        tt::tt_metal::detail::ReadDeviceProfilerResults(device_ptr);
     }
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -171,8 +171,8 @@ void run(
         tt_metal::Finish(device0->command_queue());
         tt_metal::Finish(device1->command_queue());
     }
-    tt::tt_metal::detail::DumpDeviceProfileResults(device0);
-    tt::tt_metal::detail::DumpDeviceProfileResults(device1);
+    tt::tt_metal::detail::ReadDeviceProfilerResults(device0);
+    tt::tt_metal::detail::ReadDeviceProfilerResults(device1);
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -1114,7 +1114,7 @@ int main(int argc, char** argv) {
         Finish(device->command_queue());
         auto end = std::chrono::high_resolution_clock::now();
         duration = end - start;
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -318,7 +318,7 @@ int main(int argc, char** argv) {
         Finish(device->command_queue());
         auto end = std::chrono::high_resolution_clock::now();
         duration = end - start;
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -300,7 +300,7 @@ int main(int argc, char** argv) {
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
         log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
         log_info(LogTest, "Read global to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
         log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
         log_info(LogTest, "Read local to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -40,6 +40,6 @@ int main(int argc, char** argv) {
         });
 
     tt_metal::EnqueueProgram(device->command_queue(), program, true);
-    tt_metal::detail::DumpDeviceProfileResults(device);
+    tt_metal::detail::ReadDeviceProfilerResults(device);
     tt_metal::CloseDevice(device);
 }

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -406,8 +406,8 @@ def test_matmul_2d_host_perf(
                     )
 
                 if calc_device_utilization:
-                    # Clear profiler log and dump profiler data after warmup iterations
-                    ttnn.DumpDeviceProfiler(device)
+                    # Clear profiler log and read profiler data after warmup iterations
+                    ttnn.ReadDeviceProfiler(device)
                     rm(profiler_log_path)
 
                 # Synchronize device to ensure all warmup iterations are completed and device is in clean state
@@ -447,8 +447,8 @@ def test_matmul_2d_host_perf(
                     profiler.end(f"run")
 
                 if calc_device_utilization:
-                    # Dump and read profiler log data
-                    ttnn.DumpDeviceProfiler(device)
+                    # Read profiler log data
+                    ttnn.ReadDeviceProfiler(device)
                     profiler_data = get_profiler_data()
                     trisc1_kernel_duration = profiler_data["trisc1_kernel_duration"]
 
@@ -655,8 +655,8 @@ def test_matmul_2d_host_perf_out_of_box(
                     output_t = in0_t @ in1_t
 
                 if calc_device_utilization:
-                    # Clear profiler log and dump profiler data after warmup iterations
-                    ttnn.DumpDeviceProfiler(device)
+                    # Clear profiler log and read profiler data after warmup iterations
+                    ttnn.ReadDeviceProfiler(device)
                     rm(profiler_log_path)
 
                 # Synchronize device to ensure all warmup iterations are completed and device is in clean state
@@ -680,8 +680,8 @@ def test_matmul_2d_host_perf_out_of_box(
                     profiler.end(f"run")
 
                 if calc_device_utilization:
-                    # Dump and read profiler log data
-                    ttnn.DumpDeviceProfiler(device)
+                    # Read profiler log data
+                    ttnn.ReadDeviceProfiler(device)
                     profiler_data = get_profiler_data()
                     trisc1_kernel_duration = profiler_data["trisc1_kernel_duration"]
 

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -127,7 +127,7 @@ void benchmark_all_args_combinations_single_core(
         Finish(mesh_device_->mesh_command_queue());
         log_info(tt::LogTest, "Program finished!");
     }
-    tt::tt_metal::detail::DumpDeviceProfileResults(local_device);
+    tt::tt_metal::detail::ReadDeviceProfilerResults(local_device);
 }
 
 TEST_P(AccessorBenchmarks, GetNocAddr) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -451,7 +451,7 @@ inline void RunPersistent1dFabricLatencyTest(
     }
     for (size_t i = 0; i < programs.size(); i++) {
         auto d = devices_with_workers.at(i);
-        tt_metal::detail::DumpDeviceProfileResults(d);
+        tt_metal::detail::ReadDeviceProfilerResults(d);
     }
     log_info(tt::LogTest, "Finished");
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -599,8 +599,8 @@ bool RunWriteBWTest(
         tt_metal::Finish(sender_device->command_queue());
         tt_metal::Finish(receiver_device->command_queue());
     }
-    // tt::tt_metal::detail::DumpDeviceProfileResults(receiver_device);
-    // tt::tt_metal::detail::DumpDeviceProfileResults(sender_device);
+    // tt::tt_metal::detail::ReadDeviceProfilerResults(receiver_device);
+    // tt::tt_metal::detail::ReadDeviceProfilerResults(sender_device);
     log_info(tt::LogTest, "Reading back outputs");
 
     auto is_output_correct = [&all_zeros, &inputs](const std::shared_ptr<tt_metal::Buffer>& output_buffer) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -3144,7 +3144,7 @@ void Run1DFabricPacketSendTest(
     for (size_t fabric_index = 0; fabric_index < fabrics_under_test_devices.size(); fabric_index++) {
         auto& devices = fabric_under_test_worker_devices[fabric_index];
         for (IDevice* d : devices) {
-            tt_metal::detail::DumpDeviceProfileResults(d);
+            tt_metal::detail::ReadDeviceProfilerResults(d);
         }
     }
     log_trace(tt::LogTest, "Finished");
@@ -3321,7 +3321,7 @@ void launch_kernels_and_wait_for_completion(
         tt_metal::Synchronize(device, *ttnn::DefaultQueueId);
     }
     for (const auto& [device, program] : device_programs) {
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
     }
 }
 

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -894,7 +894,7 @@ int main(int argc, char **argv) {
 
     for (uint32_t epoch = 0; epoch < num_epochs; ++epoch) {
         for (auto [features, target, masks] : train_dataloader) {
-            ttml::autograd::ctx().get_profiler().dump_results(device, "dataloader_step_done");
+            ttml::autograd::ctx().get_profiler().read_results(device, "dataloader_step_done");
 
             auto start_timer = std::chrono::high_resolution_clock::now();
             if (gradient_accumulator_helper.should_zero_grad()) {
@@ -905,7 +905,7 @@ int main(int argc, char **argv) {
             loss = gradient_accumulator_helper.scale(loss);
             float loss_float = get_loss_value(loss);
 
-            ttml::autograd::ctx().get_profiler().dump_results(device, "model_forward_done");
+            ttml::autograd::ctx().get_profiler().read_results(device, "model_forward_done");
 
             loss->backward();
             ttml::autograd::ctx().reset_graph();
@@ -951,7 +951,7 @@ int main(int argc, char **argv) {
                     }
                 }
 
-                ttml::autograd::ctx().get_profiler().dump_results(device, fmt::format("iteration_{}", global_step));
+                ttml::autograd::ctx().get_profiler().read_results(device, fmt::format("iteration_{}", global_step));
 
                 if (global_step >= config.max_steps) {
                     break;
@@ -960,7 +960,7 @@ int main(int argc, char **argv) {
                 gradient_accumulator_helper.reset();
 
                 if (!is_everything_compiled) {
-                    ttml::autograd::ctx().get_profiler().dump_results(device, "compilation_finished");
+                    ttml::autograd::ctx().get_profiler().read_results(device, "compilation_finished");
                     is_everything_compiled = true;
                 }
             }
@@ -1002,7 +1002,7 @@ int main(int argc, char **argv) {
         wandbcpp::finish();
     }
 
-    ttml::autograd::ctx().get_profiler().dump_results(device, "before close device", 0);
+    ttml::autograd::ctx().get_profiler().read_results(device, "before close device", 0);
     ttml::autograd::ctx().close_profiler();
     return 0;
 }

--- a/tt-train/sources/ttml/core/tt_profiler.cpp
+++ b/tt-train/sources/ttml/core/tt_profiler.cpp
@@ -15,18 +15,18 @@ constexpr bool is_tracy_enabled = false;
 
 namespace ttml::core {
 
-void TTProfiler::dump_results(
+void TTProfiler::read_results(
     ttnn::distributed::MeshDevice* device,
     const std::string& noop_identifier,
     const size_t number_of_noops,
-    tt::tt_metal::ProfilerDumpState dump_state) const {
+    tt::tt_metal::ProfilerReadState read_state) const {
     assert(device);
     if (!m_enabled) {
         return;
     }
     call_device_noop(device, number_of_noops, noop_identifier);
     for (auto& dev : device->get_devices()) {
-        tt::tt_metal::detail::DumpDeviceProfileResults(dev, dump_state);
+        tt::tt_metal::detail::ReadDeviceProfilerResults(dev, read_state);
     }
     call_device_noop(device, number_of_noops, noop_identifier);
 }

--- a/tt-train/sources/ttml/core/tt_profiler.hpp
+++ b/tt-train/sources/ttml/core/tt_profiler.hpp
@@ -17,11 +17,11 @@ public:
     TTProfiler(TTProfiler&&) = delete;
     TTProfiler& operator=(TTProfiler&&) = delete;
 
-    void dump_results(
+    void read_results(
         ttnn::distributed::MeshDevice* device,
         const std::string& noop_identifier = "noop_identifier",
         const size_t number_of_noops = 5U,
-        tt::tt_metal::ProfilerDumpState dump_state = tt::tt_metal::ProfilerDumpState::NORMAL) const;
+        tt::tt_metal::ProfilerReadState read_state = tt::tt_metal::ProfilerReadState::NORMAL) const;
 
     void call_device_noop(
         ttnn::distributed::MeshDevice* device, size_t count, const std::string& noop_identifier) const;

--- a/tt-train/sources/ttml/modules/gpt_block.cpp
+++ b/tt-train/sources/ttml/modules/gpt_block.cpp
@@ -52,7 +52,7 @@ autograd::TensorPtr GPTBlock::operator()(const autograd::TensorPtr& input, const
     x = (*ln2)(x);
     x = (*mlp)(x);
     x = ops::add(x, residual);
-    ttml::autograd::ctx().get_profiler().dump_results(&ttml::autograd::ctx().get_device(), "gpt_block");
+    ttml::autograd::ctx().get_profiler().read_results(&ttml::autograd::ctx().get_device(), "gpt_block");
 
     return x;
 }

--- a/tt-train/sources/ttml/modules/llama_block.cpp
+++ b/tt-train/sources/ttml/modules/llama_block.cpp
@@ -76,7 +76,7 @@ autograd::TensorPtr LlamaBlock::operator()(const autograd::TensorPtr& input, con
     auto x = (*m_mlp_norm)(h);
     x = (*m_mlp)(x);
     x = ops::add(x, residual);
-    ttml::autograd::ctx().get_profiler().dump_results(&ttml::autograd::ctx().get_device(), "llama_block");
+    ttml::autograd::ctx().get_profiler().read_results(&ttml::autograd::ctx().get_device(), "llama_block");
 
     return x;
 }

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -968,7 +968,7 @@ void LoadTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id, const TraceDes
 
 // clang-format off
 /**
- * Read device side profiler data for all devices in the mesh device and dump results into device side CSV log
+ * Read device side profiler data for all devices in the mesh device
  *
  * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
  *
@@ -977,13 +977,13 @@ void LoadTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id, const TraceDes
  * | Argument      | Description                                           | Type                     | Valid Range               | Required |
  * |---------------|-------------------------------------------------------|--------------------------|---------------------------|----------|
  * | mesh_device   | The mesh device containing the devices to be profiled | MeshDevice&              |                           | Yes      |
- * | state         | The dump state to use for this profiler dump          | ProfilerDumpState        |                           | No       |
+ * | state         | The state to use for this profiler read               | ProfilerReadState        |                           | No       |
  * | metadata      | Metadata to include in the profiler results           | ProfilerOptionalMetadata |                           | No       |
  * */
 // clang-format on
-void DumpMeshDeviceProfileResults(
+void ReadMeshDeviceProfilerResults(
     distributed::MeshDevice& mesh_device,
-    ProfilerDumpState state = ProfilerDumpState::NORMAL,
+    ProfilerReadState state = ProfilerReadState::NORMAL,
     const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 // clang-format off

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -6,7 +6,7 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerDumpState { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_DUMP };
+enum class ProfilerReadState { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_READ };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
 enum class ProfilerDataBufferSource { L1, DRAM };
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -134,7 +134,7 @@ void LaunchProgram(
     const std::shared_ptr<Program>& program,
     bool wait_until_cores_done = true,
     bool force_slow_dispatch = false);
-void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile_results = true);
+void WaitProgramDone(IDevice* device, Program& program, bool read_device_profiler_results = true);
 
 /**
  *  Compiles all kernels within the program, and generates binaries that are written to

--- a/tt_metal/api/tt-metalium/tt_metal_profiler.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal_profiler.hpp
@@ -49,19 +49,24 @@ void InitDeviceProfiler(IDevice* device);
  * */
 void ProfilerSync(ProfilerSyncState state);
 
+// clang-format off
 /**
- * Traverse all cores and read device side profiler data and dump results into device side CSV log
+ * Read device side profiler data for the device
+ *
+ * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
  *
  * Return value: void
  *
- * | Argument      | Description                                       | Type | Valid Range               | Required |
- * |---------------|---------------------------------------------------|--------------------------------------------------------------|---------------------------|----------|
- * | device        | The device holding the program being profiled.    | Device * |                           | True |
- * | satate        | Dumpprofiler various states                       | ProfilerDumpState |                  | False |
+ * | Argument      | Description                                           | Type                     | Valid Range               | Required |
+ * |---------------|-------------------------------------------------------|--------------------------|---------------------------|----------|
+ * | device        | The device to be profiled                             | IDevice*                 |                           | Yes      |
+ * | state         | The state to use for this profiler read               | ProfilerReadState        |                           | No       |
+ * | metadata      | Metadata to include in the profiler results           | ProfilerOptionalMetadata |                           | No       |
  * */
-void DumpDeviceProfileResults(
+// clang-format on
+void ReadDeviceProfilerResults(
     IDevice* device,
-    ProfilerDumpState = ProfilerDumpState::NORMAL,
+    ProfilerReadState = ProfilerReadState::NORMAL,
     const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 /**

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -550,7 +550,7 @@ bool MeshDevice::close() {
     ZoneScoped;
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
-    DumpMeshDeviceProfileResults(*this, ProfilerDumpState::LAST_FD_DUMP);
+    ReadMeshDeviceProfilerResults(*this, ProfilerReadState::LAST_FD_READ);
 
     // TODO #20966: Remove these calls
     for (auto device : view_->get_devices()) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -817,7 +817,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     // TODO(MO): Remove when legacy non-mesh device is removed
     for (const chip_id_t device_id : devices_to_close) {
         IDevice* device = tt::DevicePool::instance().get_active_device(device_id);
-        detail::DumpDeviceProfileResults(device, ProfilerDumpState::LAST_FD_DUMP);
+        detail::ReadDeviceProfilerResults(device, ProfilerReadState::LAST_FD_READ);
     }
 
     dispatch_firmware_active_ = false;
@@ -869,7 +869,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
 
     for (const chip_id_t device_id : devices_to_close) {
         IDevice* device = tt::DevicePool::instance().get_active_device(device_id);
-        detail::DumpDeviceProfileResults(device, ProfilerDumpState::ONLY_DISPATCH_CORES);
+        detail::ReadDeviceProfilerResults(device, ProfilerReadState::ONLY_DISPATCH_CORES);
     }
 
     detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -32,6 +32,7 @@
 #include "profiler_state.hpp"
 #include "tools/profiler/noc_event_profiler_utils.hpp"
 #include "tracy/Tracy.hpp"
+#include "tt-metalium/profiler_types.hpp"
 #include "tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -785,7 +786,7 @@ void dumpDeviceResultsToCSV(
 }
 
 bool isGalaxyMMIODevice(IDevice* device) {
-    // This is wrapped in a try-catch block because get_mesh_device() can throw a std::bad_weak_ptr if profiler dump is
+    // This is wrapped in a try-catch block because get_mesh_device() can throw a std::bad_weak_ptr if profiler read is
     // called during MeshDevice::close()
     try {
         if (auto mesh_device = device->get_mesh_device()) {
@@ -1081,7 +1082,7 @@ void DeviceProfiler::readRiscProfilerResults(
                     "Profiler DRAM buffers were full, markers were dropped! device {}, worker core {}, {}, Risc "
                     "{},  "
                     "bufferEndIndex = {}. "
-                    "Please either decrease the number of ops being profiled or run dump device profiler more often",
+                    "Please either decrease the number of ops being profiled or run read device profiler more often",
                     device_id,
                     worker_core.x,
                     worker_core.y,
@@ -1379,11 +1380,11 @@ void DeviceProfiler::readPacketData(
         meta_data);
 }
 
-void DeviceProfiler::setLastFDDumpAsNotDone() { this->is_last_fd_dump_done = false; }
+void DeviceProfiler::setLastFDReadAsNotDone() { this->is_last_fd_read_done = false; }
 
-void DeviceProfiler::setLastFDDumpAsDone() { this->is_last_fd_dump_done = true; }
+void DeviceProfiler::setLastFDReadAsDone() { this->is_last_fd_read_done = true; }
 
-bool DeviceProfiler::isLastFDDumpDone() const { return this->is_last_fd_dump_done; }
+bool DeviceProfiler::isLastFDReadDone() const { return this->is_last_fd_read_done; }
 
 DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
 #if defined(TRACY_ENABLE)
@@ -1408,7 +1409,7 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
         this->noc_trace_data_output_dir = this->output_dir;
     }
 
-    this->is_last_fd_dump_done = false;
+    this->is_last_fd_read_done = false;
     this->current_zone_it = this->device_events.begin();
 
     const uint32_t approximate_num_device_profiler_events =
@@ -1451,7 +1452,7 @@ void DeviceProfiler::setOutputDir(const std::string& new_output_dir) {
 void DeviceProfiler::readResults(
     IDevice* device,
     const std::vector<CoreCoord>& virtual_cores,
-    const ProfilerDumpState state,
+    const ProfilerReadState state,
     const ProfilerDataBufferSource data_source,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
@@ -1485,7 +1486,7 @@ void DeviceProfiler::readResults(
 void DeviceProfiler::processResults(
     IDevice* device,
     const std::vector<CoreCoord>& virtual_cores,
-    const ProfilerDumpState state,
+    const ProfilerReadState state,
     const ProfilerDataBufferSource data_source,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
@@ -1508,7 +1509,7 @@ void DeviceProfiler::processResults(
     }
 
     if (rtoptions.get_profiler_noc_events_enabled() &&
-        (state == ProfilerDumpState::NORMAL || state == ProfilerDumpState::LAST_FD_DUMP)) {
+        (state == ProfilerReadState::NORMAL || state == ProfilerReadState::LAST_FD_READ)) {
         const nlohmann::ordered_json noc_trace_json_log = convertNocTracePacketsToJson(
             device_data_points.begin() + num_device_data_points_before_reading, device_data_points.end());
         FabricRoutingLookup routing_lookup(device);
@@ -1570,7 +1571,6 @@ void DeviceProfiler::pushTracyDeviceResults() {
     ZoneScoped;
 
     // If this device is root, it may have new sync info updated with syncDeviceHost
-    // called during DumpDeviceProfilerResults
     for (auto& [core, info] : device_core_sync_info) {
         if (isSyncInfoNewer(device_sync_info, info)) {
             setSyncInfo(info);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -145,8 +145,8 @@ private:
     // Device frequency
     int device_core_frequency;
 
-    // Last fast dispatch dump performed flag
-    bool is_last_fd_dump_done;
+    // Last fast dispatch read performed flag
+    bool is_last_fd_read_done;
 
     // Smallest timestamp
     uint64_t smallest_timestamp = (1lu << 63);
@@ -239,7 +239,7 @@ private:
         uint32_t timer_id,
         uint64_t timestamp);
 
-    // Track the smallest timestamp dumped to file
+    // Track the smallest timestamp read
     void firstTimestamp(uint64_t timestamp);
 
     // Get tracy context for the core
@@ -290,7 +290,7 @@ public:
     void readResults(
         IDevice* device,
         const std::vector<CoreCoord>& virtual_cores,
-        ProfilerDumpState state = ProfilerDumpState::NORMAL,
+        ProfilerReadState state = ProfilerReadState::NORMAL,
         ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
         const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
@@ -298,7 +298,7 @@ public:
     void processResults(
         IDevice* device,
         const std::vector<CoreCoord>& virtual_cores,
-        ProfilerDumpState state = ProfilerDumpState::NORMAL,
+        ProfilerReadState state = ProfilerReadState::NORMAL,
         ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
         const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
@@ -315,12 +315,12 @@ public:
     // Get zone details for the zone corresponding to the given timer id
     ZoneDetails getZoneDetails(uint16_t timer_id) const;
 
-    // setter and getter on last fast dispatch dump
-    void setLastFDDumpAsDone();
+    // setter and getter on last fast dispatch read
+    void setLastFDReadAsDone();
 
-    void setLastFDDumpAsNotDone();
+    void setLastFDReadAsNotDone();
 
-    bool isLastFDDumpDone() const;
+    bool isLastFDReadDone() const;
 };
 
 bool useFastDispatch(IDevice* device);

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -54,7 +54,7 @@ bool RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     EnqueueProgram(device->command_queue(), program, false);
-    tt_metal::detail::DumpDeviceProfileResults(device);
+    tt_metal::detail::ReadDeviceProfilerResults(device);
 
     return pass;
 }

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -52,7 +52,7 @@ void RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     EnqueueProgram(device->command_queue(), program, false);
-    tt_metal::detail::DumpDeviceProfileResults(device);
+    tt_metal::detail::ReadDeviceProfilerResults(device);
 }
 
 int main() {

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -85,7 +85,7 @@ int main() {
         constexpr int device_loop_count = 150;
 
         RunFillUpAllBuffers(device, device_loop_count, USE_FAST_DISPATCH);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         pass &= tt_metal::CloseDevice(device);
 

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -55,11 +55,11 @@ int main() {
 
         // Run 1
         RunCustomCycle(device, PROFILER_OP_SUPPORT_COUNT);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         // Run 2
         RunCustomCycle(device, PROFILER_OP_SUPPORT_COUNT);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         pass &= tt_metal::CloseDevice(device);
 

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -77,10 +77,10 @@ int main() {
         EnqueueProgram(cq, program, false);
         Finish(cq);
 
-        // It is necessary to explictly dump profile results at the end of the
+        // It is necessary to explictly read profile results at the end of the
         // program to get noc traces for standalone tt_metal programs.  For
         // ttnn, this is called _automatically_
-        detail::DumpDeviceProfileResults(device);
+        detail::ReadDeviceProfilerResults(device);
 
         pass &= CloseDevice(device);
 

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -83,7 +83,7 @@ int main() {
         constexpr int device_loop_count = 150;
 
         RunFillUpAllBuffers(device, device_loop_count, USE_FAST_DISPATCH);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        tt_metal::detail::ReadDeviceProfilerResults(device);
 
         pass &= tt_metal::CloseDevice(device);
 

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -277,7 +277,7 @@ def get_ops(timeseries):
                                 assertMsg = f"This is before other cores are finished with this op. Data corruption could be the cause of this. Please retry your run"
                             else:
                                 assertMsg = f"This is before other cores have reported any activity on this op. Other cores might have their profiler buffer filled up. "
-                                assertMsg += "Please either decrease the number of ops being profiled or run dump device profiler more often"
+                                assertMsg += "Please either decrease the number of ops being profiled or run read device profiler more often"
                         else:
                             assertMsg = f"This is before a FW end was received for this op. Data corruption could be the cause of this. Please retry your run"
                         assert (

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -770,11 +770,11 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         }
     }  // Profiler scope end
     if (wait_until_cores_done) {
-        detail::DumpDeviceProfileResults(device);
+        detail::ReadDeviceProfilerResults(device);
     }
 }
 
-void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile_results) {
+void WaitProgramDone(IDevice* device, Program& program, bool read_device_profiler_results) {
     auto device_id = device->id();
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
     std::unordered_set<CoreCoord> not_done_cores;
@@ -788,8 +788,8 @@ void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile
         }
     }
     llrt::internal_::wait_until_cores_done(device_id, RUN_MSG_GO, not_done_cores);
-    if (dump_device_profile_results) {
-        detail::DumpDeviceProfileResults(device);
+    if (read_device_profiler_results) {
+        detail::ReadDeviceProfilerResults(device);
     }
 }
 

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -502,19 +502,19 @@ void device_module(py::module& m_device) {
         py::arg("cq_id") = std::nullopt,
         py::arg("sub_device_ids") = std::vector<SubDeviceId>());
     m_device.def(
-        "DumpDeviceProfiler",
+        "ReadDeviceProfiler",
         [](MeshDevice* device) {
             ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
-            tt::tt_metal::DumpMeshDeviceProfileResults(*device, ProfilerDumpState::NORMAL, prof_metadata);
+            tt::tt_metal::ReadMeshDeviceProfilerResults(*device, ProfilerReadState::NORMAL, prof_metadata);
         },
         py::arg("device"),
         R"doc(
-        Dump device side profiling data.
+        Read device side profiling data.
 
         +------------------+----------------------------------+-----------------------+-------------+----------+
         | Argument         | Description                      | Data type             | Valid range | Required |
         +==================+==================================+=======================+=============+==========+
-        | device           | Device to dump profiling data of | ttnn.Device           |             | Yes      |
+        | device           | Device to read profiling data of | ttnn.Device           |             | Yes      |
         +------------------+----------------------------------+-----------------------+-------------+----------+
     )doc");
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -237,7 +237,7 @@ from ttnn.device import (
     CreateDevices,
     CloseDevice,
     CloseDevices,
-    DumpDeviceProfiler,
+    ReadDeviceProfiler,
     SetDefaultDevice,
     GetDefaultDevice,
     format_input_tensor,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -99,8 +99,8 @@ CloseDevice = ttnn._ttnn.device.CloseDevice
 CloseDevices = ttnn._ttnn.device.CloseDevices
 
 
-def DumpDeviceProfiler(device):
-    ttnn._ttnn.device.DumpDeviceProfiler(device)
+def ReadDeviceProfiler(device):
+    ttnn._ttnn.device.ReadDeviceProfiler(device)
 
 
 GetNumAvailableDevices = ttnn._ttnn.device.GetNumAvailableDevices


### PR DESCRIPTION
This PR renames profiler-related functions, variables, comments and documentation from 'Dump' to 'Read' across the entire codebase to make it clearer that certain profiler API functions read profiler data from the device, but don't dump it anywhere. Previously, certain profiler API functions would also dump the data read from the device to a file when called, but with some recent changes, this is no longer the case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16599687121)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16599695362)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/16600850308)