### PR TITLE
#26088: Handle CCL dispatches on a collection of unit meshes

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/ttnn)
 
+add_library(test_common_utils STATIC)
+target_sources(test_common_utils PUBLIC common_test_utils.cpp)
+target_link_libraries(test_common_utils PRIVATE TTNN::CPP)
+
 function(setup_ttnn_test_target target_name)
     target_link_libraries(
         ${target_name}
@@ -23,7 +27,6 @@ TT_ENABLE_UNITY_BUILD(unit_tests_ttnn_smoke)
 target_sources(
     unit_tests_ttnn_smoke
     PRIVATE
-        common_test_utils.cpp
         test_reflect.cpp
         test_to_and_from_json.cpp
         test_sliding_window_infra.cpp
@@ -37,6 +40,7 @@ target_link_libraries(
     unit_tests_ttnn_smoke
     PRIVATE
         test_common_libs
+        test_common_utils
         TTNN::CPP
 )
 
@@ -193,6 +197,7 @@ target_link_libraries(
     PRIVATE
         Boost::asio
         Boost::lockfree
+        test_common_utils
 )
 
 # unit_tests_ttnn_emitc

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.hpp
@@ -6,9 +6,15 @@
 
 #include <vector>
 
-namespace test_utils {
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::test_utils {
 
 // Pearson Correlation Coefficient for two float vectors
 float pcc(const std::vector<float>& x, const std::vector<float>& y);
 
-}  // namespace test_utils
+// Dispatches a series of elementwise arithmetic operations over a tensor to `cq_id`, according to the expression:
+// `output_tensor = - 32 * (input_tensor) + 128`
+Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id);
+
+}  // namespace ttnn::test_utils

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -312,8 +312,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
                 // Set output_tensor into device_tensor for allgather
                 device_tensors[dev_idx] = dispatch_ops_to_device(input_tensor, ttnn::QueueId(op_cq_id));
 
-                auto operation_event = tt::tt_metal::distributed::EnqueueRecordEvent(
-                    single_mesh->mesh_command_queue(op_cq_id), std::vector<SubDeviceId>{SubDeviceId{0}});
+                auto operation_event = ttnn::record_event(single_mesh->mesh_command_queue(op_cq_id));
                 // Enqueue the task waiting for the operation_event to the ccl`s command queue
                 ttnn::wait_for_event(single_mesh->mesh_command_queue(ccl_cq_id), operation_event);
 

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -312,7 +312,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
                 // Set output_tensor into device_tensor for allgather
                 device_tensors[dev_idx] = dispatch_ops_to_device(input_tensor, ttnn::QueueId(op_cq_id));
 
-                auto operation_event = ttnn::record_event(single_mesh->mesh_command_queue(op_cq_id));
+                auto operation_event = tt::tt_metal::distributed::EnqueueRecordEvent(
+                    single_mesh->mesh_command_queue(op_cq_id), std::vector<SubDeviceId>{SubDeviceId{0}});
                 // Enqueue the task waiting for the operation_event to the ccl`s command queue
                 ttnn::wait_for_event(single_mesh->mesh_command_queue(ccl_cq_id), operation_event);
 

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "mesh_coord.hpp"
 #include "test_utils.hpp"
 #include "ttnn_test_fixtures.hpp"
 
@@ -35,7 +36,6 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/event.hpp>
 #include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/mesh_device_view.hpp>
 
 #include "gtest/gtest.h"
 
@@ -47,15 +47,17 @@ using namespace tt_metal;
 using tt::tt_metal::distributed::MeshCoordinate;
 using tt::tt_metal::distributed::MeshDevice;
 using tt::tt_metal::distributed::MeshDeviceConfig;
-using tt::tt_metal::distributed::MeshDeviceView;
 using tt::tt_metal::distributed::MeshShape;
 
 // Custom Fixture using 1D Fabric on a Multi-CQ MeshDevice
-class MultiCQFabricMeshDevice2x4Fixture : public MultiCQMeshDevice2x4Fixture {
+class MultiCQFabricMeshDevice2x4Fixture : public MeshDeviceFixtureBase {
 protected:
-    MultiCQFabricMeshDevice2x4Fixture() { tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D); }
+    MultiCQFabricMeshDevice2x4Fixture() :
+        MeshDeviceFixtureBase(Config{.system_mesh_shape = MeshShape{2, 4}, .num_cqs = 2}) {
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
     void TearDown() override {
-        MultiCQMeshDevice2x4Fixture::TearDown();
+        MeshDeviceFixtureBase::TearDown();
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 };
@@ -68,14 +70,20 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
     MeshDevice* mesh_device = this->mesh_device_.get();
 
-    auto view = mesh_device->get_view();
-
     // build a line of devices
+    std::vector<std::shared_ptr<distributed::MeshDevice>> single_meshes = {
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 3)),
+    };
     std::vector<IDevice*> devices = {
-        view.get_device(MeshCoordinate(0, 0)),
-        view.get_device(MeshCoordinate(0, 1)),
-        view.get_device(MeshCoordinate(0, 2)),
-        view.get_device(MeshCoordinate(0, 3))};
+        single_meshes[0].get(),
+        single_meshes[1].get(),
+        single_meshes[2].get(),
+        single_meshes[3].get(),
+    };
+
     const size_t num_devices = devices.size();
     TT_FATAL(
         test_expected_num_devices == num_devices,
@@ -84,10 +92,13 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
         num_devices);
 
     log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
-    auto
-        [from_remote_multi_device_global_semaphore,
-         to_remote_multi_device_global_semaphore,
-         multi_device_global_semaphore] = create_global_semaphores(this->mesh_device_, devices[0]);
+    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        devices,
+        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        0,                             // initial value
+        tt::tt_metal::BufferType::L1,  // buffer type
+        10                             // attempts
+    );
 
     const int batch_size = 8;
     const int sequence_length = 1024;
@@ -109,10 +120,9 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
         log_info(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
         for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
-            auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
             futures.push_back(promise->get_future());
-            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
                 // Generate input data for each device
                 auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
                 for (int j = 0; j < num_elems; j++) {
@@ -121,9 +131,9 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
                 // TODO (#25340): Switch to use create_device_tensor? (TensorTopology logic should mirror
                 // create_device_tensor)
-                auto single_mesh = mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, dev_idx));
+                auto& single_mesh = single_meshes[dev_idx];
                 auto input_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
-                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {MeshCoordinate(0, dev_idx)}};
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {MeshCoordinate(0, 0)}};
                 Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
 
                 // Enqueue write_buffer to the read/write command queue and record the event
@@ -131,7 +141,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
                 // Enqueue multiple operations to the operation command queue
                 // Set output_tensor into device_tensor for allreduce
-                device_tensors[dev_idx] = dispatch_ops_to_device(device, input_tensor, ttnn::QueueId(op_cq_id));
+                device_tensors[dev_idx] = dispatch_ops_to_device(input_tensor, ttnn::QueueId(op_cq_id));
 
                 promise->set_value();
             });
@@ -160,20 +170,20 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
         log_info(LogTest, "Enqueue dummy ops");
         for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
-            auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
             futures.push_back(promise->get_future());
-            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
                 auto dummy_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
                 for (int j = 0; j < num_elems; j++) {
                     dummy_data[j] = bfloat16(static_cast<float>(dev_idx));
                 }
-                auto dummy_mesh = mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, dev_idx));
-                auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(dummy_mesh.get(), tensor_spec);
-                auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer, {MeshCoordinate(0, dev_idx)}};
+                auto& single_mesh = single_meshes[dev_idx];
+                auto dummy_buffer =
+                    tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
+                auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer, {MeshCoordinate(0, 0)}};
                 Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), dummy_tensor, {dummy_data});
-                dispatch_ops_to_device(device, dummy_tensor, ttnn::QueueId(op_cq_id));
+                dispatch_ops_to_device(dummy_tensor, ttnn::QueueId(op_cq_id));
                 promise->set_value();
             });
         }
