### PR TITLE
Extend didt test timeout

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -87,7 +87,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      timeout: 10
+      timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/actions/runs/16667757071/job/47177677196) tests take slightly longer sometimes, causing them to exceed 10min timeout.

### Problem description
New didt tests have been added, and the timeout needs to be extended.

### What's changed
Extended timeout for didt tests to 20min.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16697917514) CI passes
- [x] [l2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/16681178795)