### PR TITLE
#23626 revert of revert of original Binary_ng row subtile broadcast using LLK with bfloat16

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1947,9 +1947,11 @@ def test_binary_subtile_row_bcast(a_shape, b_shape, device):
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
     torch_input_tensor_b, input_tensor_b = rand_bf16_gen(b_shape, device)
 
-    torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
+    torch_output_tensor = torch_input_tensor_a - torch_input_tensor_b
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn.subtract(
+        input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None
+    )
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
@@ -1958,27 +1960,38 @@ def test_binary_subtile_row_bcast(a_shape, b_shape, device):
 
 profile_a_b_shape_pairs = [
     # [[8192, 8192], [8192, 8192]],
-    # [[1, 8192], [8192, 8192]],
+    [[1, 8192], [8192, 8192]],
     # [[8192, 8192], [1, 8192]],
-    # [[8192, 1], [8192, 8192]],
+    # [8192, 1], [8192, 8192]],
     # [[8192, 8192], [8192, 1]],
     # [[1, 8192], [8192, 1]],
     # [[8192, 1], [1, 8192]],
     # [[1, 1], [8192, 8192]],
-    [[8192, 8192], [1, 1]],
+    # [[8192, 8192], [1, 1]],
 ]
 
 
 @pytest.mark.parametrize(
     "dtype_pt, dtype_tt",
-    ((torch.bfloat16, ttnn.bfloat16),),
+    (
+        (torch.bfloat16, ttnn.bfloat16),
+        # (torch.int32, ttnn.int32),
+        # (torch.float32, ttnn.float32)
+    ),
 )
 @pytest.mark.parametrize(
     "memory_config_input",
     [ttnn.DRAM_MEMORY_CONFIG],
 )
+@pytest.mark.parametrize(
+    "use_legacy",
+    [
+        # True,
+        False,
+    ],
+)
 @pytest.mark.parametrize("a_and_b_shape", profile_a_b_shape_pairs)
-def test_binary_bcast_profile(device, dtype_pt, dtype_tt, a_and_b_shape, memory_config_input):
+def test_binary_bcast_profile(device, dtype_pt, dtype_tt, a_and_b_shape, memory_config_input, use_legacy):
     torch.manual_seed(0)
     a_shape, b_shape = a_and_b_shape
 
@@ -1998,7 +2011,7 @@ def test_binary_bcast_profile(device, dtype_pt, dtype_tt, a_and_b_shape, memory_
         torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config_input
     )
     for _ in range(2):
-        output = ttnn.add(input_tensor_a, input_tensor_b, memory_config=memory_config_input, use_legacy=False)
+        output = ttnn.add(input_tensor_a, input_tensor_b, memory_config=memory_config_input, use_legacy=use_legacy)
         output = ttnn.to_torch(output)
 
         assert (
@@ -2122,7 +2135,7 @@ def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
 
     torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -176,17 +176,28 @@ inline auto preprocess_inputs(BinaryOpType binary_op_type, Tensor a, Tensor b) {
     return std::make_tuple(a, b);
 }
 
-inline auto any_row_broadcasted(const Tensor& a, const auto& b) {
-    if constexpr (requires { b.logical_shape(); }) {
+inline auto any_non_llk_row_broadcasted(const Tensor& a, const auto& b) {
+    if constexpr (requires {
+                      b.logical_shape();
+                      b.dtype();
+                  }) {
         const auto& a_shape = a.logical_shape();
         const auto& b_shape = b.logical_shape();
+        const auto& a_dtype = a.dtype();
+        const auto& b_dtype = b.dtype();
 
-        return (a_shape[-2] == 1 and b_shape[-2] > 1 and a_shape[-1] > 1) or
-               (b_shape[-2] == 1 and a_shape[-2] > 1 and b_shape[-1] > 1);
+        if ((a_shape[-2] == 1 and b_shape[-2] > 1 and a_shape[-1] > 1) or
+            (b_shape[-2] == 1 and a_shape[-2] > 1 and b_shape[-1] > 1)) {
+            if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
+                return false;
+            }
+            return true;
+        }
     }
 
     return false;
 }
+
 inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
     if (a.is_sharded() and is_block_format(a.dtype())) {
         return true;
@@ -304,12 +315,6 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
             return true;
         }
 
-        if (any_row_broadcasted(a, b) and
-            (binary_op_type != BinaryOpType::ADD and binary_op_type != BinaryOpType::SUB and
-             binary_op_type != BinaryOpType::MUL)) {
-            return true;
-        }
-
         if (a.logical_shape().rank() > 4 or b.logical_shape().rank() > 4) {
             return true;
         }
@@ -322,8 +327,14 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
             a.logical_shape()[-1] == 1) {
             return true;
         }
+        // check functionality first, performance second
+        if (any_non_llk_row_broadcasted(a, b) and
+            (binary_op_type != BinaryOpType::ADD and binary_op_type != BinaryOpType::SUB and
+             binary_op_type != BinaryOpType::MUL)) {
+            return true;
+        }
 
-        if (any_row_broadcasted(a, b) and (is_block_format(a.dtype()) or is_block_format(b.dtype()))) {
+        if (any_non_llk_row_broadcasted(a, b) and (is_block_format(a.dtype()) or is_block_format(b.dtype()))) {
             // TODO
             // return true;
         }
@@ -342,7 +353,7 @@ bool is_legacy_only(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations) {
     const auto& output_mem_cfg = memory_config.value_or(output ? output->memory_config() : MemoryConfig{});
 
-    if (detail::any_row_broadcasted(lhs, rhs) or detail::any_sharded_block_format(lhs, rhs) or
+    if (detail::any_non_llk_row_broadcasted(lhs, rhs) or detail::any_sharded_block_format(lhs, rhs) or
         detail::any_subtile_broadcasted_block_format(lhs, rhs) or
         detail::any_non_height_sharded_w_bcast(lhs, rhs, output_mem_cfg) or detail::any_uneven(lhs, rhs, output) or
         detail::any_sharded_scalar(lhs, rhs)) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -680,14 +680,6 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         all_device_cores,
         tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram, has_sharding}, std::move(writer_defines)));
 
-    // READER KERNEL
-
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op),
-        all_device_cores,
-        tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding, b_is_dram}, std::move(reader_defines)));
-
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
                             c_data_format == tt::DataFormat::Float32;
@@ -736,6 +728,13 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .compile_args = {num_tiles_per_cycle},
             .defines = std::move(compute_kernel_defines)});
+
+    // READER KERNEL
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op),
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding, b_is_dram}, std::move(reader_defines)));
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -459,6 +459,26 @@ KernelName get_reader_kernel_name_and_defines(
         TT_FATAL(false, "Unsupported subtile broadcast type {}", static_cast<int>(subtile_broadcast_type));
     }
 }
+
+void overwrite_compute_kernel_name_and_defines(
+    KernelName& kernel_name,
+    const SubtileBroadcastType subtile_broadcast_type,
+    std::map<std::string, std::string>& compute_defines) {
+    compute_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
+    compute_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
+    kernel_name = KernelName::ComputeRowBcastNg;
+}
+
+bool is_llk_bcast(const SubtileBroadcastType subtile_broadcast_type, const DataType a_dtype, const DataType b_dtype) {
+    if (not(subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+            subtile_broadcast_type == SubtileBroadcastType::ROW_B)) {
+        return false;
+    }
+    if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
+        return true;
+    }
+    return false;
+}
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -606,6 +626,13 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             tt::CBIndex::c_4, program, all_device_cores, b_intermediate_single_tile_size, 1, b_intermediate_format);
     }
 
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A) {
+        create_cb(tt::CBIndex::c_5, program, all_device_cores, a_single_tile_size, 2, a_data_format);
+    }
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        create_cb(tt::CBIndex::c_6, program, all_device_cores, b_single_tile_size, 2, b_data_format);
+    }
+
     auto [c_cb, c_cb_handle] = create_cb(
         tt::CBIndex::c_2,
         program,
@@ -693,7 +720,13 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
 
     const uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
-
+    if (CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(operation_attributes.subtile_broadcast_type, a_dtype, b_dtype)) {
+        CMAKE_UNIQUE_NAMESPACE::overwrite_compute_kernel_name_and_defines(
+            compute_kernel, operation_attributes.subtile_broadcast_type, compute_kernel_defines);
+        reader_defines["BCAST_LLK"] = "1";
+    } else {
+        reader_defines["BCAST_LLK"] = "0";
+    }
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(compute_kernel, is_sfpu_op),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -136,6 +136,9 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu) {
             return fmt::format(compute, root, is_sfpu ? "eltwise_binary_sfpu.cpp" : "eltwise_binary.cpp");
         case KernelName::ComputeScalar:
             return fmt::format(compute, root, is_sfpu ? "eltwise_binary_sfpu_scalar.cpp" : "eltwise_binary_scalar.cpp");
+        case KernelName::ComputeRowBcastNg:
+            return fmt::format(
+                compute, root_ng, is_sfpu ? "eltwise_binary_sfpu_row_bcast.cpp" : "eltwise_binary_row_bcast.cpp");
         default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -32,6 +32,7 @@ enum class KernelName {
     ReaderColBcastNg,
     ReaderRowBColABcastNg,
     ReaderScalarBcastNg,
+    ComputeRowBcastNg,
 };
 
 struct BinaryNgKernelConfig {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
@@ -61,17 +61,16 @@ FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t cb_id) {
     // So we have to fill faces 0 and 2 with the first row of face 0, and faces 1 and 3
     // with the first row of face 1.
     auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
-
     uint32_t row_offset = 8;  // start at second row since first row is source
     uint32_t num_rows = 15;
 
     // iterate over face pairs (0,1) and (2,3)
-    for(uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 256) {
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 256) {
         for (uint32_t row = 0; row < num_rows; ++row) {
             uint32_t dst_offset = face_offset + row_offset;
             for (uint32_t col = 0; col < 8; ++col) {
-                ptr[dst_offset + col] = ptr[col];             // left face
-                ptr[dst_offset + col + 128] = ptr[col + 128]; // right face
+                ptr[dst_offset + col] = ptr[col];              // left face
+                ptr[dst_offset + col + 128] = ptr[col + 128];  // right face
             }
             row_offset += 8;
         }
@@ -120,10 +119,10 @@ FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t cb_id) {
             uint32_t dst_offset = face_offset + row_offset;
             auto src_val = ptr[dst_offset];
 
-            ptr[dst_offset + 256] = src_val; // first column of right face
+            ptr[dst_offset + 256] = src_val;  // first column of right face
             for (uint32_t col = 1; col < 16; ++col) {
-                ptr[dst_offset + col] = src_val;       // left face
-                ptr[dst_offset + col + 256] = src_val; // right face
+                ptr[dst_offset + col] = src_val;        // left face
+                ptr[dst_offset + col + 256] = src_val;  // right face
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/bcast.h"
+
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = cb_post_lhs;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_left = tt::CBIndex::c_5;
+    constexpr auto cb_right = cb_post_rhs;
+
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = cb_post_rhs;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_left = cb_post_lhs;
+    constexpr auto cb_right = tt::CBIndex::c_6;
+#endif
+
+    binary_op_init_common(cb_left, cb_right, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+#endif
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
+
+        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
+
+        cb_reserve_back(cb_llk_post, 1);
+        unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_bcast, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        cb_push_back(cb_llk_post, 1);
+        tile_regs_release();
+
+        cb_pop_front(cb_bcast, 1);
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_left, cb_right);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_llk_post, 1);
+
+        tile_regs_acquire();
+        BINARY_OP(cb_left, cb_right, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_left, num_tiles_per_cycle);
+        cb_pop_front(cb_right, num_tiles_per_cycle);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/binary_bitwise_sfpu.h"
+#include "compute_kernel_api/binary_shift.h"
+#include "compute_kernel_api/quantization.h"
+#include "compute_kernel_api/binary_max_min.h"
+#include "compute_kernel_api/bcast.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs;
+
+#if SRC_BCAST
+
+    constexpr auto cb_bcast = cb_post_lhs;
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_left = tt::CBIndex::c_5;
+    constexpr auto cb_right = cb_post_rhs;
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = cb_post_rhs;
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    constexpr auto cb_left = cb_post_lhs;
+    constexpr auto cb_right = tt::CBIndex::c_6;
+#endif
+
+    unary_op_init_common(cb_post_lhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
+    BINARY_SFPU_INIT
+#endif
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
+
+        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
+
+        cb_reserve_back(cb_llk_post, 1);
+        unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_bcast, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        cb_push_back(cb_llk_post, 1);
+        tile_regs_release();
+
+        cb_pop_front(cb_bcast, 1);
+
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_llk_post, 1);
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
+        BINARY_SFPU_INIT
+#endif
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_right, cb_left);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_left, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_left, cb_right);
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            copy_tile(cb_right, i, i * 2 + 1);
+
+            BINARY_SFPU_OP(i * 2, i * 2 + 1);
+            PROCESS_POST_ACTIVATIONS(i * 2);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_left, num_tiles_per_cycle);
+        cb_pop_front(cb_right, num_tiles_per_cycle);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -114,10 +114,10 @@ void kernel_main() {
 #if !SRC_SHARDED || !SRC_SHARDED_B
                             noc_async_read_barrier();
 #endif
-#if SRC_BCAST  // no sharding support for row bcast yet
+#if SRC_BCAST && !BCAST_LLK  // no sharding support for row bcast yet
                             FILL_TILE_WITH_FIRST_ROW(cb_id_src);
 #endif
-#if SRC_BCAST_B  // no sharding support for row bcast yet
+#if SRC_BCAST_B && !BCAST_LLK  // no sharding support for row bcast yet
                             FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
 #endif
 #if !SRC_SHARDED


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23623)

### Problem description
Previous PR was reverted because of perf regression of whisper model.

### What's changed
Moved creation of reader kernel after compute kernel because it needs the new reader defines. The bug was due to both software broadcast and LLK broadcast run. Functionality is OK but perf was wasted on software broadcast that should not happen.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes