### PR TITLE
fix rope scaling factory

### DIFF
--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -47,8 +47,8 @@ class RotarySetup(LightweightModule):
             dhead=head_dim,
             end=max_seq_len * 2,
             theta=rope_theta,
-            scale_factor=rope_scaling.factor,
-            orig_context_len=rope_scaling.original_max_position_embeddings,
+            scale_factor=rope_scaling.factor if rope_scaling is not None else None,
+            orig_context_len=rope_scaling.original_max_position_embeddings if rope_scaling is not None else None,
             position_ids=torch.arange(max_seq_len),
         )
 

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -67,12 +67,18 @@ class RopeScalingYarn(RopeScaling):
 
 
 def rope_scaling_model_factory(rope_scaling_params: dict) -> RopeScaling:
-    if rope_scaling_params.get("rope_type") == RopeScalingType.LLAMA3:
+    rope_scaling_type = rope_scaling_params.get("rope_type") or rope_scaling_params.get("type")
+    if rope_scaling_type == RopeScalingType.LLAMA3:
         return RopeScalingLlama3(**rope_scaling_params)
-    elif rope_scaling_params.get("rope_type") == RopeScalingType.YARN:
+    elif rope_scaling_type == RopeScalingType.YARN:
         return RopeScalingYarn(**rope_scaling_params)
+    elif rope_scaling_type in ["default", "mrope"]:
+        logger.warning(
+            f"Rope scaling type was set to {rope_scaling_type}, defaulting to no rope scaling as this rope type is not supported yet by TTT"
+        )
+        return None
     else:
-        return RopeScaling(rope_type=RopeScalingType.DEFAULT, **rope_scaling_params)
+        raise ValueError(f"Unexpected RoPE scaling type: {rope_scaling_type}")
 
 
 def encode_prompt_instruct(tokenizer, prompt_text, system_prompt_text=None):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1472,15 +1472,6 @@ class ModelArgs:
         # RoPE params
         self.rope_theta = text_config.get("rope_theta")
         rope_scaling_params = text_config.get("rope_scaling", None)
-        if rope_scaling_params:
-            rope_scaling_params = {
-                "factor": rope_scaling_params.get("factor", None),
-                "original_max_position_embeddings": rope_scaling_params.get(
-                    "original_max_position_embeddings", self.max_context_len
-                ),
-            }
-        # if rope_scaling_params and rope_scaling_params.get("factor", None) is None:
-        #     rope_scaling_params = None
         self.rope_scaling = rope_scaling_model_factory(rope_scaling_params) if rope_scaling_params else None
 
         self.query_pre_attn_scalar = text_config.get("query_pre_attn_scalar", None)


### PR DESCRIPTION
### Problem description
hotfix for failing pipelines e.g https://github.com/tenstorrent/tt-metal/actions/runs/16672233133/job/47203755359#step:8:1389

Qwen2.5-VL changes introduced a new rope scaling configuration. Changes to accomodate it in model_config.py broke functionality for other rope types.

### What's changed
This change will just bypass mrope scaling (used in Qwen2.5-VL) as this isn't supported yet in TTT. 

pipelines:
https://github.com/tenstorrent/tt-metal/actions/runs/16679961176
https://github.com/tenstorrent/tt-metal/actions/runs/16679963727

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/16679961176
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
  - https://github.com/tenstorrent/tt-metal/actions/runs/16679963727 