### PR TITLE
Reduce e2e tests host computing

### DIFF
--- a/models/demos/sentence_bert/runner/performant_runner2.py
+++ b/models/demos/sentence_bert/runner/performant_runner2.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.demos.sentence_bert.runner.performant_runner_infra2 import SentenceBERTPerformanceRunnerInfra
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+class SentenceBERTPerformantRunner:
+    def __init__(
+        self,
+        device,
+        model_location_generator,
+        device_batch_size=8,
+        sequence_length=384,
+        input_ids=None,
+        extended_mask=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        act_dtype=ttnn.bfloat16,
+        weight_dtype=ttnn.bfloat8_b,
+        model_name="emrecan/bert-base-turkish-cased-mean-nli-stsb-tr",
+    ):
+        self.device = device
+        self.input_ids = input_ids
+        self.extended_mask = extended_mask
+        self.attention_mask = attention_mask
+        self.token_type_ids = token_type_ids
+        self.position_ids = position_ids
+        self.runner_infra = SentenceBERTPerformanceRunnerInfra(
+            device=self.device,
+            batch_size=device_batch_size,
+            sequence_length=sequence_length,
+            input_ids=self.input_ids,
+            extended_mask=self.extended_mask,
+            attention_mask=self.attention_mask,
+            token_type_ids=self.token_type_ids,
+            position_ids=self.position_ids,
+            model_location_generator=model_location_generator,
+        )
+        (
+            self.tt_inputs_host,
+            sharded_mem_config_DRAM,
+            self.input_mem_config,
+            self.tt_tokens_host,
+            self.tt_posids_host,
+            self.tt_ext_att_mask_host,
+            self.tt_att_mask_host,
+        ) = self.runner_infra.setup_dram_sharded_input(device)
+        self.tt_inputs = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
+        self.tt_tokens = self.tt_tokens_host.to(device, sharded_mem_config_DRAM)
+        self.tt_pos = self.tt_posids_host.to(device, sharded_mem_config_DRAM)
+        self.tt_ext_att_mask = self.tt_ext_att_mask_host.to(device, sharded_mem_config_DRAM)
+        self.tt_att_mask = self.tt_att_mask_host.to(device, sharded_mem_config_DRAM)
+
+    def _capture_sentencebert_trace_2cqs(self):
+        self.op_event = ttnn.record_event(self.device, 0)
+
+        # First run configures convs JIT
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_inputs, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_tokens_host, self.tt_tokens, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_posids_host, self.tt_pos, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_ext_att_mask_host, self.tt_ext_att_mask, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_att_mask_host, self.tt_att_mask, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.ttnn_input_ids = ttnn.to_memory_config(self.tt_inputs, self.input_mem_config)
+        self.runner_infra.ttnn_token_ids = ttnn.to_memory_config(self.tt_tokens, self.input_mem_config)
+        self.runner_infra.ttnn_pos_ids = ttnn.to_memory_config(self.tt_pos, self.input_mem_config)
+        self.runner_infra.ttnn_ext_att_mask = ttnn.to_memory_config(self.tt_ext_att_mask, self.input_mem_config)
+        self.runner_infra.ttnn_att_mask = ttnn.to_memory_config(self.tt_att_mask, self.input_mem_config)
+        spec_input = self.runner_infra.ttnn_input_ids.spec
+        spec_token = self.runner_infra.ttnn_token_ids.spec
+        spec_pos = self.runner_infra.ttnn_pos_ids.spec
+        spec_att = self.runner_infra.ttnn_ext_att_mask.spec
+        spec_att_2 = self.runner_infra.ttnn_att_mask.spec
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+        self.runner_infra.dealloc_output()
+        # Optimized run
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_inputs, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_tokens_host, self.tt_tokens, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_posids_host, self.tt_pos, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_ext_att_mask_host, self.tt_ext_att_mask, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_att_mask_host, self.tt_att_mask, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.ttnn_input_ids = ttnn.to_memory_config(self.tt_inputs, self.input_mem_config)
+        self.runner_infra.ttnn_token_ids = ttnn.to_memory_config(self.tt_tokens, self.input_mem_config)
+        self.runner_infra.ttnn_pos_ids = ttnn.to_memory_config(self.tt_pos, self.input_mem_config)
+        self.runner_infra.ttnn_ext_att_mask = ttnn.to_memory_config(self.tt_ext_att_mask, self.input_mem_config)
+        self.runner_infra.ttnn_att_mask = ttnn.to_memory_config(self.tt_att_mask, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+
+        # Capture
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_inputs, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_tokens_host, self.tt_tokens, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_posids_host, self.tt_pos, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_ext_att_mask_host, self.tt_ext_att_mask, 1)
+        ttnn.copy_host_to_device_tensor(self.tt_att_mask_host, self.tt_att_mask, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.ttnn_input_ids = ttnn.to_memory_config(self.tt_inputs, self.input_mem_config)
+        self.runner_infra.ttnn_token_ids = ttnn.to_memory_config(self.tt_tokens, self.input_mem_config)
+        self.runner_infra.ttnn_pos_ids = ttnn.to_memory_config(self.tt_pos, self.input_mem_config)
+        self.runner_infra.ttnn_ext_att_mask = ttnn.to_memory_config(self.tt_ext_att_mask, self.input_mem_config)
+        self.runner_infra.ttnn_att_mask = ttnn.to_memory_config(self.tt_att_mask, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.dealloc_output()
+        trace_input_addr = self.runner_infra.ttnn_input_ids.buffer_address()
+        trace_input_addr2 = self.runner_infra.ttnn_token_ids.buffer_address()
+        trace_input_addr3 = self.runner_infra.ttnn_pos_ids.buffer_address()
+        trace_input_addr4 = self.runner_infra.ttnn_ext_att_mask.buffer_address()
+        trace_input_addr5 = self.runner_infra.ttnn_att_mask.buffer_address()
+        self.tid = ttnn.begin_trace_capture(self.device, cq_id=0)
+        self.runner_infra.run()
+        self.ttnn_input_ids = ttnn.allocate_tensor_on_device(spec_input, self.device)
+        self.ttnn_token_ids = ttnn.allocate_tensor_on_device(spec_token, self.device)
+        self.ttnn_pos_ids = ttnn.allocate_tensor_on_device(spec_pos, self.device)
+        self.ttnn_ext_att_mask = ttnn.allocate_tensor_on_device(spec_att, self.device)
+        self.ttnn_att_mask = ttnn.allocate_tensor_on_device(spec_att_2, self.device)
+        ttnn.end_trace_capture(self.device, self.tid, cq_id=0)
+        ttnn.synchronize_device(self.device)
+        assert trace_input_addr == self.ttnn_input_ids.buffer_address()
+        assert trace_input_addr2 == self.ttnn_token_ids.buffer_address()
+        assert trace_input_addr3 == self.ttnn_pos_ids.buffer_address()
+        assert trace_input_addr4 == self.ttnn_ext_att_mask.buffer_address()
+        assert trace_input_addr5 == self.ttnn_att_mask.buffer_address()
+
+    def _execute_sentencebert_trace_2cqs_inference(
+        self, tt_inputs_host=None, tt_tokens=None, tt_posids=None, tt_ext_att_mask=None, tt_att_mask=None
+    ):
+        if tt_inputs_host is None:
+            tt_inputs_host = self.tt_inputs_host
+            tt_tokens = self.tt_tokens_host
+            tt_posids = self.tt_posids_host
+            tt_ext_att_mask = self.tt_ext_att_mask_host
+            tt_att_mask = self.tt_att_mask_host
+
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_inputs, 1)
+        ttnn.copy_host_to_device_tensor(tt_tokens, self.tt_tokens, 1)
+        ttnn.copy_host_to_device_tensor(tt_posids, self.tt_pos, 1)
+        ttnn.copy_host_to_device_tensor(tt_ext_att_mask, self.tt_ext_att_mask, 1)
+        ttnn.copy_host_to_device_tensor(tt_att_mask, self.tt_att_mask, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.ttnn_input_ids = ttnn.reshard(self.tt_inputs, self.input_mem_config, self.ttnn_input_ids)
+        self.ttnn_token_ids = ttnn.reshard(self.tt_tokens, self.input_mem_config, self.ttnn_token_ids)
+        self.ttnn_pos_ids = ttnn.reshard(self.tt_pos, self.input_mem_config, self.ttnn_pos_ids)
+        self.ttnn_ext_att_mask = ttnn.reshard(self.tt_ext_att_mask, self.input_mem_config, self.ttnn_ext_att_mask)
+        self.ttnn_att_mask = ttnn.reshard(self.tt_att_mask, self.input_mem_config, self.ttnn_att_mask)
+        self.op_event = ttnn.record_event(self.device, 0)
+        ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(self.device)
+        return self.runner_infra.ttnn_output_tensor[0]
+
+    def _validate(self, result_output_tensor):
+        torch_output_tensor = self.runner_infra.torch_output.post_processed_output
+        assert_with_pcc(torch_output_tensor, result_output_tensor, self.runner_infra.valid_pcc)
+
+    def release(self):
+        ttnn.release_trace(self.device, self.tid)
+
+    def run(self, input_ids=None, tokens=None, posids=None, ext_att_mask=None, att_mask=None):
+        (
+            tt_inputs_host,
+            _,
+            tt_tokens,
+            tt_posids,
+            tt_ext_att_mask,
+            tt_att_mask,
+        ) = self.runner_infra.setup_l1_sharded_input(input_ids, tokens, posids, ext_att_mask, att_mask)
+        output = self._execute_sentencebert_trace_2cqs_inference(
+            tt_inputs_host, tt_tokens, tt_posids, tt_ext_att_mask, tt_att_mask
+        )
+        return output

--- a/models/demos/sentence_bert/runner/performant_runner_infra2.py
+++ b/models/demos/sentence_bert/runner/performant_runner_infra2.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import torch
+import transformers
+from loguru import logger
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+import ttnn
+from models.demos.sentence_bert.common import load_torch_model
+from models.demos.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
+from models.demos.sentence_bert.ttnn.common import custom_preprocessor
+from models.demos.sentence_bert.ttnn.ttnn_sentence_bert_model import TtnnSentenceBertModel
+from models.utility_functions import is_wormhole_b0
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def load_ttnn_model(device, torch_model, config):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: torch_model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    ttnn_model = TtnnSentenceBertModel(parameters=parameters, config=config)
+    return ttnn_model
+
+
+class SentenceBERTPerformanceRunnerInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        sequence_length,
+        model_location_generator,
+        input_ids=None,
+        extended_mask=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        act_dtype=ttnn.bfloat16,
+        weight_dtype=ttnn.bfloat8_b,
+        inputs_mesh_mapper=None,
+        weights_mesh_mapper=None,
+        output_mesh_composer=None,
+        model_name="emrecan/bert-base-turkish-cased-mean-nli-stsb-tr",
+    ):
+        torch.manual_seed(0)
+        self.device = device
+        self.batch_size = batch_size
+        self.act_dtype = act_dtype
+        self.weight_dtype = weight_dtype
+        self.sequence_length = sequence_length
+        config = transformers.BertConfig.from_pretrained("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr")
+        self.torch_model = BertModel(config).to(torch.bfloat16)
+        self.torch_model = load_torch_model(
+            self.torch_model, target_prefix="", model_location_generator=model_location_generator
+        )
+        # Log device information for data parallel validation
+        num_devices = self.device.get_num_devices()
+
+        # Set up mesh mappers if not provided
+        if inputs_mesh_mapper is None and weights_mesh_mapper is None and output_mesh_composer is None:
+            self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        if input_ids is None:
+            self.batch_size = self.batch_size * self.device.get_num_devices()
+            self.input_ids = torch.randint(
+                low=0, high=config.vocab_size - 1, size=[self.batch_size, self.sequence_length], dtype=torch.int64
+            )
+            self.attention_mask = torch.ones(self.batch_size, self.sequence_length)
+            self.extended_mask = custom_extended_mask(self.attention_mask, dtype=torch.bfloat16)
+            self.token_type_ids = torch.zeros([self.batch_size, self.sequence_length], dtype=torch.int64)
+            self.position_ids = torch.arange(0, self.sequence_length, dtype=torch.int64).unsqueeze(dim=0)
+        else:
+            self.input_ids = input_ids
+            self.attention_mask = attention_mask
+            self.extended_mask = extended_mask
+            self.token_type_ids = token_type_ids
+            self.position_ids = position_ids
+
+        self.input_ids = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "input_ids.pt"))
+        self.attention_mask = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "attention_mask.pt"))
+        self.extended_mask = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "extended_mask.pt"))
+        self.token_type_ids = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "token_type_ids.pt"))
+        self.position_ids = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "position_ids.pt"))
+        self.torch_output = torch.load(
+            os.path.join(os.path.dirname(__file__), "tensors", "torch_output.pt"), weights_only=False
+        )
+
+        self.ttnn_sentencebert_model = load_ttnn_model(self.device, self.torch_model, config)
+
+    def get_mesh_mappers(self, device):
+        num_devices = device.get_num_devices()
+        if num_devices != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None  # ttnn.ReplicateTensorToMesh(device) causes unnecessary replication/takes more time on the first pass
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+            return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+        return None, None, None
+
+    def setup_l1_sharded_input(
+        self, input_ids=None, token_type_ids=None, position_ids=None, extended_mask=None, attention_mask=None
+    ):
+        if is_wormhole_b0():
+            grid_size = ttnn.CoreGrid(y=8, x=8)
+        else:
+            exit("Unsupported device")
+        input_ids = self.input_ids if input_ids is None else input_ids
+        token_type_ids = self.token_type_ids if token_type_ids is None else token_type_ids
+        position_ids = self.position_ids if position_ids is None else position_ids
+        extended_mask = self.extended_mask if extended_mask is None else extended_mask
+        attention_mask = self.attention_mask if attention_mask is None else attention_mask
+        grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+        shard_spec = ttnn.ShardSpec(
+            shard_grid, (position_ids.shape[0], position_ids.shape[1]), ttnn.ShardOrientation.ROW_MAJOR
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        )
+        ttnn_input_ids = ttnn.from_torch(input_ids, dtype=ttnn.uint32, mesh_mapper=self.inputs_mesh_mapper)
+        ttnn_token_type_ids = ttnn.from_torch(token_type_ids, dtype=ttnn.uint32, mesh_mapper=self.inputs_mesh_mapper)
+        ttnn_position_ids = ttnn.from_torch(position_ids, dtype=ttnn.uint32)
+        ttnn_extended_mask = ttnn.from_torch(extended_mask, dtype=ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper)
+        ttnn_attention_mask = ttnn.from_torch(attention_mask, dtype=ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper)
+        return (
+            ttnn_input_ids,
+            input_mem_config,
+            ttnn_token_type_ids,
+            ttnn_position_ids,
+            ttnn_extended_mask,
+            ttnn_attention_mask,
+        )
+
+    def setup_dram_sharded_input(self, device):
+        (
+            tt_inputs_host,
+            input_mem_config,
+            ttnn_token_type_ids,
+            ttnn_position_ids,
+            ttnn_extended_mask,
+            ttnn_attention_mask,
+        ) = self.setup_l1_sharded_input()
+        dram_grid_size = device.dram_grid_size()
+        dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+            ),
+            (self.position_ids.shape[0], self.position_ids.shape[1]),
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded_mem_config_DRAM = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+        )
+        return (
+            tt_inputs_host,
+            sharded_mem_config_DRAM,
+            input_mem_config,
+            ttnn_token_type_ids,
+            ttnn_position_ids,
+            ttnn_extended_mask,
+            ttnn_attention_mask,
+        )
+
+    def run(self):
+        self.ttnn_output_tensor = self.ttnn_sentencebert_model(
+            self.ttnn_input_ids,
+            extended_attention_mask=self.ttnn_ext_att_mask,
+            attention_mask=self.ttnn_att_mask,
+            token_type_ids=self.ttnn_token_ids,
+            position_ids=self.ttnn_pos_ids,
+            device=self.device,
+        )
+
+    def validate(self, output_tensor=None, torch_output_tensor=None):
+        ttnn_output_tensor = self.ttnn_output_tensor if output_tensor is None else output_tensor
+        torch_output_tensor = self.torch_output if torch_output_tensor is None else torch_output_tensor
+        output_tensor = ttnn.to_torch(ttnn_output_tensor[0], mesh_composer=self.output_mesh_composer).squeeze(dim=1)
+        self.valid_pcc = 0.987
+        self.pcc_passed, self.pcc_message = assert_with_pcc(
+            torch_output_tensor.post_processed_output, output_tensor, pcc=self.valid_pcc
+        )
+
+        logger.info(
+            f"SentenceBERT - batch_size={self.batch_size}, PCC={self.pcc_message}, act_dtype:{self.act_dtype}, weight_dtype:{self.weight_dtype}"
+        )
+
+    def dealloc_output(self):
+        ttnn.deallocate(self.ttnn_output_tensor[0])

--- a/models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant2.py
+++ b/models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant2.py
@@ -8,7 +8,7 @@ import pytest
 from loguru import logger
 
 import ttnn
-from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerformantRunner
+from models.demos.sentence_bert.runner.performant_runner2 import SentenceBERTPerformantRunner
 from models.utility_functions import run_for_wormhole_b0
 
 
@@ -35,8 +35,9 @@ def run_e2e_performant_sentencebert(
     performant_runner.release()
     end = time.time() - start
 
-    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
     logger.info(f"Total time for 50 inferences: {end:.2f} seconds")
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
     logger.info(
         f"ttnn_sentencebert_batch_size: {batch_size}, One inference iteration time (sec): {inference_time_avg}, Sentence per sec: {round(batch_size * device.get_num_devices()/inference_time_avg)}"
     )


### PR DESCRIPTION
### Ticket
This is just a reference PR for reducing host compute time in e2e performance tests

### Problem description
To reduce the CI overhead of host compute, the torch inference on cpu is removed, and tensors are directly loaded to reduce compute of PyTorch on host.

### What's changed

This is the current implementation: `models/demos/sentence_bert/runner/performant_runner_infra.py`

```
self.torch_output = self.torch_model(
            self.input_ids,
            extended_attention_mask=self.extended_mask,
            attention_mask=self.attention_mask,
            token_type_ids=self.token_type_ids,
            position_ids=self.position_ids,
        )
```
        
This is proposed implementation: `models/demos/sentence_bert/runner/performant_runner_infra2.py`

```
self.input_ids = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "input_ids.pt"))
self.attention_mask = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "attention_mask.pt"))
self.extended_mask = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "extended_mask.pt"))
self.token_type_ids = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "token_type_ids.pt"))
self.position_ids = torch.load(os.path.join(os.path.dirname(__file__), "tensors", "position_ids.pt"))
self.torch_output = torch.load(
            os.path.join(os.path.dirname(__file__), "tensors", "torch_output.pt"), weights_only=False
        )
```

This reduced the runtime of `models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py` **from 54s --> 27s**

Note: The exact time could vary across devices, the performance improvement stays intact

To test the results:

1. clone the branch and build metal
2. Run the following:
                `pytest models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py`
                `pytest models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant2.py`
3. You will observe the time difference.