### PR TITLE
MLA now uses HF reference!

### DIFF
--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -127,7 +127,8 @@ class DeepseekV3RotaryEmbedding(nn.Module):
         self.register_buffer("cos_cached", emb.cos().to(dtype), persistent=False)
         self.register_buffer("sin_cached", emb.sin().to(dtype), persistent=False)
 
-    def forward(self, x, seq_len=None):
+    def forward(self, x, seq_len=None, meta_style=False):
+        self.meta_style = meta_style
         # x: [bs, num_attention_heads, seq_len, head_size]
         if self.max_seq_len_cached is None or seq_len > self.max_seq_len_cached:
             self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
@@ -239,6 +240,7 @@ class DeepseekV3YarnRotaryEmbedding(DeepseekV3RotaryEmbedding):
         beta_slow=1,
         mscale=1,
         mscale_all_dim=0,
+        meta_style=False,
     ):
         self.scaling_factor = scaling_factor
         self.original_max_position_embeddings = original_max_position_embeddings
@@ -246,6 +248,7 @@ class DeepseekV3YarnRotaryEmbedding(DeepseekV3RotaryEmbedding):
         self.beta_slow = beta_slow
         self.mscale = mscale
         self.mscale_all_dim = mscale_all_dim
+        self.meta_style = meta_style
         super().__init__(dim, max_position_embeddings, base, device)
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -277,21 +280,30 @@ class DeepseekV3YarnRotaryEmbedding(DeepseekV3RotaryEmbedding):
             / yarn_get_mscale(self.scaling_factor, self.mscale_all_dim)
         )
 
-        emb = torch.cat((freqs, freqs), dim=-1)
+        if self.meta_style:
+            emb = torch.stack((freqs, freqs), dim=-1).flatten(-2)
+        else:
+            emb = torch.cat((freqs, freqs), dim=-1)
+
         self.register_buffer("cos_cached", (emb.cos() * _mscale).to(dtype), persistent=False)
         self.register_buffer("sin_cached", (emb.sin() * _mscale).to(dtype), persistent=False)
 
 
 # Copied from transformers.models.llama.modeling_llama.rotate_half
-def rotate_half(x):
+def rotate_half(x, meta_style=False):
     """Rotates half the hidden dims of the input."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
+    if meta_style:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+        return torch.stack((-x2, x1), dim=-1).flatten(-2)
+    else:
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat((-x2, x1), dim=-1)
 
 
 # Copied from transformers.models.llama.modeling_llama.apply_rotary_pos_emb
-def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1, meta_style=False):
     """Applies Rotary Position Embedding to the query and key tensors.
 
     Args:
@@ -315,14 +327,15 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
     cos = cos[position_ids].unsqueeze(unsqueeze_dim)
     sin = sin[position_ids].unsqueeze(unsqueeze_dim)
 
-    b, h, s, d = q.shape
-    q = q.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    if not meta_style:
+        b, h, s, d = q.shape
+        q = q.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
 
-    b, h, s, d = k.shape
-    k = k.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+        b, h, s, d = k.shape
+        k = k.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
 
-    q_embed = (q * cos) + (rotate_half(q) * sin)
-    k_embed = (k * cos) + (rotate_half(k) * sin)
+    q_embed = (q * cos) + (rotate_half(q, meta_style) * sin)
+    k_embed = (k * cos) + (rotate_half(k, meta_style) * sin)
     return q_embed, k_embed
 
 
@@ -612,6 +625,13 @@ class DeepseekV3Attention(nn.Module):
                 mscale = yarn_get_mscale(scaling_factor, mscale_all_dim)
                 self.softmax_scale = self.softmax_scale * mscale * mscale
 
