### PR TITLE
MoE: group expert token mapping tensor in reduced chunks

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_moe_expert_token_remap_t3k.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_moe_expert_token_remap_t3k.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from math import prod
+from math import prod, ceil
 import random
 
 import pytest
@@ -16,6 +16,8 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_to_all_dispatch_t3000 import 
     get_metadata_tensor,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
+
+REDUCTION_SIZE = 16
 
 
 def gen_topk(experts, indices_tensor, devices):
@@ -71,16 +73,35 @@ def gen_output_expert_token_activation(devices, topk_tensor, indices_tensor, exp
     return expert_token_activation_tensor
 
 
-def gen_tensors(devices, experts, batch, seq, selected_experts_k, mesh_shape, scheme):
+def gen_reduced_expert_token_activation(expert_token_activation_tensor, reduction_size):
+    devices, batch, seq, experts_per_device = expert_token_activation_tensor.shape
+
+    batch_seq = batch * seq
+    reduced_batch_seq = ceil(batch_seq / reduction_size)
+
+    rs_expert_token_activation_tensor = expert_token_activation_tensor.reshape((devices, batch_seq, experts_per_device))
+
+    reduced_tensor = torch.zeros((devices, 1, reduced_batch_seq, experts_per_device), dtype=torch.int16)
+    for d in range(devices):
+        for rbs in range(reduced_batch_seq):
+            ridx_start, ridx_end = rbs * reduction_size, (rbs + 1) * reduction_size
+            for e in range(experts_per_device):
+                reduced_tensor[d, 0, rbs, e] = rs_expert_token_activation_tensor[d, ridx_start:ridx_end, e].any().item()
+
+    return reduced_tensor
+
+
+def gen_tensors(devices, experts, batch, seq, selected_experts_k, mesh_shape, reduction_size, scheme):
     expert_mapping = gen_expert_mapping(experts, devices, scheme)
     expert_indices = get_expert_indices(batch, experts, selected_experts_k, seq, mesh_shape, scheme)
     topk_tensor = gen_topk(experts, expert_indices, prod(mesh_shape))
 
     output = gen_output_expert_token_activation(devices, topk_tensor, expert_indices, expert_mapping)
+    reduced_output = gen_reduced_expert_token_activation(output, reduction_size)
 
     metadata_tensor = get_metadata_tensor(expert_indices, expert_mapping, mesh_shape)
 
-    return expert_mapping, metadata_tensor, topk_tensor, output
+    return expert_mapping, metadata_tensor, topk_tensor, output, reduced_output
 
 
 @pytest.mark.parametrize(
@@ -114,11 +135,11 @@ def test_moe_expert_token_remaps(
     output_tensor_goldens_list = []
 
     for _ in range(num_iters):
-        expert_mapping, metadata_tensor, topk_tensor, output = gen_tensors(
-            devices, experts, batch, seq, selected_experts_k, mesh_shape, scheme
+        expert_mapping, metadata_tensor, topk_tensor, output_mapping, output_reduced = gen_tensors(
+            devices, experts, batch, seq, selected_experts_k, mesh_shape, REDUCTION_SIZE, scheme
         )
 
-        output_tensor_goldens_list.append(output)
+        output_tensor_goldens_list.append((output_mapping, output_reduced))
 
         tt_topk = ttnn.from_torch(
             topk_tensor,
@@ -162,10 +183,13 @@ def test_moe_expert_token_remaps(
         tt_op_out = ttnn.moe_expert_token_remap(topk, mapping, metadata)
         out_tensor_list.append(tt_op_out)
 
-    for ref, test in zip(output_tensor_goldens_list, out_tensor_list):
-        test_torch = ttnn.to_torch(test, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
-        assert_with_pcc(test_torch, ref)
+    for (mapping_ref, reduced_ref), (mapping_test, reduced_test) in zip(output_tensor_goldens_list, out_tensor_list):
+        mapping_test_torch = ttnn.to_torch(mapping_test, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+        assert_with_pcc(mapping_test_torch, mapping_ref)
 
+        reduced_test_torch = ttnn.to_torch(reduced_test, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+        assert_with_pcc(reduced_test_torch, reduced_ref)
+        
 
 @pytest.mark.parametrize(
     "mesh_shape, mesh_device", [pytest.param((2, 4), (2, 4), id="2x4_grid")], indirect=["mesh_device"]
@@ -180,11 +204,12 @@ def test_gen_tensors(mesh_device, mesh_shape, experts_per_device, batches_per_de
     batch = batches_per_device * devices
     experts = experts_per_device * devices
 
-    expert_mapping, metadata_tensor, topk_tensor, output = gen_tensors(
-        devices, experts, batch, seq, select_experts_k, mesh_shape, scheme
+    expert_mapping, metadata_tensor, topk_tensor, output, reduced_output = gen_tensors(
+        devices, experts, batch, seq, select_experts_k, mesh_shape, REDUCTION_SIZE, scheme
     )
 
     assert expert_mapping.shape == (1, 1, experts, devices)
     assert metadata_tensor.shape == (devices, batch, seq, select_experts_k)
     assert topk_tensor.shape == (devices, batch, seq, experts)
     assert output.shape == (devices, batch, seq, experts_per_device)
+    assert reduced_output.shape == (devices, 1, ceil(batch * seq / REDUCTION_SIZE), experts_per_device)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_moe_expert_token_remap_t3k.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_moe_expert_token_remap_t3k.py
@@ -15,7 +15,7 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_to_all_dispatch_t3000 import 
     get_expert_indices,
     get_metadata_tensor,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 REDUCTION_SIZE = 16
 
@@ -188,8 +188,8 @@ def test_moe_expert_token_remaps(
         assert_with_pcc(mapping_test_torch, mapping_ref)
 
         reduced_test_torch = ttnn.to_torch(reduced_test, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
-        assert_with_pcc(reduced_test_torch, reduced_ref)
-        
+        assert_equal(reduced_test_torch, reduced_ref)
+
 
 @pytest.mark.parametrize(
     "mesh_shape, mesh_device", [pytest.param((2, 4), (2, 4), id="2x4_grid")], indirect=["mesh_device"]

--- a/tt_metal/api/tt-metalium/work_split.hpp
+++ b/tt_metal/api/tt-metalium/work_split.hpp
@@ -49,5 +49,10 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
     const CoreRangeSet& core_grid, uint32_t units_to_divide, bool row_wise = false);
 
+// Splits up work in chunks of `multiple` . Not the most efficient distribution but useful for an even distribution
+// of the batch dimension
+std::tuple<std::vector<uint32_t>, CoreRangeSet> split_work_to_cores_even_multiples(
+    const CoreCoord& core_grid, uint32_t units_to_divide, uint32_t multiple, bool row_wise = false);
+
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -265,70 +265,29 @@ CoreRangeSet num_cores_to_corerangeset_in_subcoregrids(
     return CoreRangeSet(std::move(result_coreranges));
 }
 
-std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
-    const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise) {
+std::tuple<std::vector<uint32_t>, CoreRangeSet> split_work_to_cores_even_multiples(
+    const CoreCoord& core_grid, const uint32_t units_to_divide, const uint32_t multiple, const bool row_wise) {
     ZoneScoped;
-    if (units_to_divide == 0) {
-        return std::make_tuple(0, CoreRangeSet(), CoreRangeSet(), CoreRangeSet(), 0, 0);
-    }
-    uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y, max_num_cores = num_cores_x * num_cores_y,
-             target_num_cores;
-    CoreRangeSet all_cores;
-    if (units_to_divide >= max_num_cores) {
-        target_num_cores = max_num_cores;
-        all_cores = CoreRangeSet(CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1}));
-    } else {
-        target_num_cores = units_to_divide;
-        all_cores = num_cores_to_corerangeset(target_num_cores, grid_size, row_wise);
-    }
 
-    CoreRangeSet core_group_1;
-    CoreRangeSet core_group_2;
-    uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
-    uint32_t units_per_core_group_2 = 0;
-    uint32_t num_cores_with_more_work = units_to_divide % target_num_cores;
-    // Evenly divided units to all target cores
-    if (units_to_divide % target_num_cores == 0) {
-        core_group_1 = all_cores;
-    }
-    // Uneven division of units across cores
-    // This case should only be hit when there are more units of work than a full grid of cores
-    // which is implicitly assumed in the following logic
-    else {
-        // Group of cores that do more work
-        uint32_t num_core_group_1_cores = num_cores_with_more_work;
-        uint32_t num_core_group_2_cores = target_num_cores - num_core_group_1_cores;
-        core_group_1 = num_cores_to_corerangeset(num_core_group_1_cores, grid_size, row_wise);
-        const auto& last_core_group_1 = (*core_group_1.ranges().rbegin()).end_coord;
-        if (row_wise) {
-            // Start in the same row
-            if (last_core_group_1.x != num_cores_x - 1) {
-                core_group_2 = num_cores_to_corerangeset(
-                    {last_core_group_1.x + 1, last_core_group_1.y}, num_core_group_2_cores, grid_size, row_wise);
-            }
-            // Start in the next row
-            else {
-                core_group_2 = num_cores_to_corerangeset(
-                    {0, last_core_group_1.y + 1}, num_core_group_2_cores, grid_size, row_wise);
-            }
-        } else {
-            // Start in the same column
-            if (last_core_group_1.y != num_cores_y - 1) {
-                core_group_2 = num_cores_to_corerangeset(
-                    {last_core_group_1.x, last_core_group_1.y + 1}, num_core_group_2_cores, grid_size, row_wise);
-            }
-            // Start in the next column
-            else {
-                core_group_2 = num_cores_to_corerangeset(
-                    {last_core_group_1.x + 1, 0}, num_core_group_2_cores, grid_size, row_wise);
-            }
+    const uint32_t batches_to_divide = std::ceil(units_to_divide / multiple), max_num_cores = core_grid.x * core_grid.y;
+    const uint32_t target_num_cores = (batches_to_divide >= max_num_cores) ? max_num_cores : batches_to_divide;
+
+    std::vector<uint32_t> increments(target_num_cores, 0ul);
+    auto it = increments.begin();
+    for (uint32_t units = 0; units < units_to_divide; units += multiple) {
+        *(it++) += multiple;
+        if (it == increments.end()) {
+            it = increments.begin();
         }
-        units_per_core_group_2 = units_per_core_group_1;
-        units_per_core_group_1++;
     }
 
-    return std::make_tuple(
-        target_num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2);
+    auto rem = units_to_divide % multiple;
+    if (rem != 0) {
+        *it += rem;
+    }
+    const auto utilized_cores = num_cores_to_corerangeset({0, 0}, target_num_cores, core_grid, row_wise);
+
+    return std::make_tuple(increments, utilized_cores);
 }
 
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
@@ -354,6 +313,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
     uint32_t units_per_core_group_2 = 0;
     uint32_t num_cores_with_more_work = units_to_divide % target_num_cores;
+
     // Evenly divided units to all target cores
     if (target_num_cores == 0 || num_cores_with_more_work == 0) {
         core_group_1 = all_cores;
@@ -416,6 +376,76 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
 
     return std::make_tuple(
         target_num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2);
+}
+
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise) {
+    // ZoneScoped;
+    //     if (units_to_divide == 0) {
+    //         return std::make_tuple(0, CoreRangeSet(), CoreRangeSet(), CoreRangeSet(), 0, 0);
+    //     }
+    //     uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y, max_num_cores = num_cores_x * num_cores_y,
+    //              target_num_cores;
+    //     CoreRangeSet all_cores;
+    //     if (units_to_divide >= max_num_cores) {
+    //         target_num_cores = max_num_cores;
+    //         all_cores = CoreRangeSet(CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1}));
+    //     } else {
+    //         target_num_cores = units_to_divide;
+    //         all_cores = num_cores_to_corerangeset(target_num_cores, grid_size, row_wise);
+    //     }
+    //
+    //     CoreRangeSet core_group_1;
+    //     CoreRangeSet core_group_2;
+    //     uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
+    //     uint32_t units_per_core_group_2 = 0;
+    //     uint32_t num_cores_with_more_work = units_to_divide % target_num_cores;
+    //     // Evenly divided units to all target cores
+    //     if (units_to_divide % target_num_cores == 0) {
+    //         core_group_1 = all_cores;
+    //     }
+    //     // Uneven division of units across cores
+    //     // This case should only be hit when there are more units of work than a full grid of cores
+    //     // which is implicitly assumed in the following logic
+    //     else {
+    //         // Group of cores that do more work
+    //         uint32_t num_core_group_1_cores = num_cores_with_more_work;
+    //         uint32_t num_core_group_2_cores = target_num_cores - num_core_group_1_cores;
+    //         core_group_1 = num_cores_to_corerangeset(num_core_group_1_cores, grid_size, row_wise);
+    //         const auto& last_core_group_1 = (*core_group_1.ranges().rbegin()).end_coord;
+    //         if (row_wise) {
+    //             // Start in the same row
+    //             if (last_core_group_1.x != num_cores_x - 1) {
+    //                 core_group_2 = num_cores_to_corerangeset(
+    //                     {last_core_group_1.x + 1, last_core_group_1.y}, num_core_group_2_cores, grid_size, row_wise);
+    //             }
+    //             // Start in the next row
+    //             else {
+    //                 core_group_2 = num_cores_to_corerangeset(
+    //                     {0, last_core_group_1.y + 1}, num_core_group_2_cores, grid_size, row_wise);
+    //             }
+    //         } else {
+    //             // Start in the same column
+    //             if (last_core_group_1.y != num_cores_y - 1) {
+    //                 core_group_2 = num_cores_to_corerangeset(
+    //                     {last_core_group_1.x, last_core_group_1.y + 1}, num_core_group_2_cores, grid_size, row_wise);
+    //             }
+    //             // Start in the next column
+    //             else {
+    //                 core_group_2 = num_cores_to_corerangeset(
+    //                     {last_core_group_1.x + 1, 0}, num_core_group_2_cores, grid_size, row_wise);
+    //             }
+    //         }
+    //         units_per_core_group_2 = units_per_core_group_1;
+    //         units_per_core_group_1++;
+    //     }
+    //
+    //     return std::make_tuple(
+    //         target_num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2);
+
+    const auto target_num_cores = grid_size.x * grid_size.y;
+    auto core_grid = num_cores_to_corerangeset(target_num_cores, grid_size, row_wise);
+    return split_work_to_cores(core_grid, units_to_divide, row_wise);
 }
 
 }  // namespace tt_metal

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -37,9 +37,10 @@ void kernel_main() {
     constexpr uint32_t datum_size_bytes = get_compile_time_arg_val(8);
     constexpr uint32_t output_reduced_page_size_bytes = get_compile_time_arg_val(9);
     constexpr uint32_t reduction_size = get_compile_time_arg_val(10);
-    
-    constexpr auto output_mapping_args = TensorAccessorArgs<10>();
-    constexpr auto output_reduced_args = TensorAccessorArgs<output_mapping_args::output_mapping_args()>();
+
+    constexpr auto output_mapping_args = TensorAccessorArgs<11>();
+    constexpr auto output_reduced_args =
+        TensorAccessorArgs<decltype(output_mapping_args)::next_compile_time_args_offset()>();
 
     using data_addr_t = detail::DataTypeHolder<datum_size_bytes>::type;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -29,30 +29,48 @@ void kernel_main() {
     constexpr uint32_t local_experts_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t metadata_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t data_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t output_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(4);
-    constexpr uint32_t num_local_experts = get_compile_time_arg_val(5);
-    constexpr uint32_t output_page_size_bytes = get_compile_time_arg_val(6);  // num_local_experts * datum size
-    constexpr uint32_t datum_size_bytes = get_compile_time_arg_val(7);
-    constexpr auto dst_args = TensorAccessorArgs<8>();
+    constexpr uint32_t output_mapping_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t output_reduced_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(5);
+    constexpr uint32_t num_local_experts = get_compile_time_arg_val(6);
+    constexpr uint32_t output_mapping_page_size_bytes = get_compile_time_arg_val(7);  // num_local_experts * datum size
+    constexpr uint32_t datum_size_bytes = get_compile_time_arg_val(8);
+    constexpr uint32_t output_reduced_page_size_bytes = get_compile_time_arg_val(9);
+    constexpr uint32_t reduction_size = get_compile_time_arg_val(10);
+    
+    constexpr auto output_mapping_args = TensorAccessorArgs<10>();
+    constexpr auto output_reduced_args = TensorAccessorArgs<output_mapping_args::output_mapping_args()>();
 
     using data_addr_t = detail::DataTypeHolder<datum_size_bytes>::type;
 
-    const auto output_base_addr = get_arg_val<uint32_t>(0);
+    const auto output_mapping_base_addr = get_arg_val<uint32_t>(0);
     const auto start_idx = get_arg_val<uint32_t>(1);
     const auto end_idx = get_arg_val<uint32_t>(2);
+    const auto output_reduced_base_addr = get_arg_val<uint32_t>(3);
+    const auto reduce_start_idx = get_arg_val<uint32_t>(4);
 
-    const auto output_addrgen = TensorAccessor(dst_args, output_base_addr, output_page_size_bytes);
+    const auto output_mapping_addrgen = TensorAccessor(
+        output_mapping_args, output_mapping_base_addr, output_mapping_page_size_bytes);
+    const auto output_reduced_addrgen = TensorAccessor(
+        output_reduced_args, output_reduced_base_addr,output_reduced_page_size_bytes);
 
-    // scratch space
-    cb_reserve_back(output_cb_id, 1);
-    const uint32_t output_l1_addr = get_write_ptr(output_cb_id);
-    cb_push_back(output_cb_id, 1);
+    // scratch space for mapping
+    cb_reserve_back(output_mapping_cb_id, 1);
+    const uint32_t output_l1_addr = get_write_ptr(output_mapping_cb_id);
+    cb_push_back(output_mapping_cb_id, 1);
+
+    // scratch space for reduction
+    cb_reserve_back(output_reduced_cb_id, 1);
+    const uint32_t reduced_l1_addr = get_write_ptr(output_reduced_cb_id);
+    cb_push_back(output_reduced_cb_id, 1);
+    tt::data_movement::common::fill_with_val<uint16_t>(reduced_l1_addr, num_local_experts, 0u);
+    auto reduced_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(reduced_l1_addr);
 
     cb_wait_front(local_experts_cb_id, 1);
     auto local_experts_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(local_experts_cb_id));
 
-    for (uint32_t bs = start_idx; bs < end_idx; ++bs) {
+    for (uint32_t bs = start_idx, reduce_idx = reduce_start_idx, reduction_count = 0; bs < end_idx;
+         ++bs, ++reduction_count) {
         cb_wait_front(metadata_cb_id, 1);
         const uint32_t metadata_l1_addr = get_write_ptr(metadata_cb_id);
         auto metadata_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(metadata_l1_addr);
@@ -73,6 +91,8 @@ void kernel_main() {
                 const uint32_t output_l1_element_addr = output_l1_addr + e * datum_size_bytes;
                 tt::data_movement::common::tt_memmove<false, false, false, datum_size_bytes>(
                     output_l1_element_addr, topk_l1_addr, datum_size_bytes);
+
+                reduced_l1_ptr[e] = 1;
             }
         }
         const uint64_t output_noc_addr = get_noc_addr(bs, output_addrgen);
@@ -81,6 +101,14 @@ void kernel_main() {
         if (found) {
             cb_pop_front(data_cb_id, 1);
             found = false;
+        }
+
+        if (reduction_count == reduction_size - 1) {
+            const uint64_t output_reduced_noc_addr = get_noc_addr(reduce_idx++, output_reduced_addrgen);
+            noc_async_write(reduced_l1_addr, output_reduced_noc_addr, output_reduced_page_size_bytes);
+            noc_async_write_barrier();
+            tt::data_movement::common::fill_with_val<uint16_t>(reduced_l1_addr, num_local_experts, 0u);
+            reduction_count = 0;
         }
 
         cb_pop_front(metadata_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -95,8 +95,8 @@ void kernel_main() {
                 reduced_l1_ptr[e] = 1;
             }
         }
-        const uint64_t output_noc_addr = get_noc_addr(bs, output_addrgen);
-        noc_async_write(output_l1_addr, output_noc_addr, output_page_size_bytes);
+        const uint64_t output_noc_addr = get_noc_addr(bs, output_mapping_addrgen);
+        noc_async_write(output_l1_addr, output_noc_addr, output_mapping_page_size_bytes);
 
         if (found) {
             cb_pop_front(data_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.cpp
@@ -77,19 +77,35 @@ MoeExpertTokenRemapDeviceOperation::spec_return_value_t MoeExpertTokenRemapDevic
 
     const uint32_t num_local_experts = experts / num_devices;
 
-    const auto output_shape = ttnn::Shape({1, batch_size, seq_size, num_local_experts});
+    const ttnn::Shape output_mapping_shape{1, batch_size, seq_size, num_local_experts};
+
+    const uint32_t batch_seq = batch_size * seq_size;
+    const auto& reduction_size = operation_attributes.reduction_size;
+    const ttnn::Shape output_reduced_shape{1, 1, std::ceil(batch_seq / reduction_size), num_local_experts};
 
     const auto mem_config = operation_attributes.output_mem_config.value_or(MemoryConfig());
-    return TensorSpec(
-        Shape(output_shape),
+    TensorSpec output_mapping_spec(
+        Shape(output_mapping_shape),
         TensorLayout(tensor_args.topk_tensor.dtype(), PageConfig(tensor_args.topk_tensor.layout()), mem_config));
+
+    TensorSpec output_reduced_spec(
+        Shape(output_reduced_shape),
+        TensorLayout(tt::tt_metal::DataType::UINT16, PageConfig(tensor_args.topk_tensor.layout()), mem_config));
+
+    return {output_mapping_spec, output_reduced_spec};
 }
 
 MoeExpertTokenRemapDeviceOperation::tensor_return_value_t MoeExpertTokenRemapDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return tensor_args.optional_output_tensor.value_or(
-        create_device_tensor(output_spec, tensor_args.topk_tensor.device()));
+
+    const auto output_mapping_tensor = tensor_args.optional_output_mapping_tensor.value_or(
+        create_device_tensor(output_spec[0], tensor_args.topk_tensor.device()));
+
+    const auto output_reduced_tensor = tensor_args.optional_output_reduced_tensor.value_or(
+        create_device_tensor(output_spec[1], tensor_args.topk_tensor.device()));
+
+    return {output_mapping_tensor, output_reduced_tensor};
 }
 
 std::
@@ -99,14 +115,17 @@ std::
         const ttnn::Tensor& mapping_tensor,
         const ttnn::Tensor& metadata_tensor,
         const std::optional<ttnn::MemoryConfig>& output_mem_config,
-        const std::optional<ttnn::Tensor>& optional_output_tensor) {
+        const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
+        const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
+        const uint32_t reduction_size) {
     return {
-        operation_attributes_t{.output_mem_config = output_mem_config},
+        operation_attributes_t{.output_mem_config = output_mem_config, .reduction_size = reduction_size},
         tensor_args_t{
             .topk_tensor = topk_tensor,
             .mapping_tensor = mapping_tensor,
             .metadata_tensor = metadata_tensor,
-            .optional_output_tensor = optional_output_tensor}};
+            .optional_output_mapping_tensor = optional_output_mapping_tensor,
+            .optional_output_reduced_tensor = optional_output_reduced_tensor}};
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
@@ -92,7 +92,7 @@ struct MoeExpertTokenRemapDeviceOperation {
         const std::optional<ttnn::MemoryConfig>& output_mem_config,
         const std::optional<ttnn::Tensor>& optional_output_tensor,
         const std::optional<ttnn::Tensor>& optional_reduced_tensor,
-        const uint32_t reduction_size = REDUCTION_SIZE);
+        uint32_t reduction_size = REDUCTION_SIZE);
 };
 }  // namespace ttnn::operations::data_movement
 

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
@@ -17,22 +17,26 @@
 namespace ttnn::operations::data_movement {
 
 struct MoeExpertTokenRemapDeviceOperation {
+    static constexpr uint32_t REDUCTION_SIZE = 16;
+
     struct operation_attributes_t {
         const std::optional<MemoryConfig> output_mem_config;
+        const uint32_t reduction_size;
 
-        static constexpr auto attribute_names = std::forward_as_tuple("output_mem_config");
-        auto attribute_values() const { return std::forward_as_tuple(output_mem_config); };
+        static constexpr auto attribute_names = std::forward_as_tuple("output_mem_config", "reduction_size");
+        auto attribute_values() const { return std::forward_as_tuple(output_mem_config, reduction_size); };
     };
     struct tensor_args_t {
         const ttnn::Tensor topk_tensor;
         const ttnn::Tensor mapping_tensor;
         const ttnn::Tensor metadata_tensor;
-        const std::optional<ttnn::Tensor> optional_output_tensor;
+        const std::optional<ttnn::Tensor> optional_output_mapping_tensor;
+        const std::optional<ttnn::Tensor> optional_output_reduced_tensor;
     };
 
-    using spec_return_value_t = ttnn::TensorSpec;
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
 
-    using tensor_return_value_t = ttnn::Tensor;
+    using tensor_return_value_t = std::vector<ttnn::Tensor>;
 
     struct Multicore {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
@@ -86,7 +90,9 @@ struct MoeExpertTokenRemapDeviceOperation {
         const ttnn::Tensor& mapping_tensor,
         const ttnn::Tensor& metadata_tensor,
         const std::optional<ttnn::MemoryConfig>& output_mem_config,
-        const std::optional<ttnn::Tensor>& optional_output_tensor);
+        const std::optional<ttnn::Tensor>& optional_output_tensor,
+        const std::optional<ttnn::Tensor>& optional_reduced_tensor,
+        const uint32_t reduction_size = REDUCTION_SIZE);
 };
 }  // namespace ttnn::operations::data_movement
 

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
@@ -42,7 +42,7 @@ struct MoeExpertTokenRemapDeviceOperation {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
         struct shared_variables_t {
             tt::tt_metal::KernelHandle ternary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
+            tt::tt_metal::KernelHandle binary_writer_kernel_id;
             std::vector<CoreCoord> utilized_cores;
         };
         using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -194,7 +194,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     const auto num_metadata_pages = metadata_tensor.buffer()->num_pages();
 
     const auto [core_page_increments, all_cores] =
-        split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
+        tt::tt_metal::split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
 
     const auto mapping_tensor_addr = mapping_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();
     const auto metadata_tensor_addr = metadata_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();
@@ -207,7 +207,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     uint32_t page_idx_start = 0, page_idx_end = 0;
     constexpr auto num_reader_rt_args = 5, num_writer_rt_args = 5;
     std::vector<CoreCoord> utilized_cores = corerange_to_cores(all_cores, std::nullopt);
-    TT_ASSERT(utilized_cores.size() == core_page_increments.size());
+    TT_FATAL(utilized_cores.size() == core_page_increments.size(), "Internal error");
 
     auto cit = utilized_cores.begin();
     for (auto increment : core_page_increments) {

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -155,7 +155,8 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         topk_is_dram,
         mapping_is_dram,
         metadata_is_dram,
-        local_reduce};
+        local_reduce,
+        flat_mesh_idx};
 
     tt::tt_metal::KernelHandle ternary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -166,7 +167,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
 
     const auto output_datum_size_bytes = tt::datum_size(output_mapping_data_format);
     const auto reduction_size = operation_attributes.reduction_size;
-    const std::vector<uint32_t> writer_ct_args = {
+    std::vector<uint32_t> writer_ct_args = {
         local_experts_cb_id,
         metadata_cb_id,
         topk_cb_id,
@@ -193,7 +194,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     const auto num_metadata_pages = metadata_tensor.buffer()->num_pages();
 
     const auto [core_page_increments, all_cores] =
-        tt::tt_metal::split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
+        split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
 
     const auto mapping_tensor_addr = mapping_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();
     const auto metadata_tensor_addr = metadata_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -155,8 +155,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         topk_is_dram,
         mapping_is_dram,
         metadata_is_dram,
-        local_reduce,
-        flat_mesh_idx};
+        local_reduce};
 
     tt::tt_metal::KernelHandle ternary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -114,13 +114,21 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
             .set_page_size(topk_cb_id, aligned_topk_page_size_bytes);
     const auto topk_cb_handle = CreateCircularBuffer(program, total_cores, cb_topk_config);
 
-    // output staging buffer
-    const auto output_data_format = datatype_to_dataformat_converter(output_mapping_tensor.dtype());
-    const auto output_cb_id = tt::CBIndex::c_4;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(output_mapping_page_size_bytes, {{output_cb_id, output_data_format}})
-            .set_page_size(output_cb_id, output_mapping_page_size_bytes);
-    const auto output_cb_handle = CreateCircularBuffer(program, total_cores, cb_output_config);
+    // output mapping staging buffer
+    const auto output_mapping_data_format = datatype_to_dataformat_converter(output_mapping_tensor.dtype());
+    const auto output_mapping_cb_id = tt::CBIndex::c_4;
+    CircularBufferConfig cb_output_mapping_config =
+        CircularBufferConfig(output_mapping_page_size_bytes, {{output_mapping_cb_id, output_mapping_data_format}})
+            .set_page_size(output_mapping_cb_id, output_mapping_page_size_bytes);
+    const auto output_mapping_cb_handle = CreateCircularBuffer(program, total_cores, cb_output_mapping_config);
+
+    // output reduced staging buffer
+    const auto output_reduced_data_format = datatype_to_dataformat_converter(output_reduced_tensor.dtype());
+    const auto output_reduced_cb_id = tt::CBIndex::c_5;
+    CircularBufferConfig cb_output_reduced_config =
+        CircularBufferConfig(output_reduced_page_size_bytes, {{output_reduced_cb_id, output_reduced_data_format}})
+            .set_page_size(output_reduced_cb_id, output_reduced_page_size_bytes);
+    const auto output_reduced_cb_handle = CreateCircularBuffer(program, total_cores, cb_output_reduced_config);
 
     const auto& mesh_view = mesh_device->get_view();
     const uint32_t flat_mesh_idx = mesh_coordinate[0] * mesh_view.num_cols() + mesh_coordinate[1];
@@ -155,21 +163,26 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
 
-    const auto output_datum_size_bytes = tt::datum_size(output_data_format);
-    std::vector<uint32_t> writer_ct_args = {
+
+    const auto output_datum_size_bytes = tt::datum_size(output_mapping_data_format);
+    const auto reduction_size = operation_attributes.reduction_size;
+    const std::vector<uint32_t> writer_ct_args = {
         local_experts_cb_id,
         metadata_cb_id,
         topk_cb_id,
-        output_cb_id,
+        output_mapping_cb_id,
+        output_reduced_cb_id,
         selected_experts_k,
         experts_per_device,
         output_mapping_page_size_bytes,
         output_datum_size_bytes,
-        operation_attributes.reduction_size,
+        output_reduced_page_size_bytes,
+        reduction_size,
     };
     tt::tt_metal::TensorAccessorArgs(*output_mapping_tensor.buffer()).append_to(writer_ct_args);
+    tt::tt_metal::TensorAccessorArgs(*output_reduced_tensor.buffer()).append_to(writer_ct_args);
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+    tt::tt_metal::KernelHandle binary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/"
         "writer_moe_expert_token_remap.cpp",
@@ -178,12 +191,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
 
     // split work over metadata pages (batch*seq)
     const auto num_metadata_pages = metadata_tensor.buffer()->num_pages();
-    //     const auto
-    //         [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1,
-    //         num_tiles_per_core_group_2] =
-    //             tt::tt_metal::split_work_to_cores(grid, num_metadata_pages);
 
-    const auto reduction_size = operation_attributes.reduction_size;
     const auto [core_page_increments, all_cores] =
         split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
 
@@ -196,7 +204,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         output_reduced_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();
 
     uint32_t page_idx_start = 0, page_idx_end = 0;
-    constexpr auto num_reader_rt_args = 5, num_writer_rt_args = 3;
+    constexpr auto num_reader_rt_args = 5, num_writer_rt_args = 5;
     std::vector<CoreCoord> utilized_cores = corerange_to_cores(all_cores, std::nullopt);
     TT_ASSERT(utilized_cores.size() == core_page_increments.size());
 
@@ -207,14 +215,12 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
             mapping_tensor_addr, metadata_tensor_addr, topk_tensor_addr, page_idx_start, page_idx_end};
         tt::tt_metal::SetRuntimeArgs(program, ternary_reader_kernel_id, *cit, reader_runtime_args);
 
-        const uint32_t reduction_idx_start = page_idx_start / operation_attributes.reduction_size;
+        const uint32_t reduction_idx_start = page_idx_start / reduction_size;
 
         const std::array<uint32_t, num_writer_rt_args> writer_runtime_args = {
-            output_mapping_tensor_addr,
-            page_idx_start,
-            page_idx_end};  // TODO , output_reduced_tensor_addr, reduction_idx_start};
+            output_mapping_tensor_addr, page_idx_start, page_idx_end, output_reduced_tensor_addr, reduction_idx_start};
 
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, *cit, writer_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, binary_writer_kernel_id, *cit, writer_runtime_args);
 
         page_idx_start += increment;
         ++cit;
@@ -223,7 +229,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     return {
         std::move(program),
         {.ternary_reader_kernel_id = ternary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
+         .binary_writer_kernel_id = binary_writer_kernel_id,
          .utilized_cores = utilized_cores}};
 }
 
@@ -245,20 +251,19 @@ void MoeExpertTokenRemapDeviceOperation::Multicore::override_runtime_arguments(
 
         const auto& shared_variables = cached_workload.shared_variables.at(range);
         auto& ternary_reader_kernel_id = shared_variables.ternary_reader_kernel_id;
-        auto& unary_writer_kernel_id = shared_variables.unary_writer_kernel_id;
+        auto& binary_writer_kernel_id = shared_variables.binary_writer_kernel_id;
         auto& utilized_cores = shared_variables.utilized_cores;
 
         for (const auto& c : utilized_cores) {
             auto& reader_runtime_args = GetRuntimeArgs(program, ternary_reader_kernel_id, c);
-            auto& writer_runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, c);
+            auto& writer_runtime_args = GetRuntimeArgs(program, binary_writer_kernel_id, c);
 
             reader_runtime_args.at(0) = tensor_args.mapping_tensor.mesh_buffer()->get_device_buffer(coord)->address();
             reader_runtime_args.at(1) = tensor_args.metadata_tensor.mesh_buffer()->get_device_buffer(coord)->address();
             reader_runtime_args.at(2) = tensor_args.topk_tensor.mesh_buffer()->get_device_buffer(coord)->address();
 
             writer_runtime_args.at(0) = output_mapping_tensor.mesh_buffer()->get_device_buffer(coord)->address();
-
-            // TODO
+            writer_runtime_args.at(3) = output_reduced_tensor.mesh_buffer()->get_device_buffer(coord)->address();
         }
     }
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -193,7 +193,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     const auto num_metadata_pages = metadata_tensor.buffer()->num_pages();
 
     const auto [core_page_increments, all_cores] =
-        split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
+        tt::tt_metal::split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
 
     const auto mapping_tensor_addr = mapping_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();
     const auto metadata_tensor_addr = metadata_tensor.mesh_buffer()->get_device_buffer(mesh_coordinate)->address();

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.cpp
@@ -6,21 +6,28 @@
 
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
-#include "device/moe_expert_token_remap_device_operation.hpp"
 
 #include "moe_expert_token_remap.hpp"
 
 namespace ttnn::operations::data_movement {
 
-ttnn::Tensor ExecuteMoeExpertTokenRemap::invoke(
+std::vector<ttnn::Tensor> ExecuteMoeExpertTokenRemap::invoke(
     QueueId queue_id,
     const ttnn::Tensor& topk_tensor,
     const ttnn::Tensor& expert_mapping_tensor,
     const ttnn::Tensor& expert_metadata_tensor,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& optional_output_tensor) {
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    const std::optional<ttnn::Tensor>& optional_reduced_tensor,
+    const uint32_t reduction_size) {
     return ttnn::prim::moe_expert_token_remap(
-        topk_tensor, expert_mapping_tensor, expert_metadata_tensor, memory_config, optional_output_tensor);
+        topk_tensor,
+        expert_mapping_tensor,
+        expert_metadata_tensor,
+        memory_config,
+        optional_output_tensor,
+        optional_reduced_tensor,
+        reduction_size);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp
@@ -11,6 +11,7 @@ namespace ttnn {
 namespace operations::data_movement {
 
 struct ExecuteMoeExpertTokenRemap {
+    static constexpr auto REDUCTION_SIZE = MoeExpertTokenRemapDeviceOperation::REDUCTION_SIZE;
     static std::vector<ttnn::Tensor> invoke(
         QueueId queue_id,
         const ttnn::Tensor& input_tensor,
@@ -19,7 +20,7 @@ struct ExecuteMoeExpertTokenRemap {
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<ttnn::Tensor>& optional_reduced_tensor = std::nullopt,
-        uint32_t reduction_size = MoeExpertTokenRemapDeviceOperation::REDUCTION_SIZE);
+        uint32_t reduction_size = REDUCTION_SIZE);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp
@@ -5,18 +5,21 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
+#include "device/moe_expert_token_remap_device_operation.hpp"
 
 namespace ttnn {
 namespace operations::data_movement {
 
 struct ExecuteMoeExpertTokenRemap {
-    static ttnn::Tensor invoke(
+    static std::vector<ttnn::Tensor> invoke(
         QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& expert_mapping_tensor,
         const ttnn::Tensor& expert_metadata_tensor,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt);
+        const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<ttnn::Tensor>& optional_reduced_tensor = std::nullopt,
+        uint32_t reduction_size = MoeExpertTokenRemapDeviceOperation::REDUCTION_SIZE);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap_pybind.cpp
@@ -30,10 +30,14 @@ Args:
 Keyword Args:
     memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
     queue_id (int, optional): command queue id. Defaults to `0`.
-    output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+    output_mapping_tensor (ttnn.Tensor, optional): Preallocated output mapping tensor. Defaults to `None`.
+    output_reduced_tensor (ttnn.Tensor, optional): Preallocated output reduced tensor. Defaults to `None`.
+    reduction_size (int, optional): reduction chunk size
 
 Returns:
+    Tuple:
     ttnn.Tensor: Tensor that maps batch tokens to local experts, `[devices/devices, batch, seq, experts_per_device]`
+    ttnn.Tensor: Bool Tensor that reduces the mapping tensor by chunks of `reduction_size`, `[devices/devices, batch*seq/reduction_size, experts_per_device]`
 
     )doc";
 
@@ -48,7 +52,9 @@ Returns:
                const ttnn::Tensor& expert_mapping_tensor,
                const ttnn::Tensor& expert_metadata_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& optional_output_tensor,
+               const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
+               const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
+               const uint32_t reduction_size,
                QueueId queue_id) {
                 return self(
                     queue_id,
@@ -56,14 +62,18 @@ Returns:
                     expert_mapping_tensor,
                     expert_metadata_tensor,
                     memory_config,
-                    optional_output_tensor);
+                    optional_output_mapping_tensor,
+                    optional_output_reduced_tensor,
+                    reduction_size);
             },
             py::arg("topk_tensor").noconvert(),
             py::arg("expert_indices_tensor").noconvert(),
             py::arg("expert_mapping_tensor").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("optional_output_tensor") = std::nullopt,
+            py::arg("optional_output_mapping_tensor") = std::nullopt,
+            py::arg("optional_output_reduced_tensor") = std::nullopt,
+            py::arg("reduction_size") = ExecuteMoeExpertTokenRemap::REDUCTION_SIZE,
             py::arg("queue_id") = DefaultQueueId,
         });
 }


### PR DESCRIPTION
### Ticket
#25818 

### Problem description
- Provide a "chunk compressed" version of the MoE expert token mapping tensor to facilitate optimized sparse matmul 

### What's changed
- `moe_token_expert_remap` op now also produces a "reduced" tensor that tracks when an expert has been activated for any token in a batch of `reduction_size`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16778896577
- [x] T3K testhttps://github.com/tenstorrent/tt-metal/actions/runs/16834876565
- [x] New/Existing tests provide coverage for changes