### PR TITLE
#25579: Skip test_tutorials.py on BH due to hang in MetalContext

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -69,8 +69,9 @@ jobs:
       matrix:
         os: ["ubuntu-22.04"]
         test-group:
+          # Ignore tutorials for blackhole due to MetalContext hang: https://github.com/tenstorrent/tt-metal/issues/25579
           - name: ttnn group 1
-            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode"
+            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode" ${{ inputs.arch == 'blackhole' && '--ignore=tests/ttnn/unit_tests/test_tutorials.py' || '' }}
           - name: ttnn group 2
             cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3


### PR DESCRIPTION
### Ticket
#25579

### Problem description
Tutorial tests have been causing hangs in subsequent tests that close+reinit MetalContext

### What's changed
Skip the tests when arch == blackhole while #25579 is being investigated

### Checklist
- [ ] BH post commit https://github.com/tenstorrent/tt-metal/actions/runs/16650683621