### PR TITLE
Add dynamic model repository selection for Whisper based on environment variable

### DIFF
--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -494,7 +494,7 @@ def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inp
     ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
         input_path, ttnn_model, device, num_inputs, model_repo
     )
-    if is_ci_env:
+    if is_ci_env and model_repo == "distil-whisper/distil-large-v3":
         if is_blackhole():
             if device.dram_grid_size().x == 7:  # P100 DRAM grid is 7x1
                 expected_perf_metrics = {"prefill_t/s": 7.85, "decode_t/s/u": 87.0}

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -62,9 +62,7 @@ def get_whisper_model_repo():
 
 def load_conditional_generation_ref_model():
     model_repo = get_whisper_model_repo()
-    hf_ref_model = (
-        WhisperForConditionalGeneration.from_pretrained(model_repo).to(torch.bfloat16).eval()
-    )
+    hf_ref_model = WhisperForConditionalGeneration.from_pretrained(model_repo).to(torch.bfloat16).eval()
     processor = AutoProcessor.from_pretrained(model_repo, language="English", task="transcribe")
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_repo)
     config = hf_ref_model.config

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -239,9 +239,7 @@ def run_generate(
             return output
 
 
-def create_functional_whisper_for_conditional_generation_inference_pipeline(
-    ttnn_model, device, model_repo="openai/whisper-large-v3"
-):
+def create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device, model_repo):
     """
     Returns a callable with signature (data, sampling_rate, stream), where data is is a 1D numpy array
     and sampling_rate is an int representing the sampling rate used to acquire data, and stream turns
@@ -249,7 +247,7 @@ def create_functional_whisper_for_conditional_generation_inference_pipeline(
     the callable returns the full decoded output.
 
     Args:
-        ttnn_model: The compiled TTNN model
+        ttnn_model: The TTNN model
         device: The target device
         model_repo: HuggingFace model repository ID. Must be one of the supported models.
     """
@@ -387,9 +385,7 @@ def run_demo_whisper_for_audio_classification_dataset(ttnn_model, device):
     logger.info(predicted_label)
 
 
-def run_demo_whisper_for_conditional_generation_inference(
-    input_path, ttnn_model, device, num_inputs, model_repo="openai/whisper-large-v3"
-):
+def run_demo_whisper_for_conditional_generation_inference(input_path, ttnn_model, device, num_inputs, model_repo):
     torch.manual_seed(0)
 
     # instantiate model inference pipeline
@@ -424,7 +420,7 @@ def run_demo_whisper_for_conditional_generation_inference(
     return avg_ttft, avg_decode_throughput
 
 
-def run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device, model_repo="openai/whisper-large-v3"):
+def run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device, model_repo):
     torch.manual_seed(0)
 
     # instantiate model inference pipeline

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -51,10 +51,10 @@ def pad_input_32(tensor, value):
 
 def load_conditional_generation_ref_model():
     hf_ref_model = (
-        WhisperForConditionalGeneration.from_pretrained("distil-whisper/distil-large-v3").to(torch.bfloat16).eval()
+        WhisperForConditionalGeneration.from_pretrained("openai/whisper-large-v3").to(torch.bfloat16).eval()
     )
-    processor = AutoProcessor.from_pretrained("distil-whisper/distil-large-v3", language="English", task="transcribe")
-    feature_extractor = AutoFeatureExtractor.from_pretrained("distil-whisper/distil-large-v3")
+    processor = AutoProcessor.from_pretrained("openai/whisper-large-v3", language="English", task="transcribe")
+    feature_extractor = AutoFeatureExtractor.from_pretrained("openai/whisper-large-v3")
     config = hf_ref_model.config
     return (
         hf_ref_model,
@@ -79,7 +79,7 @@ def init_conditional_generation_tt_model(hf_ref_model, config, ttnn_model, devic
         device=device,
     )
 
-    # Note: config.max_length is 448 for distil-whisper/distil-large-v3
+    # Note: config.max_length is 448 for openai/whisper-large-v3
     kv_cache = init_kv_cache(config, device, max_batch_size, max_seq_len=max_seq_len)
 
     return parameters, ttnn_linear_weight, kv_cache
@@ -134,7 +134,7 @@ def run_generate(
             ttnn.from_torch(torch.zeros(unpadded_batch_size), device=device, dtype=ttnn.int32) if kv_cache else None
         )
 
-        MAX_GEN_LEN = config.max_length  # 448 for distil-whisper/distil-large-v3
+        MAX_GEN_LEN = config.max_length  # 448 for openai/whisper-large-v3
         print_each_iter = False
         output_ids = []
         total_decode_time = 0

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -49,12 +49,24 @@ def pad_input_32(tensor, value):
     return tensor
 
 
+def get_whisper_model_repo():
+    """Get whisper model repo based on environment variable"""
+    model_type = os.environ.get("WHISPER_MODEL_TYPE", "original")
+    if model_type == "distilled":
+        return "distil-whisper/distil-large-v3"
+    elif model_type == "original":
+        return "openai/whisper-large-v3"
+    else:
+        raise ValueError(f"Unknown WHISPER_MODEL_TYPE: {model_type}. Valid options are 'original' or 'distilled'")
+
+
 def load_conditional_generation_ref_model():
+    model_repo = get_whisper_model_repo()
     hf_ref_model = (
-        WhisperForConditionalGeneration.from_pretrained("openai/whisper-large-v3").to(torch.bfloat16).eval()
+        WhisperForConditionalGeneration.from_pretrained(model_repo).to(torch.bfloat16).eval()
     )
-    processor = AutoProcessor.from_pretrained("openai/whisper-large-v3", language="English", task="transcribe")
-    feature_extractor = AutoFeatureExtractor.from_pretrained("openai/whisper-large-v3")
+    processor = AutoProcessor.from_pretrained(model_repo, language="English", task="transcribe")
+    feature_extractor = AutoFeatureExtractor.from_pretrained(model_repo)
     config = hf_ref_model.config
     return (
         hf_ref_model,
@@ -79,7 +91,7 @@ def init_conditional_generation_tt_model(hf_ref_model, config, ttnn_model, devic
         device=device,
     )
 
-    # Note: config.max_length is 448 for openai/whisper-large-v3
+    # Note: config.max_length is typically 448 for whisper large models
     kv_cache = init_kv_cache(config, device, max_batch_size, max_seq_len=max_seq_len)
 
     return parameters, ttnn_linear_weight, kv_cache
@@ -134,7 +146,7 @@ def run_generate(
             ttnn.from_torch(torch.zeros(unpadded_batch_size), device=device, dtype=ttnn.int32) if kv_cache else None
         )
 
-        MAX_GEN_LEN = config.max_length  # 448 for openai/whisper-large-v3
+        MAX_GEN_LEN = config.max_length  # typically 448 for whisper large models
         print_each_iter = False
         output_ids = []
         total_decode_time = 0

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -49,18 +49,17 @@ def pad_input_32(tensor, value):
     return tensor
 
 
-
 def load_conditional_generation_ref_model(model_repo):
     """
     Load Whisper model for conditional generation.
-    
+
     Args:
         model_repo: HuggingFace model repository ID. Must be one of the supported models.
     """
     allowed_models = ["distil-whisper/distil-large-v3", "openai/whisper-large-v3"]
     if model_repo not in allowed_models:
         raise ValueError(f"Unknown model_repo: {model_repo}. Valid options are {allowed_models}")
-    
+
     hf_ref_model = WhisperForConditionalGeneration.from_pretrained(model_repo).to(torch.bfloat16).eval()
     processor = AutoProcessor.from_pretrained(model_repo, language="English", task="transcribe")
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_repo)
@@ -240,13 +239,15 @@ def run_generate(
             return output
 
 
-def create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device, model_repo="openai/whisper-large-v3"):
+def create_functional_whisper_for_conditional_generation_inference_pipeline(
+    ttnn_model, device, model_repo="openai/whisper-large-v3"
+):
     """
     Returns a callable with signature (data, sampling_rate, stream), where data is is a 1D numpy array
     and sampling_rate is an int representing the sampling rate used to acquire data, and stream turns
     signals the callable to return a generator if True, yielding the decoded tokens as they are processed, else
     the callable returns the full decoded output.
-    
+
     Args:
         ttnn_model: The compiled TTNN model
         device: The target device


### PR DESCRIPTION
Single card tests [PASS](https://github.com/tenstorrent/tt-metal/actions/runs/16787153389/job/47540978650)
Blackhole demo tests [PASS](https://github.com/tenstorrent/tt-metal/actions/runs/16809281134)

Add dynamic model repository selection for Whisper based on environment variable

- Introduced `get_whisper_model_repo` function to determine the model repository based on the `WHISPER_MODEL_TYPE` environment variable, supporting both 'original' and 'distilled' models.
- Updated model loading functions to utilize the new repository selection logic, enhancing flexibility for model deployment.
- Adjusted comments for clarity regarding model length configurations.