### PR TITLE
Fix demo test failures in CI for Qwen2.5-VL

### DIFF
--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -203,7 +203,7 @@ def create_tt_model(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"trace_region_size": 28278784, "num_command_queues": 1}],
+    [{"trace_region_size": 28467200, "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -203,7 +203,7 @@ def create_tt_model(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"trace_region_size": 28276736, "num_command_queues": 1}],
+    [{"trace_region_size": 28278784, "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Qwen2.5-VL demo tests start to fail in the CI due to trace region size insufficient issues, e.g., https://github.com/tenstorrent/tt-metal/actions/runs/16710908443/job/47295829900. 

### What's changed
Increased the trace region size specified in `demo.py`.

### Checklist
- [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
  - [x] https://github.com/tenstorrent/tt-metal/actions/runs/16725013329 --> two unrelated failed tests
- (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/w
orkflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
  - [x] https://github.com/tenstorrent/tt-metal/actions/runs/16725017600 --> qwen2.5-VL test succeeded.