### PR TITLE
Added support for different data types for nearest upsample

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -14,6 +14,60 @@ from tests.ttnn.unit_tests.operations.pool.test_upsample import upsample_multico
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [1, 256, 512, 512],
+        [1, 512, 256, 256],
+        [1, 256, 128, 128],
+        [1, 64, 64, 64],
+        [2, 64, 32, 32],
+        [5, 32, 96, 96],
+        [1, 96, 32, 32],
+        [2, 32, 80, 32],
+    ],
+)
+@pytest.mark.parametrize("scale_h", [2, 3])
+@pytest.mark.parametrize("scale_w", [2, 3])
+@pytest.mark.parametrize("memory_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "dtype_torch, dtype_ttnn",
+    [[torch.bfloat16, ttnn.bfloat8_b], [torch.float32, ttnn.float32], [torch.bfloat16, ttnn.bfloat16]],
+)
+def test_upsample_nearest_interleaved(device, input_shapes, scale_h, scale_w, memory_layout, dtype_torch, dtype_ttnn):
+    # Skip block datatypes if memory layout is not tiled
+    if dtype_ttnn == ttnn.bfloat8_b and memory_layout != ttnn.TILE_LAYOUT:
+        pytest.skip("Block datatypes require TILE_LAYOUT")
+
+    batch_size, num_channels, height, width = input_shapes
+    torch.manual_seed(0)
+
+    # Generate appropriate test data based on dtype
+    input = torch.rand(input_shapes, dtype=dtype_torch)
+    tt_input = input.permute(0, 2, 3, 1)
+    input_tensor = ttnn.from_torch(
+        tt_input, device=device, layout=memory_layout, memory_config=ttnn.DRAM_MEMORY_CONFIG, dtype=dtype_ttnn
+    )
+
+    if input_tensor.padded_shape != input_tensor.shape and memory_layout == ttnn.TILE_LAYOUT:
+        pytest.skip("Disabled until different logical and padded shapes are supported for TILE_LAYOUT")
+
+    scale_factor = (scale_h, scale_w)
+    torch_upsample = nn.Upsample(scale_factor=scale_factor, mode="nearest")
+    torch_result = torch_upsample(input)
+
+    scale_factor = (scale_h, scale_w)
+
+    output_tensor = ttnn.upsample(input_tensor, scale_factor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    torch_result = torch_result.permute(0, 2, 3, 1)
+    pcc_passed, pcc_message = assert_with_pcc(torch_result, output_tensor, 0.9999)
+    logger.info(pcc_message)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
     "batch_size, num_channels, height, width, scale_h, scale_w",
     (
         (1, 1280, 8, 8, 2, 2),

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -16,10 +16,7 @@ from tests.ttnn.unit_tests.operations.pool.test_upsample import upsample_multico
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        [1, 256, 512, 512],
-        [1, 512, 256, 256],
-        [1, 256, 128, 128],
-        [1, 64, 64, 64],
+        [1, 128, 64, 64],
         [2, 64, 32, 32],
         [5, 32, 96, 96],
         [1, 96, 32, 32],


### PR DESCRIPTION
### Ticket
#26247


### Problem description
Nearest upsample used to assert that the input dtype is bfloat_16, even though it is not needed.

### What's changed
Enabled different data types for nearest upsample and added support for bfloat8_b. Added tests for different dtypes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16650370914)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16650380202)
- [ ] [L2 nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/16650391598)