### PR TITLE
switch modules to use mesh device rather mesh row

### DIFF
--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -170,10 +170,10 @@ def test_forward_pass(
     reference,
     hf_config_short,
     tmp_path,
-    mesh_row,
+    mesh_device,
 ):
     hf_config = hf_config_short
-    mesh_shape = list(mesh_row.shape)
+    mesh_shape = list(mesh_device.shape)
 
     dp_factor = mesh_shape[1] if mode == "decode" else 1
     paged_config = (
@@ -190,17 +190,17 @@ def test_forward_pass(
     ############################
     # Setup: Convert weights and get weight_config
     logger.info(f"Converting weights for MLA1D to {tmp_path}")
-    weight_config = MLA1D.convert_weights(hf_config, reference_model.state_dict(), tmp_path, mesh_row)
+    weight_config = MLA1D.convert_weights(hf_config, reference_model.state_dict(), tmp_path, mesh_device)
 
     # Generate appropriate configs
-    ccl = CCL1D(hf_config, mesh_row)
+    ccl = CCL1D(hf_config, mesh_device)
     if mode == "prefill":
-        model_config = MLA1D.prefill_model_config(hf_config, mesh_row, ccl)
+        model_config = MLA1D.prefill_model_config(hf_config, mesh_device, ccl)
     else:
-        model_config = MLA1D.decode_model_config(hf_config, mesh_row, ccl)
+        model_config = MLA1D.decode_model_config(hf_config, mesh_device, ccl)
 
     # Create a new model state
-    model_state = MLA1D.create_state(hf_config, mesh_row, dp_factor, paged_config)
+    model_state = MLA1D.create_state(hf_config, mesh_device, dp_factor, paged_config)
 
     # Create RunConfig using both weight_config and model_config
     run_config = create_run_config(model_config, weight_config, model_state)
@@ -238,8 +238,8 @@ def test_forward_pass(
     # TODO: Need to handle padding for batch
     tt_input = ttnn.from_torch(
         torch_input,
-        device=mesh_row,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_row, dims=(None, -1), mesh_shape=mesh_shape),
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, -1), mesh_shape=mesh_shape),
         dtype=ttnn.bfloat16,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
@@ -249,9 +249,9 @@ def test_forward_pass(
     if mode == "decode":
         position_idxs_tensor = ttnn.from_torch(
             torch.tensor(position_idxs),
-            device=mesh_row,
+            device=mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_row, dims=(None, 0), mesh_shape=mesh_shape
+                mesh_device, dims=(None, 0), mesh_shape=mesh_shape
             ),  # TODO: Shard on batch when DP
             dtype=ttnn.int32,
         )
@@ -260,17 +260,17 @@ def test_forward_pass(
             batch_size,
             dp_factor=dp_factor,
             config=paged_config,
-            mesh_device=mesh_row,
+            mesh_device=mesh_device,
         )
 
     # RoPE stuff
     rope_setup = RotarySetup(
-        device=mesh_row,
+        device=mesh_device,
         batch_size=batch_size,
         hf_config=hf_config,
     )
     rope_setup_dp = RotarySetup(
-        device=mesh_row,
+        device=mesh_device,
         batch_size=batch_size,
         hf_config=hf_config,
         use_dp=True,
@@ -304,7 +304,7 @@ def test_forward_pass(
         tt_output = MLA1D.forward_decode(tt_input, run_config, position_idxs_tensor, rope_tensors, tt_page_table)
 
     tt_output_torch = ttnn.to_torch(
-        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(0, -1), mesh_shape=mesh_shape)
+        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_shape)
     )[:1, ...]
 
     if mode == "decode":
@@ -331,13 +331,13 @@ def test_forward_pass(
 
         if mode == "decode":
             tt_cache = get_cache_on_host(
-                run_config["kvpe_cache"], mesh_row
+                run_config["kvpe_cache"], mesh_device
             )  # [DP Factor * max_num_blocks, nh, block_size, head_dim + rope_head_dim]
             tt_cache = MLA1D.from_paged_cache(tt_cache, page_table, dp_factor).squeeze(
                 1
             )  # [bsz, max_seq_len, head_dim + rope_head_dim]
         else:
-            tt_cache = get_cache_on_host(run_config["kvpe_cache"], mesh_row)[: MLA1D.MAX_BATCH_SIZE, ...].squeeze(
+            tt_cache = get_cache_on_host(run_config["kvpe_cache"], mesh_device)[: MLA1D.MAX_BATCH_SIZE, ...].squeeze(
                 1
             )  # [bsz, max_seq_len, head_dim + rope_head_dim]
 

--- a/models/demos/deepseek_v3/tt/mlp/mlp_1d.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp_1d.py
@@ -193,10 +193,12 @@ class MLP1D(AbstractModule):
                 input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
             ),
             "reduce_scatter": ReduceScatterConfig(
+                mesh_device=mesh_device,
                 dim=-1,  # We are scattering across the feature dimension (last one)
                 math_op=ttnn.ReduceType.Sum,
                 topology=ttnn.Topology.Linear,  # One row of Galaxy does not form a ring
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cluster_axis=1,
             ),
             "input_memory_config": ttnn.DRAM_MEMORY_CONFIG,  # RMSNorm must provide this shard spec as its output
             "output_memory_config": ttnn.DRAM_MEMORY_CONFIG,

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -45,7 +45,7 @@ class DistributedRMSNorm(RMSNormBase):
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-1, -2), mesh_shape=tuple(mesh_device.shape)),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, -2), mesh_shape=tuple(mesh_device.shape)),
         )
 
         # Save to disk with standard naming - "rmsnorm" must match the op name used in the model config

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm_base.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm_base.py
@@ -23,7 +23,7 @@ class RMSNormBase(AbstractModule):
         Returns:
             True if the device is supported, False otherwise.
         """
-        return tuple(mesh_device.shape)[0] == 1
+        return tuple(mesh_device.shape)[1] == 8
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
PR for switching `mesh_row` to `mesh_device` for decoder integration. Majorly, MLP module required some fixes for this switch, other modules were just plain name change.

Additionally, it introduces a new `tensor_parallel_factor` parameter to improve the handling of tensor parallelism in the MLP configuration which was hardcoded for [1,8] mesh

### Refactoring for clarity and consistency:
* Replaced `mesh_row` with `mesh_device` across multiple test files (`test_mla_1d.py`, `test_mlp_1d.py`, and `test_rms_norm.py`) to standardize terminology and improve readability. [[1]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL108-R111) [[2]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL128-R138) [[3]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL185-R186) [[4]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL199-R201) [[5]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL210-R220) [[6]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL254-R254) [[7]](diffhunk://#diff-3987c92bc2040df1646e2edef71fb963962be75b38db1719b630b9afe9f0102bL282-R288) [[8]](diffhunk://#diff-38424138557631c221766adb0ae04b16ba8884bcc818b9a85bb8f59a6d857ed0L118-R118) [[9]](diffhunk://#diff-38424138557631c221766adb0ae04b16ba8884bcc818b9a85bb8f59a6d857ed0L135-R144) [[10]](diffhunk://#diff-38424138557631c221766adb0ae04b16ba8884bcc818b9a85bb8f59a6d857ed0L163-R163) [[11]](diffhunk://#diff-0b500d8957554e3a56b23e5a088f11dd7145e46fca75ecd1461bac506b6267f3L53-R53) [[12]](diffhunk://#diff-0b500d8957554e3a56b23e5a088f11dd7145e46fca75ecd1461bac506b6267f3L76-R78) [[13]](diffhunk://#diff-0b500d8957554e3a56b23e5a088f11dd7145e46fca75ecd1461bac506b6267f3L88-R90) [[14]](diffhunk://#diff-0b500d8957554e3a56b23e5a088f11dd7145e46fca75ecd1461bac506b6267f3L101-R105) [[15]](diffhunk://#diff-0b500d8957554e3a56b23e5a088f11dd7145e46fca75ecd1461bac506b6267f3L119-R119)

### Enhancements to tensor parallelism:
* Introduced `tensor_parallel_factor` in the `MLPProgramConfigData` class to replace `num_devices`, ensuring a more explicit and flexible approach to defining tensor parallelism. [[1]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L53-R58) [[2]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L115-R122) [[3]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L136-R151) [[4]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L168-L170) [[5]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L185-R186)
* Updated methods like `convert_weights`, `decode_model_config`, and related configurations to use `tensor_parallel_factor` instead of calculating based on `num_devices`. This change simplifies the logic and aligns with the new parameter. [[1]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L229-R242) [[2]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L248-R258) [[3]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L263-R271) [[4]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L272-R280) [[5]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0L283-R295) [[6]](diffhunk://#diff-53407a98d6c553c1e350067ae98d091be33b1db5df2d92703187af5dad0e5be0R304-R309)

These changes improve code clarity, maintainability, and alignment with the requirements for tensor parallelism in distributed systems.### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes