### PR TITLE
Fixed failing tests for SBert on T3K

### DIFF
--- a/models/demos/t3000/sentence_bert/README.md
+++ b/models/demos/t3000/sentence_bert/README.md
@@ -33,7 +33,7 @@ Resource link - [source](https://huggingface.co/emrecan/bert-base-turkish-cased-
 Use the following command to run the model :
 
 ```
-pytest --disable-warnings tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_model.py::test_ttnn_sentence_bert_model
+pytest --disable-warnings models/demos/sentence_bert/tests/pcc/test_ttnn_sentencebert_model.py::test_ttnn_sentence_bert_model
 ```
 
 ###  Performant Model with Trace+2CQ

--- a/models/demos/t3000/sentence_bert/demo/dataset_evaluation.py
+++ b/models/demos/t3000/sentence_bert/demo/dataset_evaluation.py
@@ -46,7 +46,14 @@ def load_sts_tr(split="test"):
     [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384, 8, 10)],
 )
 def test_sentence_bert_eval_data_parallel(
-    mesh_device, model_name, sequence_length, device_batch_size, num_samples, start=0, end=7
+    mesh_device,
+    model_name,
+    sequence_length,
+    device_batch_size,
+    num_samples,
+    start=0,
+    end=7,
+    model_location_generator=None,
 ):
     batch_size = device_batch_size * mesh_device.get_num_devices()
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
@@ -92,6 +99,7 @@ def test_sentence_bert_eval_data_parallel(
                 attention_mask=attention_mask,
                 token_type_ids=token_type_ids,
                 position_ids=position_ids,
+                model_location_generator=model_location_generator,
             )
             ttnn_module._capture_sentencebert_trace_2cqs()
         t0 = time.time()

--- a/models/demos/t3000/sentence_bert/demo/dataset_evaluation.py
+++ b/models/demos/t3000/sentence_bert/demo/dataset_evaluation.py
@@ -17,6 +17,7 @@ from scipy.stats import pearsonr, spearmanr
 from tqdm import tqdm
 
 import ttnn
+from models.demos.sentence_bert.common import load_torch_model
 from models.demos.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
 from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerformantRunner
 
@@ -64,7 +65,9 @@ def test_sentence_bert_eval_data_parallel(
     ref_pred_scores = []
     ttnn_pred_scores = []
     reference_module = BertModel(config).to(torch.bfloat16)
-    reference_module.load_state_dict(transformers_model.state_dict())
+    reference_module = load_torch_model(
+        reference_module, target_prefix="", model_location_generator=model_location_generator
+    )
     ttnn_module = None
     inference_times = []
     for i in tqdm(range(num_samples), desc="Evaluating"):

--- a/models/demos/t3000/sentence_bert/demo/demo.py
+++ b/models/demos/t3000/sentence_bert/demo/demo.py
@@ -12,6 +12,7 @@ from loguru import logger
 from sklearn.metrics.pairwise import cosine_similarity
 
 import ttnn
+from models.demos.sentence_bert.common import load_torch_model
 from models.demos.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
 from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerformantRunner
 
@@ -60,7 +61,9 @@ def test_sentence_bert_demo_inference(mesh_device, inputs, model_name, sequence_
     token_type_ids = encoded_input["token_type_ids"]
     position_ids = torch.arange(0, input_ids.shape[-1], dtype=torch.int64).unsqueeze(dim=0)
     reference_module = BertModel(config).to(torch.bfloat16)
-    reference_module.load_state_dict(transformers_model.state_dict())
+    reference_module = load_torch_model(
+        reference_module, target_prefix="", model_location_generator=model_location_generator
+    )
     reference_sentence_embeddings = reference_module(
         input_ids,
         extended_attention_mask=extended_mask,

--- a/models/demos/t3000/sentence_bert/demo/demo.py
+++ b/models/demos/t3000/sentence_bert/demo/demo.py
@@ -42,7 +42,7 @@ from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerf
     indirect=True,
 )
 @pytest.mark.parametrize("model_name, sequence_length", [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384)])
-def test_sentence_bert_demo_inference(mesh_device, inputs, model_name, sequence_length):
+def test_sentence_bert_demo_inference(mesh_device, inputs, model_name, sequence_length, model_location_generator):
     batch_size = len(inputs[0]) * mesh_device.get_num_devices()
     transformers_model = transformers.AutoModel.from_pretrained(model_name).eval()
     config = transformers.BertConfig.from_pretrained(model_name)
@@ -75,6 +75,7 @@ def test_sentence_bert_demo_inference(mesh_device, inputs, model_name, sequence_
         attention_mask=attention_mask,
         token_type_ids=token_type_ids,
         position_ids=position_ids,
+        model_location_generator=model_location_generator,
     )
     ttnn_module._capture_sentencebert_trace_2cqs()
     t0 = time.time()

--- a/models/demos/t3000/sentence_bert/demo/interactive_demo.py
+++ b/models/demos/t3000/sentence_bert/demo/interactive_demo.py
@@ -18,7 +18,7 @@ from models.demos.sentence_bert.reference.sentence_bert import custom_extended_m
 from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerformantRunner
 
 
-def compute_ttnn_embeddings(sentences, model_name, device, batch_size=64):
+def compute_ttnn_embeddings(sentences, model_name, device, batch_size=64, model_location_generator=None):
     logger.info("Loading tokenizer...")
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
     all_embeddings = []
@@ -50,6 +50,7 @@ def compute_ttnn_embeddings(sentences, model_name, device, batch_size=64):
                 attention_mask=attention_mask,
                 token_type_ids=token_type_ids,
                 position_ids=position_ids,
+                model_location_generator=model_location_generator,
             )
             sentence_bert_module._capture_sentencebert_trace_2cqs()
 
@@ -100,13 +101,15 @@ def load_knowledge_base(kb_file="knowledge_base.txt"):
     "model_name, sequence_length, device_batch_size, kb_file",
     [("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", 384, 8, "knowledge_base.txt")],
 )
-def test_interactive_demo_inference(mesh_device, model_name, sequence_length, device_batch_size, kb_file):
+def test_interactive_demo_inference(
+    mesh_device, model_name, sequence_length, device_batch_size, kb_file, model_location_generator
+):
     logger.info(f"Loading knowledge base from {kb_file}...")
     batch_size = device_batch_size * mesh_device.get_num_devices()
     logger.info(f"Batch size: {batch_size}")
     kb_sentences = load_knowledge_base(kb_file)
     kb_embeddings, kb_sentences, model_instance = compute_ttnn_embeddings(
-        kb_sentences, model_name, mesh_device, batch_size
+        kb_sentences, model_name, mesh_device, batch_size, model_location_generator
     )
     # Example query (in Turkish): "Siparişim ne zaman teslim edilir?"
     # English translation: "When will my order be delivered?"

--- a/models/demos/t3000/sentence_bert/tests/test_sentence_bert_e2e_performant.py
+++ b/models/demos/t3000/sentence_bert/tests/test_sentence_bert_e2e_performant.py
@@ -30,7 +30,7 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_e2e_performant_sentencebert_data_parallel(
-    mesh_device, device_batch_size, sequence_length, act_dtype, weight_dtype
+    mesh_device, device_batch_size, sequence_length, act_dtype, weight_dtype, model_location_generator
 ):
     batch_size = device_batch_size * mesh_device.get_num_devices()
     performant_runner = SentenceBERTPerformantRunner(
@@ -39,6 +39,7 @@ def test_e2e_performant_sentencebert_data_parallel(
         sequence_length=sequence_length,
         act_dtype=act_dtype,
         weight_dtype=weight_dtype,
+        model_location_generator=model_location_generator,
     )
     performant_runner._capture_sentencebert_trace_2cqs()
     inference_times = []


### PR DESCRIPTION
### Problem description
The SBert tests for T3K were failing due to recent changes.

### What's changed
Added model_location_generator param in all the tests

Passing CI for SBert on T3K - 
https://github.com/tenstorrent/tt-metal/actions/runs/16631460716