### PR TITLE
Update UnitMeshCQSingleCardFixture to init a single tunnel with  TT_METAL_ENABLE_REMOTE_CHIP

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -248,14 +248,27 @@ protected:
         } else {
             chip_ids.push_back(mmio_device_id);
         }
-        auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
+        reserved_devices_ = distributed::MeshDevice::create_unit_meshes(
             chip_ids, DEFAULT_L1_SMALL_SIZE, trace_region_size, 1, dispatch_core_config);
-        for (const auto& [id, device] : reserved_devices) {
-            this->devices_.push_back(device);
+
+        if (enable_remote_chip) {
+            const auto tunnels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
+            for (const auto& tunnel : tunnels) {
+                for (const auto chip_id : tunnel) {
+                    if (reserved_devices_.find(chip_id) != reserved_devices_.end()) {
+                        devices_.push_back(reserved_devices_.at(chip_id));
+                    }
+                }
+                break;
+            }
+        } else {
+            devices_.push_back(reserved_devices_.at(mmio_device_id));
         }
     }
 
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+    std::map<int, std::shared_ptr<distributed::MeshDevice>> reserved_devices_;
     distributed::MeshCoordinate zero_coord_ = distributed::MeshCoordinate::zero_coordinate(2);
     distributed::MeshCoordinateRange device_range_ = distributed::MeshCoordinateRange(zero_coord_, zero_coord_);
 };


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- TG Unit Tests are timing out on main after migrating to Unit-Mesh Test Fixtures.
- This is because the legacy fixture ran tests on a single tunnel and the new fixture ran tests on the entire cluster.

### What's changed
- Modify `UnitMeshCQSingleCardFixture` to preserve behaviour of the previous fixture and run on a single tunnel for TG clusters.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes