### PR TITLE
Increase number of cores used in distributed RMSNorm 

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * This kernel computes rmsnorm statistics.
+For rmsnorm it computes E(x**2) and returns it as a one tile wide output
+ */
+
+#include <cstdint>
+
+#define REDUCE_OP PoolType::SUM
+#define REDUCE_DIM ReduceDim::REDUCE_ROW
+
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/layernorm.h"
+#include "debug/dprint.h"
+
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t NCHt = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t blk = get_compile_time_arg_val(2);
+    constexpr uint32_t num_cores_y = get_compile_time_arg_val(3);
+    bool is_merge_core = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr uint32_t cb_inp = tt::CBIndex::c_0;
+    constexpr uint32_t cb_reduce = tt::CBIndex::c_1;
+
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t cb_x2 = tt::CBIndex::c_6;  // x**2
+    constexpr uint32_t cb_zero = tt::CBIndex::c_13;
+
+    cb_wait_front(cb_reduce, 1);  // comes from the reader
+
+    binary_op_init_common(cb_inp, cb_reduce, cb_x2);
+
+    for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
+        constexpr int dst0 = 0;
+
+        /*
+         * x**2
+         */
+        reconfig_data_format(cb_inp, cb_inp);
+        pack_reconfig_data_format(cb_x2);
+        mul_tiles_init(cb_inp, cb_inp);
+
+        for (uint32_t wt = 0; wt < Wt; wt += blk) {
+            cb_wait_front(cb_inp, wt + blk);  // cumulative wait
+
+            cb_reserve_back(cb_x2, blk);
+            ACQ();
+
+            for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                mul_tiles(cb_inp, cb_inp, wt + wtr, wt + wtr, wtr);
+                pack_tile(wtr, cb_x2, wt + wtr);
+            }
+            REL();
+
+            cb_push_back(cb_x2, blk);
+        }
+
+        /*
+         * sum(x**2)
+         */
+
+        reconfig_data_format(cb_x2, cb_reduce);
+        pack_reconfig_data_format(cb_out);
+        reduce_init(cb_x2, cb_reduce, cb_out);
+
+        cb_wait_front(cb_x2, Wt);
+
+        cb_reserve_back(cb_out, onetile);
+        ACQ();
+
+        for (uint32_t wtr = 0; wtr < Wt; wtr++) {
+            reduce_tile(cb_x2, cb_reduce, wtr, 0, dst0);
+        }
+        pack_tile(dst0, cb_out, 0);
+        REL();
+
+        cb_push_back(cb_out, onetile);
+
+        cb_pop_front(cb_x2, Wt);
+
+        reduce_uninit();
+
+        cb_pop_front(cb_inp, Wt);
+        cb_pop_front(cb_reduce, 1);
+    }
+
+    // if merge core, we need to do a final sum on the tile in cb_x2 and then write the result to cb_out_final
+    if (is_merge_core) {
+        constexpr uint32_t cb_x2_merge = tt::CBIndex::c_15;
+        constexpr uint32_t cb_out_final = tt::CBIndex::c_14;
+        constexpr int dst0 = 0;
+
+        // Wait for all num_cores_y tiles
+        cb_wait_front(cb_x2_merge, num_cores_y);
+        cb_wait_front(cb_zero, 1);
+
+        // Reserve output space
+        cb_reserve_back(cb_out_final, onetile);
+
+        // Initialize accumulation
+        binary_op_init_common(cb_x2_merge, cb_zero, cb_out_final);
+        reconfig_data_format(cb_x2_merge, cb_zero);
+        pack_reconfig_data_format(cb_out_final);
+        add_tiles_init(cb_x2_merge, cb_zero, true);
+
+        // Acquire registers
+        ACQ();
+
+        // Add all 8 tiles together
+        for (uint32_t i = 0; i < num_cores_y; i++) {
+            add_tiles(cb_x2_merge, cb_zero, i, 0, dst0);
+        }
+
+        // Pack result
+        pack_tile(dst0, cb_out_final);
+        REL();
+
+        // Push output and pop input
+        cb_push_back(cb_out_final, onetile);
+        cb_pop_front(cb_x2_merge, num_cores_y);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * This kernel reads the layernorm inputs from interleaved dram.
+ */
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
+#include "debug/assert.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);     // Source address in dram
+    const uint32_t NCHt = get_arg_val<uint32_t>(1);         // Number of NCH tiles
+    const uint32_t Wt = get_arg_val<uint32_t>(2);           // Width in tiles
+    const uint32_t tile_offset = get_arg_val<uint32_t>(3);  // Tile offset for this core
+    const bool is_merge_core = get_arg_val<uint32_t>(4);
+    const uint32_t reduce_core_noc_x = get_arg_val<uint32_t>(5);
+    const uint32_t reduce_core_noc_y = get_arg_val<uint32_t>(6);
+    const uint32_t y = get_arg_val<uint32_t>(7);
+
+    constexpr uint32_t cb_inp = tt::CBIndex::c_0;
+    constexpr uint32_t cb_reduce = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_x2_merge = tt::CBIndex::c_15;
+    constexpr uint32_t cb_zero = tt::CBIndex::c_13;
+
+    // ublocks size defined in tiles
+    const uint32_t src0_tile_bytes = get_tile_size(cb_inp);
+    const DataFormat src0_data_format = get_dataformat(cb_inp);
+    const uint32_t TILE_SIZE = 32 * 32;
+    const uint32_t BF16_TILE_BYTES = 2 * TILE_SIZE;
+    const uint32_t onetile = 1;
+
+    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t blk = get_compile_time_arg_val(1);
+    uint32_t reducer_semaphore_addr = get_semaphore(get_compile_time_arg_val(2));  // semaphore for reducer
+    constexpr uint32_t num_cores_to_wait = get_compile_time_arg_val(3);
+
+    const uint64_t in0_sender_semaphore_noc_addr =
+        get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, reducer_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reducer_semaphore_addr);
+
+    const InterleavedAddrGenFast<src0_is_dram> src_a = {
+        .bank_base_address = src_addr, .page_size = src0_tile_bytes, .data_format = src0_data_format};
+
+    // Generate constant tiles for reduce scalar
+    uint32_t scaler = get_arg_val<uint32_t>(8);
+
+    generate_reduce_scaler(cb_reduce, scaler);
+    if (is_merge_core) {
+        generate_reduce_scaler(cb_zero, 0);
+    }
+
+    uint32_t inp_tile_idx = tile_offset;
+
+    for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
+        // read input tiles
+        for (uint32_t wt = 0; wt < Wt; wt += blk) {
+            cb_reserve_back(cb_inp, blk);
+            uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
+
+            for (uint32_t r = 0; r < blk; r++) {
+                noc_async_read_tile(inp_tile_idx, src_a, inp_wr_ptr);
+                inp_wr_ptr += src0_tile_bytes;
+                inp_tile_idx++;
+            }
+            noc_async_read_barrier();
+
+            cb_push_back(cb_inp, blk);
+
+        }  // wt loop
+
+    }  // ncht loop
+
+    // wait on cb_out and then write to merge core over noc
+    cb_wait_front(cb_out, onetile);
+
+    uint32_t o_write_size = BF16_TILE_BYTES;
+    uint32_t worker_offset = o_write_size * y;
+    uint64_t output_write_addr =
+        get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, get_write_ptr(cb_x2_merge)) + worker_offset;
+
+    noc_async_write(get_read_ptr(cb_out), output_write_addr, o_write_size);
+    noc_async_write_barrier();
+    cb_pop_front(cb_out, onetile);
+
+    // increase semaphore
+    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+    noc_async_atomic_barrier();
+
+    if (is_merge_core) {
+        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, num_cores_to_wait);
+        cb_push_back(cb_x2_merge, num_cores_to_wait);
+        noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -24,6 +24,7 @@ void kernel_main() {
     const uint32_t gamma_addr = get_arg_val<uint32_t>(7);
     const uint32_t beta_addr = get_arg_val<uint32_t>(8);
     const uint32_t stats_addr = get_arg_val<uint32_t>(9);
+    const uint32_t y_offset = get_arg_val<uint32_t>(10);
 
     constexpr uint32_t cb_inp = tt::CBIndex::c_0;
     constexpr uint32_t cb_stats = tt::CBIndex::c_1;
@@ -109,7 +110,7 @@ void kernel_main() {
                     cb_reserve_back(cb_gamma, blk);
                     uint32_t l1_write_addr = get_write_ptr(cb_gamma);
                     for (uint32_t r = 0; r < blk; r++) {
-                        uint64_t gamma_noc_addr = get_noc_addr(wt + r, addrg);
+                        uint64_t gamma_noc_addr = get_noc_addr(y_offset + wt + r, addrg);
                         noc_async_read(gamma_noc_addr, l1_write_addr, 32 * 2);
                         gamma_noc_addr = get_noc_addr(l1_write_addr + 32);
                         noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -118,6 +118,14 @@ tt::tt_metal::operation::ProgramWithCallbacks LayerNormPostAllGather::create_pro
     auto& output_tensor = output_tensors.at(0);
 
     return layernorm_post_allgather_multi_core(
-        a, stats, gamma, beta, output_tensor, this->norm_type, this->eps, this->compute_kernel_config);
+        a,
+        stats,
+        gamma,
+        beta,
+        output_tensor,
+        this->norm_type,
+        this->eps,
+        this->compute_kernel_config,
+        this->use_2d_core_grid);
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.hpp
@@ -24,7 +24,8 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
     Tensor& output,
     LayerNormDistributedType norm_type,
     float eps,
-    DeviceComputeKernelConfig compute_kernel_config);
+    DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<bool> use_2d_core_grid = std::nullopt);
 
 struct LayerNormPostAllGather {
     LayerNormDistributedType norm_type;
@@ -32,6 +33,7 @@ struct LayerNormPostAllGather {
     MemoryConfig memory_config;
     const DeviceComputeKernelConfig compute_kernel_config;
     std::optional<DataType> dtype;
+    std::optional<bool> use_2d_core_grid;
 
     void validate(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
@@ -54,7 +54,8 @@ operation::ProgramWithCallbacks LayerNormPreAllGather::create_program(
     const auto& a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
-    return layernorm_pre_allgather_multi_core(a, output_tensor, this->norm_type, this->compute_kernel_config);
+    return layernorm_pre_allgather_multi_core(
+        a, output_tensor, this->norm_type, this->compute_kernel_config, this->use_2d_core_grid);
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp
@@ -20,12 +20,14 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core
     const Tensor& a,
     Tensor& output,
     LayerNormDistributedType norm_type,
-    DeviceComputeKernelConfig compute_kernel_config);
+    DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<bool> use_2d_core_grid = std::nullopt);
 
 struct LayerNormPreAllGather {
     LayerNormDistributedType norm_type;
     const DataType dtype;
     const DeviceComputeKernelConfig compute_kernel_config;
+    std::optional<bool> use_2d_core_grid;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -512,7 +512,7 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
                 uint32_t tile_offset = x * Wt + y * tiles_per_core_y;
                 uint32_t stats_offset = x * stats_tiles_cols;
 
-                log_info(
+                log_debug(
                     tt::LogOp,
                     "Setting reader runtime args for core: {}, tile_offset: {}, tiles_per_core_y: {}",
                     core.x,
@@ -528,11 +528,11 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
                      tile_offset,
                      stats_offset,
                      packed_winv_value,
-                     e.u,  // 0-5
+                     e.u,  // 0-6
                      gamma_dram_addr,
                      beta_dram_addr,
                      stats_addr,
-                     y * tiles_per_core_y}  // 6-8
+                     y * tiles_per_core_y}  // 7-9
                 );
                 SetRuntimeArgs(program, compute_kernels_id, core, {tiles_per_core_x});
                 SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -62,7 +62,8 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
     Tensor& output,
     LayerNormDistributedType norm_type,
     float eps,
-    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<bool> use_2d_core_grid) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     using tt::tt_metal::CBHandle;
     using tt::tt_metal::CircularBuffer;
@@ -164,7 +165,7 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
-    ////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
     /*
     in0_cb: a
     in1_cb: stats
@@ -248,21 +249,70 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
         block_size);
 
     auto grid_size = device->compute_with_storage_grid_size();
-    auto
-        [num_cores,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         num_tile_rows_per_core_group_1,
-         num_tile_rows_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, num_tile_rows, true);
+    uint32_t max_cores_y = grid_size.y;
+    uint32_t max_cores_x = grid_size.x;
+    uint32_t tiles_per_core_y = Wt;
 
-    log_debug(tt::LogOp, "num_cores: {}", num_cores);
-    log_debug(tt::LogOp, "grid_size: {}", grid_size);
-    log_debug(tt::LogOp, "core_group_1: {}", core_group_1.str());
-    log_debug(tt::LogOp, "num_tile_rows_per_core_group_1: {}", num_tile_rows_per_core_group_1);
-    log_debug(tt::LogOp, "core_group_2: {}", core_group_2.str());
-    log_debug(tt::LogOp, "num_tile_rows_per_core_group_2: {}", num_tile_rows_per_core_group_2);
+    // Declare all variables that will be used later
+    uint32_t cores_x = 0;
+    uint32_t cores_y = 0;
+    uint32_t tiles_per_core_x = 0;
+    uint32_t num_cores = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t num_tile_rows_per_core_group_1 = 0;
+    uint32_t num_tile_rows_per_core_group_2 = 0;
 
+    // Determine if we should use 2D kernel layout
+    // If use_2d_core_grid is explicitly set, use that value
+    // Otherwise, infer based on shape conditions (RMSNorm with small height)
+    bool use_2d_kernel = false;
+    if (use_2d_core_grid.has_value()) {
+        use_2d_kernel = *use_2d_core_grid;
+    }
+
+    if (use_2d_kernel) {
+        // 2D kernel layout: distribute work across cores in a 2D grid
+        // cores_x handles tile rows, cores_y handles tile columns
+        cores_x = std::min(max_cores_y, num_tile_rows);
+        while (num_tile_rows % cores_x != 0 && cores_x > 1) {
+            cores_x--;
+        }
+        tiles_per_core_x = num_tile_rows / cores_x;
+        cores_y = std::min(max_cores_y, Wt);
+        while (Wt % cores_y != 0 && cores_y > 1) {
+            cores_y--;
+        }
+        tiles_per_core_y = Wt / cores_y;
+
+        CoreRange all_cores_range({0, 0}, {cores_x - 1, cores_y - 1});
+        all_cores = CoreRangeSet(std::vector{all_cores_range});
+    } else {
+        auto
+            [num_cores_result,
+             all_cores_result,
+             core_group_1_result,
+             core_group_2_result,
+             num_tile_rows_per_core_group_1_result,
+             num_tile_rows_per_core_group_2_result] = tt::tt_metal::split_work_to_cores(grid_size, num_tile_rows, true);
+
+        num_cores = num_cores_result;
+        all_cores = all_cores_result;
+        core_group_1 = core_group_1_result;
+        core_group_2 = core_group_2_result;
+        num_tile_rows_per_core_group_1 = num_tile_rows_per_core_group_1_result;
+        num_tile_rows_per_core_group_2 = num_tile_rows_per_core_group_2_result;
+
+        log_debug(tt::LogOp, "num_cores: {}", num_cores);
+        log_debug(tt::LogOp, "grid_size: {}", grid_size);
+        log_debug(tt::LogOp, "core_group_1: {}", core_group_1.str());
+        log_debug(tt::LogOp, "num_tile_rows_per_core_group_1: {}", num_tile_rows_per_core_group_1);
+        log_debug(tt::LogOp, "core_group_2: {}", core_group_2.str());
+        log_debug(tt::LogOp, "num_tile_rows_per_core_group_2: {}", num_tile_rows_per_core_group_2);
+    }
+
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -327,7 +377,7 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     std::vector<uint32_t> compute_args = {
-        Wt, block_size, stats_tiles_cols, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
+        tiles_per_core_y, block_size, stats_tiles_cols, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
 
     auto compute_kernels_id = CreateKernel(
         program,
@@ -452,43 +502,83 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
         uint32_t u;
     } e;
     e.f = eps;  // epsilon
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
-        uint32_t num_tile_rows_per_core = 0;
-        if (core_group_1.contains(core)) {
-            num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tile_rows_per_core = num_tile_rows_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
+    // Set runtime arguments based on kernel layout type
+    if (use_2d_kernel) {
+        for (uint32_t x = 0; x < cores_x; ++x) {
+            for (uint32_t y = 0; y < cores_y; ++y) {
+                CoreCoord core = {x, y};
+
+                uint32_t tile_offset = x * Wt + y * tiles_per_core_y;
+                uint32_t stats_offset = x * stats_tiles_cols;
+
+                log_info(
+                    tt::LogOp,
+                    "Setting reader runtime args for core: {}, tile_offset: {}, tiles_per_core_y: {}",
+                    core.x,
+                    tile_offset,
+                    tiles_per_core_y);
+                SetRuntimeArgs(
+                    program,
+                    reader_kernels_id,
+                    core,
+                    {a_addr,
+                     tiles_per_core_x,
+                     tiles_per_core_y,
+                     tile_offset,
+                     stats_offset,
+                     packed_winv_value,
+                     e.u,  // 0-5
+                     gamma_dram_addr,
+                     beta_dram_addr,
+                     stats_addr,
+                     y * tiles_per_core_y}  // 6-8
+                );
+                SetRuntimeArgs(program, compute_kernels_id, core, {tiles_per_core_x});
+                SetRuntimeArgs(
+                    program, writer_kernels_id, core, {dst_addr, tiles_per_core_x * tiles_per_core_y, tile_offset});
+            }
         }
+    } else {
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
-        uint32_t tile_offset = curr_row * Wt;
-        uint32_t stats_offset = curr_row * stats_tiles_cols;
+            uint32_t num_tile_rows_per_core = 0;
+            if (core_group_1.contains(core)) {
+                num_tile_rows_per_core = num_tile_rows_per_core_group_1;
+            } else if (core_group_2.contains(core)) {
+                num_tile_rows_per_core = num_tile_rows_per_core_group_2;
+            } else {
+                TT_THROW("Core not in specified core ranges");
+            }
 
-        SetRuntimeArgs(
-            program,
-            reader_kernels_id,
-            core,
-            {a_addr,
-             num_tile_rows_per_core,
-             Wt,
-             tile_offset,
-             stats_offset,
-             packed_winv_value,
-             e.u,  // 0-5
-             gamma_dram_addr,
-             beta_dram_addr,
-             stats_addr}  // 6-8
-        );
-        SetRuntimeArgs(program, compute_kernels_id, core, {num_tile_rows_per_core});
-        SetRuntimeArgs(program, writer_kernels_id, core, {dst_addr, num_tile_rows_per_core * Wt, tile_offset});
-        curr_row += num_tile_rows_per_core;
+            uint32_t tile_offset = curr_row * Wt;
+            uint32_t stats_offset = curr_row * stats_tiles_cols;
+            uint32_t y_offset = 0;
+
+            SetRuntimeArgs(
+                program,
+                reader_kernels_id,
+                core,
+                {a_addr,
+                 num_tile_rows_per_core,
+                 Wt,
+                 tile_offset,
+                 stats_offset,
+                 packed_winv_value,
+                 e.u,  // 0-5
+                 gamma_dram_addr,
+                 beta_dram_addr,
+                 stats_addr,
+                 y_offset}  // 6-8
+            );
+            SetRuntimeArgs(program, compute_kernels_id, core, {num_tile_rows_per_core});
+            SetRuntimeArgs(program, writer_kernels_id, core, {dst_addr, num_tile_rows_per_core * Wt, tile_offset});
+            curr_row += num_tile_rows_per_core;
+        }
     }
-
     auto override_runtime_arguments_callback =
-        [reader_kernel_id = reader_kernels_id, writer_kernel_id = writer_kernels_id, num_cores, grid_size](
+        [reader_kernel_id = reader_kernels_id, writer_kernel_id = writer_kernels_id, cores](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
@@ -512,9 +602,7 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
             auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
             auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
 
-            for (uint32_t i = 0; i < num_cores; ++i) {
-                const CoreCoord core = {i % grid_size.x, i / grid_size.x};
-
+            for (const auto& core : cores) {
                 {
                     auto& reader_args = reader_runtime_args_by_core.at(core.x).at(core.y);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -334,9 +334,6 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     IDevice* device = a.device();
     auto grid_size = device->compute_with_storage_grid_size();
 
-    // Determine if we should use 2D kernel layout
-    // If use_2d_core_grid is explicitly set, use that value
-    // Otherwise, infer based on shape conditions (RMSNorm with single batch and small height)
     bool use_2d_kernel = false;
     if (use_2d_core_grid.has_value()) {
         use_2d_kernel = *use_2d_core_grid;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -47,8 +47,7 @@ inline uint32_t pack_two_bfloat16_into_uint32(std::pair<uint16_t, uint16_t> two_
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
-
-operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
+operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core_2d(
     const Tensor& a,
     Tensor& output,
     LayerNormDistributedType norm_type,
@@ -68,6 +67,288 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     const uint32_t tile_cols_per_device = is_rmsnorm ? 1 : 2;
 
     uint32_t num_tile_rows = NC * Ht;
+    uint32_t num_tile_cols = Wt;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                       Device Setup
+    //////////////////////////////////////////////////////////////////////////
+    IDevice* device = a.device();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                Circular Buffer Data Format Setup
+    //////////////////////////////////////////////////////////////////////////
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    uint32_t block_size = 1;  // find_max_divisor(Wt, 8);
+    uint32_t writer_block_size = 1;
+
+    tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t in_single_tile_size = tt::tt_metal::detail::TileSize(in_data_format);
+    uint32_t out_single_tile_size = tt::tt_metal::detail::TileSize(out_data_format);
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
+    uint32_t bfloat16_tile_size = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
+
+    tt::DataFormat inb_data_format = tt::DataFormat::Invalid;
+    uint32_t inb_single_tile_size = 0;
+
+    auto a_addr = a.buffer()->address();
+    auto dst_addr = output.buffer()->address();
+
+    uint32_t num_tiles = a.physical_volume() / TILE_HW;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const uint32_t double_buffer_constant = 2;
+    const uint32_t in0_tiles = Wt * double_buffer_constant;
+    const uint32_t in1_tiles = 1;  // reduce scalar
+
+    const uint32_t intermed0_tiles = Wt * double_buffer_constant;  // xˆ2
+    uint32_t out0_tiles = 1;
+
+    TT_FATAL(
+        W <= TILE_WIDTH * in0_tiles,
+        "W ({}) exceeds the maximum supported size of tile buffer ({} * {}, kernel limitation right now).",
+        W,
+        TILE_WIDTH,
+        in0_tiles);
+    TT_FATAL(
+        in0_tiles % block_size == 0,
+        "Size of buffer ({}) must be divisible by the size of block ({}) used by the reader and compute kernel.",
+        in0_tiles,
+        block_size);
+    TT_FATAL(
+        intermed0_tiles % block_size == 0,
+        "Size of buffer ({}) must be divisible by the size of block ({}) used by the reader and compute kernel.",
+        intermed0_tiles,
+        block_size);
+
+    auto grid_size = device->compute_with_storage_grid_size();
+
+    uint32_t max_cores_y = grid_size.y;
+    uint32_t max_cores_x = grid_size.x;
+    uint32_t cores_x = std::min(max_cores_y, num_tile_rows);
+    while (num_tile_rows % cores_x != 0 && cores_x > 1) {
+        cores_x--;
+    }
+    uint32_t tiles_per_core_x = num_tile_rows / cores_x;
+    uint32_t cores_y = std::min(max_cores_y, Wt);
+    while (Wt % cores_y != 0 && cores_y > 1) {
+        cores_y--;
+    }
+    uint32_t tiles_per_core_y = Wt / cores_y;
+
+    CoreRange all_cores_range({0, 0}, {cores_x - 1, cores_y - 1});
+    CoreRangeSet all_cores = CoreRangeSet(std::vector{all_cores_range});
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
+
+    std::vector<CoreRange> merge_core_ranges_vec;  // Renamed to avoid conflict
+    for (uint32_t x = 0; x < cores_x; ++x) {
+        CoreCoord merge_core = {x, 0};
+        merge_core_ranges_vec.push_back(CoreRange(merge_core, merge_core));
+    }
+    CoreRangeSet merge_cores(merge_core_ranges_vec);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    Program program = CreateProgram();
+    auto reducer_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        // interleaved accessor args
+        (std::uint32_t)is_dram(a),
+        (std::uint32_t)block_size,
+        (std::uint32_t)reducer_semaphore_id,
+        (std::uint32_t)cores_y,
+    };
+
+    std::vector<uint32_t> writer_compile_time_args = {// interleaved accessor args
+                                                      (std::uint32_t)is_dram(output),
+                                                      (std::uint32_t)writer_block_size};
+
+    bool tile_dtype_is_bfloat16 = a.dtype() == tt::tt_metal::DataType::BFLOAT16;
+    std::map<std::string, std::string> compute_defines;
+
+    compute_defines["RMSNORM"] = "1";
+
+    auto reader_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
+        "reader_layernorm_preallgather_2d.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id_blocked.cpp",
+        merge_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::vector<uint32_t> compute_args = {tiles_per_core_x, tiles_per_core_y, block_size, cores_y};
+
+    auto compute_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/"
+        "layernorm_pre_allgather_2d.cpp",
+        all_cores,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_args,
+            .defines = compute_defines});
+
+    // Create circular buffers
+    // c_in0 -> a
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(in0_tiles * in_single_tile_size, {{tt::CBIndex::c_0, in_data_format}})
+            .set_page_size(tt::CBIndex::c_0, in_single_tile_size);
+    CreateCircularBuffer(program, all_cores, cb_src0_config);
+    // c_in1 -> reduce scalar
+    CircularBufferConfig cb_reduce_config =
+        CircularBufferConfig(in1_tiles * bfloat16_tile_size, {{tt::CBIndex::c_1, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_1, bfloat16_tile_size);
+    CreateCircularBuffer(program, all_cores, cb_reduce_config);
+
+    // LN and RMS shared intermediates //
+    // c_intermed0 -> xˆ2
+    CircularBufferConfig cb_intermed0_config =
+        CircularBufferConfig(intermed0_tiles * single_tile_size, {{tt::CBIndex::c_6, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_6, single_tile_size);
+    CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    CircularBufferConfig cb_intermed1_config =
+        CircularBufferConfig(tiles_per_core_y * single_tile_size, {{tt::CBIndex::c_15, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_15, single_tile_size);
+    CreateCircularBuffer(program, all_cores, cb_intermed1_config);
+
+    CircularBufferConfig cb_out0_config =
+        CircularBufferConfig(out0_tiles * single_tile_size, {{tt::CBIndex::c_16, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_16, single_tile_size);
+    CreateCircularBuffer(program, all_cores, cb_out0_config);
+    CircularBufferConfig cb_zero_config =
+        CircularBufferConfig(out0_tiles * single_tile_size, {{tt::CBIndex::c_13, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_13, single_tile_size);
+    CreateCircularBuffer(program, all_cores, cb_zero_config);
+
+    CircularBufferConfig cb_out_final_config =
+        CircularBufferConfig(out0_tiles * out_single_tile_size, {{tt::CBIndex::c_14, out_data_format}})
+            .set_page_size(tt::CBIndex::c_14, out_single_tile_size);
+    CreateCircularBuffer(program, merge_cores, cb_out_final_config);
+
+    float winv = 1.0f;
+    auto bfloat_winv_value = bfloat16(winv);
+    uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
+    for (uint32_t x = 0; x < cores_x; ++x) {
+        for (uint32_t y = 0; y < cores_y; ++y) {
+            CoreCoord core = {x, y};
+            bool is_merge_core = y == 0;
+            const auto merge_core = device->worker_core_from_logical_core({x, 0});
+
+            uint32_t num_tile_rows_per_core = tiles_per_core_x;
+
+            uint32_t in_tile_offset = x * Wt + y * tiles_per_core_y;
+            uint32_t out_tile_offset = x * out0_tiles;
+
+            SetRuntimeArgs(
+                program,
+                reader_kernels_id,
+                core,
+                {a_addr,
+                 tiles_per_core_x,
+                 tiles_per_core_y,
+                 in_tile_offset,
+                 is_merge_core,
+                 merge_core.x,
+                 merge_core.y,
+                 y,
+                 packed_winv_value});
+            SetRuntimeArgs(program, compute_kernels_id, core, {is_merge_core});
+            if (is_merge_core) {
+                SetRuntimeArgs(
+                    program, writer_kernels_id, core, {dst_addr, num_tile_rows_per_core * out0_tiles, out_tile_offset});
+            }
+        }
+    }
+
+    auto override_runtime_arguments_callback =
+        [reader_kernel_id = reader_kernels_id, writer_kernel_id = writer_kernels_id, cores](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& input_tensor = input_tensors.at(0);
+
+            const auto input_addr = input_tensor.buffer()->address();
+
+            const auto& output_tensor = output_tensors.at(0);
+            const auto output_addr = output_tensor.buffer()->address();
+
+            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+
+            for (const auto& core : cores) {
+                {
+                    auto& reader_args = reader_runtime_args_by_core.at(core.x).at(core.y);
+
+                    reader_args[0] = input_addr;
+                }
+
+                if (core.y == 0) {
+                    auto& writer_args = writer_runtime_args_by_core.at(core.x).at(core.y);
+                    writer_args[0] = output_addr;
+                }
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
+    const Tensor& a,
+    Tensor& output,
+    LayerNormDistributedType norm_type,
+    DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<bool> use_2d_core_grid) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;
+    const bool is_rmsnorm = norm_type == LayerNormDistributedType::RMSNORM;
+    const auto& shape = a.padded_shape();
+    const uint32_t W = shape[-1], H = shape[-2];
+    const uint32_t HW = H * W;
+    const uint32_t NC = a.physical_volume() / HW;
+
+    // Kernels are configured to support BFLOAT8_B, but bad pcc so we need mixed precision support in compute
+    const auto& a_dtype = a.dtype();
+
+    const uint32_t Wt = W / TILE_WIDTH;
+    const uint32_t Ht = H / TILE_HEIGHT;
+    ////////////////////////////////////////////////////////////////////////////
+    //                       Device Setup
+    //////////////////////////////////////////////////////////////////////////
+    IDevice* device = a.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+
+    // Determine if we should use 2D kernel layout
+    // If use_2d_core_grid is explicitly set, use that value
+    // Otherwise, infer based on shape conditions (RMSNorm with single batch and small height)
+    bool use_2d_kernel = false;
+    if (use_2d_core_grid.has_value()) {
+        use_2d_kernel = *use_2d_core_grid;
+    }
+
+    if (use_2d_kernel) {
+        return layernorm_pre_allgather_multi_core_2d(a, output, norm_type, compute_kernel_config);
+    }
+
+    const uint32_t tile_cols_per_device = is_rmsnorm ? 1 : 2;
+
+    uint32_t num_tile_rows = NC * Ht;
 
     log_debug(tt::LogOp, "is_rmsnorm: {}", is_rmsnorm);
     log_debug(tt::LogOp, "W: {}", W);
@@ -75,11 +356,6 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     log_debug(tt::LogOp, "num_tile_rows: {}", num_tile_rows);
     log_debug(tt::LogOp, "Wt: {}", Wt);
     log_debug(tt::LogOp, "Ht: {}", Ht);
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                       Device Setup
-    //////////////////////////////////////////////////////////////////////////
-    IDevice* device = a.device();
 
     ////////////////////////////////////////////////////////////////////////////
     //                Circular Buffer Data Format Setup
@@ -151,7 +427,6 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
         intermed0_tiles,
         block_size);
 
-    auto grid_size = device->compute_with_storage_grid_size();
     auto
         [num_cores,
          all_cores,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
@@ -45,7 +45,8 @@ ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
                        .eps = epsilon,
                        .memory_config = memory_config.value_or(input_tensor.memory_config()),
                        .compute_kernel_config = kernel_config_val,
-                       .dtype = dtype},
+                       .dtype = dtype,
+                       .use_2d_core_grid = std::nullopt},  // LayerNorm doesn't expose this parameter
                    {input_tensor, stats},
                    {weight, bias})
             .at(0);

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -30,7 +30,8 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
             py::arg("residual_input_tensor") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("program_config") = std::nullopt,
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt,
+            py::arg("use_2d_core_grid") = std::nullopt});
 }
 
 void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
@@ -50,7 +51,8 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("program_config") = std::nullopt,
-            py::arg("dtype") = std::nullopt});
+            py::arg("dtype") = std::nullopt,
+            py::arg("use_2d_core_grid") = std::nullopt});
 }
 
 void bind_normalization_rms_norm_distributed(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
@@ -18,7 +18,8 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const LayerNormProgramConfig>& program_config,
-    const std::optional<const DataType>& dtype) {
+    const std::optional<const DataType>& dtype,
+    const std::optional<bool>& use_2d_core_grid) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
@@ -44,7 +45,8 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
                        .eps = epsilon,
                        .memory_config = memory_config.value_or(input_tensor.memory_config()),
                        .compute_kernel_config = kernel_config_val,
-                       .dtype = dtype},
+                       .dtype = dtype,
+                       .use_2d_core_grid = use_2d_core_grid},
                    {input_tensor, stats},
                    {weight, bias})
             .at(0);

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
@@ -22,7 +22,8 @@ struct ExecuteRMSNormPostAllGather {
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
-        const std::optional<const DataType>& dtype = std::nullopt);
+        const std::optional<const DataType>& dtype = std::nullopt,
+        const std::optional<bool>& use_2d_core_grid = std::nullopt);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -15,7 +15,8 @@ ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
     const std::optional<const ttnn::Tensor>& residual_input_tensor,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const LayerNormProgramConfig>& program_config,
-    const std::optional<MemoryConfig>& memory_config) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<bool>& use_2d_core_grid) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
@@ -38,7 +39,8 @@ ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
                    LayerNormPreAllGather{
                        .norm_type = LayerNormDistributedType::RMSNORM,
                        .dtype = dtype,
-                       .compute_kernel_config = kernel_config_val},
+                       .compute_kernel_config = kernel_config_val,
+                       .use_2d_core_grid = use_2d_core_grid},
                    {input_tensor})
             .at(0);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
@@ -19,7 +19,8 @@ struct ExecuteRMSNormPreAllGather {
         const std::optional<const ttnn::Tensor>& residual_input_tensor = std::nullopt,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<bool>& use_2d_core_grid = std::nullopt);
 };
 
 }  // namespace operations::normalization


### PR DESCRIPTION
### What's changed
Currently, distributed RMSNorm  only divides work amongst grid.x cores for dim [-2]
For better perf, we divide work amongst grid.y cores for dim [-1 ]

APC: https://github.com/tenstorrent/tt-metal/actions/runs/16622753078