### PR TITLE
ci: add a workflow for testing integration of llk changes into metal

### DIFF
--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -75,7 +75,6 @@ jobs:
           fetch-depth: 0
           ref: main
           clean: true
-
       - name: Configure git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -135,16 +134,16 @@ jobs:
             local retries=0
             local timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
             local elapsed=0
-            local run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+            local run_url="https://github.com/tenstorrent/tt-metal/actions/runs/$run_id"
             echo "🚀 Monitoring $workflow_name (run ID: $run_id) - $run_url"
             while [ $retries -lt $MAX_RETRIES ]; do
               while [ $elapsed -lt $timeout_seconds ]; do
                 # Use more efficient status check
-                local status=$(gh run view "$run_id" --json status,conclusion --jq '.status + ":" + (.conclusion // "unknown")' 2>/dev/null || echo "unknown:unknown")
+                local status=$(gh run view "$run_id" --json status,conclusion --jq '.status + ":" + (.conclusion // "unknown")' --repo "tenstorrent/tt-metal" 2>/dev/null || echo "unknown:unknown")
                 local run_status=$(echo "$status" | cut -d: -f1)
                 local conclusion=$(echo "$status" | cut -d: -f2)
                 if [ "$run_status" = "completed" ]; then
-                  local run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+                  local run_url="https://github.com/tenstorrent/tt-metal/actions/runs/$run_id"
                   if [ "$conclusion" = "success" ]; then
                     echo "✅ $workflow_name passed: $run_url"
                     return 0
@@ -158,7 +157,7 @@ jobs:
               done
               # Handle timeout
               if [ $elapsed -ge $timeout_seconds ]; then
-                local run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+                local run_url="https://github.com/tenstorrent/tt-metal/actions/runs/$run_id"
                 echo "⏰ $workflow_name timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
                 return 1
               fi
@@ -166,7 +165,7 @@ jobs:
               retries=$((retries + 1))
               if [ $retries -lt $MAX_RETRIES ]; then
                 echo "🔄 Retrying $workflow_name (attempt $((retries + 1))/$MAX_RETRIES)"
-                if gh run rerun "$run_id" --failed --repo "${{ github.repository }}"; then
+                if gh run rerun "$run_id" --failed --repo "tenstorrent/tt-metal"; then
                   echo "✅ Retry triggered for $workflow_name"
                   sleep 30
                   elapsed=0  # Reset timer for retry
@@ -183,10 +182,10 @@ jobs:
           for workflow in "${!TEST_CONFIGS[@]}"; do
             if [ "${TEST_CONFIGS[$workflow]}" = "true" ]; then
               echo "Triggering $workflow..."
-              gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "${{ github.repository }}"
+              gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "tenstorrent/tt-metal"
               # Wait and get run ID
               sleep 10
-              run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
+              run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' --repo "tenstorrent/tt-metal" 2>/dev/null || echo "")
               if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
                 run_ids["$workflow"]="$run_id"
                 # Start monitoring in background
@@ -220,7 +219,6 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-
       - name: Cleanup test branches
         if: needs.setup-and-test.outputs.branch-exists == 'true'
         env:

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,7 +72,7 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 0
+          fetch-depth: 200
           ref: main
           clean: true
       - name: Configure git

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -1,4 +1,4 @@
-name: Test LLK Branches
+name: Test LLK to Metal integration
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -84,8 +84,8 @@ jobs:
         id: check-branch
         run: |
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          cd ${{ github.workspace }}
           cd ${{ env.SUBMODULE_PATH }}
+          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
           if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
@@ -100,8 +100,8 @@ jobs:
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
           TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
           # Setup test branch in submodule
-          cd ${{ github.workspace }}
           cd ${{ env.SUBMODULE_PATH }}
+          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
           git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
           git push origin "$TEST_BRANCH_NAME"
           # Setup parent repository with submodule reference
@@ -230,8 +230,8 @@ jobs:
           TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
           PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
           # Clean up test branch in submodule
-          cd ${{ github.workspace }}
           cd $SUBMODULE_PATH
+          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
           git push origin --delete "$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
           # Clean up parent branch
           cd ${{ github.workspace }}

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -83,6 +83,7 @@ jobs:
         id: check-branch
         run: |
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
+          cd ${{ github.workspace }}
           cd ${{ env.SUBMODULE_PATH }}
           if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
@@ -98,6 +99,7 @@ jobs:
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
           TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
           # Setup test branch in submodule
+          cd ${{ github.workspace }}
           cd ${{ env.SUBMODULE_PATH }}
           git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
           git push origin "$TEST_BRANCH_NAME"
@@ -226,6 +228,7 @@ jobs:
           TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
           PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
           # Clean up test branch in submodule
+          cd ${{ github.workspace }}
           cd $SUBMODULE_PATH
           git push origin --delete "$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
           # Clean up parent branch

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -1,0 +1,269 @@
+name: Test LLK Branches
+
+on:
+  workflow_dispatch:
+    inputs:
+      mirrored_branch:
+        description: 'Mirrored branch name (e.g., mirror/branch-name)'
+        required: true
+        type: string
+      run_all_post_commit:
+        description: 'Run all post-commit tests (Wormhole)'
+        required: false
+        type: boolean
+        default: false
+      run_blackhole_post_commit:
+        description: 'Run Blackhole post-commit tests'
+        required: false
+        type: boolean
+        default: false
+      workflow_timeout:
+        description: 'Timeout for workflows in minutes'
+        required: false
+        type: number
+        default: 240
+  workflow_call:
+    inputs:
+      mirrored_branch:
+        description: 'Mirrored branch name (e.g., mirror/branch-name)'
+        required: true
+        type: string
+      run_all_post_commit:
+        description: 'Run all post-commit tests (Wormhole)'
+        required: false
+        type: boolean
+        default: false
+      run_blackhole_post_commit:
+        description: 'Run Blackhole post-commit tests'
+        required: false
+        type: boolean
+        default: false
+      workflow_timeout:
+        description: 'Timeout for workflows in minutes'
+        required: false
+        type: number
+        default: 240
+
+env:
+  PARENT_BRANCH_NAME: test-llk-${{ inputs.mirrored_branch }}-${{ github.run_id }}
+  SUBMODULE_PATH: tt_metal/third_party/tt_llk
+  WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 240 }}
+  MAX_RETRIES: 3
+  POLL_INTERVAL: 120
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  issues: write
+  checks: read
+
+jobs:
+  setup-and-test:
+    runs-on: ubuntu-latest
+    outputs:
+      branch-exists: ${{ steps.check-branch.outputs.branch-exists }}
+      test-branch-name: ${{ steps.setup-branch.outputs.test-branch-name }}
+      parent-branch-name: ${{ env.PARENT_BRANCH_NAME }}
+    steps:
+      - name: Setup
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.TEMP_METAL_PAT }}
+          fetch-depth: 0
+          ref: main
+          clean: true
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Check if mirrored branch exists in submodule
+        id: check-branch
+        run: |
+          MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
+          cd ${{ env.SUBMODULE_PATH }}
+          if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
+            echo "branch-exists=true" >> $GITHUB_OUTPUT
+            echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
+          else
+            echo "branch-exists=false" >> $GITHUB_OUTPUT
+            echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"
+          fi
+      - name: Setup test branch and parent repository
+        id: setup-branch
+        if: steps.check-branch.outputs.branch-exists == 'true'
+        run: |
+          MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
+          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
+          # Setup test branch in submodule
+          cd ${{ env.SUBMODULE_PATH }}
+          git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+          git push origin "$TEST_BRANCH_NAME"
+          # Setup parent repository with submodule reference
+          cd ${{ github.workspace }}
+          git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
+          git add ${{ env.SUBMODULE_PATH }}
+          git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch ${{ inputs.mirrored_branch }}"
+          git push origin "${{ env.PARENT_BRANCH_NAME }}"
+          echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
+      - name: Run selected tests
+        if: |
+          steps.check-branch.outputs.branch-exists == 'true' &&
+          (inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true)
+        env:
+          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          WORKFLOW_TIMEOUT: ${{ env.WORKFLOW_TIMEOUT }}
+          MAX_RETRIES: ${{ env.MAX_RETRIES }}
+          POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
+          PARENT_BRANCH_NAME: ${{ env.PARENT_BRANCH_NAME }}
+          SUBMODULE_PATH: ${{ env.SUBMODULE_PATH }}
+        run: |
+          # Define test configurations
+          declare -A TEST_CONFIGS
+          TEST_CONFIGS["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}"
+          TEST_CONFIGS["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
+          # Helper function for workflow monitoring
+          monitor_workflow() {
+            local run_id=$1
+            local workflow_name=$2
+            local retries=0
+            local timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
+            local elapsed=0
+            local run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+            echo "🚀 Monitoring $workflow_name (run ID: $run_id) - $run_url"
+            while [ $retries -lt $MAX_RETRIES ]; do
+              while [ $elapsed -lt $timeout_seconds ]; do
+                # Use more efficient status check
+                local status=$(gh run view "$run_id" --json status,conclusion --jq '.status + ":" + (.conclusion // "unknown")' 2>/dev/null || echo "unknown:unknown")
+                local run_status=$(echo "$status" | cut -d: -f1)
+                local conclusion=$(echo "$status" | cut -d: -f2)
+                if [ "$run_status" = "completed" ]; then
+                  local run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+                  if [ "$conclusion" = "success" ]; then
+                    echo "✅ $workflow_name passed: $run_url"
+                    return 0
+                  else
+                    echo "❌ $workflow_name failed (attempt $((retries + 1))): $run_url"
+                    break
+                  fi
+                fi
+                sleep $POLL_INTERVAL
+                elapsed=$((elapsed + POLL_INTERVAL))
+              done
+              # Handle timeout
+              if [ $elapsed -ge $timeout_seconds ]; then
+                local run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+                echo "⏰ $workflow_name timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
+                return 1
+              fi
+              # Retry logic
+              retries=$((retries + 1))
+              if [ $retries -lt $MAX_RETRIES ]; then
+                echo "🔄 Retrying $workflow_name (attempt $((retries + 1))/$MAX_RETRIES)"
+                if gh run rerun "$run_id" --failed --repo "${{ github.repository }}"; then
+                  echo "✅ Retry triggered for $workflow_name"
+                  sleep 30
+                  elapsed=0  # Reset timer for retry
+                else
+                  echo "❌ Failed to trigger retry for $workflow_name"
+                  break
+                fi
+              fi
+            done
+            return 1
+          }
+          declare -A pids
+          declare -A run_ids
+          for workflow in "${!TEST_CONFIGS[@]}"; do
+            if [ "${TEST_CONFIGS[$workflow]}" = "true" ]; then
+              echo "Triggering $workflow..."
+              gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "${{ github.repository }}"
+              # Wait and get run ID
+              sleep 10
+              run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
+              if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+                run_ids["$workflow"]="$run_id"
+                # Start monitoring in background
+                monitor_workflow "$run_id" "$workflow" &
+                pids["$workflow"]=$!
+              else
+                echo "❌ Failed to get run ID for $workflow"
+                exit 1
+              fi
+            fi
+          done
+          # Wait for all background processes
+          exit_code=0
+          for workflow in "${!pids[@]}"; do
+            if wait "${pids[$workflow]}"; then
+              echo "✅ $workflow completed successfully"
+            else
+              echo "❌ $workflow failed"
+              exit_code=1
+            fi
+          done
+          exit $exit_code
+  cleanup:
+    needs: setup-and-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.TEMP_METAL_PAT }}
+
+      - name: Cleanup test branches
+        if: needs.setup-and-test.outputs.branch-exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          SUBMODULE_PATH: ${{ env.SUBMODULE_PATH }}
+        run: |
+          TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
+          PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
+          # Clean up test branch in submodule
+          cd $SUBMODULE_PATH
+          git push origin --delete "$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
+          # Clean up parent branch
+          cd ${{ github.workspace }}
+          git push origin --delete "$PARENT_BRANCH_NAME" 2>/dev/null || echo "Parent branch already deleted or doesn't exist"
+          echo "✅ Cleaned up test branches"
+  report-results:
+    needs: [setup-and-test, cleanup]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate test report
+        run: |
+          echo "## Test Results Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Mirrored Branch:** ${{ inputs.mirrored_branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow ID:** ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.setup-and-test.outputs.branch-exists }}" = "true" ]; then
+            echo "✅ **Branch Setup:** Successfully created test branch from mirrored branch" >> $GITHUB_STEP_SUMMARY
+            echo "**Test Branch:** ${{ needs.setup-and-test.outputs.test-branch-name }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Test Configuration:**" >> $GITHUB_STEP_SUMMARY
+            echo "- All Post-Commit Tests (Wormhole): ${{ inputs.run_all_post_commit && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- Blackhole Post-Commit Tests: ${{ inputs.run_blackhole_post_commit && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ needs.setup-and-test.result }}" = "success" ]; then
+              echo "✅ **Test Execution:** All selected tests completed successfully" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ needs.setup-and-test.result }}" = "skipped" ]; then
+              echo "ℹ️ **Test Execution:** No tests were selected to run" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "❌ **Test Execution:** Some tests failed" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "❌ **Branch Setup:** Mirrored branch '${{ inputs.mirrored_branch }}' does not exist" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Please ensure the branch has been mirrored using the mirror workflow first." >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow Status:** ${{ needs.setup-and-test.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Duration:** ${{ github.event.workflow_run.duration || 'N/A' }} seconds" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -77,7 +77,7 @@ jobs:
           clean: true
       - name: Configure git
         run: |
-          git config --global user.name "github-actions[bot]"
+          git config --global user.name "LLK Integration Tester [bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Check if mirrored branch exists in submodule
         id: check-branch

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Setup
         uses: actions/checkout@v4
         with:
+          repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
           fetch-depth: 0
@@ -216,6 +217,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
 


### PR DESCRIPTION
### Ticket
None

### Problem description
The main idea is to enable testing LLK changes from the tt-llk repository using tt-metal’s APC/BPC workflows.
The next step is to add a workflow in tt-llk that triggers this one via workflow_call.

This will make our lives much easier with all the bounties and changes coming from external developers.
No more handholding, just add a label to the PR and call this workflow from tt-llk.
Example of run: https://github.com/tenstorrent/tt-metal/actions/runs/16657023055

tt-llk counterpart (which calls tt-metal workflow): https://github.com/tenstorrent/tt-llk/pull/557
Example of run: https://github.com/tenstorrent/tt-llk/actions/runs/16677603772 (I killed it, because I didn't want to pressure the runners)

### What's changed
New workflow.