### PR TITLE
ci: fix llk post-commit workflow

### DIFF
--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -106,13 +106,14 @@ jobs:
             echo "🔍 Checking if branch needs updates from latest submodule main..."
             BRANCH_VS_MAIN_COMMITS=$(git rev-list --count HEAD..origin/main)
             if [ "$BRANCH_VS_MAIN_COMMITS" -gt 0 ]; then
-              echo "🔄 Branch is $BRANCH_VS_MAIN_COMMITS commits behind latest main - rebasing to include latest changes"
-              if ! git rebase origin/main; then
-                echo "❌ Rebase onto latest main failed - conflicts need manual resolution"
-                echo "💡 Please rebase your branch locally onto latest submodule main and resolve conflicts"
+              echo "🔄 Branch is $BRANCH_VS_MAIN_COMMITS commits behind latest main - merging latest changes"
+              if ! git merge origin/main --no-edit; then
+                echo "❌ Merge with latest main failed - conflicts need manual resolution"
+                echo "💡 This suggests genuine conflicts between your changes and recent main updates"
+                echo "💡 Please resolve conflicts locally and push updated branch"
                 exit 1
               fi
-              echo "✅ Successfully rebased branch onto latest submodule main"
+              echo "✅ Successfully merged latest submodule main into branch"
             else
               echo "✅ Branch is up to date with latest submodule main"
             fi

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -44,10 +44,17 @@ on:
         type: number
         default: 240
 
+concurrency:
+  group: llk-integration-${{ inputs.mirrored_branch }}
+  cancel-in-progress: true
+
 env:
   PARENT_BRANCH_NAME: test-llk-${{ inputs.mirrored_branch }}-${{ github.run_id }}
   SUBMODULE_PATH: tt_metal/third_party/tt_llk
   WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 240 }}
+  METAL_REPO: tenstorrent/tt-metal
+  LLK_REPO: tenstorrent/tt-llk
+  GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
   MAX_RETRIES: 3
   POLL_INTERVAL: 120
 
@@ -147,7 +154,7 @@ jobs:
           steps.check-branch.outputs.branch-exists == 'true' &&
           (inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true)
         env:
-          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          GH_TOKEN: ${{ env.GH_TOKEN }}
           WORKFLOW_TIMEOUT: ${{ env.WORKFLOW_TIMEOUT }}
           MAX_RETRIES: ${{ env.MAX_RETRIES }}
           POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
@@ -170,7 +177,7 @@ jobs:
             while [ $retries -lt $MAX_RETRIES ]; do
               while [ $elapsed -lt $timeout_seconds ]; do
                 # Use more efficient status check
-                local status=$(gh run view "$run_id" --json status,conclusion --jq '.status + ":" + (.conclusion // "unknown")' --repo "tenstorrent/tt-metal" 2>/dev/null || echo "unknown:unknown")
+                local status=$(gh run view "$run_id" --json status,conclusion --jq '.status + ":" + (.conclusion // "unknown")' --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "unknown:unknown")
                 local run_status=$(echo "$status" | cut -d: -f1)
                 local conclusion=$(echo "$status" | cut -d: -f2)
                 if [ "$run_status" = "completed" ]; then
@@ -196,7 +203,7 @@ jobs:
               retries=$((retries + 1))
               if [ $retries -lt $MAX_RETRIES ]; then
                 echo "🔄 Retrying $workflow_name (attempt $((retries + 1))/$MAX_RETRIES)"
-                if gh run rerun "$run_id" --failed --repo "tenstorrent/tt-metal"; then
+                if gh run rerun "$run_id" --failed --repo "${{ env.METAL_REPO }}"; then
                   echo "🔄 Retry triggered for $workflow_name"
                   sleep 30
                   elapsed=0  # Reset timer for retry
@@ -213,13 +220,13 @@ jobs:
           for workflow in "${!TEST_CONFIGS[@]}"; do
             if [ "${TEST_CONFIGS[$workflow]}" = "true" ]; then
               echo "Triggering $workflow..."
-              gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "tenstorrent/tt-metal"
+              gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
 
               # Poll for run ID
               run_id=""
               for i in {1..12}; do  # Try for 60 seconds max
                 sleep 5
-                run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' --repo "tenstorrent/tt-metal" 2>/dev/null || echo "")
+                run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
                 if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
                   echo "Found run ID: $run_id for $workflow"
                   break
@@ -257,17 +264,17 @@ jobs:
       - name: Cleanup test branches
         if: needs.setup-and-test.outputs.branch-exists == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          GH_TOKEN: ${{ env.GH_TOKEN }}
         run: |
           TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
           PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
 
           # Clean up test branch in submodule
 
-          gh api --method DELETE "repos/tenstorrent/tt-llk/git/refs/heads/$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
+          gh api --method DELETE "repos/${{ env.LLK_REPO }}/git/refs/heads/$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
 
           # Clean up parent branch
-          gh api --method DELETE "repos/tenstorrent/tt-metal/git/refs/heads/$PARENT_BRANCH_NAME" 2>/dev/null || echo "Parent branch already deleted or doesn't exist"
+          gh api --method DELETE "repos/${{ env.METAL_REPO }}/git/refs/heads/$PARENT_BRANCH_NAME" 2>/dev/null || echo "Parent branch already deleted or doesn't exist"
 
           echo "✅ Cleaned up test branches"
       - name: Generate test report

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -186,7 +186,7 @@ jobs:
                     echo "🎯 $workflow_name passed: $run_url"
                     return 0
                   else
-                    echo "💥 $workflow_name failed (attempt $((retries + 1))): $run_url"
+                    echo "🛑 $workflow_name failed (attempt $((retries + 1))): $run_url"
                     break
                   fi
                 fi
@@ -208,7 +208,7 @@ jobs:
                   sleep 30
                   elapsed=0  # Reset timer for retry
                 else
-                  echo "💥 Failed to trigger retry for $workflow_name"
+                  echo "🛑 Failed to trigger retry for $workflow_name"
                   break
                 fi
               fi
@@ -239,7 +239,7 @@ jobs:
                 monitor_workflow "$run_id" "$workflow" &
                 pids["$workflow"]=$!
               else
-                echo "💥 Failed to get run ID for $workflow after 60 seconds"
+                echo "🛑 Failed to get run ID for $workflow after 60 seconds"
                 exit 1
               fi
             fi
@@ -250,7 +250,7 @@ jobs:
             if wait "${pids[$workflow]}"; then
               echo "🎯 $workflow completed successfully"
             else
-              echo "💥 $workflow failed"
+              echo "🛑 $workflow failed"
               exit_code=1
             fi
           done
@@ -297,7 +297,7 @@ jobs:
             elif [ "${{ needs.setup-and-test.result }}" = "skipped" ]; then
               echo "ℹ️ **Test Execution:** No tests were selected to run" >> $GITHUB_STEP_SUMMARY
             else
-              echo "💥 **Test Execution:** Some tests failed" >> $GITHUB_STEP_SUMMARY
+              echo "🛑 **Test Execution:** Some tests failed" >> $GITHUB_STEP_SUMMARY
             fi
           else
             echo "❌ **Branch Setup:** Mirrored branch '${{ inputs.mirrored_branch }}' does not exist" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,45 +72,44 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 1000
+          fetch-depth: 1
           ref: main
           clean: true
       - name: Configure git
         run: |
           git config --global user.name "LLK Integration Tester [bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Check if mirrored branch exists in submodule
-        id: check-branch
+      - name: Check mirrored branch and create test branch
+        id: setup-branch
         run: |
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          cd ${{ env.SUBMODULE_PATH }}
+          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
+          SUBMODULE_PATH="${{ env.SUBMODULE_PATH }}"
+
+          cd "$SUBMODULE_PATH"
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
+
+          # Try to fetch branch and create test branch if exists
+          if git fetch origin "$MIRRORED_BRANCH:$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
+
+            git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+            git push origin "$TEST_BRANCH_NAME"
+
+            # Update parent repo to reference new test branch
+            cd "${{ github.workspace }}"
+            git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
+            git add "$SUBMODULE_PATH"
+            git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
+            git push origin "${{ env.PARENT_BRANCH_NAME }}"
+
+            echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
+            echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"
           fi
-      - name: Setup test branch and parent repository
-        id: setup-branch
-        if: steps.check-branch.outputs.branch-exists == 'true'
-        run: |
-          MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
-          # Setup test branch in submodule
-          cd ${{ env.SUBMODULE_PATH }}
-          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
-          git push origin "$TEST_BRANCH_NAME"
-          # Setup parent repository with submodule reference
-          cd ${{ github.workspace }}
-          git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
-          git add ${{ env.SUBMODULE_PATH }}
-          git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch ${{ inputs.mirrored_branch }}"
-          git push origin "${{ env.PARENT_BRANCH_NAME }}"
-          echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
       - name: Run selected tests
         if: |
           steps.check-branch.outputs.branch-exists == 'true' &&

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,7 +72,7 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 500
+          fetch-depth: 0
           ref: main
           clean: true
       - name: Configure git

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -102,7 +102,7 @@ jobs:
           cd ${{ env.SUBMODULE_PATH }}
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
           git fetch --all
-          git checkout -b "$TEST_BRANCH_NAME" "$MIRRORED_BRANCH"
+          git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
           git push origin "$TEST_BRANCH_NAME"
           # Setup parent repository with submodule reference
           cd ${{ github.workspace }}

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -101,6 +101,7 @@ jobs:
           # Setup test branch in submodule
           cd ${{ env.SUBMODULE_PATH }}
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
+          git fetch --all
           git checkout -b "$TEST_BRANCH_NAME" "$MIRRORED_BRANCH"
           git push origin "$TEST_BRANCH_NAME"
           # Setup parent repository with submodule reference

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -90,11 +90,11 @@ jobs:
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
 
           # Try to fetch branch and create test branch if exists
-          if git fetch origin "$MIRRORED_BRANCH:$MIRRORED_BRANCH" 2>/dev/null; then
+          if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
 
-            git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+            git checkout -b "$TEST_BRANCH_NAME" FETCH_HEAD
             git push origin "$TEST_BRANCH_NAME"
 
             # Update parent repo to reference new test branch

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -79,38 +79,47 @@ jobs:
         run: |
           git config --global user.name "LLK Integration Tester [bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Check if mirrored branch exists in submodule
+      - name: Setup test branch and parent repository
         id: check-branch
         run: |
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          cd ${{ env.SUBMODULE_PATH }}
+          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
+          SUBMODULE_PATH="${{ env.SUBMODULE_PATH }}"
+          cd "$SUBMODULE_PATH"
+
+          # Ensure correct remote
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
+
+          # Fetch mirrored branch
+          if git fetch origin "$MIRRORED_BRANCH"; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
+
+            # Get the commit currently pinned in the parent repo
+            cd "${{ github.workspace }}"
+            PARENT_PINNED_COMMIT=$(git ls-tree main "$SUBMODULE_PATH" | awk '{print $3}')
+            cd "$SUBMODULE_PATH"
+
+            # Checkout mirrored branch and rebase onto pinned commit
+            git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+            git rebase "$PARENT_PINNED_COMMIT"
+
+            # Push rebased branch to origin
+            git push origin "$TEST_BRANCH_NAME"
+
+            # Update parent repository to reference new submodule commit
+            cd "${{ github.workspace }}"
+            git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
+            git add "$SUBMODULE_PATH"
+            git commit -m "test: update LLK submodule to rebased test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
+            git push origin "${{ env.PARENT_BRANCH_NAME }}"
+
+            echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
+            echo "✅ Created test branch '$TEST_BRANCH_NAME' with rebased commits and updated parent repository"
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"
           fi
-      - name: Setup test branch and parent repository
-        id: setup-branch
-        if: steps.check-branch.outputs.branch-exists == 'true'
-        run: |
-          MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
-          # Setup test branch in submodule
-          cd ${{ env.SUBMODULE_PATH }}
-          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
-          git push origin "$TEST_BRANCH_NAME"
-          # Setup parent repository with submodule reference
-          cd ${{ github.workspace }}
-          git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
-          git add ${{ env.SUBMODULE_PATH }}
-          git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch ${{ inputs.mirrored_branch }}"
-          git push origin "${{ env.PARENT_BRANCH_NAME }}"
-          echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
       - name: Run selected tests
         if: |
           steps.check-branch.outputs.branch-exists == 'true' &&

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -101,7 +101,7 @@ jobs:
           # Setup test branch in submodule
           cd ${{ env.SUBMODULE_PATH }}
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+          git checkout -b "$TEST_BRANCH_NAME" "$MIRRORED_BRANCH"
           git push origin "$TEST_BRANCH_NAME"
           # Setup parent repository with submodule reference
           cd ${{ github.workspace }}

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,44 +72,45 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 1
+          fetch-depth: 0
           ref: main
           clean: true
       - name: Configure git
         run: |
           git config --global user.name "LLK Integration Tester [bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Check mirrored branch and create test branch
-        id: setup-branch
+      - name: Check if mirrored branch exists in submodule
+        id: check-branch
         run: |
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
-          SUBMODULE_PATH="${{ env.SUBMODULE_PATH }}"
-
-          cd "$SUBMODULE_PATH"
+          cd ${{ env.SUBMODULE_PATH }}
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-
-          # Try to fetch branch and create test branch if exists
           if git fetch origin "$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
-
-            git checkout -b "$TEST_BRANCH_NAME" FETCH_HEAD
-            git push origin "$TEST_BRANCH_NAME"
-
-            # Update parent repo to reference new test branch
-            cd "${{ github.workspace }}"
-            git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
-            git add "$SUBMODULE_PATH"
-            git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
-            git push origin "${{ env.PARENT_BRANCH_NAME }}"
-
-            echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
-            echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"
           fi
+      - name: Setup test branch and parent repository
+        id: setup-branch
+        if: steps.check-branch.outputs.branch-exists == 'true'
+        run: |
+          MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
+          TEST_BRANCH_NAME="test-llk-$MIRRORED_BRANCH-$(date +%s)"
+          # Setup test branch in submodule
+          cd ${{ env.SUBMODULE_PATH }}
+          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
+          git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+          git push origin "$TEST_BRANCH_NAME"
+          # Setup parent repository with submodule reference
+          cd ${{ github.workspace }}
+          git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
+          git add ${{ env.SUBMODULE_PATH }}
+          git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch ${{ inputs.mirrored_branch }}"
+          git push origin "${{ env.PARENT_BRANCH_NAME }}"
+          echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
       - name: Run selected tests
         if: |
           steps.check-branch.outputs.branch-exists == 'true' &&

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -49,7 +49,7 @@ env:
   SUBMODULE_PATH: tt_metal/third_party/tt_llk
   WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 240 }}
   MAX_RETRIES: 3
-  POLL_INTERVAL: 120
+  POLL_INTERVAL: 60
 
 permissions:
   contents: write
@@ -87,11 +87,9 @@ jobs:
           SUBMODULE_PATH="${{ env.SUBMODULE_PATH }}"
           cd "$SUBMODULE_PATH"
 
-          # Ensure correct remote
+          # Ensure correct remote and fetch mirrored branch in one operation
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-
-          # Fetch mirrored branch
-          if git fetch origin "$MIRRORED_BRANCH"; then
+          if git fetch origin "$MIRRORED_BRANCH:$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
 
@@ -101,25 +99,34 @@ jobs:
             cd "$SUBMODULE_PATH"
 
             # Checkout mirrored branch
-            git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
+            git checkout -b "$TEST_BRANCH_NAME" "$MIRRORED_BRANCH"
 
             # Check if rebase is needed
-            if git merge-base --is-ancestor "$PARENT_PINNED_COMMIT" "$TEST_BRANCH_NAME"; then
+            if git merge-base --is-ancestor "$PARENT_PINNED_COMMIT" HEAD; then
               echo "✅ Branch is already based on or ahead of pinned commit - no rebase needed"
             else
               echo "🔄 Rebasing branch onto pinned commit for compatibility"
-              git rebase "$PARENT_PINNED_COMMIT"
+              if ! git rebase "$PARENT_PINNED_COMMIT"; then
+                echo "❌ Rebase failed - there may be conflicts that need manual resolution"
+                exit 1
+              fi
             fi
 
             # Push test branch to origin
-            git push origin "$TEST_BRANCH_NAME"
+            if ! git push origin "$TEST_BRANCH_NAME"; then
+              echo "❌ Failed to push test branch to origin"
+              exit 1
+            fi
 
             # Update parent repository to reference new submodule commit
             cd "${{ github.workspace }}"
             git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
             git add "$SUBMODULE_PATH"
             git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
-            git push origin "${{ env.PARENT_BRANCH_NAME }}"
+            if ! git push origin "${{ env.PARENT_BRANCH_NAME }}"; then
+              echo "❌ Failed to push parent branch to origin"
+              exit 1
+            fi
 
             echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
             echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
@@ -199,16 +206,25 @@ jobs:
             if [ "${TEST_CONFIGS[$workflow]}" = "true" ]; then
               echo "Triggering $workflow..."
               gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "tenstorrent/tt-metal"
-              # Wait and get run ID
-              sleep 10
-              run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' --repo "tenstorrent/tt-metal" 2>/dev/null || echo "")
+
+              # Poll for run ID more efficiently
+              run_id=""
+              for i in {1..12}; do  # Try for 60 seconds max
+                sleep 5
+                run_id=$(gh run list --workflow "$workflow" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' --repo "tenstorrent/tt-metal" 2>/dev/null || echo "")
+                if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+                  echo "Found run ID: $run_id for $workflow"
+                  break
+                fi
+              done
+
               if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
                 run_ids["$workflow"]="$run_id"
                 # Start monitoring in background
                 monitor_workflow "$run_id" "$workflow" &
                 pids["$workflow"]=$!
               else
-                echo "❌ Failed to get run ID for $workflow"
+                echo "❌ Failed to get run ID for $workflow after 60 seconds"
                 exit 1
               fi
             fi
@@ -224,38 +240,26 @@ jobs:
             fi
           done
           exit $exit_code
-  cleanup:
+  cleanup-and-report:
     needs: setup-and-test
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/tt-metal
-          submodules: recursive
-          token: ${{ secrets.TEMP_METAL_PAT }}
       - name: Cleanup test branches
         if: needs.setup-and-test.outputs.branch-exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
-          SUBMODULE_PATH: ${{ env.SUBMODULE_PATH }}
         run: |
           TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
           PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
-          # Clean up test branch in submodule
-          cd $SUBMODULE_PATH
-          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          git push origin --delete "$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
+
+          # Clean up test branch in submodule (direct API call, no checkout needed)
+          gh api --method DELETE "repos/tenstorrent/tt-llk/git/refs/heads/$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
+
           # Clean up parent branch
-          cd ${{ github.workspace }}
-          git push origin --delete "$PARENT_BRANCH_NAME" 2>/dev/null || echo "Parent branch already deleted or doesn't exist"
+          gh api --method DELETE "repos/tenstorrent/tt-metal/git/refs/heads/$PARENT_BRANCH_NAME" 2>/dev/null || echo "Parent branch already deleted or doesn't exist"
+
           echo "✅ Cleaned up test branches"
-  report-results:
-    needs: [setup-and-test, cleanup]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
       - name: Generate test report
         run: |
           echo "## Test Results Summary" >> $GITHUB_STEP_SUMMARY
@@ -285,4 +289,3 @@ jobs:
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Workflow Status:** ${{ needs.setup-and-test.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Duration:** ${{ github.event.workflow_run.duration || 'N/A' }} seconds" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,7 +72,7 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 500
+          fetch-depth: 1000
           ref: main
           clean: true
       - name: Configure git

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -174,10 +174,10 @@ jobs:
                 if [ "$run_status" = "completed" ]; then
                   local run_url="https://github.com/tenstorrent/tt-metal/actions/runs/$run_id"
                   if [ "$conclusion" = "success" ]; then
-                    echo "✅ $workflow_name passed: $run_url"
+                    echo "🎯 $workflow_name passed: $run_url"
                     return 0
                   else
-                    echo "❌ $workflow_name failed (attempt $((retries + 1))): $run_url"
+                    echo "💥 $workflow_name failed (attempt $((retries + 1))): $run_url"
                     break
                   fi
                 fi
@@ -195,11 +195,11 @@ jobs:
               if [ $retries -lt $MAX_RETRIES ]; then
                 echo "🔄 Retrying $workflow_name (attempt $((retries + 1))/$MAX_RETRIES)"
                 if gh run rerun "$run_id" --failed --repo "tenstorrent/tt-metal"; then
-                  echo "✅ Retry triggered for $workflow_name"
+                  echo "🔄 Retry triggered for $workflow_name"
                   sleep 30
                   elapsed=0  # Reset timer for retry
                 else
-                  echo "❌ Failed to trigger retry for $workflow_name"
+                  echo "💥 Failed to trigger retry for $workflow_name"
                   break
                 fi
               fi
@@ -230,7 +230,7 @@ jobs:
                 monitor_workflow "$run_id" "$workflow" &
                 pids["$workflow"]=$!
               else
-                echo "❌ Failed to get run ID for $workflow after 60 seconds"
+                echo "💥 Failed to get run ID for $workflow after 60 seconds"
                 exit 1
               fi
             fi
@@ -239,9 +239,9 @@ jobs:
           exit_code=0
           for workflow in "${!pids[@]}"; do
             if wait "${pids[$workflow]}"; then
-              echo "✅ $workflow completed successfully"
+              echo "🎯 $workflow completed successfully"
             else
-              echo "❌ $workflow failed"
+              echo "💥 $workflow failed"
               exit_code=1
             fi
           done
@@ -279,15 +279,15 @@ jobs:
             echo "**Test Branch:** ${{ needs.setup-and-test.outputs.test-branch-name }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Test Configuration:**" >> $GITHUB_STEP_SUMMARY
-            echo "- All Post-Commit Tests (Wormhole): ${{ inputs.run_all_post_commit && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
-            echo "- Blackhole Post-Commit Tests: ${{ inputs.run_blackhole_post_commit && '✅ Enabled' || '❌ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- All Post-Commit Tests (Wormhole): ${{ inputs.run_all_post_commit && '🟢 Enabled' || '⚪ Disabled' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- Blackhole Post-Commit Tests: ${{ inputs.run_blackhole_post_commit && '🟢 Enabled' || '⚪ Disabled' }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             if [ "${{ needs.setup-and-test.result }}" = "success" ]; then
-              echo "✅ **Test Execution:** All selected tests completed successfully" >> $GITHUB_STEP_SUMMARY
+              echo "🎯 **Test Execution:** All selected tests completed successfully" >> $GITHUB_STEP_SUMMARY
             elif [ "${{ needs.setup-and-test.result }}" = "skipped" ]; then
               echo "ℹ️ **Test Execution:** No tests were selected to run" >> $GITHUB_STEP_SUMMARY
             else
-              echo "❌ **Test Execution:** Some tests failed" >> $GITHUB_STEP_SUMMARY
+              echo "💥 **Test Execution:** Some tests failed" >> $GITHUB_STEP_SUMMARY
             fi
           else
             echo "❌ **Branch Setup:** Mirrored branch '${{ inputs.mirrored_branch }}' does not exist" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch-exists: ${{ steps.check-branch.outputs.branch-exists }}
-      test-branch-name: ${{ steps.setup-branch.outputs.test-branch-name }}
+      test-branch-name: ${{ steps.check-branch.outputs.test-branch-name }}
       parent-branch-name: ${{ env.PARENT_BRANCH_NAME }}
     steps:
       - name: Setup
@@ -100,22 +100,40 @@ jobs:
             PARENT_PINNED_COMMIT=$(git ls-tree main "$SUBMODULE_PATH" | awk '{print $3}')
             cd "$SUBMODULE_PATH"
 
-            # Checkout mirrored branch and rebase onto pinned commit
-            git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
-            git rebase "$PARENT_PINNED_COMMIT"
+            # Create clean test branch with only user commits
+            git checkout -b "$TEST_BRANCH_NAME" "$PARENT_PINNED_COMMIT"
 
-            # Push rebased branch to origin
+            # Get the author of the latest commit in the mirrored branch to filter by
+            BRANCH_AUTHOR=$(git log -1 --format="%ae" "origin/$MIRRORED_BRANCH")
+            echo "Filtering commits by author: $BRANCH_AUTHOR"
+
+            # Get commits in the mirrored branch that are not in pinned commit, filtered by author
+            COMMITS_TO_CHERRY_PICK=$(git log --reverse "$PARENT_PINNED_COMMIT..origin/$MIRRORED_BRANCH" --author="$BRANCH_AUTHOR" --format="%H")
+
+            if [ -n "$COMMITS_TO_CHERRY_PICK" ]; then
+              echo "Cherry-picking commits from $BRANCH_AUTHOR to isolate changes"
+              echo "$COMMITS_TO_CHERRY_PICK" | while read commit; do
+                if ! git cherry-pick "$commit"; then
+                  echo "❌ Failed to cherry-pick $commit"
+                  exit 1
+                fi
+              done
+            else
+              echo "No commits from $BRANCH_AUTHOR to cherry-pick - test branch remains at pinned commit"
+            fi
+
+            # Push cherry-picked branch to origin
             git push origin "$TEST_BRANCH_NAME"
 
             # Update parent repository to reference new submodule commit
             cd "${{ github.workspace }}"
             git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
             git add "$SUBMODULE_PATH"
-            git commit -m "test: update LLK submodule to rebased test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
+            git commit -m "test: update LLK submodule to isolated test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
             git push origin "${{ env.PARENT_BRANCH_NAME }}"
 
             echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
-            echo "✅ Created test branch '$TEST_BRANCH_NAME' with rebased commits and updated parent repository"
+            echo "✅ Created test branch '$TEST_BRANCH_NAME' with isolated commits and updated parent repository"
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,7 +72,7 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 0
+          fetch-depth: 500
           ref: main
           clean: true
       - name: Configure git
@@ -101,7 +101,6 @@ jobs:
           # Setup test branch in submodule
           cd ${{ env.SUBMODULE_PATH }}
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
-          git fetch --all
           git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
           git push origin "$TEST_BRANCH_NAME"
           # Setup parent repository with submodule reference

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -101,16 +101,22 @@ jobs:
             # Checkout mirrored branch
             git checkout -b "$TEST_BRANCH_NAME" "$MIRRORED_BRANCH"
 
-            # Check if rebase is needed
-            if git merge-base --is-ancestor "$PARENT_PINNED_COMMIT" HEAD; then
-              echo "✅ Branch is already based on or ahead of pinned commit - no rebase needed"
-            else
-              echo "🔄 Rebasing branch onto pinned commit for compatibility"
-              if ! git rebase "$PARENT_PINNED_COMMIT"; then
-                echo "❌ Rebase failed - there may be conflicts that need manual resolution"
+            # Ensure branch is up to date with latest submodule's main
+            echo "🔍 Checking if branch needs updates from latest submodule main..."
+            BRANCH_VS_MAIN_COMMITS=$(git rev-list --count HEAD..origin/main)
+            if [ "$BRANCH_VS_MAIN_COMMITS" -gt 0 ]; then
+              echo "🔄 Branch is $BRANCH_VS_MAIN_COMMITS commits behind latest main - rebasing to include latest changes"
+              if ! git rebase origin/main; then
+                echo "❌ Rebase onto latest main failed - conflicts need manual resolution"
+                echo "💡 Please rebase your branch locally onto latest submodule main and resolve conflicts"
                 exit 1
               fi
+              echo "✅ Successfully rebased branch onto latest submodule main"
+            else
+              echo "✅ Branch is up to date with latest submodule main"
             fi
+
+            echo "✅ Branch updated with latest submodule changes - ready for testing"
 
             # Push test branch to origin
             if ! git push origin "$TEST_BRANCH_NAME"; then
@@ -253,8 +259,8 @@ jobs:
           TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
           PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
 
-          # Clean up test branch in submodule 
-          
+          # Clean up test branch in submodule
+
           gh api --method DELETE "repos/tenstorrent/tt-llk/git/refs/heads/$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
 
           # Clean up parent branch

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -207,7 +207,7 @@ jobs:
               echo "Triggering $workflow..."
               gh workflow run "$workflow" --ref "$PARENT_BRANCH_NAME" --repo "tenstorrent/tt-metal"
 
-              # Poll for run ID more efficiently
+              # Poll for run ID
               run_id=""
               for i in {1..12}; do  # Try for 60 seconds max
                 sleep 5

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -87,7 +87,7 @@ jobs:
           SUBMODULE_PATH="${{ env.SUBMODULE_PATH }}"
           cd "$SUBMODULE_PATH"
 
-          # Ensure correct remote and fetch mirrored branch in one operation
+          # Ensure correct remote and fetch mirrored branch
           git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
           if git fetch origin "$MIRRORED_BRANCH:$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
@@ -253,7 +253,8 @@ jobs:
           TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
           PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
 
-          # Clean up test branch in submodule (direct API call, no checkout needed)
+          # Clean up test branch in submodule 
+          
           gh api --method DELETE "repos/tenstorrent/tt-llk/git/refs/heads/$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
 
           # Clean up parent branch

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -100,40 +100,29 @@ jobs:
             PARENT_PINNED_COMMIT=$(git ls-tree main "$SUBMODULE_PATH" | awk '{print $3}')
             cd "$SUBMODULE_PATH"
 
-            # Create clean test branch with only user commits
-            git checkout -b "$TEST_BRANCH_NAME" "$PARENT_PINNED_COMMIT"
+            # Checkout mirrored branch
+            git checkout -b "$TEST_BRANCH_NAME" "origin/$MIRRORED_BRANCH"
 
-            # Get the author of the latest commit in the mirrored branch to filter by
-            BRANCH_AUTHOR=$(git log -1 --format="%ae" "origin/$MIRRORED_BRANCH")
-            echo "Filtering commits by author: $BRANCH_AUTHOR"
-
-            # Get commits in the mirrored branch that are not in pinned commit, filtered by author
-            COMMITS_TO_CHERRY_PICK=$(git log --reverse "$PARENT_PINNED_COMMIT..origin/$MIRRORED_BRANCH" --author="$BRANCH_AUTHOR" --format="%H")
-
-            if [ -n "$COMMITS_TO_CHERRY_PICK" ]; then
-              echo "Cherry-picking commits from $BRANCH_AUTHOR to isolate changes"
-              echo "$COMMITS_TO_CHERRY_PICK" | while read commit; do
-                if ! git cherry-pick "$commit"; then
-                  echo "❌ Failed to cherry-pick $commit"
-                  exit 1
-                fi
-              done
+            # Check if rebase is needed
+            if git merge-base --is-ancestor "$PARENT_PINNED_COMMIT" "$TEST_BRANCH_NAME"; then
+              echo "✅ Branch is already based on or ahead of pinned commit - no rebase needed"
             else
-              echo "No commits from $BRANCH_AUTHOR to cherry-pick - test branch remains at pinned commit"
+              echo "🔄 Rebasing branch onto pinned commit for compatibility"
+              git rebase "$PARENT_PINNED_COMMIT"
             fi
 
-            # Push cherry-picked branch to origin
+            # Push test branch to origin
             git push origin "$TEST_BRANCH_NAME"
 
             # Update parent repository to reference new submodule commit
             cd "${{ github.workspace }}"
             git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
             git add "$SUBMODULE_PATH"
-            git commit -m "test: update LLK submodule to isolated test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
+            git commit -m "test: update LLK submodule to test branch $TEST_BRANCH_NAME from mirrored branch $MIRRORED_BRANCH"
             git push origin "${{ env.PARENT_BRANCH_NAME }}"
 
             echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
-            echo "✅ Created test branch '$TEST_BRANCH_NAME' with isolated commits and updated parent repository"
+            echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -49,7 +49,7 @@ env:
   SUBMODULE_PATH: tt_metal/third_party/tt_llk
   WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 240 }}
   MAX_RETRIES: 3
-  POLL_INTERVAL: 60
+  POLL_INTERVAL: 120
 
 permissions:
   contents: write

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -61,6 +61,7 @@ permissions:
 jobs:
   setup-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 300
     outputs:
       branch-exists: ${{ steps.check-branch.outputs.branch-exists }}
       test-branch-name: ${{ steps.check-branch.outputs.test-branch-name }}
@@ -250,6 +251,7 @@ jobs:
     needs: setup-and-test
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Cleanup test branches
         if: needs.setup-and-test.outputs.branch-exists == 'true'

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -72,7 +72,7 @@ jobs:
           repository: tenstorrent/tt-metal
           submodules: recursive
           token: ${{ secrets.TEMP_METAL_PAT }}
-          fetch-depth: 200
+          fetch-depth: 500
           ref: main
           clean: true
       - name: Configure git


### PR DESCRIPTION
### Ticket
None

### Problem description
In my previous PR I showed examples of successful runs, but after optimizing checkout (changed fetch-depth from 0 do 200) and merging the PR, code stopped working.
This is why in this follow up I am reverting to fetch-depth 0. I tried setting different depths (up to 3000), but it would always fail on checking out llk branch I want to test in TT-metal.
The solution I found on the web was to use depth 0. More about it [here](https://github.com/orgs/community/discussions/26818#discussioncomment-3253521).

Second big issue:
There was a potential submodule integration gap where feature branches could be tested without latest changes on submodule’s main. Previously, if a feature branch was based on an older commit that was still an ancestor of the parent repo's pinned commit, no rebase would occur, potentially missing important integration issues with recent submodule commits.

Example of run: https://github.com/tenstorrent/tt-llk/actions/runs/16704604454

### What's changed
I changed fetch depth and optimize a few more things in the workflow.

Now the workflow always checks if the branch is behind the latest submodule main and rebases to include all recent changes before testing. This ensures feature branches are tested against the complete, current submodule state rather than potentially stale versions.
