### PR TITLE
api change fix for deepseek mla ops

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_deepseek_mla_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_deepseek_mla_ops.py
@@ -757,8 +757,8 @@ def run_rmsnorm_impl(
     )
 
     # Setup: Convert weights and get weight_config
-    state_dict = {"weight": rms_norm.weight.unsqueeze(0)}
-    weight_config = RMSNorm.convert_weights(hf_config, state_dict, temp_dir, device)
+    state_dicts = ({"weight": rms_norm.weight.to(torch.bfloat16)},)  # Tuple of dictionaries
+    weight_config = RMSNorm.convert_weights(hf_config, state_dicts, temp_dir, device)
 
     # Generate appropriate config
     if mode == "prefill":
@@ -780,7 +780,7 @@ def run_rmsnorm_impl(
     #################
     ### Validation
     #################
-    pcc_threshold = 0.9999
+    pcc_threshold = 0.9995
 
     out_pass, out_pcc = comp_pcc(tt_out_torch, out_torch, pcc_threshold)
     logger.info(f"Output PCC: {out_pcc}")


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes