### PR TITLE
Fix default minimal-RS optional buffer initialization

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -349,7 +349,7 @@ Tensor reduce_scatter_minimal_async_impl(
     std::vector<std::optional<Tensor>> optional_output_tensors =
         persistent_output_buffers
             ? std::vector<std::optional<Tensor>>(persistent_output_buffers->begin(), persistent_output_buffers->end())
-            : std::vector<std::optional<Tensor>>{};
+            : std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt};
 
     return tt::tt_metal::operation::run(
                ttnn::ReduceScatterMinimalAsync(


### PR DESCRIPTION
### Problem description
Minimal Reduce Scatter errored with OOB vector access when creating output tensors if persistent output buffers are not provided.

### What's changed
Initialize optional output tensors to a vector of size 2 if persistent output buffers are not provided.

### Checklist
- [x] TG nightly https://github.com/tenstorrent/tt-metal/actions/runs/16683110277