### PR TITLE
Put the worker end point 2 first for the dram channel 1 in the soc desc of BH

### DIFF
--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -27,7 +27,7 @@ dram_views:
   [
     {
       channel: 0,
-      eth_endpoint: [0, 1],
+      eth_endpoint: [2, 1],
       worker_endpoint: [2, 1],
       address_offset: 0
     },

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -28,7 +28,7 @@ dram_views:
     {
       channel: 0,
       eth_endpoint: [0, 1],
-      worker_endpoint: [0, 1],
+      worker_endpoint: [2, 1],
       address_offset: 0
     },
     {


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/26051

### Problem description
The perf microbenchmark ` ./build_Debug_tracy/test/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read` fails on blackhole.
The validation of read-back data from the worker cores fails on the host side.

### What's changed
#### Before
The selection of nearest worker cores for the first dram bank and the second dram bank was overlapping to (1,2) tensix core. This was because of the underlying std::max(..., 2) operation and the dram tile (end point) was chosen to be (0, 0) for the dram bank 0.
#### After
Modified the `soc_descriptors/blackhole_140_arch.yaml` file to put the last dram tile (2) for the first dram channel/bank first in the list of dram tiles/end points. This makes the underlying algorithm to select the 3rd dram tile for the first dram channel which in turn results in selection of nearest tensix core for the first DRAM channel to be (1, 11), thus fixing the issue.