### PR TITLE
#25958: [skip ci] Clean malformed XML if parsing fails

### DIFF
--- a/infra/data_collection/junit_xml_utils.py
+++ b/infra/data_collection/junit_xml_utils.py
@@ -13,6 +13,7 @@ from toolz.dicttoolz import merge
 def clean_and_parse_xml(filepath):
     """
     Clean corrupted XML content and parse it safely.
+    Needed due to https://github.com/tenstorrent/tt-metal/issues/25958 where the XML file is corrupted.
 
     Args:
         filepath: Path to the XML file

--- a/infra/data_collection/junit_xml_utils.py
+++ b/infra/data_collection/junit_xml_utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import io
 from functools import reduce
 
 from loguru import logger
@@ -9,8 +10,57 @@ from defusedxml.ElementTree import parse as XMLParse
 from toolz.dicttoolz import merge
 
 
+def clean_and_parse_xml(filepath):
+    """
+    Clean corrupted XML content and parse it safely.
+
+    Args:
+        filepath: Path to the XML file
+
+    Returns:
+        ElementTree: Parsed XML tree
+
+    Raises:
+        Exception: If parsing fails after cleaning attempts
+    """
+    # Try parsing the file directly first
+    try:
+        root_element_tree = XMLParse(filepath)
+        return root_element_tree
+    except Exception as e:
+        logger.warning(f"Initial XML parse failed for {filepath}, attempting to clean: {str(e)}")
+
+        # If direct parsing fails, try cleaning the file
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Clean trailing junk characters that might cause parse errors
+        # Remove trailing whitespace and any stray characters after the closing tag
+        content = content.rstrip()
+
+        # Find the last proper closing tag and drop everything after it
+        last_testsuites = content.rfind("</testsuites>")
+        last_testsuite = content.rfind("</testsuite>")
+        last_proper_close = max(last_testsuites, last_testsuite)
+
+        if last_proper_close != -1:
+            # Keep everything up to and including the last proper closing tag
+            closing_tag = "</testsuites>" if last_testsuites > last_testsuite else "</testsuite>"
+            content = content[: last_proper_close + len(closing_tag)]
+
+        # Parse the cleaned content
+        try:
+            root_element_tree = XMLParse(io.StringIO(content))
+            return root_element_tree
+        except Exception as e:
+            logger.error(f"Failed to parse XML file {filepath} even after cleaning: {str(e)}")
+            logger.error(f"File content length: {len(content)} characters")
+            logger.error(f"Last 100 characters: {content[-100:]}")
+            raise
+
+
 def get_xml_file_root_element_tree(filepath):
-    root_element_tree = XMLParse(filepath)
+    root_element_tree = clean_and_parse_xml(filepath)
     root_element = root_element_tree.getroot()
 
     # For ctest, the junit XML root element tag is <testsuite> instead of <testsuites>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25958

### Problem description
T3k multiprocess gtest XML reports sometimes fail to parse with additional garbage characters tacked onto the end of the report (maybe due to tt-run/multiprocessing).
https://github.com/tenstorrent/tt-metal/actions/runs/16570519195/job/46861211485#step:10:231
```
Analyzing test report /home/runner/work/tt-metal/tt-metal/generated/cicd/16569229334/artifacts/test_reports_21e46442-e0d7-4ca4-b871-7dfac5dacf61/unit_tests_ttnn_multihost_ccl_ops.xml
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/xml/etree/ElementTree.py", line 1718, in feed
    self.parser.Parse(data, False)
xml.parsers.expat.ExpatError: junk after document element: line 259, column 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/tt-metal/tt-metal/.github/scripts/data_analysis/create_pipeline_json.py", line 15, in <module>
    pipeline = create_cicd_json_for_data_analysis(
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/cicd.py", line 75, in create_cicd_json_for_data_analysis
    tests += get_tests_from_test_report_path(test_report_path)
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/github/workflows.py", line 397, in get_tests_from_test_report_path
    report_root_tree = junit_xml_utils.get_xml_file_root_element_tree(test_report_path)
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/junit_xml_utils.py", line 13, in get_xml_file_root_element_tree
    root_element_tree = XMLParse(filepath)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/defusedxml/common.py", line 100, in parse
    return _parse(source, parser)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/xml/etree/ElementTree.py", line 1222, in parse
    tree.parse(source, parser)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/xml/etree/ElementTree.py", line 586, in parse
    parser.feed(data)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/xml/etree/ElementTree.py", line 1720, in feed
    self._raiseerror(v)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/xml/etree/ElementTree.py", line 1627, in _raiseerror
    raise err
xml.etree.ElementTree.ParseError: junk after document element: line 259, column 0
```

### What's changed
Drop any additional characters past the closing root element.

### Checklist
- [x] Produce data passing on branch: https://github.com/tenstorrent/tt-metal/actions/runs/16600622158/job/46958961443#step:10:205
https://github.com/tenstorrent/tt-metal/actions/runs/16600741301/job/46959404910