### PR TITLE
SDXL: VAE untilize removed

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upblock2d.py
@@ -42,9 +42,7 @@ class TtUpDecoderBlock2D(nn.Module):
 
         ttnn.deallocate(input_tensor)
         if self.upsamplers is not None:
-            hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
             hidden_states = ttnn.reshape(hidden_states, (B, H, W, C))
             hidden_states, [C, H, W] = self.upsamplers.forward(hidden_states)
-            hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
 
         return hidden_states, [C, H, W]


### PR DESCRIPTION
### What's changed
Since tiled upsample is enabled, untilize is removed from VAE.

New device time: 2,477,064 us (main 2,478,437 us)

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16649990522) CI passes