### PR TITLE
Fix Blackhole APC tests related to recent migration to TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -111,14 +111,11 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
 
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
-
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
 
     std::map<std::string, std::string> reader_defines;
+    std::vector<uint32_t> reader_compile_time_args;
     std::map<std::string, std::string> bcast_compute_defines = bcast_op_utils::get_defines(BcastOpDim::HW, bcast_math);
     if (bnc1) {
         reader_defines["BCAST_SCALAR"] = "1";
@@ -126,7 +123,10 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(
     }
     if (src0_sharded) {
         reader_defines["IN0_SHARDED"] = "1";
+    } else {
+        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     }
+    TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
     KernelHandle binary_reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/"


### PR DESCRIPTION
### Ticket

### Problem description
Currently Blackhole APC tests are broken by https://github.com/tenstorrent/tt-metal/pull/25976
The issue is caused by accidentally passing incorrect compile time arguments in some cases

### What's changed
Updated `bcast_op_multi_core_hw.cpp` to pass correct arguments to the reader kernel 

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16633949935)
- [x] [Blackhole Post commit CI with demo tests passes](http://github.com/tenstorrent/tt-metal/actions/runs/16633957431)
- [x] New/Existing tests provide coverage for changes