### PR TITLE
Removed out_subblock_h and w reliance on enabled_split_reader flag in conv2d

### DIFF
--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -112,7 +112,7 @@ def create_unet_model_parameters(
 
     parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 3 * 32}
     parameters.c7["use_activation_double_buffer"] = True
-    parameters.c7["use_split_reader"] = False
+    parameters.c7["use_split_reader"] = True
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
     parameters.c7_2["use_activation_double_buffer"] = True
@@ -122,7 +122,7 @@ def create_unet_model_parameters(
 
     parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
     parameters.c8["use_activation_double_buffer"] = True
-    parameters.c8["use_split_reader"] = False
+    parameters.c8["use_split_reader"] = True
     parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -112,7 +112,7 @@ def create_unet_model_parameters(
 
     parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 3 * 32}
     parameters.c7["use_activation_double_buffer"] = True
-    parameters.c7["use_split_reader"] = True
+    parameters.c7["use_split_reader"] = False
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
     parameters.c7_2["use_activation_double_buffer"] = True
@@ -122,7 +122,7 @@ def create_unet_model_parameters(
 
     parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
     parameters.c8["use_activation_double_buffer"] = True
-    parameters.c8["use_split_reader"] = True
+    parameters.c8["use_split_reader"] = False
     parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -116,7 +116,8 @@ std::vector<CBInfo> get_cb_info(
         // ACT and ACT_SECOND_READER CB
         uint32_t act_cb_num_tiles = act_block_num_tiles;
         uint32_t act_block_split_num_tiles = 0;
-        if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED && conv_config.enable_split_reader) {
+        if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED && conv_config.enable_split_reader &&
+            !is_1d_depthwise_conv) {
             uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles;
             uint32_t act_block_h_nsubblocks_split_last = act_block_h_nsubblocks / 2;
             uint32_t act_block_h_nsubblocks_split = act_block_h_nsubblocks - act_block_h_nsubblocks_split_last;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -117,14 +117,12 @@ std::vector<CBInfo> get_cb_info(
         uint32_t act_cb_num_tiles = act_block_num_tiles;
         uint32_t act_block_split_num_tiles = 0;
         if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED && conv_config.enable_split_reader) {
-            uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
+            uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles;
             uint32_t act_block_h_nsubblocks_split_last = act_block_h_nsubblocks / 2;
             uint32_t act_block_h_nsubblocks_split = act_block_h_nsubblocks - act_block_h_nsubblocks_split_last;
 
-            act_cb_num_tiles =
-                act_block_h_nsubblocks_split * block_config.out_subblock_h_ntiles * block_config.act_block_w_ntiles;
-            act_block_split_num_tiles = act_block_h_nsubblocks_split_last * block_config.out_subblock_h_ntiles *
-                                        block_config.act_block_w_ntiles;
+            act_cb_num_tiles = act_block_h_nsubblocks_split * block_config.act_block_w_ntiles;
+            act_block_split_num_tiles = act_block_h_nsubblocks_split_last * block_config.act_block_w_ntiles;
         }
         if (conv_config.enable_act_double_buffer) {
             act_cb_num_tiles *= 2;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -329,7 +329,7 @@ OptimizedConvParallelizationConfig determine_conv_op_parallel_config_from_conv_o
 }
 
 static std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
-    uint32_t block_height, uint32_t block_width, bool fp32_accum, bool split_reader_enabled) {
+    uint32_t block_height, uint32_t block_width, bool fp32_accum) {
     constexpr std::array<std::pair<uint32_t, uint32_t>, 20> subblocks = {{
         {2, 4}, {4, 2}, {1, 8}, {8, 1}, {1, 7}, {7, 1}, {2, 3}, {3, 2}, {1, 6}, {6, 1},
         {1, 5}, {5, 1}, {2, 2}, {1, 4}, {4, 1}, {1, 3}, {3, 1}, {1, 2}, {2, 1}, {1, 1},
@@ -339,10 +339,6 @@ static std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
     uint32_t subblock_w = 0;
     for (auto [subblock_height, subblock_width] : subblocks) {
         if (fp32_accum && (subblock_height * subblock_width > 4)) {
-            continue;
-        }
-
-        if (split_reader_enabled && (block_height / subblock_height) < 2) {
             continue;
         }
 
@@ -357,10 +353,9 @@ static std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
     }
     TT_FATAL(
         subblock_h > 0 && subblock_w > 0,
-        "Could not find valid subblock size for block size {}x{}, split_reader_enabled: {}, fp32_accum: {}",
+        "Could not find valid subblock size for block size {}x{}, fp32_accum: {}",
         block_height,
         block_width,
-        split_reader_enabled,
         fp32_accum);
     return {subblock_h, subblock_w};
 }
@@ -431,8 +426,8 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     TT_ASSERT(act_block_w % 32 == 0);
     uint32_t act_block_w_ntiles = act_block_w / 32;
     uint32_t weight_block_w_ntiles = conv_op_parallel_config.per_core_out_matrix_width_ntile;
-    auto [out_subblock_h_ntiles, out_subblock_w_ntiles] = determine_largest_subblock_size(
-        act_block_h_ntiles, weight_block_w_ntiles, fp32_accum, act_block_h_ntiles > 1 && split_reader_enabled);
+    auto [out_subblock_h_ntiles, out_subblock_w_ntiles] =
+        determine_largest_subblock_size(act_block_h_ntiles, weight_block_w_ntiles, fp32_accum);
     return {
         .act_block_h_ntiles = act_block_h_ntiles,
         .act_block_w_ntiles = act_block_w_ntiles,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -116,7 +116,6 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     uint32_t window_h,
     uint32_t window_w,
     bool fp32_accum,
-    bool split_reader_enabled,
     bool full_inner_dim);
 
 std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryConfig> get_conv_configs(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -782,8 +782,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         act_num_subblocks,
         act_block_num_tiles,
         act_subblock_num_tiles,
-        enable_split_reader ? 1 : act_subblock_h_ntiles,
-
+        enable_split_reader ? act_block_h_ntiles : act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
         weight_num_subblocks,
         weight_block_num_tiles,
         weight_block_w_ntiles,
@@ -812,9 +811,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
         get_cb_info_by_name(cb_info, Conv2dCb::TEMP_SUM).index,
         partials_cb_uses_output,
-        conv_act_c_blocks,
-        enable_split_reader ? block_config.act_block_h_ntiles : act_num_subblocks,
-    };
+        conv_act_c_blocks};
 
     const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(device->arch());
     const tt::tt_metal::NOC reader_noc =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -234,7 +234,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t act_block_w_datums = act_matrix_width / num_blocks_act_w;
     uint32_t act_block_h_datums = act_matrix_height / num_blocks_act_h;
 
-    // ------------------------------------------------------------
     uint32_t act_block_h_nsubblocks_split = block_config.act_block_h_ntiles;
     uint32_t act_block_h_nsubblocks_split_last = 0;
     if (enable_split_reader) {
@@ -246,7 +245,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     uint32_t act_block_num_tiles_split = act_block_h_nsubblocks_split * act_block_w_ntiles;
     uint32_t act_block_num_tiles_split_last = act_block_h_nsubblocks_split_last * act_block_w_ntiles;
-    // ------------------------------------------------------------
 
     // weight block info
     uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
@@ -784,24 +782,24 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         act_num_subblocks,
         act_block_num_tiles,
         act_subblock_num_tiles,
-        enable_split_reader ? 1 : act_subblock_h_ntiles,  // 4
+        enable_split_reader ? 1 : act_subblock_h_ntiles,
 
         weight_num_subblocks,
         weight_block_num_tiles,
-        weight_block_w_ntiles,  // 7
+        weight_block_w_ntiles,
 
         num_blocks_act_h_per_core,
         in0_num_blocks_w,
-        num_blocks_weight_w_per_core,  // 10
+        num_blocks_weight_w_per_core,
 
         out_subblock_h_ntiles,
         out_subblock_w_ntiles,
-        out_subblock_num_tiles,  // 13
+        out_subblock_num_tiles,
 
         height_sharded,
         untilize_out,
 
-        bias_ntiles_per_core,  // 16
+        bias_ntiles_per_core,
 
         get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
@@ -812,7 +810,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
 
         get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::TEMP_SUM).index,  // 25
+        get_cb_info_by_name(cb_info, Conv2dCb::TEMP_SUM).index,
         partials_cb_uses_output,
         conv_act_c_blocks,
         enable_split_reader ? block_config.act_block_h_ntiles : act_num_subblocks,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -391,11 +391,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     const tt::tt_metal::CBHandle cb_partials = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     compute_kernel_args = {
-        act_block_w_ntiles,      // in0_block_w
-        act_num_subblocks,       // in0_num_sublocks
-        act_block_num_tiles,     // in0_block_num_tiles,
-        act_subblock_num_tiles,  // in0_sublock_num_tiles
-        act_subblock_h_ntiles,   // in0_subblock_h
+        act_block_w_ntiles,                         // in0_block_w
+        act_num_subblocks,                          // in0_num_sublocks
+        act_block_num_tiles,                        // in0_block_num_tiles,
+        act_subblock_num_tiles,                     // in0_sublock_num_tiles
+        act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
 
         weight_num_subblocks,    // in1_num_sublocks
         weight_block_num_tiles,  // in1_block_num_tiles,
@@ -424,7 +424,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         0,
         partials_cb_uses_output,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
-        act_num_subblocks,
+
     };
 
     activation_kernel_compile_args = {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -424,7 +424,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         0,
         partials_cb_uses_output,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
-
+        act_num_subblocks,
     };
 
     activation_kernel_compile_args = {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -23,17 +23,14 @@
 ALWI void ACQ() { acquire_dst(); }
 ALWI void REL() { release_dst(); }
 
-inline void tilize_in(
-    uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
+inline void tilize_in(uint32_t in_cb_id, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
     tilize_init(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
-        for (uint32_t h = 0; h < in_subblock_h; ++h) {
-            cb_wait_front(in_cb_id, in_block_w);
-            cb_reserve_back(out_cb_id, in_block_w);
-            tilize_block(in_cb_id, in_block_w, out_cb_id);
-            cb_push_back(out_cb_id, in_block_w);
-            cb_pop_front(in_cb_id, in_block_w);
-        }
+        cb_wait_front(in_cb_id, in_block_w);
+        cb_reserve_back(out_cb_id, in_block_w);
+        tilize_block(in_cb_id, in_block_w, out_cb_id);
+        cb_push_back(out_cb_id, in_block_w);
+        cb_pop_front(in_cb_id, in_block_w);
     }
     tilize_uninit(in_cb_id, out_cb_id);
 }
@@ -102,7 +99,7 @@ void MAIN {
     constexpr uint32_t in0_block_num_tiles =
         get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
     constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
-    constexpr uint32_t in0_subblock_h = get_compile_time_arg_val(4);
+    constexpr uint32_t reader_num_h_subblocks = get_compile_time_arg_val(4);
     constexpr uint32_t in1_num_subblocks =
         get_compile_time_arg_val(5);  // outer column block size (in inner column blocks)
     constexpr uint32_t in1_block_num_tiles =
@@ -143,7 +140,7 @@ void MAIN {
             if constexpr (tilize_in0) {
                 reconfig_data_format_srca(in0_cb_id);
                 pack_reconfig_data_format(tilized_in0_cb_id);
-                tilize_in(in0_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
+                tilize_in(in0_cb_id, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
             }
             reconfig_data_format_srca(tilized_in0_cb_id);
             pack_reconfig_data_format(eltwise_mul_partials_cb);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -121,8 +121,6 @@ void MAIN {
 
     constexpr uint32_t mm_in0_cb_id = height_sharded ? tilized_in0_cb_id : in0_cb_id;
 
-// TODO change for better split reader
-// ------------------------------------------------------------
 #ifdef SPLIT_READER
     constexpr bool split_reader = true;
     constexpr uint32_t in0_num_subblocks_read_last = reader_num_subblocks / 2;
@@ -131,7 +129,6 @@ void MAIN {
     constexpr bool split_reader = false;
     constexpr uint32_t in0_num_subblocks_read = reader_num_subblocks;
 #endif
-    // ------------------------------------------------------------
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef SFPU_OP_INIT_ACTIVATION

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -97,6 +97,7 @@ void MAIN {
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
     constexpr bool partials_cb_uses_output = get_compile_time_arg_val(26);
     constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(27);
+    constexpr uint32_t reader_num_subblocks = get_compile_time_arg_val(28);
 
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     constexpr uint32_t out_block_w = in1_block_w;
@@ -115,12 +116,15 @@ void MAIN {
 
     constexpr uint32_t mm_in0_cb_id = height_sharded ? tilized_in0_cb_id : in0_cb_id;
 
+// TODO change for better split reader
+// ------------------------------------------------------------
 #ifdef SPLIT_READER
-    constexpr uint32_t in0_num_subblocks_read_last = in0_num_subblocks / 2;
-    constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks - in0_num_subblocks_read_last;
+    constexpr uint32_t in0_num_subblocks_read_last = reader_num_subblocks / 2;
+    constexpr uint32_t in0_num_subblocks_read = reader_num_subblocks - in0_num_subblocks_read_last;
 #else
-    constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks;
+    constexpr uint32_t in0_num_subblocks_read = reader_num_subblocks;
 #endif
+    // ------------------------------------------------------------
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -159,7 +163,7 @@ void MAIN {
 #endif
 
                         tilize_in(
-                            in0_pretilize_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks, tilized_in0_cb_id);
+                            in0_pretilize_cb_id, in0_subblock_h, in0_block_w, reader_num_subblocks, tilized_in0_cb_id);
 
                         mm_block_init_short_with_both_dt(
                             in0_cb_id,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -806,7 +806,6 @@ static OptimizedConvBlockConfig get_opt_block_config(
         kernel_size[0],
         kernel_size[1],
         get_fp32_dest_acc_en(compute_config),
-        conv_config.enable_split_reader,
         conv_config.full_inner_dim);
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -210,7 +210,6 @@ Result conv_transpose2d(
         kernel_size[0],
         kernel_size[1],
         get_fp32_dest_acc_en(compute_config),
-        conv_config.enable_split_reader,
         conv_config.full_inner_dim);
 
     bool weight_is_on_device = tt::tt_metal::is_device_tensor(weight_tensor);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26331

### Problem description
Currently split reader unnecessarily affects choice of out_subblock_h and out_subblock_w in convolutions

### What's changed
- Removed split reader from calculation of out_subblock_h and out_subblock_w
- enabled split reader in 2 of the remaining unet convs that have it disabled

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16727092237)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/16752103960)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16752154031)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16752146488)