### PR TITLE
#25975: Migrate clone, copy, fill, fold OPs to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp
@@ -12,12 +12,10 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto src0_args = TensorAccessorArgs<2>();
 
-    const auto s0 = get_interleaved_addr_gen<src0_is_dram, src_stick_size_is_pow2>(
-        src_addr, stick_size, src_log_base_2_of_page_size);
+    const auto s0 = TensorAccessor(src0_args, src_addr, page_size);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
@@ -12,13 +12,10 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto dst0_args = TensorAccessorArgs<2>();
 
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
-
-    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_stick_size_is_pow2>(
-        dst_addr, stick_size, dst_log_base_2_of_page_size);
+    const auto s0 = TensorAccessor(dst0_args, dst_addr, page_size);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
@@ -10,13 +10,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGenFast<input_is_dram> s = {
-        .bank_base_address = input_buffer_address,
-        .page_size = get_tile_size(src_cb_id),
-        .data_format = get_dataformat(src_cb_id),
-    };
+    const auto s = TensorAccessor(src_args, input_buffer_address, get_tile_size(src_cb_id));
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
@@ -11,13 +11,10 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(1);
+    constexpr auto input_args = TensorAccessorArgs<2>();
 
-    constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
-
-    const auto s = get_interleaved_addr_gen<input_is_dram, src_stick_size_is_power_of_two>(
-        input_buffer_address, stick_size, src_log_base_2_of_page_size);
+    const auto s = TensorAccessor(input_args, input_buffer_address, input_page_size);
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
@@ -10,13 +10,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGenFast<output_is_dram> s = {
-        .bank_base_address = output_buffer_address,
-        .page_size = get_tile_size(dst_cb_id),
-        .data_format = get_dataformat(dst_cb_id),
-    };
+    const auto s = TensorAccessor(dst_args, output_buffer_address, get_tile_size(dst_cb_id));
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm.cpp
@@ -11,13 +11,10 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(1);
+    constexpr auto output_args = TensorAccessorArgs<2>();
 
-    constexpr bool dst_stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
-
-    const auto s = get_interleaved_addr_gen<output_is_dram, dst_stick_size_is_power_of_two>(
-        output_buffer_address, stick_size, dst_log_base_2_of_page_size);
+    const auto s = TensorAccessor(output_args, output_buffer_address, output_page_size);
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/constants.hpp>
 #include <algorithm>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 
 using namespace tt::constants;
