### PR TITLE
Deepseek - use repo deepseek code for data generation

### DIFF
--- a/.github/workflows/tg-deepseek-tests-impl.yaml
+++ b/.github/workflows/tg-deepseek-tests-impl.yaml
@@ -43,7 +43,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         ARCH_NAME: ${{ matrix.test-group.arch }}
-        HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -60,7 +60,7 @@ def mesh_device(request, device_params):
 
 @pytest.fixture(scope="session")
 def model_path():
-    return Path(os.getenv("HF_MODEL", "models/demos/deepseek_v3/reference"))
+    return Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "models/demos/deepseek_v3/reference"))
 
 
 @pytest.fixture(scope="session")

--- a/models/demos/deepseek_v3/scripts/generate_test_inputs_outputs.py
+++ b/models/demos/deepseek_v3/scripts/generate_test_inputs_outputs.py
@@ -122,15 +122,12 @@ def convert_layer_log_entry(
         return log
 
     # If the layer is an attention layer, we need to put the kv_cache back
+    output_kv_cache_length = kwargs.pop("kv_cache_length")
     output_tensor, _, output_cache = output
     layer_idx: int = module.layer_idx
-    _, outputs_length, _ = output_tensor.shape
-    _, _, output_history_length, _ = kwargs["attention_mask"].shape
-
-    kwargs["past_key_value"] = trim_kv_cache(
-        kwargs["past_key_value"], layer_idx, output_history_length - outputs_length
-    )
-    return (name, args, kwargs, (output_tensor, trim_kv_cache(output_cache, layer_idx, output_history_length)))
+    _, input_length, _ = kwargs["hidden_states"].shape
+    kwargs["past_key_value"] = trim_kv_cache(kwargs["past_key_value"], layer_idx, output_kv_cache_length - input_length)
+    return (name, args, kwargs, (output_tensor, trim_kv_cache(output_cache, layer_idx, output_kv_cache_length)))
 
 
 def save_io_logs(
@@ -164,8 +161,8 @@ def main():
     print("Tokenizer loaded successfully")
 
     # Load the model with uninitialized weights
-    print("Loading uninitialized model")
-    model = load_model_uninitialized(args.local_model_path)
+    print("Loading uninitialized model from repo version")
+    model = load_model_uninitialized()
     print("Model loaded successfully")
 
     # Load the model weights
@@ -200,6 +197,11 @@ def main():
         early_stop_layer: str | None = args.early_stop_layer,
         layer_groups_map: dict[str, str] = layer_groups_map,
     ):
+        module = dict(model.named_modules())[name]
+        if module.__class__.__name__ == "DeepseekV3Attention":
+            _, _, kwargs["kv_cache_length"], _ = kwargs["past_key_value"][module.layer_idx][
+                0
+            ].shape  # For restoring the cache length later to a proper size
         log_dict[layer_groups_map[name]].append((name, args, kwargs, output))
         if name == early_stop_layer:
             raise CaptureFinished()

--- a/models/demos/deepseek_v3/scripts/test_run_model.py
+++ b/models/demos/deepseek_v3/scripts/test_run_model.py
@@ -32,8 +32,8 @@ def main():
 
     with torch.no_grad():
         # Load the model with uninitialized weights
-        print("Loading uninitialized model")
-        model = load_model_uninitialized(args.local_model_path)
+        print("Loading uninitialized model from repo version")
+        model = load_model_uninitialized()
         model.eval()
         print("Model loaded successfully")
 

--- a/models/demos/deepseek_v3/utils/hf_model_utils.py
+++ b/models/demos/deepseek_v3/utils/hf_model_utils.py
@@ -20,7 +20,7 @@ def load_tokenizer(model_path: str):
     return AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
 
-def load_model_uninitialized(model_path: str):
+def load_model_uninitialized(model_path: str = os.path.dirname(os.path.dirname(__file__)) + "/reference"):
     model_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
     current_dtype = torch.get_default_dtype()


### PR DESCRIPTION
### What's changed
This PR makes the deepseek reference IO generation script use the implementation present inside of the repository, instead of the one that comes with the weights.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16721217219) CI passes (failures unrelated to the PR)