### PR TITLE
Enable Uint32/Int32 on Pad

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -520,6 +520,7 @@ on:
           - data_movement.repeat_interleave.repeat_interleave
           - data_movement.nonzero.nonzero
           - data_movement.backward.concat_bw.concat_bw
+          - data_movement.pad.pad
           - conv_transpose2d.short.conv_transpose2d_short_sweep
           - conv2d.full.conv2d_misc
           - conv2d.full.conv2d_sharding

--- a/tests/sweep_framework/sweeps/data_movement/pad/pad.py
+++ b/tests/sweep_framework/sweeps/data_movement/pad/pad.py
@@ -78,12 +78,10 @@ def run(
     torch_input = random_torch_tensor(dtype, shape)
     ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=dtype)
 
-    # print(padding)
     torch_padding = []
     for i in range(len(padding) - 1, -1, -1):  # go through each dim of padding
         for p in padding[i]:
             torch_padding.append(p)  # each dim has 2 padding values
-    # print(torch_padding)
     padding = tuple(padding)
 
     # Measure performance of the embedding operation in ttnn
@@ -99,6 +97,6 @@ def run(
     ttnn_output_tensor = ttnn.to_torch(ttnn_output_tensor)
 
     # Compare the results and return performance and accuracy check
-    result = check_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
+    result = check_with_pcc(torch_output_tensor, ttnn_output_tensor, 1.0)
 
     return [result, e2e_perf]

--- a/tests/sweep_framework/sweeps/data_movement/pad/pad.py
+++ b/tests/sweep_framework/sweeps/data_movement/pad/pad.py
@@ -33,8 +33,7 @@ parameters = {
             ((1, 1), (4, 2)),
         ],
         "value": [0, 3],
-        # "dtype": [ttnn.bfloat16],
-        "dtype": [ttnn.int32, ttnn.uint32],
+        "dtype": [ttnn.int32, ttnn.uint32, ttnn.bfloat16],
         "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
     }
 }

--- a/tests/sweep_framework/sweeps/data_movement/pad/pad.py
+++ b/tests/sweep_framework/sweeps/data_movement/pad/pad.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import random
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+TIMEOUT = 10
+# seed for random
+random.seed(0)
+
+parameters = {
+    "nightly": {
+        "shape": [[16, 3, 224, 224], [1, 1, 31, 31], [16, 3, 230, 224], [20, 3, 224, 256], [32, 64]],
+        "padding": [
+            ((0, 0), (0, 32), (0, 32)),  # +[0, 0, 32, 32]
+            ((0, 0), (0, 15), (0, 31)),  # +[0, 0, 15, 31]
+            ((0, 1), (3, 25), (32, 32)),
+            ((0, 1), (3, 25), (4, 6)),
+            ((0, 1), (3, 25), (4, 7)),
+            ((0, 1), (0, 32), (0, 32)),
+            ((1, 1), (2, 32), (0, 0)),
+            [(32, 32)],
+            ((0, 1), (0, 2)),
+            ((1, 1), (4, 2)),
+            ((0, 1), (0, 2)),
+            ((1, 1), (4, 2)),
+        ],
+        "value": [0, 3],
+        # "dtype": [ttnn.bfloat16],
+        "dtype": [ttnn.int32, ttnn.uint32],
+        "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+    }
+}
+
+
+def random_torch_tensor(dtype, shape):
+    if dtype == ttnn.uint16:
+        return torch.randint(0, 100, shape).to(torch.int16)
+    if dtype == ttnn.int32:
+        return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
+    return torch.rand(shape).bfloat16().float()
+
+
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        if test_vector["dtype"] == ttnn.bfloat8_b:
+            return True, "bfloat8_b not supported with ROW_MAJOR_LAYOUT"
+    if len(test_vector["shape"]) < len(test_vector["padding"]):
+        return True, "Padding must be less than or equal to length of shape"
+    front_padding = False
+    for pad in test_vector["padding"]:
+        if pad[0] > 0:
+            front_padding = True
+            break
+    if front_padding and test_vector["layout"] == ttnn.TILE_LAYOUT:
+        return True, "Front padding not supported with TILE_LAYOUT"
+
+    return False, None
+
+
+def run(
+    shape,
+    padding,
+    value,
+    dtype,
+    layout,
+    *,
+    device,
+):
+    torch_input = random_torch_tensor(dtype, shape)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=dtype)
+
+    # print(padding)
+    torch_padding = []
+    for i in range(len(padding) - 1, -1, -1):  # go through each dim of padding
+        for p in padding[i]:
+            torch_padding.append(p)  # each dim has 2 padding values
+    # print(torch_padding)
+    padding = tuple(padding)
+
+    # Measure performance of the embedding operation in ttnn
+    start_time = start_measuring_time()
+
+    ttnn_output_tensor = ttnn.pad(ttnn_input, padding=padding, value=value)
+
+    e2e_perf = stop_measuring_time(start_time)
+
+    torch_output_tensor = torch.nn.functional.pad(torch_input, torch_padding, mode="constant", value=value)
+
+    # Convert the ttnn tensor back to PyTorch for comparison
+    ttnn_output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    # Compare the results and return performance and accuracy check
+    result = check_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
+
+    return [result, e2e_perf]

--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -15,6 +15,8 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 from tests.ttnn.utils_for_testing import assert_with_pcc
 import ttnn
 
+torch.manual_seed(0)
+
 
 def random_torch_tensor(dtype, shape):
     if dtype == ttnn.uint16:
@@ -51,7 +53,7 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, output_tensor)
 
 
 def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype):
@@ -65,7 +67,7 @@ def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, va
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [16])
@@ -145,7 +147,7 @@ def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
 
     assert tt_output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, tt_output_tensor)
 
 
 def to_torch_padding(padspec):
@@ -306,7 +308,7 @@ def test_pad(device, h, w, padding, torch_padding, value):
     output_tensor = ttnn.to_torch(output_tensor)
     assert output_tensor.shape == torch_output_tensor.shape
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("h", [32])
@@ -362,7 +364,7 @@ def test_pad(device, h, w, padding, torch_padding, value):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.skip(reason="ttnn.pad does not support row_major tensors because the kernel currently causes a PCC error")
@@ -389,7 +391,7 @@ def test_pad_back_to_back(device, h, w, padding, torch_padding, value):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.skip(reason="ttnn.pad requires pad to start at 0")
@@ -425,7 +427,7 @@ def test_pad_for_tensor_in_tile_layout(device, h, w, padding, value):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.equal(torch_output_tensor, output_tensor)
 
 
 @skip_for_blackhole("Fails on Blackhole. Issue #20698")
@@ -449,7 +451,7 @@ def test_pad_conv2d_sweep(device, dtype, use_multicore, shape, padded_shape):
     out_torch = out_ttnn.cpu().to_torch().float()
 
     out_torch = out_torch[: shape[0], : shape[1], : shape[2], : shape[3]]
-    assert_with_pcc(in_torch, out_torch, 0.9999)
+    assert torch.equal(in_torch, out_torch)
 
 
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32])
@@ -466,7 +468,7 @@ def test_pad_op(device, in_dtype, shape, padshape, use_multicore):
 
     shape_diff = list(map(lambda x, y: x - y, padshape, shape))
     output_torch = torch.nn.functional.pad(torch_input, [0, shape_diff[-1], 0, shape_diff[-2]], value=0)
-    assert_with_pcc(output_tt, output_torch, 0.9999)
+    assert torch.equal(output_tt, output_torch)
 
 
 def _unsqueeze(smaller, larger, fill):
@@ -501,4 +503,4 @@ def test_pad_tile(shape, padding, dtype, device):
 
     out_tt = ttnn.to_torch(output)
 
-    assert_with_pcc(out_tt, torch_output, 0.9999)
+    assert torch.equal(out_tt, torch_output)

--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -16,6 +16,16 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 import ttnn
 
 
+def random_torch_tensor(dtype, shape):
+    if dtype == ttnn.uint16:
+        return torch.randint(0, 100, shape).to(torch.int16)
+    if dtype == ttnn.int32:
+        return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
+    return torch.rand(shape).bfloat16().float()
+
+
 @pytest.mark.parametrize("n", [16])
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [230])
@@ -28,14 +38,15 @@ import ttnn
         (((0, 1), (3, 25), (4, 7)), (4, 7, 3, 25, 0, 1)),  # Odd padding widths (5 and 7)
     ],
 )
-@pytest.mark.parametrize("value", [0])
-def test_pad_rm(device, n, c, h, w, padding, torch_padding, value):
+@pytest.mark.parametrize("value", [-1])
+@pytest.mark.parametrize("dtype", [ttnn.int32])
+def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+    torch_input_tensor = random_torch_tensor(dtype, (n, c, h, w))
     torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
     output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -43,13 +54,13 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
-def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value):
+def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+    torch_input_tensor = random_torch_tensor(dtype, (n, c, h, w))
     torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
     output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -62,10 +73,11 @@ def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, va
 @pytest.mark.parametrize("h", [224])
 @pytest.mark.parametrize("w", [224])
 @pytest.mark.parametrize("padding,torch_padding", [(((0, 1), (0, 32), (0, 32)), (0, 32, 0, 32, 0, 1))])
-@pytest.mark.parametrize("value", [0])
-def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value):
+@pytest.mark.parametrize("value", [4])
+@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.uint32])
+def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype):
     for _ in range(2):
-        run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value)
+        run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
@@ -79,15 +91,17 @@ def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, v
     assert device.num_program_cache_entries() == 1
 
 
-def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient):
+def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient, dtype):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+    # torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+    torch_input_tensor = random_torch_tensor(dtype, (n, c, h, w))
     torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
 
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor,
-        dtype=ttnn.DataType.BFLOAT16,
+        # dtype=ttnn.DataType.BFLOAT16,
+        dtype=dtype,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=device,
         memory_config=ttnn.L1_MEMORY_CONFIG,
@@ -215,8 +229,11 @@ def to_torch_padding(padspec):
         ],
     ],
 )
+@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.uint32])
+# @pytest.mark.parametrize("dtype", [ttnn.int32])
+# @pytest.mark.parametrize("dtype", [ttnn.float32])
 def test_pad_rm_sharded_stickwise(
-    device, input_shape, pad_to_shape, input_tensor_start, pad_value, input_sharded_memory_config_args
+    device, input_shape, pad_to_shape, input_tensor_start, pad_value, input_sharded_memory_config_args, dtype
 ):
     core_grid_x_ok = device.core_grid.x >= input_sharded_memory_config_args["core_grid"].x
     core_grid_y_ok = device.core_grid.y >= input_sharded_memory_config_args["core_grid"].y
@@ -226,10 +243,9 @@ def test_pad_rm_sharded_stickwise(
 
     input_shard_memory_config = ttnn.create_sharded_memory_config(input_shape, **input_sharded_memory_config_args)
 
-    torch_input_tensor = torch.ones(input_shape, dtype=torch.float32)
-    ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
-    )
+    # torch_input_tensor = torch.ones(input_shape, dtype=torch.int32)
+    torch_input_tensor = torch.arange(torch.prod(torch.tensor(input_shape)), dtype=torch.int32).reshape(input_shape)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
     # Still relay on keep_l1_aligned = True to make it work with the current implementation
     ttnn_sharded_input_tensor = ttnn.interleaved_to_sharded(
         ttnn_input_tensor, input_shard_memory_config, keep_l1_aligned=True
@@ -260,17 +276,20 @@ def test_pad_rm_sharded_stickwise(
 @pytest.mark.parametrize("padding,torch_padding", [(((1, 1), (2, 32), (0, 0)), (0, 0, 2, 32, 1, 1))])
 @pytest.mark.parametrize("value", [8])
 @pytest.mark.parametrize("shard_orient", [ttnn.ShardOrientation.COL_MAJOR, ttnn.ShardOrientation.ROW_MAJOR])
-def test_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient):
+@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.uint32])
+# @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient, dtype):
     if device.core_grid.y < 8:
         pytest.skip("n300 does not have 8x8 grid")
     for _ in range(2):
-        run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient)
+        run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient, dtype)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
         tt_dummy_tensor = ttnn.from_torch(
             py_dummy_tensor,
-            dtype=ttnn.DataType.BFLOAT16,
+            # dtype=ttnn.DataType.BFLOAT16,
+            dtype=dtype,
             layout=ttnn.TILE_LAYOUT,
             device=device,
             memory_config=ttnn.L1_MEMORY_CONFIG,
@@ -440,12 +459,12 @@ def test_pad_conv2d_sweep(device, dtype, use_multicore, shape, padded_shape):
     assert_with_pcc(in_torch, out_torch, 0.9999)
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32])
 @pytest.mark.parametrize("shape", [[1, 1, 18, 13]])
 @pytest.mark.parametrize("padshape", [[1, 1, TILE_HEIGHT, TILE_WIDTH]])
 @pytest.mark.parametrize("use_multicore", [False, True])
 def test_pad_op(device, in_dtype, shape, padshape, use_multicore):
-    torch_input = torch.randn(shape, dtype=torch.bfloat16).bfloat16()
+    torch_input = random_torch_tensor(in_dtype, shape)
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tt = ttnn.pad(ttnn_input, padshape, [0, 0, 0, 0], value=0, use_multicore=use_multicore)
@@ -469,7 +488,15 @@ def _unsqueeze(smaller, larger, fill):
 @pytest.mark.parametrize(
     "padding", [[25, 1], [5, 4], [64], [32, 32], [1, 0, 0, 0], [1, 0, 0], [32, 32, 32, 64], [0, 64], [0, 0, 0, 64]]
 )
-def test_pad_tile(shape, padding, device):
+# @pytest.mark.parametrize(
+#     "shape",
+#     [[2, 128]],
+# )
+# @pytest.mark.parametrize(
+#     "padding", [[25, 1]]
+# )
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_pad_tile(shape, padding, dtype, device):
     if (shape, padding) in [([5, 4, 3, 2, 1], [1, 0, 0, 0]), ([5, 4, 3, 2, 1], [32, 32, 32, 64])]:
         pytest.xfail("Can't pad upper dims with rank>4")
 
@@ -479,7 +506,7 @@ def test_pad_tile(shape, padding, device):
         padding = _unsqueeze(padding, shape, 0)
 
     input = torch.ones(prod(shape), dtype=torch.bfloat16).reshape(shape)
-    input_tensor = ttnn.from_torch(input, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.from_torch(input, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT)
 
     torch_padding = sum([[0, p] for p in reversed(padding)], [])
     torch_output = torch.nn.functional.pad(input, torch_padding, value=5)

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -50,11 +50,11 @@ void kernel_main() {
     uint32_t num_end_pad_sticks_read = 0;
     uint32_t num_sticks_padded_read = 0;
     if constexpr (not_pad_by_zero) {
-        packed_pad_value = kernel_compile_time_args[14];
-        row_major_min_bytes = kernel_compile_time_args[15];
-        num_front_pad_sticks_read = kernel_compile_time_args[16];
-        num_end_pad_sticks_read = kernel_compile_time_args[17];
-        num_sticks_padded_read = kernel_compile_time_args[18];
+        packed_pad_value = kernel_compile_time_args[13];
+        row_major_min_bytes = kernel_compile_time_args[14];
+        num_front_pad_sticks_read = kernel_compile_time_args[15];
+        num_end_pad_sticks_read = kernel_compile_time_args[16];
+        num_sticks_padded_read = kernel_compile_time_args[17];
     }
 
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -46,11 +46,13 @@ void Pad::validate_with_output_tensors(
         TT_FATAL((this->output_padded_shape[2] % TILE_HEIGHT == 0), "Can only pad tilized tensor with full tiles");
         TT_FATAL((this->output_padded_shape[3] % TILE_WIDTH == 0), "Can only pad tilized tensor with full tiles");
         TT_FATAL(
-            input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16,
+            input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
+                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32,
             "Cannot pad tilized tensor with specified format");
     } else if (input_tensor.layout() == Layout::ROW_MAJOR) {
         TT_FATAL(
-            input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16,
+            input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
+                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32,
             "Cannot pad RM tensor with specified format");
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -73,9 +73,12 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     bfloat16 bfloat_zero = bfloat16(0.0f);
-    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
-                                    ? pad_value
-                                    : pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+    }
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -212,11 +215,12 @@ operation::ProgramWithCallbacks pad_tile(
     tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    uint32_t pad_bits;
-    std::memcpy(&pad_bits, &pad_value, sizeof(uint32_t));
-    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
-                                    ? pad_bits
-                                    : pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    }
 
     uint32_t num_unpadded_Xt = a.padded_shape()[3] / TILE_WIDTH;
     uint32_t num_total_Xt = output_shape[3] / TILE_WIDTH;
@@ -518,9 +522,12 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     bfloat16 bfloat_zero = bfloat16(0.0f);
-    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
-                                    ? pad_value
-                                    : pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+    }
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -841,9 +848,12 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
-                                    ? pad_value
-                                    : pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    }
 
     bool dst_is_dram = dst_buffer->buffer_type() == BufferType::DRAM;
     bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
@@ -1252,9 +1262,12 @@ operation::ProgramWithCallbacks pad_rm_sharded_height_only(
     tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
-                                    ? pad_value
-                                    : pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    }
 
     std::vector<uint32_t> reader_ct_args = {(std::uint32_t)stick_size_padded, (std::uint32_t)shard_height_padded};
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -73,7 +73,9 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     bfloat16 bfloat_zero = bfloat16(0.0f);
-    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
+                                    ? pad_value
+                                    : pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -210,7 +212,11 @@ operation::ProgramWithCallbacks pad_tile(
     tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    uint32_t pad_bits;
+    std::memcpy(&pad_bits, &pad_value, sizeof(uint32_t));
+    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
+                                    ? pad_bits
+                                    : pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
     uint32_t num_unpadded_Xt = a.padded_shape()[3] / TILE_WIDTH;
     uint32_t num_total_Xt = output_shape[3] / TILE_WIDTH;
@@ -512,7 +518,9 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     bfloat16 bfloat_zero = bfloat16(0.0f);
-    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
+                                    ? pad_value
+                                    : pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -833,7 +841,9 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
+                                    ? pad_value
+                                    : pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
     bool dst_is_dram = dst_buffer->buffer_type() == BufferType::DRAM;
     bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
@@ -1242,7 +1252,9 @@ operation::ProgramWithCallbacks pad_rm_sharded_height_only(
     tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    uint32_t packed_pad_value = (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32)
+                                    ? pad_value
+                                    : pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
     std::vector<uint32_t> reader_ct_args = {(std::uint32_t)stick_size_padded, (std::uint32_t)shard_height_padded};
 
@@ -1383,6 +1395,10 @@ operation::ProgramWithCallbacks pad_rm_sharded_width_only(
         padding_value_as_u32 = *reinterpret_cast<uint32_t*>(&bfloat_pad_value_bits);
     } else if (input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32) {
         padding_value_as_u32 = *reinterpret_cast<uint32_t*>(&pad_value);
+    } else if (
+        input_tensor.dtype() == tt::tt_metal::DataType::INT32 ||
+        input_tensor.dtype() == tt::tt_metal::DataType::UINT32) {
+        padding_value_as_u32 = static_cast<uint32_t>(pad_value);  // for INT32 and UINT32
     } else {
         TT_THROW("ttnn.pad: unsupported data type for pad_rm_sharded_stickwise");
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25789)

### Problem description
Pad did not have uint32/int32 support. the pad value was always assumed to be bfloat/float

### What's changed
Added checks to enable the pad value to be uint32/int32

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16732207728) CI passes
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16730835001) CI passes (if applicable)