### PR TITLE
Avoid calling MetalContext in DeviceProfiler destructor

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -456,11 +456,12 @@ def test_noc_event_profiler():
 
     testCommand = f"build/{PROG_EXMP_DIR}/test_noc_event_profiler"
     clear_profiler_runtime_artifacts()
+    nocEventsRptPathEnv = f"TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH={PROFILER_ARTIFACTS_DIR}/noc_events_rpt"
     nocEventProfilerEnv = "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1"
-    profilerRun = os.system(f"cd {TT_METAL_HOME} && {nocEventProfilerEnv} {testCommand}")
+    profilerRun = os.system(f"cd {TT_METAL_HOME} && {nocEventsRptPathEnv} {nocEventProfilerEnv} {testCommand}")
     assert profilerRun == 0
 
-    expected_trace_file = f"{PROFILER_LOGS_DIR}/noc_trace_dev0_ID0.json"
+    expected_trace_file = f"{PROFILER_ARTIFACTS_DIR}/noc_events_rpt/noc_trace_dev0_ID0.json"
     assert os.path.isfile(expected_trace_file)
 
     with open(expected_trace_file, "r") as nocTraceJson:

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1400,6 +1400,14 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
         std::filesystem::remove(log_path);
     }
 
+    const std::string noc_events_report_path =
+        tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
+    if (!noc_events_report_path.empty()) {
+        this->noc_trace_data_output_dir = std::filesystem::path(noc_events_report_path);
+    } else {
+        this->noc_trace_data_output_dir = this->output_dir;
+    }
+
     this->is_last_fd_dump_done = false;
     this->current_zone_it = this->device_events.begin();
 
@@ -1499,7 +1507,8 @@ void DeviceProfiler::processResults(
         readRiscProfilerResults(device, virtual_core, data_source, metadata);
     }
 
-    if (rtoptions.get_profiler_noc_events_enabled() && state == ProfilerDumpState::NORMAL) {
+    if (rtoptions.get_profiler_noc_events_enabled() &&
+        (state == ProfilerDumpState::NORMAL || state == ProfilerDumpState::LAST_FD_DUMP)) {
         const nlohmann::ordered_json noc_trace_json_log = convertNocTracePacketsToJson(
             device_data_points.begin() + num_device_data_points_before_reading, device_data_points.end());
         FabricRoutingLookup routing_lookup(device);
@@ -1511,23 +1520,11 @@ void DeviceProfiler::processResults(
 }
 
 void DeviceProfiler::dumpRoutingInfo() const {
-    // if defined, used profiler_noc_events_report_path to to dump routing info. otherwise use output_dir
-    std::string rpt_path = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
-    if (rpt_path.empty()) {
-        rpt_path = output_dir.string();
-    }
-
-    tt::tt_metal::dumpRoutingInfo(std::filesystem::path(rpt_path) / "topology.json");
+    tt::tt_metal::dumpRoutingInfo(noc_trace_data_output_dir / "topology.json");
 }
 
 void DeviceProfiler::dumpClusterCoordinates() const {
-    // if defined, used profiler_noc_events_report_path to to dump cluster coordinates. otherwise use output_dir
-    std::string rpt_path = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
-    if (rpt_path.empty()) {
-        rpt_path = output_dir.string();
-    }
-
-    tt::tt_metal::dumpClusterCoordinatesAsJson(std::filesystem::path(rpt_path) / "cluster_coordinates.json");
+    tt::tt_metal::dumpClusterCoordinatesAsJson(noc_trace_data_output_dir / "cluster_coordinates.json");
 }
 
 bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
@@ -1544,15 +1541,9 @@ void DeviceProfiler::dumpDeviceResults() const {
     const std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
     dumpDeviceResultsToCSV(device_data_points, device_arch, device_core_frequency, log_path);
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
-        // if defined, use profiler_noc_events_report_path to dump noc traces. otherwise use output_dir
-        std::string rpt_path = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
-        if (rpt_path.empty()) {
-            rpt_path = output_dir.string();
-        }
-        dumpJsonNocTraces(noc_trace_data, device_id, std::filesystem::path(rpt_path));
+    if (!noc_trace_data.empty()) {
+        dumpJsonNocTraces(noc_trace_data, device_id, noc_trace_data_output_dir);
     }
-
 #endif
 }
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1520,10 +1520,28 @@ void DeviceProfiler::processResults(
 }
 
 void DeviceProfiler::dumpRoutingInfo() const {
+    std::filesystem::create_directories(noc_trace_data_output_dir);
+    if (!std::filesystem::is_directory(noc_trace_data_output_dir)) {
+        log_error(
+            tt::LogMetal,
+            "Could not dump topology to '{}' because the directory path could not be created!",
+            noc_trace_data_output_dir);
+        return;
+    }
+
     tt::tt_metal::dumpRoutingInfo(noc_trace_data_output_dir / "topology.json");
 }
 
 void DeviceProfiler::dumpClusterCoordinates() const {
+    std::filesystem::create_directories(noc_trace_data_output_dir);
+    if (!std::filesystem::is_directory(noc_trace_data_output_dir)) {
+        log_error(
+            tt::LogMetal,
+            "Could not dump cluster coordinates to '{}' because the directory path could not be created!",
+            noc_trace_data_output_dir);
+        return;
+    }
+
     tt::tt_metal::dumpClusterCoordinatesAsJson(noc_trace_data_output_dir / "cluster_coordinates.json");
 }
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -151,7 +151,7 @@ private:
     // Smallest timestamp
     uint64_t smallest_timestamp = (1lu << 63);
 
-    // Output dir for device Profile Logs
+    // Output directory for device profiler logs
     std::filesystem::path output_dir;
 
     // Hash to zone source locations
@@ -184,6 +184,9 @@ private:
 
     // Storage for all noc trace data
     std::vector<std::unordered_map<RuntimeID, nlohmann::json::array_t>> noc_trace_data;
+
+    // Output directory for noc trace data
+    std::filesystem::path noc_trace_data_output_dir;
 
     // Read all control buffers
     void readControlBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores);


### PR DESCRIPTION
`MetalContext` should not be used in the `DeviceProfiler` destructor as the `MetalContext` object has already been destroyed by the time the `DeviceProfiler` destructor runs. This PR stores the noc trace data directory path in a member variable of `DeviceProfiler` so that it can be used in the destructor.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16656761202)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16656772926)
- [x] [Metal Microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/16656782380)
- [x] New/Existing tests provide coverage for changes