### PR TITLE
#26025: Fix tt-run to sort the rank entries to match the implicit ordering of mpirun

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -364,9 +364,8 @@ void run_mcast_sender_step(
 
     std::vector<uint32_t> mcast_header_rtas(4, 0);
     for (const auto& routing_info : mcast_routing_info) {
-        // Increment hop count to account for the mcast start node
-        mcast_header_rtas[static_cast<uint32_t>(control_plane.routing_direction_to_eth_direction(
-            routing_info.mcast_dir))] = routing_info.num_mcast_hops + 1;
+        mcast_header_rtas[static_cast<uint32_t>(
+            control_plane.routing_direction_to_eth_direction(routing_info.mcast_dir))] = routing_info.num_mcast_hops;
     }
 
     sender_runtime_args.insert(sender_runtime_args.end(), mcast_header_rtas.begin(), mcast_header_rtas.end());

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(unit_tests_ttnn_multihost_ccl_ops)
 target_sources(
     unit_tests_ttnn_multihost_ccl_ops
     PRIVATE
+        multihost_ccl/main.cpp
         ${PROJECT_SOURCE_DIR}/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
         multihost_ccl/test_send_recv_ops.cpp
 )

--- a/tests/ttnn/unit_tests/gtests/multihost_ccl/main.cpp
+++ b/tests/ttnn/unit_tests/gtests/multihost_ccl/main.cpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tests/tt_metal/multihost/common/multihost_test_tools.hpp"
+
+int main(int argc, char** argv) { return multihost::common::multihost_main(argc, argv); }

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -251,7 +251,6 @@ def main(ctx: click.Context, rank_binding: Path, dry_run: bool, verbose: bool, m
         - TT_METAL_HOME: TT-Metal installation directory
         - PYTHONPATH: Python module search path
         - TT_MESH_GRAPH_DESC_PATH: Path to mesh graph descriptor
-        - GTEST_OUTPUT: If GTEST_OUTPUT is set to a directory, a subdirectory will be created for each rank.
 
     See examples/ttrun/ for example configuration files.
     """

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -97,15 +97,6 @@ def get_rank_environment(
         "TT_HOST_RANK": str(mesh_to_host_rank_id[binding.mesh_id]),
         "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,
     }
-    gtest_output_str = os.environ.get("GTEST_OUTPUT")
-    if gtest_output_str is not None:
-        gtest_output_path = Path(gtest_output_str)
-
-        # Check if path ends with a separator or has no extension
-        is_dir_like = gtest_output_str.endswith(os.sep) or gtest_output_path.suffix == ""
-        if is_dir_like:
-            gtest_output_path = gtest_output_path / str(binding.rank)
-        env["GTEST_OUTPUT"] = f"{gtest_output_path}/"
     mesh_to_host_rank_id[binding.mesh_id] += 1
 
     # Apply environment variables with expansion and proper precedence


### PR DESCRIPTION
#25958: Update multiprocess gtests to append rank to gtest output dir automatically

### Ticket
https://github.com/tenstorrent/tt-metal/issues/26025
https://github.com/tenstorrent/tt-metal/issues/25958

### Problem description
Our rankbindings file for tt-run lists each entry with a rank. This is used for ex setting the cache dir, but the ranks specified do not actually map to the mpirun ranks assigned to a process.
The other issue is that GTEST_OUTPUT is specified on CI, which means each gtest process will write to a file in the specified directory, but there is a race in that both processes might write to the same file and one might be overwritten.

### What's changed
Sort the cmds generated by tt-run by the ranks in the rankbinding file, so that mpirun will assign the correct ranks matching it.
Update multiprocess gtests to append rank to gtest output dir automatically

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/16780581922