### PR TITLE
Revert "MLP and RMSNorm metamodules"

### DIFF
--- a/models/demos/deepseek_v3/tests/test_mlp_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mlp_1d.py
@@ -23,11 +23,8 @@ from models.demos.deepseek_v3.utils.test_utils import (
 )
 from models.utility_functions import comp_pcc
 
-DEVICE_SHAPE = ttnn.MeshShape(2, min(ttnn.get_num_devices() // 2, 8))
 
-
-@pytest.mark.parametrize("device_params", [{"mesh_shape": DEVICE_SHAPE}], indirect=True)
-def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_device):
+def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_row):
     reference_model = DeepseekV3MLP(hf_config)
     reference_state_dict = reference_model.state_dict()
     run_weight_conversion_test(
@@ -35,24 +32,23 @@ def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_devic
         hf_config=hf_config,
         state_dict=reference_model.state_dict(),
         tmp_path=tmp_path,
-        mesh_device=mesh_device,
+        mesh_row=mesh_row,
         reference_w1=reference_state_dict["gate_proj.weight"],
     )
 
 
-@pytest.mark.parametrize("device_params", [{"mesh_shape": DEVICE_SHAPE}], indirect=True)
 @pytest.mark.parametrize(
     "MLPClass,module_path",
     [(NonExpert, "model.layers.0.mlp"), (SharedExpert, "model.layers.3.mlp.shared_experts")],
 )
-def test_convert_weights_for_dequantized_mlps(MLPClass, model_path, module_path, hf_config, tmp_path, mesh_device):
+def test_convert_weights_for_dequantized_mlps(MLPClass, model_path, module_path, hf_config, tmp_path, mesh_row):
     state_dict = load_state_dict(model_path, module_path)
     run_weight_conversion_test(
         MLPClass=MLPClass,
         hf_config=hf_config,
         state_dict=state_dict,
         tmp_path=tmp_path,
-        mesh_device=mesh_device,
+        mesh_row=mesh_row,
         reference_w1=dequantize(
             state_dict["gate_proj.weight"],
             state_dict["gate_proj.weight_scale_inv"],
@@ -61,13 +57,9 @@ def test_convert_weights_for_dequantized_mlps(MLPClass, model_path, module_path,
     )
 
 
-def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, reference_w1, mesh_device):
-    num_module_layers, _ = mesh_device.shape
-
+def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, reference_w1, mesh_row):
     # Convert the weights
-    weight_config = MLPClass.convert_weights(
-        hf_config, [state_dict] + [None] * (num_module_layers - 1), tmp_path, mesh_device
-    )
+    weight_config = MLPClass.convert_weights(hf_config, state_dict, tmp_path, mesh_row)
 
     # Verify weight_config structure
     assert "w1" in weight_config
@@ -83,30 +75,23 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
     assert Path(weight_config["w3"]["input_tensor_b"]).exists()
 
     # Load and verify a weight
-    w1_ttnn = ttnn.load_tensor(weight_config["w1"]["input_tensor_b"], device=mesh_device)
-    w1_ttnn = ttnn.unsqueeze(w1_ttnn, 0)  # Unsqueeze to collect shards on a separate dim
+    w1_ttnn = ttnn.load_tensor(weight_config["w1"]["input_tensor_b"], device=mesh_row)
     w1_torch = ttnn.to_torch(
         w1_ttnn,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=tuple(mesh_device.shape)),
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(-2, -1), mesh_shape=tuple(mesh_row.shape)),
     )
 
     # Weight should be transposed from PyTorch format
-    assert w1_torch.shape == (
-        num_module_layers,
-        *[1 for _ in range(w1_torch.ndim - 3)],
-        reference_w1.shape[1],
-        reference_w1.shape[0],
-    )
+    assert w1_torch.shape == (1,) * (w1_torch.ndim - 2) + (reference_w1.shape[1], reference_w1.shape[0])
 
     # Verify the values match (accounting for transpose and bfloat8 conversion)
-    passing, pcc_msg = comp_pcc(reference_w1.T, w1_torch[0], 0.99)
+    passing, pcc_msg = comp_pcc(reference_w1.T, w1_torch, 0.99)
     assert passing, f"Weight conversion PCC failed: {pcc_msg}"
 
     # Cleanup
     ttnn.deallocate(w1_ttnn)
 
 
-@pytest.mark.parametrize("device_params", [{"mesh_shape": DEVICE_SHAPE}], indirect=True)
 @pytest.mark.parametrize(
     "MLPClass,module_path",
     [
@@ -130,35 +115,33 @@ def test_forward_pass(
     seq_len,
     hf_config,
     tmp_path,
-    mesh_device,
+    mesh_row,
     model_path,
 ):
-    num_module_layers, _ = mesh_device.shape
-
     # Get the reference IO
     if not issubclass(MLPClass, MLP1DDequant):
-        torch.set_default_dtype(torch.bfloat16)
         reference_model = DeepseekV3MLP(hf_config).eval()
         state_dict = reference_model.state_dict()
-        torch_input = torch.randn(4, 1, seq_len, hf_config.hidden_size)
+
+        torch_input = torch.randn(1, 1, seq_len, hf_config.hidden_size)
         reference_output = reference_model(torch_input)
     else:
         state_dict = load_state_dict(model_path, module_path)
-        torch_input, reference_output = load_reference_io_tensors_for_module(
-            mode, module_path, seq_len, num_module_layers
-        )
+        torch_input, reference_output = load_reference_io_tensors_for_module(mode, module_path, seq_len)
+        torch_input.unsqueeze_(0)
+        reference_output.unsqueeze_(0)
 
     # Generate module configs and state
-    weight_config = MLPClass.convert_weights(hf_config, [state_dict] * num_module_layers, tmp_path, mesh_device)
-    model_config = get_model_config(MLPClass, mode, hf_config, mesh_device)
-    model_state = MLPClass.create_state(hf_config, mesh_device=mesh_device)
+    weight_config = MLPClass.convert_weights(hf_config, state_dict, tmp_path, mesh_row)
+    model_config = get_model_config(MLPClass, mode, hf_config, mesh_row)
+    model_state = MLPClass.create_state(hf_config, mesh_device=mesh_row)
     run_config = create_run_config(model_config, weight_config, model_state)
 
     # Convert input to TTNN
     tt_input = ttnn.from_torch(
         torch_input,
-        device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, (0, None)),
+        device=mesh_row,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_row),
         dtype=ttnn.bfloat16,
         memory_config=run_config["input_memory_config"],
         layout=ttnn.TILE_LAYOUT,
@@ -177,7 +160,7 @@ def test_forward_pass(
     # Convert output back to torch
     tt_output_torch = ttnn.to_torch(
         tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=tuple(mesh_device.shape)),
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(-2, -1), mesh_shape=tuple(mesh_row.shape)),
     )
 
     # Cleanup

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -50,34 +50,32 @@ def test_forward_pass(
     model_path,
     hf_config,
     tmp_path,
-    mesh_device,
+    mesh_row,
 ):
-    num_module_layers, _ = mesh_device.shape
-
     # Get the hidden_size of the norm
     hidden_size = getattr(hf_config, hf_config_size_attr)
 
     # Get the reference inputs and outputs
     if reference_layernorm_path is None:
-        torch.set_default_dtype(torch.bfloat16)
         reference_model = DeepseekV3RMSNorm(
             hidden_size=hidden_size,
             eps=hf_config.rms_norm_eps,
         ).eval()
         state_dict = reference_model.state_dict()
 
-        torch_input = torch.randn(num_module_layers, 1, seq_len, hidden_size)
+        torch_input = torch.randn(1, 1, seq_len, hidden_size)
         reference_output = reference_model(torch_input)
     else:
         state_dict = load_state_dict(model_path, reference_layernorm_path)
-        torch_input, reference_output = load_reference_io_tensors_for_module(
-            mode, reference_layernorm_path, seq_len, num_module_layers
-        )
+        torch_input, reference_output = load_reference_io_tensors_for_module(mode, reference_layernorm_path, seq_len)
+        print(torch_input.shape, reference_output.shape)
+        torch_input.unsqueeze_(0)
+        reference_output.unsqueeze_(0)
 
     # Generate module configs and state
-    weight_config = RMSNormClass.convert_weights(hf_config, [state_dict] * num_module_layers, tmp_path, mesh_device)
-    model_config = get_model_config(RMSNormClass, mode, hf_config, mesh_device)
-    model_state = RMSNormClass.create_state(hf_config, mesh_device)
+    weight_config = RMSNormClass.convert_weights(hf_config, state_dict, tmp_path, mesh_row)
+    model_config = get_model_config(RMSNormClass, mode, hf_config, mesh_row)
+    model_state = RMSNormClass.create_state(hf_config, mesh_row)
     run_config = create_run_config(model_config, weight_config, model_state)
 
     # Convert the input to TTNN tensor
@@ -87,9 +85,9 @@ def test_forward_pass(
         shard_core_grid = ttnn.CoreGrid(x=4, y=7)
         memory_config = ttnn.create_sharded_memory_config(
             shape=(
-                ttnn.core.roundup(even_int_div(seq_len, num_module_layers), ttnn.TILE_SIZE),
+                ttnn.core.roundup(even_int_div(seq_len, tuple(mesh_row.shape)[0]), ttnn.TILE_SIZE),
                 ttnn.core.roundup(
-                    even_int_div(hidden_size, shard_core_grid.num_cores * mesh_device.shape[1]),
+                    even_int_div(hidden_size, shard_core_grid.num_cores * tuple(mesh_row.shape)[1]),
                     ttnn.TILE_SIZE,
                 ),
             ),
@@ -100,9 +98,11 @@ def test_forward_pass(
         )
     tt_input = ttnn.from_torch(
         torch_input,
-        device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, mesh_device.shape, dims=(0, -1 if RMSNormClass is DistributedRMSNorm else None)
+        device=mesh_row,
+        mesh_mapper=(
+            ttnn.ShardTensor2dMesh(mesh_row, dims=(-2, -1), mesh_shape=tuple(mesh_row.shape))
+            if RMSNormClass is DistributedRMSNorm
+            else ttnn.ReplicateTensorToMesh(mesh_row)
         ),
         dtype=ttnn.bfloat16,
         memory_config=memory_config,
@@ -113,12 +113,13 @@ def test_forward_pass(
     tt_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
 
     # Convert output back to torch
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
-    )
-    if RMSNormClass is RMSNorm:
-        tt_output_torch = tt_output_torch[..., :hidden_size]
+    if RMSNormClass is DistributedRMSNorm:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_row, dims=(-2, -1), mesh_shape=tuple(mesh_row.shape)),
+        )
+    else:
+        tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_output)[0])
 
     # Cleanup
     ttnn.deallocate(tt_input)

--- a/models/demos/deepseek_v3/tt/mlp/mlp_1d.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp_1d.py
@@ -27,7 +27,6 @@ from models.demos.deepseek_v3.utils.config_helpers import (
     find_largest_divisor,
     get_activation_sharding_core_counts_for_dram_matmul,
     get_dram_sharded_matmul_config,
-    get_state_dicts,
     save_and_get_path,
 )
 from models.demos.deepseek_v3.utils.run_config import (
@@ -45,9 +44,6 @@ class MLP1D(AbstractModule):
     NOTE: This is not the MLP we will use for DeepSeek-R1, but we do use it as a base class for the other MLPs.
     """
 
-    WEIGHT_TORCH_DTYPE = torch.float32
-    WEIGHT_DTYPE = ttnn.bfloat4_b
-
     @dataclass
     class MLPProgramConfigData(OpConfigBase):
         """Data class for the data for generating the PC for ttnn.linear."""
@@ -64,39 +60,36 @@ class MLP1D(AbstractModule):
     def convert_weights(
         cls,
         hf_config: PretrainedConfig,
-        state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
+        state_dict: dict[str, torch.Tensor],
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
+        assert cls.is_device_supported(mesh_device)
         return {
             models_name: {
                 "input_tensor_b": save_and_get_path(
                     output_path / f"{models_name}.input_tensor_b",
-                    cls.convert_metaweight(
-                        get_state_dicts(
-                            state_dicts,
-                            f"{hf_name}.weight",
-                            shape=(out_features, in_features),
-                            dtype=cls.WEIGHT_TORCH_DTYPE,
-                        ),
+                    cls.convert_weight(
+                        hf_config,
+                        state_dict[f"{hf_name}.weight"],
                         mesh_device,
-                        is_w2,
+                        is_w2=(models_name == "w2"),
                     ),
                 )
             }
-            for hf_name, models_name, is_w2 in [
-                ("gate_proj", "w1", False),
-                ("down_proj", "w2", True),
-                ("up_proj", "w3", False),
+            for hf_name, models_name in [
+                ("gate_proj", "w1"),
+                ("down_proj", "w2"),
+                ("up_proj", "w3"),
             ]
-            for in_features, out_features in [cls.get_weight_shape(hf_config, is_w2)]
         }
 
     @final
     @classmethod
-    def convert_metaweight(
+    def convert_weight(
         cls,
-        torch_metaweight_tensor: torch.Tensor,
+        hf_config: PretrainedConfig,
+        weight_tensor: torch.Tensor,
         mesh_device: ttnn.Device,
         is_w2: bool,
     ) -> ttnn.Tensor:
@@ -104,32 +97,35 @@ class MLP1D(AbstractModule):
         Convert a normal (non-quantized) weight tensor to a format suitable for TTNN.
 
         Args:
-            metaweight_tensor: The weight tensor.
+            weight_tensor: The weight tensor.
             mesh_device: The mesh device to use for the conversion.
 
         Returns:
             The converted TTNN tensor.
         """
-        torch_metaweight_tensor = torch_metaweight_tensor.transpose(
-            2, 1
+        dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
+
+        torch_weight_tensor = weight_tensor.permute(
+            1, 0
         )  # In torch the weights are in (out_features, in_features) format
 
-        # Calculate the expected weight dimensions
-        num_shards, per_device_in_features, per_device_out_features = torch_metaweight_tensor.shape
-        mp, tp = mesh_device.shape
-        assert num_shards == mp, "Number of mesh rows does not match weight shards"
-
         if is_w2:
-            per_device_in_features = even_int_div(per_device_in_features, tp)
-            mesh_sharded_dim = 1
+            assert torch_weight_tensor.shape == (hidden_dim, dim)
+            per_device_in_features, per_device_out_features = (
+                even_int_div(hidden_dim, mesh_device.get_num_devices()),
+                dim,
+            )
+            mesh_sharded_dim = 0
         else:
-            per_device_out_features = even_int_div(per_device_out_features, tp)
-            mesh_sharded_dim = 2
+            assert torch_weight_tensor.shape == (dim, hidden_dim)
+            per_device_in_features, per_device_out_features = dim, even_int_div(
+                hidden_dim, mesh_device.get_num_devices()
+            )
+            mesh_sharded_dim = 1
 
-        # Convert the torch tensor to a TTNN tensor
-        metaweight_tensor = ttnn.from_torch(
-            torch_metaweight_tensor,
-            dtype=cls.WEIGHT_DTYPE,
+        return ttnn.from_torch(
+            torch_weight_tensor,
+            dtype=ttnn.bfloat4_b,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=dram_sharded_weight_config(
@@ -137,19 +133,21 @@ class MLP1D(AbstractModule):
                 per_device_out_features,
                 mesh_device.dram_grid_size(),
             ),
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, (0, mesh_sharded_dim)),
+            mesh_mapper=ttnn.shard_tensor_to_mesh_mapper(mesh_device, mesh_sharded_dim),
         )
-        return ttnn.squeeze(metaweight_tensor, 0)  # Remove the row shard dimension
 
-    @final
     @classmethod
-    def get_weight_shape(cls, hf_config: PretrainedConfig, is_w2: bool) -> tuple[int, int]:
-        """Get the shape of the weight tensor for the MLP."""
-        dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
-        if is_w2:
-            return hidden_dim, dim
-        else:
-            return dim, hidden_dim
+    def is_device_supported(cls, mesh_device: ttnn.Device) -> bool:
+        """
+        As we only support 1D tensor parallelism, we only support 1D mesh devices.
+
+        Args:
+            mesh_device: The mesh device to check.
+
+        Returns:
+            True if the device is supported, False otherwise.
+        """
+        return tuple(mesh_device.shape)[0] == 1
 
     @classmethod
     def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
@@ -168,7 +166,7 @@ class MLP1D(AbstractModule):
         )  # NOTE: we might modify this later during optimization stage
 
         # Calculate device metrics
-        _, mesh_width = mesh_device.shape
+        num_devices = mesh_device.get_num_devices()
 
         # Extract dimensions from HF config
         dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
@@ -184,7 +182,7 @@ class MLP1D(AbstractModule):
         return {
             "max_rows": SEQ_LEN_CHUNK_SIZE,  # NOTE: should be 512 for blackhole (in case of future bring-up)
             "linear_pc_gen": MLP1D.MLPProgramConfigData(
-                dim=dim, hidden_dim=hidden_dim, num_devices=mesh_width, core_grid_size=matmul_core_grid_size
+                dim=dim, hidden_dim=hidden_dim, num_devices=num_devices, core_grid_size=matmul_core_grid_size
             ),
             "w1": linear_op_config,
             "w2": linear_op_config,
@@ -195,8 +193,6 @@ class MLP1D(AbstractModule):
             ),
             "reduce_scatter": ReduceScatterConfig(
                 dim=-1,  # We are scattering across the feature dimension (last one)
-                cluster_axis=1,  # Reduce-scatter across the mesh rows
-                mesh_device=MeshDeviceStub(mesh_device.shape),
                 math_op=ttnn.ReduceType.Sum,
                 topology=ttnn.Topology.Linear,  # One row of Galaxy does not form a ring
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -230,16 +226,16 @@ class MLP1D(AbstractModule):
         dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
 
         # Calculate device metrics
-        _, mesh_width = mesh_device.shape
+        num_devices = mesh_device.get_num_devices()
         max_num_cores = mesh_device.core_grid.x * mesh_device.core_grid.y
         input_num_cores = input_num_cores or max(
             get_activation_sharding_core_counts_for_dram_matmul(dim, max_num_cores)
         )
         inner_num_cores = max(
-            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(hidden_dim, mesh_width), max_num_cores)
+            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(hidden_dim, num_devices), max_num_cores)
         )
         output_num_cores = output_num_cores or max(
-            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(dim, mesh_width), max_num_cores)
+            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(dim, num_devices), max_num_cores)
         )
         assert (
             input_num_cores <= max_num_cores
@@ -249,13 +245,13 @@ class MLP1D(AbstractModule):
         ), "output_num_cores must be less than or equal to the maximum number of cores"
         assert dim % input_num_cores == 0, "input_num_cores must divide the input tensor width evenly"
         assert (
-            even_int_div(dim, mesh_width) % output_num_cores == 0
+            even_int_div(dim, num_devices) % output_num_cores == 0
         ), "output_num_cores must divide the output tensor width evenly"
 
         # Calculate input and output memory configurations
         input_memory_config = cls._get_decode_activation_memory_config(dim, input_num_cores, mesh_device)
         output_memory_config = cls._get_decode_activation_memory_config(
-            even_int_div(dim, mesh_width), output_num_cores, mesh_device
+            even_int_div(dim, num_devices), output_num_cores, mesh_device
         )
 
         # Construct the config
@@ -264,7 +260,7 @@ class MLP1D(AbstractModule):
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 program_config=get_dram_sharded_matmul_config(
-                    MAX_BATCH_SIZE, dim, even_int_div(hidden_dim, mesh_width), input_num_cores, inner_num_cores
+                    MAX_BATCH_SIZE, dim, even_int_div(hidden_dim, num_devices), input_num_cores, inner_num_cores
                 ),
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),
@@ -273,7 +269,7 @@ class MLP1D(AbstractModule):
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 program_config=get_dram_sharded_matmul_config(
                     MAX_BATCH_SIZE,
-                    even_int_div(hidden_dim, mesh_width),
+                    even_int_div(hidden_dim, num_devices),
                     dim,
                     inner_num_cores,
                     output_num_cores,
@@ -284,7 +280,7 @@ class MLP1D(AbstractModule):
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 program_config=get_dram_sharded_matmul_config(
-                    MAX_BATCH_SIZE, dim, even_int_div(hidden_dim, mesh_width), input_num_cores, inner_num_cores
+                    MAX_BATCH_SIZE, dim, even_int_div(hidden_dim, num_devices), input_num_cores, inner_num_cores
                 ),
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),
@@ -294,11 +290,9 @@ class MLP1D(AbstractModule):
             ),
             "reduce_scatter": ReduceScatterConfig(
                 dim=-1,  # We are scattering across the feature dimension (last one)
-                cluster_axis=1,  # Reduce-scatter across the mesh rows
-                mesh_device=MeshDeviceStub(mesh_device.shape),
                 math_op=ttnn.ReduceType.Sum,
-                topology=ttnn.Topology.Linear,  # One row of Galaxy does not form a ring
                 memory_config=output_memory_config,
+                topology=ttnn.Topology.Linear,  # One row of Galaxy does not form a ring
             ),
             "input_memory_config": input_memory_config,  # For asserting the input to the MLP
             "output_memory_config": output_memory_config,  # For asserting the output of the MLP
@@ -373,10 +367,10 @@ class MLP1D(AbstractModule):
     def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
         assert x.memory_config() == cfg["input_memory_config"]
 
-        num_layers, _, seq_len, _ = x.shape
+        _, _, seq_len, _ = x.shape
 
         if seq_len > cfg["max_rows"]:  # For large sequence lengths, process the input in chunks
-            x = ttnn.reshape(x, [num_layers, even_int_div(seq_len, cfg["max_rows"]), cfg["max_rows"], -1])
+            x = ttnn.reshape(x, [1, even_int_div(seq_len, cfg["max_rows"]), cfg["max_rows"], -1])
             seq_len = cfg["max_rows"]
 
         # Gate and up projections with dynamic program configs
@@ -407,7 +401,7 @@ class MLP1D(AbstractModule):
         # De-chunk the output if the input was chunked
         _, num_chunks, _, output_dim = output.shape
         if num_chunks > 1:
-            output = ttnn.reshape(output, [num_layers, 1, -1, output_dim])
+            output = ttnn.reshape(output, [1, 1, -1, output_dim])
 
         assert output.memory_config() == cfg["output_memory_config"]
         return output

--- a/models/demos/deepseek_v3/tt/mlp/mlp_1d_dequant.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp_1d_dequant.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
-from typing import final
+from typing import Any, final
 
 import torch
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.demos.deepseek_v3.tt.mlp.mlp_1d import MLP1D
-from models.demos.deepseek_v3.utils.config_helpers import dequantize, get_state_dicts, save_and_get_path
+from models.demos.deepseek_v3.utils.config_helpers import dequantize, save_and_get_path
 from models.demos.deepseek_v3.utils.run_config import WeightConfig
 
 
@@ -18,61 +18,44 @@ class MLP1DDequant(MLP1D):
     Base class for MLP modules in DeepSeek V3.
     """
 
-    WEIGHT_TORCH_DTYPE = torch.float8_e4m3fn
-    WEIGHT_SCALE_INV_TORCH_DTYPE = torch.float32
-
     @classmethod
     def convert_weights(
         cls,
         hf_config: PretrainedConfig,
-        state_dict: tuple[dict[str, torch.Tensor] | None, ...],
+        state_dict: dict[str, torch.Tensor],
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
-        weight_block_height, weight_block_width = hf_config.quantization_config["weight_block_size"]
+        assert cls.is_device_supported(mesh_device)
         return {
             models_name: {
                 "input_tensor_b": save_and_get_path(
                     output_path / f"{models_name}.input_tensor_b",
-                    cls.convert_quantized_metaweight(
-                        get_state_dicts(
-                            state_dict,
-                            f"{hf_name}.weight",
-                            shape=(out_features, in_features),
-                            dtype=cls.WEIGHT_TORCH_DTYPE,
-                        ),
-                        get_state_dicts(
-                            state_dict,
-                            f"{hf_name}.weight_scale_inv",
-                            shape=(
-                                ttnn.core.divup(out_features, weight_block_height),
-                                ttnn.core.divup(in_features, weight_block_width),
-                            ),
-                            dtype=cls.WEIGHT_SCALE_INV_TORCH_DTYPE,
-                        ),
+                    cls.convert_quantized_weight(
+                        hf_config,
+                        state_dict[f"{hf_name}.weight"],
+                        state_dict[f"{hf_name}.weight_scale_inv"],
                         mesh_device,
-                        is_w2=is_w2,
-                        metaweight_block_size=(1, weight_block_height, weight_block_width),
+                        is_w2=(models_name == "w2"),
                     ),
                 )
             }
-            for hf_name, models_name, is_w2 in [
-                ("gate_proj", "w1", False),
-                ("down_proj", "w2", True),
-                ("up_proj", "w3", False),
+            for hf_name, models_name in [
+                ("gate_proj", "w1"),
+                ("down_proj", "w2"),
+                ("up_proj", "w3"),
             ]
-            for in_features, out_features in [cls.get_weight_shape(hf_config, is_w2)]
         }
 
     @final
     @classmethod
-    def convert_quantized_metaweight(
+    def convert_quantized_weight(
         cls,
+        hf_config: Any,
         quantized_weight_tensor: torch.Tensor,
         scale_inv_tensor: torch.Tensor,
         mesh_device: ttnn.Device,
         is_w2: bool,
-        metaweight_block_size: tuple[int, ...],
     ) -> ttnn.Tensor:
         """
         Convert the quantized weight tensor to a format suitable for TTNN.
@@ -86,8 +69,11 @@ class MLP1DDequant(MLP1D):
         Returns:
             The converted TTNN tensor.
         """
-        return cls.convert_metaweight(
-            torch_metaweight_tensor=dequantize(quantized_weight_tensor, scale_inv_tensor, metaweight_block_size),
+        return cls.convert_weight(
+            hf_config=hf_config,
+            weight_tensor=dequantize(
+                quantized_weight_tensor, scale_inv_tensor, hf_config.quantization_config["weight_block_size"]
+            ),
             mesh_device=mesh_device,
             is_w2=is_w2,
         )

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -10,7 +10,7 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm_base import RMSNormBase
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, RMSNormConfig
-from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_LOFI, get_state_dicts, save_and_get_path
+from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_HIFI2, save_and_get_path
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -25,25 +25,20 @@ class RMSNorm(RMSNormBase):
     def convert_weights(
         cls,
         hf_config: PretrainedConfig,
-        state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
+        state_dict: dict[str, torch.Tensor],
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
-        assert mesh_device.shape[0] > 0, "RMSNorm does not support 0D devices"
+        assert cls.is_device_supported(mesh_device)
 
-        torch_metaweight = get_state_dicts(state_dicts, "weight", dtype=torch.bfloat16)
-        num_shards = torch_metaweight.shape[0]
-        assert num_shards == mesh_device.shape[0], "Number of state dicts does not match the number of rows."
-
+        torch_weight = state_dict["weight"]
         tt_weight = ttnn.as_tensor(
-            torch_metaweight.reshape(
-                (num_shards, 1, -1, ttnn.TILE_SIZE)
-            ),  # Reshape to tile width sticks for optimal performance
+            torch_weight.reshape((1, 1, -1, ttnn.TILE_SIZE)),  # Reshape to tile width sticks for optimal performance
             device=mesh_device,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=(0, None)),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
 
         # Save to disk with standard naming - "rmsnorm" must match the op name used in the model config
@@ -57,7 +52,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
@@ -66,7 +61,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
         )
 
     @classmethod
@@ -80,5 +75,4 @@ class RMSNorm(RMSNormBase):
         Returns:
             Output tensor after embedding lookup
         """
-        pc = cls._get_pc(x.memory_config())
         return ttnn.rms_norm(x, program_config=cls._get_pc(x.memory_config()), **cfg)

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm_base.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm_base.py
@@ -4,6 +4,8 @@
 
 from abc import abstractmethod
 
+import torch
+
 import ttnn
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.run_config import RunDecodeConfig, RunPrefillConfig
@@ -22,6 +24,11 @@ class RMSNormBase(AbstractModule):
             True if the device is supported, False otherwise.
         """
         return tuple(mesh_device.shape)[0] == 1
+
+    @classmethod
+    @abstractmethod
+    def _convert_weight(cls, torch_weight: torch.Tensor, mesh_device: ttnn.Device) -> ttnn.Tensor:
+        raise NotImplementedError("This method should be implemented in subclasses")
 
     @classmethod
     def _get_pc(

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -495,11 +495,10 @@ def dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: Seque
 
 
 def get_state_dicts(
-    dicts: Sequence[dict[str, torch.Tensor] | None],
     key: Any,
-    shape: Sequence[int] | None = None,
-    dtype: torch.dtype | None = None,
+    dicts: Sequence[dict[str, torch.Tensor] | None],
     concat_dim: int = 0,
+    shape: Sequence[int] | None = None,
     concat: bool = False,
 ) -> torch.Tensor:
     """Get a weight from a list of state dictionaries and combine them into a single tensor.
@@ -520,20 +519,12 @@ def get_state_dicts(
     )
     assert expected_shape is not None, "At least one dictionary must be non-empty, or a shape must be provided"
 
-    expected_dtype = (
-        next(map(lambda d: d[key].dtype, filter(lambda d: d is not None, dicts)), None) if dtype is None else dtype
-    )
-    assert expected_dtype is not None, "At least one dictionary must be non-empty, or a dtype must be provided"
-
     assert all(key in d for d in dicts if d is not None), f"Key {key} not found in all dictionaries"
     assert all(
         d[key].shape == expected_shape for d in dicts if d is not None
-    ), f"Key {key} must have the value shaped as {expected_shape} in all dictionaries; instead got {[d[key].shape if d is not None else None for d in dicts]}"
-    assert all(
-        d[key].dtype == expected_dtype for d in dicts if d is not None
-    ), f"Key {key} must have the dtype as {expected_dtype} in all dictionaries; instead got {[d[key].dtype if d is not None else None for d in dicts]}"
+    ), f"Key {key} must have the value shaped as {expected_shape} in all dictionaries"
 
-    tensors = [torch.zeros(expected_shape, dtype=dtype) if d is None else d[key] for d in dicts]
+    tensors = [torch.zeros(expected_shape) if d is None else d[key] for d in dicts]
 
     if concat:
         return torch.concat(tensors, dim=concat_dim)

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -42,7 +42,6 @@ def load_reference_io_tensors_for_module(
     mode: Literal["prefill", "decode"],
     module: str,
     seq_len: int,
-    num_expand_rows: int,
     concat_dim: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert mode in ["prefill", "decode"], f"Unsupported mode: {mode}"
@@ -62,11 +61,7 @@ def load_reference_io_tensors_for_module(
         assert set(io_module_paths) == {module}
         torch_input = torch.concat(torch_inputs, dim=concat_dim)
         reference_output = torch.concat(reference_outputs, dim=concat_dim)
-    torch_input.unsqueeze_(0)
-    reference_output.unsqueeze_(0)
-    return pad_tensor(torch_input, mode, seq_len).expand(
-        num_expand_rows, *(-1 for _ in range(torch_input.ndim - 1))
-    ), reference_output.expand(num_expand_rows, *(-1 for _ in range(reference_output.ndim - 1)))
+    return pad_tensor(torch_input, mode, seq_len), reference_output
 
 
 def load_reference_io(mode: Literal["prefill", "decode"], module_range: str):


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#26009

Breaking all post commit ttnn group 2 unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/16659150664/job/47152702693