### PR TITLE
Llama70B topK op - unit test update

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_topk.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_topk.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.reduce.test_topk import run_topk_test

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_topk.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_topk.py
@@ -1,0 +1,66 @@
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.reduce.test_topk import run_topk_test
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+    ids=[
+        "BFLOAT16_B",
+    ],
+)
+@pytest.mark.parametrize(
+    "N, C, H, W, dim, k",
+    ((1, 1, 32, 16 * 1024, 3, 32),),
+)
+@pytest.mark.parametrize(
+    "sorted",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "largest",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "pass_indices_tensor",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "sub_core_grids",
+    [
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+            ]
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+        }
+    ],
+    indirect=True,
+)
+def test_topk_sub_core_grids(
+    N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids, pass_indices_tensor, galaxy_type
+):
+    # skip if galaxy_type is None
+    if galaxy_type is None:
+        pytest.skip("Test is not applicable for non-galaxy devices")
+    if dim == 0 or dim == 1:
+        # As of now, when we try to get top-k for dim = 0 or 1, we get following error from transpose_op.cpp's validate():
+        # input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32
+        # this is because, transpose.cpp always typecasts bf8 to bf16
+        # and when dim = 0 or 1, transpose converts it into TransposeOpDim::HC & this dim doesnt support bf16 or fp32
+        pytest.skip()
+    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -147,7 +147,7 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
 @pytest.mark.parametrize(
     "pass_indices_tensor",
     [
-        False,
+        True,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -20,7 +20,7 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         indices_tensor_torch = torch.zeros(shape, dtype=torch.int32)
         for i in range(W):
             indices_tensor_torch[:, :, :, i] = i
-        indices_tensor = ttnn.from_torch(indices_tensor_torch, ttnn.uint32, layout=ttnn.Layout.TILE, device=device)
+        indices_tensor = ttnn.from_torch(indices_tensor_torch, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
     else:
         indices_tensor = None
 


### PR DESCRIPTION
### Problem description
Llama unit test for topK is not reflecting actual usage of topK in Llama model. 

### What's changed
- Updated dtype for indices_tensor to uint16
- Updated flag to True for indices_tensor
- Added llama shaped test to llama directory
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16675294890)