### PR TITLE
SDXL Conv2d tweak float32 acc settings

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -99,5 +99,5 @@ def test_crossattnmid(
     del unet, tt_crosattn
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.989)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.988)
     logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -49,7 +49,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 245_115_735
+    expected_device_perf_cycles_per_iteration = 239_878_868
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -58,21 +58,10 @@ def prepare_linear_params(device, weights, bias, dtype):
 
 
 def prepare_conv_params(
-    device,
     weights,
     bias,
     dtype,
-    fp32_dest_acc_en=False,
-    math_fidelity=ttnn.MathFidelity.HiFi2,
-    packer_l1_acc=False,
 ):
-    compute_config = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=math_fidelity,
-        fp32_dest_acc_en=fp32_dest_acc_en,
-        packer_l1_acc=packer_l1_acc,
-    )
-
     dtype = ttnn.float32 if dtype == ttnn.bfloat8_b else dtype
     tt_weights = ttnn.from_torch(weights, dtype)
     tt_bias = ttnn.from_torch(bias, dtype) if bias is not None else None
@@ -83,26 +72,16 @@ def prepare_conv_params(
         "kernel_size": (tt_weights.shape[2], tt_weights.shape[3]),
     }
 
-    return compute_config, tt_weights, tt_bias, conv_params
+    return tt_weights, tt_bias, conv_params
 
 
 def prepare_split_conv_params(
-    device,
     weights,
     bias,
     dtype,
     split_in,
     split_out,
-    fp32_dest_acc_en=False,
-    math_fidelity=ttnn.MathFidelity.HiFi2,
 ):
-    compute_config = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=math_fidelity,
-        fp32_dest_acc_en=fp32_dest_acc_en,
-        packer_l1_acc=False,
-    )
-
     dtype = ttnn.float32 if dtype == ttnn.bfloat8_b else dtype  # TODO: figure out why PCC drops when dtype is used
 
     Cout, Cin, _, _ = weights.shape
@@ -155,7 +134,7 @@ def prepare_split_conv_params(
         ]
         for tt_w_out in tt_weights
     ]
-    return compute_config, tt_weights, tt_bias, conv_params
+    return tt_weights, tt_bias, conv_params
 
 
 def split_conv2d(

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
@@ -23,13 +23,11 @@ class TtDownsample2D(nn.Module):
 
         self.conv_output_dtype = model_config.get_conv_output_dtype()
         self.conv_config = model_config.get_conv_config(conv_path=module_path)
-        self.compute_config, self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
-            device,
+        self.compute_config = model_config.get_conv_compute_config(module_path=module_path)
+        self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
             weights,
             bias,
             self.conv_config.weights_dtype,
-            fp32_dest_acc_en=(self.conv_config.weights_dtype == ttnn.bfloat8_b)
-            and (self.conv_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
         )
 
     def forward(self, hidden_states, input_shape):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -92,52 +92,41 @@ class TtResnetBlock2D(nn.Module):
 
         self.conv_output_dtype = model_config.get_conv_output_dtype()
         self.conv1_config = model_config.get_conv_config(conv_path=f"{module_path}.conv1")
+        self.compute1_config = model_config.get_conv_compute_config(module_path=f"{module_path}.conv1")
         if self.split_conv:
             (
-                self.compute1_config,
                 self.tt_conv1_weights,
                 self.tt_conv1_bias,
                 self.conv1_params,
             ) = prepare_split_conv_params(
-                device,
                 conv_weights_1,
                 conv_bias_1,
                 self.conv1_config.weights_dtype,
                 split_in,
                 split_out,
-                fp32_dest_acc_en=(self.conv1_config.weights_dtype == ttnn.bfloat8_b)
-                and (self.conv1_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
             )
         else:
             (
-                self.compute1_config,
                 self.tt_conv1_weights,
                 self.tt_conv1_bias,
                 self.conv1_params,
             ) = prepare_conv_params(
-                device,
                 conv_weights_1,
                 conv_bias_1,
                 self.conv1_config.weights_dtype,
-                fp32_dest_acc_en=(self.conv1_config.weights_dtype == ttnn.bfloat8_b)
-                and (self.conv1_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
             )
-
         self.conv2_config = model_config.get_conv_config(conv_path=f"{module_path}.conv2")
+        self.compute2_config = model_config.get_conv_compute_config(module_path=f"{module_path}.conv2")
+
         (
-            self.compute2_config,
             self.tt_conv2_weights,
             self.tt_conv2_bias,
             self.conv2_params,
         ) = prepare_conv_params(
-            device,
             conv_weights_2,
             conv_bias_2,
             self.conv2_config.weights_dtype,
-            fp32_dest_acc_en=(self.conv2_config.weights_dtype == ttnn.bfloat8_b)
-            and (self.conv2_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
         )
-
         if conv_shortcut:
             self.tt_conv3_weights, self.tt_conv3_bias = prepare_linear_params(
                 device, conv_weights_3, conv_bias_3, model_config.conv_w_dtype

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -129,33 +129,27 @@ class TtUNet2DConditionModel(nn.Module):
 
         self.conv_output_dtype = model_config.get_conv_output_dtype()
         self.conv1_config = model_config.get_conv_config(conv_path="conv_in")
+        self.compute1_config = model_config.get_conv_compute_config(module_path="conv_in")
         (
-            self.compute1_config,
             self.tt_conv1_weights,
             self.tt_conv1_bias,
             self.conv1_params,
         ) = prepare_conv_params(
-            device,
             conv_weights_in,
             conv_bias_in,
             self.conv1_config.weights_dtype,
-            fp32_dest_acc_en=(self.conv1_config.weights_dtype == ttnn.bfloat8_b)
-            and (self.conv1_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
         )
 
         self.conv2_config = model_config.get_conv_config(conv_path="conv_out")
+        self.compute2_config = model_config.get_conv_compute_config(module_path="conv_out")
         (
-            self.compute2_config,
             self.tt_conv2_weights,
             self.tt_conv2_bias,
             self.conv2_params,
         ) = prepare_conv_params(
-            device,
             conv_weights_out,
             conv_bias_out,
             self.conv2_config.weights_dtype,
-            fp32_dest_acc_en=(self.conv2_config.weights_dtype == ttnn.bfloat8_b)
-            and (self.conv2_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
         )
 
         self.norm_core_grid = ttnn.CoreGrid(y=8, x=8)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
@@ -36,13 +36,11 @@ class TtUpsample2D(nn.Module):
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         self.conv_config = model_config.get_conv_config(conv_path=module_path)
-        self.compute_config, self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
-            device,
+        self.compute_config = model_config.get_conv_compute_config(module_path=module_path)
+        self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
             weights,
             bias,
             self.conv_config.weights_dtype,
-            fp32_dest_acc_en=(self.conv_config.weights_dtype == ttnn.bfloat8_b)
-            and (self.conv_config.shard_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
         )
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -65,34 +65,28 @@ class TtDecoder(nn.Module):
             self.device, norm_out_weights.shape[0], self.norm_groups, self.norm_core_grid.y
         )
 
+        self.compute_in_config = model_config.get_conv_compute_config(module_path="decoder.conv_in")
         (
-            self.compute_in_config,
             self.tt_conv_in_weights,
             self.tt_conv_in_bias,
             self.conv_in_params,
         ) = prepare_conv_params(
-            device,
             conv_in_weights,
             conv_in_bias,
             model_config.conv_w_dtype,
-            fp32_dest_acc_en=True,
-            math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv_in_slice_config = get_DRAM_conv_config(None, 1)
         self.conv_in_config = model_config.get_conv_config(conv_path="decoder.conv_in")
 
+        self.compute_out_config = model_config.get_conv_compute_config(module_path="decoder.conv_out")
         (
-            self.compute_out_config,
             self.tt_conv_out_weights,
             self.tt_conv_out_bias,
             self.conv_out_params,
         ) = prepare_conv_params(
-            device,
             conv_out_weights,
             conv_out_bias,
             model_config.conv_w_dtype,
-            fp32_dest_acc_en=True,
-            math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv_out_slice_config = get_DRAM_conv_config(None, 2)
         self.conv_out_config = model_config.get_conv_config(conv_path="decoder.conv_out")

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -66,35 +66,29 @@ class TtResnetBlock2D(nn.Module):
             self.device, self.norm_weights_2.shape[0], self.norm_groups, self.norm_core_grid_2.y
         )
 
+        self.compute1_config = model_config.get_conv_compute_config(module_path=f"{module_path}.conv1")
         (
-            self.compute1_config,
             self.tt_conv1_weights,
             self.tt_conv1_bias,
             self.conv1_params,
         ) = prepare_conv_params(
-            device,
             conv_weights_1,
             conv_bias_1,
             model_config.conv_w_dtype,
-            fp32_dest_acc_en=True,
-            math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv1_slice_config = get_DRAM_conv_config(module_path, 1)
         self.conv1_config = model_config.get_conv_config(conv_path=f"{module_path}.conv1")
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
+        self.compute2_config = model_config.get_conv_compute_config(module_path=f"{module_path}.conv2")
         (
-            self.compute2_config,
             self.tt_conv2_weights,
             self.tt_conv2_bias,
             self.conv2_params,
         ) = prepare_conv_params(
-            device,
             conv_weights_2,
             conv_bias_2,
             model_config.conv_w_dtype,
-            fp32_dest_acc_en=True,
-            math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv2_slice_config = get_DRAM_conv_config(module_path, 2)
         self.conv2_config = model_config.get_conv_config(conv_path=f"{module_path}.conv2")

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
@@ -36,13 +36,11 @@ class TtUpsample2D(nn.Module):
         weights = state_dict[f"{module_path}.conv.weight"]
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
-        self.compute_config, self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
-            device,
+        self.compute_config = model_config.get_conv_compute_config(module_path=module_path)
+        self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
             weights,
             bias,
             model_config.conv_w_dtype,
-            fp32_dest_acc_en=True,
-            math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv_slice_config = get_DRAM_conv_config(module_path, 1)
         self.conv_config = model_config.get_conv_config(conv_path=module_path)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3142,15 +3142,15 @@ def test_conv2d_model_fruit(
 
         # UNet
         # kernel 3x3
-        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
+        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
+        (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
         (1, 1280, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
+        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
         (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 640, 1280, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
+        (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
+        (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
+        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
+        (1, 640, 1280, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, False, 1, 1, True, True),
         (1, 640, 640, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
         (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
         (1, 640, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),


### PR DESCRIPTION
In many cases using float32 accumulation leads to
bad choice of output subblock h/w for matmul within conv2d compute kernel, which leads to bad matmul
utilisation.

Disable float32 accumulation for conv2d in cases
where quality allows it, and enable l1 accumulation for these cases to compensate for the loss of precision.

### Checklist
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16627027993)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/16627059265)