### PR TITLE
Gemma3 decoder changes

### DIFF
--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -83,25 +83,93 @@ class TransformerBlock(LightweightModule):
             args,
             TG=args.is_galaxy,
         )
-        self.ff_norm = DistributedNorm(
-            RMSNorm(
-                device=mesh_device,
-                dim=args.dim,
-                eps=args.norm_eps,
-                state_dict=state_dict,
-                state_dict_prefix=args.get_state_dict_prefix("", layer_num),
-                weight_cache_path=None if args.dummy_weights else weight_cache_path,
-                weight_dtype=ttnn.bfloat16,
-                weight_key="ffn_norm",
-                is_distributed=self.args.is_distributed_norm,
-                add_unit_offset=self.args.rms_norm_add_unit_offset,
-                sharded_program_config=self.model_config["SHARDED_NORM_MLP_PRGM_CFG"],
-                sharded_output_config=self.model_config["SHARDED_MLP_INPUT_MEMCFG"],
-                ccl_topology=self.args.ccl_topology(),
-            ),
-            args,
-            TG=args.is_galaxy,
-        )
+
+        if not self.args.use_pre_ffn:
+            self.ff_norm = DistributedNorm(
+                RMSNorm(
+                    device=mesh_device,
+                    dim=args.dim,
+                    eps=args.norm_eps,
+                    state_dict=state_dict,
+                    state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                    weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                    weight_dtype=ttnn.bfloat16,
+                    weight_key="ffn_norm",
+                    is_distributed=self.args.is_distributed_norm,
+                    add_unit_offset=self.args.rms_norm_add_unit_offset,
+                    sharded_program_config=self.model_config["SHARDED_NORM_MLP_PRGM_CFG"],
+                    sharded_output_config=self.model_config["SHARDED_MLP_INPUT_MEMCFG"],
+                    ccl_topology=self.args.ccl_topology(),
+                ),
+                args,
+                TG=args.is_galaxy,
+            )
+
+        if self.args.use_pre_ffn:
+            self.ff_norm = DistributedNorm(
+                RMSNorm(
+                    device=mesh_device,
+                    dim=args.dim,
+                    eps=args.norm_eps,
+                    state_dict=state_dict,
+                    state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                    weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                    weight_dtype=ttnn.bfloat16,
+                    weight_key="ffn_norm",
+                    is_distributed=self.args.is_distributed_norm,
+                    add_unit_offset=self.args.rms_norm_add_unit_offset,
+                    sharded_program_config=self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
+                    sharded_output_config=self.model_config["SHARDED_ATTN_INPUT_MEMCFG"],
+                    ccl_topology=self.args.ccl_topology(),
+                ),
+                args,
+                TG=args.is_galaxy,
+            )
+
+            self.pre_ffn_norm = DistributedNorm(
+                RMSNorm(
+                    device=mesh_device,
+                    dim=args.dim,
+                    eps=args.norm_eps,
+                    state_dict=state_dict,
+                    state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                    weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                    weight_dtype=ttnn.bfloat16,
+                    weight_key="pre_feedforward_layernorm",
+                    is_distributed=self.args.is_distributed_norm,
+                    add_unit_offset=self.args.rms_norm_add_unit_offset,
+                    sharded_program_config=self.model_config["SHARDED_NORM_MLP_PRGM_CFG"],
+                    sharded_output_config=self.model_config["SHARDED_MLP_INPUT_MEMCFG"],
+                    ccl_topology=self.args.ccl_topology(),
+                ),
+                args,
+                TG=args.is_galaxy,
+            )
+        else:
+            self.pre_ffn_norm = None
+
+        if self.args.use_post_ffn:
+            self.post_ffn_norm = DistributedNorm(
+                RMSNorm(
+                    device=mesh_device,
+                    dim=args.dim,
+                    eps=args.norm_eps,
+                    state_dict=state_dict,
+                    state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                    weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                    weight_dtype=ttnn.bfloat16,
+                    weight_key="post_feedforward_layernorm",
+                    is_distributed=self.args.is_distributed_norm,
+                    add_unit_offset=self.args.rms_norm_add_unit_offset,
+                    sharded_program_config=self.model_config["SHARDED_NORM_MLP_PRGM_CFG"],
+                    sharded_output_config=self.model_config["SHARDED_MLP_INPUT_MEMCFG"],
+                    ccl_topology=self.args.ccl_topology(),
+                ),
+                args,
+                TG=args.is_galaxy,
+            )
+        else:
+            self.post_ffn_norm = None
 
     def forward(
         self,
@@ -135,28 +203,91 @@ class TransformerBlock(LightweightModule):
             chunk_start_idx=chunk_start_idx,
             kv_cache=kv_cache,
         )
-        # Here x and attn_out are both fractured across devices
-        h = ttnn.add(x, attn_out, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None)
-        ttnn.deallocate(attn_out)
-        if mode == "prefill":
-            x.deallocate(True)
+        attn_in.deallocate(True)
 
-        # Norms take fractured inputs and output replicated across devices
-        ff_in = self.ff_norm(h, mode)
-        if TG and mode == "decode":
-            ff_in = ttnn.to_memory_config(ff_in, memory_config=self.model_config["MLP_ACT_MEMCFG"])
-        # MLP takes replicated inputs and produces fractured outputs
-        ff_out = self.feed_forward.forward(ff_in, mode)
-        # ff_out and h are both fractured across devices
-        activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
-            decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
-        )
-        out = ttnn.add(
-            h,
-            ff_out,
-            memory_config=skip_mem_cfg,
-            dtype=self.args.ccl_dtype
-            if TG and not self.args.is_distributed_norm(mode)
-            else activation_dtype or ttnn.bfloat16,
-        )
+        if not (self.pre_ffn_norm and self.post_ffn_norm):
+            """
+            Llama like
+
+            h = x + attn_out
+
+            ff_in = post_attention_layernorm(h)
+            ff_out = mlp(ff_in)
+            out = h + ff_out
+            """
+            # Here x and attn_out are both fractured across devices
+            h = ttnn.add(x, attn_out, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None)
+            ttnn.deallocate(attn_out)
+            if mode == "prefill":
+                x.deallocate(True)
+
+            # Norms take fractured inputs and output replicated across devices
+            ff_in = self.ff_norm(h, mode)
+            if TG and mode == "decode":
+                ff_in = ttnn.to_memory_config(ff_in, memory_config=self.model_config["MLP_ACT_MEMCFG"])
+
+            ff_out = self.feed_forward.forward(ff_in, mode)
+
+            # ff_out and h are both fractured across devices
+            activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+                decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+            )
+            out = ttnn.add(
+                h,
+                ff_out,
+                memory_config=skip_mem_cfg,
+                dtype=self.args.ccl_dtype
+                if TG and not self.args.is_distributed_norm(mode)
+                else activation_dtype or ttnn.bfloat16,
+            )
+        else:
+            """
+            Gemma like
+
+            post_attn_out = post_attention_layernorm(attn_out)
+            add_out = x + post_attn_out
+
+            pre_ffn_out = pre_feedforward_layernorm(add_out)
+            ff_out = mlp(pre_ffn_out)
+            post_ffn_out = post_feedforward_layernorm(ff_out)
+            out = add_out + post_ffn_out
+            """
+            # Here x and attn_out are both fractured across devices
+            post_attn_out = self.ff_norm(attn_out, mode)
+            attn_out.deallocate(True)
+
+            add_out = ttnn.add(
+                x,
+                post_attn_out,
+                memory_config=skip_mem_cfg,
+                dtype=self.args.ccl_dtype,
+            )
+            x.deallocate(True)
+            post_attn_out.deallocate(True)
+
+            # Norms take fractured inputs and output replicated across devices
+            if TG and mode == "decode":
+                add_out = ttnn.to_memory_config(add_out, memory_config=self.model_config["MLP_ACT_MEMCFG"])
+
+            # MLP takes replicated inputs and produces fractured outputs
+            pre_ffn_out = self.pre_ffn_norm.forward(add_out, mode)
+            ff_out = self.feed_forward.forward(pre_ffn_out, mode)
+            pre_ffn_out.deallocate(True)
+            post_ffn_out = self.post_ffn_norm.forward(ff_out, mode)
+            ff_out.deallocate(True)
+
+            # ff_out and h are both fractured across devices
+            activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+                decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+            )
+            out = ttnn.add(
+                add_out,
+                post_ffn_out,
+                memory_config=skip_mem_cfg,
+                dtype=self.args.ccl_dtype
+                if TG and not self.args.is_distributed_norm(mode)
+                else activation_dtype or ttnn.bfloat16,
+            )
+            add_out.deallocate(True)
+            post_ffn_out.deallocate(True)
         return out  # fractured across devices

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -104,8 +104,9 @@ class TransformerBlock(LightweightModule):
                 args,
                 TG=args.is_galaxy,
             )
+            self.pre_ffn_norm = None
 
-        if self.args.use_pre_ffn:
+        elif self.args.use_pre_ffn:
             self.ff_norm = DistributedNorm(
                 RMSNorm(
                     device=mesh_device,
@@ -145,8 +146,6 @@ class TransformerBlock(LightweightModule):
                 args,
                 TG=args.is_galaxy,
             )
-        else:
-            self.pre_ffn_norm = None
 
         if self.args.use_post_ffn:
             self.post_ffn_norm = DistributedNorm(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22808

### Problem description
Implements pre- and post- layer normalization as found in Gemma 3 models.

### What's changed
Extracts just the decoder changes from https://github.com/flexaihq/tt-metal/pull/5. 

Note, without the upcoming RoPE changes this is not functional.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes