### PR TITLE
chore: update uplift llk workflow after BH post-commit updates

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -314,7 +314,7 @@ jobs:
           # Trigger workflow with appropriate inputs
           echo "Triggering $WORKFLOW..."
           if [ "$WORKFLOW" = "blackhole-post-commit.yaml" ]; then
-            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" -f enable-ttnn-unit-tests=true --repo "${{ github.repository }}"
+            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
           else
             gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
           fi

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -313,11 +313,7 @@ jobs:
 
           # Trigger workflow with appropriate inputs
           echo "Triggering $WORKFLOW..."
-          if [ "$WORKFLOW" = "blackhole-post-commit.yaml" ]; then
-            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
-          else
-            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
-          fi
+          gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
 
           # Wait for the new run to appear and ensure it's created after trigger time
           run_id=""


### PR DESCRIPTION
### Ticket
None

### Problem description
After https://github.com/tenstorrent/tt-metal/pull/25844 gets merged, BH post-commit workflow will run ttnn tests by default, and it won't be accepting `enable-ttnn-unit-tests` as an argument.

### What's changed
Removed passing obsolete argument to blackhole post-commit workflow.