### PR TITLE
Change partial benchmark data to pkl instead of json to preserve nan/inf float values

### DIFF
--- a/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
+++ b/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
@@ -1,10 +1,10 @@
 from infra.data_collection.github.utils import (
-    get_github_partial_benchmark_json_filenames,
+    get_github_partial_benchmark_data_filenames,
     create_json_with_github_benchmark_environment,
 )
 
 if __name__ == "__main__":
-    github_partial_benchmark_json_filenames = get_github_partial_benchmark_json_filenames()
+    github_partial_benchmark_data_filenames = get_github_partial_benchmark_data_filenames()
 
-    for json_filename in github_partial_benchmark_json_filenames:
-        create_json_with_github_benchmark_environment(json_filename)
+    for benchmark_data_filename in github_partial_benchmark_data_filenames:
+        create_json_with_github_benchmark_environment(benchmark_data_filename)

--- a/.github/scripts/data_analysis/create_dummy_partial_benchmark_json.py
+++ b/.github/scripts/data_analysis/create_dummy_partial_benchmark_json.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import pickle
 
 from infra.data_collection.pydantic_models import BenchmarkMeasurement, PartialBenchmarkRun
 
@@ -23,13 +24,13 @@ if __name__ == "__main__":
         measurements=measurements,
     )
 
-    json_data = partial_benchmark_run.model_dump_json()
+    pkl_data = pickle.dumps(partial_benchmark_run)
 
     current_data_analysis_path = Path(__file__)
     benchmark_data_dir = current_data_analysis_path.parent.parent.parent.parent / "generated/benchmark_data"
     assert benchmark_data_dir.exists()
     assert benchmark_data_dir.is_dir()
 
-    output_path = os.path.join(benchmark_data_dir, f"partial_run_{run_start_ts}.json")
-    with open(output_path, "w") as f:
-        f.write(json_data)
+    output_path = os.path.join(benchmark_data_dir, f"partial_run_{run_start_ts}.pkl")
+    with open(output_path, "wb") as f:
+        f.write(pkl_data)

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -2,9 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-import csv
 import pathlib
+import pickle
 import os
 from datetime import datetime
 from typing import Optional, Union
@@ -340,7 +339,7 @@ def get_job_rows_from_github_info(workflow_outputs_dir, github_jobs_json, github
     return [x for x in job_rows if x is not None]
 
 
-def get_github_partial_benchmark_json_filenames():
+def get_github_partial_benchmark_data_filenames():
     logger.info("We are assuming generated/benchmark_data exists from previous passing test")
 
     current_utils_path = pathlib.Path(__file__)
@@ -348,15 +347,15 @@ def get_github_partial_benchmark_json_filenames():
     assert benchmark_data_dir.exists()
     assert benchmark_data_dir.is_dir()
 
-    benchmark_json_paths = list(benchmark_data_dir.glob("partial_run_*.json"))
+    benchmark_data_paths = list(benchmark_data_dir.glob("partial_run_*.pkl"))
     assert len(
-        benchmark_json_paths
-    ), f"There needs to be at least one benchmark data json since we're completing the environment data for each one"
+        benchmark_data_paths
+    ), f"There needs to be at least one benchmark data pkl since we're completing the environment data for each one"
 
     logger.info(
-        f"The following partial benchmark data JSONs should be completed with environment data: {benchmark_json_paths}"
+        f"The following partial benchmark data PKLs should be completed with environment data: {benchmark_data_paths}"
     )
-    return benchmark_json_paths
+    return benchmark_data_paths
 
 
 def get_github_runner_environment():
@@ -368,7 +367,7 @@ def get_github_runner_environment():
     }
 
 
-def create_json_with_github_benchmark_environment(github_partial_benchmark_json_filename):
+def create_json_with_github_benchmark_environment(github_partial_benchmark_data_filename):
     assert "GITHUB_REPOSITORY" in os.environ
     git_repo_name = os.environ["GITHUB_REPOSITORY"]
 
@@ -410,30 +409,36 @@ def create_json_with_github_benchmark_environment(github_partial_benchmark_json_
 
     device_info = {"card_type": device_type, "dram_size": device_memory_size}
 
-    with open(github_partial_benchmark_json_filename, "r") as f:
-        partial_benchmark_data = json.load(f)
+    with open(github_partial_benchmark_data_filename, "rb") as f:
+        partial_benchmark_data = pickle.load(f)
 
-    partial_benchmark_data["git_repo_name"] = git_repo_name
-    partial_benchmark_data["git_commit_hash"] = git_commit_hash
-    partial_benchmark_data["git_commit_ts"] = git_commit_ts
-    partial_benchmark_data["git_branch_name"] = git_branch_name
-    partial_benchmark_data["github_pipeline_id"] = github_pipeline_id
-    partial_benchmark_data["github_pipeline_link"] = github_pipeline_link
-    partial_benchmark_data["github_job_id"] = github_job_id
-    partial_benchmark_data["user_name"] = user_name
-    partial_benchmark_data["docker_image"] = docker_image
-    partial_benchmark_data["device_hostname"] = device_hostname
-    partial_benchmark_data["device_ip"] = device_ip
-    partial_benchmark_data["device_info"] = device_info
+    partial_benchmark_data = partial_benchmark_data.model_copy(
+        update={
+            "git_repo_name": git_repo_name,
+            "git_commit_hash": git_commit_hash,
+            "git_commit_ts": git_commit_ts,
+            "git_branch_name": git_branch_name,
+            "github_pipeline_id": github_pipeline_id,
+            "github_pipeline_link": github_pipeline_link,
+            "github_job_id": github_job_id,
+            "user_name": user_name,
+            "docker_image": docker_image,
+            "device_hostname": device_hostname,
+            "device_ip": device_ip,
+            "device_info": device_info,
+        }
+    )
 
-    complete_benchmark_run = CompleteBenchmarkRun(**partial_benchmark_data)
+    complete_benchmark_run = CompleteBenchmarkRun(**partial_benchmark_data.model_dump())
 
     json_data = complete_benchmark_run.model_dump_json()
 
     # Save complete run json
-    output_path = pathlib.Path(str(github_partial_benchmark_json_filename).replace("partial_run_", "complete_run_"))
+    output_path = pathlib.Path(
+        str(github_partial_benchmark_data_filename).replace("partial_run_", "complete_run_")
+    ).with_suffix(".json")
     with open(output_path, "w") as f:
         f.write(json_data)
 
-    # Delete partial run json
-    os.remove(github_partial_benchmark_json_filename)
+    # Delete partial run pkl
+    os.remove(github_partial_benchmark_data_filename)

--- a/models/perf/benchmarking_utils.py
+++ b/models/perf/benchmarking_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import pickle
 from datetime import datetime
 from typing import List
 
@@ -167,14 +168,14 @@ class BenchmarkData:
                 measurements=self.measure_data,
             )
 
-            json_data = partial_benchmark_run.model_dump_json()
+            pkl_data = pickle.dumps(partial_benchmark_run)
 
-            filename = os.path.join(self.output_folder, f"partial_run_{run_start_ts}.json")
+            filename = os.path.join(self.output_folder, f"partial_run_{run_start_ts}.pkl")
             parent_dir = os.path.dirname(filename)
             if parent_dir != "" and not os.path.exists(parent_dir):
                 os.makedirs(parent_dir)
-            with open(filename, "w") as f:
-                f.write(json_data)
+            with open(filename, "wb") as f:
+                f.write(pkl_data)
             logger.info(f"Run and measurement data saved to {filename}")
         else:
-            logger.info("Skipping saving benchmark data JSON since not running in CI environment")
+            logger.info("Skipping saving partial benchmark data PKL since not running in CI environment")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The pipeline for uploading model benchmark data to Superset could fail in the case where the partial benchmark data contained NaN/float vals due to saving the partial data as jsons (which does not preserve nan/inf floats) prior to re-loading them for completing environment data.

### What's changed
- Changed the format of the partial data to pickle files to preserve nan/inf floats. (the complete data is still uploaded to Superset as jsons)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes