### PR TITLE
[skip ci] Don't run test-wheels job in package and release

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -65,12 +65,6 @@ jobs:
       tracy: true
       build-wheel: true
       fetch-depth: 0
-  test-wheels:
-    needs: [build-artifact, get-params]
-    uses: ./.github/workflows/_test-wheels-impl.yaml
-    with:
-      from-precompiled: true
-    secrets: inherit
   single-card-demos:
     needs: build-artifact
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml
@@ -188,7 +182,7 @@ jobs:
           path: RELEASE_NOTES.txt
   # Candidate for breaking up
   create-and-upload-draft-release:
-    needs: [create-tag, create-release-notes, build-artifact, test-wheels]
+    needs: [create-tag, create-release-notes, build-artifact]
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
@@ -261,7 +255,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    needs: [build-artifact, test-wheels]
+    needs: [build-artifact]
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     environment:


### PR DESCRIPTION
### Ticket
NA

### Problem description
package and release workflow is failing due to wheel artifact name changes. test-wheels workflow does not accept an input for wheel artifact name.

### What's changed
Since the wheel is thoroughly tested in other ways in package and release, including in the wheel build stage, there is no need to run this in package and release.

In the future, we can consider removing test-wheel workflow.

### Checklist
- YOLO