+    def init_weights_with_random(self):
+        for name, param in self.named_parameters():
+            if param.requires_grad:
+                print(f"Initializing {name} with torch.randn")
+                with torch.no_grad():
+                    param.copy_(torch.randn_like(param) * 0.1)
+
     def _init_rope(self):
         if self.config.rope_scaling is None:
             self.rotary_emb = DeepseekV3RotaryEmbedding(
@@ -737,6 +757,107 @@ class DeepseekV3Attention(nn.Module):
         attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
         attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
         attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.v_head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.v_head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+
+        attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.v_head_dim)
+
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+    def forward_mla(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            )
+        bsz, q_len, _ = hidden_states.size()
+
+        if self.q_lora_rank is None:
+            q = self.q_proj(hidden_states)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
+        q = q.view(bsz, q_len, self.num_heads, self.q_head_dim).transpose(1, 2)
+        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        # KV b1 projection
+        kv_b1_proj = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)[:, : self.qk_nope_head_dim]
+        q_nope = torch.matmul(q_nope, kv_b1_proj)
+
+        compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
+        compressed_kv, k_pe = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        k_pe = k_pe.view(bsz, 1, q_len, self.qk_rope_head_dim)
+        k_nope = self.kv_a_layernorm(compressed_kv).view(bsz, 1, q_len, self.kv_lora_rank)
+
+        kv_seq_len = k_nope.shape[-2]
+        if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
+                    "with a layer index."
+                )
+            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+        cos, sin = self.rotary_emb(k_nope, seq_len=kv_seq_len, meta_style=True)
+
+        q_pe, k_pe = apply_rotary_pos_emb(q_pe, k_pe, cos, sin, position_ids, meta_style=True)
+
+        query_states = k_pe.new_empty(bsz, self.num_heads, q_len, self.kv_lora_rank + self.qk_rope_head_dim)
+        query_states[:, :, :, : self.kv_lora_rank] = q_nope
+        query_states[:, :, :, self.kv_lora_rank :] = q_pe
+
+        key_states = k_pe.new_empty(bsz, 1, q_len, self.kv_lora_rank + self.qk_rope_head_dim)
+        key_states[:, :, :, : self.kv_lora_rank] = k_nope
+        key_states[:, :, :, self.kv_lora_rank :] = k_pe
+        if past_key_value is not None:
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, _ = past_key_value.update(key_states, key_states, self.layer_idx, cache_kwargs)
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.softmax_scale
+
+        if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
+                f" {attn_weights.size()}"
+            )
+        assert attention_mask is not None
+        if attention_mask is not None:
+            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                )
+            attn_weights = attn_weights + attention_mask
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
+
+        # KV and shared, so V is just a slice of K
+        value_states = key_states[:, :, :, : self.kv_lora_rank]
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        # KV b2 projection
+        kv_b2_proj = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)[:, -self.v_head_dim :].transpose(
+            1, 2
+        )
+        attn_output = torch.matmul(attn_output, kv_b2_proj)
 
         if attn_output.size() != (bsz, self.num_heads, q_len, self.v_head_dim):
             raise ValueError(

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -8,15 +8,18 @@ import pytest
 import torch
 from loguru import logger
 
-import ttnn
-
 # Import from local reference files instead of HuggingFace
-from models.demos.deepseek_v3.reference.deepseek.model import MLA, ModelArgs, precompute_freqs_cis
+from transformers import DynamicCache
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention
 from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from models.demos.deepseek_v3.tt.mla_1d import MLA1D
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.utility_functions import comp_pcc
+
+MAX_START_POS = 512
 
 
 @pytest.fixture
@@ -30,35 +33,97 @@ def hf_config_short(hf_config):
 @pytest.fixture
 def reference(hf_config_short, reset_seeds):
     """Get the actual DeepSeek MLA model using local implementation."""
-    hf_config = hf_config_short
 
-    model_args_dict = {
-        "vocab_size": hf_config.vocab_size,
-        "dim": hf_config.hidden_size,
-        "inter_dim": hf_config.intermediate_size,
-        "n_layers": hf_config.num_hidden_layers,
-        "n_heads": hf_config.num_attention_heads,
-        "q_lora_rank": hf_config.q_lora_rank,
-        "kv_lora_rank": hf_config.kv_lora_rank,
-        "qk_nope_head_dim": hf_config.qk_nope_head_dim,
-        "qk_rope_head_dim": hf_config.qk_rope_head_dim,
-        "v_head_dim": hf_config.v_head_dim,
-        "max_batch_size": MLA1D.MAX_BATCH_SIZE,
-        "original_seq_len": hf_config.rope_scaling["original_max_position_embeddings"],
-        "rope_theta": hf_config.rope_theta,
-        "rope_factor": hf_config.rope_scaling["factor"],
-        "beta_fast": hf_config.rope_scaling["beta_fast"],
-        "beta_slow": hf_config.rope_scaling["beta_slow"],
-        "mscale": hf_config.rope_scaling["mscale"],
-    }
+    model = DeepseekV3Attention(hf_config_short, layer_idx=0)
+    model.init_weights_with_random()  # Initialize weights with random values
+    return model
 
-    model_args = ModelArgs(**model_args_dict)
-    model_args.max_seq_len = hf_config.max_seq_len
 
-    model = MLA(model_args)
-    model.init_weights_with_random()
+def reference_forward(
+    reference_model: DeepseekV3Attention,
+    torch_input: torch.Tensor,
+    position_ids: torch.LongTensor,
+    mode: str,
+) -> torch.Tensor:
+    """Run the reference model forward pass.
 
-    return model_args, model
+    This function specifically uses MLA with the "absorption" implementation,
+    called with `forward_mla`, which is simply an extension on top of HF's DeepSeek implementation.
+
+    Notes for Decode Mode:
+        NOTE: This function currently does not support multi-iteration decoding.
+
+        It is critical to note that since the HF implementation uses DynamicCache, we cannot just
+        perform decode on users with arbitrry position_ids. Instead, if we want to simulate this situation,
+        we need to pad the input to the largest position id in the batch, and then use it for the forward pass.
+
+        This has the same effect as doing prefill. As such, on the output side, we must also
+        slice the output to only return the last token for each user.
+
+        The reference cache is also sliced in a similar manner to only return the last token's cache.
+
+    Notes on position_ids_expanded:
+        The HF implementation uses position_ids_expanded, which is a tensor of shape [bsz, q_len].
+
+
+    Args:
+        reference_model (DeepseekV3Attention): The reference model to run.
+        torch_input (torch.Tensor): The input tensor to the model.
+        position_ids (torch.LongTensor): The position ids for the input.
+        mode (str): The mode of operation, either "decode" or "prefill".
+    Returns:
+        torch.Tensor: The output tensor from the model.
+    """
+
+    config = reference_model.config
+    bsz, q_len, dim = torch_input.shape
+    torch_input = torch_input.to(dtype=torch.float32)
+
+    assert bsz == position_ids.shape[0], "Batch size of input and position_ids must match"
+
+    # Generate the cache
+    cache = DynamicCache()
+
+    if mode == "prefill":
+        # Create the mask
+        mask = torch.triu(torch.full((bsz, 1, q_len, q_len), float("-inf")), diagonal=1)
+    else:
+        assert q_len == 1, "Decode mode should have sequence length of 1"
+
+        # Perform special padding for decode mode
+        max_position_idx = position_ids.max().item()
+        new_torch_input = torch.zeros(bsz, max_position_idx + 1, dim)
+        for b in range(bsz):
+            pos = position_ids[b].item()
+            new_torch_input[b, pos] = torch_input[b, 0]
+        torch_input = new_torch_input
+        q_len = torch_input.shape[1]  # Update q_len to the new sequence length
+
+        # Create the mask
+        mask = torch.full((bsz, 1, q_len, q_len), float("-inf"))
+        for i in range(bsz):
+            usable_len = position_ids[i].item() + 1
+            mask[i, 0, :usable_len, :usable_len] = torch.triu(
+                torch.full((usable_len, usable_len), float("-inf")), diagonal=1
+            )
+
+    position_ids_expanded = torch.arange(0, q_len, dtype=torch.long).unsqueeze(0).repeat(bsz, 1)
+
+    out, _, past_key_value = reference_model.forward_mla(
+        hidden_states=torch_input,
+        attention_mask=mask,
+        position_ids=position_ids_expanded,
+        past_key_value=cache,
+    )
+    cache = past_key_value.key_cache[reference_model.layer_idx].squeeze(1)
+
+    if mode == "decode":
+        # Get last token
+        batch_indices = torch.arange(bsz)
+        out = out[batch_indices, position_ids, :].unsqueeze(1)  # [bsz, 1, hidden_size]
+        cache = cache[batch_indices, position_ids, :].unsqueeze(1)  # [bsz, 1, head_dim + rope_head_dim]
+
+    return out, cache
 
 
 def get_cache_on_host(tt_cache, mesh_device):
@@ -115,7 +180,7 @@ def test_forward_pass(
         MLA1D.get_valid_paged_config(hf_config.max_seq_len, batch_size, dp_factor) if mode == "decode" else None
     )
 
-    reference_args, reference_model = reference
+    reference_model = reference
 
     if mode == "prefill":
         assert batch_size == 1, "Prefill mode only supports batch size of 1"
@@ -143,31 +208,22 @@ def test_forward_pass(
     ############################
     ### Torch inputs
     ############################
-    start_pos = randint(0, hf_config.max_seq_len // 2) if mode == "decode" else 0
-
-    freqs_cis = precompute_freqs_cis(reference_args)
-    if mode == "prefill":
-        freqs_cis = freqs_cis[:seq_len, :]
-    else:
-        freqs_cis = freqs_cis[start_pos, :]
 
     torch_input = torch.randn(batch_size, seq_len, hf_config.hidden_size).to(dtype=torch.bfloat16)
-
-    # Generate the mask
-    mask = None
     if mode == "prefill":
-        # For prefill, we need to create a causal mask
-        mask = torch.triu(torch.full((seq_len, seq_len), float("-inf")), diagonal=1)
+        position_idxs = torch.tensor([seq_len for _ in range(batch_size)])
+    else:
+        position_idxs = torch.tensor([randint(0, MAX_START_POS) for _ in range(batch_size)])
 
     ############################
     ### Torch reference
     ############################
     # TODO: Save reference output?
-    reference_output = reference_model(
+    reference_output, reference_cache = reference_forward(
+        reference_model,
         torch_input,
-        start_pos=start_pos,
-        freqs_cis=freqs_cis,
-        mask=mask,
+        position_ids=position_idxs,
+        mode=mode,
     )
 
     ############################
@@ -188,9 +244,6 @@ def test_forward_pass(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
     )
-    position_idxs = (
-        [start_pos] * batch_size if mode == "decode" else None
-    )  # TODO: Only support same position for all users
     tt_page_table, page_table = None, None
 
     if mode == "decode":
@@ -275,7 +328,6 @@ def test_forward_pass(
         logger.info("Checking KVPE cache PCC")
 
         pcc_required_kvpe = 0.999
-        range_to_check = range(start_pos, start_pos + seq_len)
 
         if mode == "decode":
             tt_cache = get_cache_on_host(
@@ -288,11 +340,19 @@ def test_forward_pass(
             tt_cache = get_cache_on_host(run_config["kvpe_cache"], mesh_row)[: MLA1D.MAX_BATCH_SIZE, ...].squeeze(
                 1
             )  # [bsz, max_seq_len, head_dim + rope_head_dim]
-        tt_cache_kv = tt_cache[:, range_to_check, : hf_config.kv_lora_rank]
-        tt_cache_pe = tt_cache[:, range_to_check, hf_config.kv_lora_rank :]
 
-        ref_cache_kv = reference_model.kv_cache[:, range_to_check, :]  # [bsz, _, head_dim]
-        ref_cache_pe = reference_model.pe_cache[:, range_to_check, :]  # [bsz, _, rope_head_dim]
+        # Slice the correct region of the cache
+        if mode == "decode":
+            batch_indices = torch.arange(batch_size)
+            tt_cache = tt_cache[batch_indices, position_idxs, :].unsqueeze(1)  # [bsz, 1, head_dim + rope_head_dim]
+        else:
+            tt_cache = tt_cache[:batch_size, :seq_len, :]
+
+        tt_cache_kv = tt_cache[..., : hf_config.kv_lora_rank]
+        tt_cache_pe = tt_cache[..., hf_config.kv_lora_rank :]
+
+        ref_cache_kv = reference_cache[..., : hf_config.kv_lora_rank]  # [bsz, _, head_dim]
+        ref_cache_pe = reference_cache[..., hf_config.kv_lora_rank :]  # [bsz, _, rope_head_dim]
 
         kv_passing, kv_pcc_message = comp_pcc(ref_cache_kv, tt_cache_kv, pcc_required_kvpe)
         pe_passing, pe_pcc_message = comp_pcc(ref_cache_pe, tt_cache_pe, pcc_required_kvpe)

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -77,12 +77,14 @@ class MLA1D(AbstractModule):
             "kv_a_proj_with_mqa": "wkv_a",
             "kv_b_proj": "wkv_b",
             "o_proj": "wo",
+            "q_a_layernorm": "q_norm",
+            "kv_a_layernorm": "kv_norm",
         }
 
         # wq_a
         hf_name = "q_a_proj"
         our_name = hf_ttnn_name_mapping[hf_name]
-        torch_weight = state_dict[f"{our_name}.weight"]
+        torch_weight = state_dict[f"{hf_name}.weight"]
         torch_weight = torch.transpose(torch_weight, -2, -1)
 
         wq_a_weight_config = MLA1D.convert_weight(
@@ -104,7 +106,7 @@ class MLA1D(AbstractModule):
         # wq_b
         hf_name = "q_b_proj"
         our_name = hf_ttnn_name_mapping[hf_name]
-        torch_weight = state_dict[f"{our_name}.weight"]
+        torch_weight = state_dict[f"{hf_name}.weight"]
         torch_weight = torch.transpose(torch_weight, -2, -1)
 
         wq_b_weight_config = MLA1D.convert_weight(
@@ -126,7 +128,7 @@ class MLA1D(AbstractModule):
         # wkv_a
         hf_name = "kv_a_proj_with_mqa"
         our_name = hf_ttnn_name_mapping[hf_name]
-        torch_weight = state_dict[f"{our_name}.weight"]
+        torch_weight = state_dict[f"{hf_name}.weight"]
         torch_weight = torch.transpose(torch_weight, -2, -1)
 
         wkv_a_weight_config = MLA1D.convert_weight(
@@ -148,7 +150,7 @@ class MLA1D(AbstractModule):
         # wkv_b1
         hf_name = "kv_b_proj"
         our_name = hf_ttnn_name_mapping[hf_name]
-        torch_weight = state_dict[f"{our_name}.weight"]
+        torch_weight = state_dict[f"{hf_name}.weight"]
 
         # This weight needs to be split
         torch_weight = torch_weight.view(kv_lora_rank, num_heads * (qk_nope_head_dim + v_head_dim))
@@ -194,7 +196,7 @@ class MLA1D(AbstractModule):
         # wo
         hf_name = "o_proj"
         our_name = hf_ttnn_name_mapping[hf_name]
-        torch_weight = state_dict[f"{our_name}.weight"]
+        torch_weight = state_dict[f"{hf_name}.weight"]
         torch_weight = torch.transpose(torch_weight, -2, -1)
 
         wo_weight_config = MLA1D.convert_weight(
@@ -214,8 +216,9 @@ class MLA1D(AbstractModule):
         )
 
         # Norm weights
-        our_name = "q_norm"
-        q_norm_state_dict = {"weight": state_dict[f"{our_name}.weight"]}
+        hf_name = "q_a_layernorm"
+        our_name = hf_ttnn_name_mapping[hf_name]
+        q_norm_state_dict = {"weight": state_dict[f"{hf_name}.weight"]}
         q_norm_weight_config = RMSNorm.convert_weights(
             hf_config,
             q_norm_state_dict,
@@ -223,8 +226,9 @@ class MLA1D(AbstractModule):
             mesh_device,
         )
 
-        our_name = "kv_norm"
-        kv_norm_state_dict = {"weight": state_dict[f"{our_name}.weight"]}
+        hf_name = "kv_a_layernorm"
+        our_name = hf_ttnn_name_mapping[hf_name]
+        kv_norm_state_dict = {"weight": state_dict[f"{hf_name}.weight"]}
         kv_norm_weight_config = RMSNorm.convert_weights(
             hf_config,
             kv_norm_state_dict,


### PR DESCRIPTION
### Ticket
- #23022 

### Problem description
The MLA module currently uses the DeepSeek reference implementation, because the TTNN implementation uses "absorption", but the HF implementation does not. However, as we continue bring-up, having a separate reference module for MLA will make it challenging to do testing.

### What's changed
- Removed all testing dependency on DeepSeek's `model.py`
- Added a new `forward_mla` to `DeepseekV3Attention` to perform MLA using "absorption", forked from the initial HF implementation
    - Because the TTNN RoPE is a Meta-style implementation, there is a new flag `meta_style` in the HF RoPE module that can perform RoPE in Meta-Style
    - ⚠️ **Note** ⚠️ If loading weights from HF, we should NOT permute the projection matrices since RoPE is now Meta-style
- Added a `reference_forward` in `test_mla_1d.py` that handles the prefill/decode inference through the HF reference

### Checklist
- [x] [TG DeepSeek](https://github.com/tenstorrent/tt-metal/actions/runs/16608796641) (MLA passes, MLP fails but I assume this is unrelated as it was not changed)