### PR TITLE
Integrated page table with prefill MLA

### DIFF
--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -205,7 +205,7 @@ def test_forward_pass(
     weight_config = MLA1D.convert_weights(hf_config, state_dicts, tmp_path, mesh_device)
 
     # Generate appropriate configs
-    ccl = CCL1D(mesh_row)
+    ccl = CCL1D(mesh_device)
     if mode == "prefill":
         model_config = MLA1D.prefill_model_config(hf_config, mesh_device)
     else:

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -14,7 +14,6 @@ from transformers import DynamicCache
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention
-from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from models.demos.deepseek_v3.tt.mla_1d import MLA1D
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.run_config import create_run_config
@@ -180,6 +179,7 @@ def test_forward_pass(
     hf_config_short,
     tmp_path,
     mesh_device,
+    ccl,
 ):
     # Hang workaround for large shapes
     if seq_len > 1024:
@@ -205,7 +205,6 @@ def test_forward_pass(
     weight_config = MLA1D.convert_weights(hf_config, state_dicts, tmp_path, mesh_device)
 
     # Generate appropriate configs
-    ccl = CCL1D(mesh_device)
     if mode == "prefill":
         model_config = MLA1D.prefill_model_config(hf_config, mesh_device)
     else:

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -182,10 +182,8 @@ def test_forward_pass(
     hf_config = hf_config_short
     mesh_shape = list(mesh_device.shape)
 
-    dp_factor = mesh_shape[1] if mode == "decode" else 1
-    paged_config = (
-        MLA1D.get_valid_paged_config(hf_config.max_seq_len, batch_size, dp_factor) if mode == "decode" else None
-    )
+    dp_factor = mesh_shape[1]
+    paged_config = MLA1D.get_valid_paged_config(hf_config.max_seq_len, MLA1D.MAX_BATCH_SIZE, dp_factor)
 
     reference_model = reference
 
@@ -208,7 +206,7 @@ def test_forward_pass(
         model_config = MLA1D.decode_model_config(hf_config, mesh_device)
 
     # Create a new model state
-    model_state = MLA1D.create_state(hf_config, mesh_device, dp_factor, paged_config, ccl)
+    model_state = MLA1D.create_state(hf_config, mesh_device, paged_config, ccl)
 
     # Create RunConfig using both weight_config and model_config
     run_config = create_run_config(model_config, weight_config, model_state)
@@ -238,6 +236,9 @@ def test_forward_pass(
     ### TTNN inputs
     ############################
     logger.info("Preparing TTNN inputs")
+
+    user_id = None if mode == "decode" else randint(0, MLA1D.MAX_BATCH_SIZE - 1)
+
     if mode == "decode":
         # TT Shape: [1, seq_len, batch_size, hidden_size]
         torch_input = torch_input.permute(1, 0, 2)
@@ -252,23 +253,21 @@ def test_forward_pass(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
     )
+
     tt_page_table, page_table = None, None
+    tt_page_table, page_table = MLA1D.create_page_table(
+        MLA1D.MAX_BATCH_SIZE,
+        dp_factor=dp_factor,
+        config=paged_config,
+        mesh_device=mesh_device,
+    )
 
     if mode == "decode":
         position_idxs_tensor = ttnn.from_torch(
             torch.tensor(position_idxs),
             device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, dims=(None, 0), mesh_shape=mesh_shape
-            ),  # TODO: Shard on batch when DP
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 0), mesh_shape=mesh_shape),
             dtype=ttnn.int32,
-        )
-
-        tt_page_table, page_table = MLA1D.create_page_table(
-            batch_size,
-            dp_factor=dp_factor,
-            config=paged_config,
-            mesh_device=mesh_device,
         )
 
     # RoPE stuff
@@ -300,8 +299,6 @@ def test_forward_pass(
         "trans_matrix_dp": rot_mats_dp[2],
     }
 
-    user_id = None if mode == "decode" else 0  # TODO: randint(0, MLA1D.MAX_BATCH_SIZE)
-
     ############################
     ### TTNN forward pass
     ############################
@@ -310,7 +307,7 @@ def test_forward_pass(
     cur_row_idx = randint(0, mesh_shape[0] - 1)
 
     if mode == "prefill":
-        tt_output = MLA1D.forward_prefill(tt_input, run_config, user_id, rope_tensors)
+        tt_output = MLA1D.forward_prefill(tt_input, run_config, user_id, rope_tensors, tt_page_table, cur_row_idx)
     else:
         tt_output = MLA1D.forward_decode(
             tt_input, run_config, position_idxs_tensor, rope_tensors, tt_page_table, cur_row_idx
@@ -342,26 +339,22 @@ def test_forward_pass(
 
         pcc_required_kvpe = 0.999
 
-        if mode == "decode":
-            tt_cache = get_cache_on_host(
-                run_config["kvpe_cache"], cur_row_idx, mesh_device
-            )  # [DP Factor * max_num_blocks, nh, block_size, head_dim + rope_head_dim]
-            tt_cache = MLA1D.from_paged_cache(tt_cache, page_table, dp_factor).squeeze(
-                1
-            )  # [bsz, max_seq_len, head_dim + rope_head_dim]
-        else:
-            tt_cache = get_cache_on_host(run_config["kvpe_cache"], cur_row_idx, mesh_device)[
-                : MLA1D.MAX_BATCH_SIZE, ...
-            ].squeeze(
-                1
-            )  # [bsz, max_seq_len, head_dim + rope_head_dim]
+        tt_cache = get_cache_on_host(
+            run_config["kvpe_cache"], cur_row_idx, mesh_device
+        )  # [DP Factor * max_num_blocks, nh, block_size, head_dim + rope_head_dim]
+        tt_cache = MLA1D.from_paged_cache(tt_cache, page_table, dp_factor).squeeze(
+            1
+        )  # [bsz, max_seq_len, head_dim + rope_head_dim]
 
         # Slice the correct region of the cache
         if mode == "decode":
+            # Advanced indexing to get the correct position for each user
             batch_indices = torch.arange(batch_size)
-            tt_cache = tt_cache[batch_indices, position_idxs, :].unsqueeze(1)  # [bsz, 1, head_dim + rope_head_dim]
+            tt_cache = tt_cache[batch_indices, position_idxs, :].unsqueeze(
+                1
+            )  # [bsz, 1(seq_len), head_dim + rope_head_dim]
         else:
-            tt_cache = tt_cache[:batch_size, :seq_len, :]
+            tt_cache = tt_cache[user_id, :seq_len, :].unsqueeze(1)  # [1(bsz), seq_len, head_dim + rope_head_dim]
 
         tt_cache_kv = tt_cache[..., : hf_config.kv_lora_rank]
         tt_cache_pe = tt_cache[..., hf_config.kv_lora_rank :]
@@ -376,6 +369,34 @@ def test_forward_pass(
         logger.info(f"Cache PE PCC: {pe_pcc_message}")
 
         all_passing = all_passing and kv_passing and pe_passing
+
+        # Check the rest of the cache is empty
+        row_idxs = list(range(mesh_shape[0]))
+        row_idxs.remove(cur_row_idx)
+
+        for r in row_idxs:
+            other_cache = get_cache_on_host(run_config["kvpe_cache"], r, mesh_device)
+            passing = torch.all(other_cache == 0)
+
+            if not passing:
+                logger.error(f"Cache for row {r} is not empty")
+                all_passing = all_passing and passing
+
+        # Check if cache is empty for other users in prefill mode
+        if mode == "prefill":
+            other_cache = get_cache_on_host(run_config["kvpe_cache"], cur_row_idx, mesh_device)
+
+            # Convert to paged cache format so we can index by user_id
+            other_cache = MLA1D.from_paged_cache(other_cache, page_table, dp_factor)
+
+            # Mask out the user_id and it's sequence length
+            mask = torch.ones_like(other_cache, dtype=torch.bool)
+            mask[user_id, :, :seq_len, :] = False  # Mask out
+            passing = torch.all(other_cache[mask] == 0)
+
+            if not passing:
+                logger.error(f"Cache for users other than {user_id} are not empty in prefill mode")
+                all_passing = all_passing and passing
 
     assert (
         all_passing

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -90,8 +90,8 @@ class MLA1D(AbstractModule):
 
         def convert_linear_weight(
             hf_name: str | None,
-            shape: tuple[int, ...] | None,
-            mesh_dims: tuple[int, ...],
+            shape: tuple[int] | None,
+            mesh_dims: tuple[int],
             dtype: ttnn.DataType = ttnn.bfloat8_b,
             mem_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
             layout: ttnn.Layout = ttnn.TILE_LAYOUT,
@@ -1119,9 +1119,7 @@ class MLA1D(AbstractModule):
         page_table: ttnn.Tensor,
         row_idx: int,
     ) -> ttnn.Tensor:
-        """Forward pass of the MLP.
-
-        Prefill mode we reshape to respect cfg["max_rows"] and generate program configs from the seq-len lambda.
+        """Forward pass of MLA1D in prefill mode.
 
         Args:
             x: Input tensor

--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -850,40 +850,26 @@ class MLA1D(AbstractModule):
     def create_state(
         cls,
         hf_config: PretrainedConfig,
-        mesh_device: ttnn.Device,
-        dp_factor: int,
+        mesh_device: ttnn.MeshDevice,
         paged_config: PagedAttentionConfig,
         ccl: CCL1D,
     ) -> Any:
         kv_lora_rank = hf_config.kv_lora_rank
         qk_rope_head_dim = hf_config.qk_rope_head_dim
-        max_seq_len = hf_config.max_seq_len
 
         kvpe_dim = kv_lora_rank + qk_rope_head_dim
         kvpe_cache_dtype = ttnn.bfloat8_b
         kvpe_cache_layout = ttnn.TILE_LAYOUT
         kvpe_cache_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
-        mesh_shape = list(mesh_device.shape)
-
-        if paged_config:
-            cache = torch.zeros(
-                (
-                    paged_config.max_num_blocks,
-                    1,  # 1 latent kv heads
-                    paged_config.block_size,
-                    kvpe_dim,
-                )
+        cache = torch.zeros(
+            (
+                paged_config.max_num_blocks,
+                1,  # 1 latent kv heads
+                paged_config.block_size,
+                kvpe_dim,
             )
-        else:
-            cache = torch.zeros(
-                (
-                    even_int_div(MLA1D.MAX_BATCH_SIZE, dp_factor),
-                    1,  # 1 latent kv heads
-                    max_seq_len,
-                    kvpe_dim,
-                )
-            )
+        )
 
         tt_cache = ttnn.as_tensor(
             cache,
@@ -931,12 +917,18 @@ class MLA1D(AbstractModule):
         }
 
     @classmethod
-    def row_to_device_coords(cls, row: int, mesh_shape: list[int]) -> set[ttnn.MeshCoordinate]:
+    def get_mesh_coores(cls, mesh_shape: list[int], row: int = None, col: int = None) -> set[ttnn.MeshCoordinate]:
         """
         Get the devices in the current row.
         """
-        assert 0 <= row < mesh_shape[0], "Row index out of bounds"
-        device_coords = {(row, col) for col in range(mesh_shape[1])}
+        if row:
+            assert 0 <= row < mesh_shape[0], "Row index out of bounds"
+        if col:
+            assert 0 <= col < mesh_shape[1], "Column index out of bounds"
+
+        row_select = range(mesh_shape[0]) if row is None else [row]
+        col_select = range(mesh_shape[1]) if col is None else [col]
+        device_coords = {(r, c) for r in row_select for c in col_select}
         return {ttnn.MeshCoordinate(*coord) for coord in device_coords}
 
     @classmethod
@@ -962,10 +954,12 @@ class MLA1D(AbstractModule):
 
         """
         mesh_shape = cfg["mesh_shape"]
+        sdpa_dp_factor = mesh_shape[1]
+        mla_tp_factor = mesh_shape[1]
 
         hf_config = cfg["hf_config"]
         num_heads = hf_config.num_attention_heads
-        num_heads_local = even_int_div(num_heads, mesh_shape[1])
+        num_heads_local = even_int_div(num_heads, mla_tp_factor)
         kv_lora_rank = hf_config.kv_lora_rank
         qk_nope_head_dim = hf_config.qk_nope_head_dim
         qk_rope_head_dim = hf_config.qk_rope_head_dim
@@ -975,7 +969,7 @@ class MLA1D(AbstractModule):
         kvpe_cache = cfg["kvpe_cache"]
 
         bsz = x.shape[2]
-        scale = 1.0 / mesh_shape[1]
+        scale = 1.0 / mla_tp_factor
 
         # wq_a and wq_b
         tt_q = ttnn.linear(x, **cfg["wq_a"])
@@ -1076,7 +1070,7 @@ class MLA1D(AbstractModule):
             tt_kvpe,
             update_idxs_tensor=position_idxs,
             page_table=page_table,
-            mesh_coords=cls.row_to_device_coords(row_idx, mesh_shape),
+            mesh_coords=cls.get_mesh_coores(mesh_shape, row_idx),
         )
 
         # FlashMLA
@@ -1116,7 +1110,15 @@ class MLA1D(AbstractModule):
         return out
 
     @classmethod
-    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig, user_id: int, rope_tensors: dict) -> ttnn.Tensor:
+    def forward_prefill(
+        cls,
+        x: ttnn.Tensor,
+        cfg: RunPrefillConfig,
+        batch_idx: int,
+        rope_tensors: dict,
+        page_table: ttnn.Tensor,
+        row_idx: int,
+    ) -> ttnn.Tensor:
         """Forward pass of the MLP.
 
         Prefill mode we reshape to respect cfg["max_rows"] and generate program configs from the seq-len lambda.
@@ -1124,18 +1126,22 @@ class MLA1D(AbstractModule):
         Args:
             x: Input tensor
             cfg: RunConfig containing weights and op configurations
-            user_id: Batch index for cache updates
+            batch_idx: Batch index for cache updates (wrt to global batch size)
             rope_tensors: Dictionary containing RoPE tensors
+            page_table: Page table tensor for paged attention
+            row_idx: Row index in the mesh
 
         Returns:
             Output tensor after MLP computation
         """
 
         mesh_shape = cfg["mesh_shape"]
+        sdpa_dp_factor = mesh_shape[0]
+        mla_tp_factor = mesh_shape[1]
 
         hf_config = cfg["hf_config"]
         num_heads = hf_config.num_attention_heads
-        num_heads_local = even_int_div(num_heads, mesh_shape[1])
+        num_heads_local = even_int_div(num_heads, mla_tp_factor)
         kv_lora_rank = hf_config.kv_lora_rank
         qk_nope_head_dim = hf_config.qk_nope_head_dim
         qk_rope_head_dim = hf_config.qk_rope_head_dim
@@ -1210,10 +1216,14 @@ class MLA1D(AbstractModule):
         tt_kvpe = ttnn.typecast(tt_kvpe, dtype=kvpe_cache.dtype)
 
         # Update KVPE Cache
-        ttnn.fill_cache(
+        local_batch_idx = batch_idx % sdpa_dp_factor  # Local batch index within the DP shard
+        col_idx = batch_idx // sdpa_dp_factor  # Which DP shard the batch belongs to
+        ttnn.experimental.paged_fill_cache(
             kvpe_cache,
             tt_kvpe,
-            batch_idx=user_id,
+            page_table=page_table,
+            batch_idx=local_batch_idx,
+            mesh_coords=cls.get_mesh_coores(mesh_shape, row_idx, col_idx),
         )
 
         # FlashMLA


### PR DESCRIPTION
### Ticket
- #23022 

### Problem description
Currently, MLA prefill mode does not use paging.

### What's changed
- MLA now only supports paged SDPA (non-paged version has been removed as it is redundant)
- Added `page_table` and `paged_fill_cache` to prefill forward in MLA
    - In current implementation of TG Llama with a DP factor, the page table entries for users other than `user_id` are set to -1, to ensure that other DP shards don't update their cache. However, for the DeepSeek implementation, we look to simplify this mechanism by simply supplying a `batch_idx` which indexes the global batch size. Then, based on the DP factor, a `local_batch_idx` is calculated, that will then be passed to the `paged_fill_cache` op. On top of that, we can ensure that other DP shards don't have their cache updated by using the `mesh_coords` parameter to selectively run the op on the devices that correspond to the current batch.
- Re-vamped cache checking
    - Validates other rows to make sure they are empty (prefill/decode)
    - Validates other users to make sure they are empty (prefill)
- `get_mesh_cords` -> Now supports row and column indexing


### TODOs
- [x] Update MLA APC tests to use paged cache ops

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16754497115) CI passes
- [ ] [TG Deepseek](https://github.com/tenstorrent/tt-metal/actions/runs/16754513864) passes