### PR TITLE
ci: fix condition for marking llk uplift PRs ready

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -476,7 +476,7 @@ jobs:
           PR_NUMBER="${{ inputs.recheck_tests == true && needs.recheck-tests.outputs.pr-number || needs.update-submodule.outputs.pr-number }}"
 
           # Mark as ready if needed
-          if [ "${{ inputs.draft == 'true' || github.event_name == 'repository_dispatch' }}" = "true" ]; then
+          if [ "${{ inputs.draft }}" = "true" ] || [ "${{ github.event_name }}" = "repository_dispatch" ]; then
             echo "Marking PR as ready for review"
             if gh pr ready "$PR_NUMBER" --repo "${{ github.repository }}" 2>/dev/null; then
               echo "ℹ️ PR converted to ready-for-review"

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -478,7 +478,7 @@ jobs:
           # Mark as ready if needed
           if [ "${{ inputs.draft == 'true' || github.event_name == 'repository_dispatch' }}" = "true" ]; then
             echo "Marking PR as ready for review"
-            if gh pr ready "$PR_NUMBER" --repo "$ {{ github.repository }}" 2>/dev/null; then
+            if gh pr ready "$PR_NUMBER" --repo "${{ github.repository }}" 2>/dev/null; then
               echo "ℹ️ PR converted to ready-for-review"
             else
               echo "⚠️ PR already ready or failed to convert (check permissions)"

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -476,8 +476,14 @@ jobs:
           PR_NUMBER="${{ inputs.recheck_tests == true && needs.recheck-tests.outputs.pr-number || needs.update-submodule.outputs.pr-number }}"
 
           # Mark as ready if needed
-          [ "${{ inputs.draft }}" == "true" ] && gh pr ready "$PR_NUMBER" --repo "${{ github.repository }}" 2>/dev/null || true
-
+          if [ "${{ inputs.draft == 'true' || github.event_name == 'repository_dispatch' }}" = "true" ]; then
+            echo "Marking PR as ready for review"
+            if gh pr ready "$PR_NUMBER" --repo "$ {{ github.repository }}" 2>/dev/null; then
+              echo "ℹ️ PR converted to ready-for-review"
+            else
+              echo "⚠️ PR already ready or failed to convert (check permissions)"
+            fi
+          fi
           # Build test status for PR body update
           TEST_STATUS="### 🧪 Test Status"$'\n'
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Another issue we discovered during the latest uplift. After all the checks have passed, we failed to mark PR as ready for review, since we were relying on inputs.draft that isn’t set when running a workflow using repository dispatch. See [here](https://github.com/tenstorrent/tt-metal/pull/25985#issuecomment-3134582415).

### What's changed
Improved logic for marking uplift PRs as ready.