### PR TITLE
Fix Int32 comparison on WH

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -6,12 +6,27 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "ckernel_sfpu_int_sum.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+// These constants and function should ideally go to SFPI
+// Copied from ckernel_sfpu_int_sum.h to avoid dependency complications
+#define BIT_MASK_32 0xFFFFFFFF
+#define SIGN 0x80000000
+#define MAGNITUDE 0x7FFFFFFF
+
+// Convert from sign-magnitude to two's complement format
+sfpi_inline vInt sfpu_sign_mag_to_twos_comp(vInt value) {
+    v_if(value & SIGN) {
+        vInt magnitude = value & MAGNITUDE;
+        value = (~magnitude + 1) & BIT_MASK_32;
+    }
+    v_endif;
+    return value;
+}
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp(uint exponent_size_8) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -6,14 +6,12 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "ckernel_sfpu_int_sum.h"  // For existing conversion functions
+#include "ckernel_sfpu_int_sum.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
-
-// Use existing sfpu_sign_mag_to_twos_comp() from ckernel_sfpu_int_sum.h
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp(uint exponent_size_8) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -6,11 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_int_sum.h"  // For existing conversion functions
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+// Use existing sfpu_sign_mag_to_twos_comp() from ckernel_sfpu_int_sum.h
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp(uint exponent_size_8) {
@@ -121,46 +124,34 @@ inline void calculate_comp_int() {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_unary_int(int scalar) {
+    // Convert both operands to two's complement format
+    //
+    // LOGIC:
+    // - Scalar is already in two's complement (from host)
+    // - Convert SFPU input data from sign-magnitude to two's complement
+    // - Perform comparison with both in two's complement format
+
+    // Scalar stays in original two's complement format
+    vInt converted_scalar = scalar;
+
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
         vInt val = 0;
-        vInt s = scalar;
 
-        // a[i] != scalar
+        // Convert input data from sign-magnitude to two's complement
+        v = sfpu_sign_mag_to_twos_comp(v);
+
+        // Now both operands are in two's complement format
+        // Use simple comparison like Blackhole
         if constexpr (COMP_MODE == SfpuType::unary_ne) {
-            v_if(v >= 0) {
-                v_if(v != scalar) { val = 1; }
-                v_endif;
-            }  // negative comparison not working as expected in WH hence alternate implementation
-            v_else {
-                v_if(s < 0) {
-                    vInt xor_val = reinterpret<vInt>(sfpi::abs(reinterpret<vFloat>(v))) ^ -s;
-                    v_if(xor_val != 0) { val = 1; }
-                    v_endif;
-                }
-                v_else { val = 1; }
-                v_endif;
-            }
+            v_if(v != converted_scalar) { val = 1; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_eq) {
+            v_if(v == converted_scalar) { val = 1; }
             v_endif;
         }
-        // a[i] == scalar
-        else if constexpr (COMP_MODE == SfpuType::unary_eq) {
-            v_if(v >= 0) {
-                v_if(v == scalar) { val = 1; }
-                v_endif;
-            }
-            v_else {
-                v_if(s < 0) {
-                    vInt xor_val = reinterpret<vInt>(sfpi::abs(reinterpret<vFloat>(v))) ^ -s;
-                    v_if(xor_val == 0) { val = 1; }
-                    v_endif;
-                }
-                v_else { val = 0; }
-                v_endif;
-            }
-            v_endif;
-        }
+
         dst_reg[0] = val;
         dst_reg++;
     }


### PR DESCRIPTION
### Ticket
#21946 

### Problem description
When running the comparison test with _use_legacy_ parameter set to True, comparison operators were not working properly for negative numbers on WH. 

### What's changed
In order to simplify the current fix that was on the main branch, conversion from sign-magnitude format to two's complement was added prior to comparison, forcing operands to be in the same format. 

The test and the table with the results can be found [here](https://github.com/tenstorrent/tt-metal/issues/21946#issuecomment-3133389961).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16618794001)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16618823970)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) [Same](https://github.com/tenstorrent/tt-metal/actions/runs/16618807391/job/47025238752) as [main](https://github.com/tenstorrent/tt-metal/actions/runs/16619525897)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes