### PR TITLE
Enable MCW-Models eval and align scripts with #26061 (WIP)

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -42,7 +42,7 @@ jobs:
                     { name: "sentence_bert", runner-label: "N150", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
                     { name: "yolov11", runner-label: "N150", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
                     { name: "yolov9c", runner-label: "N150", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-                    # { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+                    { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                     { name: "yolov8s_world", runner-label: "N150", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                     { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                    { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
@@ -68,7 +68,7 @@ jobs:
                    { name: "yolov8x", runner-label: "N300", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                    { name: "yolov8s", runner-label: "N300", performance: false, cmd: run_yolov8s_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                     { name: "yolov9c", runner-label: "N300", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-                    # { name: "mobilenetv2", runner-label: "N300", performance: true, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+                    { name: "mobilenetv2", runner-label: "N300", performance: true, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                     { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
           #          # { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
                     { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -48,7 +48,7 @@ jobs:
                    { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
                    { name: "yolov8x", runner-label: "N150", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                    { name: "yolov8s", runner-label: "N150", performance: false, cmd: run_yolov8s_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-                    # { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
+                    { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
                     { name: "yolov4", runner-label: "N150", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (Sudhanshu Singhal)
                     { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
                     { name: "sdxl", runner-label: "N150", performance: false, cmd: run_sdxl_func, owner_id: U0837MYG788}, # Marko Radosavljevic
@@ -81,7 +81,7 @@ jobs:
                     { name: "yolov11", runner-label: "N300", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
                     { name: "yolov8s_world", runner-label: "N300", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                     { name: "vanilla_unet", runner-label: "N300", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-                    # { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
+                    { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
                     { name: "yolov4", runner-label: "N300", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (Sudhanshu Singhal)
                     { name: "yolov10x", runner-label: "N300", performance: false, cmd: run_yolov10x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
                     { name: "yolov7", runner-label: "N300", performance: false, cmd: run_yolov7_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians

--- a/models/demos/mobilenetv2/README.md
+++ b/models/demos/mobilenetv2/README.md
@@ -1,16 +1,9 @@
 # Mobilenetv2 Model
 
-### Platforms:
 
-Wormhole N150, N300
+## Platforms:
+    WH N150/N300
 
-
-**Note:** On N300 ,Make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
-
-Or, make sure to set the following environment variable in the terminal:
-```
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-```
 
 To obtain the perf reports through profiler, please build with following command:
 ```

--- a/models/demos/ufld_v2/README.md
+++ b/models/demos/ufld_v2/README.md
@@ -4,13 +4,6 @@
 
 Wormhole N150, N300
 
-**Note:** On N300, make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
-
-Or, make sure to set the following environment variable in the terminal:
-```
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-```
-
 To obtain the perf reports through profiler, please build with following command:
 ```
 ./build_metal.sh -p

--- a/models/demos/vgg_unet/README.md
+++ b/models/demos/vgg_unet/README.md
@@ -77,7 +77,7 @@ pytest --disable-warnings models/demos/vgg_unet/demo/demo.py::test_demo_dp
 Use the following command to run the performant evaluation with Trace+2CQs:
 
 ```sh
-pytest models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet
+pytest models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet[device_params0-res0-1-pretrained_weight_true-tt_model]
 ```
 
 #### Multi Device (DP=2, N300):
@@ -85,5 +85,5 @@ pytest models/experimental/segmentation_evaluation/test_segmentation_eval.py::te
 Use the following command to run the performant evaluation with Trace+2CQs:
 
 ```sh
-pytest models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet_dp
+pytest models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet_dp[wormhole_b0-device_params0-res0-1-pretrained_weight_true-tt_model]
 ```

--- a/models/demos/vgg_unet/README.md
+++ b/models/demos/vgg_unet/README.md
@@ -3,13 +3,6 @@
 
 Wormhole N150, N300
 
-**Note:** On N300, make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
-
-Or, make sure to set the following environment variable in the terminal:
-```
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-```
-
 To obtain the perf reports through profiler, please build with following command:
 ```
 ./build_metal.sh -p

--- a/models/demos/yolov8s/README.md
+++ b/models/demos/yolov8s/README.md
@@ -3,12 +3,6 @@
 ## Platforms:
 
     WH N150/N300
-**Note:** On N300 ,Make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
-
-Or, make sure to set the following environment variable in the terminal:
-```
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-```
 
 To obtain the perf reports through profiler, please build with following command:
 ```

--- a/models/demos/yolov8x/README.md
+++ b/models/demos/yolov8x/README.md
@@ -5,16 +5,12 @@
 
 ### Note:
 
-- On N300, Make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
 
-- Or, make sure to set the following environment variable in the terminal:
-  ```
-  export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-  ```
-- To obtain the perf reports through profiler, please build with following command:
-  ```
-  ./build_metal.sh -p
-  ```
+To obtain the perf reports through profiler, please build with following command:
+```
+./build_metal.sh -p
+```
+
 
 ### Introduction
 YOLOv8 is one of the recent iterations in the YOLO series of real-time object detectors, offering cutting-edge performance in terms of accuracy and speed.
@@ -101,6 +97,16 @@ pytest --disable-warnings models/demos/yolov8x/tests/pcc/test_yolov8x.py::test_y
   pytest --disable-warnings models/demos/yolov8x/demo/demo.py::test_demo_dataset_dp
   ```
 
+
+### Performant Data evaluation with Trace+2CQ:
+
+#### Single Device (BS=1):
+
+Use the following command to run the performant evaluation with Trace+2CQs:
+
+```sh
+pytest models/experimental/yolo_eval/evaluate.py::test_yolov8x[res0-device_params0-tt_model]
+```
 
 #### Note: The post-processing is performed using PyTorch.
 

--- a/models/experimental/classification_eval/classification_eval.py
+++ b/models/experimental/classification_eval/classification_eval.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from loguru import logger
 
 import torch
@@ -242,44 +241,25 @@ def run_mobilenetv2_image_classification_eval(
 ):
     from models.demos.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
     from models.demos.mobilenetv2.runner.performant_runner import MobileNetV2Trace2CQ
-    import torchvision.models as models
+    from models.demos.mobilenetv2.common import load_torch_model
     from models.demos.ttnn_resnet.tests.demo_utils import get_batch
 
-    weights_path = "models/demos/mobilenetv2/mobilenet_v2-b0353104.pth"
     model_version = "microsoft/resnet-50"
     image_processor = AutoImageProcessor.from_pretrained(model_version)
 
-    if model_type == "torch_model":
-        torch_model = models.mobilenet_v2(pretrained=True)
-    else:
-        if not os.path.exists(weights_path):
-            os.system("bash models/demos/mobilenetv2/weights_download.sh")
-
-        reference_model = Mobilenetv2()
-
-        state_dict = torch.load(weights_path)
-        ds_state_dict = {k: v for k, v in state_dict.items()}
-        new_state_dict = {
-            name1: parameter2
-            for (name1, _), (_, parameter2) in zip(reference_model.state_dict().items(), ds_state_dict.items())
-            if isinstance(parameter2, torch.FloatTensor)
-        }
-        reference_model.load_state_dict(new_state_dict)
-
-        reference_model.eval()
-
-        mobilenetv2_trace_2cq = MobileNetV2Trace2CQ()
-
-        mobilenetv2_trace_2cq.initialize_mobilenetv2_trace_2cqs_inference(
-            device,
-            device_batch_size,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
-        )
+    reference_model = Mobilenetv2()
+    reference_model = load_torch_model(reference_model, model_location_generator)
+    mobilenetv2_trace_2cq = MobileNetV2Trace2CQ()
+    mobilenetv2_trace_2cq.initialize_mobilenetv2_trace_2cqs_inference(
+        device,
+        device_batch_size,
+        ttnn.bfloat8_b,
+        ttnn.bfloat8_b,
+    )
 
     evaluation(
         device=device,
-        model=mobilenetv2_trace_2cq if model_type == "tt_model" else torch_model,
+        model=mobilenetv2_trace_2cq if model_type == "tt_model" else reference_model,
         model_location_generator=model_location_generator,
         model_type=model_type,
         model_name="mobilenetv2",

--- a/models/experimental/yolo_eval/evaluate.py
+++ b/models/experimental/yolo_eval/evaluate.py
@@ -622,13 +622,12 @@ def test_yolov9c(device, model_type, res, reset_seeds):
     "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize("res", [(640, 640)])
-def test_yolov8s(device, model_type, res, reset_seeds):
+def test_yolov8s(device, model_type, res, model_location_generator, reset_seeds):
     from models.demos.yolov8s.runner.performant_runner import YOLOv8sPerformantRunner
+    from models.demos.yolov8s.common import load_torch_model
 
     if model_type == "torch_model":
-        torch_model = YOLO("yolov8s.pt")
-        torch_model = torch_model.model
-        model = torch_model.eval()
+        model = load_torch_model(model_location_generator)
     else:
         model = YOLOv8sPerformantRunner(device, device_batch_size=1)
         logger.info("Inferencing using ttnn Model")

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -321,13 +321,15 @@ run_yolov7_demo() {
 
 }
 
-# Commenting out VGG_Unet Demo since CIv2 does not support dataset download from Kaggle
-# Raised issue to whitelist dataset- https://github.com/tenstorrent/tt-metal/issues/25866
-# run_vgg_unet_demo() {
 
-#  pytest -n auto models/demos/vgg_unet/demo/demo.py --timeout 600
+run_vgg_unet_demo() {
 
-# }
+ pytest -n auto --disable-warnings models/demos/vgg_unet/demo/demo.py --timeout 600
+
+ # Dataset Evaluation
+ pytest -n auto --disable-warnings models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet --timeout 600
+
+}
 
 
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -101,14 +101,12 @@ run_llama3_func() {
 
 }
 
-## comment out ufld_v2 from CI tests for now unitl dataset_evaluation test failure is debugged.
+
 run_ufld_v2_func() {
-  #ufld_v2
+
   pytest -n auto models/demos/ufld_v2/demo/demo.py --timeout 600
-  #ufld_v2 eval
-  ## Commenting out UFLDv2 eval since CIv2 does not support dataset download from Kaggle
-  # Raised issue to whitelist dataset- https://github.com/tenstorrent/tt-metal/issues/25866
-  #pytest -n auto models/demos/ufld_v2/demo/dataset_evaluation.py --timeout 1500
+  pytest -n auto models/demos/ufld_v2/demo/dataset_evaluation.py --timeout 1500
+
 }
 run_vgg_func() {
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -272,6 +272,9 @@ run_yolov8s_perf() {
 
   pytest -n auto --disable-warnings models/demos/yolov8s/demo/demo.py --timeout 600
 
+  # Dataset Evaluation
+  pytest -n auto --disable-warnings models/experimental/yolo_eval/evaluate.py::test_yolov8s[res0-device_params0-tt_model] --timeout 600
+
 }
 
 
@@ -280,7 +283,7 @@ run_mobilenetv2_perf(){
  pytest -n auto --disable-warnings models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo --timeout 600
 
  # Dataset Evaluation
- pytest -n auto --disable-warnings models/experimental/classification_eval/classification_eval.py --timeout 600
+ pytest -n auto --disable-warnings models/experimental/classification_eval/classification_eval.py::test_mobilenetv2_image_classification_eval_dp --timeout 600
 
 }
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -303,6 +303,9 @@ run_yolov8x_perf() {
 
   pytest -n auto --disable-warnings models/demos/yolov8x/demo/demo.py --timeout 600
 
+  # Dataset Evaluation
+  pytest -n auto --disable-warnings models/experimental/yolo_eval/evaluate.py::test_yolov8x[res0-device_params0-tt_model] --timeout 600
+
 }
 run_yolov4_perf() {
 ## Removed coco dataset evaluation for now because CIv2 does not support downloading of the dataset.
@@ -327,8 +330,8 @@ run_vgg_unet_demo() {
  pytest -n auto --disable-warnings models/demos/vgg_unet/demo/demo.py --timeout 600
 
  # Dataset Evaluation
- pytest -n auto --disable-warnings models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet --timeout 600
-
+ pytest -n auto --disable-warnings models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet[device_params0-res0-1-pretrained_weight_true-tt_model] --timeout 600
+ pytest -n auto --disable-warnings models/experimental/segmentation_evaluation/test_segmentation_eval.py::test_vgg_unet_dp[wormhole_b0-device_params0-res0-1-pretrained_weight_true-tt_model] --timeout 600
 }
 
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -3,7 +3,7 @@ set -e
 
 run_falcon7b_func() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k "default_mode_1024_stochastic"
+  pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k "default_mode_1024_stochastic"
 
 }
 
@@ -11,13 +11,13 @@ run_mistral7b_func() {
 
   mistral7b=/mnt/MLPerf/tt_dnn-models/Mistral/hub/models--mistralai--Mistral-7B-Instruct-v0.3/snapshots/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db
   mistral_cache=/mnt/MLPerf/tt_dnn-models/Mistral/TT_CACHE/Mistral-7B-Instruct-v0.3
-  HF_MODEL=$mistral7b TT_CACHE_PATH=$mistral_cache WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/tt_transformers/tests/test_accuracy.py -k perf --timeout 1200; fail+=$?
+  HF_MODEL=$mistral7b TT_CACHE_PATH=$mistral_cache pytest -n auto models/tt_transformers/tests/test_accuracy.py -k perf --timeout 1200; fail+=$?
 
 }
 
 run_qwen7b_func() {
 
-  HF_MODEL=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml MESH_DEVICE=N300 pytest -n auto models/tt_transformers/demo/simple_text_demo.py -k performance-ci-1 --timeout 1800
+  HF_MODEL=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct MESH_DEVICE=N300 pytest -n auto models/tt_transformers/demo/simple_text_demo.py -k performance-ci-1 --timeout 1800
 
 }
 
@@ -35,12 +35,12 @@ run_qwen25_vl_func() {
   # todo)) Qwen2.5-VL-7B-Instruct
 
   # simple generation-accuracy tests for qwen25_vl_3b
-  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 600 || fail=1
+  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 600 || fail=1
   echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
 
   # complete demo tests
   for qwen_dir in "$qwen25_vl_3b"; do
-    MESH_DEVICE=N300 HF_MODEL=$qwen_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 600 || fail=1
+    MESH_DEVICE=N300 HF_MODEL=$qwen_dir pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 600 || fail=1
     echo "LOG_METAL: Tests for $qwen_dir on N300 completed"
   done
 
@@ -51,18 +51,18 @@ run_qwen25_vl_func() {
 
 run_segformer_func() {
   #Segformer Segmentation Demo
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/segformer/demo/demo_for_semantic_segmentation.py --timeout 600; fail+=$?
+  pytest --disable-warnings models/demos/segformer/demo/demo_for_semantic_segmentation.py --timeout 600; fail+=$?
 
   ## Commenting out Segformer Classification Demo. Raised issue to whitelist dataset- https://github.com/tenstorrent/tt-metal/issues/25866
   #Segformer Classification Demo
-  # WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/segformer/demo/demo_for_image_classification.py --timeout 600; fail+=$?
+  # pytest --disable-warnings models/demos/segformer/demo/demo_for_image_classification.py --timeout 600; fail+=$?
 
 }
 
 run_sentencebert_func() {
 
   #SentenceBERT Demo
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/sentence_bert/demo/demo.py --timeout 600; fail+=$?
+  pytest --disable-warnings models/demos/sentence_bert/demo/demo.py --timeout 600; fail+=$?
 
   #SentenceBERT eval
   # comment out SentenceBERT eval from CI tests for now unitl dataset_evaluation test is available in CIv2 (issue: #25866)
@@ -74,7 +74,7 @@ run_sentencebert_func() {
 run_yolov11_func() {
 
  #Yolov11 Demo
- WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/yolov11/demo/demo.py --timeout 600; fail+=$?
+ pytest --disable-warnings models/demos/yolov11/demo/demo.py --timeout 600; fail+=$?
 
 }
 
@@ -91,7 +91,7 @@ run_llama3_func() {
 
   # Run Llama3 accuracy tests for 1B, 3B, 8B weights
   for llama_dir in "$llama1b" "$llama3b" "$llama8b"; do
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/tt_transformers/tests/test_accuracy.py -k perf --timeout 420 || fail=1
+    LLAMA_DIR=$llama_dir pytest -n auto models/tt_transformers/tests/test_accuracy.py -k perf --timeout 420 || fail=1
     echo "LOG_METAL: Llama3 accuracy tests for $llama_dir completed"
   done
 
@@ -104,25 +104,25 @@ run_llama3_func() {
 ## comment out ufld_v2 from CI tests for now unitl dataset_evaluation test failure is debugged.
 run_ufld_v2_func() {
   #ufld_v2
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/demo/demo.py --timeout 600
+  pytest -n auto models/demos/ufld_v2/demo/demo.py --timeout 600
   #ufld_v2 eval
   ## Commenting out UFLDv2 eval since CIv2 does not support dataset download from Kaggle
   # Raised issue to whitelist dataset- https://github.com/tenstorrent/tt-metal/issues/25866
-  #WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/demo/dataset_evaluation.py --timeout 1500
+  #pytest -n auto models/demos/ufld_v2/demo/dataset_evaluation.py --timeout 1500
 }
 run_vgg_func() {
 
   #VGG11/VGG16
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg/demo/demo.py --timeout 600
+  pytest -n auto models/demos/vgg/demo/demo.py --timeout 600
 
 }
 
 run_bert_tiny_func() {
   fail=0
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/bert_tiny/demo/demo.py --timeout 600 || fail=1
+  pytest -n auto models/demos/bert_tiny/demo/demo.py --timeout 600 || fail=1
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/bert_tiny/demo/demo.py --timeout 600 || fail=1
+  pytest -n auto models/demos/wormhole/bert_tiny/demo/demo.py --timeout 600 || fail=1
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -134,7 +134,7 @@ run_bert_func() {
   fail=0
 
   pytest -n auto --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py -k batch_7 || fail=1
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py -k batch_8 || fail=1
+  pytest -n auto --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py -k batch_8 || fail=1
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -144,13 +144,13 @@ run_bert_func() {
 
 run_resnet_stability() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/tests/test_resnet50_stability.py -k "short"
+  pytest -n auto --disable-warnings models/demos/wormhole/resnet50/tests/test_resnet50_stability.py -k "short"
 
 }
 
 run_resnet_func() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/demo/demo.py
+  pytest -n auto --disable-warnings models/demos/wormhole/resnet50/demo/demo.py
 
 }
 
@@ -163,7 +163,7 @@ run_distilbert_func() {
 
   pytest --disable-warnings models/demos/distilbert/demo/demo.py --timeout 600 || fail=1
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/wormhole/distilbert/demo/demo.py --timeout 600 || fail=1
+  pytest --disable-warnings models/demos/wormhole/distilbert/demo/demo.py --timeout 600 || fail=1
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -197,7 +197,7 @@ run_roberta_func() {
 
 run_stable_diffusion_func() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings --input-path="models/demos/wormhole/stable_diffusion/demo/input_data.json" models/demos/wormhole/stable_diffusion/demo/demo.py::test_demo --timeout 900
+  pytest -n auto --disable-warnings --input-path="models/demos/wormhole/stable_diffusion/demo/input_data.json" models/demos/wormhole/stable_diffusion/demo/demo.py::test_demo --timeout 900
 
 }
 
@@ -207,9 +207,9 @@ run_mistral7b_perf() {
   mistral7b=/mnt/MLPerf/tt_dnn-models/Mistral/hub/models--mistralai--Mistral-7B-Instruct-v0.3/snapshots/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db
   mistral_cache=/mnt/MLPerf/tt_dnn-models/Mistral/TT_CACHE/Mistral-7B-Instruct-v0.3
   # Run Mistral-7B-v0.3 for N150
-  MESH_DEVICE=N150 HF_MODEL=$mistral7b TT_CACHE_PATH=$mistral_cache WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1"; fail+=$?
+  MESH_DEVICE=N150 HF_MODEL=$mistral7b TT_CACHE_PATH=$mistral_cache pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1"; fail+=$?
   # Run Mistral-7B-v0.3 for N300
-  MESH_DEVICE=N300 HF_MODEL=$mistral7b TT_CACHE_PATH=$mistral_cache WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1"; fail+=$?
+  MESH_DEVICE=N300 HF_MODEL=$mistral7b TT_CACHE_PATH=$mistral_cache pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1"; fail+=$?
 
 }
 
@@ -228,12 +228,12 @@ run_llama3_perf() {
   # Run all Llama3 tests for 1B, 3B, 8B weights for N150
   # To ensure a proper perf measurement and dashboard upload of the Llama3 models on a N150, we have to run them on the N300 perf pipeline for now
   for llama_dir in "$llama1b" "$llama3b" "$llama8b"; do
-    MESH_DEVICE=N150 LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" || fail=1
+    MESH_DEVICE=N150 LLAMA_DIR=$llama_dir pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" || fail=1
     echo "LOG_METAL: Llama3 tests for $llama_dir completed on N150"
   done
   # Run all Llama3 tests for 1B, 3B, 8B and 11B weights
   for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b"; do
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" || fail=1
+    LLAMA_DIR=$llama_dir pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" || fail=1
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 
@@ -246,73 +246,75 @@ run_llama3_perf() {
 run_falcon7b_perf() {
 
   # Falcon7b (perf verification for 128/1024/2048 seq lens and output token verification)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py
+  pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py
 
 }
 
 run_mamba_perf() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420
+  pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420
 
 }
 
 run_whisper_perf() {
 
   # Whisper conditional generation
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
+  pytest -n auto models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
 
 }
 
 run_yolov9c_perf() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/yolov9c/demo/demo.py --timeout 600
+  pytest -n auto --disable-warnings models/demos/yolov9c/demo/demo.py --timeout 600
 
 }
 run_yolov8s_perf() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/yolov8s/demo/demo.py --timeout 600
+  pytest -n auto --disable-warnings models/demos/yolov8s/demo/demo.py --timeout 600
 
 }
 
-# commenting out the test from CI due to HF issue. TODO explore AWS alternative suggested by infra team.
-# Raised issue to whitelist dataset- https://github.com/tenstorrent/tt-metal/issues/25866
-# run_mobilenetv2_perf(){
 
-#  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo --timeout 600
+run_mobilenetv2_perf(){
 
-# }
+ pytest -n auto --disable-warnings models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo --timeout 600
+
+ # Dataset Evaluation
+ pytest -n auto --disable-warnings models/experimental/classification_eval/classification_eval.py --timeout 600
+
+}
 
 run_yolov8s_world_perf() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/yolov8s_world/demo/demo.py --timeout 600
+  pytest -n auto --disable-warnings models/demos/yolov8s_world/demo/demo.py --timeout 600
 
 }
 
 #comment out vanilla unet for now unitl data and weights loading issues are resolved.
 run_vanilla_unet_demo() {
 
- WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/vanilla_unet/demo/demo.py::test_unet_demo_single_image
+ pytest -n auto models/experimental/vanilla_unet/demo/demo.py::test_unet_demo_single_image
 
 }
 run_yolov8x_perf() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/yolov8x/demo/demo.py --timeout 600
+  pytest -n auto --disable-warnings models/demos/yolov8x/demo/demo.py --timeout 600
 
 }
 run_yolov4_perf() {
 ## Removed coco dataset evaluation for now because CIv2 does not support downloading of the dataset.
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/yolov4/demo.py::test_yolov4 --timeout 600
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings models/demos/yolov4/demo.py::test_yolov4_dp --timeout 600
+  pytest --disable-warnings models/demos/yolov4/demo.py::test_yolov4 --timeout 600
+  pytest --disable-warnings models/demos/yolov4/demo.py::test_yolov4_dp --timeout 600
 }
 run_yolov10x_demo() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings  models/demos/yolov10x/demo/demo.py --timeout 600
+  pytest -n auto --disable-warnings  models/demos/yolov10x/demo/demo.py --timeout 600
 
 }
 
 run_yolov7_demo() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/demo/demo.py --timeout 600
+  pytest -n auto models/demos/yolov7/demo/demo.py --timeout 600
 
 }
 
@@ -320,7 +322,7 @@ run_yolov7_demo() {
 # Raised issue to whitelist dataset- https://github.com/tenstorrent/tt-metal/issues/25866
 # run_vgg_unet_demo() {
 
-#  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/demo/demo.py --timeout 600
+#  pytest -n auto models/demos/vgg_unet/demo/demo.py --timeout 600
 
 # }
 


### PR DESCRIPTION
### Problem description
Enabling Dataset Evaluation for the MCW-Models

### What's changed
Enable Dataset Evaluation scripts in the CIs.
Aligned with #26061 PR (w.r.t. README and deprecating WH_ARCH_YAML env variable)

Completed for [MobilenetV2, VGG_Unet, Yolov8s, Yolov8x]

--------------------------------------
**CIs triggered to test MobilenetV2**
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16699778191) - Passed
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16699779280) - Passed
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16703889081) - Roberta, BertTiny failed
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16699780853) - In progress