### PR TITLE
swiched slow matmuls for throttle level 5 in SD

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -94,7 +94,7 @@ jobs:
       matrix:
         test-config:
           - model: "stable_diffusion"
-            cmd: SLOW_MATMULS=1 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
+            cmd: TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
               # Skipping due to issue #15932
               # - model: "mamba 1"
               # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -67,7 +67,7 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
     profiler.clear()
 
     # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
@@ -225,7 +225,7 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
     enable_persistent_kernel_cache()
 
     # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
@@ -365,7 +365,7 @@ def run_demo_inference_diffusiondb(
     enable_persistent_kernel_cache()
 
     # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
     assert (
         num_inference_steps >= 4

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -39,7 +39,7 @@ def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
     disable_persistent_kernel_cache()
 
     # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -409,7 +409,7 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((10.65),),
+    ((11.30),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -50,7 +50,7 @@ def test_stable_diffusion_unet_trace(device):
     assert is_wormhole_b0() or is_blackhole(), "SD 1.4 runs on Wormhole B0 or Blackhole"
 
     if is_wormhole_b0():
-        os.environ["SLOW_MATMULS"] = "1"
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
     profiler.clear()
     torch.manual_seed(0)
@@ -174,7 +174,7 @@ def test_stable_diffusion_unet_trace(device):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192, "trace_region_size": 6458368}], indirect=True)
 def test_stable_diffusion_vae_trace(device):
     if is_wormhole_b0():
-        os.environ["SLOW_MATMULS"] = "1"
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
     profiler.clear()
     torch.manual_seed(0)
@@ -253,7 +253,7 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
     # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
     # Clear global profiler state before starting measurements
     profiler.clear()
 
@@ -428,7 +428,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
         if "WH_ARCH_YAML" in os.environ:
             wh_arch_yaml_backup = os.environ["WH_ARCH_YAML"]
         os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-        os.environ["SLOW_MATMULS"] = "1"
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
     post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)

--- a/tests/scripts/single_card/nightly/run_wh_b0_unstable.sh
+++ b/tests/scripts/single_card/nightly/run_wh_b0_unstable.sh
@@ -10,7 +10,7 @@ fail=0
 
 echo "Running unstable nightly tests for WH B0 only"
 
-env SLOW_MATMULS=1 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/nightly/single_card/wh_b0_unstable/ --timeout=600; fail+=$?
+env TT_MM_THROTTLE_PERF=5 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/nightly/single_card/wh_b0_unstable/ --timeout=600; fail+=$?
 
 if [[ $fail -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Demo tests for Stable Diffusion hang in Frequent model and ttnn tests pipeline.
Current approach to stopping stable diffusion hangs due to di/dt issues is to use environment flag `SLOW_MATMULS`.
It sets the `out_subblock_h=1` and `out_subblock_h=1` which will in turn lower the matmul perf.

A better and more straightforward alternative to this is to use `TT_MM_THROTTLE_PERF` environment
variable which lowers the conv and matmul ops perf by adding noops during matmul LLK execution, whereas
the `SLOW_MATMULS` only affected matmuls, not convolutions.

`TT_MM_THROTTLE_PERF` **Level 5** is used in this PR which sets the max perf of matmul LLK to 33% (this is used
both in convs and matmul operations)

This approach is also already being used on Stable Diffusion XL.

NOTE: 
- This is a temporary measure to rule out di/dt issues for hangs and was expected to impact perf of stable_diffusion
*negatively* but in fact improved the device perf.
- If the hangs stop, further testing will go into lowering the throttle so that minimal perf impact is
achieved.
- If the hangs don't stop, this rules out di/dt and the reason for the hangs should be found.

### What's changed
- switched to using throttle 5 instead of slow matmuls (max throttle)

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [relevant tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/16645152076)