### PR TITLE
migration to fabric-based ccls for DeepSeek MLP and DistributedRMSNorm

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -8,6 +8,7 @@ from loguru import logger
 from transformers import AutoConfig
 
 import ttnn
+from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from tests.scripts.common import get_updated_device_params
 
 
@@ -82,3 +83,12 @@ def mesh_row(mesh_device):
         yield rows[0]
     else:
         yield mesh_device
+
+
+@pytest.fixture
+def ccl(mesh_device):
+    """
+    Fixture to create a CCL1D instance for testing.
+    This is used to test distributed operations in DeepSeek modules.
+    """
+    return CCL1D(mesh_device)

--- a/models/demos/deepseek_v3/tests/test_embedding_1d.py
+++ b/models/demos/deepseek_v3/tests/test_embedding_1d.py
@@ -58,7 +58,7 @@ def test_embedding_forward_pass(
         reference_output = reference_model(torch_input)
     else:
         state_dict = load_state_dict(model_path, module_path)
-        torch_input, reference_output = load_reference_io_tensors_for_module(mode, module_path, seq_len)
+        torch_input, reference_output = load_reference_io_tensors_for_module(mode, module_path, seq_len, 1)
         torch_input.unsqueeze_(0)
         reference_output.unsqueeze_(0)
 

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -201,7 +201,7 @@ def test_forward_pass(
     weight_config = MLA1D.convert_weights(hf_config, state_dicts, tmp_path, mesh_device)
 
     # Generate appropriate configs
-    ccl = CCL1D(hf_config, mesh_device)
+    ccl = CCL1D(mesh_row)
     if mode == "prefill":
         model_config = MLA1D.prefill_model_config(hf_config, mesh_device)
     else:

--- a/models/demos/deepseek_v3/tests/test_mlp_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mlp_1d.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MLP
@@ -26,7 +27,9 @@ from models.utility_functions import comp_pcc
 DEVICE_SHAPE = ttnn.MeshShape(2, min(ttnn.get_num_devices() // 2, 8))
 
 
-@pytest.mark.parametrize("device_params", [{"mesh_shape": DEVICE_SHAPE}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"mesh_shape": DEVICE_SHAPE, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+)
 def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_device):
     reference_model = DeepseekV3MLP(hf_config)
     reference_state_dict = reference_model.state_dict()
@@ -40,7 +43,9 @@ def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_devic
     )
 
 
-@pytest.mark.parametrize("device_params", [{"mesh_shape": DEVICE_SHAPE}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"mesh_shape": DEVICE_SHAPE, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+)
 @pytest.mark.parametrize(
     "MLPClass,module_path",
     [(NonExpert, "model.layers.0.mlp"), (SharedExpert, "model.layers.3.mlp.shared_experts")],
@@ -99,14 +104,17 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
     )
 
     # Verify the values match (accounting for transpose and bfloat8 conversion)
-    passing, pcc_msg = comp_pcc(reference_w1.T, w1_torch[0], 0.99)
-    assert passing, f"Weight conversion PCC failed: {pcc_msg}"
+    passing, pcc = comp_pcc(reference_w1.T, w1_torch[0], 0.99)
+    logger.info(f"PCC: {pcc}")
+    assert passing, f"Weight conversion PCC failed: {pcc}"
 
     # Cleanup
     ttnn.deallocate(w1_ttnn)
 
 
-@pytest.mark.parametrize("device_params", [{"mesh_shape": DEVICE_SHAPE}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"mesh_shape": DEVICE_SHAPE, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+)
 @pytest.mark.parametrize(
     "MLPClass,module_path",
     [
@@ -132,6 +140,7 @@ def test_forward_pass(
     tmp_path,
     mesh_device,
     model_path,
+    ccl,
 ):
     num_module_layers, _ = mesh_device.shape
 
@@ -140,7 +149,7 @@ def test_forward_pass(
         torch.set_default_dtype(torch.bfloat16)
         reference_model = DeepseekV3MLP(hf_config).eval()
         state_dict = reference_model.state_dict()
-        torch_input = torch.randn(4, 1, seq_len, hf_config.hidden_size)
+        torch_input = torch.randn(num_module_layers, 1, seq_len, hf_config.hidden_size)
         reference_output = reference_model(torch_input)
     else:
         state_dict = load_state_dict(model_path, module_path)
@@ -151,7 +160,7 @@ def test_forward_pass(
     # Generate module configs and state
     weight_config = MLPClass.convert_weights(hf_config, [state_dict] * num_module_layers, tmp_path, mesh_device)
     model_config = get_model_config(MLPClass, mode, hf_config, mesh_device)
-    model_state = MLPClass.create_state(hf_config, mesh_device=mesh_device)
+    model_state = MLPClass.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
 
     # Convert input to TTNN

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -10,7 +10,6 @@ import ttnn
 
 # Import from local reference files instead of HuggingFace
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
-from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from models.demos.deepseek_v3.tt.moe import MoE
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.utility_functions import comp_pcc
@@ -46,6 +45,7 @@ def test_forward_pass(
     hf_config,
     tmp_path,
     mesh_device,
+    ccl,
 ):
     """Test forward pass against reference model."""
     batch_size = 1
@@ -63,7 +63,6 @@ def test_forward_pass(
     weight_config = MoE.convert_weights(hf_config, hf_state_dict, tmp_path, mesh_device)
 
     # Generate appropriate config
-    ccl = CCL1D(hf_config, mesh_device)
     if mode == "prefill":
         model_config = MoE.prefill_model_config(hf_config, mesh_device, ccl, batch_size=seq_len, seq_len=1)
     else:

--- a/models/demos/deepseek_v3/tt/ccl_1d.py
+++ b/models/demos/deepseek_v3/tt/ccl_1d.py
@@ -10,7 +10,7 @@ class CCL1D:
     A class to handle all CCL (Collective Communication Library) operations
     """
 
-    def __init__(self, hf_config, mesh_device):
+    def __init__(self, mesh_device):
         self.mesh_device = mesh_device
         self.grid = mesh_device.compute_with_storage_grid_size()
         self.num_cores = self.grid.x * self.grid.y

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -5,12 +5,14 @@
 from pathlib import Path
 
 import torch
+import ttnn.experimental
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm_base import RMSNormBase
 from models.demos.deepseek_v3.utils.config_dataclass import (
-    AllGatherConfig,
+    AllGatherAsyncConfig,
     FromWeightConfig,
     MeshDeviceStub,
     OpConfigBase,
@@ -19,8 +21,10 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
 )
 from models.demos.deepseek_v3.utils.config_helpers import get_state_dicts, save_and_get_path
 from models.demos.deepseek_v3.utils.run_config import (
+    MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
     ModelPrefillConfig,
+    ModelState,
     RunDecodeConfig,
     RunPrefillConfig,
     WeightConfig,
@@ -104,10 +108,10 @@ class DistributedRMSNorm(RMSNormBase):
             "rms_norm_pre_all_gather": RMSNormPreAllGatherConfig(
                 dtype=ttnn.bfloat16,
             ),
-            "all_gather": AllGatherConfig(
+            "all_gather": AllGatherAsyncConfig(
                 dim=3,
                 cluster_axis=1,
-                mesh_device=mesh_device,
+                mesh_device=MeshDeviceStub(mesh_device.shape),
                 memory_config=rms_norm_stats_memory_config,
                 topology=ttnn.Topology.Linear,
             ),
@@ -116,6 +120,25 @@ class DistributedRMSNorm(RMSNormBase):
                 weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 dtype=ttnn.bfloat16,
             ),
+        }
+
+    @classmethod
+    def create_state(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, ccl: CCL1D) -> ModelState:
+        """Create the model state for this module.
+
+        Args:
+            hf_config: HuggingFace model configuration object
+            mesh_device: TTNN mesh device the model will be placed later on
+            ccl: CCL1D instance for async CCLs
+
+        Returns:
+            ModelState containing the state information for this module
+        """
+        return {
+            MESH_DEVICE_STATE_DICT_KEY: mesh_device,
+            "all_gather": {
+                "multi_device_global_semaphore": ccl.get_semaphore(1),
+            },
         }
 
     @classmethod
@@ -135,7 +158,7 @@ class DistributedRMSNorm(RMSNormBase):
         tt_stats = ttnn.rms_norm_pre_all_gather(x, program_config=program_config, **cfg["rms_norm_pre_all_gather"])
 
         # AllGather stats
-        tt_gathered_stats = ttnn.all_gather(tt_stats, **cfg["all_gather"])
+        tt_gathered_stats = ttnn.experimental.all_gather_async(tt_stats, **cfg["all_gather"])
         ttnn.deallocate(tt_stats)
 
         # Run distributed rmsnorm part 2

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -105,28 +105,28 @@ class AllReduceConfig(OpConfigBase):
 class AllGatherAsyncConfig(OpConfigBase):
     """Common parameters for a ttnn.experimental.all_gather_async op"""
 
-    mesh_device: ConfigDevice
-    cluster_axis: int
-    dim: int
+    mesh_device: ConfigDevice | None = None
+    cluster_axis: int | None = None
+    dim: int | None = None
     multi_device_global_semaphore: object | None = None
     num_links: int | None = None
-    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG
-    topology: ttnn.Topology = ttnn.Topology.Linear
+    memory_config: ttnn.MemoryConfig | None = None
+    topology: ttnn.Topology | None = None
 
 
 @dataclass
 class ReduceScatterAsyncConfig(OpConfigBase):
     """Common parameters for a ttnn.experimental.reduce_scatter_async op"""
 
-    mesh_device: ConfigDevice
-    cluster_axis: int
-    dim: int
-    math_op: ttnn.ReduceType
+    mesh_device: ConfigDevice | None = None
+    cluster_axis: int | None = None
+    dim: int | None = None
     from_remote_multi_device_global_semaphore: object | None = None
     to_remote_multi_device_global_semaphore: object | None = None
+    math_op: ttnn.ReduceType | None = None
     num_links: int | None = None
-    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG
-    topology: ttnn.Topology = ttnn.Topology.Linear
+    memory_config: ttnn.MemoryConfig | None = None
+    topology: ttnn.Topology | None = None
 
 
 @dataclass


### PR DESCRIPTION
### Ticket
migration to fabric-based ccls for DeepSeek MLP and DistributedRMSNorm 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (failing APC are unrelated to these changes)