### PR TITLE
Skip tutorial tests on BH because of test hanging

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -291,14 +291,16 @@ jobs:
       product: tt-nn
 
   test-ttnn-tutorials:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
     strategy:
       fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}

--- a/tests/ttnn/unit_tests/test_tutorials.py
+++ b/tests/ttnn/unit_tests/test_tutorials.py
@@ -5,6 +5,7 @@
 import subprocess
 from pathlib import Path
 
+from models.utility_functions import skip_for_blackhole
 import nbformat
 import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
@@ -19,6 +20,7 @@ def collect_ttnn_tutorials(path: Path, extension: str = "*.py"):
         yield file_name
 
 
+@skip_for_blackhole("Fails on BH. Issue #25579")
 @pytest.mark.parametrize("notebook_path", collect_ttnn_tutorials(path=TUTORIALS_NOTEBOOK_PATH, extension="*.ipynb"))
 def test_ttnn_notebook_tutorials(notebook_path):
     with open(notebook_path) as f:
@@ -27,6 +29,7 @@ def test_ttnn_notebook_tutorials(notebook_path):
         ep.preprocess(notebook)
 
 
+@skip_for_blackhole("Fails on BH. Issue #25579")
 @pytest.mark.parametrize("python_path", collect_ttnn_tutorials(path=TUTORIALS_PYTHON_PATH, extension="*.py"))
 def test_ttnn_python_tutorials(python_path):
     result = subprocess.run(


### PR DESCRIPTION
### Problem description
ttnn unit test group 1 was hanging on bh post commit (due to issue https://github.com/tenstorrent/tt-metal/issues/25579)

### What's changed
We added ignoring of test tutorials

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16652710782