### PR TITLE
#23016: Migrate softshrink as a device op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -510,29 +510,6 @@ def test_unary_swiglu_ttnn(input_shapes, dim, device):
         (torch.Size([1, 1, 32, 32])),
         (torch.Size([1, 1, 320, 384])),
         (torch.Size([1, 3, 320, 384])),
-    ),
-)
-@pytest.mark.parametrize(
-    "param",
-    {0.45, 7.7, 36.89, 58.4, 89.9},
-)
-def test_unary_softshrink(input_shapes, param, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-
-    output_tensor = ttnn.softshrink(input_tensor, lambd=param)
-    golden_function = ttnn.get_golden_function(ttnn.softshrink)
-    golden_tensor = golden_function(in_data, lambd=param)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
         (torch.Size([7, 185, 20])),
         (torch.Size([6, 45, 233])),
     ),

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_softshrink(uint32_t param0) {
+    // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
+    // SFPU microcode
+    sfpi::vFloat lambda = Converter::as_float(param0);
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = sfpi::vConst0;
+        v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
+        v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
+        v_endif;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -7,11 +7,13 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "ckernel_sfpu_softsign.h"
+#include "ckernel_sfpu_softshrink.h"
 
 namespace ckernel {
 
 // New LLK SFPU APIs
 
+// Hardsigmoid
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardsigmoid, APPROXIMATE>(
@@ -56,4 +58,17 @@ inline void llk_math_eltwise_unary_sfpu_celu(
         alpha,
         alpha_recip);
 }
+
+// softshrink
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -113,6 +113,7 @@ enum SfpuType {
     unary_min,
     gcd,
     lcm,
+    softshrink,
     hardsigmoid,
     where,
     softsign,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_softshrink(uint32_t param0) {
+    // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
+    // SFPU microcode
+    sfpi::vFloat lambda = Converter::as_float(param0);
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = sfpi::vConst0;
+        v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
+        v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
+        v_endif;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -7,7 +7,7 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "ckernel_sfpu_softsign.h"
-#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_softshrink.h"
 
 namespace ckernel {
 
@@ -57,4 +57,17 @@ inline void llk_math_eltwise_unary_sfpu_celu(
         alpha,
         alpha_recip);
 }
+
+// softshrink
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -114,6 +114,7 @@ enum SfpuType {
     cpy_values,
     gcd,
     lcm,
+    softshrink,
     hardsigmoid,
     where,
     softsign,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/activations.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/activations.h
@@ -81,4 +81,27 @@ ALWI void celu_tile(uint32_t idst, uint32_t alpha, uint32_t alpha_recip) {
  */
 ALWI void celu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_celu_init<APPROX>())); }
 
+// clang-format off
+ /**
+ * Performs element-wise softshrink operation. The DST
+ * register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
+ * compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The λ value for the Softshrink formulation                                 | uint32   |                                                       | True     |
+ */
+ // clang-format on
+ ALWI void softshrink_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_softshrink<APPROX>(idst, param0)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void softshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_softshrink_init<APPROX>())); }
+
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -103,6 +103,7 @@ enum class UnaryOpType {
     MAXIMUM,
     MINIMUM,
     TANHSHRINK,
+    SOFTSHRINK,
     HARDSHRINK,
     HARDTANH,
     HARDSIGMOID,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -80,6 +80,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::GEZ:
         case UnaryOpType::NEZ: return "SFPU_OP_UNARY_COMP_INCLUDE";
         case UnaryOpType::WHERE_TSS: return "SFPU_OP_WHERE_INCLUDE";
+        case UnaryOpType::SOFTSHRINK:
         case UnaryOpType::SOFTSIGN:
         case UnaryOpType::HARDSIGMOID:
         case UnaryOpType::CELU: return "SFPU_OP_ACTIVATIONS_INCLUDE";
@@ -371,6 +372,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                     std::bit_cast<uint32_t>(1.0f / param0))};
             break;
         case UnaryOpType::HARDSHRINK: op_init_and_name = {}; break;
+        case UnaryOpType::SOFTSHRINK:
+            op_init_and_name = {
+                "softshrink_tile_init();",
+                fmt::format("softshrink_tile({}, {}u);", idst, std::bit_cast<uint32_t>(param0))};
+            break;
         case UnaryOpType::WHERE_TSS: {
             std::string where_call;
             if (input_dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -77,6 +77,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::MINIMUM:
         case UnaryOpType::MAXIMUM:
         case UnaryOpType::LOG1P:
+        case UnaryOpType::SOFTSHRINK:
         case UnaryOpType::HARDSHRINK:
         case UnaryOpType::WHERE_TSS:
         case UnaryOpType::CELU:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -551,21 +551,6 @@ Tensor ExecuteRdiv::invoke(
         ttnn::eqz(queue_id, input_tensor, memory_config), t_inf, result, memory_config, optional_output_tensor);
 }
 
-// Function: softshrink
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softshrink.html
-Tensor _softshrink(const Tensor& a, float param, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_ASSERT(param >= 0);
-    Tensor t_a_plus_param = ttnn::add(a, param, std::nullopt, output_mem_config);
-    Tensor t1 =
-        ttnn::multiply(ttnn::ltz(t_a_plus_param, output_mem_config), t_a_plus_param, std::nullopt, output_mem_config);
-    t_a_plus_param.deallocate();
-    Tensor t_a_minus_param = ttnn::subtract(a, param, std::nullopt, output_mem_config);
-    Tensor t2 =
-        ttnn::multiply(ttnn::gtz(t_a_minus_param, output_mem_config), t_a_minus_param, std::nullopt, output_mem_config);
-    t_a_minus_param.deallocate();
-    return ttnn::add(t1, t2, std::nullopt, output_mem_config);
-}
-
 // logit(input, eps)=log(input / 1 - input)
 Tensor _logit(const Tensor& input_a, float eps, const std::optional<MemoryConfig>& output_mem_config) {
     float t1m_eps = 1 - eps;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -32,7 +32,6 @@ enum class UnaryCompositeOpType {
     TRIL,
     TRIU,
     POLYGAMMA,
-    SOFTSHRINK,
     LOGIT,
     LOGICAL_NOT_,
     RPOW,
@@ -65,8 +64,6 @@ Tensor _swiglu(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
 Tensor _tril(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _triu(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _polygamma(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
-Tensor _softshrink(
-    const Tensor& a, float lambd = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _logit(const Tensor& a, float eps = 0.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _logical_not_(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _rpow(const Tensor& a, float param, const std::optional<MemoryConfig>&);
@@ -196,13 +193,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::SWIGLU> {
     static Tensor handle(const Tensor& t1, int32_t dim, const std::optional<MemoryConfig>& mem_cfg) {
         return _swiglu(t1, dim, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::SOFTSHRINK> {
-    static Tensor handle(const Tensor& t1, float lambd, const std::optional<MemoryConfig>& mem_cfg) {
-        return _softshrink(t1, lambd, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -398,6 +398,22 @@ Tensor Hardtanh::invoke(
         optional_output_tensor);
 }
 
+Tensor Softshrink::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float lambda,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::SOFTSHRINK;
+    TT_ASSERT(lambda >= 0);
+    return detail::unary_impl(
+        queue_id,
+        input_tensor,
+        {UnaryWithParam{op_type, static_cast<float>(lambda)}},
+        memory_config,
+        optional_output_tensor);
+}
+
 Tensor Deg2Rad::invoke(
     QueueId queue_id,
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -273,6 +273,15 @@ struct Hardtanh {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Softshrink {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        float lambda = 0.5f,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct Deg2Rad {
     static Tensor invoke(
         QueueId queue_id,
@@ -426,6 +435,7 @@ constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::u
 constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto hardshrink = ttnn::register_operation<"ttnn::hardshrink", ttnn::operations::unary::Hardshrink>();
 constexpr auto hardtanh = ttnn::register_operation<"ttnn::hardtanh", ttnn::operations::unary::Hardtanh>();
+constexpr auto softshrink = ttnn::register_operation<"ttnn::softshrink", ttnn::operations::unary::Softshrink>();
 constexpr auto deg2rad = ttnn::register_operation<"ttnn::deg2rad", ttnn::operations::unary::Deg2Rad>();
 constexpr auto rad2deg = ttnn::register_operation<"ttnn::rad2deg", ttnn::operations::unary::Rad2Deg>();
 constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -206,9 +206,6 @@ constexpr auto swiglu = ttnn::register_operation<
 constexpr auto logical_not_ = ttnn::register_operation<
     "ttnn::logical_not_",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOGICAL_NOT_>>();
-constexpr auto softshrink = ttnn::register_operation<
-    "ttnn::softshrink",
-    operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::SOFTSHRINK>>();
 constexpr auto logit = ttnn::register_operation<
     "ttnn::logit",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::LOGIT>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -2252,10 +2252,10 @@ void py_module(py::module& module) {
 
     // unary composite with float imported into ttnn
     bind_unary_composite_float_with_default(
-        module, ttnn::hardshrink, "lambd", "lambd value", 0.5f, R"doc(BFLOAT16, BFLOAT8_B)doc");
+        module, ttnn::hardshrink, "lambd", "lambd value", 0.5f, R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
 
     bind_unary_composite_float_with_default(
-        module, ttnn::softshrink, "lambd", "lambd value", 0.5f, R"doc(BFLOAT16, BFLOAT8_B)doc");
+        module, ttnn::softshrink, "lambd", "lambd value", 0.5f, R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
 
     bind_unary_composite_float_with_default(module, ttnn::logit, "eps", "eps", 0.0f, R"doc(BFLOAT16)doc");
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #23016 

### Problem description
Softshrink implemented  as a composite op.

### What's changed
Implemented soft shrink as a llk op.

Performance results:
Shape used : [1, 1, 8192, 8192]
In main:
<img width="374" height="235" alt="Screenshot 2025-08-01 at 4 46 51 PM" src="https://github.com/user-attachments/assets/4ad6ef84-35b3-4468-aaea-30f04cd7eadc" />

Updated version:
<img width="356" height="63" alt="Screenshot 2025-08-01 at 4 47 12 PM" src="https://github.com/user-attachments/assets/2bde34aa-b2ad-4235-b24c-387adc23eeff" />


So it is ~87% faster compared to previous approach.

### Checklist
- [ ] All post commit CI
- [ ] Blackhole Post commit CI