@@ -204,8 +214,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
     pool.join();
 
-    for (auto device : devices) {
-        ttnn::queue_synchronize(device->command_queue(op_cq_id));
+    for (auto& single_mesh : single_meshes) {
+        ttnn::queue_synchronize(single_mesh->mesh_command_queue(op_cq_id));
     }
 
     log_info(tt::LogTest, "Finished");
@@ -218,17 +228,23 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
-    auto view = mesh_device->get_view();
 
     // build a line of devices
+    std::vector<std::shared_ptr<distributed::MeshDevice>> single_meshes = {
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2)),
+        mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 3)),
+    };
     std::vector<IDevice*> devices = {
-        view.get_device(MeshCoordinate(0, 0)),
-        view.get_device(MeshCoordinate(0, 1)),
-        view.get_device(MeshCoordinate(0, 2)),
-        view.get_device(MeshCoordinate(0, 3))};
+        single_meshes[0].get(),
+        single_meshes[1].get(),
+        single_meshes[2].get(),
+        single_meshes[3].get(),
+    };
 
     // https://github.com/tenstorrent/tt-metal/issues/24235
-    for (auto device : devices) {
+    for (auto& device : single_meshes) {
         device->disable_and_clear_program_cache();
     }
 
@@ -240,10 +256,14 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
         num_devices);
 
     log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
-    auto
-        [from_remote_multi_device_global_semaphore,
-         to_remote_multi_device_global_semaphore,
-         multi_device_global_semaphore] = create_global_semaphores(this->mesh_device_, devices[0]);
+
+    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        devices,
+        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        0,                             // initial value
+        tt::tt_metal::BufferType::L1,  // buffer type
+        10                             // attempts
+    );
 
     const int batch_size = 8;
     const int sequence_length = 1024;
@@ -261,7 +281,6 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
     for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
         log_info(LogTest, "Running outer loop {}", outer_loop);
         std::vector<Tensor> device_tensors(devices.size());
-        std::vector<std::shared_ptr<distributed::MeshDevice>> single_meshes(devices.size());
 
         TensorSpec tensor_spec(
             input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
@@ -269,21 +288,18 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
         log_info(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
         for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
-            auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
             futures.push_back(promise->get_future());
-            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
                 // Generate input data for each device
                 auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
                 for (int j = 0; j < num_elems; j++) {
                     host_data[j] = bfloat16(static_cast<float>(dev_idx));
                 }
 
-                single_meshes[dev_idx] = mesh_device->create_submesh(MeshShape(1, 1), MeshCoordinate(0, dev_idx));
                 auto& single_mesh = single_meshes[dev_idx];
                 auto input_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
-                auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
-                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {MeshCoordinate(0, dev_idx)}};
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {MeshCoordinate(0, 0)}};
 
                 // TODO (#25340): Switch to use create_device_tensor? (TensorTopology logic should mirror
                 // create_device_tensor)
@@ -294,7 +310,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
 
                 // Enqueue multiple operations to the operation command queue
                 // Set output_tensor into device_tensor for allgather
-                device_tensors[dev_idx] = dispatch_ops_to_device(device, input_tensor, ttnn::QueueId(op_cq_id));
+                device_tensors[dev_idx] = dispatch_ops_to_device(input_tensor, ttnn::QueueId(op_cq_id));
 
                 auto operation_event = ttnn::record_event(single_mesh->mesh_command_queue(op_cq_id));
                 // Enqueue the task waiting for the operation_event to the ccl`s command queue
@@ -327,10 +343,9 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
 
         log_info(LogTest, "Enqueue dummy ops");
         for (size_t dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
-            auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
             futures.push_back(promise->get_future());
-            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
                 auto& single_mesh = single_meshes[dev_idx];
                 // TODO: investigate why other OPs can't be scheduled on a different command queue until CCL is finished
                 ttnn::queue_synchronize(single_mesh->mesh_command_queue(ccl_cq_id));
@@ -340,10 +355,10 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
                     dummy_data[j] = bfloat16(static_cast<float>(dev_idx));
                 }
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(single_mesh.get(), tensor_spec);
-                auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer, {MeshCoordinate(0, dev_idx)}};
+                auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer, {MeshCoordinate(0, 0)}};
                 Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), dummy_tensor, {dummy_data});
-                dispatch_ops_to_device(device, dummy_tensor, ttnn::QueueId(op_cq_id));
+                dispatch_ops_to_device(dummy_tensor, ttnn::QueueId(op_cq_id));
                 promise->set_value();
             });
             futures.back().wait();
@@ -396,8 +411,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
 
     pool.join();
 
-    for (auto device : devices) {
-        ttnn::queue_synchronize(device->command_queue(op_cq_id));
+    for (auto& single_mesh : single_meshes) {
+        ttnn::queue_synchronize(single_mesh->mesh_command_queue(op_cq_id));
     }
 
     log_info(tt::LogTest, "Finished");

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
@@ -49,7 +49,7 @@ static constexpr size_t TEST_EDM_FABRIC_SUBDEVICE_INDEX = 1;
 using namespace tt;
 using namespace tt_metal;
 
-Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id) {
+Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id) {
     using ttnn::operations::unary::UnaryOpType;
     using ttnn::operations::unary::UnaryWithParam;
 
@@ -145,38 +145,4 @@ void persistent_fabric_teardown_sequence(
     });
 }
 
-std::tuple<
-    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
-    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
-    ttnn::global_semaphore::MultiDeviceGlobalSemaphore>
-create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, IDevice* device) {
-    auto from_remote_multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        mesh_device->get_devices(),
-        device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        10                             // attempts
-    );
-
-    auto to_remote_multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        mesh_device->get_devices(),
-        device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        10                             // attempts
-    );
-
-    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        mesh_device->get_devices(),
-        device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        10                             // attempts
-    );
-
-    return {
-        from_remote_multi_device_global_semaphore,
-        to_remote_multi_device_global_semaphore,
-        multi_device_global_semaphore};
-}
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
@@ -49,22 +49,6 @@ static constexpr size_t TEST_EDM_FABRIC_SUBDEVICE_INDEX = 1;
 using namespace tt;
 using namespace tt_metal;
 
-Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id) {
-    using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-
-    Tensor output_tensor = ttnn::mul_sfpu(cq_id, input_tensor, 2);
-    for (int i = 0; i < 3; i++) {
-        output_tensor = ttnn::neg(cq_id, output_tensor);
-        output_tensor = ttnn::neg(cq_id, output_tensor);
-        output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
-    }
-    output_tensor = ttnn::neg(cq_id, output_tensor);
-    output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
-    output_tensor = ttnn::add_sfpu(cq_id, output_tensor, 128);
-    return output_tensor;
-}
-
 SubdeviceInfo create_subdevices(const std::vector<IDevice*>& devices) {
     SubdeviceInfo subdevice_info;
     std::unordered_map<chip_id_t, SubDeviceManagerId> sub_device_manager_ids;

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
@@ -20,8 +20,7 @@ namespace ttnn::distributed::test {
 using namespace tt;
 using namespace tt_metal;
 
-Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id);
-
+Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id);
 struct SubdeviceInfo {
     std::unordered_map<chip_id_t, SubDeviceManagerId> sub_device_managers;
     std::unordered_map<chip_id_t, SubDeviceId> worker_subdevice_id;
@@ -45,11 +44,5 @@ void persistent_fabric_teardown_sequence(
     std::optional<SubdeviceInfo>& subdevice_managers,
     ttnn::ccl::EdmLineFabricOpInterface& line_fabric,
     tt::tt_fabric::TerminationSignal termination_mode = tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
-
-std::tuple<
-    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
-    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
-    ttnn::global_semaphore::MultiDeviceGlobalSemaphore>
-create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, IDevice* device);
 
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
@@ -20,7 +20,6 @@ namespace ttnn::distributed::test {
 using namespace tt;
 using namespace tt_metal;
 
-Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id);
 struct SubdeviceInfo {
     std::unordered_map<chip_id_t, SubDeviceManagerId> sub_device_managers;
     std::unordered_map<chip_id_t, SubDeviceId> worker_subdevice_id;

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -50,7 +50,7 @@ using namespace tt;
 using namespace tt_metal;
 using MultiCommandQueueT3KFixture = ttnn::MultiCommandQueueT3KFixture;
 
-Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id) {
+Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id) {
     using ttnn::operations::unary::UnaryOpType;
     using ttnn::operations::unary::UnaryWithParam;
 
@@ -94,7 +94,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                     {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
                 auto write_event = ttnn::record_event(device->mesh_command_queue(0));
                 ttnn::wait_for_event(device->mesh_command_queue(1), write_event);
-                auto output_tensor = dispatch_ops_to_device(device.get(), input_tensor, ttnn::QueueId(1));
+                auto output_tensor = dispatch_ops_to_device(input_tensor, ttnn::QueueId(1));
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(0), workload_event);
 
@@ -147,7 +147,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                     {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
                 auto write_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(0), write_event);
-                auto output_tensor = dispatch_ops_to_device(device.get(), input_tensor, ttnn::DefaultQueueId);
+                auto output_tensor = dispatch_ops_to_device(input_tensor, ttnn::DefaultQueueId);
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(0));
                 ttnn::wait_for_event(device->mesh_command_queue(1), workload_event);
                 // std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -198,7 +198,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
                     {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
                 auto write_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(1), write_event);
-                auto output_tensor = dispatch_ops_to_device(device.get(), input_tensor, ttnn::QueueId(1));
+                auto output_tensor = dispatch_ops_to_device(input_tensor, ttnn::QueueId(1));
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(1), workload_event);
                 ttnn::read_buffer(

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "common_test_utils.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -50,22 +51,6 @@ using namespace tt;
 using namespace tt_metal;
 using MultiCommandQueueT3KFixture = ttnn::MultiCommandQueueT3KFixture;
 
-Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id) {
-    using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-
-    Tensor output_tensor = ttnn::mul_sfpu(cq_id, input_tensor, 2);
-    for (int i = 0; i < 3; i++) {
-        output_tensor = ttnn::neg(cq_id, output_tensor);
-        output_tensor = ttnn::neg(cq_id, output_tensor);
-        output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
-    }
-    output_tensor = ttnn::neg(cq_id, output_tensor);
-    output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
-    output_tensor = ttnn::add_sfpu(cq_id, output_tensor, 500);
-    return output_tensor;
-}
-
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
     MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
 
@@ -94,7 +79,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                     {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
                 auto write_event = ttnn::record_event(device->mesh_command_queue(0));
                 ttnn::wait_for_event(device->mesh_command_queue(1), write_event);
-                auto output_tensor = dispatch_ops_to_device(input_tensor, ttnn::QueueId(1));
+                auto output_tensor = ttnn::test_utils::dispatch_ops_to_device(input_tensor, ttnn::QueueId(1));
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(0), workload_event);
 
@@ -111,7 +96,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                      readback_data});
 
                 for (int j = 0; j < 3 * 2048 * 2048; j++) {
-                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);
+                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 128);
                 }
             }
         }
@@ -147,7 +132,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                     {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
                 auto write_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(0), write_event);
-                auto output_tensor = dispatch_ops_to_device(input_tensor, ttnn::DefaultQueueId);
+                auto output_tensor = ttnn::test_utils::dispatch_ops_to_device(input_tensor, ttnn::DefaultQueueId);
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(0));
                 ttnn::wait_for_event(device->mesh_command_queue(1), workload_event);
                 // std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -164,7 +149,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                      readback_data});
 
                 for (int j = 0; j < 3 * 2048 * 2048; j++) {
-                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);
+                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 128);
                 }
             }
         }
@@ -198,7 +183,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
                     {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
                 auto write_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(1), write_event);
-                auto output_tensor = dispatch_ops_to_device(input_tensor, ttnn::QueueId(1));
+                auto output_tensor = ttnn::test_utils::dispatch_ops_to_device(input_tensor, ttnn::QueueId(1));
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(1));
                 ttnn::wait_for_event(device->mesh_command_queue(1), workload_event);
                 ttnn::read_buffer(
@@ -214,7 +199,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
                      readback_data});
 
                 for (int j = 0; j < 3 * 2048 * 2048; j++) {
-                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);
+                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 128);
                 }
             }
         }

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -617,7 +617,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event(
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
 
     MeshEvent event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range);
-    for (const auto& sub_device_id : sub_device_ids) {
+    for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
         auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
         sub_device_entry.recorded_event(event.id(), event.mesh_cq_id());
     }
@@ -631,7 +631,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host_nolock(
         std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
     this->increment_num_entries_in_completion_queue();
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
-    for (const auto& sub_device_id : sub_device_ids) {
+    for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
         auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
         sub_device_entry.recorded_event(event.id(), event.mesh_cq_id());
     }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -340,6 +340,7 @@ std::shared_ptr<MeshDevice> MeshDevice::create_unit_mesh(
 
 std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
     const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset) {
+    auto lock_api = this->lock_api();
     TT_FATAL(
         std::all_of(submesh_shape.cbegin(), submesh_shape.cend(), [](size_t dim) { return dim > 0; }),
         "Invalid submesh shape: ({}). All dimensions must be positive.",

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -357,12 +357,6 @@ std::vector<Tensor> all_gather(
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const ttnn::ccl::Topology topology) {
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
-
     std::vector<Tensor> output_tensors;
     output_tensors.reserve(input_tensors.size());
     for (const auto& input_tensor : input_tensors) {
@@ -374,7 +368,7 @@ std::vector<Tensor> all_gather(
             user_defined_num_workers,
             user_defined_num_buffers_per_channel,
             topology,
-            devices));
+            ttnn::ccl::get_active_physical_devices(input_tensors)));
     }
     return output_tensors;
 }

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/barrier.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/barrier.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "barrier.hpp"
+
+#include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/barrier/device/barrier_op.hpp"
 
 namespace ttnn::operations::ccl {
@@ -17,13 +19,12 @@ std::vector<ttnn::Tensor> BarrierOperation::invoke(
     const std::vector<ttnn::Tensor>& input_tensors,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     ttnn::ccl::Topology topology) {
-    MemoryConfig out_memory_config = memory_config.value_or(input_tensors[0].memory_config());
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
-    return barrier_function(input_tensors, Barrier{out_memory_config, topology, devices});
+    return barrier_function(
+        input_tensors,
+        Barrier{
+            memory_config.value_or(input_tensors[0].memory_config()),
+            topology,
+            ttnn::ccl::get_active_physical_devices(input_tensors)});
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -149,6 +149,18 @@ std::vector<IDevice*> get_active_physical_devices(const Tensor& tensor) {
     return devices;
 }
 
+std::vector<IDevice*> get_active_physical_devices(const std::vector<Tensor>& tensor_shards) {
+    std::vector<IDevice*> devices;
+    devices.reserve(tensor_shards.size());
+    for (const auto& tensor : tensor_shards) {
+        TT_FATAL(
+            tensor.mesh_device()->shape().mesh_size() == 1,
+            "Running a CCL over individual tensor shards requires the shards to be allocated on unit-meshes.");
+        devices.push_back(tensor.mesh_device()->get_device(MeshCoordinate(0, 0)));
+    }
+    return devices;
+}
+
 std::vector<ttnn::Tensor> unpad_output_tensor(
     const std::vector<ttnn::Tensor>& output_tensor,
     const uint32_t num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -51,6 +51,11 @@ SenderRecieverConfig get_device_sender_receiver_config_in_ring(
 // Returns a vector of devices that the given tensor is stored on.
 std::vector<IDevice*> get_active_physical_devices(const Tensor& tensor);
 
+// Returns a vector of devices that `tensor_shards` are stored on.
+// Each `tensor_shard` is assumed to be allocated on a 1x1 "unit-mesh"; the function returns the devices that the shards
+// to run a CCL over the unit-meshes.
+std::vector<IDevice*> get_active_physical_devices(const std::vector<Tensor>& tensor_shards);
+
 struct SyncModeSpec {
     uint32_t num_signals = 0;
     CoreCoord core;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -219,11 +219,6 @@ std::vector<Tensor> reduce_scatter(
     ttnn::ccl::Topology topology,
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel) {
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
     std::vector<Tensor> output_tensors;
     output_tensors.reserve(input_tensors.size());
     for (const auto& input_tensor : input_tensors) {
@@ -236,7 +231,7 @@ std::vector<Tensor> reduce_scatter(
             topology,
             user_defined_num_workers,
             user_defined_num_buffers_per_channel,
-            devices));
+            ttnn::ccl::get_active_physical_devices(input_tensors)));
     }
     return output_tensors;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -621,11 +621,6 @@ std::vector<Tensor> all_gather_async(
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
     std::vector<GlobalSemaphore> semaphore;
     semaphore.reserve(multi_device_global_semaphore.size());
     for (size_t i = 0; i < multi_device_global_semaphore.size(); i++) {
@@ -642,7 +637,7 @@ std::vector<Tensor> all_gather_async(
             memory_config,
             topology,
             sub_device_id,
-            devices,
+            ttnn::ccl::get_active_physical_devices(input_tensors),
             use_optimal_ccl_for_llama,
             barrier_semaphore));
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -286,11 +286,6 @@ std::vector<ttnn::Tensor> all_gather_matmul(
     const std::optional<const std::string>& activation,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const ttnn::CoreGrid> core_grid) {
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
     std::vector<ttnn::Tensor> output_tensors;
     for (size_t i = 0; i < input_tensors.size(); i++) {
         auto results = all_gather_matmul_impl(
@@ -311,7 +306,7 @@ std::vector<ttnn::Tensor> all_gather_matmul(
             activation,
             compute_kernel_config,
             core_grid,
-            devices);
+            ttnn::ccl::get_active_physical_devices(input_tensors));
         for (auto& result : results) {
             output_tensors.push_back(std::move(result));
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -484,11 +484,7 @@ std::vector<Tensor> all_reduce(
     TT_FATAL(
         std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "All Reduce op is only supported for Fast Dispatch");
 
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
+    std::vector<IDevice*> devices = ttnn::ccl::get_active_physical_devices(input_tensors);
     uint32_t num_devices = devices.size();
     TT_FATAL(num_devices > 1, "all_reduce op will only work for num_devices > 1, but has {}", num_devices);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -393,11 +393,6 @@ std::vector<Tensor> reduce_scatter(
     ttnn::ccl::Topology topology,
     const std::optional<size_t> num_links_preferred,
     std::optional<SubDeviceId> worker_subdevice_id_opt) {
-    std::vector<IDevice*> devices;
-    devices.reserve(input_tensors.size());
-    for (auto& input_tensor : input_tensors) {
-        devices.push_back(input_tensor.device());
-    }
     std::vector<Tensor> output_tensors;
     output_tensors.reserve(input_tensors.size());
     for (size_t i = 0; i < input_tensors.size(); ++i) {
@@ -411,7 +406,7 @@ std::vector<Tensor> reduce_scatter(
             topology,
             num_links_preferred,
             worker_subdevice_id_opt,
-            devices));
+            ttnn::ccl::get_active_physical_devices(input_tensors)));
     }
     return output_tensors;
 }


### PR DESCRIPTION
### Ticket
#26088

### Problem description
#25687 removed support of `IDevice*` in `Tensor`. This broke some CCLs tests that relied on a collection of individual devices to run the op, as querying `id()` on `IDevice` returned `chip_id_t`, while `MeshDevice` returns a unique ID generated sequentially.

### What's changed
Extract individual `IDevice*` from unit meshes, when a vector of tensors on is supplied.



### Checklist
- [x] New/Existing tests provide coverage for changes - tested `MultiCQFabricMeshDevice2x4Fixture` locally.
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16666572576)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16666581539)
