### PR TITLE
add extract_output_tensor() to handle vector of tensors

### DIFF
--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -29,6 +29,9 @@ namespace detail {
 // most ops just return a tensor
 inline Tensor extract_output_tensor(const Tensor& result) { return result; }
 
+// multi-output ops like sort
+inline Tensor extract_output_tensor(const std::vector<Tensor>& result) { return result[0]; }
+
 // conv2d output
 template <typename... Args1, typename... Args2>
 Tensor extract_output_tensor(const std::variant<


### PR DESCRIPTION
### Ticket
#26081

This is to support `sortOp` in tt-mlir's constraint API. This op returns two tensors, and an appropriate `extract_output_tensor()` definition was needed for `query_op_constraints()` to work.