### PR TITLE
[skip ci] Bump build timeout

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -155,7 +155,7 @@ jobs:
   build-artifact:
     name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
-    timeout-minutes: 45
+    timeout-minutes: 100
     runs-on: tt-beta-ubuntu-2204-large
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When significant changes are made to the codebase, the build hits so many cache misses that we hit this timeout.

### What's changed
Bump the timeout higher.