### PR TITLE
LMHead implementation of deepseek

### DIFF
--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+import torch.nn as nn
+
+import ttnn
+from models.demos.deepseek_v3.tt.lm_head import LMHead as TTLMHead
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import assert_hidden_dim_pcc, pad_tensor, run_module_forward
+
+
+class DeepseekV3LMHead(nn.Module):
+    """
+    Language model head for Deepseek V3.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states):
+        return self.lm_head(hidden_states)
+
+
+# @pytest.mark.skip(reason="This test hangs for some reason")
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for test outputs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.mark.parametrize(
+    "mode,seq_len",
+    [
+        ("decode", 32),
+        # ("prefill", 128),
+        # ("prefill", 256),
+    ],
+)
+def test_forward_pass(
+    mode: str,
+    seq_len: int,
+    hf_config: Any,
+    temp_dir: Path,
+    mesh_device: Any,
+):
+    batch_size = 1
+    torch.manual_seed(0)
+
+    reference_model = DeepseekV3LMHead(hf_config)
+    # Create input tensor
+    hf_state_dict = reference_model.state_dict()
+    torch_input = torch.randn(batch_size, 1, seq_len, hf_config.hidden_size)
+    reference_output = reference_model(torch_input)
+
+    # Pad input to SEQ_LEN_CHUNK_SIZE if necessary
+    print(f"torch_input before pad_tensor: shape = {torch_input.shape}, mode = {mode}, seq_len = {seq_len}")
+    torch_input = pad_tensor(torch_input, mode, seq_len)
+    print(f"torch_input after pad_tensor: shape = {torch_input.shape}")
+
+    # Setup: Convert weights and get weight_config
+    weight_config = TTLMHead.convert_weights(hf_config, hf_state_dict, temp_dir, mesh_device)
+    # Generate appropriate config
+    if mode == "prefill":
+        model_config = TTLMHead.prefill_model_config(hf_config, mesh_device)
+    else:
+        model_config = TTLMHead.decode_model_config(hf_config, mesh_device)
+
+    # Create a new model state
+    model_state = TTLMHead.create_state(hf_config, mesh_device=mesh_device)
+
+    # Create RunConfig using both weight_config and model_config
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Convert input to TTNN
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat16,
+        memory_config=run_config["input_memory_config"],
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # TTNN forward pass
+    tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+    tt_output = run_module_forward(TTLMHead, mode, tt_input, run_config, mesh_device=mesh_device)
+
+    expected_output_memory_config = run_config["output_memory_config"]
+
+    # Verify output memory config matches expected
+    actual_output_memory_config = tt_output.memory_config()
+    assert (
+        actual_output_memory_config == expected_output_memory_config
+    ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=3))
+
+    # Cleanup
+    ttnn.deallocate(tt_input)
+    ttnn.deallocate(tt_output)
+
+    # Check PCC
+    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from pathlib import Path
+from typing import final
+
+import torch
+from transformers.configuration_utils import PretrainedConfig
+
+import ttnn
+from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
+from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, LinearConfig, MeshDeviceStub
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_LOFI,
+    MAX_BATCH_SIZE,
+    dram_sharded_weight_config,
+    even_int_div,
+    get_activation_sharding_core_counts_for_dram_matmul,
+    get_dram_sharded_matmul_config,
+    save_and_get_path,
+)
+from models.demos.deepseek_v3.utils.run_config import (
+    ModelDecodeConfig,
+    ModelPrefillConfig,
+    RunDecodeConfig,
+    RunPrefillConfig,
+    WeightConfig,
+)
+
+
+class LMHead(AbstractModule):
+    """Language model head for Deepseek V3."""
+
+    @classmethod
+    def _get_model_dims_from_cfg(cls, hf_config: PretrainedConfig) -> tuple[int, int]:
+        """Get the dimensions of the model from the HuggingFace config.
+
+        Args:
+            hf_config: HuggingFace model configuration object.
+
+        Returns:
+            Tuple containing the hidden dimension and vocab_size of the LMHHead.
+        """
+
+        return hf_config.hidden_size, hf_config.vocab_size
+
+    @classmethod
+    def convert_weights(
+        cls,
+        hf_config: PretrainedConfig,
+        state_dict: dict[str, torch.Tensor],
+        output_path: Path,
+        mesh_device: ttnn.Device,
+    ) -> WeightConfig:
+        return {
+            "lm_head.weight": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / "lm_head.weight.input_tensor_b",
+                    cls._convert_weight(
+                        hf_config,
+                        state_dict["lm_head.weight"],
+                        mesh_device,
+                    ),
+                )
+            }
+        }
+
+    @final
+    @classmethod
+    def _convert_weight(
+        cls,
+        hf_config: PretrainedConfig,
+        weight_tensor: torch.Tensor,
+        mesh_device: ttnn.Device,
+    ) -> ttnn.Tensor:
+        """
+        Convert a normal (non-quantized) weight tensor to a format suitable for TTNN.
+
+        Args:
+            hf_config: HuggingFace model configuration object.
+            weight_tensor: The weight tensor.
+            mesh_device: The mesh device to use for the conversion.
+
+        Returns:
+            The converted TTNN tensor.
+        """
+
+        hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
+        weight_tensor = weight_tensor.permute(1, 0)  # In torch the weights are in (out_features, in_features) format
+
+        assert weight_tensor.shape == (hidden_dim, vocab_size)
+        per_device_in_features = hidden_dim
+        per_device_out_features = even_int_div(vocab_size, mesh_device.get_num_devices())
+        mesh_sharded_dim = 3
+
+        weight_tensor.unsqueeze_(0).unsqueeze_(0)  # Add batch and sequence dimensions
+
+        weight_memory_config = dram_sharded_weight_config(
+            per_device_in_features,
+            per_device_out_features,
+            mesh_device.dram_grid_size(),
+        )
+        return ttnn.from_torch(
+            weight_tensor,
+            dtype=ttnn.bfloat4_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=weight_memory_config,
+            mesh_mapper=ttnn.shard_tensor_to_mesh_mapper(mesh_device, mesh_sharded_dim),
+        )
+
+    @classmethod
+    def is_device_supported(cls, mesh_device: ttnn.Device) -> bool:
+        """
+        Check if the given mesh device is supported by this module.
+        Args:
+            mesh_device: The mesh device to check.
+
+        Returns:
+            True if the device is supported, False otherwise.
+        """
+        return tuple(mesh_device.shape) == (4, 8)
+
+    @final
+    @classmethod
+    def _get_decode_activation_memory_config(
+        cls, per_device_width: int, activation_sharding_num_cores: int, mesh_device: ttnn.Device
+    ) -> ttnn.MemoryConfig:
+        """Get the memory config for an activation tensor in decode mode."""
+        return ttnn.create_sharded_memory_config_(
+            shape=(
+                ttnn.core.roundup(MAX_BATCH_SIZE, ttnn.TILE_SIZE),
+                even_int_div(ttnn.core.roundup(per_device_width, ttnn.TILE_SIZE), activation_sharding_num_cores),
+            ),
+            core_grid=ttnn.num_cores_to_corerangeset(
+                activation_sharding_num_cores,
+                ttnn.CoreCoord(mesh_device.core_grid.x, mesh_device.core_grid.y),
+                row_wise=True,
+            ),
+            strategy=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    @classmethod
+    def decode_model_config(
+        cls,
+        hf_config: PretrainedConfig,
+        mesh_device: ttnn.Device,
+        input_num_cores: int | None = None,
+        output_num_cores: int | None = None,
+    ) -> ModelDecodeConfig:
+        """Generate decode configuration for this module.
+
+        Args:
+            hf_config: HuggingFace model configuration object
+            mesh_device: TTNN mesh device the model will be placed later on
+
+        Returns:
+            ModelDecodeConfig containing operator configurations for decode mode
+        """
+
+        hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
+
+        # Calculate device metrics
+        num_devices = mesh_device.get_num_devices()
+        max_num_cores = mesh_device.core_grid.x * mesh_device.core_grid.y
+        input_num_cores = input_num_cores or max(
+            get_activation_sharding_core_counts_for_dram_matmul(hidden_dim, max_num_cores)
+        )
+
+        output_num_cores = output_num_cores or max(
+            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(vocab_size, num_devices), max_num_cores)
+        )
+        assert (
+            input_num_cores <= max_num_cores
+        ), "input_num_cores must be less than or equal to the maximum number of cores"
+        assert (
+            output_num_cores <= max_num_cores
+        ), "output_num_cores must be less than or equal to the maximum number of cores"
+        assert hidden_dim % input_num_cores == 0, "input_num_cores must divide the input tensor width evenly"
+        assert (
+            even_int_div(hidden_dim, num_devices) % output_num_cores == 0
+        ), "output_num_cores must divide the output tensor width evenly"
+
+        # Calculate input and output memory configurations
+
+        input_memory_config = cls._get_decode_activation_memory_config(hidden_dim, input_num_cores, mesh_device)
+        output_memory_config = cls._get_decode_activation_memory_config(
+            even_int_div(vocab_size, num_devices), output_num_cores, mesh_device
+        )
+
+        # Construct the config
+        return {
+            "lm_head.weight": LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                program_config=get_dram_sharded_matmul_config(
+                    MAX_BATCH_SIZE, hidden_dim, even_int_div(vocab_size, num_devices), input_num_cores, output_num_cores
+                ),
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            ),
+            "input_memory_config": input_memory_config,
+            "output_memory_config": output_memory_config,
+        }
+
+    @classmethod
+    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
+        """Generate prefill configuration for this module.
+
+        Args:
+            hf_config: HuggingFace model configuration object
+            mesh_device: TTNN mesh device the model will be placed later on
+
+        Returns:
+            ModelPrefillConfig containing operator configurations for prefill mode
+        """
+        return None
+
+    @classmethod
+    def _forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig, mesh_device) -> ttnn.Tensor:
+        assert x.memory_config() == cfg["input_memory_config"], f"{x.memory_config()} != {cfg['input_memory_config']}"
+
+        w1_out = ttnn.linear(x, **cfg["lm_head.weight"])
+
+        return w1_out
+
+    @classmethod
+    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig, mesh_device) -> ttnn.Tensor:
+        return cls._forward(x, cfg, mesh_device)
+
+    @classmethod
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig, mesh_device) -> ttnn.Tensor:
+        return cls._forward(x, cfg, mesh_device)


### PR DESCRIPTION
### Ticket
None

### Problem description
LMHead implementation for Deepseek

### What's changed
Added LMhead class and associated test

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes