### PR TITLE
Fix groupnorm multicore coregrid assert

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -1199,10 +1199,10 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
     uint32_t num_batches_per_core_group_1 = num_batches > num_shards_r ? num_batches / num_shards_r : 1;
     uint32_t num_batches_per_core_group_2 = num_batches_per_core_group_1;  // need this to be non-zero even if unused
     uint32_t num_groups_per_core = num_groups > num_shards_c ? num_groups / num_shards_c : 1;
-    TT_FATAL(num_groups % num_cores_r == 0, "num_groups: {} must divide cores_y: {}", num_groups, num_cores_r);
+    TT_FATAL(num_groups % num_cores_c == 0, "num_groups: {} must divide cores_y: {}", num_groups, num_cores_c);
     TT_FATAL(
-        (num_groups / num_cores_r) * group_size % TILE_WIDTH == 0,
-        "(num_groups: {}/cores_x: {})*(num_channels: {}/num_groups: {}) must be divisible by {}",
+        (num_groups / num_cores_c) * group_size % TILE_WIDTH == 0,
+        "(num_groups: {}/cores_y: {})*(num_channels: {}/num_groups: {}) must be divisible by {}",
         num_groups,
         num_cores_r,
         W,


### PR DESCRIPTION
### Problem description
Groupnorm r/c x/y relationship is reversed. This leads to an inappropriate TT_FATAL assert which limits the coregrid that can be used by groupnorm.

### What's changed
The initial solution is to fix the relationship between r/c and x/y in this assert. 

Opening PR on behalf of @sadesoyeTT @jonathansuTT 
### Checklist
- [x] APC https://github.com/tenstorrent/tt-metal/actions/runs/16683430000