### PR TITLE
[DM] Add loopback directed ideal test

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -12,7 +12,7 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 | One to all           | 6-8        | Writes transaction from one core to all cores.                                       |
 | One to all Multicast | 9-14, 52   | Writes transaction from one core to all cores using multicast.                       |
 | One From All         | 15, 30     | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
-| Loopback             | 16         | Does a loopback operation where one cores writes to itself.                          |
+| Loopback             | 16, 55     | Does a loopback operation where one cores writes to itself.                          |
 | Reshard Hardcoded    | 17-20      | Uses existing reshard tests to analyse their bandwidth and latency.                  |
 | Conv Hardcoded       | 21-23      | Uses existing conv tests to analyse their bandwidth and latency.                     |
 | Deinterleave         | 200-201    | Tests deinterleaving                                                                 |

--- a/tests/tt_metal/tt_metal/data_movement/loopback/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/README.md
@@ -27,3 +27,4 @@ Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B fo
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
 1. Loopback Packet Sizes: Tests loopback
+2. Loopback Directed Ideal: Tests the most optimal data movement setup on the core itself that reduces the number of transactions while maximizing transaction size to minimize the effects of initialization overhead.

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -176,4 +176,32 @@ TEST_F(DeviceFixture, TensixDataMovementLoopbackPacketSizes) {
     }
 }
 
+TEST_F(DeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
+    uint32_t test_id = 55;
+
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    uint32_t num_of_transactions = 128;
+    uint32_t transaction_size_pages =
+        max_transmittable_pages / (num_of_transactions * 2);  // Since we need to fit 2 buffers, we divide by 2
+
+    CoreCoord master_core_coord = {0, 0};
+    NOC noc_id = NOC::NOC_0;
+
+    unit_tests::dm::core_loopback::LoopbackConfig test_config = {
+        .test_id = test_id,
+        .master_core_coord = master_core_coord,
+        .num_of_transactions = num_of_transactions,
+        .transaction_size_pages = transaction_size_pages,
+        .page_size_bytes = page_size_bytes,
+        .l1_data_format = DataFormat::Float16_b,
+        .noc_id = noc_id};
+
+    // Run
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -163,3 +163,13 @@
     riscv_1:
       latency: 60000
       bandwidth: 2
+
+"Loopback Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      latency: 24000
+      bandwidth: 30
+  blackhole:
+    riscv_0:
+      latency: 13000
+      bandwidth: 60

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -131,6 +131,9 @@ tests:
   54:
     name: "One to All Multicast Linked Directed Ideal"
 
+  55:
+    name: "Loopback Directed Ideal"
+
   60:
     name: "All to All Packet Sizes"
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25824)

### Problem description
Data Movement test suite was missing a loopback ideal test.

### What's changed
Added the directed ideal loopback test with the allowed bounds on BH and WH.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes