### PR TITLE
Global and local embeddings

### DIFF
--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -172,7 +172,7 @@ def test_decoder_inference(
         tt_out = tt_model(
             decode_input,
             current_pos_tensor,
-            rot_mats=rot_mats,
+            rot_mats_global=rot_mats,
             mode="decode",
             page_table=page_table_tt,
         )

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -159,7 +159,9 @@ def test_decoder_inference(
         attn_mask_torch = torch.triu(attn_mask, diagonal=1)
         ref_output = reference_model(pt_decode_input, positions[0], freqs_cis_i, mask=attn_mask_torch)
         # Run TT model
-        tt_out = tt_model(decode_input, None, rot_mats, user_id=0, mode="prefill", page_table=page_table_tt)
+        tt_out = tt_model(
+            decode_input, None, rot_mats_global=rot_mats, user_id=0, mode="prefill", page_table=page_table_tt
+        )
         tt_out = ttnn.to_torch(
             tt_out,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=model_args.cluster_shape),

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -93,6 +93,9 @@ class Attention(LightweightModule):
         self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
 
         self.transformation_mats = transformation_mats
+        self.is_sliding = (
+            configuration.layer_types[layer_num] == "sliding_window" if configuration.layer_types else False
+        )
 
         self.model_config = configuration.get_model_config()
         self.ccl_topology = configuration.ccl_topology()

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -104,7 +104,8 @@ class TransformerBlock(LightweightModule):
         self,
         x: ttnn.Tensor,
         current_pos,
-        rot_mats=None,
+        rot_mats_global=None,
+        rot_mats_local=None,
         user_id=0,
         mode="decode",
         page_table=None,
@@ -118,6 +119,10 @@ class TransformerBlock(LightweightModule):
         assert (
             x.memory_config() == skip_mem_cfg
         ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
+
+        # Choose the correct rotation matrices based on the mode
+        rot_mats = rot_mats_local if self.attention.is_sliding else rot_mats_global
+
         # Norms take fractured inputs and output replicated across devices
         attn_in = self.attention_norm(x, mode)
         # Attention takes replicated inputs and produces fractured outputs

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -157,7 +157,8 @@ class Generator:
 
                 (
                     chunk_prefill_input,
-                    chunk_rot_mats_prefill,
+                    chunk_rot_mats_global_prefill,
+                    chunk_rot_mats_local_prefill,
                     page_table_tt,
                     chunk_page_table_tt,
                 ) = self.model[model_id].prepare_inputs_prefill(
@@ -168,7 +169,8 @@ class Generator:
                 )
                 tt_logits = self.model[model_id].ttnn_prefill_forward(
                     chunk_prefill_input,
-                    rot_mats=chunk_rot_mats_prefill,
+                    rot_mats_global=chunk_rot_mats_global_prefill,
+                    rot_mats_local=chunk_rot_mats_local_prefill,
                     user_id=CHUNK_USER_ID,
                     page_table=page_table_tt,
                     chunk_page_table=chunk_page_table_tt,
@@ -182,14 +184,21 @@ class Generator:
                 else:
                     del tt_logits
         else:
-            prefill_input, rot_mats_prefill, page_table_tt, _ = self.model[model_id].prepare_inputs_prefill(
+            (
+                prefill_input,
+                rot_mats_global_prefill,
+                rot_mats_local_prefill,
+                page_table_tt,
+                _,
+            ) = self.model[model_id].prepare_inputs_prefill(
                 tokens,
                 page_table=page_table,
             )
 
             tt_logits = self.model[model_id].ttnn_prefill_forward(
                 prefill_input,
-                rot_mats=rot_mats_prefill,
+                rot_mats_global=rot_mats_global_prefill,
+                rot_mats_local=rot_mats_local_prefill,
                 user_id=user_id,
                 page_table=page_table_tt,
                 get_last_token=(last_token_idx // 32) * 32,
@@ -252,17 +261,24 @@ class Generator:
 
         tt_tokens = []
         tt_current_pos = []
-        tt_rot_mats = []
+        tt_rot_mats_global = []
+        tt_rot_mats_local = []
         tt_page_table = []
 
         for i in range(self.data_parallel):
             user_page_table = page_table[i] if page_table is not None else None
-            tt_tokens_i, tt_current_pos_i, tt_rot_mats_i, tt_page_table_i = self.model[i].prepare_inputs_decode(
-                tokens[i], current_pos[i], user_page_table
-            )
+            model_i = self.model[i]
+            (
+                tt_tokens_i,
+                tt_current_pos_i,
+                tt_rot_mats_global_i,
+                tt_rot_mats_local_i,
+                tt_page_table_i,
+            ) = model_i.prepare_inputs_decode(tokens[i], current_pos[i], user_page_table)
             tt_tokens.append(tt_tokens_i)
             tt_current_pos.append(tt_current_pos_i)
-            tt_rot_mats.append(tt_rot_mats_i)
+            tt_rot_mats_global.append(tt_rot_mats_global_i)
+            tt_rot_mats_local.append(tt_rot_mats_local_i)
             tt_page_table.append(tt_page_table_i)
 
         for i in range(self.data_parallel):
@@ -270,7 +286,8 @@ class Generator:
             tt_logits_i = self.model[i].ttnn_decode_forward(
                 tt_tokens[i],
                 tt_current_pos[i],
-                rot_mats=tt_rot_mats[i],
+                rot_mats_global=tt_rot_mats_global[i],
+                rot_mats_local=tt_rot_mats_local[i],
                 page_table=tt_page_table[i],
                 kv_cache=user_kv_cache,
                 argmax_on_device=argmax_on_device,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1455,8 +1455,11 @@ class ModelArgs:
                     )
                     self.hidden_dim = padded_hidden_dim
 
+        self.layer_types = text_config.get("layer_types", None)
+
         # RoPE params
         self.rope_theta = text_config.get("rope_theta")
+        self.rope_theta_local = text_config.get("rope_local_base_freq", None)
         # If use_scaled_rope is not present, assume setting rope_scaling means use scaled rope
         # If it is present and is set to false, do not use scaled rope
         # Setting self.rope_scaling_factor to None is our way of saying do not use scaled rope

--- a/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -303,7 +303,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
             h = layer(
                 h,
                 current_pos,
-                rot_mats=rot_mats,
+                rot_mats_global=rot_mats,
                 user_id=user_id,
                 mode=mode,
                 page_table=page_table,

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional
+
 import torch
 
 import ttnn
@@ -24,8 +26,8 @@ class RotarySetup(LightweightModule):
         head_dim: int,
         max_seq_len: int,
         rope_theta: float,
-        scale_factor: float,  # use None to disable rope scaling
-        orig_context_len: int,  # only used if scaling enabled
+        scale_factor: Optional[float] = None,  # use None to disable rope scaling
+        orig_context_len: Optional[int] = None,  # only used if scaling enabled
         datatype=ttnn.bfloat16,
     ):
         super().__init__()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22809

### Problem description
Gemma3 uses both global and local embeddings, and tt_transformers supports only global.

### What's changed
Added local rotation matrices next to global in all calls.
Assume that global is always used, local can be None.

This PR is the second variant of https://github.com/tenstorrent/tt-metal/pull/25934

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) - TODO
- [ ] [T3K Unit and Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16605145838)
- [ ] [New tests] - TODO