### PR TITLE
#24695: Migrate hardtanh as a device op

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -771,7 +771,7 @@ class TestEltwiseUnary:
             test_args,
         )
 
-    @pytest.mark.parametrize("clip_kind", ["clip", "hardtanh"])
+    @pytest.mark.parametrize("clip_kind", ["clip"])
     @pytest.mark.parametrize("clip_range", ({"low": -2.0, "high": 2.0}, {"low": -5.5, "high": 27.5}))
     def test_run_eltwise_clip_ops(
         self,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -192,25 +192,6 @@ def test_unary_composite_digamma_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_hardtanh_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-
-    output_tensor = ttnn.hardtanh(input_tensor1)
-    golden_function = ttnn.get_golden_function(ttnn.hardtanh)
-    golden_tensor = golden_function(in_data1)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 def test_unary_composite_lgamma_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 0.1, 100, device)
 

--- a/tests/ttnn/unit_tests/operations/test_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/test_hardtanh.py
@@ -50,13 +50,13 @@ def test_hardtanh_args(device, shapes, min, max):
     torch_input_tensor_a = torch.randn(shapes[0], dtype=torch.bfloat16) * 10
 
     golden_fn = ttnn.get_golden_function(ttnn.hardtanh)
-    torch_output_tensor = golden_fn(torch_input_tensor_a, min, max)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, min_val=min, max_val=max)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
 
-    output_tensor = ttnn.hardtanh(input_tensor_a, min, max)
+    output_tensor = ttnn.hardtanh(input_tensor_a, min_val=min, max_val=max)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -1,47 +1,26 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_hardtanh(uint param0, uint param1, uint param2) {
-    // All params are in FP16_B format
-    // param0 = -(neg_threshold)
-    // param1 = -(pos_threshold - neg_threshold)
-    // param2 = -(pos_threshold)
-
-    vFloat p0 = s2vFloat16(param0);
-    vFloat p1 = s2vFloat16(param1);
-    vFloat p2 = s2vFloat16(param2);
-// SFPU microcode
-#pragma GCC unroll 0
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+// Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
+inline void calculate_hardtanh(uint param0, uint param1) {
+    sfpi::vFloat min_val = Converter::as_float(param0);
+    sfpi::vFloat max_val = Converter::as_float(param1);
+    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-
-        val += p0;  // 12 bits
-        v_if(val < 0.0f) { val = 0.0f; }
+        sfpi::vFloat val = sfpi::dst_reg[0];
+        v_if(val < min_val) { sfpi::dst_reg[0] = min_val; }
+        v_elseif(val > max_val) { sfpi::dst_reg[0] = max_val; }
         v_endif;
-
-        val += p1;  // 12 bits
-        v_if(val >= 0.0f) { val = 0.0f; }
-        v_endif;
-
-        val += p2;  // 12 bits
-
-        dst_reg[0] = val;
-
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,6 @@
 #include "ckernel_sfpu_hardtanh.h"
 
 namespace ckernel {
-
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
@@ -17,11 +16,11 @@ inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
-    uint dst_index, uint param0, uint param1, uint param2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_hardtanh<APPROXIMATE>, dst_index, vector_mode, param0, param1, param2);
+        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -1,48 +1,26 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_hardtanh(uint param0, uint param1, uint param2) {
-    // All params are in FP16_B format
-    // param0 = -(neg_threshold)
-    // param1 = -(pos_threshold - neg_threshold)
-    // param2 = -(pos_threshold)
-
-    vFloat p0 = s2vFloat16(param0);
-    vFloat p1 = s2vFloat16(param1);
-    vFloat p2 = s2vFloat16(param2);
-// SFPU microcode
-#pragma GCC unroll 0
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+// Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
+inline void calculate_hardtanh(uint param0, uint param1) {
+    sfpi::vFloat min_val = Converter::as_float(param0);
+    sfpi::vFloat max_val = Converter::as_float(param1);
+    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-
-        val += p0;  // 12 bits
-        v_if(val < 0.0f) { val = 0.0f; }
+        sfpi::vFloat val = sfpi::dst_reg[0];
+        v_if(val < min_val) { sfpi::dst_reg[0] = min_val; }
+        v_elseif(val > max_val) { sfpi::dst_reg[0] = max_val; }
         v_endif;
-
-        val += p1;  // 12 bits
-        v_if(val >= 0.0f) { val = 0.0f; }
-        v_endif;
-
-        val += p2;  // 12 bits
-
-        dst_reg[0] = val;
-
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -9,7 +9,6 @@
 #include "ckernel_sfpu_hardtanh.h"
 
 namespace ckernel {
-
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
@@ -17,11 +16,11 @@ inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
-    uint dst_index, uint param0, uint param1, uint param2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_hardtanh<APPROXIMATE>, dst_index, vector_mode, param0, param1, param2);
+        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/hardtanh.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/hardtanh.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_hardtanh.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+ /**
+ * Performs element-wise hardtanh operation. The DST
+ * register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
+ * compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The minimum value of the linear region range                               | uint32_t |                                                       | True     |
+ * | param1          | The maximum value of the linear region range                               | uint32_t |                                                       | True     |
+
+ */
+// clang-format on
+ALWI void hardtanh_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_hardtanh<APPROX>(idst, param0, param1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void hardtanh_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardtanh_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -144,6 +144,10 @@
 #include "compute_kernel_api/eltwise_unary/where.h"
 #endif
 
+#if SFPU_OP_HARDTANH_INCLUDE
+#include "compute_kernel_api/eltwise_unary/hardtanh.h"
+#endif
+
 #if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "compute_kernel_api.h"
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -104,6 +104,7 @@ enum class UnaryOpType {
     MINIMUM,
     TANHSHRINK,
     HARDSHRINK,
+    HARDTANH,
     HARDSIGMOID,
     HARDSWISH,
     WHERE_TSS,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -83,6 +83,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::SOFTSIGN:
         case UnaryOpType::HARDSIGMOID:
         case UnaryOpType::CELU: return "SFPU_OP_ACTIVATIONS_INCLUDE";
+        case UnaryOpType::HARDTANH: return "SFPU_OP_HARDTANH_INCLUDE";
         default: return "SFPU_OP_COMPUTE_KERNEL_API_INCLUDE";
     };
 }
@@ -380,6 +381,17 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 where_call = fmt::format("where_tile({}, {}, {});", idst, 1, 2);
             }
             op_init_and_name = std::make_pair("where_tile_init();", where_call);
+            break;
+        }
+        case UnaryOpType::HARDTANH: {
+            float param1 = params[1];
+            op_init_and_name = {
+                "hardtanh_tile_init();",
+                fmt::format(
+                    "hardtanh_tile({}, {:#x}u, {:#x}u);",
+                    idst,
+                    std::bit_cast<uint32_t>(param0),
+                    std::bit_cast<uint32_t>(param1))};
             break;
         }
         default: TT_THROW("unexpected parameterized op type {}", op_type);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -79,7 +79,8 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::LOG1P:
         case UnaryOpType::HARDSHRINK:
         case UnaryOpType::WHERE_TSS:
-        case UnaryOpType::CELU: return true;
+        case UnaryOpType::CELU:
+        case UnaryOpType::HARDTANH: return true;
         default: return false;
     }
     return false;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -361,16 +361,6 @@ Tensor ExecuteUnaryCompositeClamp::invoke(
         output_memory_config);
 }
 
-// hardtanh
-Tensor _hardtanh(
-    const Tensor& a,
-    float low /* = -1.0f */,
-    float high /* = +1.0f */,
-    const std::optional<MemoryConfig>& output_mem_config) {
-    auto output_memory_config = output_mem_config.value_or(a.memory_config());
-    return ExecuteUnaryCompositeClamp::invoke(a, low, high, output_memory_config);
-}
-
 // Theano defines this differently...
 /**
  *

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -23,7 +23,6 @@ enum class UnaryCompositeOpType {
     VAR_HW,
     STD_HW,
     NORMALIZE_HW,
-    HARDTANH,
     SELU,
     GLU,
     REGLU,
@@ -54,8 +53,6 @@ Tensor _std(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _std(const Tensor&, const Tensor&, Tensor&, const std::optional<MemoryConfig>&);
 Tensor _std_overload(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _normalize(const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _hardtanh(
-    const Tensor&, float min = -1, float max = 1, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _selu(
     const Tensor&,
     float scale = 1.0507,
@@ -142,13 +139,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::NORMALIZE_HW> {
     static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg) {
         return _normalize(t1, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::HARDTANH> {
-    static Tensor handle(const Tensor& t1, float low, float high, const std::optional<MemoryConfig>& mem_cfg) {
-        return _hardtanh(t1, low, high, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -382,6 +382,22 @@ Tensor Hardshrink::invoke(
         optional_output_tensor);
 }
 
+Tensor Hardtanh::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float min_val,
+    const float max_val,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::HARDTANH;
+    return detail::unary_impl(
+        queue_id,
+        input_tensor,
+        {UnaryWithParam{op_type, std::vector<float>{static_cast<float>(min_val), static_cast<float>(max_val)}}},
+        memory_config,
+        optional_output_tensor);
+}
+
 Tensor Deg2Rad::invoke(
     QueueId queue_id,
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -263,6 +263,16 @@ struct Hardshrink {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Hardtanh {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        float min_val = -1.0f,
+        float max_val = 1.0f,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct Deg2Rad {
     static Tensor invoke(
         QueueId queue_id,
@@ -415,6 +425,7 @@ constexpr auto eqz = ttnn::register_operation<"ttnn::eqz", ttnn::operations::una
 constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::unary::Mish>();
 constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto hardshrink = ttnn::register_operation<"ttnn::hardshrink", ttnn::operations::unary::Hardshrink>();
+constexpr auto hardtanh = ttnn::register_operation<"ttnn::hardtanh", ttnn::operations::unary::Hardtanh>();
 constexpr auto deg2rad = ttnn::register_operation<"ttnn::deg2rad", ttnn::operations::unary::Deg2Rad>();
 constexpr auto rad2deg = ttnn::register_operation<"ttnn::rad2deg", ttnn::operations::unary::Rad2Deg>();
 constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -184,9 +184,6 @@ constexpr auto std_hw = ttnn::register_operation<
 constexpr auto normalize_hw = ttnn::register_operation<
     "ttnn::normalize_hw",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_HW>>();
-constexpr auto hardtanh = ttnn::register_operation<
-    "ttnn::hardtanh",
-    operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::HARDTANH>>();
 constexpr auto clip = ttnn::register_operation<"ttnn::clip", operations::unary::ExecuteUnaryCompositeClip>();
 constexpr auto clamp = ttnn::register_operation<"ttnn::clamp", operations::unary::ExecuteUnaryCompositeClamp>();
 constexpr auto selu = ttnn::register_operation<

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1380,85 +1380,7 @@ void bind_unary_composite_floats_with_default(
             py::arg("memory_config") = std::nullopt});
 }
 
-template <typename unary_operation_t>
-void bind_hardtanh(
-    py::module& module,
-    const unary_operation_t& operation,
-    const std::string& parameter_name_a,
-    const std::string& parameter_a_doc,
-    float parameter_a_value,
-    const std::string& parameter_name_b,
-    const std::string& parameter_b_doc,
-    float parameter_b_value,
-    const std::string& supported_dtype = "BFLOAT16, BFLOAT8_B",
-    const std::string& info_doc = "") {
-    auto doc = fmt::format(
-        R"doc(
-        Performs {0} function on :attr:`input_tensor`, :attr:`{2}`, :attr:`{5}`.
-
-        Args:
-            input_tensor (ttnn.Tensor): the input tensor.
-            {2} (float): {3}. Defaults to `{4}`.
-            {5} (float): {6}. Defaults to `{7}`.
-
-        Keyword args:
-            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-
-        Returns:
-            ttnn.Tensor: the output tensor.
-
-        Note:
-            Supported dtypes, layouts, and ranks:
-
-            .. list-table::
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-                 - Ranks
-               * - {8}
-                 - TILE
-                 - 2, 3, 4
-
-            {9}
-
-        Example:
-            >>> tensor = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-            >>> min = 2
-            >>> max = 8
-            >>> output = {1}(tensor, min, max)
-        )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        parameter_name_a,
-        parameter_a_doc,
-        parameter_a_value,
-        parameter_name_b,
-        parameter_b_doc,
-        parameter_b_value,
-        supported_dtype,
-        info_doc);
-
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const ttnn::Tensor& input_tensor,
-               float parameter_a,
-               float parameter_b,
-               const std::optional<MemoryConfig>& memory_config) {
-                return self(input_tensor, parameter_a, parameter_b, memory_config);
-            },
-            py::arg("input_tensor"),
-            py::arg(parameter_name_a.c_str()) = parameter_a_value,
-            py::arg(parameter_name_b.c_str()) = parameter_b_value,
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt});
-}
-
-// OpHandler_two_float_with_default
+// OpHandler_one_int
 template <typename unary_operation_t>
 void bind_unary_composite_int(
     py::module& module,
@@ -1520,7 +1442,7 @@ void bind_unary_composite_int(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_two_float_with_default
+// OpHandler_threshold
 template <typename unary_operation_t>
 void bind_unary_composite_threshold(
     py::module& module,
@@ -2258,8 +2180,6 @@ void py_module(py::module& module) {
         "",
         R"doc(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16))doc");
 
-    bind_hardtanh(module, ttnn::hardtanh, "min_val", "min value", -1.0f, "max_val", "max value", 1.0f);
-
     bind_unary_composite_optional_floats_with_default(
         module,
         ttnn::clip,
@@ -2282,6 +2202,16 @@ void py_module(py::module& module) {
         R"doc(Performs clamp function on :attr:`input_tensor`, :attr:`min`, :attr:`max`. Only one of 'min' or 'max' value can be None.)doc");
     bind_unary_composite_floats_with_default(
         module, ttnn::selu, "scale", "Scale value", 1.0507, "alpha", "Alpha value", 1.67326);
+    bind_unary_composite_floats_with_default(
+        module,
+        ttnn::hardtanh,
+        "min_val",
+        "min value",
+        -1.0f,
+        "max_val",
+        "max value",
+        1.0f,
+        R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
     bind_unary_composite_threshold(
         module,
         ttnn::threshold,

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -249,7 +249,7 @@ def _golden_function_elu(input_tensor_a, *args, alpha=1.0, **kwargs):
 ttnn.attach_golden_function(ttnn.elu, golden_function=_golden_function_elu)
 
 
-def _golden_function_hardtanh(input_tensor_a, min_val=-1.0, max_val=1.0, *args, **kwargs):
+def _golden_function_hardtanh(input_tensor_a, *args, min_val=-1.0, max_val=1.0, **kwargs):
     import torch
 
     return torch.nn.functional.hardtanh(input_tensor_a, min_val, max_val)


### PR DESCRIPTION
### Ticket
Link to Github Issue #24695 

### Problem description
Hardtanh implemented as a composite op.

### What's changed
Implemented hardtanh as a llk op.

Performance results:
Shape used : [1, 1, 8192, 8192]
In main:
<img width="353" height="112" alt="Screenshot 2025-07-30 at 5 46 19 PM" src="https://github.com/user-attachments/assets/ce232f60-6aba-4b0e-8cee-536997e1c20a" />
Updated version:
<img width="356" height="60" alt="Screenshot 2025-07-30 at 5 45 37 PM" src="https://github.com/user-attachments/assets/bd30408e-b853-453b-9c62-8fc7731d9c8e" />


So it is ~49% faster compared to previous approach.

For a single tile,
In main : 3667ns
Updated version : 2053ns  => ~44% faster

### Checklist
- [ ] All post commit
- [ ] Blackhole Post commit