### PR TITLE
Set In CB Height Base on Kernel Size

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -323,10 +323,10 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t in_cb_sz = 0;
     uint32_t in_nblocks_c = 1;
     if (params.is_wide_reduction) {
-        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_HW;
+        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * params.num_tilized_rows;
         in_nblocks_c = std::ceil((float)params.in_ntiles_c / params.MAX_TILES_PER_REDUCTION);
     } else {
-        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_HW;
+        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
     }
 
     // reader output == input to tilize

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -140,8 +140,9 @@ FactoryParameters get_factory_parameters(
     uint32_t nbytes = datum_size(data_format);
 
     uint32_t kernel_size_hw = kernel_h * kernel_w;  // number of valid rows, to read
-    // for medium kernels we tilize an entire tile even if some rows are unused, so the in_cb has to be TILE_HEIGHT,
-    // but for kernels spanning 1 only face we set the face_r_dim to only tilize the necessary number of rows
+    // for medium kernels with sizes 16 < kernel_size_hw < 32 we tilize an entire tile even if some rows are unused,
+    // so the in_cb height must be equal to the TILE_HEIGHT, but for kernels spanning only one face we set the
+    // face_r_dim to only tilize the necessary number of rows, thus we can make the in_cb height smaller
     uint32_t num_tilized_rows = kernel_size_hw <= 16 ? kernel_size_hw : tt::constants::TILE_HEIGHT;
     uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / num_shards_c / tt::constants::TILE_WIDTH);
 

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -140,6 +140,9 @@ FactoryParameters get_factory_parameters(
     uint32_t nbytes = datum_size(data_format);
 
     uint32_t kernel_size_hw = kernel_h * kernel_w;  // number of valid rows, to read
+    // for medium kernels we tilize an entire tile even if some rows are unused, so the in_cb has to be TILE_HEIGHT,
+    // but for kernels spanning 1 only face we set the face_r_dim to only tilize the necessary number of rows
+    uint32_t num_tilized_rows = kernel_size_hw <= 16 ? kernel_size_hw : tt::constants::TILE_HEIGHT;
     uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / num_shards_c / tt::constants::TILE_WIDTH);
 
     bool is_avg_pool = pool_type == Pool2DType::AVG_POOL2D;
@@ -160,7 +163,8 @@ FactoryParameters get_factory_parameters(
         .max_rows_for_reduction = max_rows_for_reduction,
         .is_large_kernel = is_large_kernel,
         .MAX_TILES_PER_REDUCTION = MAX_TILES_PER_REDUCTION,
-        .is_wide_reduction = is_wide_reduction};
+        .is_wide_reduction = is_wide_reduction,
+        .num_tilized_rows = num_tilized_rows};
 }
 
 uint32_t calculate_L1_usage(
@@ -210,9 +214,9 @@ uint32_t calculate_L1_usage(
 
     uint32_t in_cb_sz = 0;
     if (params.is_wide_reduction) {
-        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_HW;
+        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * params.num_tilized_rows;
     } else {
-        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_HW;
+        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
     }
 
     uint32_t in_cb_page_padded = tt::round_up(in_cb_sz, tt::constants::TILE_HW);

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -50,6 +50,7 @@ struct FactoryParameters {
     bool is_large_kernel;
     uint32_t MAX_TILES_PER_REDUCTION;
     bool is_wide_reduction;
+    uint32_t num_tilized_rows;
 };
 
 uint32_t get_bf16_pool_scalar(


### PR DESCRIPTION
### Problem description
@skrsticTT noticed that since we now set `face_r_dim` to the kernel height for kernels with size <= 16 sticks, the In CB does not need to span a whole tile height for these cases.

### What's changed
The In CB height is now set based on the kernel height, and for 2x2, 3x3 and 4x4 kernels (or any shape with total size <= 16 sticks) it can be smaller than the tile height which saves significant memory.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688225959
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688227280
Failing on main, this PR hits unrelated error
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688235608
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688234016
Failing on main, this PR hits unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688232300
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688228529
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16688236596
Failing on main, this PR hits unrelated error
- [x] New/Existing tests provide coverage for changes
