### PR TITLE
[skip ci] Move N300 ttnn unit tests back to CIv1

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -101,7 +101,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150, N300', inputs.runner-label)) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
N300 CIv2 backlog is very large

### What's changed
Move ttnn jobs back to Civ1

### Checklist
- [ ] New/Existing tests provide coverage for changes