### PR TITLE
Resolving Llama 70B model device perf hang on TG and 6U

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -121,6 +121,7 @@ void sub_exp_block_bcast_cols_inplace_reduce(uint32_t in1_cb, uint32_t reduce_cb
     exp_tile_init<true, true, scale_fp32>();
     cb_wait_front(in0_cb, rows * cols);
     cb_wait_front(in1_cb, rows);
+    cb_reserve_back(reduce_cb, rows);
 
 #ifdef SUB_EXP_GRANULARITY
     uint32_t dst_tiles = SUB_EXP_GRANULARITY;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -121,7 +121,6 @@ void sub_exp_block_bcast_cols_inplace_reduce(uint32_t in1_cb, uint32_t reduce_cb
     exp_tile_init<true, true, scale_fp32>();
     cb_wait_front(in0_cb, rows * cols);
     cb_wait_front(in1_cb, rows);
-    cb_reserve_back(reduce_cb, rows);
 
 #ifdef SUB_EXP_GRANULARITY
     uint32_t dst_tiles = SUB_EXP_GRANULARITY;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -273,7 +273,7 @@ void MAIN {
                  */
 
                 if constexpr (is_causal) {
-                    // For decode, we only apply mask at the last chunk for causal modes
+                    // For decode, we only apply mask at the last chunk for causal mode
                     if (k_chunk == k_chunk_end - 1 && apply_mask_at_last_chunk) {
                         /* QK += MASK */
                         reconfig_data_format(cb_qk_im, cb_mask_in);
@@ -421,9 +421,10 @@ void MAIN {
                 }
             }
             /* cb_cur_sum = 1.0 / cb_cur_sum */
+
             reconfig_data_format(cb_prev_sum, cb_prev_sum);  // DEBUG
             pack_reconfig_data_format(cb_prev_sum);
-            recip_block_inplace(cb_prev_sum, Sq_chunk_t);
+            recip_block_inplace<vector_mode>(cb_prev_sum, Sq_chunk_t);
 
             /* cb_out_accumulate_im *= cb_prev_sum */
             reconfig_data_format(cb_out_accumulate_im, cb_prev_sum);  // DEBUG

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -273,7 +273,7 @@ void MAIN {
                  */
 
                 if constexpr (is_causal) {
-                    // For decode, we only apply mask at the last chunk for causal mode
+                    // For decode, we only apply mask at the last chunk for causal modes
                     if (k_chunk == k_chunk_end - 1 && apply_mask_at_last_chunk) {
                         /* QK += MASK */
                         reconfig_data_format(cb_qk_im, cb_mask_in);
@@ -371,8 +371,8 @@ void MAIN {
                 if (k_chunk < k_chunk_end - 1 || do_reduce) {
                     reconfig_data_format(cb_cur_max, cb_cur_max);  // DEBUG
                     pack_reconfig_data_format(cb_prev_max);
-                    std::swap(cb_cur_sum, cb_prev_sum);
                     move_block<true>(cb_cur_max, cb_prev_max, Sq_chunk_t);
+                    move_block<true>(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
                 } else {
                     // Write o, m, l into cb_out
                     move_block<true>(cb_out_accumulate_im, cb_out_o, out_chunk_tiles);
@@ -421,15 +421,16 @@ void MAIN {
                 }
             }
             /* cb_cur_sum = 1.0 / cb_cur_sum */
+            cb_push_back(cb_cur_sum, Sq_chunk_t);
 
-            reconfig_data_format(cb_prev_sum, cb_prev_sum);  // DEBUG
-            pack_reconfig_data_format(cb_prev_sum);
-            recip_block_inplace<vector_mode>(cb_prev_sum, Sq_chunk_t);
+            reconfig_data_format(cb_cur_sum, cb_cur_sum);  // DEBUG
+            pack_reconfig_data_format(cb_cur_sum);
+            recip_block_inplace(cb_cur_sum, Sq_chunk_t);
 
-            /* cb_out_accumulate_im *= cb_prev_sum */
-            reconfig_data_format(cb_out_accumulate_im, cb_prev_sum);  // DEBUG
+            /* cb_out_accumulate_im *= cb_cur_sum */
+            reconfig_data_format(cb_out_accumulate_im, cb_cur_sum);  // DEBUG
             pack_reconfig_data_format(cb_out_accumulate_im);
-            mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_prev_sum, Sq_chunk_t, vDHt);
+            mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_cur_sum, Sq_chunk_t, vDHt);
             pack_reconfig_data_format(cb_out_final);
 
             if constexpr (untilize_output) {
@@ -457,6 +458,7 @@ void MAIN {
             }
             // free up cb_prev_max after K chunks
             cb_pop_front(cb_prev_max, Sq_chunk_t);
+            cb_pop_front(cb_prev_sum, Sq_chunk_t);
         }
     }
     cb_pop_front(cb_q_in, q_chunk_tiles);


### PR DESCRIPTION
### Ticket
#25330

### Problem description
CB swapping in SDPA op resulted in a hang on model device perf on TG and 6U. 

### What's changed
The cb swap was replaced with logic to remove need for swapping. Led to 0.3us improvement from the std::swap() on 4U but led to 0.6us increase on 6U (from optimized version). 4U and 6U numbers are both 9.8us as per model device perf.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16635342733) CI passes
- [ ] [TG everything](https://github.com/tenstorrent/tt-metal/actions/runs/16635345716) CI passes 