### PR TITLE
Allow software format conversions when writing to the device

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -474,7 +474,7 @@ TEST_F(MeshBufferTestSuite, DistributedHostBufferReadWriteWithFloat32ToBfloat16C
     }
 }
 
-TEST_F(MeshBufferTestSuite, ShardingTestithFloat32ToBfloat16Conversion) {
+TEST_F(MeshBufferTestSuite, ShardingTestWithFloat32ToBfloat16Conversion) {
     std::array<uint32_t, 2> num_pages_per_core = {1, 1};
     std::array<uint32_t, 2> page_shape = {1, 1024};
     auto shard_strategy = TensorMemoryLayout::HEIGHT_SHARDED;

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -452,7 +452,8 @@ TEST_F(MeshBufferTestSuite, DistributedHostBufferReadWriteWithFloat32ToBfloat16C
                     });
                 }
             }
-            mesh_device_->mesh_command_queue().enqueue_write_with_conversion(buf, DataFormat::Float16_b, host_buffer, DataFormat::Float32, false);
+            mesh_device_->mesh_command_queue().enqueue_write_with_conversion(
+                buf, DataFormat::Float16_b, host_buffer, DataFormat::Float32, false);
             // Generate golden vector
             std::vector<bfloat16> golden_vec(num_random_tiles * single_tile_size / sizeof(uint16_t), 0);
             std::transform(src_vec.begin(), src_vec.end(), golden_vec.begin(), [](float f) { return bfloat16(f); });
@@ -633,7 +634,6 @@ TEST_F(MeshBufferTestSuite, RowMajorShardingAndReplicationWithFloat32ToBfloat16C
         EXPECT_EQ(dst_vec, golden_vec_uint16);
     }
 }
-
 
 TEST_F(MeshBufferTestSuite, ColMajorShardingAndReplication) {
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -364,6 +364,117 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
     }
 }
 
+TEST_F(MeshBufferTestSuite, InterleavedShardsReadWriteWithFloat32ToBfloat16Conversion) {
+    constexpr uint32_t NUM_ITERS = 100;
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", 0);
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+
+    for (auto buffer_type : {BufferType::L1, BufferType::DRAM}) {
+        DeviceLocalBufferConfig per_device_buffer_config{
+            .page_size = single_tile_size, .buffer_type = BufferType::L1, .bottom_up = false};
+
+        std::uniform_int_distribution<int> gen_num_tiles(1, 1024);
+        std::mt19937 rng(seed);
+        for (int i = 0; i < NUM_ITERS; i++) {
+            uint32_t num_random_tiles = gen_num_tiles(rng);
+            ReplicatedBufferConfig global_buffer_config = {
+                .size = num_random_tiles * single_tile_size,
+            };
+
+            std::shared_ptr<MeshBuffer> buf =
+                MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+            std::vector<float> src_vec(num_random_tiles * single_tile_size / sizeof(uint16_t), 0);
+            // Initialize src_vec with random values
+            std::generate(src_vec.begin(), src_vec.end(), [&rng]() { return static_cast<float>(rng() % 100); });
+
+            for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+                for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+                    WriteShardWithConversion(
+                        mesh_device_->mesh_command_queue(),
+                        buf,
+                        DataFormat::Float16_b,
+                        src_vec,
+                        DataFormat::Float32,
+                        MeshCoordinate(logical_y, logical_x));
+                }
+            }
+            // Generate golden vector
+            std::vector<bfloat16> golden_vec(num_random_tiles * single_tile_size / sizeof(uint16_t), 0);
+            std::transform(src_vec.begin(), src_vec.end(), golden_vec.begin(), [](float f) { return bfloat16(f); });
+            std::vector<uint16_t> golden_vec_uint16(num_random_tiles * single_tile_size / sizeof(uint16_t), 0);
+            std::transform(golden_vec.begin(), golden_vec.end(), golden_vec_uint16.begin(), [](bfloat16 bf16) {
+                return bf16.to_packed();
+            });
+
+            for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+                for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+                    std::vector<uint16_t> dst_vec = {};
+                    ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, MeshCoordinate(logical_y, logical_x));
+
+                    EXPECT_EQ(dst_vec, golden_vec_uint16);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(MeshBufferTestSuite, ShardingTestithFloat32ToBfloat16Conversion) {
+    std::array<uint32_t, 2> num_pages_per_core = {1, 1};
+    std::array<uint32_t, 2> page_shape = {1, 1024};
+    auto shard_strategy = TensorMemoryLayout::HEIGHT_SHARDED;
+
+    CoreCoord core_grid_size = mesh_device_->compute_with_storage_grid_size();
+
+    DeviceLocalShardedBufferTestConfig test_config{
+        .num_pages_per_core = num_pages_per_core,
+        .num_cores = {core_grid_size.x, core_grid_size.y},
+        .page_shape = page_shape,
+        .mem_config = shard_strategy};
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = test_config.page_size(),
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(test_config.shard_parameters(), test_config.mem_config),
+        .bottom_up = false};
+
+    uint32_t buf_size = test_config.num_pages() * test_config.page_size();
+    ReplicatedBufferConfig global_buffer_config{
+        .size = buf_size,
+    };
+
+    auto buf = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+    //   std::vector<uint32_t> src_vec(buf_size / sizeof(uint32_t), 0);
+    //  std::iota(src_vec.begin(), src_vec.end(), 0);
+    std::vector<float> src_vec(buf_size / sizeof(uint16_t), 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+            WriteShardWithConversion(
+                mesh_device_->mesh_command_queue(),
+                buf,
+                DataFormat::Float16_b,
+                src_vec,
+                DataFormat::Float32,
+                MeshCoordinate(logical_y, logical_x));
+        }
+    }
+    std::vector<bfloat16> golden_vec(buf_size / sizeof(uint16_t), 0);
+    std::transform(src_vec.begin(), src_vec.end(), golden_vec.begin(), [](float f) { return bfloat16(f); });
+    std::vector<uint16_t> golden_vec_uint16(buf_size / sizeof(uint16_t), 0);
+    std::transform(golden_vec.begin(), golden_vec.end(), golden_vec_uint16.begin(), [](bfloat16 bf16) {
+        return bf16.to_packed();
+    });
+
+    for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+            std::vector<uint16_t> dst_vec = {};
+            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, MeshCoordinate(logical_y, logical_x));
+            EXPECT_EQ(dst_vec, golden_vec_uint16);
+        }
+    }
+}
+
 TEST_F(MeshBufferTestSuite, RowMajorShardingAndReplication) {
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
 
@@ -412,6 +523,60 @@ TEST_F(MeshBufferTestSuite, RowMajorShardingAndReplication) {
         for (int i = 0; i < dst_vec.size(); i++) {
             EXPECT_EQ(dst_vec[i], i % (src_vec.size()));
         }
+    }
+}
+
+TEST_F(MeshBufferTestSuite, RowMajorShardingAndReplicationWithFloat32ToBfloat16Conversion) {
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+    std::vector<Shape2D> global_buffer_shapes = {{64, 256}, {128, 128}, {256, 2048}, {32, 512}, {512, 1024}};
+
+    for (int i = 0; i < global_buffer_shapes.size(); i++) {
+        auto global_buffer_shape = global_buffer_shapes[i];
+        Shape2D shard_shape = {0, global_buffer_shape.width() / mesh_device_->num_cols()};
+        // Mesh-Level Sharding Parameters for the MeshBufferView that will be read to verify correctness
+        Shape2D global_buffer_read_shape = {
+            global_buffer_shape.height() * mesh_device_->num_rows(), global_buffer_shape.width()};
+        Shape2D shard_read_shape = {
+            global_buffer_shape.height(), global_buffer_shape.width() / mesh_device_->num_cols()};
+
+        uint32_t global_buffer_size = global_buffer_shape.height() * global_buffer_shape.width() * sizeof(uint16_t);
+        auto shard_orientation = ShardOrientation::ROW_MAJOR;
+
+        ShardedBufferConfig sharded_config{
+            .global_size = global_buffer_size,
+            .global_buffer_shape = global_buffer_shape,
+            .shard_shape = shard_shape,
+            .shard_orientation = shard_orientation,
+        };
+        // Initialize the ShardedBufferConfig for reading and verifying replicated data
+        ShardedBufferConfig sharded_read_view_config{
+            .global_size = global_buffer_read_shape.height() * global_buffer_read_shape.width() * sizeof(uint16_t),
+            .global_buffer_shape = global_buffer_read_shape,
+            .shard_shape = shard_read_shape,
+            .shard_orientation = shard_orientation};
+
+        auto mesh_buffer = MeshBuffer::create(sharded_config, per_device_buffer_config, mesh_device_.get());
+        std::vector<float> src_vec = std::vector<float>(global_buffer_shape.height() * global_buffer_shape.width(), 0);
+        std::iota(src_vec.begin(), src_vec.end(), 0);
+
+        auto mesh_buffer_read_view = MeshBuffer::create(
+            sharded_read_view_config, per_device_buffer_config, mesh_device_.get(), mesh_buffer->address());
+        EnqueueWriteMeshBufferWithConversion(
+            mesh_device_->mesh_command_queue(), mesh_buffer, DataFormat::Float16_b, src_vec, DataFormat::Float32);
+        std::vector<bfloat16> golden_vec(src_vec.size(), 0);
+        std::transform(src_vec.begin(), src_vec.end(), golden_vec.begin(), [](float f) { return bfloat16(f); });
+        std::vector<uint16_t> golden_vec_uint16(src_vec.size(), 0);
+        std::transform(golden_vec.begin(), golden_vec.end(), golden_vec_uint16.begin(), [](bfloat16 bf16) {
+            return bf16.to_packed();
+        });
+        std::vector<uint16_t> dst_vec = std::vector<uint16_t>(src_vec.size(), 0);
+        EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer_read_view);
+
+        EXPECT_EQ(dst_vec, golden_vec_uint16);
     }
 }
 

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -58,6 +58,24 @@ void WriteShard(
 }
 
 template <typename DType>
+void WriteShardWithConversion(
+    MeshCommandQueue& mesh_cq,
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    tt::DataFormat data_format,
+    std::vector<DType>& src,
+    tt::DataFormat src_data_format,
+    const MeshCoordinate& coord,
+    bool blocking = false) {
+    std::vector<MeshCommandQueue::ShardDataTransfer> shard_data_transfers = {{
+        .shard_coord = coord,
+        .host_data = src.data(),
+        .region = std::nullopt,
+    }};
+    mesh_cq.enqueue_write_shards_with_conversion(
+        mesh_buffer, data_format, shard_data_transfers, src_data_format, blocking);
+}
+
+template <typename DType>
 void ReadShard(
     MeshCommandQueue& mesh_cq,
     std::vector<DType>& dst,
@@ -81,6 +99,17 @@ void EnqueueWriteMeshBuffer(
     const std::vector<DType>& src,
     bool blocking = false) {
     mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
+}
+
+template <typename DType>
+void EnqueueWriteMeshBufferWithConversion(
+    MeshCommandQueue& mesh_cq,
+    std::shared_ptr<MeshBuffer>& mesh_buffer,
+    tt::DataFormat data_format,
+    const std::vector<DType>& src,
+    tt::DataFormat src_data_format,
+    bool blocking = false) {
+    mesh_cq.enqueue_write_mesh_buffer_with_conversion(mesh_buffer, data_format, src.data(), src_data_format, blocking);
 }
 
 template <typename DType>

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -119,9 +119,13 @@ public:
      * @param data_format The target data format for the buffer
      * @param host_data Pointer to the source data on the host
      * @param src_data_format The source data format of the host data
-     * @param device_range If the buffer is replicated, the range of mesh coordinates defining the sub-grid to write to. If the buffer is sharded, this is ignored.
+     * @param device_range If the buffer is replicated, the range of mesh coordinates defining the sub-grid to write to.
+     * If the buffer is sharded, this is ignored.
      * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
      * @param region Optional buffer region to write to; if not provided, writes to the entire buffer area
+     *
+     * @note If the identity conversion is not used, the region specified must be a multiple of the buffer data format
+     * element size, and the corresponding source size must be a multiple of the source data format element size.
      */
     virtual void enqueue_write_shard_to_sub_grid_with_conversion(
         const MeshBuffer& buffer,
@@ -153,6 +157,9 @@ public:
      * @note All host data in the shard_data_transfers must be in the same source format
      * @note The data conversion is performed during the write operation for each shard
      *
+     * @note If the identity conversion is not used, each region specified in the shard_data_transfers must be a
+     * multiple of the buffer data format element size, and the corresponding source size must be a multiple of the
+     * source data format element size.
      * @see ShardDataTransfer for details on specifying per-shard data and regions
      */
     virtual void enqueue_write_shards_with_conversion(
@@ -178,7 +185,6 @@ public:
      * @param src_data_format The source data format of the host data
      * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
      *
-     * @note The host_data is broadcasted to all shards in the MeshBuffer
      * @note The data conversion is performed during the write operation
      */
     virtual void enqueue_write_mesh_buffer_with_conversion(

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -111,6 +111,10 @@ public:
      * This allows writing data in one format (e.g., Float32) to a buffer that stores
      * data in a different format (e.g., BFloat16).
      *
+     * Only a limited number of data formats are supported for conversion, including:
+     * - Float32 to Float16_b
+     * - Identity conversion (Float32 to Float32, Float16_b to Float16_b, etc.)
+     *
      * @param buffer The MeshBuffer to write data to
      * @param data_format The target data format for the buffer
      * @param host_data Pointer to the source data on the host
@@ -134,6 +138,10 @@ public:
      * Writes data to multiple specific shards of a MeshBuffer, performing data format
      * conversion from the source format to the target buffer format. Each shard can
      * receive different data, allowing for fine-grained control over distributed data placement.
+     *
+     * Only a limited number of data formats are supported for conversion, including:
+     * - Float32 to Float16_b
+     * - Identity conversion (Float32 to Float32, Float16_b to Float16_b, etc.)
      *
      * @param mesh_buffer Shared pointer to the MeshBuffer to write data to
      * @param data_format The target data format for the buffer
@@ -160,6 +168,10 @@ public:
      * Writes host data to all devices in a MeshBuffer, performing data format conversion from the source format to the
      * target buffer format. This operation writes the data using the sharding specification in the buffer.
      *
+     * Only a limited number of data formats are supported for conversion, including:
+     * - Float32 to Float16_b
+     * - Identity conversion (Float32 to Float32, Float16_b to Float16_b, etc.)
+     *
      * @param buffer Shared pointer to the MeshBuffer to write data to
      * @param data_format The target data format for the buffer
      * @param host_data Pointer to the source data on the host
@@ -183,6 +195,10 @@ public:
      * conversion from the source format to the target buffer format. The DistributedHostBuffer
      * provides per-shard data distribution, allowing different data to be written to each
      * shard in the mesh while maintaining format conversion capabilities.
+     *
+     * Only a limited number of data formats are supported for conversion, including:
+     * - Float32 to Float16_b
+     * - Identity conversion (Float32 to Float32, Float16_b to Float16_b, etc.)
      *
      * @param mesh_buffer Shared pointer to the MeshBuffer to write data to
      * @param data_format The target data format for the buffer

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -119,7 +119,7 @@ public:
      * @param data_format The target data format for the buffer
      * @param host_data Pointer to the source data on the host
      * @param src_data_format The source data format of the host data
-     * @param device_range The range of mesh coordinates defining the sub-grid to write to
+     * @param device_range If the buffer is replicated, the range of mesh coordinates defining the sub-grid to write to. If the buffer is sharded, this is ignored.
      * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
      * @param region Optional buffer region to write to; if not provided, writes to the entire buffer area
      */

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -103,6 +103,103 @@ public:
     virtual void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
 
+    /**
+     * @brief Enqueue a write operation to a sub-grid of devices with data format conversion
+     *
+     * Writes host data to a specific sub-grid range of devices within a MeshBuffer,
+     * performing data format conversion from the source format to the target buffer format.
+     * This allows writing data in one format (e.g., Float32) to a buffer that stores
+     * data in a different format (e.g., BFloat16).
+     *
+     * @param buffer The MeshBuffer to write data to
+     * @param data_format The target data format for the buffer
+     * @param host_data Pointer to the source data on the host
+     * @param src_data_format The source data format of the host data
+     * @param device_range The range of mesh coordinates defining the sub-grid to write to
+     * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
+     * @param region Optional buffer region to write to; if not provided, writes to the entire buffer area
+     */
+    virtual void enqueue_write_shard_to_sub_grid_with_conversion(
+        const MeshBuffer& buffer,
+        tt::DataFormat data_format,
+        const void* host_data,
+        tt::DataFormat src_data_format,
+        const MeshCoordinateRange& device_range,
+        bool blocking,
+        std::optional<BufferRegion> region = std::nullopt) = 0;
+
+    /**
+     * @brief Enqueue a write operation to multiple shards with data format conversion
+     *
+     * Writes data to multiple specific shards of a MeshBuffer, performing data format
+     * conversion from the source format to the target buffer format. Each shard can
+     * receive different data, allowing for fine-grained control over distributed data placement.
+     *
+     * @param mesh_buffer Shared pointer to the MeshBuffer to write data to
+     * @param data_format The target data format for the buffer
+     * @param shard_data_transfers Vector of ShardDataTransfer objects, each specifying
+     *                            a shard coordinate, host data pointer, and optional buffer region
+     * @param src_data_format The source data format of all host data
+     * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
+     *
+     * @note All host data in the shard_data_transfers must be in the same source format
+     * @note The data conversion is performed during the write operation for each shard
+     *
+     * @see ShardDataTransfer for details on specifying per-shard data and regions
+     */
+    virtual void enqueue_write_shards_with_conversion(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        tt::DataFormat data_format,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        tt::DataFormat src_data_format,
+        bool blocking) = 0;
+
+    /**
+     * @brief Enqueue a write operation to an entire MeshBuffer with data format conversion
+     *
+     * Writes host data to all devices in a MeshBuffer, performing data format conversion from the source format to the
+     * target buffer format. This operation writes the data using the sharding specification in the buffer.
+     *
+     * @param buffer Shared pointer to the MeshBuffer to write data to
+     * @param data_format The target data format for the buffer
+     * @param host_data Pointer to the source data on the host
+     * @param src_data_format The source data format of the host data
+     * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
+     *
+     * @note The host_data is broadcasted to all shards in the MeshBuffer
+     * @note The data conversion is performed during the write operation
+     */
+    virtual void enqueue_write_mesh_buffer_with_conversion(
+        const std::shared_ptr<MeshBuffer>& buffer,
+        tt::DataFormat data_format,
+        const void* host_data,
+        tt::DataFormat src_data_format,
+        bool blocking) = 0;
+
+    /**
+     * @brief Enqueue a write operation using a DistributedHostBuffer with data format conversion
+     *
+     * Writes data from a DistributedHostBuffer to a MeshBuffer, performing data format
+     * conversion from the source format to the target buffer format. The DistributedHostBuffer
+     * provides per-shard data distribution, allowing different data to be written to each
+     * shard in the mesh while maintaining format conversion capabilities.
+     *
+     * @param mesh_buffer Shared pointer to the MeshBuffer to write data to
+     * @param data_format The target data format for the buffer
+     * @param host_buffer Reference to the DistributedHostBuffer containing the source data
+     *                    with per-shard data distribution
+     * @param src_data_format The source data format of the data in the DistributedHostBuffer
+     * @param blocking If true, the operation blocks until completion; if false, it's asynchronous
+     *
+     * @see DistributedHostBuffer for details on distributed data management
+     */
+    virtual void enqueue_write_with_conversion(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        tt::DataFormat data_format,
+        const DistributedHostBuffer& host_buffer,
+        tt::DataFormat src_data_format,
+        bool blocking) = 0;
+
     // MeshBuffer Read APIs
     virtual void enqueue_read_mesh_buffer(
         void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) = 0;

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -463,7 +463,9 @@ void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids)
 void FDMeshCommandQueue::write_shard_to_device(
     const MeshBuffer& buffer,
     const MeshCoordinate& device_coord,
+    tt::DataFormat data_format,
     const void* src,
+    tt::DataFormat src_data_format,
     const std::optional<BufferRegion>& region,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
@@ -479,7 +481,14 @@ void FDMeshCommandQueue::write_shard_to_device(
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     buffer_dispatch::write_to_device_buffer(
-        src, *shard_view, id_, expected_num_workers_completed_, this->dispatch_core_type(), sub_device_ids);
+        src,
+        src_data_format,
+        *shard_view,
+        data_format,
+        id_,
+        expected_num_workers_completed_,
+        this->dispatch_core_type(),
+        sub_device_ids);
 }
 
 void FDMeshCommandQueue::read_shard_from_device(

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -172,7 +172,9 @@ protected:
     void write_shard_to_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
+        tt::DataFormat data_format,
         const void* src,
+        tt::DataFormat src_data_format,
         const std::optional<BufferRegion>& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void read_shard_from_device(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -313,6 +313,14 @@ void MeshCommandQueueBase::enqueue_write_shards_with_conversion(
     this->enqueue_write_shards_nolock(mesh_buffer, data_format, shard_data_transfers, src_data_format, blocking);
 }
 
+static BufferRegion buffer_region_from_host_buffer(const HostBuffer& host_buffer, tt::DataFormat data_format, tt::DataFormat src_data_format) {
+    size_t src_element_size = datum_size(src_data_format);
+    size_t dst_element_size = datum_size(data_format);
+    size_t src_size = host_buffer.view_bytes().size();
+    TT_FATAL(src_size % src_element_size == 0, "Source size {} must be a multiple of source element size {}", src_size, src_element_size);
+    return BufferRegion(0, src_size * dst_element_size / src_element_size);
+}
+
 void MeshCommandQueueBase::enqueue_write(
     const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
     auto lock = lock_api_function_();
@@ -347,7 +355,7 @@ void MeshCommandQueueBase::enqueue_write_with_conversion(
             shard_data_transfers.push_back(
                 {.shard_coord = host_buffer_coord,
                  .host_data = buf->view_bytes().data(),
-                 .region = BufferRegion(0, buf->view_bytes().size())});
+                 .region = buffer_region_from_host_buffer(*buf, data_format, src_data_format)});
         }
     }
 

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -21,7 +21,6 @@
 
 namespace tt::tt_metal::distributed {
 
-// TODO calculate data format size.
 void MeshCommandQueueBase::write_sharded_buffer(
     const MeshBuffer& buffer, tt::DataFormat data_format, const void* src, tt::DataFormat src_data_format) {
     auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -313,11 +313,16 @@ void MeshCommandQueueBase::enqueue_write_shards_with_conversion(
     this->enqueue_write_shards_nolock(mesh_buffer, data_format, shard_data_transfers, src_data_format, blocking);
 }
 
-static BufferRegion buffer_region_from_host_buffer(const HostBuffer& host_buffer, tt::DataFormat data_format, tt::DataFormat src_data_format) {
+static BufferRegion buffer_region_from_host_buffer(
+    const HostBuffer& host_buffer, tt::DataFormat data_format, tt::DataFormat src_data_format) {
     size_t src_element_size = datum_size(src_data_format);
     size_t dst_element_size = datum_size(data_format);
     size_t src_size = host_buffer.view_bytes().size();
-    TT_FATAL(src_size % src_element_size == 0, "Source size {} must be a multiple of source element size {}", src_size, src_element_size);
+    TT_FATAL(
+        src_size % src_element_size == 0,
+        "Source size {} must be a multiple of source element size {}",
+        src_size,
+        src_element_size);
     return BufferRegion(0, src_size * dst_element_size / src_element_size);
 }
 

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -21,11 +21,20 @@
 
 namespace tt::tt_metal::distributed {
 
-void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const void* src) {
+// TODO calculate data format size.
+void MeshCommandQueueBase::write_sharded_buffer(
+    const MeshBuffer& buffer, tt::DataFormat data_format, const void* src, tt::DataFormat src_data_format) {
     auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;
 
     auto shard_shape = buffer.physical_shard_shape();
-    auto datum_size_bytes = buffer.datum_size_bytes();
+    auto dst_datum_size_bytes = buffer.datum_size_bytes();
+    size_t datum_size_bytes = dst_datum_size_bytes;
+
+    if (data_format != src_data_format) {
+        size_t temp_datum_size = dst_datum_size_bytes * datum_size(src_data_format);
+        TT_FATAL(temp_datum_size % datum_size(data_format) == 0, "Data format conversion must use integer ratios.");
+        datum_size_bytes = temp_datum_size / datum_size(data_format);
+    }
 
     auto stride_size_bytes = datum_size_bytes * global_buffer_shape.width();
     auto single_read_size = datum_size_bytes * shard_shape.width();
@@ -62,7 +71,9 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
                         this->write_shard_to_device(
                             buffer,
                             MeshCoordinate(replicated_device_y, replicated_device_x),
+                            data_format,
                             shard_data.data(),
+                            src_data_format,
                             /*region=*/std::nullopt);
                     }
                 }
@@ -72,7 +83,9 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
                         this->write_shard_to_device(
                             buffer,
                             MeshCoordinate(replicated_device_y, device_x),
+                            data_format,
                             shard_data.data(),
+                            src_data_format,
                             /*region=*/std::nullopt);
                     }
                     device_x++;
@@ -81,14 +94,21 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
                         this->write_shard_to_device(
                             buffer,
                             MeshCoordinate(device_y, replicated_device_x),
+                            data_format,
                             shard_data.data(),
+                            src_data_format,
                             /*region=*/std::nullopt);
                     }
                     device_y++;
                 }
             } else {
                 this->write_shard_to_device(
-                    buffer, MeshCoordinate(device_y, device_x), shard_data.data(), /*region=*/std::nullopt);
+                    buffer,
+                    MeshCoordinate(device_y, device_x),
+                    data_format,
+                    shard_data.data(),
+                    src_data_format,
+                    /*region=*/std::nullopt);
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     if (++device_x == num_devices_x) {
                         device_x = 0;
@@ -173,7 +193,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
         // Currently not supported when doing TT-Mesh Native sharding, since we
         // rely on TTNN to perform sharding and call enqueue_write_shards
         auto dispatch_lambda = [this, &buffer, host_data, &region](const MeshCoordinate& coord) {
-            this->write_shard_to_device(buffer, coord, host_data, region);
+            this->write_shard_to_device(buffer, coord, tt::DataFormat::UInt8, host_data, tt::DataFormat::UInt8, region);
         };
         for (const auto& coord : device_range) {
             dispatch_thread_pool_->enqueue(
@@ -181,7 +201,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
         }
         dispatch_thread_pool_->wait();
     } else {
-        this->write_sharded_buffer(buffer, host_data);
+        this->write_sharded_buffer(buffer, tt::DataFormat::UInt8, host_data, tt::DataFormat::UInt8);
     }
 
     if (blocking) {
@@ -189,10 +209,48 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     }
 }
 
+void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid_with_conversion(
+    const MeshBuffer& buffer,
+    tt::DataFormat data_format,
+    const void* host_data,
+    tt::DataFormat src_data_format,
+    const MeshCoordinateRange& device_range,
+    bool blocking,
+    std::optional<BufferRegion> region) {
+    auto lock = lock_api_function_();
+    if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
+        // Multi-Threaded writes supported for Replicated buffers.
+        // Currently not supported when doing TT-Mesh Native sharding, since we
+        // rely on TTNN to perform sharding and call enqueue_write_shards
+        auto dispatch_lambda =
+            [this, &buffer, host_data, &region, data_format, src_data_format](const MeshCoordinate& coord) {
+                this->write_shard_to_device(buffer, coord, data_format, host_data, src_data_format, region);
+            };
+        for (const auto& coord : device_range) {
+            dispatch_thread_pool_->enqueue(
+                [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
+        }
+        dispatch_thread_pool_->wait();
+    } else {
+        this->write_sharded_buffer(buffer, data_format, host_data, src_data_format);
+    }
+}
+
 void MeshCommandQueueBase::enqueue_write_mesh_buffer(
     const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
     MeshCoordinateRange mesh_device_extent(buffer->device()->shape());
     this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
+}
+
+void MeshCommandQueueBase::enqueue_write_mesh_buffer_with_conversion(
+    const std::shared_ptr<MeshBuffer>& buffer,
+    tt::DataFormat data_format,
+    const void* host_data,
+    tt::DataFormat src_data_format,
+    bool blocking) {
+    MeshCoordinateRange mesh_device_extent(buffer->device()->shape());
+    this->enqueue_write_shard_to_sub_grid_with_conversion(
+        *buffer, data_format, host_data, src_data_format, mesh_device_extent, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_read_mesh_buffer(
@@ -207,14 +265,21 @@ void MeshCommandQueueBase::enqueue_read_mesh_buffer(
 
 void MeshCommandQueueBase::enqueue_write_shards_nolock(
     const std::shared_ptr<MeshBuffer>& buffer,
+    tt::DataFormat data_format,
     const std::vector<ShardDataTransfer>& shard_data_transfers,
+    tt::DataFormat src_data_format,
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    auto dispatch_lambda = [&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
+    auto dispatch_lambda = [&shard_data_transfers, &buffer, this, data_format, src_data_format](uint32_t shard_idx) {
         auto& shard_data_transfer = shard_data_transfers[shard_idx];
         this->write_shard_to_device(
-            *buffer, shard_data_transfer.shard_coord, shard_data_transfer.host_data, shard_data_transfer.region);
+            *buffer,
+            shard_data_transfer.shard_coord,
+            data_format,
+            shard_data_transfer.host_data,
+            src_data_format,
+            shard_data_transfer.region);
     };
 
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
@@ -234,7 +299,18 @@ void MeshCommandQueueBase::enqueue_write_shards(
     const std::vector<ShardDataTransfer>& shard_data_transfers,
     bool blocking) {
     auto lock = lock_api_function_();
-    this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking);
+    this->enqueue_write_shards_nolock(
+        mesh_buffer, tt::DataFormat::UInt8, shard_data_transfers, tt::DataFormat::UInt8, blocking);
+}
+
+void MeshCommandQueueBase::enqueue_write_shards_with_conversion(
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    tt::DataFormat data_format,
+    const std::vector<ShardDataTransfer>& shard_data_transfers,
+    tt::DataFormat src_data_format,
+    bool blocking) {
+    auto lock = lock_api_function_();
+    this->enqueue_write_shards_nolock(mesh_buffer, data_format, shard_data_transfers, src_data_format, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_write(
@@ -252,7 +328,30 @@ void MeshCommandQueueBase::enqueue_write(
         }
     }
 
-    this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking);
+    this->enqueue_write_shards_nolock(
+        mesh_buffer, tt::DataFormat::UInt8, shard_data_transfers, tt::DataFormat::UInt8, blocking);
+}
+
+void MeshCommandQueueBase::enqueue_write_with_conversion(
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    tt::DataFormat data_format,
+    const DistributedHostBuffer& host_buffer,
+    tt::DataFormat src_data_format,
+    bool blocking) {
+    auto lock = lock_api_function_();
+    // Iterate over global coordinates; skip host-remote coordinates, as per `host_buffer` configuration.
+    std::vector<ShardDataTransfer> shard_data_transfers;
+    for (const auto& host_buffer_coord : host_buffer.shard_coords()) {
+        auto buf = host_buffer.get_shard(host_buffer_coord);
+        if (buf.has_value()) {
+            shard_data_transfers.push_back(
+                {.shard_coord = host_buffer_coord,
+                 .host_data = buf->view_bytes().data(),
+                 .region = BufferRegion(0, buf->view_bytes().size())});
+        }
+    }
+
+    this->enqueue_write_shards_nolock(mesh_buffer, data_format, shard_data_transfers, src_data_format, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_read_shards_nolock(

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -23,7 +23,9 @@ protected:
     virtual void write_shard_to_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
+        tt::DataFormat data_format,
         const void* src,
+        tt::DataFormat src_data_format,
         const std::optional<BufferRegion>& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void read_shard_from_device(
@@ -39,7 +41,8 @@ protected:
 
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers
-    void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
+    void write_sharded_buffer(
+        const MeshBuffer& buffer, tt::DataFormat data_format, const void* src, tt::DataFormat src_data_format);
     void read_sharded_buffer(MeshBuffer& buffer, void* dst);
 
     // Must be called with lock_api_function_() held.
@@ -50,7 +53,9 @@ private:
     // Must be called with lock_api_function_() held.
     void enqueue_write_shards_nolock(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        tt::DataFormat data_format,
         const std::vector<ShardDataTransfer>& shard_data_transfers,
+        tt::DataFormat src_data_format,
         bool blocking);
 
 public:
@@ -78,6 +83,32 @@ public:
     void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
+        bool blocking) override;
+    void enqueue_write_shard_to_sub_grid_with_conversion(
+        const MeshBuffer& buffer,
+        tt::DataFormat data_format,
+        const void* host_data,
+        tt::DataFormat src_data_format,
+        const MeshCoordinateRange& device_range,
+        bool blocking,
+        std::optional<BufferRegion> region = std::nullopt) override;
+    void enqueue_write_shards_with_conversion(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        tt::DataFormat data_format,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        tt::DataFormat src_data_format,
+        bool blocking) override;
+    void enqueue_write_mesh_buffer_with_conversion(
+        const std::shared_ptr<MeshBuffer>& buffer,
+        tt::DataFormat data_format,
+        const void* host_data,
+        tt::DataFormat src_data_format,
+        bool blocking) override;
+    void enqueue_write_with_conversion(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        tt::DataFormat data_format,
+        const DistributedHostBuffer& host_buffer,
+        tt::DataFormat src_data_format,
         bool blocking) override;
 
     // MeshBuffer Read APIs

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -13,7 +13,9 @@ protected:
     void write_shard_to_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
+        tt::DataFormat data_format,
         const void* src,
+        tt::DataFormat src_data_format,
         const std::optional<BufferRegion>& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void read_shard_from_device(

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -436,6 +436,14 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
         const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
         const uint32_t num_full_pages = total_pages_to_write;
         total_pages_to_write = num_full_pages * partial_page_spec.num_partial_pages_per_full_page;
+        dispatch_params.emplace<InterleavedBufferWriteLargePageDispatchParams>(
+            buffer,
+            dst_page_index,
+            partial_page_spec,
+            total_pages_to_write,
+            num_full_pages,
+            cq_id,
+            expected_num_workers_completed);
     } else {
         dispatch_params.emplace<InterleavedBufferWriteDispatchParams>(
             buffer, dst_page_index, total_pages_to_write, cq_id, expected_num_workers_completed);

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -452,9 +452,10 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
     return dispatch_params;
 }
 
-void copy_with_conversion(
+// Copy with conversion between data formats.
+static void copy_with_conversion(
     const void* src,
-    size_t src_offset,
+    size_t src_offset,  // Offset in destination data format bytes.
     tt::DataFormat src_data_format,
     void* dst,
     tt::DataFormat data_format,

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -436,14 +436,6 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
         const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
         const uint32_t num_full_pages = total_pages_to_write;
         total_pages_to_write = num_full_pages * partial_page_spec.num_partial_pages_per_full_page;
-        dispatch_params.emplace<InterleavedBufferWriteLargePageDispatchParams>(
-            buffer,
-            dst_page_index,
-            partial_page_spec,
-            total_pages_to_write,
-            num_full_pages,
-            cq_id,
-            expected_num_workers_completed);
     } else {
         dispatch_params.emplace<InterleavedBufferWriteDispatchParams>(
             buffer, dst_page_index, total_pages_to_write, cq_id, expected_num_workers_completed);
@@ -452,11 +444,36 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
     return dispatch_params;
 }
 
+void copy_with_conversion(
+    const void* src,
+    size_t src_offset,
+    tt::DataFormat src_data_format,
+    void* dst,
+    tt::DataFormat data_format,
+    size_t dst_bytes) {
+    if (src_data_format == data_format) {
+        std::memcpy(dst, (const char*)src + src_offset, dst_bytes);
+    } else {
+        if (src_data_format == tt::DataFormat::Float32 && data_format == tt::DataFormat::Float16_b) {
+            TT_ASSERT(src_offset % 2 == 0, "src_offset must be even");
+            const float* src_float = (const float*)((const char*)src + src_offset * 2);
+            uint16_t* dst_uint16 = (uint16_t*)dst;
+            for (size_t i = 0; i < dst_bytes / 2; i++) {
+                dst_uint16[i] = bfloat16(src_float[i]).to_packed();
+            }
+        } else {
+            TT_FATAL(false, "Conversion from {} to {} is not supported", src_data_format, data_format);
+        }
+    }
+}
+
 // Populate/Assemble dispatch commands for writing buffer data
 void populate_interleaved_buffer_write_dispatch_cmds(
     const void* src,
+    tt::DataFormat src_data_format,
     HugepageDeviceCommand& command_sequence,
     Buffer& buffer,
+    tt::DataFormat data_format,
     InterleavedBufferWriteDispatchParams& dispatch_params) {
     const uint8_t is_dram = uint8_t(buffer.is_dram());
     TT_ASSERT(
@@ -486,8 +503,9 @@ void populate_interleaved_buffer_write_dispatch_cmds(
                 num_full_pages_written * buffer.page_size() +
                 num_partial_pages_written_per_curr_full_pages * dispatch_params.partial_page_size() +
                 num_partial_pages_written_curr_txn * buffer.page_size();
-            command_sequence.add_data(
-                (char*)src + src_address_offset, dispatch_params.data_size_to_copy, dispatch_params.page_size_to_write);
+            void* dst = command_sequence.reserve_space<void*, true>(dispatch_params.page_size_to_write);
+            copy_with_conversion(
+                src, src_address_offset, src_data_format, dst, data_format, dispatch_params.data_size_to_copy);
             num_partial_pages_written_curr_txn += 1;
         }
     } else {
@@ -496,25 +514,30 @@ void populate_interleaved_buffer_write_dispatch_cmds(
             // If page size is not aligned, we cannot do a contiguous write
             for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
                  sysmem_address_offset += dispatch_params.page_size_to_write) {
-                command_sequence.add_data(
-                    (char*)src + src_address_offset,
-                    dispatch_params.data_size_to_copy,
-                    dispatch_params.page_size_to_write);
+                void* dst = command_sequence.reserve_space<void*, true>(dispatch_params.page_size_to_write);
+                copy_with_conversion(
+                    src, src_address_offset, src_data_format, dst, data_format, dispatch_params.data_size_to_copy);
                 src_address_offset += dispatch_params.data_size_to_copy;
             }
         } else {
-            command_sequence.add_data(
-                (char*)src + src_address_offset,
-                dispatch_params.data_size_to_copy * dispatch_params.pages_per_txn,
-                data_size_bytes);
+            void* dst = command_sequence.reserve_space<void*, true>(data_size_bytes);
+            copy_with_conversion(
+                src,
+                src_address_offset,
+                src_data_format,
+                dst,
+                data_format,
+                dispatch_params.data_size_to_copy * dispatch_params.pages_per_txn);
         }
     }
 }
 
 void populate_sharded_buffer_write_dispatch_cmds(
     const void* src,
+    tt::DataFormat src_data_format,
     HugepageDeviceCommand& command_sequence,
     Buffer& buffer,
+    tt::DataFormat data_format,
     ShardedBufferWriteDispatchParams& dispatch_params) {
     const uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
     const CoreCoord virtual_core =
@@ -539,8 +562,8 @@ void populate_sharded_buffer_write_dispatch_cmds(
                 (*cur_host_page * buffer.page_size()) +
                 (dispatch_params.num_partial_pages_written_for_current_transaction_full_page() + i) *
                     dispatch_params.partial_page_size();
-            command_sequence.update_cmd_sequence(
-                dst_offset, (char*)(src) + src_offset, dispatch_params.data_size_to_copy);
+            void* dst = (char*)command_sequence.data() + dst_offset;
+            copy_with_conversion(src, src_offset, src_data_format, dst, data_format, dispatch_params.data_size_to_copy);
             dst_offset += dispatch_params.page_size_to_write;
         }
     } else if (buffer.page_size() == dispatch_params.page_size_to_write) {
@@ -551,9 +574,14 @@ void populate_sharded_buffer_write_dispatch_cmds(
             if (range.num_pages == 0) {
                 break;
             }
-            command_sequence.update_cmd_sequence(
-                dst_offset + (range.device_page_offset - start_device_page_offset) * dispatch_params.page_size_to_write,
-                (char*)(src) + range.host_page_start * dispatch_params.page_size_to_write,
+            void* dst = (char*)command_sequence.data() + dst_offset +
+                        (range.device_page_offset - start_device_page_offset) * dispatch_params.page_size_to_write;
+            copy_with_conversion(
+                src,
+                range.host_page_start * dispatch_params.page_size_to_write,
+                src_data_format,
+                dst,
+                data_format,
                 range.num_pages * dispatch_params.page_size_to_write);
         }
     } else {
@@ -565,7 +593,8 @@ void populate_sharded_buffer_write_dispatch_cmds(
                 continue;
             }
             const uint32_t src_offset = *cur_host_page * buffer.page_size();
-            command_sequence.update_cmd_sequence(dst_offset, (char*)(src) + src_offset, buffer.page_size());
+            void* dst = (char*)command_sequence.data() + dst_offset;
+            copy_with_conversion(src, src_offset, src_data_format, dst, data_format, buffer.page_size());
             dst_offset += dispatch_params.page_size_to_write;
         }
     }
@@ -575,7 +604,9 @@ void populate_sharded_buffer_write_dispatch_cmds(
 template <typename T>
 void issue_buffer_dispatch_command_sequence(
     const void* src,
+    tt::DataFormat src_data_format,
     Buffer& buffer,
+    tt::DataFormat data_format,
     T& dispatch_params,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     CoreType dispatch_core_type) {
@@ -606,9 +637,11 @@ void issue_buffer_dispatch_command_sequence(
         }
     }
     if constexpr (std::is_same_v<T, ShardedBufferWriteDispatchParams>) {
-        populate_sharded_buffer_write_dispatch_cmds(src, command_sequence, buffer, dispatch_params);
+        populate_sharded_buffer_write_dispatch_cmds(
+            src, src_data_format, command_sequence, buffer, data_format, dispatch_params);
     } else {
-        populate_interleaved_buffer_write_dispatch_cmds(src, command_sequence, buffer, dispatch_params);
+        populate_interleaved_buffer_write_dispatch_cmds(
+            src, src_data_format, command_sequence, buffer, data_format, dispatch_params);
     }
 
     sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, dispatch_params.cq_id);
@@ -619,8 +652,10 @@ void issue_buffer_dispatch_command_sequence(
 // Top level helper functions to write buffer data
 void write_interleaved_buffer_to_device(
     const void* src,
+    tt::DataFormat src_data_format,
     InterleavedBufferWriteDispatchParams& dispatch_params,
     Buffer& buffer,
+    tt::DataFormat data_format,
     const BufferDispatchConstants& buf_dispatch_constants,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     CoreType dispatch_core_type) {
@@ -648,16 +683,19 @@ void write_interleaved_buffer_to_device(
         log_debug(tt::LogDispatch, "EnqueueWriteBuffer for command queue {}", dispatch_params.cq_id);
 
         dispatch_params.calculate_num_pages_for_write_transaction(num_pages_available_in_cq);
-        issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
+        issue_buffer_dispatch_command_sequence(
+            src, src_data_format, buffer, data_format, dispatch_params, sub_device_ids, dispatch_core_type);
         dispatch_params.update_params_after_write_transaction();
     }
 }
 
 void write_sharded_buffer_to_core(
     const void* src,
+    tt::DataFormat src_data_format,
     uint32_t core_id,
     const BufferCorePageMapping& core_page_mapping,
     Buffer& buffer,
+    tt::DataFormat data_format,
     ShardedBufferWriteDispatchParams& dispatch_params,
     const BufferDispatchConstants& buf_dispatch_constants,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
@@ -693,7 +731,8 @@ void write_sharded_buffer_to_core(
         log_debug(tt::LogDispatch, "EnqueueWriteBuffer for command queue {}", dispatch_params.cq_id);
 
         dispatch_params.calculate_params_for_write_transaction(num_pages_available_in_cq);
-        issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
+        issue_buffer_dispatch_command_sequence(
+            src, src_data_format, buffer, data_format, dispatch_params, sub_device_ids, dispatch_core_type);
         dispatch_params.update_params_after_write_transaction();
     }
 }
@@ -701,7 +740,9 @@ void write_sharded_buffer_to_core(
 // Main API to write buffer data
 void write_to_device_buffer(
     const void* src,
+    tt::DataFormat src_data_format,
     Buffer& buffer,
+    tt::DataFormat data_format,
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,
@@ -728,9 +769,11 @@ void write_to_device_buffer(
                  dispatch_params.buffer_page_mapping->core_page_mappings[core_id]) {
                 write_sharded_buffer_to_core(
                     src,
+                    src_data_format,
                     core_id,
                     core_page_mapping,
                     buffer,
+                    data_format,
                     dispatch_params,
                     buf_dispatch_constants,
                     sub_device_ids,
@@ -755,7 +798,14 @@ void write_to_device_buffer(
         TT_ASSERT(dispatch_params != nullptr);
 
         write_interleaved_buffer_to_device(
-            src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);
+            src,
+            src_data_format,
+            *dispatch_params,
+            *root_buffer,
+            data_format,
+            buf_dispatch_constants,
+            sub_device_ids,
+            dispatch_core_type);
     }
 }
 
@@ -1150,9 +1200,21 @@ tt::stl::Span<const SubDeviceId> select_sub_device_ids(
 }
 
 template void issue_buffer_dispatch_command_sequence<InterleavedBufferWriteDispatchParams>(
-    const void*, Buffer&, InterleavedBufferWriteDispatchParams&, tt::stl::Span<const SubDeviceId>, CoreType);
+    const void*,
+    tt::DataFormat,
+    Buffer&,
+    tt::DataFormat,
+    InterleavedBufferWriteDispatchParams&,
+    tt::stl::Span<const SubDeviceId>,
+    CoreType);
 template void issue_buffer_dispatch_command_sequence<ShardedBufferWriteDispatchParams>(
-    const void*, Buffer&, ShardedBufferWriteDispatchParams&, tt::stl::Span<const SubDeviceId>, CoreType);
+    const void*,
+    tt::DataFormat,
+    Buffer&,
+    tt::DataFormat,
+    ShardedBufferWriteDispatchParams&,
+    tt::stl::Span<const SubDeviceId>,
+    CoreType);
 
 template void issue_read_buffer_dispatch_command_sequence<BufferReadDispatchParams>(
     Buffer&, BufferReadDispatchParams&, tt::stl::Span<const SubDeviceId>, CoreType);

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -17,6 +17,7 @@
 #include "core_coord.hpp"
 #include <tt_stl/span.hpp>
 #include "dispatch/system_memory_manager.hpp"
+#include "tt_backend_api_types.hpp"
 
 enum class CoreType;
 namespace tt {
@@ -105,7 +106,9 @@ struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
 
 void write_to_device_buffer(
     const void* src,
+    tt::DataFormat src_data_format,
     Buffer& buffer,
+    tt::DataFormat data_format,
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -326,7 +326,14 @@ void HWCommandQueue::enqueue_write_buffer(
 
     auto dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     buffer_dispatch::write_to_device_buffer(
-        data, *buffer_obj, this->id_, this->expected_num_workers_completed_, dispatch_core_type, sub_device_ids);
+        data,
+        tt::DataFormat::UInt8,
+        *buffer_obj,
+        tt::DataFormat::UInt8,
+        this->id_,
+        this->expected_num_workers_completed_,
+        dispatch_core_type,
+        sub_device_ids);
 
     if (blocking) {
         this->finish(sub_device_ids);


### PR DESCRIPTION
### Ticket
#25664

### Problem description
If the format of a tensor on the host is different from the format on the device, ttnn does a software conversion (using torch) before passing the data to metal to copy into the hugepage.

### What's changed
Add APIs to perform format conversions while writing data to the device. Currently only a float32 -> bfloat16 conversion is supported because that's the most popular, but other conversions will probably be added in the future.

In the future we may also perform format conversions in the dispatcher, which will allow us to continue to do this conversions when reading directly from pinned memory without doing a host-side copy.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes