### PR TITLE
#26044: Fix ct args passed to element wise kernel after TensorAccessor refactoring

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -137,20 +137,21 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_output_config);
 
     std::map<std::string, std::string> reader_defines;
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
     if (src0_sharded) {
         reader_defines["IN0_SHARDED"] = "1";
+    } else {
+        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     }
     if (src1_sharded) {
         reader_defines["IN1_SHARDED"] = "1";
+    } else {
+        TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
     }
     std::map<std::string, std::string> writer_defines;
     if (out_sharded) {
         writer_defines["OUT_SHARDED"] = "1";
     }
-
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
@@ -134,20 +134,21 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_output_config);
 
     std::map<std::string, std::string> reader_defines;
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
     if (src0_sharded) {
         reader_defines["IN0_SHARDED"] = "1";
+    } else {
+        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     }
     if (src1_sharded) {
         reader_defines["IN1_SHARDED"] = "1";
+    } else {
+        TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
     }
     std::map<std::string, std::string> writer_defines;
     if (out_sharded) {
         writer_defines["OUT_SHARDED"] = "1";
     }
-
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp
@@ -22,12 +22,12 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
     constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
     constexpr bool block_or_width_sharded = get_compile_time_arg_val(0) == 1;
-#if !IN0_SHARDED && !IN1_SHARDED
+#if !defined(IN0_SHARDED) && !defined(IN1_SHARDED)
     constexpr auto src0_args = TensorAccessorArgs<1>();
     constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
-#elif !IN0_SHARDED
+#elif !defined(IN0_SHARDED)
     constexpr auto src0_args = TensorAccessorArgs<1>();
-#elif !IN1_SHARDED
+#elif !defined(IN1_SHARDED)
     constexpr auto src1_args = TensorAccessorArgs<1>();
 #endif
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26044

### Problem description
During the TensorAccessor migration (https://github.com/tenstorrent/tt-metal/pull/25976) there was a bug causing incorrect compile time arguments being passed for elementwise kernel in some cases

### What's changed
Fixed the compile time arguments passed to `element_wise_multi_core_program_factory.cpp` kernel
Updated the defines handling in the kernel to be more consistent

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16644433957)
- [x] Manually verified the fix with the custom branch and steps in the ticket 
- [x] New/Existing tests provide coverage for changes