### PR TITLE
[DM]: Re-enabling tests failing with too many runtime args

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -302,9 +302,6 @@ IDEAS:
 /* ======== PACKET SIZES ======== */
 
 TEST_F(DeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
     uint32_t test_case_id = 0;
 
     /* Parameters */
@@ -325,9 +322,6 @@ TEST_F(DeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
 
 /* ======== All from All ======== */
 TEST_F(DeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
     uint32_t test_case_id = 1;
 
     /* Parameters */

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -304,9 +304,6 @@ IDEAS:
 /* ======== PACKET SIZES ======== */
 
 TEST_F(DeviceFixture, TensixDataMovementAllToAllPacketSizes) {
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
     uint32_t test_case_id = 0;
 
     /* Parameters */
@@ -327,9 +324,6 @@ TEST_F(DeviceFixture, TensixDataMovementAllToAllPacketSizes) {
 
 /* ======== All to All ======== */
 TEST_F(DeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
-    }
     uint32_t test_case_id = 1;
 
     /* Parameters */


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24584)

### Problem description
BH post commit slow dispatch data movement tests were failing with too many runtime args on unharvested P150a. The following tests were therefore skipped:

- TensixDataMovementAllFromAllPacketSizes
- TensixDataMovementAllFromAllDirectedIdeal
- TensixDataMovementAllToAllPacketSizes
- TensixDataMovementAllToAllDirectedIdeal

### What's changed
Re-enable these tests as runtime arg cap was increased to 256 -> 341 which is >260 (the number of runtime args we use).

### Checklist
- [x] [Custom test dispatch](https://github.com/tenstorrent/tt-metal/actions/runs/16685510900)
- [x] [Blackhole Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/16751138885)
- [x] [metal - Run microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/16751136086)