### PR TITLE
[DM]: Updating test suite to use Mesh Device API with Fast Dispatch

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -42,8 +42,6 @@ jobs:
               rm -rf /tmp/kernels
               mkdir -p /tmp/kernels
               TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
-          - name: data_movement
-            cmd: ./build/test/tt_metal/unit_tests_data_movement
           - name: debug_tools and device and dispatch
             cmd: |
               ./build/test/tt_metal/unit_tests_debug_tools

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -42,6 +42,8 @@ jobs:
               rm -rf /tmp/kernels
               mkdir -p /tmp/kernels
               TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
+          - name: data_movement
+            cmd: ./build/test/tt_metal/unit_tests_data_movement
           - name: debug_tools and device and dispatch
             cmd: |
               ./build/test/tt_metal/unit_tests_debug_tools

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -63,6 +63,8 @@ jobs:
               ./build/test/tt_metal/unit_tests_debug_tools
           - name: ttnn tensor accessor
             cmd: "./build/test/ttnn/unit_tests_ttnn_accessor"
+          - name: data movement
+            cmd: ./build/test/tt_metal/unit_tests_data_movement
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image }}

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -2,6 +2,9 @@
 
 This test suite addresses the functionality and performance (i.e. bandwidth) of various data movement scenarios.
 
+## Dispatch Mode Compatibility
+All test suites in this directory support both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases. Each individual test suite includes specific instructions for running in both modes.
+
 ## Tests in the Test Suite
 
 | Name                        | ID(s)        | Description                                                                          |
@@ -23,12 +26,24 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 ## Running Tests
 ### C++ Gtests
 Before running any tests, build the repo with tests: ```./build_metal.sh --build-tests```
-Then, to run the whole test suite execute the following command:
+
+**Fast Dispatch Mode (Recommended):**
+To run the whole test suite in fast dispatch mode (default):
+```
+./build/test/tt_metal/unit_tests_data_movement
+```
+
+**Slow Dispatch Mode:**
+To run the whole test suite in slow dispatch mode:
 ```
 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement
 ```
 
 To run a single test, add a gtest filter with the name of the test. Example:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
+```
+Or in slow dispatch mode:
 ```
 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
 ```

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -2,34 +2,41 @@
 
 This test suite addresses the functionality and performance (i.e. bandwidth) of various data movement scenarios.
 
-## Mesh Device API Support
-All test suites in this directory have been converted to use the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+## Dispatch Mode Support
+This test suite includes tests using both fast dispatch (Mesh Device API) and slow dispatch modes:
 
-**Important**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations. All tests now run exclusively in fast dispatch mode through the Mesh Device API.
+### Fast Dispatch (Mesh Device API)
+Most test suites use the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. These tests use `GenericMeshDeviceFixture` and run on single-device unit meshes with fast dispatch mode for optimal performance.
+
+### Slow Dispatch
+Some test suites use slow dispatch mode for reliable program execution. These tests use `DeviceFixture` and execute programs directly using `tt::tt_metal::detail::LaunchProgram()`. Tests requiring slow dispatch include:
+- **Deinterleave Hardcoded** (IDs 200-201)
+- **Conv Hardcoded** (IDs 21-23)
+- **Reshard Hardcoded** (IDs 17-20)
 
 ## Tests in the Test Suite
 
-| Name                        | ID(s)        | Description                                                                          |
-| ----------                  | -----        | ----------------------------------------------------                                 |
-| DRAM Unary                  | 0-3          | Transactions between DRAM and a single Tensix core.                                  |
-| One to One                  | 4, 50        | Write transactions between two Tensix cores.                                         |
-| One From One                | 5, 51        | Read transactions between two Tensix cores.                                          |
-| One to all                  | 6-8          | Writes transaction from one core to all cores.                                       |
-| One to all Multicast        | 9-14, 52     | Writes transaction from one core to all cores using multicast.                       |
-| One From All                | 15, 30       | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
-| Loopback                    | 16           | Does a loopback operation where one cores writes to itself.                          |
-| Reshard Hardcoded           | 17-20        | Uses existing reshard tests to analyse their bandwidth and latency.                  |
-| Conv Hardcoded              | 21-23        | Uses existing conv tests to analyse their bandwidth and latency.                     |
-| All to all                  | 60           | Write transactions from multiple cores to multiple cores.                            |
-| All from all                | 70           | Read transactions from multiple cores to multiple cores.                             |
-| Interleaved Page Read/Write | 61-69, 71-75 | Reads and writes pages between interleaved buffers and a Tensix core.                |
-| Deinterleave                | 200-201      | Tests deinterleaving                                                                 |
+| Name                        | ID(s)        | Description                                                                             |
+| --------------------------- | ------------ | --------------------------------------------------------------------------------------- |
+| DRAM Unary                  | 0-3          | Transactions between DRAM and a single Tensix core.                                     |
+| One to One                  | 4, 50        | Write transactions between two Tensix cores.                                            |
+| One From One                | 5, 51        | Read transactions between two Tensix cores.                                             |
+| One to all                  | 6-8          | Writes transaction from one core to all cores.                                          |
+| One to all Multicast        | 9-14, 52     | Writes transaction from one core to all cores using multicast.                          |
+| One From All                | 15, 30       | Read transactions between one gatherer Tensix core and multiple sender Tensix cores.    |
+| Loopback                    | 16           | Does a loopback operation where one cores writes to itself.                             |
+| Reshard Hardcoded           | 17-20        | Uses existing reshard tests to analyse their bandwidth and latency. **(Slow Dispatch)** |
+| Conv Hardcoded              | 21-23        | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
+| All to all                  | 60           | Write transactions from multiple cores to multiple cores.                               |
+| All from all                | 70           | Read transactions from multiple cores to multiple cores.                                |
+| Interleaved Page Read/Write | 61-69, 71-75 | Reads and writes pages between interleaved buffers and a Tensix core.                   |
+| Deinterleave                | 200-201      | Tests deinterleaving **(Slow Dispatch)**                                                |
 
 ## Running Tests
 ### C++ Gtests
 Before running any tests, build the repo with tests: ```./build_metal.sh --build-tests```
 
-All tests use the Mesh Device API with fast dispatch mode:
+Most tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement
 ```
@@ -37,6 +44,11 @@ All tests use the Mesh Device API with fast dispatch mode:
 To run a single test, add a gtest filter with the name of the test. Example:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
+```
+
+For tests that require slow dispatch mode (Deinterleave, Conv, and Reshard Hardcoded tests), run with:
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*|*ConvHardcoded*|*ReshardHardcoded*"
 ```
 
 ### Pytest
@@ -52,21 +64,25 @@ An exhaustive list of options and their descriptions can be found in `./conftest
 ## Adding Tests
 Follow these steps to add new tests to this test suite.
 
-1. Create a new directory with a descriptive name for the test.
+1. **Choose dispatch mode:** Decide whether your test should use fast dispatch (Mesh Device API) or slow dispatch:
+    - **Fast Dispatch (recommended)**: Use `GenericMeshDeviceFixture` for new performance tests
+    - **Slow Dispatch**: Use `DeviceFixture` only if fast dispatch APIs don't work for your specific test case
+2. Create a new directory with a descriptive name for the test.
     - **Example:** `./dram_unary`
-2. In this directory, create the c++ test file with a filename that starts with "test_".
+3. In this directory, create the c++ test file with a filename that starts with "test_".
     - **Example:** `./dram_unary/test_unary_dram.cpp`
-3. Write your test in this file and place the kernels you use within this test in "kernels" directory.
+4. Write your test in this file and place the kernels you use within this test in "kernels" directory.
     - **Example:** `./dram_unary/kernels/reader_unary.cpp`
-4. Assign your test a unique test id to make sure your test results are grouped together and are plotted separately from other tests.
+5. Assign your test a unique test id to make sure your test results are grouped together and are plotted separately from other tests.
     - Refer to the "Tests in the Test Suite" section for already taken test ids.
     - Preferably use the next integer available.
     - Update the `test_id_to_name` and `test_bounds` objects with the test id, test name and test bounds.
-5. Create a README file within the test directory that describes:
+6. Create a README file within the test directory that describes:
     1. What your test does,
     2. What the test parameters are,
-    3. And what different test cases are implemented.
-6. In the `CMakeLists.txt` file, add your test path in the `set(UNIT_TESTS_DATA_MOVEMENT_SRC ... )` call.
+    3. What different test cases are implemented,
+    4. And which dispatch mode it uses.
+7. In the `CMakeLists.txt` file, add your test path in the `set(UNIT_TESTS_DATA_MOVEMENT_SRC ... )` call.
     - **Example:** `${CMAKE_CURRENT_SOURCE_DIR}/dram_unary/test_unary_dram.cpp`
 
 **Note:** Make sure the tests pass by building and running as above.

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -2,8 +2,10 @@
 
 This test suite addresses the functionality and performance (i.e. bandwidth) of various data movement scenarios.
 
-## Dispatch Mode Compatibility
-All test suites in this directory support both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases. Each individual test suite includes specific instructions for running in both modes.
+## Mesh Device API Support
+All test suites in this directory have been converted to use the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Important**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations. All tests now run exclusively in fast dispatch mode through the Mesh Device API.
 
 ## Tests in the Test Suite
 
@@ -27,25 +29,14 @@ All test suites in this directory support both fast dispatch (default) and slow 
 ### C++ Gtests
 Before running any tests, build the repo with tests: ```./build_metal.sh --build-tests```
 
-**Fast Dispatch Mode (Recommended):**
-To run the whole test suite in fast dispatch mode (default):
+All tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement
-```
-
-**Slow Dispatch Mode:**
-To run the whole test suite in slow dispatch mode:
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement
 ```
 
 To run a single test, add a gtest filter with the name of the test. Example:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
-```
-Or in slow dispatch mode:
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
 ```
 
 ### Pytest

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
@@ -1,9 +1,13 @@
-# All from All Core Data Movement Tests
+# All From All Core Data Movement Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from all subordinate cores to all master cores.
+
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-
 L1 space is allocated on all Tensix cores involved in the data movement test. Based on a given number of reservable pages, subsets of these pages are designated as either requestor pages (masters) or responder pages (subordinates).
 
 The subsets are determined as follows:
@@ -23,37 +27,38 @@ A pcc check is performed by cross-checking the data of all the subordinate cores
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllFromAll*"
 ```
 
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllFromAll*"
-```
-
 ## Test Parameters
-| Parameter                             | Data Type             | Description                                                               |
-| ------------------------------------- | --------------------- | ------------------------------------------------------------------------- |
-| test_id                               | uint32_t              | Test ID for identifying different test cases.                             |
-| mst_logical_start_coord               | CoreCoord             | Logical starting coordinates for the master core range.                   |
-| sub_logical_start_coord               | CoreCoord             | Logical starting coordinates for the subordinate core range.              |
-| mst_grid_size                         | CoreCoord             | Grid size of the master core range.                                       |
-| sub_grid_size                         | CoreCoord             | Grid size of the subordinate core range.                                  |
-| num_of_transactions_per_subordinate   | uint32_t              | Number of transactions performed per subordinate core.                    |
-| pages_reservable_per_transaction      | uint32_t              | Number of reservable pages per transaction in L1.                         |
-| bytes_per_page                        | uint32_t              | Size of each page in bytes.                                               |
-| l1_data_format                        | DataFormat            | Data format used for L1 data movement.                                    |
-| noc_id                                | NOC                   | Specifies which NOC to use for the test.                                  |
+| Parameter                              | Data Type             | Description |
+| -------------------------------------- | --------------------- | ----------- |
+| test_id                                | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| mst_logical_start_coord                | CoreCoord             | Starting logical coordinates for the master core grid. |
+| sub_logical_start_coord                | CoreCoord             | Starting logical coordinates for the subordinate core grid. |
+| mst_grid_size                          | CoreCoord             | Size of the master core grid. |
+| sub_grid_size                          | CoreCoord             | Size of the subordinate core grid. |
+| num_of_transactions_per_subordinate    | uint32_t              | Number of noc transactions that each subordinate core will issue. |
+| pages_reservable_per_transaction       | uint32_t              | Size of the issued noc transactions in pages. |
+| bytes_per_page                         | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format                         | DataFormat            | Data format of data that will be moved. |
+| noc_id                                 | NOC                   | Specifies which NOC to use for the test. |
+| virtual_channel                        | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| posted                                 | N/A                   | Posted flag (posted multicast has much better performance at larger grid sizes, than non-posted due to response packets) (TODO)|
 
 ## Test Cases
-Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size. Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. **All from All Packet Sizes:** Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters.
-a. **2x2 Packet Sizes**
-2. **All from All Directed Ideal:** Tests the most optimal data movement setup between two ranges of cores.
-a. **2x2 from 1x1**
-b. **4x4 from 1x1**
-c. **1x1 from 2x2**
-d. **1x1 from 4x4**
+1. **All From All Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions_per_subordinate and pages_reservable_per_transaction parameters across a full compute grid.
+
+2. **All From All Directed Ideal**: Tests the most optimal data movement setup between all subordinate and master cores that maximizes the transaction size and performs enough transactions to amortize initialization overhead.
+
+3. **Grid Configuration Tests**: Multiple test cases testing different master and subordinate grid configurations:
+   - 2x2 From 1x1: 2x2 master grid receiving from 1x1 subordinate grid
+   - 4x4 From 1x1: 4x4 master grid receiving from 1x1 subordinate grid
+   - 1x1 From 2x2: 1x1 master grid receiving from 2x2 subordinate grid
+   - 1x1 From 4x4: 1x1 master grid receiving from 4x4 subordinate grid
+   - 2x2 From 2x2: 2x2 master grid receiving from 2x2 subordinate grid

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
@@ -22,6 +22,17 @@ A pcc check is performed by cross-checking the data of all the subordinate cores
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllFromAll*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllFromAll*"
+```
+
 ## Test Parameters
 | Parameter                             | Data Type             | Description                                                               |
 | ------------------------------------- | --------------------- | ------------------------------------------------------------------------- |

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -398,9 +398,6 @@ TO-DO:
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
-    if (device->arch() == ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
     uint32_t test_case_id = 310;
 
     /* Parameters */
@@ -420,10 +417,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
-
-    if (device->arch() == ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
 
     uint32_t test_case_id = 311;
 

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -351,8 +351,7 @@ void custom_test(
     CoreCoord sub_grid_size,
     uint32_t num_of_transactions_per_subordinate,
     uint32_t pages_per_transaction,
-    uint32_t num_virtual_channels,
-    DispatchFixture* fixture) {
+    uint32_t num_virtual_channels) {
     NOC noc_id = NOC::NOC_1;
 
     // Physical Constraints
@@ -429,14 +428,13 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
     uint32_t test_case_id = 311;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
     CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
     CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    tt::tt_metal::unit_tests::dm::all_from_all::packet_sizes_test(
+    unit_tests::dm::all_from_all::packet_sizes_test(
         mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
@@ -445,8 +443,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedI
     uint32_t test_case_id = 312;
 
     /* Parameters */
-    auto mesh_device = get_mesh_device();
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {4, 4};
 
@@ -454,7 +450,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedI
     CoreCoord sub_grid_size = {1, 1};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 4x4 to 1x1 ======== */
@@ -462,8 +458,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedI
     uint32_t test_case_id = 313;
 
     /* Parameters */
-    auto mesh_device = get_mesh_device();
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
@@ -471,7 +465,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedI
     CoreCoord sub_grid_size = {1, 1};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 2x2 ======== */
@@ -479,8 +473,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedI
     uint32_t test_case_id = 314;
 
     /* Parameters */
-    auto mesh_device = get_mesh_device();
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {4, 4};
 
@@ -488,7 +480,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedI
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 4x4 ======== */
@@ -496,8 +488,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedI
     uint32_t test_case_id = 315;
 
     /* Parameters */
-    auto mesh_device = get_mesh_device();
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
@@ -505,7 +495,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedI
     CoreCoord sub_grid_size = {4, 4};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 2x2 ======== */
@@ -513,8 +503,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedI
     uint32_t test_case_id = 316;
 
     /* Parameters */
-    auto mesh_device = get_mesh_device();
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
@@ -522,38 +510,37 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedI
     CoreCoord sub_grid_size = {2, 2};
 
     unit_tests::dm::all_from_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== VIRTUAL CHANNELS ======== */
 
-TEST_F(DeviceFixture, TensixDataMovementAllFromAllVirtualChannels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 317;
 
-    unit_tests::dm::all_from_all::virtual_channels_test(arch_, devices_, num_devices_, test_case_id);
+    unit_tests::dm::all_from_all::virtual_channels_test(get_mesh_device(), test_case_id);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementAllFromAllCustom) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 318;
+
+    auto mesh_device = get_mesh_device();
+    auto device = mesh_device->get_device(0);
 
     // Parameters
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     uint32_t num_of_transactions_per_subordinate = 256;
     uint32_t pages_per_transaction = 1;
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::all_from_all::custom_test(
-        arch_,
-        devices_,
-        num_devices_,
+        mesh_device,
         test_case_id,
         mst_start_coord,
         sub_start_coord,
@@ -561,8 +548,7 @@ TEST_F(DeviceFixture, TensixDataMovementAllFromAllCustom) {
         sub_grid_size,
         num_of_transactions_per_subordinate,
         pages_per_transaction,
-        num_virtual_channels,
-        this);
+        num_virtual_channels);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
@@ -22,6 +22,17 @@ A pcc check is performed by cross-checking the data of all the master cores piec
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllToAll*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllToAll*"
+```
+
 ## Test Parameters
 | Parameter                         | Data Type             | Description                                                               |
 | --------------------------------- | --------------------- | ------------------------------------------------------------------------- |

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
@@ -1,10 +1,14 @@
-# All to All Core Data Movement Tests
+# All To All Core Data Movement Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from all master cores to all subordinate cores.
+
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-
-L1 space is allocated on all Tensix cores involved in the data movement test. Based on a given number of reservable pages, subsets of these pages are designated as either sender pages or receiver pages.
+L1 memory is allocated on multiple Tensix cores: master cores (senders) and subordinate cores (receivers). Data is written into L1 memory on all master cores. Each master core issues NOC transactions to transfer its data into L1 memory on all subordinate cores. Once data is transferred from all master cores, hardware barriers ensure data validity and completion of the transaction.
 
 The subsets are determined as follows:
 - num_sender_pages = num_reservable_pages / (1 + num_master_cores)
@@ -23,37 +27,38 @@ A pcc check is performed by cross-checking the data of all the master cores piec
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllToAll*"
 ```
 
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*AllToAll*"
-```
-
 ## Test Parameters
-| Parameter                         | Data Type             | Description                                                               |
-| --------------------------------- | --------------------- | ------------------------------------------------------------------------- |
-| test_id                           | uint32_t              | Test ID for identifying different test cases.                             |
-| mst_logical_start_coord           | CoreCoord             | Logical starting coordinates for the master core range.                   |
-| sub_logical_start_coord           | CoreCoord             | Logical starting coordinates for the subordinate core range.              |
-| mst_grid_size                     | CoreCoord             | Grid size of the master core range.                                       |
-| sub_grid_size                     | CoreCoord             | Grid size of the subordinate core range.                                  |
-| num_of_transactions_per_master    | uint32_t              | Number of transactions issued per master core.                            |
-| pages_reservable_per_transaction  | uint32_t              | Number of reservable pages per transaction in L1.                         |
-| bytes_per_page                    | uint32_t              | Size of each page in bytes.                                               |
-| l1_data_format                    | DataFormat            | Data format used for L1 data movement.                                    |
-| noc_id                            | NOC                   | Specifies which NOC to use for the test.                                  |
+| Parameter                              | Data Type             | Description |
+| -------------------------------------- | --------------------- | ----------- |
+| test_id                                | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| mst_logical_start_coord                | CoreCoord             | Starting logical coordinates for the master core grid. |
+| sub_logical_start_coord                | CoreCoord             | Starting logical coordinates for the subordinate core grid. |
+| mst_grid_size                          | CoreCoord             | Size of the master core grid. |
+| sub_grid_size                          | CoreCoord             | Size of the subordinate core grid. |
+| num_of_transactions_per_master         | uint32_t              | Number of noc transactions that each master core will issue. |
+| pages_reservable_per_transaction       | uint32_t              | Size of the issued noc transactions in pages. |
+| bytes_per_page                         | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format                         | DataFormat            | Data format of data that will be moved. |
+| noc_id                                 | NOC                   | Specifies which NOC to use for the test. |
+| virtual_channel                        | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| posted                                 | N/A                   | Posted flag (posted multicast has much better performance at larger grid sizes, than non-posted due to response packets) (TODO)|
 
 ## Test Cases
-Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size. Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. **All to All Packet Sizes:** Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters.
-a. **2x2 Packet Sizes**
-2. **All to All Directed Ideal:** Tests the most optimal data movement setup between two ranges of cores.
-a. **2x2 to 1x1**
-b. **4x4 to 1x1**
-c. **1x1 to 2x2**
-d. **1x1 to 4x4**
+1. **All To All Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions_per_master and pages_reservable_per_transaction parameters across a full compute grid.
+
+2. **All To All Directed Ideal**: Tests the most optimal data movement setup between all master and subordinate cores that maximizes the transaction size and performs enough transactions to amortize initialization overhead.
+
+3. **Grid Configuration Tests**: Multiple test cases testing different master and subordinate grid configurations:
+   - 1x1 To 2x2: 1x1 master grid sending to 2x2 subordinate grid
+   - 1x1 To 4x4: 1x1 master grid sending to 4x4 subordinate grid
+   - 2x2 To 1x1: 2x2 master grid sending to 1x1 subordinate grid
+   - 4x4 To 1x1: 4x4 master grid sending to 1x1 subordinate grid
+   - 2x2 To 2x2: 2x2 master grid sending to 2x2 subordinate grid

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -407,9 +407,7 @@ TO-DO:
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
-    if (device->arch() == ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
+
     uint32_t test_case_id = 300;
 
     /* Parameters */
@@ -428,9 +426,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
-    if (device->arch() == ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
 
     uint32_t test_case_id = 301;
 

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -2,16 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/dispatch_fixture.hpp"
+#include "../../common/multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 namespace tt::tt_metal {
 
 using namespace std;
-using namespace tt;
-using namespace tt::test_utils;
+using namespace test_utils;
 
 namespace unit_tests::dm::all_to_all {
 
@@ -23,10 +24,10 @@ struct AllToAllConfig {
     uint32_t test_id = START_ID;
 
     /* Grid configurations */
-    CoreCoord mst_logical_start_coord = CoreCoord();
-    CoreCoord sub_logical_start_coord = CoreCoord();
-    CoreCoord mst_grid_size = CoreCoord();
-    CoreCoord sub_grid_size = CoreCoord();
+    CoreCoord mst_logical_start_coord = {0, 0};
+    CoreCoord sub_logical_start_coord = {0, 0};
+    CoreCoord mst_grid_size = {0, 0};
+    CoreCoord sub_grid_size = {0, 0};
 
     /* Transaction size configurations */
     uint32_t num_of_transactions_per_master = 1;
@@ -44,10 +45,12 @@ struct AllToAllConfig {
 };
 
 /// @brief Performs communication from L1 Sender Cores to L1 Receiver Cores.
-/// @param device The device on which the test is executed.
+/// @param mesh_device The mesh device on which the test is executed.
 /// @param test_config Configuration of the test, defined by a specific struct.
 /// @return Status of the test execution (e.g., success or failure).
-bool run_dm(IDevice* device, const AllToAllConfig& test_config, DispatchFixture* fixture) {
+bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const AllToAllConfig& test_config) {
+    // Get the actual device for this single-device test
+    IDevice* device = mesh_device->get_device(0);
     /* ================ SETUP ================ */
 
     // Program
@@ -107,7 +110,7 @@ bool run_dm(IDevice* device, const AllToAllConfig& test_config, DispatchFixture*
 
     // Obtain L1 Address for Storing Data
 
-    L1AddressInfo core_l1_info = unit_tests::dm::get_l1_address_and_size(device, {0, 0});
+    L1AddressInfo core_l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, {0, 0});
     uint32_t mst_l1_base_address = core_l1_info.base_address;
     uint32_t sub_l1_base_address = mst_l1_base_address + bytes_per_transaction;
 
@@ -170,9 +173,16 @@ bool run_dm(IDevice* device, const AllToAllConfig& test_config, DispatchFixture*
         MetalContext::instance().get_cluster().l1_barrier(device->id());
     }
 
-    // LAUNCH PROGRAM
-    // Launch the program - Use dispatch-aware method
-    fixture->RunProgram(device, program);
+    // LAUNCH PROGRAM - Use mesh workload approach
+    auto mesh_workload = distributed::CreateMeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices =
+        distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
+    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
 
     vector<uint32_t> packed_output;
     packed_output.reserve(bytes_per_transaction / sizeof(uint32_t));
@@ -186,10 +196,10 @@ bool run_dm(IDevice* device, const AllToAllConfig& test_config, DispatchFixture*
         pcc = is_close_packed_vectors<bfloat16, uint32_t>(
             packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
         if (!pcc) {
-            log_error(tt::LogTest, "PCC Check failed");  // TO-DO: Print the failed core's coordinates here
-            log_info(tt::LogTest, "Golden vector");
+            log_error(LogTest, "PCC Check failed");  // TO-DO: Print the failed core's coordinates here
+            log_info(LogTest, "Golden vector");
             print_vector<uint32_t>(packed_golden);
-            log_info(tt::LogTest, "Output vector");
+            log_info(LogTest, "Output vector");
             print_vector<uint32_t>(packed_output);
             return pcc;
         }
@@ -243,25 +253,22 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    tt::ARCH arch_,
-    std::vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
     CoreCoord mst_grid_size,
-    CoreCoord sub_grid_size,
-    DispatchFixture* fixture) {
+    CoreCoord sub_grid_size) {
     NOC noc_id = NOC::NOC_0;
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
-        unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        unit_tests::dm::compute_physical_constraints(mesh_device);
 
     /* Running the Test */
 
     uint32_t max_transactions_per_master = 256;
     uint32_t max_reservable_pages_per_transaction =
-        arch_ == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        mesh_device->get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions_per_master = 1; num_of_transactions_per_master <= max_transactions_per_master;
          num_of_transactions_per_master *= 4) {
@@ -292,25 +299,22 @@ void packet_sizes_test(
             };
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config, fixture));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
-void virtual_channels_test(ARCH arch_, vector<IDevice*>& devices_, uint32_t num_devices_, uint32_t test_case_id) {
+void virtual_channels_test(shared_ptr<distributed::MeshDevice> mesh_device, uint32_t test_case_id) {
+    auto device = mesh_device->get_device(0);
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
-        unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters for literal all-to-all (use the full grid for both master and subordinate)
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     std::uint32_t max_num_pages_per_transaction = 1 << 12;
     std::uint32_t num_of_transactions = 256;  // Constant value
@@ -346,18 +350,14 @@ void virtual_channels_test(ARCH arch_, vector<IDevice*>& devices_, uint32_t num_
                 };
 
                 // Run
-                for (unsigned int id = 0; id < num_devices_; id++) {
-                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-                }
+                EXPECT_TRUE(run_dm(mesh_device, test_config));
             }
         }
     }
 }
 
 void custom_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_case_id,
     uint32_t num_of_transactions,
     uint32_t pages_per_transaction,
@@ -367,15 +367,13 @@ void custom_test(
 
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
-        unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters for literal all-to-all (use the full grid for both master and subordinate)
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
-    CoreCoord mst_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     // Test config
     unit_tests::dm::all_to_all::AllToAllConfig test_config = {
@@ -393,9 +391,7 @@ void custom_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, fixture));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 }  // namespace unit_tests::dm::all_to_all
@@ -412,167 +408,125 @@ TO-DO:
 /* ======== DIRECTED IDEAL ======== */
 
 /* ======== All to All ======== */
-TEST_F(DispatchFixture, TensixDataMovementAllToAllDirectedIdeal) {
-    if (arch_ == tt::ARCH::BLACKHOLE) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
+    auto mesh_device = get_mesh_device();
+    auto device = mesh_device->get_device(0);
+    if (device->arch() == ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
     }
     uint32_t test_case_id = 300;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
-    CoreCoord mst_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    unit_tests::dm::all_to_all::directed_ideal_test(
-        arch_, devices_, num_devices_, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+    unit_tests::dm::all_to_all::packet_sizes_test(
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== PACKET SIZES ======== */
 
-TEST_F(DispatchFixture, TensixDataMovementAllToAllPacketSizes) {
-    if (arch_ == tt::ARCH::BLACKHOLE) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes) {
+    auto mesh_device = get_mesh_device();
+    auto device = mesh_device->get_device(0);
+    if (device->arch() == ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
     }
 
     uint32_t test_case_id = 301;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
-    CoreCoord mst_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
-    CoreCoord sub_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    tt::tt_metal::unit_tests::dm::all_to_all::packet_sizes_test(
-        arch_, devices_, num_devices_, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+    unit_tests::dm::all_to_all::directed_ideal_test(
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 1x1 ======== */
-TEST_F(DispatchFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal) {
     uint32_t test_case_id = 302;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {4, 4};
 
     CoreCoord mst_grid_size = {2, 2};
     CoreCoord sub_grid_size = {1, 1};
 
+    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        arch_,
-        devices_,
-        NumDevices(),
-        test_case_id,
-        mst_start_coord,
-        sub_start_coord,
-        mst_grid_size,
-        sub_grid_size,
-        this);
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 4x4 to 1x1 ======== */
-TEST_F(DispatchFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal) {
     uint32_t test_case_id = 303;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
     CoreCoord mst_grid_size = {4, 4};
     CoreCoord sub_grid_size = {1, 1};
 
+    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        arch_,
-        devices_,
-        NumDevices(),
-        test_case_id,
-        mst_start_coord,
-        sub_start_coord,
-        mst_grid_size,
-        sub_grid_size,
-        this);
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 2x2 ======== */
-TEST_F(DispatchFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal) {
     uint32_t test_case_id = 304;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {4, 4};
 
     CoreCoord mst_grid_size = {1, 1};
     CoreCoord sub_grid_size = {2, 2};
 
+    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        arch_,
-        devices_,
-        NumDevices(),
-        test_case_id,
-        mst_start_coord,
-        sub_start_coord,
-        mst_grid_size,
-        sub_grid_size,
-        this);
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 4x4 ======== */
-TEST_F(DispatchFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal) {
     uint32_t test_case_id = 305;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
     CoreCoord mst_grid_size = {1, 1};
     CoreCoord sub_grid_size = {4, 4};
 
+    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        arch_,
-        devices_,
-        NumDevices(),
-        test_case_id,
-        mst_start_coord,
-        sub_start_coord,
-        mst_grid_size,
-        sub_grid_size,
-        this);
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 2x2 ======== */
-TEST_F(DispatchFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal) {
     uint32_t test_case_id = 306;
 
     /* Parameters */
-
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
 
     CoreCoord mst_grid_size = {2, 2};
     CoreCoord sub_grid_size = {2, 2};
 
+    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        arch_,
-        devices_,
-        NumDevices(),
-        test_case_id,
-        mst_start_coord,
-        sub_start_coord,
-        mst_grid_size,
-        sub_grid_size,
-        this);
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== VIRTUAL CHANNELS ======== */
@@ -596,7 +550,14 @@ TEST_F(DeviceFixture, TensixDataMovementAllToAllCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::all_to_all::custom_test(
-        arch_, devices_, NumDevices(), test_case_id, num_of_transactions, pages_per_transaction, num_virtual_channels, this);
+        arch_,
+        devices_,
+        NumDevices(),
+        test_case_id,
+        num_of_transactions,
+        pages_per_transaction,
+        num_virtual_channels,
+        this);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -209,9 +209,7 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const AllToAllConfi
 }
 
 void directed_ideal_test(
-    tt::ARCH arch_,
-    std::vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
@@ -221,7 +219,7 @@ void directed_ideal_test(
 
     // Physical Constraints
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
-        unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        unit_tests::dm::compute_physical_constraints(mesh_device);
     /* Running the Test */
 
     uint32_t num_of_transactions_per_master = 1;
@@ -247,9 +245,7 @@ void directed_ideal_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 void packet_sizes_test(
@@ -361,8 +357,8 @@ void custom_test(
     uint32_t test_case_id,
     uint32_t num_of_transactions,
     uint32_t pages_per_transaction,
-    uint32_t num_virtual_channels,
-    DispatchFixture* fixture) {
+    uint32_t num_virtual_channels) {
+    auto device = mesh_device->get_device(0);
     NOC noc_id = NOC::NOC_0;
 
     // Physical Constraints
@@ -460,9 +456,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To1x1DirectedIdeal
     CoreCoord mst_grid_size = {2, 2};
     CoreCoord sub_grid_size = {1, 1};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 4x4 to 1x1 ======== */
@@ -476,9 +471,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll4x4To1x1DirectedIdeal
     CoreCoord mst_grid_size = {4, 4};
     CoreCoord sub_grid_size = {1, 1};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 2x2 ======== */
@@ -492,9 +486,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To2x2DirectedIdeal
     CoreCoord mst_grid_size = {1, 1};
     CoreCoord sub_grid_size = {2, 2};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 1x1 to 4x4 ======== */
@@ -508,9 +501,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal
     CoreCoord mst_grid_size = {1, 1};
     CoreCoord sub_grid_size = {4, 4};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== 2x2 to 2x2 ======== */
@@ -524,22 +516,21 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal
     CoreCoord mst_grid_size = {2, 2};
     CoreCoord sub_grid_size = {2, 2};
 
-    auto mesh_device = get_mesh_device();
     unit_tests::dm::all_to_all::directed_ideal_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
+        get_mesh_device(), test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
 /* ======== VIRTUAL CHANNELS ======== */
 
-TEST_F(DeviceFixture, TensixDataMovementAllToAllVirtualChannels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 307;
 
-    unit_tests::dm::all_to_all::virtual_channels_test(arch_, devices_, num_devices_, test_case_id);
+    unit_tests::dm::all_to_all::virtual_channels_test(get_mesh_device(), test_case_id);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementAllToAllCustom) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllCustom) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 308;
@@ -550,14 +541,7 @@ TEST_F(DeviceFixture, TensixDataMovementAllToAllCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::all_to_all::custom_test(
-        arch_,
-        devices_,
-        NumDevices(),
-        test_case_id,
-        num_of_transactions,
-        pages_per_transaction,
-        num_virtual_channels,
-        this);
+        get_mesh_device(), test_case_id, num_of_transactions, pages_per_transaction, num_virtual_channels);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/README.md
@@ -3,6 +3,9 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of conv transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 
 This test creates a buffer for various conv patterns as gotten from `pytest test_conv2d.py::test_unet_conv_wh`. It plots the bandwidth of each core.
@@ -10,6 +13,17 @@ This test creates a buffer for various conv patterns as gotten from `pytest test
 It does not check pcc as the afformentioned test does this.
 
 The conv patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ConvHardcoded*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ConvHardcoded*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/README.md
@@ -3,8 +3,10 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of conv transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
 
@@ -15,14 +17,9 @@ It does not check pcc as the afformentioned test does this.
 The conv patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ConvHardcoded*"
-```
-
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ConvHardcoded*"
 ```
 
 ## Test Parameters

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/README.md
@@ -3,10 +3,10 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of conv transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
-## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+## Slow Dispatch Support
+This test suite uses the TT-Metal slow dispatch mode for reliable program execution. The tests use `DeviceFixture` and are designed to work with the slow dispatch API.
 
-**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+**Note**: These tests require slow dispatch mode for proper operation. They use `tt::tt_metal::detail::LaunchProgram()` for direct program execution without command queues.
 
 ## Test Flow
 
@@ -17,7 +17,12 @@ It does not check pcc as the afformentioned test does this.
 The conv patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
 
 ## Running the Tests
-The tests use the Mesh Device API with fast dispatch mode:
+The tests use slow dispatch mode. Run with the slow dispatch environment variable:
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ConvHardcoded*"
+```
+
+Or run normally (the DeviceFixture will automatically enforce slow dispatch mode):
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ConvHardcoded*"
 ```

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "../../common/dispatch_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -32,7 +32,7 @@ struct ConvConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(IDevice* device, const ConvConfig& test_config) {
+bool run_dm(IDevice* device, const ConvConfig& test_config, DispatchFixture* fixture) {
     // Program
     Program program = CreateProgram();
 
@@ -55,13 +55,14 @@ bool run_dm(IDevice* device, const ConvConfig& test_config) {
 
     // Launch program
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    detail::LaunchProgram(device, program);
+    // Launch the program - Use dispatch-aware method
+    fixture->RunProgram(device, program);
 
     return true;
 }
 }  // namespace unit_tests::dm::conv_hardcoded
 
-TEST_F(DeviceFixture, TensixDataMovementConvActHalo3x3) {
+TEST_F(DispatchFixture, TensixDataMovementConvActHalo3x3) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -127,12 +128,12 @@ TEST_F(DeviceFixture, TensixDataMovementConvActHalo3x3) {
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementConvActHalo3x3Smaller) {
+TEST_F(DispatchFixture, TensixDataMovementConvActHalo3x3Smaller) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -198,12 +199,12 @@ TEST_F(DeviceFixture, TensixDataMovementConvActHalo3x3Smaller) {
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementConvHaloGather) {
+TEST_F(DispatchFixture, TensixDataMovementConvHaloGather) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -262,8 +263,8 @@ TEST_F(DeviceFixture, TensixDataMovementConvHaloGather) {
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/README.md
@@ -1,0 +1,56 @@
+# Core Bidirectional Data Movement Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of bidirectional data movement transactions between two Tensix cores where one core simultaneously sends and receives data.
+
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+
+## Test Flow
+L1 memory is allocated on two Tensix cores: one master core and one subordinate core. The master core can run either a single kernel that performs both sending and receiving operations, or separate sender and receiver kernels. Data is written into both cores' L1 memory. The kernels perform simultaneous NOC write and read transactions between the two cores. Hardware barriers ensure data validity and completion of all transactions.
+
+Test attributes such as transaction sizes, number of transactions, and virtual channel configuration are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+
+Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+The tests use the Mesh Device API with fast dispatch mode:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*CoreBidirectional*"
+```
+
+## Test Parameters
+| Parameter                     | Data Type             | Description |
+| ----------------------------- | --------------------- | ----------- |
+| test_id                       | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| master_core_coord             | CoreCoord             | Logical coordinates for the master core that performs bidirectional operations. |
+| subordinate_core_coord        | CoreCoord             | Logical coordinates for the subordinate core that participates in bidirectional operations. |
+| num_of_transactions           | uint32_t              | Number of transaction pairs (send + receive) to perform. |
+| pages_per_transaction         | uint32_t              | Number of pages per individual transaction. |
+| bytes_per_page                | uint32_t              | Size of each page in bytes. |
+| l1_data_format                | DataFormat            | Type of data in transaction (typically Float16_b). |
+| write_vc                      | uint32_t              | Virtual channel to use for write operations (0-3). |
+| same_kernel                   | bool                  | True if using a single kernel for both send/receive, false for separate kernels. |
+
+## Test Cases
+Each test case uses bfloat16 as L1 data format.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. **Directed Ideal Same Kernel**: Tests optimal bidirectional transactions using a single kernel that performs both send and receive operations.
+
+2. **Directed Ideal Different Kernels**: Tests optimal bidirectional transactions using separate sender and receiver kernels.
+
+3. **Same VC Same Kernel**: Tests bidirectional operations where both send and receive use the same virtual channel with a single kernel.
+
+4. **Same VC Different Kernels**: Tests bidirectional operations where both send and receive use the same virtual channel with separate kernels.
+
+5. **Write VC Sweep Same Kernel**: Tests bidirectional operations sweeping through different virtual channels (0-3) for write operations using a single kernel.
+
+6. **Write VC Sweep Different Kernels**: Tests bidirectional operations sweeping through different virtual channels (0-3) for write operations using separate kernels.
+
+7. **Packet Sizes Same Kernel**: Tests bidirectional operations over varying transaction sizes using a single kernel.
+
+8. **Packet Sizes Different Kernels**: Tests bidirectional operations over varying transaction sizes using separate kernels.
+
+9. **Custom Test**: Configurable test case using a single kernel with write VC 0 for specific parameter testing.

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace tt::tt_metal {
 
@@ -34,10 +36,12 @@ struct CoreBidirectionalConfig {
 };
 
 /// @brief Does L1 Sender Core --> L1 Receiver Core
-/// @param device
+/// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(IDevice* device, const CoreBidirectionalConfig& test_config) {
+bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const CoreBidirectionalConfig& test_config) {
+    // Get the actual device for this single-device test
+    IDevice* device = mesh_device->get_device(0);
     /* ================ SETUP ================ */
 
     // Program
@@ -49,7 +53,7 @@ bool run_dm(IDevice* device, const CoreBidirectionalConfig& test_config) {
     // Obtain L1 Address for Storing Data
 
     L1AddressInfo master_l1_info =
-        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.master_core_coord);
 
     // Check if the L1 size is sufficient for the test configuration
     if (master_l1_info.size / 2 < bytes_per_transaction) {
@@ -157,8 +161,15 @@ bool run_dm(IDevice* device, const CoreBidirectionalConfig& test_config) {
     tt_metal::detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, l1_base_read_address, packed_input);
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
-    // LAUNCH THE PROGRAM
-    detail::LaunchProgram(device, program);
+    auto mesh_workload = distributed::CreateMeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices =
+        distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
+    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
 
     // Record Output from Subordinate L1
     std::vector<uint32_t> packed_sender_output;
@@ -190,9 +201,7 @@ bool run_dm(IDevice* device, const CoreBidirectionalConfig& test_config) {
 }
 
 void directed_ideal_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {0, 1},
@@ -200,7 +209,7 @@ void directed_ideal_test(
     bool same_kernel = false) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Adjustable Parameters
     // Ideal: Less transactions, more data per transaction
@@ -220,41 +229,35 @@ void directed_ideal_test(
         .same_kernel = same_kernel};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 void same_vc_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {0, 1},
     bool same_kernel = false) {
     uint32_t read_req_vc = 1;
 
-    directed_ideal_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, read_req_vc, same_kernel);
+    directed_ideal_test(mesh_device, test_id, master_core_coord, subordinate_core_coord, read_req_vc, same_kernel);
 }
 
 void packet_sizes_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1},
     bool same_kernel = false) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters
+    IDevice* device = mesh_device->get_device(0);
     uint32_t max_transactions = 256;
     uint32_t max_pages_per_transaction =
-        arch_ == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        device->arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -276,9 +279,7 @@ void packet_sizes_test(
                 .same_kernel = same_kernel};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
@@ -287,7 +288,7 @@ void packet_sizes_test(
 
 // ========== Directed Ideal Tests ==========
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealSameKernel) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealSameKernel) {
     // Test ID (Arbitrary)
     uint32_t test_id = 140;
     bool same_kernel = true;
@@ -296,10 +297,10 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealSameKernel
     uint32_t write_vc = 0;
 
     unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealDifferentKernels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealDifferentKernels) {
     // Test ID (Arbitrary)
     uint32_t test_id = 141;
     bool same_kernel = false;
@@ -308,12 +309,12 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalDirectedIdealDifferentK
     uint32_t write_vc = 0;
 
     unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
 // ========== Same VC Tests ==========
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalSameVCSameKernel) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCSameKernel) {
     // Test ID (Arbitrary)
     uint32_t test_id = 142;
     bool same_kernel = true;
@@ -321,10 +322,10 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalSameVCSameKernel) {
     CoreCoord subordinate_core_coord = {0, 1};
 
     unit_tests::dm::core_to_and_from_core::same_vc_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalSameVCDifferentKernels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCDifferentKernels) {
     // Test ID (Arbitrary)
     uint32_t test_id = 143;
     bool same_kernel = false;
@@ -332,12 +333,12 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalSameVCDifferentKernels)
     CoreCoord subordinate_core_coord = {0, 1};
 
     unit_tests::dm::core_to_and_from_core::same_vc_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
 // ========== Write VC Sweep Tests ==========
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepSameKernel) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepSameKernel) {
     // Test ID base
     uint32_t test_id_base = 146;
     bool same_kernel = true;
@@ -349,11 +350,11 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepSameKernel)
         uint32_t test_id = test_id_base + write_vc;
 
         unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-            arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+            get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepDifferentKernels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepDifferentKernels) {
     // Test ID base
     uint32_t test_id_base = 150;
     bool same_kernel = false;
@@ -365,13 +366,13 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepDifferentKe
         uint32_t test_id = test_id_base + write_vc;
 
         unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-            arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+            get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
     }
 }
 
 // ========== Packet Sizes Tests ==========
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesSameKernel) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesSameKernel) {
     // Test ID
     uint32_t test_id = 144;
     bool same_kernel = true;
@@ -379,10 +380,10 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesSameKernel) 
     CoreCoord subordinate_core_coord = {1, 1};
 
     unit_tests::dm::core_to_and_from_core::packet_sizes_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKernels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKernels) {
     // Test ID
     uint32_t test_id = 145;
     bool same_kernel = false;
@@ -390,12 +391,12 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKer
     CoreCoord subordinate_core_coord = {1, 1};
 
     unit_tests::dm::core_to_and_from_core::packet_sizes_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, same_kernel);
 }
 
 // ========== Custom Test Case ==========
 
-TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalCustom) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalCustom) {
     // Test ID
     uint32_t test_id = 147;
     bool same_kernel = true;
@@ -404,7 +405,7 @@ TEST_F(DeviceFixture, TensixDataMovementCoreBidirectionalCustom) {
     uint32_t write_vc = 0;
 
     unit_tests::dm::core_to_and_from_core::directed_ideal_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord, write_vc, same_kernel);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/README.md
@@ -3,10 +3,10 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of deinterleave transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
-## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+## Slow Dispatch Support
+This test suite uses the TT-Metal slow dispatch mode for reliable program execution. The tests use `DeviceFixture` and are designed to work with the slow dispatch API.
 
-**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+**Note**: These tests require slow dispatch mode for proper operation. They use `tt::tt_metal::detail::LaunchProgram()` for direct program execution without command queues.
 
 ## Test Flow
 
@@ -17,7 +17,12 @@ It does not check pcc as the afformentioned test does this.
 The deinterleave patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
 
 ## Running the Tests
-The tests use the Mesh Device API with fast dispatch mode:
+The tests use slow dispatch mode. Run with the slow dispatch environment variable:
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*"
+```
+
+Or run normally (the DeviceFixture will automatically enforce slow dispatch mode):
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*"
 ```

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/README.md
@@ -3,6 +3,9 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of deinterleave transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 
 This test creates a buffer for various deinterleave patterns as gotten from `pytest test_deinterleave.py`. It plots the bandwidth of each core.
@@ -10,6 +13,17 @@ This test creates a buffer for various deinterleave patterns as gotten from `pyt
 It does not check pcc as the afformentioned test does this.
 
 The deinterleave patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type                          | Description |

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/README.md
@@ -3,8 +3,10 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of deinterleave transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
 
@@ -15,14 +17,9 @@ It does not check pcc as the afformentioned test does this.
 The deinterleave patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*"
-```
-
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DeinterleaveHardcoded*"
 ```
 
 ## Test Parameters

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "../../common/dispatch_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -31,7 +31,7 @@ struct DeinterleaveConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(IDevice* device, const DeinterleaveConfig& test_config) {
+bool run_dm(IDevice* device, const DeinterleaveConfig& test_config, DispatchFixture* fixture) {
     // Program
     Program program = CreateProgram();
 
@@ -56,13 +56,14 @@ bool run_dm(IDevice* device, const DeinterleaveConfig& test_config) {
 
     // Launch program
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    detail::LaunchProgram(device, program);
+    // Launch the program - Use dispatch-aware method
+    fixture->RunProgram(device, program);
 
     return true;
 }
 }  // namespace unit_tests::dm::deinterleave_hardcoded
 
-TEST_F(DeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
+TEST_F(DispatchFixture, TensixDataMovementDeinterleaveSingleCore) {
     if (arch_ != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Skipping test for non-WH architecture";
     }
@@ -126,13 +127,13 @@ TEST_F(DeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
             .noc_id = noc_id};
 
         // Run
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+        for (unsigned int id = 0; id < NumDevices(); id++) {
+            EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
         }
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
+TEST_F(DispatchFixture, TensixDataMovementDeinterleaveMultiCore) {
     if (arch_ != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Skipping test for non-WH architecture";
     }
@@ -220,8 +221,8 @@ TEST_F(DeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
             .noc_id = noc_id};
 
         // Run
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+        for (unsigned int id = 0; id < NumDevices(); id++) {
+            EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
         }
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
-#include <tt-metalium/distributed.hpp>
-#include <tt-metalium/mesh_coord.hpp>
+#include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -32,8 +30,7 @@ struct DeinterleaveConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const DeinterleaveConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+bool run_dm(IDevice* device, const DeinterleaveConfig& test_config) {
     // Program
     Program program = CreateProgram();
 
@@ -56,23 +53,17 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const DeinterleaveC
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
-    // Launch program
+    // Launch program using slow dispatch
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    // Launch the program - Use mesh device API
-    auto workload = distributed::CreateMeshWorkload();
-    vector<uint32_t> coord_data = {0, 0};
-    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), target_devices);
-    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(0), workload, false);
-    Finish(mesh_device->mesh_command_queue(0));
+    tt::tt_metal::detail::LaunchProgram(device, program);
 
     return true;
 }
 }  // namespace unit_tests::dm::deinterleave_hardcoded
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
-    auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->get_device(0)->arch();
+TEST_F(DeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
+    IDevice* device = devices_.at(0);
+    auto arch_ = device->arch();
 
     if (arch_ != ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Skipping test for non-WH architecture";
@@ -137,13 +128,13 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
             .noc_id = noc_id};
 
         // Run
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(device, test_config));
     }
 }
 
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
-    auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->get_device(0)->arch();
+TEST_F(DeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
+    IDevice* device = devices_.at(0);
+    auto arch_ = device->arch();
 
     if (arch_ != ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Skipping test for non-WH architecture";
@@ -232,7 +223,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
             .noc_id = noc_id};
 
         // Run
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(device, test_config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
@@ -6,7 +6,8 @@
 #define DM_COMMON_HPP
 
 #include <cstdint>
-#include "device_fixture.hpp"
+// #include "device_fixture.hpp"
+#include <tt-metalium/mesh_device.hpp>
 #include <tuple>
 
 namespace tt::tt_metal::unit_tests::dm {
@@ -21,7 +22,8 @@ struct L1AddressInfo {
 };
 
 // Function to get L1 address and size
-L1AddressInfo get_l1_address_and_size(const IDevice* device, const CoreCoord& core_coord = {0, 0});
+L1AddressInfo get_l1_address_and_size(
+    std::shared_ptr<distributed::MeshDevice> mesh_device, const CoreCoord& core_coord = {0, 0});
 
 struct DramAddressInfo {
     uint64_t base_address;
@@ -29,10 +31,11 @@ struct DramAddressInfo {
 };
 
 // Function to get DRAM address and size
-DramAddressInfo get_dram_address_and_size(const IDevice* device);
+DramAddressInfo get_dram_address_and_size(std::shared_ptr<distributed::MeshDevice> mesh_device);
 
 // Function to compute physical constraints
-std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(tt::ARCH arch, const IDevice* device);
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(
+    std::shared_ptr<distributed::MeshDevice> mesh_device);
 
 }  // namespace tt::tt_metal::unit_tests::dm
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
@@ -2,45 +2,43 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM and a single Tensix core.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-Data is loaded into an L1 circular buffer by the reader kernel and written out to DRAM from the same L1 buffer by the writer kernel. A compute kernel is omitted as these tests are purely for data movement.
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler.
-Resulting data is cross-checked with original data and validated through a pcc check.
+Data is loaded into an L1 circular buffer by the reader kernel and written out to DRAM from the same L1 buffer by the writer kernel. A compute kernel is omitted as these tests are purely for data movement. Hardware barriers ensure data validity and completion of transactions.
+
+Test attributes such as transaction sizes, number of transactions, core locations, and DRAM channels as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DRAM*"
 ```
 
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DRAM*"
-```
-
 ## Test Parameters
-| Parameter                 | Data Type             | Description |
-| ------------------------- | --------------------- | ----------- |
-| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
-| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
-| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
-| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
-| l1_data_format            | DataFormat            | Data format data that will be moved. |
-| cores                     | CoreRangeSet          | Tensix cores that are used for the transactions. |
-| tensor_shape_in_pages     | array<uint32_t, 2>    | 2D-Shape of an arbitrary tensor in pages. Used mainly for sharding. |
-| num_dram_banks            | array<uint32_t, 2>    | Number of DRAM banks, for two dimensions, that will be used for sharding. |
+| Parameter                     | Data Type             | Description |
+| ----------------------------- | --------------------- | ----------- |
+| test_id                       | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| num_of_transactions           | uint32_t              | Number of DRAM transactions that will be issued. |
+| pages_per_transaction         | uint32_t              | Size of the issued DRAM transactions in pages. |
+| bytes_per_page                | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format                | DataFormat            | Data format of data that will be moved. |
+| core_coord                    | CoreCoord             | Logical coordinates for the Tensix core. |
+| dram_channel                  | uint32_t              | Specifies which DRAM channel to use for the test. |
 
 ## Test Cases
-Three different test cases are implemented using the above parameters.
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. DRAM Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and pages_per_transaction parameters.
-2. DRAM Core Locations: Tests different cores on device (core grid dependent on architecture) by varying the core_coord parameter.
-3. DRAM Channels: Tests different DRAM channels by varying the dram_channel parameter.
-4. DRAM Directed Ideal: Tests the most optimal transaction between two cores that maximizes the transaction size and performs enough transactions to amortize initialization overhead.
+1. **DRAM Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions and pages_per_transaction parameters. Various packet configurations are tested between DRAM and Tensix core.
+
+2. **DRAM Core Locations**: Tests data movement between DRAM and different Tensix core locations to evaluate performance across various core positions on the chip.
+
+3. **DRAM Channels**: Tests data movement using different DRAM channels to evaluate bandwidth utilization across multiple memory interfaces.
+
+4. **DRAM Directed Ideal**: Tests the most optimal data movement setup between DRAM and a Tensix core that maximizes the transaction size and performs enough transactions to amortize initialization overhead.

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
@@ -2,12 +2,26 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM and a single Tensix core.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 Data is loaded into an L1 circular buffer by the reader kernel and written out to DRAM from the same L1 buffer by the writer kernel. A compute kernel is omitted as these tests are purely for data movement.
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler.
 Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DRAM*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*DRAM*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -264,9 +264,9 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMChannels) {
 
     for (unsigned int dram_channel = 0; dram_channel < device->num_dram_channels(); dram_channel++) {
         for (unsigned int vc = 0; vc < 4; vc++) {
-            unit_tests::dm::dram::directed_ideal_test(
-                get_mesh_device(), test_case_id, core_coord, dram_channel, vc);
+            unit_tests::dm::dram::directed_ideal_test(mesh_device, test_case_id, core_coord, dram_channel, vc);
         }
+    }
 }
 
 /* ========== Directed ideal test case; Test id = 3 ========== */
@@ -274,9 +274,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
     // Test ID (Arbitrary)
     uint32_t test_id = 3;
 
-    auto mesh_device = get_mesh_device();
-
-    unit_tests::dm::dram::directed_ideal_test(mesh_device, test_id);
+    unit_tests::dm::dram::directed_ideal_test(get_mesh_device(), test_id);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/README.md
@@ -2,6 +2,11 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM or L1 interleaved buffers and a Tensix core using `noc_async_*_page` APIs.
 
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+
 ## Test Flow
 Runs a reader kernel and/or a writer kernel on a tensix core.
 
@@ -12,6 +17,12 @@ The writer kernel issues NOC instructions to write data from the L1 address of t
 Transactions exceeding 16 pages will consecutively overwrite the same 16 pages so as not to take up excess L1 memory. Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is read from the output interleaved buffer if the writer kernel is run (or directly from L1 memory otherwise), cross-checked with original data, and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+The tests use the Mesh Device API with fast dispatch mode:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*Interleaved*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace tt::tt_metal {
 
@@ -30,16 +32,12 @@ struct InterleavedConfig {
 };
 
 /// @brief Does Interleaved buffer --> Reader --> L1 --> Writer --> Interleaved buffer
-/// @param device
+/// @param mesh_device - MeshDevice to run the test on
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(IDevice* device, const InterleavedConfig& test_config) {
-    log_info(
-        tt::LogTest,
-        "num transaction {}, num pages: {}, page size bytes: {}",
-        test_config.num_of_transactions,
-        test_config.num_pages,
-        test_config.page_size_bytes);
+bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const InterleavedConfig& test_config) {
+    // Get the actual device for this single-device test
+    IDevice* device = mesh_device->get_device(0);
 
     // Program
     Program program = CreateProgram();
@@ -102,7 +100,7 @@ bool run_dm(IDevice* device, const InterleavedConfig& test_config) {
         CreateCircularBuffer(program, test_config.cores, l1_cb_config);
     }
 
-    uint32_t l1_addr = get_l1_address_and_size(device, corerange_to_cores(test_config.cores)[0]).base_address;
+    uint32_t l1_addr = get_l1_address_and_size(mesh_device, corerange_to_cores(test_config.cores)[0]).base_address;
     // log_info(tt::LogTest, "l1 addr: {}, bytes: {}, input buffer addr: {}, output buffer addr: {}", l1_addr,
     // total_size_bytes, input_buffer_address, output_buffer_address);
     if (!test_config.is_dram) {
@@ -164,7 +162,15 @@ bool run_dm(IDevice* device, const InterleavedConfig& test_config) {
         MetalContext::instance().get_cluster().l1_barrier(device->id());
     }
 
-    detail::LaunchProgram(device, program);
+    auto mesh_workload = distributed::CreateMeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices =
+        distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
+    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
 
     if (test_config.write_kernel) {
         detail::ReadFromBuffer(output_buffer, packed_output);
@@ -192,10 +198,12 @@ bool run_dm(IDevice* device, const InterleavedConfig& test_config) {
 /* ========== INTERLEAVED DRAM TESTS ========== */
 
 /* ========== Test case for varying number of pages; Test id = 61 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
+    auto mesh_device = get_mesh_device();
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -225,15 +233,13 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
                 .cores = core_range_set};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Test case for varying core location; Test id = 62 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocations) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocations) {
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
@@ -241,35 +247,36 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocations) {
     uint32_t page_size_bytes = 32 * 32 * 2;  // = tile
     uint32_t num_of_transactions = 16;
 
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        // Cores
-        auto grid_size = devices_.at(id)->compute_with_storage_grid_size();
-        log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
-        for (unsigned int x = 0; x < grid_size.x; x++) {
-            for (unsigned int y = 0; y < grid_size.y; y++) {
-                CoreRangeSet core_range_set({CoreRange({x, y}, {x, y})});
-                log_info(tt::LogTest, "Core Location x: {}, y: {}", x, y);
-                // Test config
-                unit_tests::dm::interleaved_page::InterleavedConfig test_config = {
-                    .test_id = 62,
-                    .num_of_transactions = num_of_transactions,
-                    .num_pages = num_pages,
-                    .page_size_bytes = page_size_bytes,
-                    .l1_data_format = DataFormat::Float16_b,
-                    .cores = core_range_set};
+    // Cores
+    auto mesh_device = get_mesh_device();
+    auto device = mesh_device->get_device(0);
+    auto grid_size = device->compute_with_storage_grid_size();
+    log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
+    for (unsigned int x = 0; x < grid_size.x; x++) {
+        for (unsigned int y = 0; y < grid_size.y; y++) {
+            CoreRangeSet core_range_set({CoreRange({x, y}, {x, y})});
+            log_info(tt::LogTest, "Core Location x: {}, y: {}", x, y);
+            // Test config
+            unit_tests::dm::interleaved_page::InterleavedConfig test_config = {
+                .test_id = 62,
+                .num_of_transactions = num_of_transactions,
+                .num_pages = num_pages,
+                .page_size_bytes = page_size_bytes,
+                .l1_data_format = DataFormat::Float16_b,
+                .cores = core_range_set};
 
-                // Run
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            // Run
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Test noc_async_read_page kernel only; Test id = 63 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageReadNumbers) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageReadNumbers) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -302,18 +309,17 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageReadNumbers) {
                 .write_kernel = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Test noc_async_write_page kernel only; Test id = 64 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -346,18 +352,17 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
                 .write_kernel = true};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Directed Ideal Test Case; Test id = 65 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t num_pages = 16;
@@ -377,18 +382,17 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
         .cores = core_range_set};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 /* ========== Test noc_async_read_page kernel only with swapped noc; Test id = 72 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -422,20 +426,19 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
                 .default_noc = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Test noc_async_write_page kernel only with swapped noc; Test id = 73 ========== */
-TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -469,9 +472,7 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
                 .default_noc = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
@@ -479,10 +480,11 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
 /* ========== INTERLEAVED L1 TESTS ========== */
 
 /* ========== Test case for varying number of pages using interleaved L1; Test id = 66 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageNumbers) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageNumbers) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -513,51 +515,50 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageNumbers) {
                 .is_dram = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Test case for varying core location; Test id = 67 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageCoreLocations) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageCoreLocations) {
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
     uint32_t num_pages = 16;
     uint32_t page_size_bytes = 32 * 32 * 2;  // = tile
 
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        // Cores
-        auto grid_size = devices_.at(id)->compute_with_storage_grid_size();
-        log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
-        for (unsigned int x = 0; x < grid_size.x; x++) {
-            for (unsigned int y = 0; y < grid_size.y; y++) {
-                CoreRangeSet core_range_set({CoreRange({x, y}, {x, y})});
-                log_info(tt::LogTest, "Core Location x: {}, y: {}", x, y);
-                // Test config
-                unit_tests::dm::interleaved_page::InterleavedConfig test_config = {
-                    .test_id = 67,
-                    .num_of_transactions = 16,
-                    .num_pages = num_pages,
-                    .page_size_bytes = page_size_bytes,
-                    .l1_data_format = DataFormat::Float16_b,
-                    .cores = core_range_set,
-                    .is_dram = false};
+    // Cores
+    auto mesh_device = get_mesh_device();
+    auto device = mesh_device->get_device(0);
+    auto grid_size = device->compute_with_storage_grid_size();
+    log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
+    for (unsigned int x = 0; x < grid_size.x; x++) {
+        for (unsigned int y = 0; y < grid_size.y; y++) {
+            CoreRangeSet core_range_set({CoreRange({x, y}, {x, y})});
+            log_info(tt::LogTest, "Core Location x: {}, y: {}", x, y);
+            // Test config
+            unit_tests::dm::interleaved_page::InterleavedConfig test_config = {
+                .test_id = 67,
+                .num_of_transactions = 16,
+                .num_pages = num_pages,
+                .page_size_bytes = page_size_bytes,
+                .l1_data_format = DataFormat::Float16_b,
+                .cores = core_range_set,
+                .is_dram = false};
 
-                // Run
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            // Run
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Test noc_async_read_page only; Test id = 68 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageReadNumbers) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageReadNumbers) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -590,17 +591,16 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageReadNumbers) {
                 .write_kernel = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 /* ========== Test noc_async_write_page only; Test id = 69 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -633,18 +633,17 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
                 .write_kernel = true};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 /* ========== Directed Ideal Test Case; Test id = 71 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t num_pages = 16;
@@ -665,18 +664,17 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
         .is_dram = false};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 /* ========== Test noc_async_read_page only with swapped noc; Test id = 74 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -710,19 +708,18 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
                 .default_noc = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 /* ========== Test noc_async_write_page only; Test id = 75 ========== */
-TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
     GTEST_SKIP() << "Skipping test";
 
+    auto mesh_device = get_mesh_device();
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
     // Parameters
     uint32_t max_page_size_bytes = 256 * flit_size_bytes;  // 1 packet = 16 kB for BH, 8 kB for WH
     uint32_t max_num_pages = 256;
@@ -756,9 +753,7 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
                 .default_noc = false};
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/loopback/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/README.md
@@ -8,7 +8,7 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-Sharded L1 buffers are created on one Tensix core: the same core getting the same data. Data is written into the L1 buffer on the sender kernel. The sender kernel issues NOC transactions to transfer this data into the L1 buffer on the receiver kernel. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
+L1 memory is allocated on a single Tensix core with separate address offsets for input and output data. Data is written into the input L1 memory location. The sender kernel issues NOC transactions to transfer this data from the input L1 address to the output L1 address within the same core (loopback). Once data is transferred, the sender kernel uses hardware barriers to ensure data validity and completion of the transaction.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 

--- a/tests/tt_metal/tt_metal/data_movement/loopback/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/README.md
@@ -2,8 +2,10 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
 Sharded L1 buffers are created on one Tensix core: the same core getting the same data. Data is written into the L1 buffer on the sender kernel. The sender kernel issues NOC transactions to transfer this data into the L1 buffer on the receiver kernel. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
@@ -13,14 +15,9 @@ Test attributes such as transaction sizes and number of transactions as well as 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*Loopback*"
-```
-
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*Loopback*"
 ```
 
 ## Test Parameters

--- a/tests/tt_metal/tt_metal/data_movement/loopback/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/README.md
@@ -2,12 +2,26 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 Sharded L1 buffers are created on one Tensix core: the same core getting the same data. Data is written into the L1 buffer on the sender kernel. The sender kernel issues NOC transactions to transfer this data into the L1 buffer on the receiver kernel. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*Loopback*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*Loopback*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -176,11 +176,14 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes) {
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
+    auto mesh_device = get_mesh_device();
+    auto device = mesh_device->get_device(0);
+
     uint32_t test_id = 55;
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     uint32_t num_of_transactions = 128;
     uint32_t transaction_size_pages =
@@ -199,9 +202,7 @@ TEST_F(DeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
         .noc_id = noc_id};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -2,12 +2,26 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a gatherer Tensix core and a grid of sender Tensix cores.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 Data is written directly into the L1 memory of the sender cores. The gatherer kernel issues read NOC transactions to request a transfer of this data from each sender core to its L1 memory. A read barrier is placed after these transactions in order to ensure data validity.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromAll*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromAll*"
+```
 
 ## Test Parameters
 | Parameter              | Data Type    | Description |

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -1,44 +1,42 @@
 # One From All Core Data Movement Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a gatherer Tensix core and a grid of sender Tensix cores.
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from all subordinate cores to one master core.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-Data is written directly into the L1 memory of the sender cores. The gatherer kernel issues read NOC transactions to request a transfer of this data from each sender core to its L1 memory. A read barrier is placed after these transactions in order to ensure data validity.
+L1 memory is allocated on multiple Tensix cores: multiple subordinate cores (senders) and one master core (receiver). Data is written into L1 memory on all subordinate cores. The master core issues NOC read transactions to retrieve data from all subordinate cores' L1 memory. Once data is transferred from all subordinate cores, the master core uses hardware barriers to ensure data validity and completion of the transaction.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromAll*"
 ```
 
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromAll*"
-```
-
 ## Test Parameters
-| Parameter              | Data Type    | Description |
-| ---------------------- | ------------ | ----------- |
-| test_id                | uint32_t     | Test id for signifying different test cases. Can be used for grouping different tests. |
-| num_of_transactions    | uint32_t     | Number of noc transactions/calls that will be issued. |
-| transaction_size_pages | uint32_t     | Size of the issued noc transactions in pages. |
-| page_size_bytes        | uint32_t     | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
-| l1_data_format         | DataFormat   | Data format data that will be moved. |
-| master_core_coord      | CoreCoord    | Logical coordinates for the gatherer core. |
-| subordinate_core_set   | CoreRangeSet | Set of logical coordinates for the sender cores. |
-| virtual_channel        | N/A          | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
-| noc                    | N/A          | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
+| Parameter                     | Data Type             | Description |
+| ----------------------------- | --------------------- | ----------- |
+| test_id                       | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| master_core_coord             | CoreCoord             | Logical coordinates for the master (receiver) core. |
+| subordinate_core_set          | CoreRangeSet          | Set of logical coordinates for all subordinate (sender) cores. |
+| num_of_transactions           | uint32_t              | Number of noc transactions that will be issued. |
+| transaction_size_pages        | uint32_t              | Size of the issued noc transactions in pages. |
+| page_size_bytes               | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format                | DataFormat            | Data format of data that will be moved. |
+| virtual_channel               | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| noc                           | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. One From All Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters (skips cases where total data size exceeds L1 capacity). Uses master logical coordinate (0,0) and a grid of 16 subordinate cores: (1,1)-(4,4).
-2. One From All Directed Ideal: Tests optimal data movement setup between master logical coordinate (0,0) and a grid of 16 subordinate cores (1,1)-(4,4). Uses large transaction size and number of transactions to amortize initialization overhead and maximize bandwidth utilization.
+1. **One From All Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions and pages_per_transaction parameters. Multiple subordinate cores send data to a single master core.
+
+2. **One From All Directed Ideal**: Tests the most optimal data movement setup from multiple subordinate cores to one master core that maximizes the transaction size and performs enough transactions to amortize initialization overhead. This test uses neighboring cores to minimize latency.

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -329,7 +329,7 @@ void custom_test(
 }  // namespace unit_tests::dm::core_from_all
 
 /* ========== Test case for one from all data movement; Test id = 15 ========== */
-TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     uint32_t test_id = 15;
     auto mesh_device = get_mesh_device();
     Device* device = mesh_device->get_device(0);
@@ -343,7 +343,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 }
 
 /* ========== Test case for one from all data movement; Test id = 30 ========== */
-TEST_F(DeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
     uint32_t test_id = 30;
     auto mesh_device = get_mesh_device();
     Device* device = mesh_device->get_device(0);
@@ -356,7 +356,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
         get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 153;
@@ -371,7 +371,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
         get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneFromAllCustom) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/dispatch_fixture.hpp"
+#include "../../common/multi_device_fixture.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -12,7 +14,7 @@ namespace tt::tt_metal {
 
 using namespace std;
 using namespace tt;
-using namespace tt::test_utils;
+using namespace test_utils;
 
 namespace unit_tests::dm::core_from_all {
 // Test config, i.e. test parameters
@@ -40,7 +42,8 @@ struct OneFromAllConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixture* fixture) {
+bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const OneFromAllConfig& test_config) {
+    IDevice* device = mesh_device->get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -61,22 +64,21 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixtur
     // Obtain L1 Address for Storing Data
     // NOTE: We don't know if the whole block of memory is actually available.
     //       This is something that could probably be checked
-    L1AddressInfo master_l1_info =
-        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+    L1AddressInfo master_l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.master_core_coord);
 
     auto sub_core_list = corerange_to_cores(subordinate_core_set);
     for (auto& core : sub_core_list) {
-        L1AddressInfo subordinate_l1_info = tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, core);
+        L1AddressInfo subordinate_l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, core);
         // Checks that both master and subordinate cores have the same L1 base address and size
         if (master_l1_info.base_address != subordinate_l1_info.base_address ||
             master_l1_info.size != subordinate_l1_info.size) {
-            log_error(tt::LogTest, "Mismatch in L1 address or size between master and subordinate cores");
+            log_error(LogTest, "Mismatch in L1 address or size between master and subordinate cores");
             return false;
         }
     }
     // Check if the L1 size is sufficient for the test configuration
     if (master_l1_info.size < transaction_size_bytes) {
-        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
+        log_error(LogTest, "Insufficient L1 size for the test configuration");
         return false;
     }
     // Assigns a "safe" L1 local address for the master and subordinate cores
@@ -113,7 +115,7 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixtur
     SetRuntimeArgs(program, gatherer_kernel, master_core_set, master_runtime_args);
 
     // Assign unique id
-    log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Input
@@ -132,8 +134,15 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixtur
     }
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
-    // Launch the program - Use dispatch-aware method
-    fixture->RunProgram(device, program);
+    // LAUNCH PROGRAM - Use mesh workload approach
+    auto mesh_workload = distributed::CreateMeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
 
     vector<uint32_t> packed_output;
     detail::ReadFromDeviceL1(
@@ -144,10 +153,10 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixtur
         packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
 
     if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
-        log_info(tt::LogTest, "Golden vector");
+        log_error(LogTest, "PCC Check failed");
+        log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
-        log_info(tt::LogTest, "Output vector");
+        log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
@@ -155,9 +164,7 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixtur
 }
 
 void directed_ideal_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -165,7 +172,7 @@ void directed_ideal_test(
     NOC noc_id = NOC::RISCV_1_default) {
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     size_t total_subordinate_cores = subordinate_grid_size.x * subordinate_grid_size.y;
 
@@ -188,15 +195,11 @@ void directed_ideal_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 void packet_sizes_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -204,12 +207,12 @@ void packet_sizes_test(
     NOC noc_id = NOC::RISCV_1_default) {
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages =
-        arch_ == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        mesh_device->get_device(0)->arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
@@ -232,24 +235,20 @@ void packet_sizes_test(
             };
 
             // Run
-            for (unsigned int id = 0; id < NumDevices(); id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 void virtual_channels_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
     CoreCoord subordinate_grid_size) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     std::uint32_t max_num_pages_per_transaction = 1 << 12;
     std::uint32_t num_of_transactions = 256;  // Constant value
@@ -283,18 +282,14 @@ void virtual_channels_test(
                 };
 
                 // Run
-                for (unsigned int id = 0; id < num_devices_; id++) {
-                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-                }
+                EXPECT_TRUE(run_dm(mesh_device, test_config));
             }
         }
     }
 }
 
 void custom_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_start_coord,
@@ -305,7 +300,7 @@ void custom_test(
     NOC noc_id = NOC::RISCV_1_default) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     size_t total_subordinate_cores = subordinate_grid_size.x * subordinate_grid_size.y;
     if (pages_per_transaction > max_transmittable_pages / total_subordinate_cores) {
@@ -328,9 +323,7 @@ void custom_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < NumDevices(); id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 }  // namespace unit_tests::dm::core_from_all
@@ -338,47 +331,55 @@ void custom_test(
 /* ========== Test case for one from all data movement; Test id = 15 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     uint32_t test_id = 15;
+    auto mesh_device = get_mesh_device();
+    Device* device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     unit_tests::dm::core_from_all::packet_sizes_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
+        get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
 /* ========== Test case for one from all data movement; Test id = 30 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
     uint32_t test_id = 30;
+    auto mesh_device = get_mesh_device();
+    Device* device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     unit_tests::dm::core_from_all::directed_ideal_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
+        get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 153;
+    auto mesh_device = get_mesh_device();
+    Device* device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     unit_tests::dm::core_from_all::virtual_channels_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
+        get_mesh_device(), test_id, master_core_coord, subordinate_start_coord, subordinate_grid_size);
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
+    auto mesh_device = get_mesh_device();
+    Device* device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
-        devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
+        device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
     // Parameters
     uint32_t num_of_transactions = 256;
@@ -386,9 +387,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::core_from_all::custom_test(
-        arch_,
-        devices_,
-        num_devices_,
+        get_mesh_device(),
         test_id,
         master_core_coord,
         subordinate_start_coord,

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "../../common/dispatch_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -38,8 +38,9 @@ struct OneFromAllConfig {
 /// @brief Does Gatherer Core --> L1 Responder Cores --> L1 Gatherer Core
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
+/// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
+bool run_dm(IDevice* device, const OneFromAllConfig& test_config, DispatchFixture* fixture) {
     // Program
     Program program = CreateProgram();
 
@@ -131,7 +132,8 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
     }
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
-    detail::LaunchProgram(device, program);
+    // Launch the program - Use dispatch-aware method
+    fixture->RunProgram(device, program);
 
     vector<uint32_t> packed_output;
     detail::ReadFromDeviceL1(
@@ -230,8 +232,8 @@ void packet_sizes_test(
             };
 
             // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+            for (unsigned int id = 0; id < NumDevices(); id++) {
+                EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
             }
         }
     }
@@ -326,8 +328,8 @@ void custom_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -332,7 +332,7 @@ void custom_test(
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     uint32_t test_id = 15;
     auto mesh_device = get_mesh_device();
-    Device* device = mesh_device->get_device(0);
+    auto device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -346,7 +346,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
     uint32_t test_id = 30;
     auto mesh_device = get_mesh_device();
-    Device* device = mesh_device->get_device(0);
+    auto device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -361,7 +361,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
     // Test ID (Arbitrary)
     uint32_t test_id = 153;
     auto mesh_device = get_mesh_device();
-    Device* device = mesh_device->get_device(0);
+    auto device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -375,7 +375,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
     auto mesh_device = get_mesh_device();
-    Device* device = mesh_device->get_device(0);
+    auto device = mesh_device->get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -1,44 +1,42 @@
 # One From One Core Data Movement Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from one subordinate core to one master core.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-Data is written directly into the L1 memory on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 address of the responder core to the L1 address of its core. A read barrier is placed after these transactions in order to ensure data validity.
+L1 memory is allocated on two Tensix cores: one subordinate core (sender) and one master core (receiver). Data is written into the L1 memory on the subordinate core. The master core issues NOC read transactions to retrieve data from the subordinate core's L1 memory. Once data is transferred, the master core uses hardware barriers to ensure data validity and completion of the transaction.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromOne*"
 ```
 
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromOne*"
-```
-
 ## Test Parameters
-| Parameter                 | Data Type             | Description |
-| ------------------------- | --------------------- | ----------- |
-| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
-| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
-| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
-| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
-| l1_data_format            | DataFormat            | Data format data that will be moved. |
-| master_core_coord         | CoreCoord             | Logical coordinates for the requestor core. |
-| subordinate_core_coord    | CoreCoord             | Logical coordinates for the responder core. |
-| virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
-| noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
+| Parameter                     | Data Type             | Description |
+| ----------------------------- | --------------------- | ----------- |
+| test_id                       | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| master_core_coord             | CoreCoord             | Logical coordinates for the master (receiver) core. |
+| subordinate_core_coord        | CoreCoord             | Logical coordinates for the subordinate (sender) core. |
+| num_of_transactions           | uint32_t              | Number of noc transactions that will be issued. |
+| transaction_size_pages        | uint32_t              | Size of the issued noc transactions in pages. |
+| page_size_bytes               | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format                | DataFormat            | Data format of data that will be moved. |
+| virtual_channel               | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| noc                           | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. One From One Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters.
-2. One From One Directed Ideal: Tests the most optimal data movement setup between two cores that reduces the number of transactions while maximizing transaction size to minimize the effects of initialization overhead. This test is performed between neigbouring cores on a torus to minimize latency.
+1. **One From One Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. The subordinate core sends data to the master core using various packet configurations.
+
+2. **One From One Directed Ideal**: Tests the most optimal data movement setup from one subordinate core to one master core that maximizes the transaction size and performs enough transactions to amortize initialization overhead. This test uses neighboring cores to minimize latency.

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -2,12 +2,26 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 Data is written directly into the L1 memory on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 address of the responder core to the L1 address of its core. A read barrier is placed after these transactions in order to ensure data validity.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromOne*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneFromOne*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/dispatch_fixture.hpp"
+#include "../../common/multi_device_fixture.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -12,14 +14,14 @@ namespace tt::tt_metal {
 
 using namespace std;
 using namespace tt;
-using namespace tt::test_utils;
+using namespace test_utils;
 
 namespace unit_tests::dm::core_from_core {
 // Test config, i.e. test parameters
 struct OneFromOneConfig {
     uint32_t test_id = 0;
-    CoreCoord master_core_coord = CoreCoord();
-    CoreCoord subordinate_core_coord = CoreCoord();
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 0};
     uint32_t num_of_transactions = 0;
     uint32_t transaction_size_pages = 0;
     uint32_t page_size_bytes = 0;
@@ -37,7 +39,8 @@ struct OneFromOneConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
-bool run_dm(IDevice* device, const OneFromOneConfig& test_config, DispatchFixture* fixture) {
+bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const OneFromOneConfig& test_config) {
+    IDevice* device = mesh_device->get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -49,19 +52,18 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config, DispatchFixtur
     // Obtain L1 Address for Storing Data
     // NOTE: We don't know if the whole block of memory is actually available.
     //       This is something that could probably be checked
-    L1AddressInfo master_l1_info =
-        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+    L1AddressInfo master_l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.master_core_coord);
     L1AddressInfo subordinate_l1_info =
-        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.subordinate_core_coord);
+        unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.subordinate_core_coord);
     // Checks that both master and subordinate cores have the same L1 base address and size
     if (master_l1_info.base_address != subordinate_l1_info.base_address ||
         master_l1_info.size != subordinate_l1_info.size) {
-        log_error(tt::LogTest, "Mismatch in L1 address or size between master and subordinate cores");
+        log_error(LogTest, "Mismatch in L1 address or size between master and subordinate cores");
         return false;
     }
     // Check if the L1 size is sufficient for the test configuration
     if (master_l1_info.size < transaction_size_bytes) {
-        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
+        log_error(LogTest, "Insufficient L1 size for the test configuration");
         return false;
     }
     // Assigns a "safe" L1 local address for the master and subordinate cores
@@ -91,7 +93,7 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config, DispatchFixtur
         program, requestor_kernel, master_core_set, {physical_subordinate_core.x, physical_subordinate_core.y});
 
     // Assign unique id
-    log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Input
@@ -107,8 +109,15 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config, DispatchFixtur
     // Launch program and record outputs
     detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, l1_base_address, packed_input);
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    // Launch the program - Use dispatch-aware method
-    fixture->RunProgram(device, program);
+
+    auto mesh_workload = distributed::CreateMeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
     vector<uint32_t> packed_output;
     detail::ReadFromDeviceL1(
         device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
@@ -118,10 +127,10 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config, DispatchFixtur
         packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
 
     if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
-        log_info(tt::LogTest, "Golden vector");
+        log_error(LogTest, "PCC Check failed");
+        log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
-        log_info(tt::LogTest, "Output vector");
+        log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
@@ -129,16 +138,15 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config, DispatchFixtur
 }
 
 void directed_ideal_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
     NOC noc_id = NOC::RISCV_1_default) {
+    IDevice* device = mesh_device->get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters
     // Ideal: Less transactions, more data per transaction
@@ -158,27 +166,24 @@ void directed_ideal_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 void packet_sizes_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
     NOC noc_id = NOC::RISCV_1_default) {
+    IDevice* device = mesh_device->get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages =
-        arch_ == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+        device->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
@@ -200,23 +205,19 @@ void packet_sizes_test(
             };
 
             // Run
-            for (unsigned int id = 0; id < NumDevices(); id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-            }
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
 }
 
 void virtual_channels_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1}) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     std::uint32_t max_num_pages_per_transaction = 1 << 12;
     std::uint32_t num_of_transactions = 256;  // Constant value
@@ -249,18 +250,14 @@ void virtual_channels_test(
                 };
 
                 // Run
-                for (unsigned int id = 0; id < num_devices_; id++) {
-                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
-                }
+                EXPECT_TRUE(run_dm(mesh_device, test_config));
             }
         }
     }
 }
 
 void custom_test(
-    ARCH arch_,
-    vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
@@ -270,7 +267,7 @@ void custom_test(
     NOC noc_id = NOC::RISCV_1_default) {
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     if (pages_per_transaction > max_transmittable_pages) {
         log_trace(LogTest, "Skipping test due to page size limitations");
@@ -291,9 +288,7 @@ void custom_test(
     };
 
     // Run
-    for (unsigned int id = 0; id < NumDevices(); id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 }  // namespace unit_tests::dm::core_from_core
@@ -305,7 +300,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
     CoreCoord subordinate_core_coord = {1, 1};
 
     unit_tests::dm::core_from_core::packet_sizes_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord);
 }
 
 /* ========== Test case for one from one data movement; Test id = 51 ========== */
@@ -315,7 +310,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
     CoreCoord subordinate_core_coord = {0, 1};
 
     unit_tests::dm::core_from_core::directed_ideal_test(
-        arch_, devices_, num_devices_, test_id, master_core_coord, subordinate_core_coord);
+        get_mesh_device(), test_id, master_core_coord, subordinate_core_coord);
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
@@ -324,9 +319,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
     uint32_t test_id = 151;
 
     unit_tests::dm::core_from_core::virtual_channels_test(
-        arch_,
-        devices_,
-        num_devices_,
+        get_mesh_device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1)   // Subordinate Core
@@ -343,9 +336,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneCustom) {
     uint32_t num_virtual_channels = 4;
 
     unit_tests::dm::core_from_core::custom_test(
-        arch_,
-        devices_,
-        num_devices_,
+        get_mesh_device(),
         test_id,
         CoreCoord(0, 0),  // Master Core
         CoreCoord(0, 1),  // Subordinate Core

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -294,7 +294,7 @@ void custom_test(
 }  // namespace unit_tests::dm::core_from_core
 
 /* ========== Test case for one from one data movement; Test id = 5 ========== */
-TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
     uint32_t test_id = 5;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {1, 1};
@@ -304,7 +304,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
 }
 
 /* ========== Test case for one from one data movement; Test id = 51 ========== */
-TEST_F(DeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
     uint32_t test_id = 51;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
@@ -313,7 +313,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
         get_mesh_device(), test_id, master_core_coord, subordinate_core_coord);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 151;
@@ -326,7 +326,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
     );
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneFromOneCustom) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
 

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
@@ -2,6 +2,11 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a sender and a receiver Tensix core using the one_packet APIs.
 
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+
 ## Test Flow
 Runs either the reader kernel or the writer kernel on the master core.
 
@@ -12,6 +17,12 @@ If the writer kernel is run, data is written directly into the L1 memory of the 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+The tests use the Mesh Device API with fast dispatch mode:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementOnePacket*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -1,56 +1,55 @@
-# One to all Core Data Movement Tests
+# One To All Core Data Movement Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from one master core to all subordinate cores.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-Data is written directly into the L1 memory on the sender Tensix core. The sender kernel issues NOC transactions to transfer this data into the L1 memory of each receiver core in a grid. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
+L1 memory is allocated on multiple Tensix cores: one master core (sender) and multiple subordinate cores (receivers). Data is written into the L1 memory on the master core. The master core issues NOC transactions (either unicast or multicast) to transfer its data to L1 memory on all subordinate cores. Once data is transferred to all subordinate cores, hardware barriers ensure data validity and completion of the transaction.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes, number of transactions, and grid configurations as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToAll*"
 ```
 
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToAll*"
-```
-
 ## Test Parameters
-| Parameter                 | Data Type             | Description |
-| ------------------------- | --------------------- | ----------- |
-| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
-| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
-| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
-| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
-| l1_data_format            | DataFormat            | Data format data that will be moved. |
-| master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
-| grid_size                 | CoreCoord             | Grid size of the receiver cores, with origin at 0-0 |
-| virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
-| noc_id                    | N/A                   | Specify which NOC to use for the test |
-| posted                    | N/A                   | Posted flag. Determines if write is posted or non-posted (TODO) |
-| loopback                  | bool                  | Whether to include the sender core in the receiver core list. |
-| is_multicast              | bool                  | Whether to do a multicast rather than sending to each core individually. |
-| is_linked                 | bool                  | Whether multicast is linked. |
+| Parameter                     | Data Type             | Description |
+| ----------------------------- | --------------------- | ----------- |
+| test_id                       | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| mst_core_coord                | CoreCoord             | Logical coordinates for the master (sender) core. |
+| sub_start_core_coord          | CoreCoord             | Starting logical coordinates for the subordinate core grid. |
+| sub_grid_size                 | CoreCoord             | Size of the subordinate core grid. |
+| num_of_transactions           | uint32_t              | Number of noc transactions that will be issued. |
+| pages_per_transaction         | uint32_t              | Size of the issued noc transactions in pages. |
+| bytes_per_page                | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format                | DataFormat            | Data format of data that will be moved. |
+| noc_id                        | NOC                   | Specifies which NOC to use for the test. |
+| loopback                      | bool                  | Determines if loopback (self-send) is included in the test. |
+| is_multicast                  | bool                  | Determines if the test uses multicast or unicast NOC transactions. |
+| is_linked                     | bool                  | Determines if linked/chained NOC transactions are used. |
+| multicast_scheme_type         | uint32_t              | Specifies the multicast scheme type for advanced multicast tests. |
+| virtual_channel               | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. One to All 2x2 Packet Sizes: Tests one to all on a 2x2 grid.
-2. One to All 4x4 Packet Sizes: Tests one to all on a 4x4 grid.
-3. One to All 10x10 Packet Sizes: Tests one to all on a 10x10 grid.
-4. One to All Multicast 2x2 Packet Sizes: Tests one to all multicast on a 2x2 grid.
-5. One to All Multicast 5x5 Packet Sizes: Tests one to all multicast on a 5x5 grid.
-6. One to All Multicast 11x10 Packet Sizes: Tests one to all multicast on a 11x10 grid.
-7. One to All Multicast Linked 2x2 Packet Sizes: Tests one to all linked multicast on a 2x2 grid.
-8. One to All Multicast Linked 5x5 Packet Sizes: Tests one to all linked multicast on a 5x5 grid.
-9. One to All Multicast Linked 11x10 Packet Sizes: Tests one to all linked multicast on a 11x10 grid.
-10. One to All Directed Ideal: Tests the most optimal one to all linked multicast data movement setup. Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.
+1. **One To All Unicast Tests**: Tests unicast data movement from one master core to various grid configurations:
+   - 2x2 Packet Sizes: Master core sends to 2x2 grid of subordinate cores using unicast
+   - 5x5 Packet Sizes: Master core sends to 5x5 grid of subordinate cores using unicast
+   - All Packet Sizes: Master core sends to full compute grid using unicast
+
+2. **One To All Multicast Tests**: Tests multicast data movement with various configurations:
+   - Multiple multicast schemes and grid configurations
+   - Support for linked/chained transactions
+   - Support for loopback operations
+
+3. **Advanced Multicast Schemes**: Tests different multicast implementation strategies for optimal performance across various grid sizes and communication patterns.

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -2,12 +2,26 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 Data is written directly into the L1 memory on the sender Tensix core. The sender kernel issues NOC transactions to transfer this data into the L1 memory of each receiver core in a grid. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToAll*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToAll*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/dispatch_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "../../common/dispatch_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -98,11 +98,11 @@ std::pair<CoreCoord, CoreCoord> get_coordinates(uint32_t sub_grid_dimension_size
 void test(
     tt::ARCH arch_,
     std::vector<IDevice*>& devices_,
-    uint32_t num_devices_,
     uint32_t test_case_id,
     uint32_t sub_grid_dimension_size,
     NOC noc_id,
     MulticastSchemeType multicast_scheme_type,
+    DispatchFixture* fixture,
     bool loopback = true,
     bool is_linked = true) {
     bool is_multicast = true;
@@ -115,7 +115,6 @@ void test(
     tt::tt_metal::unit_tests::dm::core_to_all::directed_ideal_test(
         arch_,
         devices_,
-        num_devices_,
         test_case_id,
         is_multicast,
         is_linked,
@@ -124,14 +123,15 @@ void test(
         sub_grid_size,
         loopback,
         noc_id,
-        static_cast<uint32_t>(multicast_scheme_type));
+        static_cast<uint32_t>(multicast_scheme_type),
+        fixture);
 }
 
 void run_all_tests(
     tt::ARCH arch_,
     std::vector<IDevice*>& devices_,
-    uint32_t num_devices_,
     uint32_t test_case_id,
+    DispatchFixture* fixture,
     bool loopback = true) {
     std::vector<NOC> noc_ids = {NOC::NOC_0, NOC::NOC_1};
     uint32_t starting_sub_grid_dimension_size = 2;  // Minimum size for sub-grid dimension
@@ -149,11 +149,11 @@ void run_all_tests(
                 test(
                     arch_,
                     devices_,
-                    num_devices_,
                     test_case_id,
                     sub_grid_dimension_size,
                     (noc_id),
                     static_cast<MulticastSchemeType>(multicast_scheme_type),
+                    fixture,
                     loopback);
             }
         }
@@ -166,26 +166,24 @@ void run_all_tests(
 /* =================== LOOP THROUGH SCHEMES ==================== */
 /* ============================================================= */
 
-TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesLoopback) {
+TEST_F(DispatchFixture, TensixDataMovementOneToAllMulticastSchemesLoopback) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 100;
-
     bool loopback = true;
 
     tt::tt_metal::unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(
-        arch_, devices_, num_devices_, test_case_id, loopback);
+        arch_, devices_, test_case_id, this, loopback);
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
+TEST_F(DispatchFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 101;
-
     bool loopback = false;
 
     tt::tt_metal::unit_tests::dm::core_to_all::multicast_schemes::run_all_tests(
-        arch_, devices_, num_devices_, test_case_id, loopback);
+        arch_, devices_, test_case_id, this, loopback);
 }
 
 /* ============================================================= */
@@ -209,7 +207,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
         10. Sender out grid ending not row not column
 */
 
-TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
+TEST_F(DispatchFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
     GTEST_SKIP() << "Skipping test";
 
     uint32_t test_case_id = 110;
@@ -221,7 +219,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
         unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType::SenderInGridTopRight;
 
     tt::tt_metal::unit_tests::dm::core_to_all::multicast_schemes::test(
-        arch_, devices_, num_devices_, test_case_id, sub_grid_dimension_size, noc_id, multicast_scheme, loopback);
+        arch_, devices_, test_case_id, sub_grid_dimension_size, noc_id, multicast_scheme, this, loopback);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -201,11 +201,11 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle
     uint32_t test_case_id = 110;
 
     auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->get_device(0)->arch();
 
     bool loopback = false;
     NOC noc_id = NOC::NOC_0;
-    uint32_t sub_grid_dimension_size = arch_ == ARCH::WORMHOLE_B0 ? 7 : 9;  // Adjust based on architecture
+    uint32_t sub_grid_dimension_size =
+        mesh_device->get_device(0)->arch() == ARCH::WORMHOLE_B0 ? 7 : 9;  // Adjust based on architecture
     unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType multicast_scheme =
         unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType::SenderInGridTopRight;
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -5,7 +5,7 @@
 // Note: The sender kernels in One To All write the same transaction_size_bytes amount of data to the same location
 // num_of_transactions times
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.hpp
@@ -8,9 +8,7 @@
 namespace tt::tt_metal::unit_tests::dm::core_to_all {
 
 void directed_ideal_test(
-    tt::ARCH arch_,
-    std::vector<IDevice*>& devices_,
-    uint32_t num_devices_,
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
     uint32_t test_case_id,
     bool is_multicast,
     bool is_linked,

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -2,37 +2,34 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-Sharded L1 buffers are created on two Tensix cores: one sender and one receiver core. Data is written into the L1 buffer on the sender core. The sender kernel issues NOC transactions to transfer this data into the L1 buffer on the receiver core. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
+L1 memory is allocated on two Tensix cores: one sender and one receiver core. Data is written into the L1 memory on the sender core. The sender kernel issues NOC transactions to transfer this data into the L1 memory on the receiver core. Once data is transferred, the sender kernel uses hardware barriers to ensure data validity and completion of the transaction.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToOne*"
-```
-
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToOne*"
 ```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |
 | ------------------------- | --------------------- | ----------- |
 | test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
-| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
-| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
-| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
-| l1_data_format            | DataFormat            | Data format data that will be moved. |
 | master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
 | subordinate_core_coord    | CoreCoord             | Logical coordinates for the receiver core. |
+| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
+| pages_per_transaction     | uint32_t              | Size of the issued noc transactions in pages. |
+| bytes_per_page            | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format            | DataFormat            | Data format data that will be moved. |
 | virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
 | noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
 | posted                    | N/A                   | Posted flag. Determines if write is posted or non-posted (TODO)|

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -2,12 +2,26 @@
 
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 Sharded L1 buffers are created on two Tensix cores: one sender and one receiver core. Data is written into the L1 buffer on the sender core. The sender kernel issues NOC transactions to transfer this data into the L1 buffer on the receiver core. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToOne*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*OneToOne*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -336,7 +336,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneDirectedIdeal) {
     );
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 150;
@@ -349,7 +349,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
     );
 }
 
-TEST_F(DeviceFixture, TensixDataMovementOneToOneCustom) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneCustom) {
     GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -27,7 +27,15 @@ class StatsCollector:
     def gather_analysis_stats(self):
         # Gather stats from csv and set up analysis
         stats = self.gather_stats_from_csv()
-        cores = [key for key in stats["devices"][0]["cores"].keys() if key != "DEVICE"]
+        cores = [
+            key
+            for key in stats["devices"][0]["cores"].keys()
+            if (
+                "BRISC" in stats["devices"][0]["cores"][key]["riscs"]
+                or "NCRISC" in stats["devices"][0]["cores"][key]["riscs"]
+            )
+            and key != "DEVICE"
+        ]
 
         dm_stats = {}
         for risc in RISCV_PROCESSORS:

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -77,7 +77,7 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
 def profile_dm_tests(verbose=False, gtest_filter=None):
     if verbose:
         logger.info(f"Profiling Kernels...")
-    cmd = f"TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_DEVICE_PROFILER=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/unit_tests_data_movement"
+    cmd = f"TT_METAL_DEVICE_PROFILER=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/unit_tests_data_movement"
 
     if gtest_filter:
         cmd += f' --gtest_filter="*{gtest_filter}*"'

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/README.md
@@ -3,10 +3,10 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of reshard transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
-## Mesh Device API Support
-This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+## Slow Dispatch Support
+This test suite uses the TT-Metal slow dispatch mode for reliable program execution. The tests use `DeviceFixture` and are designed to work with the slow dispatch API.
 
-**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+**Note**: These tests require slow dispatch mode for proper operation. They use `tt::tt_metal::detail::LaunchProgram()` for direct program execution without command queues.
 
 ## Test Flow
 
@@ -17,7 +17,12 @@ It does not check pcc as the afformentioned test does this.
 The sharding patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
 
 ## Running the Tests
-The tests use the Mesh Device API with fast dispatch mode:
+The tests use slow dispatch mode. Run with the slow dispatch environment variable:
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ReshardHardcoded*"
+```
+
+Or run normally (the DeviceFixture will automatically enforce slow dispatch mode):
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ReshardHardcoded*"
 ```

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/README.md
@@ -3,6 +3,9 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of reshard transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
+## Dispatch Mode Compatibility
+This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+
 ## Test Flow
 
 This test creates a buffer for various sharding patterns as gotten from `pytest test_core.py -k test_reshard`. It plots the bandwidth of each core.
@@ -10,6 +13,17 @@ This test creates a buffer for various sharding patterns as gotten from `pytest 
 It does not check pcc as the afformentioned test does this.
 
 The sharding patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
+
+## Running the Tests
+**Fast Dispatch Mode (Recommended):**
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ReshardHardcoded*"
+```
+
+**Slow Dispatch Mode:**
+```
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ReshardHardcoded*"
+```
 
 ## Test Parameters
 | Parameter                 | Data Type             | Description |

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/README.md
@@ -3,8 +3,10 @@
 This test suite implements tests that measure the performance (i.e. bandwidth) of reshard transactions between Tensix cores.
 They are based on kernel runtime arguments of existing metal tests.
 
-## Dispatch Mode Compatibility
-This test suite supports both fast dispatch (default) and slow dispatch modes. Fast dispatch mode provides better performance and is recommended for most use cases.
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
 
@@ -15,14 +17,9 @@ It does not check pcc as the afformentioned test does this.
 The sharding patterns are the exact ones as gotten from the base tests, as such this is a directed test is is not general.
 
 ## Running the Tests
-**Fast Dispatch Mode (Recommended):**
+The tests use the Mesh Device API with fast dispatch mode:
 ```
 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ReshardHardcoded*"
-```
-
-**Slow Dispatch Mode:**
-```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*ReshardHardcoded*"
 ```
 
 ## Test Parameters

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/multi_device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../../common/dispatch_fixture.hpp"
+#include "../../common/multi_device_fixture.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -12,7 +14,7 @@ namespace tt::tt_metal {
 
 using namespace std;
 using namespace tt;
-using namespace tt::test_utils;
+using namespace test_utils;
 
 namespace unit_tests::dm::reshard_hardcoded {
 
@@ -22,16 +24,17 @@ constexpr uint32_t START_ID = 17;
 struct ReshardConfig {
     uint32_t test_id = 0;
     CoreRangeSet dest_core_set;
-    std::vector<uint32_t> dest_core_compile_args;
-    std::vector<uint32_t> dest_core_runtime_args;
+    vector<uint32_t> dest_core_compile_args;
+    vector<uint32_t> dest_core_runtime_args;
     NOC noc_id = NOC::NOC_0;
 };
 
 /// @brief Does L1 Sender Core --> L1 Receiver Core
-/// @param device
+/// @param mesh_device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(IDevice* device, const ReshardConfig& test_config, DispatchFixture* fixture) {
+bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const ReshardConfig& test_config) {
+    IDevice* device = mesh_device->get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -49,30 +52,38 @@ bool run_dm(IDevice* device, const ReshardConfig& test_config, DispatchFixture* 
     SetRuntimeArgs(program, receiver_kernel, test_config.dest_core_set, test_config.dest_core_runtime_args);
 
     // Assign unique id
-    log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Launch program
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    // Launch the program - Use dispatch-aware method
-    fixture->RunProgram(device, program);
+
+    auto workload = distributed::CreateMeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), target_devices);
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(0), workload, false);
+    Finish(mesh_device->mesh_command_queue(0));
 
     return true;
 }
 }  // namespace unit_tests::dm::reshard_hardcoded
 
-TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
-    if (arch_ != tt::ARCH::BLACKHOLE) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
+    auto mesh_device = get_mesh_device();
+    auto arch_ = mesh_device->get_device(0)->arch();
+
+    if (arch_ != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
     // Parameters
     uint32_t test_id = unit_tests::dm::reshard_hardcoded::START_ID + 0;
     NOC noc_id = NOC::NOC_0;
-    std::set<CoreRange> dest_core_set = {CoreRange(CoreCoord(0, 0)), CoreRange(CoreCoord(1, 0))};
+    set<CoreRange> dest_core_set = {CoreRange(CoreCoord(0, 0)), CoreRange(CoreCoord(1, 0))};
     CoreRangeSet wrapper_dest_core_set(dest_core_set);
-    std::vector<uint32_t> dest_core_compile_args;
-    std::vector<uint32_t> dest_core_runtime_args;
+    vector<uint32_t> dest_core_compile_args;
+    vector<uint32_t> dest_core_runtime_args;
 
     dest_core_compile_args.push_back(1566720);  // l1_write_addr
     dest_core_compile_args.push_back(11);       // num_x_cores
@@ -127,23 +138,24 @@ TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
     };
 
     // Run
-    for (unsigned int id = 0; id < NumDevices(); id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
-TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
-    if (arch_ != tt::ARCH::BLACKHOLE) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
+    auto mesh_device = get_mesh_device();
+    auto arch_ = mesh_device->get_device(0)->arch();
+
+    if (arch_ != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
     // Parameters
     uint32_t test_id = unit_tests::dm::reshard_hardcoded::START_ID + 1;
     NOC noc_id = NOC::NOC_0;
-    std::set<CoreRange> dest_core_set = {CoreRange(CoreCoord(0, 0)), CoreRange(CoreCoord(1, 0))};
+    set<CoreRange> dest_core_set = {CoreRange(CoreCoord(0, 0)), CoreRange(CoreCoord(1, 0))};
     CoreRangeSet wrapper_dest_core_set(dest_core_set);
-    std::vector<uint32_t> dest_core_compile_args;
-    std::vector<uint32_t> dest_core_runtime_args;
+    vector<uint32_t> dest_core_compile_args;
+    vector<uint32_t> dest_core_runtime_args;
 
     dest_core_compile_args.push_back(1480704);  // l1_write_addr
     dest_core_compile_args.push_back(11);       // num_x_cores
@@ -218,20 +230,21 @@ TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
     };
 
     // Run
-    for (unsigned int id = 0; id < NumDevices(); id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
-TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
-    if (arch_ != tt::ARCH::BLACKHOLE) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
+    auto mesh_device = get_mesh_device();
+    auto arch_ = mesh_device->get_device(0)->arch();
+
+    if (arch_ != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
     // Parameters
     uint32_t test_id = unit_tests::dm::reshard_hardcoded::START_ID + 2;
     NOC noc_id = NOC::NOC_0;
-    std::set<CoreRange> dest_core_set = {
+    set<CoreRange> dest_core_set = {
         CoreRange(CoreCoord(0, 0)),
         CoreRange(CoreCoord(1, 0)),
         CoreRange(CoreCoord(2, 0)),
@@ -241,8 +254,8 @@ TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) 
         CoreRange(CoreCoord(6, 0)),
         CoreRange(CoreCoord(7, 0))};
     CoreRangeSet wrapper_dest_core_set(dest_core_set);
-    std::vector<uint32_t> dest_core_compile_args;
-    std::vector<uint32_t> dest_core_runtime_args;
+    vector<uint32_t> dest_core_compile_args;
+    vector<uint32_t> dest_core_runtime_args;
 
     dest_core_compile_args.push_back(1499136);  // l1_write_addr
     dest_core_compile_args.push_back(11);       // num_x_cores
@@ -307,28 +320,29 @@ TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) 
     };
 
     // Run
-    for (unsigned int id = 0; id < NumDevices(); id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
-TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCoresSizes) {
-    if (arch_ != tt::ARCH::BLACKHOLE) {
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCoresSizes) {
+    auto mesh_device = get_mesh_device();
+    auto arch_ = mesh_device->get_device(0)->arch();
+
+    if (arch_ != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
     // Parameters
     uint32_t test_id = unit_tests::dm::reshard_hardcoded::START_ID + 3;
     NOC noc_id = NOC::NOC_0;
-    std::set<CoreRange> dest_core_set = {
+    set<CoreRange> dest_core_set = {
         CoreRange(CoreCoord(0, 0)),
         CoreRange(CoreCoord(1, 0)),
         CoreRange(CoreCoord(2, 0)),
         CoreRange(CoreCoord(3, 0)),
         CoreRange(CoreCoord(4, 0))};
     CoreRangeSet wrapper_dest_core_set(dest_core_set);
-    std::vector<uint32_t> dest_core_compile_args;
-    std::vector<uint32_t> dest_core_runtime_args;
+    vector<uint32_t> dest_core_compile_args;
+    vector<uint32_t> dest_core_runtime_args;
 
     dest_core_compile_args.push_back(1558528);  // l1_write_addr
     dest_core_compile_args.push_back(11);       // num_x_cores
@@ -393,9 +407,7 @@ TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToMany
     };
 
     // Run
-    for (unsigned int id = 0; id < NumDevices(); id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
-    }
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "device_fixture.hpp"
+#include "../../common/dispatch_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -31,7 +31,7 @@ struct ReshardConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(IDevice* device, const ReshardConfig& test_config) {
+bool run_dm(IDevice* device, const ReshardConfig& test_config, DispatchFixture* fixture) {
     // Program
     Program program = CreateProgram();
 
@@ -54,13 +54,14 @@ bool run_dm(IDevice* device, const ReshardConfig& test_config) {
 
     // Launch program
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    detail::LaunchProgram(device, program);
+    // Launch the program - Use dispatch-aware method
+    fixture->RunProgram(device, program);
 
     return true;
 }
 }  // namespace unit_tests::dm::reshard_hardcoded
 
-TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
+TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -126,12 +127,12 @@ TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
+TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -217,12 +218,12 @@ TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
+TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -306,12 +307,12 @@ TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 
-TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCoresSizes) {
+TEST_F(DispatchFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCoresSizes) {
     if (arch_ != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
@@ -392,8 +393,8 @@ TEST_F(DeviceFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCo
     };
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    for (unsigned int id = 0; id < NumDevices(); id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config, this));
     }
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24644) https://github.com/tenstorrent/tt-metal/issues/22803

### Problem description
All of the DM tests are using slow-dispatch host APIs, that are slow for performance dumping, and also are deprecated for the new mesh device APIs that can be configured for single chip.

### What's changed
Migrated all tests (except the hardcoded ones) to use mesh device APIs. Now tests run on fast dispatch. Since mesh device APIs only work with fast dispatch, slow dispatch mode is also deprecated for the changed tests. All READMEs are updated accordingly. 

Loopback test suite is updated to use direct L1 access and sharded buffer usage is removed. Loopback README updated accordingly.

### Impact
On Blackhole, each test case running with the profiler previously took around 5s to complete. With these new changes, that number came down to ~0.5s (i.e. a 10x increase in test run speed). Considering that our test suite runs 1500+ of such tests, the time save is significant.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16992409898) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16992411225) CI passes
- [x] [metal - Run microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/16992412591) (same fail as main)