### PR TITLE
sfpi v6.16.1

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -142,7 +142,15 @@ if(NOT EXISTS "${GPP_CMD}")
     message(FATAL_ERROR "GPP_CMD path '${GPP_CMD}' does not exist. Please check your configuration.")
 endif()
 
-message(STATUS "Using SFPI compiler: ${GPP_CMD}")
+execute_process(
+    COMMAND
+        ${GPP_CMD} --version
+    COMMAND
+        head -1
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE GPP_VERSION
+)
+message(STATUS "Using SFPI compiler: ${GPP_CMD}, ${GPP_VERSION}")
 
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
 

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,13 +1,13 @@
 # set SFPI release version information
 
-sfpi_version=v6.15.0
+sfpi_version=v6.16.1
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi-\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_aarch64_Linux_txz_md5=cd8be4bd648abf0afa90bf5e57065964
-sfpi_aarch64_Linux_deb_md5=11bec863fbcd9b6b2643e69c09963fc1
-sfpi_aarch64_Linux_rpm_md5=4ee22d067a3ac0de6726d9d05c944f3e
-sfpi_x86_64_Linux_txz_md5=f74ab94d47b6f8e8d97c96039fa501da
-sfpi_x86_64_Linux_deb_md5=6e897ab3b10a61ef0e4d916f6c5d4f48
-sfpi_x86_64_Linux_rpm_md5=8a91fb64c2db79038a5b747113b66222
+sfpi_aarch64_Linux_txz_md5=b500c36c84c780259a5e4ba95def2339
+sfpi_aarch64_Linux_deb_md5=5fbcfd2da0c445bf8a1235513958b46e
+sfpi_aarch64_Linux_rpm_md5=a16ebf12ea2a0070909599a4b73b5d21
+sfpi_x86_64_Linux_txz_md5=faf2e68c95544eec714a607712b6cdf0
+sfpi_x86_64_Linux_deb_md5=87575d71b03571fa5be20051f41137df
+sfpi_x86_64_Linux_rpm_md5=5286554401f85379ca59b0c3c43f0746


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25891#issuecomment-3127556920

### Problem description
We generated bogus assembler

### What's changed
Fixed compiler

### Checklist
- [YES ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes