### PR TITLE
Increase Falcon7b-WH demo prefill perf target

### DIFF
--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -12,7 +12,7 @@ from models.utility_functions import is_wormhole_b0
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
         (True, 128, {"prefill_t/s": 1720, "decode_t/s": 549, "decode_t/s/u": 17.16}, False, None),
-        (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 487, "decode_t/s/u": 15.24}, False, None),
+        (True, 1024, {"prefill_t/s": 2300, "decode_t/s": 487, "decode_t/s/u": 15.24}, False, None),
         (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7b-WH demo prefill perf has improved, target needs to be updated

### What's changed
- Increased Falcon7b-WH demo prefill perf target

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes