### PR TITLE
Fix attn_matmul kernel to work for bfloat8_b

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
@@ -64,7 +64,6 @@ def test_attn_matmul(num_loops, in0_dtype, in1_dtype, out_dtype, device):
             assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Bad pcc on BH. Issue #25421")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("num_loops", [20])
 def test_attn_matmul_fp32(num_loops, in_dtype, device):
@@ -135,7 +134,6 @@ def test_attn_matmul_with_program_cache(num_loops, in0_dtype, in1_dtype, out_dty
             assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Bad pcc on BH. Issue #25421")
 @pytest.mark.parametrize(
     "shard_orientation",
     (ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR),
@@ -249,7 +247,6 @@ def test_group_attn_matmul(
         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Bad pcc on BH. Issue #25421")
 @pytest.mark.parametrize("sharded", [False, True])
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -335,7 +332,6 @@ def test_group_attn_matmul_with_program_cache(num_loops, in0_dtype, in1_dtype, o
     assert num_cache_entries == 1
 
 
-@skip_for_blackhole("Bad pcc on BH. Issue #25421")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize(
     "shard_orientation",

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -84,7 +84,7 @@ void MAIN {
                 cb_push_back(out_cb_id, onetile);
 
                 cb_pop_front(cb_intermed2, onetile);
-                tilize_uninit(cb_intermed2, out_cb_id);
+                tilize_uninit_with_dt(cb_intermed2, cb_in1, out_cb_id);
 
                 pack_reconfig_data_format(out_cb_id, cb_intermed0);
                 // Workaround, needs to be reverted to the following when fix is found:


### PR DESCRIPTION
### Ticket
#25421

### Problem description
Multiple tests in `tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py` were being skipped for BH due to assertion error occurring, specifically for bfloat8_b input data type. 

### What's changed
Replaced tilize_uninit with tilize_uninit_with_dt inside `ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp`.
Removed @skip_for_blackohole for related tests. 
Tested on 3 BH machines:

- bh-38 -> p150a
- bh-35 -> p100a
- bh-37 -> p150b

The tests are passing for all three machines. 
Running the CIs including BH nightly tests to confirm that the fix is working. 

BH nightly [passing](https://github.com/tenstorrent/tt-metal/actions/runs/16707263818)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16707248239)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16707277839)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16707285899)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16707288874)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes