### PR TITLE
#26001: Support tile dest offset in pack untilize dest

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -250,7 +250,8 @@ inline void llk_pack_untilize(
     std::uint32_t output,
     const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t num_faces = 4,
-    const std::uint32_t block_c_index = 0) {
+    const std::uint32_t block_c_index = 0,
+    const std::uint32_t tile_dst_offset = 0) {
     static_assert(diagonal == false && "Diagonal packing is not supported for BH!");
     const std::uint32_t output_id = get_output_id(output);
     std::uint32_t pack_tile_addr =
@@ -262,7 +263,11 @@ inline void llk_pack_untilize(
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
-            pack_tile_addr, pack_dst_format[output_id], face_r_dim, num_faces, block_rt * block_ct_dim);
+            pack_tile_addr,
+            pack_dst_format[output_id],
+            face_r_dim,
+            num_faces,
+            block_rt * block_ct_dim + tile_dst_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -251,7 +251,8 @@ inline void llk_pack_untilize(
     std::uint32_t output,
     const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t num_faces = 4,
-    const std::uint32_t block_c_index = 0) {
+    const std::uint32_t block_c_index = 0,
+    const std::uint32_t tile_dst_offset = 0) {
     const std::uint32_t output_id = get_output_id(output);
     std::uint32_t pack_tile_addr =
         get_local_cb_interface(output_id).fifo_wr_ptr - 1 +
@@ -262,7 +263,11 @@ inline void llk_pack_untilize(
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
-            pack_tile_addr, pack_dst_format[output_id], face_r_dim, num_faces, block_rt * block_ct_dim);
+            pack_tile_addr,
+            pack_dst_format[output_id],
+            face_r_dim,
+            num_faces,
+            block_rt * block_ct_dim + tile_dst_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -183,6 +183,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
  * | Function   | block_c_index  | Block column index (used when full_ct_dim > block_ct_dim)     | uint32_t  | >= 0            | False (default=0) |
  * | Function   | face_r_dim     | Face height in rows                                           | uint32_t  | 1, 8 or 16      | False (default=16) |
  * | Function   | num_faces      | Number of faces                                               | uint32_t  | 1, 2 or 4       | False (default=4) |
+ * | Function   | tile_dst_offset | Index of the tile in the dest from which to pack             | uint32_t  | 0 to 7 (0 to 3 if fp32 dest is enabled) | False (default=0) |
  */
 // clang-format on
 template <
@@ -196,9 +197,10 @@ ALWI void pack_untilize_dest(
     uint32_t block_rt_dim = 1,
     uint32_t block_c_index = 0 /* used when full_ct_dim > block_ct_dim*/,
     uint32_t face_r_dim = 16,
-    uint32_t num_faces = 4) {
+    uint32_t num_faces = 4,
+    uint32_t tile_dst_offset = 0) {
     PACK((llk_pack_untilize<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
-        block_rt_dim, ocb, face_r_dim, num_faces, block_c_index)));
+        block_rt_dim, ocb, face_r_dim, num_faces, block_c_index, tile_dst_offset)));
 }
 
 // clang-format off


### PR DESCRIPTION
### Ticket
#26001 

### Problem description
In the `void pack_untilize_dest` function of the compute kernel API, it is not possible to pass the tile dest offset, and packing is always done from the first tile. However, the LLK supports this functionality.

### What's changed
Simply push the parameter through the LLK.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16619103013) ✅
- [x] [Blackhole all post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16643688631) ✅ (failing test is red on the last few runs on main, not related to this change)