### PR TITLE
Handle Core OOB Issue on Special Case in Split

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -100,8 +100,13 @@ std::vector<ttnn::Tensor> SplitOperation::invoke(
     const auto& input_shape = input_tensor.logical_shape();
 
     // special case to use hardcoded kernel for two chunks sometimes
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    uint32_t grid_size_x = device->compute_with_storage_grid_size().x + 1;  // total size of grid in x direction
+    bool fits_in_core_grid =
+        (input_shape[0] * input_shape[1] <
+         grid_size_x);  // special case parallelizes across first 2 dims without wrapping
     if (split_sizes.size() == detail::TWO_CHUNKS && dim == input_shape.rank() - 1 &&
-        input_tensor.layout() == Layout::TILE && input_shape.rank() >= 2 &&
+        input_tensor.layout() == Layout::TILE && input_shape.rank() >= 2 && fits_in_core_grid &&
         input_shape[-2] / tt::constants::TILE_HEIGHT >= 2 && input_shape[-1] / tt::constants::TILE_WIDTH >= 2) {
         ttnn::Tensor input_tensor_4d;
         if (input_shape.rank() > detail::RANK_FOUR) {

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -103,8 +103,8 @@ std::vector<ttnn::Tensor> SplitOperation::invoke(
     tt::tt_metal::IDevice* device = input_tensor.device();
     uint32_t grid_size_x = device->compute_with_storage_grid_size().x + 1;  // total size of grid in x direction
     bool fits_in_core_grid =
-        (input_shape[0] * input_shape[1] <
-         grid_size_x);  // special case parallelizes across first 2 dims without wrapping
+        input_shape.rank() >= 2 && (input_shape[0] * input_shape[1] <
+                                    grid_size_x);  // special case parallelizes across first 2 dims without wrapping
     if (split_sizes.size() == detail::TWO_CHUNKS && dim == input_shape.rank() - 1 &&
         input_tensor.layout() == Layout::TILE && input_shape.rank() >= 2 && fits_in_core_grid &&
         input_shape[-2] / tt::constants::TILE_HEIGHT >= 2 && input_shape[-1] / tt::constants::TILE_WIDTH >= 2) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20325)

### Problem description
Trying to access out of bounds core somewhere in split. Diagnosed it to be on a special 2 chunk output tiled case. There is parallelization over the inner dims without wrapping over the x dim.

### What's changed
I constrained that the special case should only handle loads that fit the grid size, it will default to the slice approach otherwise.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16665764294) CI passes
- [ ] [Model performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16665813988) CI passes (if applicable)