### PR TITLE
TensorAccessorArgs pybinds

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_accessor_args.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_accessor_args.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+import ttnn
+
+
+def test_arg_config_enum_values():
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.Sharded).raw() == 1
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.IsDram).raw() == 2
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.RuntimeRank).raw() == 4
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.RuntimeNumBanks).raw() == 8
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.RuntimeTensorShape).raw() == 16
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.RuntimeShardShape).raw() == 32
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.RuntimeBankCoords).raw() == 64
+    assert ttnn.ArgsConfig(ttnn.ArgConfig.Runtime).raw() == 124
+
+
+def test_args_config_creation():
+    config = ttnn.ArgsConfig()
+    config = config | ttnn.ArgConfig.RuntimeRank
+    config = config | ttnn.ArgConfig.RuntimeNumBanks
+    config = config | ttnn.ArgConfig.RuntimeTensorShape
+    config = config | ttnn.ArgConfig.RuntimeShardShape
+    config = config | ttnn.ArgConfig.RuntimeBankCoords
+    assert config.raw() == 124
+
+
+@pytest.mark.parametrize(
+    "args_config",
+    [
+        ttnn.ArgsConfig(getattr(ttnn.ArgConfig, "None")),
+        ttnn.ArgsConfig(ttnn.ArgConfig.RuntimeNumBanks, ttnn.ArgConfig.RuntimeBankCoords),
+        ttnn.ArgsConfig(ttnn.ArgConfig.Runtime),
+    ],
+)
+def test_tensor_accessor_args(device, args_config):
+    shape = [3, 128, 160]
+    shard_shape = [3, 128, 32]
+    py_tensor = torch.rand(shape).to(torch.bfloat16)
+    grid_size = device.compute_with_storage_grid_size()
+    core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
+    grid = ttnn.CoreRangeSet([core_range])
+    nd_shard_spec = ttnn.NdShardSpec(shape, grid)
+
+    sharded_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
+    tt_tensor_sharded = ttnn.from_torch(
+        py_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=sharded_memory_config
+    )
+
+    dram_memory_config = ttnn.DRAM_MEMORY_CONFIG
+    tt_tensor_dram = ttnn.from_torch(
+        py_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_memory_config
+    )
+
+    sharded_accessor = ttnn.TensorAccessorArgs(tt_tensor_sharded, args_config)
+    dram_accessor = ttnn.TensorAccessorArgs(tt_tensor_dram, args_config)
+
+    sharded_accessor_cta = sharded_accessor.get_compile_time_args()
+    sharded_accessor_crta = sharded_accessor.get_common_runtime_args()
+
+    dram_accessor_cta = dram_accessor.get_compile_time_args()
+    dram_accessor_crta = dram_accessor.get_common_runtime_args()
+    assert len(accessor_dram_cta) == 1
+    assert len(accessor_dram_crta) == 0
+
+    cta = [True]
+    crta = [True]
+    if args_config.raw() > 2:
+        sharded_cta_after, sharded_crta_after = sharded_accessor.append_to(cta, crta)
+        dram_cta_after, dram_crta_after = dram_accessor.append_to(cta, crta)
+        assert sharded_crta_after == crta + sharded_accessor_crta
+        assert dram_crta_after == crta + dram_accessor_crta
+    else:
+        sharded_cta_after = sharded_accessor.append_to(cta)
+        dram_cta_after = dram_accessor.append_to(cta)
+
+    assert sharded_cta_after == cta + sharded_accessor_cta
+    assert dram_cta_after == cta + dram_accessor_cta

--- a/tests/ttnn/unit_tests/tensor/test_tensor_accessor_args.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_accessor_args.py
@@ -64,8 +64,8 @@ def test_tensor_accessor_args(device, args_config):
 
     dram_accessor_cta = dram_accessor.get_compile_time_args()
     dram_accessor_crta = dram_accessor.get_common_runtime_args()
-    assert len(accessor_dram_cta) == 1
-    assert len(accessor_dram_crta) == 0
+    assert len(dram_accessor_cta) == 1
+    assert len(dram_accessor_crta) == 0
 
     cta = [True]
     crta = [True]

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -343,6 +343,7 @@ list(
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-${PY_BINDING}/operations/core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-${PY_BINDING}/operations/creation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-${PY_BINDING}/operations/trace.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-${PY_BINDING}/tensor_accessor_args.cpp
 )
 
 ##################################################

--- a/ttnn/cpp/ttnn-pybind/__init__.cpp
+++ b/ttnn/cpp/ttnn-pybind/__init__.cpp
@@ -24,6 +24,7 @@
 #include "ttnn-pybind/operations/trace.hpp"
 #include "ttnn-pybind/profiler.hpp"
 #include "ttnn-pybind/program_descriptors.hpp"
+#include "ttnn-pybind/tensor_accessor_args.hpp"
 #include "ttnn-pybind/reports.hpp"
 #include "ttnn-pybind/tensor.hpp"
 #include "ttnn-pybind/types.hpp"
@@ -226,6 +227,7 @@ PYBIND11_MODULE(_ttnn, module) {
     auto m_operations = module.def_submodule("operations", "ttnn Operations");
     auto m_fabric = module.def_submodule("fabric", "Fabric instantiation APIs");
     auto m_program_descriptors = module.def_submodule("program_descriptor", "Program descriptors types");
+    auto m_tensor_accessor_args = module.def_submodule("tensor_accessor_args", "Tensor accessor args types");
 
     // TYPES
     ttnn::tensor::tensor_mem_config_module_types(m_tensor);
@@ -245,6 +247,7 @@ PYBIND11_MODULE(_ttnn, module) {
     ttnn::mesh_socket::py_module_types(m_mesh_socket);
     ttnn::reports::py_module_types(m_reports);
     ttnn::program_descriptors::py_module_types(m_program_descriptors);
+    ttnn::tensor_accessor_args::py_module_types(m_tensor_accessor_args);
 
     // FUNCTIONS / OPERATIONS
     ttnn::tensor::tensor_mem_config_module(m_tensor);
@@ -271,6 +274,7 @@ PYBIND11_MODULE(_ttnn, module) {
     ttnn::mesh_socket::py_module(m_mesh_socket);
     ttnn::profiler::py_module(m_profiler);
     ttnn::reports::py_module(m_reports);
+    ttnn::tensor_accessor_args::py_module(m_tensor_accessor_args);
 
     // ttnn operations have to come before the deprecated ones,
     // because ttnn defines additional type bindings.

--- a/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
@@ -4,72 +4,25 @@
 
 #include "tensor_accessor_args.hpp"
 
-#include <optional>
-#include <string>
-
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
 
-#include "ttnn-pybind/decorators.hpp"
-#include "ttnn-pybind/export_enum.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <hostdevcommon/tensor_accessor/arg_config.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::tensor_accessor_args {
 
-void py_module_types(py::module& module) {
-    export_enum<tensor_accessor::ArgConfig>(module);
-    py::class_<tt::tt_metal::TensorAccessorArgs>(module, "TensorAccessorArgs");
-    py::class_<tensor_accessor::ArgsConfig>(module, "ArgsConfig");
-}
+void py_module_types(py::module& module) { py::class_<tt::tt_metal::TensorAccessorArgs>(module, "TensorAccessorArgs"); }
 
 void py_module(py::module& module) {
-    static_cast<py::class_<tensor_accessor::ArgsConfig>>(module.attr("ArgsConfig"))
-        .def(py::init<>())
-        .def(py::init<tensor_accessor::ArgConfig>())
-        .def(py::init<tensor_accessor::ArgConfig, tensor_accessor::ArgConfig>())
-        .def("test", &tensor_accessor::ArgsConfig::test)
-        .def("set", &tensor_accessor::ArgsConfig::set)
-        .def("raw", &tensor_accessor::ArgsConfig::raw)
-        .def(py::self | tensor_accessor::ArgConfig())
-        .def(py::self | py::self)
-        .def(py::self & tensor_accessor::ArgConfig());
-
     static_cast<py::class_<tt::tt_metal::TensorAccessorArgs>>(module.attr("TensorAccessorArgs"))
         .def(
-            py::init([](const ttnn::Tensor& tensor, tensor_accessor::ArgsConfig args_config) {
-                return tt::tt_metal::TensorAccessorArgs(*tensor.buffer(), args_config);
-            }),
+            py::init([](const ttnn::Tensor& tensor) { return tt::tt_metal::TensorAccessorArgs(*tensor.buffer()); }),
             py::arg("tensor"),
-            py::arg("args_config") = tensor_accessor::ArgsConfig(tensor_accessor::ArgConfig::None),
             R"doc(
                 Initialize a TensorAccessorArgs with a buffer and an optional args config.
-            )doc")
-        .def(
-            "append_to",
-            [](const tt::tt_metal::TensorAccessorArgs& self,
-               std::vector<uint32_t>& compile_time_args,
-               std::vector<uint32_t>& common_runtime_args) {
-                self.append_to(compile_time_args, common_runtime_args);
-                return py::make_tuple(compile_time_args, common_runtime_args);
-            },
-            py::arg("compile_time_args"),
-            py::arg("common_runtime_args"),
-            R"doc(
-                Append the tensor accessor args to the compile time and common runtime args.
-            )doc")
-        .def(
-            "append_to",
-            [](const tt::tt_metal::TensorAccessorArgs& self, std::vector<uint32_t>& compile_time_args) {
-                self.append_to(compile_time_args);
-                return compile_time_args;
-            },
-            py::arg("compile_time_args"),
-            R"doc(
-                Append the tensor accessor args to the compile time args.
             )doc")
         .def(
             "get_compile_time_args",

--- a/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor_accessor_args.hpp"
+
+#include <optional>
+#include <string>
+
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+
+#include "ttnn-pybind/decorators.hpp"
+#include "ttnn-pybind/export_enum.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <hostdevcommon/tensor_accessor/arg_config.hpp>
+
+namespace ttnn::tensor_accessor_args {
+
+void py_module_types(py::module& module) {
+    py::class_<tt::tt_metal::TensorAccessorArgs>(module, "TensorAccessorArgs");
+    export_enum<tensor_accessor::ArgConfig>(module);
+}
+
+void py_module(py::module& module) {
+    static_cast<py::class_<tt::tt_metal::TensorAccessorArgs>>(module.attr("TensorAccessorArgs"))
+        .def(
+            py::init<const tt::tt_metal::Buffer&, tensor_accessor::ArgsConfig>(),
+            py::arg("buffer"),
+            py::arg("args_config") = tensor_accessor::ArgConfig::None,
+            R"doc(
+                Initialize a TensorAccessorArgs with a buffer and an optional args config.
+            )doc")
+        .def(
+            "append_to",
+            py::overload_cast<std::vector<uint32_t>&, std::vector<uint32_t>&>(
+                &tt::tt_metal::TensorAccessorArgs::append_to, py::const_),
+            py::arg("compile_time_args"),
+            py::arg("common_runtime_args"),
+            R"doc(
+                Append the tensor accessor args to the compile time and common runtime args.
+            )doc")
+        .def(
+            "append_to",
+            py::overload_cast<std::vector<uint32_t>&>(&tt::tt_metal::TensorAccessorArgs::append_to, py::const_),
+            py::arg("compile_time_args"),
+            R"doc(
+                Append the tensor accessor args to the compile time args.
+            )doc")
+        .def(
+            "get_compile_time_args",
+            &tt::tt_metal::TensorAccessorArgs::get_compile_time_args,
+            R"doc(
+                Get the compile time args.
+            )doc")
+        .def(
+            "get_common_runtime_args",
+            &tt::tt_metal::TensorAccessorArgs::get_common_runtime_args,
+            R"doc(
+                Get the common runtime args.
+            )doc");
+}
+
+}  // namespace ttnn::tensor_accessor_args

--- a/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
@@ -10,32 +10,50 @@
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
 
 #include "ttnn-pybind/decorators.hpp"
 #include "ttnn-pybind/export_enum.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::tensor_accessor_args {
 
 void py_module_types(py::module& module) {
-    py::class_<tt::tt_metal::TensorAccessorArgs>(module, "TensorAccessorArgs");
     export_enum<tensor_accessor::ArgConfig>(module);
+    py::class_<tt::tt_metal::TensorAccessorArgs>(module, "TensorAccessorArgs");
+    py::class_<tensor_accessor::ArgsConfig>(module, "ArgsConfig")
+        .def(py::init<>())
+        .def(py::init<tensor_accessor::ArgConfig>())
+        .def(py::init<tensor_accessor::ArgConfig, tensor_accessor::ArgConfig>())
+        .def("test", &tensor_accessor::ArgsConfig::test)
+        .def("set", &tensor_accessor::ArgsConfig::set)
+        .def("raw", &tensor_accessor::ArgsConfig::raw)
+        .def(py::self | tensor_accessor::ArgConfig())
+        .def(py::self | py::self)
+        .def(py::self & tensor_accessor::ArgConfig());
 }
 
 void py_module(py::module& module) {
     static_cast<py::class_<tt::tt_metal::TensorAccessorArgs>>(module.attr("TensorAccessorArgs"))
         .def(
-            py::init<const tt::tt_metal::Buffer&, tensor_accessor::ArgsConfig>(),
-            py::arg("buffer"),
-            py::arg("args_config") = tensor_accessor::ArgConfig::None,
+            py::init([](const ttnn::Tensor& tensor, tensor_accessor::ArgsConfig args_config) {
+                return tt::tt_metal::TensorAccessorArgs(*tensor.buffer(), args_config);
+            }),
+            py::arg("tensor"),
+            py::arg("args_config") = tensor_accessor::ArgsConfig(tensor_accessor::ArgConfig::None),
             R"doc(
                 Initialize a TensorAccessorArgs with a buffer and an optional args config.
             )doc")
         .def(
             "append_to",
-            py::overload_cast<std::vector<uint32_t>&, std::vector<uint32_t>&>(
-                &tt::tt_metal::TensorAccessorArgs::append_to, py::const_),
+            [](const tt::tt_metal::TensorAccessorArgs& self,
+               std::vector<uint32_t>& compile_time_args,
+               std::vector<uint32_t>& common_runtime_args) {
+                self.append_to(compile_time_args, common_runtime_args);
+                return py::make_tuple(compile_time_args, common_runtime_args);
+            },
             py::arg("compile_time_args"),
             py::arg("common_runtime_args"),
             R"doc(
@@ -43,7 +61,10 @@ void py_module(py::module& module) {
             )doc")
         .def(
             "append_to",
-            py::overload_cast<std::vector<uint32_t>&>(&tt::tt_metal::TensorAccessorArgs::append_to, py::const_),
+            [](const tt::tt_metal::TensorAccessorArgs& self, std::vector<uint32_t>& compile_time_args) {
+                self.append_to(compile_time_args);
+                return compile_time_args;
+            },
             py::arg("compile_time_args"),
             R"doc(
                 Append the tensor accessor args to the compile time args.

--- a/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor_accessor_args.cpp
@@ -23,7 +23,11 @@ namespace ttnn::tensor_accessor_args {
 void py_module_types(py::module& module) {
     export_enum<tensor_accessor::ArgConfig>(module);
     py::class_<tt::tt_metal::TensorAccessorArgs>(module, "TensorAccessorArgs");
-    py::class_<tensor_accessor::ArgsConfig>(module, "ArgsConfig")
+    py::class_<tensor_accessor::ArgsConfig>(module, "ArgsConfig");
+}
+
+void py_module(py::module& module) {
+    static_cast<py::class_<tensor_accessor::ArgsConfig>>(module.attr("ArgsConfig"))
         .def(py::init<>())
         .def(py::init<tensor_accessor::ArgConfig>())
         .def(py::init<tensor_accessor::ArgConfig, tensor_accessor::ArgConfig>())
@@ -33,9 +37,7 @@ void py_module_types(py::module& module) {
         .def(py::self | tensor_accessor::ArgConfig())
         .def(py::self | py::self)
         .def(py::self & tensor_accessor::ArgConfig());
-}
 
-void py_module(py::module& module) {
     static_cast<py::class_<tt::tt_metal::TensorAccessorArgs>>(module.attr("TensorAccessorArgs"))
         .def(
             py::init([](const ttnn::Tensor& tensor, tensor_accessor::ArgsConfig args_config) {

--- a/ttnn/cpp/ttnn-pybind/tensor_accessor_args.hpp
+++ b/ttnn/cpp/ttnn-pybind/tensor_accessor_args.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::tensor_accessor_args {
+
+namespace py = pybind11;
+void py_module_types(py::module& module);
+void py_module(py::module& module);
+
+}  // namespace ttnn::tensor_accessor_args

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -216,6 +216,9 @@ from ttnn.types import (
     KernelDescriptor,
     SemaphoreDescriptor,
     ProgramDescriptor,
+    TensorAccessorArgs,
+    ArgsConfig,
+    ArgConfig,
 )
 
 from ttnn.device import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -217,8 +217,6 @@ from ttnn.types import (
     SemaphoreDescriptor,
     ProgramDescriptor,
     TensorAccessorArgs,
-    ArgsConfig,
-    ArgConfig,
 )
 
 from ttnn.device import (

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -100,5 +100,3 @@ SemaphoreDescriptor = ttnn._ttnn.program_descriptor.SemaphoreDescriptor
 ProgramDescriptor = ttnn._ttnn.program_descriptor.ProgramDescriptor
 
 TensorAccessorArgs = ttnn._ttnn.tensor_accessor_args.TensorAccessorArgs
-ArgsConfig = ttnn._ttnn.tensor_accessor_args.ArgsConfig
-ArgConfig = ttnn._ttnn.tensor_accessor_args.ArgConfig

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -98,3 +98,7 @@ ComputeConfigDescriptor = ttnn._ttnn.program_descriptor.ComputeConfigDescriptor
 KernelDescriptor = ttnn._ttnn.program_descriptor.KernelDescriptor
 SemaphoreDescriptor = ttnn._ttnn.program_descriptor.SemaphoreDescriptor
 ProgramDescriptor = ttnn._ttnn.program_descriptor.ProgramDescriptor
+
+TensorAccessorArgs = ttnn._ttnn.tensor_accessor_args.TensorAccessorArgs
+ArgsConfig = ttnn._ttnn.tensor_accessor_args.ArgsConfig
+ArgConfig = ttnn._ttnn.tensor_accessor_args.ArgConfig


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25655)

### Problem description
Want to expose `TensorAccessorArgs` to more easily generate args to pass to kernels in ttnn.

### What's changed
- pybinded `TensorAccessorArgs` and `ArgsConfig` class
   - `TensorAccessorArgs` takes a tensor instead of a buffer ptr, as to not expose `tt_metal::Buffer` type to python
- pybinded `ArgConfig` enum
- added some basic tests

### Checklist
- [x] [All post commit]https://github.com/tenstorrent/tt-metal/actions/runs/16633959456
- [x] New/Existing tests provide coverage for changes