@@ -80,29 +81,19 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        reader_compile_time_args = {(uint32_t)src_is_dram};
         writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
     } else {
-        bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_unit_size);
-        uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (std::uint32_t)log2(input_unit_size) : 0;
-        reader_compile_time_args = {
-            (std::uint32_t)src0_cb_index,
-            (std::uint32_t)src_is_dram,
-            (std::uint32_t)src_stick_size_is_power_of_two,
-            (std::uint32_t)src_log2_stick_size};
-        bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(output_unit_size);
-        uint32_t dst_log2_stick_size = dst_stick_size_is_power_of_two ? (std::uint32_t)log2(output_unit_size) : 0;
-        writer_compile_time_args = {
-            (std::uint32_t)output_cb_index,
-            (std::uint32_t)dst_is_dram,
-            (std::uint32_t)dst_stick_size_is_power_of_two,
-            (std::uint32_t)dst_log2_stick_size};
+        reader_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)input_unit_size};
+        writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)output_unit_size};
     }
     std::map<std::string, std::string> kernel_defines;
     if (sharded) {
         kernel_defines["SHARDED"] = "1";
         shard_builder::extend_sharding_compile_time_args(input, writer_compile_time_args);
         shard_builder::extend_sharding_compile_time_args(input, reader_compile_time_args);
+    } else {
+        TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
     }
     if (backwards) {
         kernel_defines["BACKWARDS"] = "1";

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -81,7 +81,7 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+        writer_compile_time_args = {(std::uint32_t)output_cb_index};
     } else {
         reader_compile_time_args = {(std::uint32_t)src0_cb_index, (std::uint32_t)input_unit_size};
         writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)output_unit_size};

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -15,18 +15,16 @@ void kernel_main() {
     uint32_t num_shards = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
 
     typedef ShardedInfo<
+        get_compile_time_arg_val(2),
+        get_compile_time_arg_val(3),
         get_compile_time_arg_val(4),
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
-        get_compile_time_arg_val(8),
-        get_compile_time_arg_val(9),
-        get_compile_time_arg_val(10)>
+        get_compile_time_arg_val(8)>
         tensor_shard_info;
 
     const auto [mapping_table, rt_increment] =

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -15,19 +15,16 @@ void kernel_main() {
     uint32_t num_shards = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
 
     typedef ShardedInfo<
+        get_compile_time_arg_val(2),
+        get_compile_time_arg_val(3),
         get_compile_time_arg_val(4),
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
-        get_compile_time_arg_val(8),
-        get_compile_time_arg_val(9),
-        get_compile_time_arg_val(10)>
+        get_compile_time_arg_val(8)>
         tensor_shard_info;
 
     const auto [mapping_table, rt_increment] =

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 
 #include "fill_pad_program_factory.hpp"
@@ -95,6 +96,8 @@ tt::tt_metal::operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& 
     if (sharded) {
         shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_time_args);
         compute_defines["SHARDED"] = "1";
+    } else {
+        tt::tt_metal::TensorAccessorArgs(*tens_buffer).append_to(writer_compile_time_args);
     }
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -44,12 +44,8 @@ void kernel_main() {
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(rt_arg_ind));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 #else
-    const DataFormat data_format = get_dataformat(cb_id_0);
-    const InterleavedAddrGenFast<tensor_in_dram> s0 = {
-        .bank_base_address = dst_addr,
-        .page_size = tile_hw * element_size_bytes,
-        .data_format = data_format  // page_size needs to be tile_size_bytes
-    };
+    constexpr auto dst_args = TensorAccessorArgs<12>();
+    const auto s0 = TensorAccessor(dst_args, dst_addr, tile_hw * element_size_bytes);
 #endif
 
     // Reserve and push the fill value into the circular buffer

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
@@ -48,8 +49,8 @@ operation::ProgramWithCallbacks fill_rm_single_core(
             .set_page_size(1, single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)dst_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*dst_buffer).append_to(reader_compile_time_args);
 
     tt::tt_metal::KernelHandle binary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp
@@ -22,8 +22,8 @@ void kernel_main() {
     uint32_t val_hi = get_arg_val<uint32_t>(6);
     uint32_t val_lo = get_arg_val<uint32_t>(7);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = W << 1};
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(dst_args, dst_addr, W << 1);
 
     // DPRINT << "fill_rm_8bank: NC=" << NC << " H=" << H << " W=" << W << " fillH=" << fillH << " fillW=" << fillW <<
     // ENDL();

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
@@ -10,6 +10,8 @@
 #include "fold_device_op.hpp"
 #include "ttnn/operations/math.hpp"
 
+#include <tt-metalium/tensor_accessor_args.hpp>
+
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
@@ -62,14 +64,8 @@ Fold::SingleCore::cached_program_t fold_single_core(
     std::shared_ptr<tt::tt_metal::Buffer> scratch_buffer = CreateBuffer(l1_config);
 
     // Setup kernels
-    uint32_t src_unit_size_is_power_of_two = is_power_of_two_at_least_32(aligned_pixel_size);
-    uint32_t src_log2_unit_size = src_unit_size_is_power_of_two ? (std::uint32_t)std::log2(aligned_pixel_size) : 0;
-    std::vector<uint32_t> reader_compile_time_args = {
-        cb_src0_index,
-        src_is_dram,
-        src_unit_size_is_power_of_two,
-        src_log2_unit_size,
-    };
+    std::vector<uint32_t> reader_compile_time_args = {cb_src0_index, aligned_pixel_size};
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     uint32_t dst_unit_size_is_power_of_two = is_power_of_two_at_least_32(aligned_dst_pixel_size);
     uint32_t dst_log2_unit_size = dst_unit_size_is_power_of_two ? (std::uint32_t)std::log2(aligned_dst_pixel_size) : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
@@ -67,15 +67,8 @@ Fold::SingleCore::cached_program_t fold_single_core(
     std::vector<uint32_t> reader_compile_time_args = {cb_src0_index, aligned_pixel_size};
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    uint32_t dst_unit_size_is_power_of_two = is_power_of_two_at_least_32(aligned_dst_pixel_size);
-    uint32_t dst_log2_unit_size = dst_unit_size_is_power_of_two ? (std::uint32_t)std::log2(aligned_dst_pixel_size) : 0;
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        cb_dst0_index,
-        dst_is_dram,
-        dst_unit_size_is_power_of_two,
-        dst_log2_unit_size,
-    };
+    std::vector<uint32_t> writer_compile_time_args = {cb_dst0_index, aligned_dst_pixel_size};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -9,17 +9,15 @@
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
-    constexpr bool src_stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t src_log2_stick_size = get_compile_time_arg_val(3);
-    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(4);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(5);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
-    constexpr uint32_t input_width = get_compile_time_arg_val(7);
-    constexpr uint32_t work_per_core = get_compile_time_arg_val(8);
+    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(2);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(3);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(4);
+    constexpr uint32_t input_width = get_compile_time_arg_val(5);
+    constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
+    constexpr auto src_args = TensorAccessorArgs<7>();
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const auto s_in =
-        get_interleaved_addr_gen<true, src_stick_size_is_power_of_two>(src_addr, stick_nbytes, src_log2_stick_size);
+    const auto s_in = TensorAccessor(src_args, src_addr, stick_nbytes);
 
     uint32_t src_index = get_arg_val<uint32_t>(1);
     uint32_t curr_src_row_index = get_arg_val<uint32_t>(2);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -16,11 +16,10 @@ void kernel_main() {
     uint32_t num_blocks = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
     // Initialize interleaved address generator for DRAM access
-    const InterleavedAddrGenFast<true> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto src_args = TensorAccessorArgs<2>();
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     // Process each block of data
     uint32_t end_block_id = start_block_id + num_blocks;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -9,17 +9,15 @@
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
-    constexpr bool dst_stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t dst_log2_stick_size = get_compile_time_arg_val(3);
-    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(4);
-    constexpr uint32_t stride_h = get_compile_time_arg_val(5);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(6);
-    constexpr uint32_t input_width = get_compile_time_arg_val(7);
-    constexpr uint32_t work_per_core = get_compile_time_arg_val(8);
+    constexpr uint32_t aligned_stick_nbytes_dram = get_compile_time_arg_val(2);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(3);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(4);
+    constexpr uint32_t input_width = get_compile_time_arg_val(5);
+    constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
+    constexpr auto dst_args = TensorAccessorArgs<7>();
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const auto s_out =
-        get_interleaved_addr_gen<true, dst_stick_size_is_power_of_two>(dst_addr, stick_nbytes, dst_log2_stick_size);
+    const auto s_out = TensorAccessor(dst_args, dst_addr, stick_nbytes);
     uint32_t dst_index = get_arg_val<uint32_t>(1);
     constexpr uint32_t patch_size = stride_h * stride_w;
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -17,6 +17,7 @@ void kernel_main() {
     constexpr uint32_t ntiles_per_row = get_compile_time_arg_val(6);  // Number of tiles per row
     constexpr uint32_t element_size = get_compile_time_arg_val(7);    // Size of each element in bytes
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(8);       // Input compute buffer ID
+    constexpr auto dst_args = TensorAccessorArgs<9>();
 
     // Runtime arguments
     uint32_t dst_addr = get_arg_val<uint32_t>(0);          // Destination address in DRAM
@@ -30,7 +31,7 @@ void kernel_main() {
     // dump(stick_nbytes);
 
     // Initialize DRAM address generator
-    const InterleavedAddrGen<true> d = {.bank_base_address = dst_addr, .page_size = stick_nbytes};
+    const auto d = TensorAccessor(dst_args, dst_addr, stick_nbytes);
 
     // Pre-calculate output dimensions and patch size - moved outside loops
     const uint32_t OH = input_height / stride_height;                   // Output height

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_unary_stick_layout_concatenate_rows_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_unary_stick_layout_concatenate_rows_interleaved.cpp
@@ -25,13 +25,9 @@ void kernel_main() {
     const uint32_t cb_pages_per_dst_row = get_arg_val<uint32_t>(11);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-
-    constexpr bool stick_size_is_power_of_two = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(3);
-
-    const auto s = get_interleaved_addr_gen<dst_is_dram, stick_size_is_power_of_two>(
-        dst_addr, dst_page_size, log_base_2_of_page_size);
+    constexpr uint32_t aligned_page_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+    const auto s = TensorAccessor(dst_args, dst_addr, aligned_page_size);
 
     auto dst_noc_addr = NOC_XY_ADDR(NOC_X(my_x[0]), NOC_Y(my_y[0]), scratch_addr);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::tt_metal;
 
@@ -76,11 +77,8 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)cb_index,
-        (std::uint32_t)out_is_dram,
-        (std::uint32_t)stick_size_is_power_of_two,
-        (std::uint32_t)log2_stick_size};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)cb_index, (std::uint32_t)page_size};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include <tracy/Tracy.hpp>
 
@@ -523,11 +524,8 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     // Tilized writer
     KernelHandle writer_kernel_id = 0;
     if (!output_sharded) {
-        std::vector<uint32_t> writer_compile_time_args = {
-            (std::uint32_t)out_cb_index,
-            (std::uint32_t)out_is_dram,
-            (std::uint32_t)output_stick_size_is_power_of_two,
-            (std::uint32_t)output_log2_stick_size};
+        std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)out_cb_index, (std::uint32_t)output_page_size};
+        TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
         writer_kernel_id = tt_metal::CreateKernel(
             program,
@@ -742,11 +740,8 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_tilized_indices(
     bool output_stick_size_is_power_of_two = is_power_of_two_at_least_32(output_page_size);
     uint32_t output_log2_stick_size =
         output_stick_size_is_power_of_two ? (std::uint32_t)std::log2(output_page_size) : 0;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)out_is_dram,
-        (std::uint32_t)output_stick_size_is_power_of_two,
-        (std::uint32_t)output_log2_stick_size};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)output_page_size};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
     // Tilized writer
     auto writer_kernel_id = tt_metal::CreateKernel(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs

### What's changed
Updated all clone, copy, fill, fold kernels to use TensorAccessor
Updated corresponding program factories to pass different compile time arguments

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16609066990)
- [x] [Nightly tt-metal L2 CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16618918288)
- [x] New/Existing tests provide coverage for changes