### PR TITLE
[skip ci] Create concurrency groups for MQ jobs

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -21,6 +21,15 @@ on:
     branches:
       - main # Builds on main will populate the shared ccache to speed up builds on branches
 
+concurrency:
+  # Groups to control cancelling of obsolete runs.
+  # main (or any protected branch): run_id (read: never cancel other jobs)
+  # PRs: PR #
+  # Merge Queue: A value unique to each PR (merge_group.head_ref)
+  # All others: commit ID (read: never cancel other jobs)
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -27,7 +27,12 @@ concurrency:
   # PRs: PR #
   # Merge Queue: A value unique to each PR (merge_group.head_ref)
   # All others: commit ID (read: never cancel other jobs)
-  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_protected && github.run_id
+        || github.event.pull_request.number
+        || github.event.merge_group.head_ref
+        || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -40,7 +40,13 @@ concurrency:
   # PRs: PR #
   # Merge Queue: A value unique to each PR (merge_group.head_ref)
   # All others: commit ID (read: never cancel other jobs)
-  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}-${{ inputs.build-type || 'default' }}
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_protected && github.run_id
+        || github.event.pull_request.number
+        || github.event.merge_group.head_ref
+        || github.ref }}-
+    ${{ inputs.build-type || 'default' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -35,14 +35,12 @@ on:
       - main # Builds on main will populate the shared ccache to speed up builds on branches
 
 concurrency:
-  # Use github.run_id on main branch (or any protected branch)
-  # This ensure that no runs get cancelled on main
-  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
-  # and will cancel obsolete runs
-  # Use github.ref on other branches, so it's unique per branch
-  # Possibly PRs can also just use `github.ref`, but for now just copy/pasting from
-  # https://www.meziantou.net/how-to-cancel-github-workflows-when-pushing-new-commits-on-a-branch.htm
-  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}-${{ inputs.build-type || 'default' }}
+  # Groups to control cancelling of obsolete runs.
+  # main (or any protected branch): run_id (read: never cancel other jobs)
+  # PRs: PR #
+  # Merge Queue: A value unique to each PR (merge_group.head_ref)
+  # All others: commit ID (read: never cancel other jobs)
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}-${{ inputs.build-type || 'default' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We are very wasteful with very scarce resources.

### What's changed
I think I found the magic to cancel obsolete jobs in the Merge Queue.  Fingers crossed.  Won't know for sure until we FAFO it.