### PR TITLE
SDPA Optimizations: Reading cur pos + page table sharded

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/demo_decode.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_decode.py
@@ -119,6 +119,8 @@ def run_llama3_demo(
     start_pos,
     enable_prefetcher_performance_mode=True,
     galaxy_type="4U",
+    is_cur_pos_sharded=True,
+    is_page_table_sharded=True,
 ):
     # Creat batch output file
     benchmark_data = BenchmarkData()
@@ -216,13 +218,43 @@ def run_llama3_demo(
             model_args.batch_size_per_device_group,
             paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
         )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
-        )
+
+        # OPTIMIZATION: We repeat the page table on each core in L1
+        if is_page_table_sharded:
+            # We repeat each batch by num_cores_to_shard times then concat them back together
+            # This tensor is sharded along the height first across devices (/4) then within device (/50) on dim 0
+            page_table_chunks = page_table.split(8, dim=0)
+            repeated_page_table_chunks = [
+                chunk.repeat(model_args.sub_core_grids.num_cores(), 1) for chunk in page_table_chunks
+            ]
+            page_table = torch.cat(repeated_page_table_chunks, dim=0)
+            page_table_shard_spec = ttnn.ShardSpec(
+                model_args.sub_core_grids,
+                (
+                    model_args.batch_size_per_device_group,
+                    paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
+                ),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            page_table_memory_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
+            )
+            page_table_tt = ttnn.from_torch(
+                page_table,
+                device=mesh_device,
+                dtype=ttnn.uint16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
+                memory_config=page_table_memory_config,
+            )
+        else:
+            page_table_tt = ttnn.from_torch(
+                page_table,
+                device=mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
+            )
         logger.info("Page table tensor done")
 
     # Load TTNN Llama-3.1 model
@@ -273,28 +305,45 @@ def run_llama3_demo(
 
     user_done = [False] * batch_size  # Keeps track when a user reaches EoD token
 
+    # Defining core grids
     logger.info("Starting decode...")
-    # Initial positions
+
+    # Create initial current position tensors
     decoding_pos = [start_pos] * batch_size
     current_pos = torch.tensor([decoding_pos[b] for b in range(batch_size)])
 
+    # OPTIMIZATION: sharding the current position tensor on each core
+    if is_cur_pos_sharded:
+        # Each core will have a copy of the current position tensor in L1
+        current_pos_sram = torch.tensor(
+            [[decoding_pos[b] for b in range(batch_size)]] * model_args.sub_core_grids.num_cores()
+        )
+        cur_pos_shard_spec = ttnn.ShardSpec(
+            model_args.sub_core_grids, (1, batch_size // mesh_device.shape[1]), ttnn.ShardOrientation.ROW_MAJOR
+        )
+        cur_pos_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cur_pos_shard_spec
+        )
     current_pos_tensor = ttnn.from_torch(
-        current_pos,
-        device=mesh_device,
+        current_pos_sram if is_cur_pos_sharded else current_pos,
         dtype=ttnn.int32,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device,
-            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            dims=(None, 1 if is_cur_pos_sharded else 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
             mesh_shape=model_args.cluster_shape,
         ),
     )
-
     logger.info("Current pos tensor done")
-
     # Get cos/sin matrices for the current position of each user
     rot_mats, rot_mat_idxs = tt_model.rope_setup.get_rm_rot_mats(current_pos, return_rot_idxs=True)
 
     logger.info("Rot mats done")
+
+    # Move the cur pos tensor to device
+    if is_cur_pos_sharded:
+        current_pos_tensor = current_pos_tensor.to(mesh_device, cur_pos_memory_config)
+    else:
+        current_pos_tensor = current_pos_tensor.to(mesh_device)
 
     # Prepare the encoded prompts for the decode input
     tt_out_tok = ttnn.from_torch(
@@ -304,12 +353,6 @@ def run_llama3_demo(
         layout=ttnn.ROW_MAJOR_LAYOUT,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    sub_core_grids = ttnn.CoreRangeSet(
-        [
-            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
-            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
-        ]
     )
 
     # Compile
@@ -339,7 +382,7 @@ def run_llama3_demo(
     if not stress_test:
         ttnn.plus_one(
             current_pos_tensor,
-            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+            sub_core_grids=model_args.sub_core_grids,
         )
         ttnn.plus_one(
             rot_mat_idxs,
@@ -375,7 +418,7 @@ def run_llama3_demo(
     if not stress_test:
         ttnn.plus_one(
             current_pos_tensor,
-            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+            sub_core_grids=model_args.sub_core_grids,
         )
         ttnn.plus_one(
             rot_mat_idxs,
@@ -387,11 +430,11 @@ def run_llama3_demo(
 
     # Reset the decoding position for the proper run of the model
     current_pos_reset = ttnn.from_torch(
-        current_pos,
+        current_pos_sram if is_cur_pos_sharded else current_pos,
         dtype=ttnn.int32,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device,
-            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            dims=(None, 1 if is_cur_pos_sharded else 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
             mesh_shape=model_args.cluster_shape,
         ),
     )
@@ -605,7 +648,7 @@ def run_llama3_demo(
 #
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 @pytest.mark.parametrize(
-    "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos",
+    "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos, is_cur_pos_sharded, is_page_table_sharded",
     [
         (  # full demo, batch 32
             "instruct",
@@ -621,6 +664,8 @@ def run_llama3_demo(
             {"top_k": 32, "top_p": 0.9, "temperature": 0.7, "seed": 42},  # sampling_params
             False,  # stress_test
             0,  # start_pos
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # quick 1L demo
             "random",
@@ -636,6 +681,8 @@ def run_llama3_demo(
             {"top_k": 1, "top_p": 0.00, "temperature": 1.0, "seed": 42},  # sampling_params (argmax)
             False,  # stress_test
             0,  # start_pos
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # Stress test: 4*128k generation length
             "instruct",
@@ -651,6 +698,8 @@ def run_llama3_demo(
             {"top_k": 1, "top_p": 0.0, "temperature": 1.0, "seed": 42},  # sampling_params
             True,  # stress_test
             0,  # start_pos
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # mini stress test
             "instruct",
@@ -666,6 +715,8 @@ def run_llama3_demo(
             {"top_k": 1, "top_p": 0.00, "temperature": 1.0, "seed": 42},  # sampling_params (argmax)
             True,  # stress_test
             0,  # start_pos
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # 10 layers for devive perf measurements
             "instruct",
@@ -681,6 +732,8 @@ def run_llama3_demo(
             {"top_k": 1, "top_p": 0.00, "temperature": 1.0, "seed": 42},  # sampling_params (argmax)
             False,  # stress_test
             127,  # start_pos
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # ND hang test
             "instruct",
@@ -696,6 +749,8 @@ def run_llama3_demo(
             {"top_k": 1, "top_p": 0.00, "temperature": 1.0, "seed": 42},  # sampling_params (argmax)
             True,  # stress_test
             0,  # start_pos
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
     ],
     ids=[
@@ -727,7 +782,7 @@ def run_llama3_demo(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
-            "worker_l1_size": 1344544,
+            "worker_l1_size": 1345000,
             "fabric_config": True,
         }
     ],
@@ -753,6 +808,8 @@ def test_llama_demo(
     reset_seeds,
     request,
     galaxy_type,
+    is_cur_pos_sharded,
+    is_page_table_sharded,
 ):
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
@@ -793,4 +850,6 @@ def test_llama_demo(
         start_pos=start_pos,
         enable_prefetcher_performance_mode=enable_pf_perf_mode,
         galaxy_type=galaxy_type,
+        is_cur_pos_sharded=is_cur_pos_sharded,
+        is_page_table_sharded=is_page_table_sharded,
     )

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -157,11 +157,7 @@ def create_tt_model(
         # Page table which maps virtual blocks to physical
         reverse_permutation = torch.argsort(permutation)
         page_table = reverse_permutation.reshape(
-            max_batch_size, paged_attention_config.max_num_blocks // max_batch_size
-        )
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
+            tt_model_args.max_batch_size, paged_attention_config.max_num_blocks // tt_model_args.max_batch_size
         )
 
     model = TtTransformer(
@@ -196,7 +192,7 @@ def create_tt_model(
 #
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, prefill_profile, num_layers, print_outputs",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, prefill_profile, num_layers, print_outputs, is_cur_pos_sharded, is_page_table_sharded",
     [
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -214,6 +210,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # Batch-1 run (Throughput) - 1 user, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -231,6 +229,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # evals-1 run (Throughput) - 1 user, smaller prompts, batch repeat 32
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/eval_repeat_prompts.json",  # input_prompts
@@ -248,6 +248,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            False,  # is_cur_pos_sharded
+            False,  # is_page_table_sharded
         ),
         (  # evals-32 run (Throughput) - 32 users, smaller prompts, batch repeat 32
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/eval_repeat_prompts.json",  # input_prompts
@@ -265,6 +267,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            False,  # is_cur_pos_sharded
+            False,  # is_page_table_sharded
         ),
         (  # evals-long-prompts run (Throughput) - 1 user, smaller prompts, batch repeat 12
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/eval_repeat_prompts_very_long.json",  # input_prompts
@@ -282,6 +286,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            False,  # is_cur_pos_sharded
+            False,  # is_page_table_sharded
         ),
         (  # Repeat2 (Batch-1) run (Throughput) - 1 user, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -299,6 +305,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            False,  # is_cur_pos_sharded
+            False,  # is_page_table_sharded
         ),
         (  # long-4k-b1 - Single user, 4K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -316,6 +324,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # long-8k-b1 - Single user, 8K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
@@ -333,6 +343,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # long-16k-b32 - 32 users, 16K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
@@ -350,6 +362,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # long-32k-b1 - Single user, 32K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
@@ -367,6 +381,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # long-64k-b1 - Single user, 64K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
@@ -384,6 +400,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # long-128k-b1 - Single user, 128K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
@@ -401,6 +419,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # prefill-profile [default 4K seqlen] - Runs 1L prefill-only
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -418,6 +438,8 @@ def create_tt_model(
             True,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # apc-test Run for PCC check, perf and functionality check: Batch-32 run (Throughput) - 32 users, prompt is "This is a test"
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_reference.json",  # input_prompts
@@ -435,6 +457,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
         (  # pcc-80L - CI Run for PCC check for 80 Layers + Teacher Forced: Batch-32 run (Throughput) - 32 users, prompt is "This is a test"
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_reference.json",  # input_prompts
@@ -452,6 +476,8 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
+            True,  # is_cur_pos_sharded
+            True,  # is_page_table_sharded
         ),
     ],
     ids=[
@@ -489,7 +515,7 @@ def create_tt_model(
             "trace_region_size": 102000000,
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "worker_l1_size": 1344544,
+            "worker_l1_size": 1345000,
             "fabric_config": True,
         }
     ],
@@ -525,6 +551,8 @@ def test_demo_text(
     request,
     galaxy_type,
     print_outputs,
+    is_cur_pos_sharded,
+    is_page_table_sharded,
 ):
     """
     Simple demo with limited dependence on reference code.
@@ -870,6 +898,7 @@ def test_demo_text(
         top_1_accs = []
         read_events = []
         tt_out_toks = []
+
         while users_decoding:
             if iteration == 0:  # First iteration also accounts for compile time
                 profiler.start(f"compile_decode", iteration=batch_idx)
@@ -895,6 +924,8 @@ def test_demo_text(
                     sampling_params=device_sampling_params,
                     reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
+                    is_cur_pos_sharded=is_cur_pos_sharded,
+                    is_page_table_sharded=is_page_table_sharded,
                 )
                 read_events.append(read_event)
                 tt_out_toks.append(tt_out_tok)

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
@@ -51,6 +51,8 @@ from models.utility_functions import skip_for_grayskull
         "default_attention",
     ),
 )
+@pytest.mark.parametrize("is_cur_pos_sharded", (True,))
+@pytest.mark.parametrize("is_page_table_sharded", (True,))
 @pytest.mark.parametrize(
     "page_params",
     [{"page_block_size": 64, "page_max_num_blocks": 4096}],
@@ -82,7 +84,7 @@ from models.utility_functions import skip_for_grayskull
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "worker_l1_size": 1344544,
+            "worker_l1_size": 1345000,
             "fabric_config": True,
         }
     ],
@@ -101,6 +103,8 @@ def test_llama_model_inference(
     mesh_device,
     reset_seeds,
     ensure_gc,
+    is_cur_pos_sharded,
+    is_page_table_sharded,
 ):
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
@@ -205,19 +209,36 @@ def test_llama_model_inference(
         # Page table which maps virtual blocks to physical
         reverse_permutation = torch.argsort(permutation)
         page_table = reverse_permutation.reshape(
-            model_args.batch_size_per_device_group,
-            paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
+            batch_size,
+            paged_attention_config.max_num_blocks // batch_size,
+        )
+        page_table_chunks = page_table.split(batch_size // model_args.cluster_shape[1], dim=0)
+        repeated_page_table_chunks = [
+            chunk.repeat(model_args.sub_core_grids.num_cores(), 1) for chunk in page_table_chunks
+        ]
+        page_table = torch.cat(repeated_page_table_chunks, dim=0)
+        page_table_shard_spec = ttnn.ShardSpec(
+            model_args.sub_core_grids,
+            (
+                batch_size,
+                paged_attention_config.max_num_blocks // batch_size,
+            ),
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        page_table_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
         )
         page_table_tt = ttnn.from_torch(
             page_table,
             device=mesh_device,
-            dtype=ttnn.int32,
+            dtype=ttnn.uint16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=(None, None),
+                dims=(None, 0),
                 mesh_shape=model_args.cluster_shape,
             ),
+            memory_config=page_table_memory_config,
         )
 
     # Load TTNN model
@@ -243,7 +264,6 @@ def test_llama_model_inference(
 
     seqlen = 1  # Generating one token per user at a time
     batch = model_args.max_batch_size
-
     # Select the first token from the prompts for initial decoding
     encoded_prompts_tensor = torch.tensor(encoded_prompts)  # [:,0]
     pt_decode_input = embd(encoded_prompts_tensor[:, 0]).view(batch, seqlen, -1)
@@ -256,22 +276,32 @@ def test_llama_model_inference(
 
     # Initial positions
     current_pos = torch.tensor([generation_start_pos for _ in range(batch)])
+    if is_cur_pos_sharded:
+        current_pos_sram = torch.tensor(
+            [[generation_start_pos for _ in range(batch)]] * model_args.sub_core_grids.num_cores()
+        )
+        cur_pos_shard_spec = ttnn.ShardSpec(
+            model_args.sub_core_grids, (1, batch // mesh_device.shape[1]), ttnn.ShardOrientation.ROW_MAJOR
+        )
+        cur_pos_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cur_pos_shard_spec
+        )
     current_pos_tensor = ttnn.from_torch(
-        current_pos,
+        current_pos_sram if is_cur_pos_sharded else current_pos,
         device=mesh_device,
         dtype=ttnn.int32,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device,
-            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            dims=(None, 1 if is_cur_pos_sharded else 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
             mesh_shape=model_args.cluster_shape,
         ),
+        memory_config=cur_pos_memory_config,
     )
     all_pccs = []
 
     try:
         for i in range(generation_length):
             logger.info(f"[Llama3 Model] Generating token {i}")
-
             decode_input = model_args.prepare_residual_tensor_decode(
                 tt_decode_input,
                 model_args.model_config["DECODE_RESIDUAL_MEMCFG"],
@@ -310,16 +340,21 @@ def test_llama_model_inference(
                 ref_output = reference_model(pt_decode_input, current_pos[0])
 
             # Increment position
-            current_pos = torch.tensor([generation_start_pos + i for _ in range(batch)])
+            current_pos = torch.full((batch,), generation_start_pos + i)
+
+            current_pos_sram = torch.full((model_args.sub_core_grids.num_cores(), batch), generation_start_pos + i)
             current_pos_tensor = ttnn.from_torch(
-                current_pos,
+                current_pos_sram,
                 device=mesh_device,
                 dtype=ttnn.int32,
                 mesh_mapper=ttnn.ShardTensor2dMesh(
                     mesh_device,
-                    dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+                    dims=(None, 1 if is_cur_pos_sharded else 0)
+                    if (model_args.is_galaxy and batch_size > 1)
+                    else (None, None),
                     mesh_shape=model_args.cluster_shape,
                 ),
+                memory_config=cur_pos_memory_config,
             )
 
             # Append the generated token to the list of outputs

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention.py
@@ -125,16 +125,30 @@ def test_llama_attention_inference(
             model_args.batch_size_per_device_group,
             paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
         )
+        page_table = page_table.repeat(model_args.sub_core_grids.num_cores(), 1)
+        page_table_shard_spec = ttnn.ShardSpec(
+            model_args.sub_core_grids,
+            (
+                model_args.batch_size_per_device_group,
+                paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
+            ),
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        page_table_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
+        )
+
         page_table_tt = ttnn.from_torch(
             page_table,
             device=mesh_device,
-            dtype=ttnn.int32,
+            dtype=ttnn.uint16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
                 dims=(None, None),
                 mesh_shape=model_args.cluster_shape,
             ),
+            memory_config=page_table_memory_config,
         )
 
     prefetcher_setup = TtLlamaPrefetcherSetup(
@@ -171,16 +185,27 @@ def test_llama_attention_inference(
     freqs_cis = torch.complex(cos, sin)
 
     # Initial positions
-    current_pos = torch.tensor([generation_start_pos for _ in range(batch_size)])
+    current_pos_dram = torch.tensor([generation_start_pos for _ in range(batch_size)])
+    is_cur_pos_sharded = True
+    cur_pos_mesh_shard_dim = 1 if is_cur_pos_sharded else 0
+    if is_cur_pos_sharded:
+        current_pos_sram = torch.tensor(
+            [[generation_start_pos for _ in range(batch_size)]] * model_args.sub_core_grids.num_cores()
+        )
+        cur_pos_shard_spec = ttnn.ShardSpec(model_args.sub_core_grids, (1, batch_size), ttnn.ShardOrientation.ROW_MAJOR)
+        cur_pos_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cur_pos_shard_spec
+        )
     current_pos_tensor = ttnn.from_torch(
-        current_pos,
+        current_pos_sram if is_cur_pos_sharded else current_pos_dram,
         device=mesh_device,
         dtype=ttnn.int32,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device,
-            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            dims=(None, cur_pos_mesh_shard_dim) if (model_args.is_galaxy and batch_size > 1) else (None, None),
             mesh_shape=model_args.cluster_shape,
         ),
+        memory_config=cur_pos_memory_config if is_cur_pos_sharded else None,
     )
     # Explicitly allocate global CB to avoid memory fragmentation
     prefetcher_setup.create_global_cb()
@@ -198,7 +223,7 @@ def test_llama_attention_inference(
         )
 
         # Get cos/sin matrices for the current position of each user
-        rot_mats = rope_setup.get_rm_rot_mats(current_pos)
+        rot_mats = rope_setup.get_rm_rot_mats(current_pos_dram)
 
         ttnn.dram_prefetcher(
             prefetcher_setup.get_input_tensors(),
@@ -222,33 +247,25 @@ def test_llama_attention_inference(
         tt_output_torch = tt_out[:, 0:1, : model_args.max_batch_size, : model_args.dim].view(-1, 1, model_args.dim)
 
         # In this test all users have the same position (if using batch > 1)
-        freqs_cis_i = freqs_cis[current_pos[0], :].unsqueeze(0)
+        freqs_cis_i = freqs_cis[current_pos_dram[0], :].unsqueeze(0)
 
-        reference_output = reference_model(pt_attention_input, current_pos[0], freqs_cis_i, mask=None)
+        reference_output = reference_model(pt_attention_input, current_pos_dram[0], freqs_cis_i, mask=None)
 
         passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
 
         logger.info(comp_allclose(reference_output, tt_output_torch))
         logger.info(f"PCC: {pcc_message}")
         if passing:
-            logger.info(f"[pos={current_pos[0]}] Llama_Attention Passed!")
+            logger.info(f"[pos={current_pos_dram[0]}] Llama_Attention Passed!")
         else:
-            logger.warning(f"[pos={current_pos[0]}] Llama_Attention Failed!")
+            logger.warning(f"[pos={current_pos_dram[0]}] Llama_Attention Failed!")
             all_tests_pass = False
 
         # Increment position
-        current_pos = torch.tensor([generation_start_pos + i + 1 for _ in range(batch_size)])
-        current_pos_tensor = ttnn.from_torch(
-            current_pos,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device,
-                dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
-                mesh_shape=model_args.cluster_shape,
-            ),
+        ttnn.plus_one(
+            current_pos_tensor,
+            sub_core_grids=model_args.sub_core_grids,
         )
-
         check_kv_cache = True
         if check_kv_cache:
             # PyTorch output --------------------------------------------------------------------

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -343,6 +343,8 @@ class Generator:
         sampling_params: SamplingParams = None,  # Should be None if not greedy decoding / sampling on device.
         reset_inputs=False,
         tt_out_logits_saved=None,
+        is_cur_pos_sharded=False,
+        is_page_table_sharded=False,
     ):
         if self.prev_page_table is None:
             self.prev_page_table = page_table
@@ -359,6 +361,8 @@ class Generator:
             "tokens": tokens,
             "page_table": page_table,
             "kv_cache": kv_cache,
+            "is_cur_pos_sharded": is_cur_pos_sharded,
+            "is_page_table_sharded": is_page_table_sharded,
         }
         if reset_inputs and sampling_params is not None:
             if sampling_params.temperature == 0:  # argmax
@@ -370,7 +374,6 @@ class Generator:
             )
         if tt_out_logits_saved is not None:
             decode_kwargs["tt_out_logits_saved"] = tt_out_logits_saved
-
         if enable_trace:
             tt_tok = self._easy_trace_text(**decode_kwargs, reset_inputs=reset_inputs)
         else:
@@ -389,13 +392,15 @@ class Generator:
         page_table=None,
         kv_cache=None,
         tt_out_logits_saved=None,
+        is_cur_pos_sharded=False,
+        is_page_table_sharded=False,
     ):
         """
         Performs text decode step.
         Returns tt_logits on device
         """
         tt_tokens, tt_current_pos, rot_mat_idxs, tt_page_table = self.model.prepare_inputs_decode(
-            tokens, current_pos, page_table
+            tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
         )
         tt_tok = self.model.ttnn_decode_forward(
             tt_tokens,
@@ -408,30 +413,38 @@ class Generator:
         return tt_tok
 
     def _capture_trace_text(
-        self,
-        tokens,
-        current_pos,
-        page_table=None,
-        kv_cache=None,
+        self, tokens, current_pos, page_table=None, kv_cache=None, is_cur_pos_sharded=False, is_page_table_sharded=False
     ):
         """
         Captures a trace for the decode_forward method.
         """
 
         # Compile run
-        self._decode_forward_no_trace_text(tokens, current_pos, page_table=page_table, kv_cache=kv_cache)
+        self._decode_forward_no_trace_text(
+            tokens,
+            current_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            is_cur_pos_sharded=is_cur_pos_sharded,
+            is_page_table_sharded=is_page_table_sharded,
+        )
         logger.info("Done Compiling Model")
 
         # Get inputs ready for trace run
-        host_inputs = self.model.prepare_decode_inputs_host(tokens, current_pos, page_table=page_table)
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
+        tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt = self.model.prepare_inputs_decode(
+            tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
+        )
 
+        # Save the buffer addresses for preallocated tensors
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
-        tt_out_tok = self.model.ttnn_decode_forward(*device_inputs, kv_cache=kv_cache)
+        tt_out_tok = self.model.ttnn_decode_forward(
+            tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt, kv_cache=kv_cache
+        )
 
+        # Try allocating our persistent tensors here and verifying it matches the address that trace captured
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
         logger.info("Done Capturing Decode Trace")
-        return trace_id, tt_out_tok, *device_inputs
+        return trace_id, tt_out_tok, tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt
 
     def _decode_forward_trace_text(
         self,
@@ -456,6 +469,8 @@ class Generator:
         page_table=None,
         kv_cache=None,
         reset_inputs=False,
+        is_cur_pos_sharded=False,
+        is_page_table_sharded=False,
     ):
         """
         Tracing is easy! Just call this method and we'll handle tracing for you.
@@ -464,16 +479,25 @@ class Generator:
 
         if not hasattr(self, "trace_id_text"):
             trace_id, tt_out_tok, *device_inputs = self._capture_trace_text(
-                tokens, current_pos, page_table=page_table, kv_cache=kv_cache
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                is_cur_pos_sharded=is_cur_pos_sharded,
+                is_page_table_sharded=is_page_table_sharded,
             )
             self.trace_id_text = trace_id
             self.trace_inputs_text = device_inputs
             self.trace_output_text = tt_out_tok
         if reset_inputs:
-            host_inputs = self.model.prepare_decode_inputs_host(tokens, current_pos, page_table)
+            host_inputs = self.model.prepare_decode_inputs_host(
+                tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
+            )
+            shard_specs = self.model.prepare_decode_shard_configs(is_cur_pos_sharded, is_page_table_sharded)
             device_inputs = copy_host_to_device(
                 host_tensors=host_inputs,
                 device_tensors=self.trace_inputs_text,
+                shard_specs=shard_specs,
             )
 
         trace_tok_rm = self._decode_forward_trace_text(

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -347,13 +347,11 @@ class TtLlamaAttention(LightweightModule):
         ttnn.deallocate(v_heads_1BKD)
 
         # print("done update cache")
-
         # NOTE: Varying the batch size will result in slightly different outputs.
         # For example, a prompt w/ 1 user vs, the same prompt repeated N times for N users, will produce different outputs
         # This is because the SDPA op in decode mode has different number of reductions depending on batch size
         # Which leads to slightly different outputs from attention (due to accumulated errors)
         sdpa_out_mem_cfg = self.model_config["SCORES_BATCHED_MM_OUTPUT_MEMCFG"](self.batch_size_per_device_group)
-
         if page_table:
             attn_output_1G4D_sharded = ttnn.transformer.paged_scaled_dot_product_attention_decode(
                 q_heads_1BQD,

--- a/models/demos/llama3_70b_galaxy/tt/llama_common.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_common.py
@@ -208,7 +208,7 @@ def num_to_core_range_set(x):
     )
 
 
-def copy_host_to_device(host_tensors, device_tensors=None, mesh_device=None):
+def copy_host_to_device(host_tensors, device_tensors=None, shard_specs=None, mesh_device=None):
     """
     Helper function which copies host tensors to device tensors.
     If no device_tensors are provided, it creates new device tensors and returns them.
@@ -217,7 +217,10 @@ def copy_host_to_device(host_tensors, device_tensors=None, mesh_device=None):
         assert mesh_device is not None, "mesh_device is required when device_tensors is None"
         ret = []
         for i in range(len(host_tensors)):
-            on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
+            if shard_specs and shard_specs[i] is not None:
+                on_device = host_tensors[i].to(mesh_device, shard_specs[i]) if host_tensors[i] else None
+            else:
+                on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
             ret.append(on_device)
         return ret
     else:

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -45,6 +45,7 @@ class TtTransformer(LightweightModule):
         self.enable_prefetcher_performance_mode = enable_prefetcher_performance_mode
         state_dict_prefix = args.get_state_dict_prefix("", None)
         self.allocate_prefill_buffers = allocate_prefill_buffers
+        self.paged_attention_config = paged_attention_config
 
         self.embd = TtLlamaEmbedding(
             mesh_device=mesh_device,
@@ -269,21 +270,59 @@ class TtTransformer(LightweightModule):
         transformed_device_inputs = self.transform_prefill_inputs_device(*device_inputs)
         return transformed_device_inputs
 
-    def prepare_inputs_decode(self, *inputs):
+    def prepare_inputs_decode(self, tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded):
         """
         Inputs are torch tensors or python types. This function returns ttnn
         tensors on device.
         Its implementation can take advantage of a few other functions which the
         model must implement.
         """
-        host_inputs = self.prepare_decode_inputs_host(*inputs)
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)  # Helper function
+        host_tensors = self.prepare_decode_inputs_host(
+            tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
+        )
+        shard_specs = self.prepare_decode_shard_configs(is_cur_pos_sharded, is_page_table_sharded)
+        device_inputs = copy_host_to_device(
+            host_tensors, mesh_device=self.mesh_device, shard_specs=shard_specs
+        )  # Helper function
         return device_inputs
 
-    def prepare_decode_inputs_host(self, tokens, current_pos, page_table=None):
+    def prepare_decode_shard_configs(self, is_cur_pos_sharded=False, is_page_table_sharded=False):
+        """
+        Prepares the sharding configuration for cur_pos and page_table tensors
+        """
+        cur_pos_memory_config = None
+        page_table_memory_config = None
+        if is_cur_pos_sharded:
+            cur_pos_shard_spec = ttnn.ShardSpec(
+                self.args.sub_core_grids,
+                (1, self.args.max_batch_size // self.mesh_device.shape[1]),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            cur_pos_memory_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cur_pos_shard_spec
+            )
+        if is_page_table_sharded:
+            page_table_shard_spec = ttnn.ShardSpec(
+                self.args.sub_core_grids,
+                (
+                    self.args.batch_size_per_device_group,
+                    self.paged_attention_config.max_num_blocks // self.args.max_batch_size,
+                ),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            page_table_memory_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
+            )
+        return [None, cur_pos_memory_config, None, page_table_memory_config]
+
+    def prepare_decode_inputs_host(
+        self, tokens, current_pos, page_table=None, is_cur_pos_sharded=False, is_page_table_sharded=False
+    ):
         """
         Inputs are torch tensors or python types. Outputs are ttnn tensors on host.
         NOTE: Tokens and current_pos are padded to batch
+        NOTE: if is_cur_pos_sharded is True, current_pos_tt is returned as a device tensor
+        NOTE: if is_page_table_sharded is True, page_table is returned as a device tensor
         """
         B = tokens.shape[0]
         # assert current_pos.shape[0] == B, "Batch size mismatch"
@@ -302,22 +341,32 @@ class TtTransformer(LightweightModule):
             current_pos, torch.tensor(0, dtype=torch.int64)
         )  # Ensure position indices are non-negative
         rope_idxs = self.rope_setup.get_rm_rot_idxs(rot_current_pos, on_host=True)
+        cur_pos_shard_dim = 0
+        if is_cur_pos_sharded:
+            cur_pos_shard_dim = 1
+            current_pos = current_pos.repeat(self.args.sub_core_grids.num_cores(), 1)
         current_pos_tt = ttnn.from_torch(
             current_pos,
             device=None,
             dtype=ttnn.int32,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 self.mesh_device,
-                dims=(None, 0) if (self.args.is_galaxy and B > 1) else (None, None),
+                dims=(None, cur_pos_shard_dim) if (self.args.is_galaxy and B > 1) else (None, None),
                 mesh_shape=self.args.cluster_shape,
             ),
         )
-
         if page_table is not None:
+            if is_page_table_sharded:
+                page_table_chunks = page_table.split(B // self.args.cluster_shape[1], dim=0)
+                repeated_page_table_chunks = [
+                    chunk.repeat(self.args.sub_core_grids.num_cores(), 1) for chunk in page_table_chunks
+                ]
+                page_table = torch.cat(repeated_page_table_chunks, dim=0)
+
             page_table = ttnn.from_torch(
                 page_table,
                 device=None,
-                dtype=ttnn.int32,
+                dtype=ttnn.uint16 if is_page_table_sharded else ttnn.int32,
                 mesh_mapper=ttnn.ShardTensor2dMesh(
                     self.mesh_device,
                     dims=(None, -2) if (self.args.is_galaxy and B > 1) else (None, None),
@@ -460,7 +509,7 @@ class TtTransformer(LightweightModule):
 
         ttnn.plus_one(
             current_pos,
-            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+            sub_core_grids=self.args.sub_core_grids,
         )
         ttnn.plus_one(
             rot_mat_idxs,

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -401,7 +401,12 @@ def num_to_core_range_set(x):
     )
 
 
-def copy_host_to_device(host_tensors, device_tensors=None, mesh_device=None):
+def copy_host_to_device(
+    host_tensors,
+    device_tensors=None,
+    mesh_device=None,
+    shard_specs=None,
+):
     """
     Helper function which copies host tensors to device tensors.
     If no device_tensors are provided, it creates new device tensors and returns them.
@@ -410,7 +415,10 @@ def copy_host_to_device(host_tensors, device_tensors=None, mesh_device=None):
         assert mesh_device is not None, "mesh_device is required when device_tensors is None"
         ret = []
         for i in range(len(host_tensors)):
-            on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
+            if shard_specs and shard_specs[i] is not None:
+                on_device = host_tensors[i].to(mesh_device, shard_specs[i]) if host_tensors[i] else None
+            else:
+                on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
             ret.append(on_device)
         return ret
     else:

--- a/tests/ttnn/unit_tests/operations/test_paged_fused_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_fused_update_cache.py
@@ -24,6 +24,8 @@ def run_test_paged_fused_update_cache_decode(
     pcc,
     sub_core_grids=None,
     row_major=False,
+    is_cur_pos_sharded=False,
+    is_page_table_sharded=False,
 ):
     max_num_blocks_per_seq = max_seq_len // block_size
     assert max_num_blocks_per_seq * block_size == max_seq_len
@@ -51,7 +53,30 @@ def run_test_paged_fused_update_cache_decode(
         permutation = torch.randperm(max_num_blocks)
         reverse_permutation = torch.argsort(permutation)
         page_table = reverse_permutation.reshape(num_users, max_num_blocks_per_seq)
-        page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+        if is_page_table_sharded:
+            page_table_core_grids = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 1), ttnn.CoreCoord(7, 1)),
+                ]
+            )
+            page_table = page_table.repeat(page_table_core_grids.num_cores(), 1)
+            page_table_shard_spec = ttnn.ShardSpec(
+                page_table_core_grids, (num_users, max_num_blocks_per_seq), ttnn.ShardOrientation.ROW_MAJOR
+            )
+            page_table_memory_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
+            )
+            page_table_tt = ttnn.as_tensor(
+                page_table,
+                device=device,
+                dtype=ttnn.uint16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=page_table_memory_config,
+            )
+        else:
+            page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
         # Prepare paged caches for both cache1 and cache2
         shuffled_cache1 = prepare_paged_cache(cache1, permutation)
@@ -132,7 +157,22 @@ def run_test_paged_fused_update_cache_decode(
     cache_idxs = [cache_idx + i * 17 for i in range(num_users)]
     if num_heads == 1:
         cache_idxs[num_users // 2] = -1
-    cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
+    cache_idxs_memory_config = None
+    if is_cur_pos_sharded:
+        cache_idxs_core_grids = ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0)),
+                ttnn.CoreRange(ttnn.CoreCoord(0, 1), ttnn.CoreCoord(7, 1)),
+            ]
+        )
+        cache_idxs_pt = torch.tensor([cache_idxs] * cache_idxs_core_grids.num_cores())
+        cache_idxs_shard_spec = ttnn.ShardSpec(cache_idxs_core_grids, (1, num_users), ttnn.ShardOrientation.ROW_MAJOR)
+        cache_idxs_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cache_idxs_shard_spec
+        )
+        cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs_pt), ttnn.int32).to(device, cache_idxs_memory_config)
+    else:
+        cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
 
     # Perform fused update cache operation
     cachett1, cachett2 = ttnn.experimental.paged_fused_update_cache(

--- a/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
@@ -54,11 +54,15 @@ def run_test_update_cache_decode(
         cache_idxs = [cache_idx + i for i in range(num_users)]
     else:
         cache_idxs = [cache_idx + i * 17 for i in range(num_users)]
+
     if cache_idx_tensor and not share_cache:
         cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
         cachett = ttnn.experimental.paged_update_cache(cachett, xt, update_idxs_tensor=cache_idxs_tt, share_cache=False)
     else:
-        cachett = ttnn.experimental.paged_update_cache(cachett, xt, update_idxs=cache_idxs, share_cache=share_cache)
+        cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
+        cachett = ttnn.experimental.paged_update_cache(
+            cachett, xt, update_idxs_tensor=cache_idxs_tt, share_cache=share_cache
+        )
 
     for i in range(num_users):
         update_idx = cache_idxs[i]

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 
     const uint32_t St = get_compile_time_arg_val(20);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));  // semaphore for receiver
-
+    constexpr uint32_t batch_size = get_compile_time_arg_val(22);
     constexpr uint32_t head_offset_t = Wt * St;
 
     // Kick off compute
@@ -76,31 +76,51 @@ void kernel_main() {
         cb_reserve_back(cb_index_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
         // index_tensor has one page to read
-        uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
-        noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-        noc_async_read_barrier();
+        if constexpr (index_is_dram) {
+            uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
+            noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
+            noc_async_read_barrier();
+        }
+
         cb_push_back(cb_index_id, 1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
         const uint32_t update_idx = index_ptr[my_batch_idx];
+
         if (update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
-                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
-                cb_reserve_back(page_table_cb_id, 1);
+                uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
+
+                cb_reserve_back(page_table_cb_id, num_pages_to_read);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
-                uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
-                noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-                noc_async_read_barrier();
-                cb_push_back(page_table_cb_id, 1);
-                volatile tt_l1_ptr uint32_t* page_table_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
+
+                if constexpr (page_table_is_dram) {
+                    const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                        .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
+                    uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
+                    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
+                    noc_async_read_barrier();
+                } else {
+                    page_table_cb_wr_ptr += my_batch_idx * page_table_stick_size;
+                }
+                cb_push_back(page_table_cb_id, num_pages_to_read);
+                // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
+                volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
+                volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
+                if constexpr (page_table_is_dram) {
+                    page_table_ptr_u32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
+                } else {
+                    page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);
+                }
 
                 const uint32_t virtual_block_id = update_idx / block_size;
-                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
+                const uint32_t physical_block_id = (page_table_is_dram)
+                                                       ? page_table_ptr_u32[virtual_block_id]
+                                                       : static_cast<uint32_t>(page_table_ptr_u16[virtual_block_id]);
+
                 const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -42,6 +42,9 @@ void kernel_main() {
     constexpr uint32_t St = get_compile_time_arg_val(16);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
     constexpr uint32_t head_offset_t = Wt * St;
+    constexpr uint32_t batch_size = get_compile_time_arg_val(18);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(19);
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(20);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
@@ -67,13 +70,25 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                cb_wait_front(page_table_cb_id, 1);
+                uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
+                cb_wait_front(page_table_cb_id, num_pages_to_read);
                 uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
-                volatile tt_l1_ptr uint32_t* page_table_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
+                if constexpr (!page_table_is_dram) {
+                    page_table_cb_rd_ptr += my_batch_idx * page_table_stick_size;
+                }
+                // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
+                volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
+                volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
+                if constexpr (page_table_is_dram) {
+                    page_table_ptr_u32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
+                } else {
+                    page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_rd_ptr);
+                }
 
                 const uint32_t virtual_block_id = update_idx / block_size;
-                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
+                const uint32_t physical_block_id = (page_table_is_dram)
+                                                       ? page_table_ptr_u32[virtual_block_id]
+                                                       : static_cast<uint32_t>(page_table_ptr_u16[virtual_block_id]);
                 const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -43,6 +43,9 @@ void kernel_main() {
 
     constexpr uint32_t St = get_compile_time_arg_val(17);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(18));  // semaphore for receiver
+    constexpr uint32_t batch_size = get_compile_time_arg_val(19);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(20);
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(21);
 
     uint32_t untilized_input_cb_id = untilized_input1_cb_id;
     if (!is_input1) {
@@ -74,13 +77,25 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                cb_wait_front(page_table_cb_id, 1);
+                uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
+                cb_wait_front(page_table_cb_id, num_pages_to_read);
                 uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
-                volatile tt_l1_ptr uint32_t* page_table_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
+                if constexpr (!page_table_is_dram) {
+                    page_table_cb_rd_ptr += my_batch_idx * page_table_stick_size;
+                }
+                // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
+                volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
+                volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
+                if constexpr (page_table_is_dram) {
+                    page_table_ptr_u32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
+                } else {
+                    page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_rd_ptr);
+                }
 
                 const uint32_t virtual_block_id = update_idx / block_size;
-                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
+                const uint32_t physical_block_id = (page_table_is_dram)
+                                                       ? page_table_ptr_u32[virtual_block_id]
+                                                       : static_cast<uint32_t>(page_table_ptr_u16[virtual_block_id]);
                 const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -82,11 +82,28 @@ void PagedUpdateCacheDeviceOperation::validate(
             TT_FATAL(optional_input_tensors.at(0).has_value(), "Paged cache requires update_idxs tensor");
 
             auto page_table = optional_input_tensors.at(1).value();
-            TT_FATAL(page_table.dtype() == DataType::INT32, "Error");
-            TT_FATAL(page_table.layout() == Layout::ROW_MAJOR, "Error");
-            TT_FATAL(
-                page_table.padded_shape()[0] == input_tensor.padded_shape()[1],
-                "Batch size between page_table and input_tensor must match");
+
+            if (page_table.is_sharded()) {
+                TT_FATAL(page_table.dtype() == DataType::UINT16, "Expect page table to have datatype UINT16");
+            } else {
+                TT_FATAL(page_table.dtype() == DataType::INT32, "Expect page table to have datatype INT32");
+            }
+
+            TT_FATAL(page_table.layout() == Layout::ROW_MAJOR, "Expect page table to have memory layout in ROW MAJOR");
+
+            if (page_table.is_sharded()) {
+                uint32_t num_cores = page_table.memory_config().shard_spec()->grid.num_cores();
+                uint32_t page_table_shard_height = page_table.padded_shape()[0] / num_cores;
+                TT_FATAL(
+                    page_table_shard_height == input_tensor.padded_shape()[1],
+                    "Batch size in input tensor {} should match page table shard height {}",
+                    input_tensor.padded_shape()[1],
+                    page_table_shard_height);
+            } else {
+                TT_FATAL(
+                    page_table.padded_shape()[0] == input_tensor.padded_shape()[1],
+                    "Batch size between page_table and input_tensor must match");
+            }
             TT_FATAL(
                 page_table.padded_shape()[1] <= cache_tensor.padded_shape()[0],
                 "max_num_blocks_per_seq must be less than max_num_blocks: max_num_blocks_per_seq={}, "
@@ -103,32 +120,75 @@ void PagedUpdateCacheDeviceOperation::validate(
             optional_input_tensors.at(0).has_value() != update_idxs.size() > 0,
             "Only an update tensor or an update vector can be provided. Not both or neither.");
 
-        uint32_t num_indices;
+        uint32_t num_indices = 0;
+        uint32_t num_cores_cur_pos = 0;
         if (optional_input_tensors.at(0).has_value()) {
             const auto& update_idxs_tensor = optional_input_tensors.at(0).value();
-            TT_FATAL(update_idxs_tensor.dtype() == DataType::INT32, "Error");
-            TT_FATAL(update_idxs_tensor.layout() == Layout::ROW_MAJOR, "Error");
-            num_indices = update_idxs_tensor.padded_shape()[0];
+            TT_FATAL(update_idxs_tensor.dtype() == DataType::INT32, "Expected update_idxs to have datatype INT32");
+            TT_FATAL(
+                update_idxs_tensor.layout() == Layout::ROW_MAJOR,
+                "Expected update_idxs to have memory layout in ROW MAJOR");
 
-            TT_FATAL(update_idxs_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-            TT_FATAL(update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Error");
+            if (optional_input_tensors.at(0)->is_sharded()) {
+                TT_FATAL(
+                    update_idxs_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+                    "Expect update_idxs to be HEIGHT SHARDED if sharded");
+                TT_FATAL(
+                    update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::L1,
+                    "Expect update_idxs to have buffer type L1 if sharded");
+                num_cores_cur_pos = update_idxs_tensor.padded_shape()[0];
+                num_indices = update_idxs_tensor.logical_shape()[1];
+            } else {
+                TT_FATAL(
+                    update_idxs_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Expect update_idxs to be DRAM INTERLEAVED");
+                TT_FATAL(
+                    update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
+                    "Expect update_idxs to have buffer type DRAM");
+                num_cores_cur_pos = 0;
+                num_indices = update_idxs_tensor.padded_shape()[0];
+            }
         } else {
             num_indices = update_idxs.size();
         }
-
-        TT_FATAL(input_tensor.padded_shape()[1] == num_indices, "Number of update_idxs should match batch size");
+        if (optional_input_tensors.at(0)->is_sharded()) {
+            uint32_t in_num_cores_cur_pos = optional_input_tensors.at(0)->shard_spec().value().grid.num_cores();
+            TT_FATAL(
+                input_tensor.logical_shape()[1] == num_indices,
+                "Number of update_idxs ({}) should match batch size ({}) if sharded",
+                num_indices,
+                input_tensor.logical_shape()[1]);
+            TT_FATAL(
+                in_num_cores_cur_pos == num_cores_cur_pos,
+                "Number of cores sharded on L1 ({}) should match dimension of update_idxs at 0 ({})",
+                in_num_cores_cur_pos,
+                num_cores_cur_pos);
+        } else {
+            TT_FATAL(
+                input_tensor.padded_shape()[1] == num_indices,
+                "Number of update_idxs ({}) should match batch size ({})",
+                num_indices,
+                input_tensor.padded_shape()[1]);
+        }
     };
 
     const auto validateSharding = [](const Tensor& input_tensor) {
-        TT_FATAL(input_tensor.is_sharded(), "Error");
+        TT_FATAL(input_tensor.is_sharded(), "Expect input_tensor to be sharded");
         if (input_tensor.is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1], "Error");
+            TT_FATAL(
+                input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                "Expect input_tensor to have memory layout WIDTH SHARDED");
+            TT_FATAL(
+                input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
+                "Expect input_tensor to have ");
             TT_FATAL(
                 (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) %
                         input_tensor.shard_spec().value().shape[0] ==
                     0,
-                "Error");
+                "Input tensor's height must be divisible by the number of shards along the height dimension. Got "
+                "height = {}, number of shards = {}.",
+                (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]),
+                input_tensor.shard_spec().value().shape[0]);
             TT_FATAL(
                 input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
                 "Only ROW_MAJOR sharding is supported");
@@ -151,7 +211,7 @@ void PagedUpdateCacheDeviceOperation::validate(
         validateUpdateIndices(input_tensor, optional_input_tensors, update_idxs);
         validateSharding(input_tensor);
 
-        TT_FATAL(batch_offset == 0, "Error");
+        TT_FATAL(batch_offset == 0, "batch_offset must be 0");
     };
 
     const auto validateFillOperation = [](const Tensor& cache_tensor,
@@ -163,15 +223,19 @@ void PagedUpdateCacheDeviceOperation::validate(
                 cache_tensor.dtype() == DataType::BFLOAT8_B || cache_tensor.dtype() == DataType::BFLOAT4_B,
             "Data type of input tensor for fill cache must be FLOAT32, BFLOAT16, or BFLOAT8_b");
 
-        TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-        TT_FATAL(page_table_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-        TT_FATAL(page_table_tensor.dtype() == DataType::INT32, "Error");
+        TT_FATAL(
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Expect input_tensor to have memory layout INTERLEAVED");
+        TT_FATAL(
+            page_table_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Expect page_table_tensor to have memory layout INTERLEAVED");
+        TT_FATAL(page_table_tensor.dtype() == DataType::INT32, "Expect page_table_tensor to have datatype INT32");
 
         auto cache_shape = cache_tensor.padded_shape();
         auto input_shape = input_tensor.padded_shape();
         auto page_table_shape = page_table_tensor.padded_shape();
 
-        TT_FATAL(batch_idx <= cache_shape[0], "Error");
+        TT_FATAL(batch_idx <= cache_shape[0], "Batch idx must fit in cache batch size");
         TT_FATAL(
             input_shape[2] <= cache_shape[2] * page_table_shape[1], "Input seq_len must fit in max_num_blocks_per_seq");
     };

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
@@ -92,6 +92,9 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     tt::DataFormat interm_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     uint32_t interm_single_tile_size = tt_metal::detail::TileSize(interm_cb_data_format);
 
+    const uint32_t B = input_tensor1.padded_shape()[1];
+    const uint32_t num_heads = cache_tensor1.padded_shape()[1];
+
     // Index tensor-specific parameters
     bool use_index_tensor = update_idxs_tensor.has_value();
     uint32_t index_tensor_tile_size = 0;
@@ -100,7 +103,9 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
     bool index_is_dram = true;
+    Buffer* index_buffer_ptr = nullptr;
     if (use_index_tensor) {
+        index_buffer_ptr = update_idxs_tensor.value().is_sharded() ? update_idxs_tensor.value().buffer() : nullptr;
         index_buffer_addr = use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_tensor_tile_size = tt_metal::detail::TileSize(index_data_format);
@@ -115,18 +120,19 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     uint32_t max_blocks_per_seq = 0;
     uint32_t page_table_stick_size = 0;
     uint32_t log2_page_table_stick_size = 0;
+    uint32_t num_pages_page_table = 1;
     tt::DataFormat page_table_data_format = tt::DataFormat::Int32;
     bool page_table_is_dram = true;
+    Buffer* page_table_buffer_ptr = nullptr;
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
-
+        page_table_buffer_ptr = page_table.value().is_sharded() ? page_table_tensor.buffer() : nullptr;
+        num_pages_page_table = page_table.value().is_sharded() ? B : 1;
         block_size = cache_tensor1.padded_shape()[2];
         block_size_t = block_size / TILE_HEIGHT;
         max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-        page_table_stick_size = page_table_tensor.padded_shape()[-1] * page_table_tensor.element_size();
-
+        page_table_stick_size = page_table.value().buffer()->aligned_page_size();
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
-
         page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     }
 
@@ -140,8 +146,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
                     : cache_total_num_tiles /
                           cache_tensor1.padded_shape()[0];  // if share cache, we can set cache batch num tiles to 0
                                                             // so batch offset would be 0 in future calculations
-    uint32_t B = input_tensor1.padded_shape()[1];
-    uint32_t num_heads = cache_tensor1.padded_shape()[1];
 
     log_debug(tt::LogOp, "cache_cb_data_format: {}", cache_cb_data_format);
     log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
@@ -210,12 +214,24 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
         program, all_cores_bb, 0);  // used for share cache for signaling when the cache is ready to be read
 
+    CBHandle cb_cur_pos_id = 0;
     if (use_index_tensor) {
-        create_cb(cb_index_id, program, all_cores_bb, index_tensor_tile_size, 1, index_data_format);
+        auto [_3, cb_src5] =
+            create_cb(cb_index_id, program, all_cores_bb, index_stick_size, 1, index_data_format, index_buffer_ptr);
+        cb_cur_pos_id = cb_src5;
     }
 
+    CBHandle cb_page_table_id = 0;
     if (is_paged_cache) {
-        create_cb(cb_pagetable_id, program, all_cores_bb, page_table_stick_size, 1, page_table_data_format);
+        auto [_4, cb_src7] = create_cb(
+            cb_pagetable_id,
+            program,
+            all_cores_bb,
+            page_table_stick_size,
+            num_pages_page_table,
+            page_table_data_format,
+            page_table_buffer_ptr);
+        cb_page_table_id = cb_src7;
     }
 
     auto dst1_buffer = cache_tensor1.buffer();
@@ -249,7 +265,7 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-    };
+        B};
 
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)dst_is_dram,
@@ -272,7 +288,9 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-    };
+        B,
+        page_table_stick_size,
+        page_table_is_dram};
 
     std::vector<uint32_t> compute_kernel_args = {
         src1_cb_index,
@@ -445,6 +463,8 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
          Wt,
          cb_src1,
          cb_src3,
+         cb_cur_pos_id,
+         cb_page_table_id,
          cache_batch_num_tiles,
          use_index_tensor,
          is_paged_cache](
@@ -462,6 +482,8 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
             auto dst1_buffer = input_tensors.at(0).buffer();
             auto dst2_buffer = input_tensors.at(2).buffer();
 
+            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : 0;
+            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : 0;
             auto index_tensor_addr = use_index_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             auto page_table_tensor_addr = is_paged_cache ? optional_input_tensors.at(1).value().buffer()->address() : 0;
 
@@ -471,7 +493,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
             if (input_tensors.at(3).is_sharded()) {
                 UpdateDynamicCircularBufferAddress(program, cb_src3, *src2_buffer);
             }
-
             auto& reader_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
 
@@ -518,6 +539,12 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
                     runtime_args[3] = tile_update_offset_B;
                 }
             }
+            if (use_index_tensor and optional_input_tensors.at(0)->is_sharded()) {
+                UpdateDynamicCircularBufferAddress(program, cb_cur_pos_id, *index_tensor_buffer);
+            }
+            if (is_paged_cache and optional_input_tensors.at(1)->is_sharded()) {
+                UpdateDynamicCircularBufferAddress(program, cb_page_table_id, *page_table_buffer);
+            }
         };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
@@ -549,6 +576,9 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const tt::DataFormat interm_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const uint32_t interm_single_tile_size = tt_metal::detail::TileSize(interm_cb_data_format);
 
+    const uint32_t B = input_tensor1.padded_shape()[1];
+    const uint32_t num_heads = cache_tensor1.padded_shape()[1];
+
     // Index tensor-specific parameters
     const bool use_index_tensor = update_idxs_tensor.has_value();
     uint32_t index_tensor_tile_size = 0;
@@ -556,8 +586,10 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const uint32_t log2_page_size = 0;
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
+    Buffer* index_buffer_ptr = nullptr;
     bool index_is_dram = true;
     if (use_index_tensor) {
+        index_buffer_ptr = update_idxs_tensor.value().is_sharded() ? update_idxs_tensor.value().buffer() : nullptr;
         index_buffer_addr = use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_tensor_tile_size = tt_metal::detail::TileSize(index_data_format);
@@ -574,16 +606,17 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const uint32_t log2_page_table_stick_size = 0;
     tt::DataFormat page_table_data_format = tt::DataFormat::Int32;
     bool page_table_is_dram = true;
+    uint32_t num_pages_page_table = 1;
+    Buffer* page_table_buffer_ptr = nullptr;
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
-
+        page_table_buffer_ptr = page_table.value().is_sharded() ? page_table_tensor.buffer() : nullptr;
+        num_pages_page_table = page_table.value().is_sharded() ? B : 1;
         block_size = cache_tensor1.padded_shape()[2];
         block_size_t = block_size / TILE_HEIGHT;
         max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-        page_table_stick_size = page_table_tensor.padded_shape()[-1] * page_table_tensor.element_size();
-
+        page_table_stick_size = page_table.value().buffer()->aligned_page_size();
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
-
         page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     }
 
@@ -597,8 +630,6 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
                     : cache_total_num_tiles /
                           cache_tensor1.padded_shape()[0];  // if share cache, we can set cache batch num tiles to 0
                                                             // so batch offset would be 0 in future calculations
-    const uint32_t B = input_tensor1.padded_shape()[1];
-    const uint32_t num_heads = cache_tensor1.padded_shape()[1];
 
     log_debug(tt::LogOp, "cache_cb_data_format: {}", cache_cb_data_format);
     log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
@@ -671,12 +702,24 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
         program, all_cores_bb, 0);  // used for share cache for signaling when the cache is ready to be read
 
+    CBHandle cb_cur_pos_id = 0;
     if (use_index_tensor) {
-        create_cb(cb_index_id, program, all_cores_bb, index_tensor_tile_size, 1, index_data_format);
+        auto [_3, cb_src5] =
+            create_cb(cb_index_id, program, all_cores_bb, index_stick_size, 1, index_data_format, index_buffer_ptr);
+        cb_cur_pos_id = cb_src5;
     }
 
+    CBHandle cb_page_table_id = 0;
     if (is_paged_cache) {
-        create_cb(cb_pagetable_id, program, all_cores_bb, page_table_stick_size, 1, page_table_data_format);
+        auto [_4, cb_src7] = create_cb(
+            cb_pagetable_id,
+            program,
+            all_cores_bb,
+            page_table_stick_size,
+            num_pages_page_table,
+            page_table_data_format,
+            page_table_buffer_ptr);
+        cb_page_table_id = cb_src7;
     }
 
     const auto dst1_buffer = cache_tensor1.buffer();
@@ -710,7 +753,7 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-    };
+        B};
 
     std::vector<uint32_t> writer_compile_time_args = {
         dst_is_dram,
@@ -734,7 +777,9 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-    };
+        B,
+        page_table_stick_size,
+        page_table_is_dram};
 
     std::vector<uint32_t> compute_kernel_args = {
         src1_cb_index,
@@ -909,6 +954,8 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
          Wt,
          cb_src1,
          cb_src3,
+         cb_cur_pos_id,
+         cb_page_table_id,
          cache_batch_num_tiles,
          use_index_tensor,
          is_paged_cache](
@@ -926,6 +973,8 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
             const auto dst1_buffer = input_tensors.at(0).buffer();
             const auto dst2_buffer = input_tensors.at(2).buffer();
 
+            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : 0;
+            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : 0;
             const auto index_tensor_addr =
                 use_index_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             const auto page_table_tensor_addr =
@@ -937,7 +986,6 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
             if (input_tensors.at(3).is_sharded()) {
                 UpdateDynamicCircularBufferAddress(program, cb_src3, *src2_buffer);
             }
-
             auto& reader_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
 
@@ -983,6 +1031,12 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
                     runtime_args[2] = cache_start_id;
                     runtime_args[3] = tile_update_offset_B;
                 }
+            }
+            if (use_index_tensor and optional_input_tensors.at(0)->is_sharded()) {
+                UpdateDynamicCircularBufferAddress(program, cb_cur_pos_id, *index_tensor_buffer);
+            }
+            if (is_paged_cache and optional_input_tensors.at(1)->is_sharded()) {
+                UpdateDynamicCircularBufferAddress(program, cb_page_table_id, *page_table_buffer);
             }
         };
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -32,7 +32,7 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
     const auto& input_shape = input.padded_shape();
     uint32_t W = input_shape[-1];
     uint32_t H = 1;
-    if (input_shape.size() > 1) {
+    if (!input.is_sharded() && input_shape.size() > 1) {
         for (uint32_t i = 0; i < input_shape.size() - 1; ++i) {
             H *= input_shape[i];
         }
@@ -40,19 +40,22 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = W;
-    uint32_t aligned_input_unit_size = round_up_to_mul32(num_input_units * input_unit_size);
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, aligned_input_unit_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
-
+    uint32_t aligned_input_page_size = round_up_to_mul32(num_input_units * input_unit_size);
     auto src_buffer = input.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(aligned_input_page_size, {{src0_cb_index, input_cb_data_format}})
+            .set_page_size(src0_cb_index, aligned_input_page_size);
+    if (input.is_sharded()) {
+        cb_src0_config.set_globally_allocated_address(*src_buffer);
+    }
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     std::vector<uint32_t> reader_compile_time_args = {
         src0_cb_index,
         src_is_dram,
-        aligned_input_unit_size,
+        aligned_input_page_size,
         W,
         H,
     };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -140,19 +140,42 @@ void ScaledDotProductAttentionDecode::validate(
                 "Expect cur_pos to be ROW_MAJOR, got {}",
                 cur_pos_tensor.layout());
             const auto cur_pos_shape = cur_pos_tensor.padded_shape();
-            TT_FATAL(
-                cur_pos_shape[0] == B, "cur_pos must have batch size equal to Q, got {} and {}", cur_pos_shape[0], B);
+
+            if (!cur_pos_tensor.is_sharded()) {
+                TT_FATAL(
+                    cur_pos_shape[-1] == B,
+                    "cur_pos must have batch size equal to Q, got {} and {}",
+                    cur_pos_shape[0],
+                    B);
+            }
         }
 
         TT_FATAL(optional_input_tensors.at(1).has_value(), "Must have page_table tensor for paged attention");
         const auto& page_table_tensor = optional_input_tensors.at(1).value();
 
-        TT_FATAL(page_table_tensor.dtype() == DataType::INT32, "Error");
+        if (page_table_tensor.is_sharded()) {
+            TT_FATAL(
+                page_table_tensor.dtype() == DataType::UINT16,
+                "Error: SDPA currently only supports UINT16 datatype for sharded configurations");
+        } else {
+            TT_FATAL(
+                page_table_tensor.dtype() == DataType::INT32, "Error: SDPA currently only supports INT32 datatype");
+        }
+
         TT_FATAL(page_table_tensor.layout() == Layout::ROW_MAJOR, "Error");
 
         const auto page_table_shape = page_table_tensor.padded_shape();
 
-        TT_FATAL(page_table_shape[0] == B, "page_table must have hidden size equal to Q");
+        if (page_table_tensor.is_sharded()) {
+            uint32_t num_cores = page_table_tensor.memory_config().shard_spec()->grid.num_cores();
+            TT_FATAL(
+                page_table_shape[0] / num_cores == B,
+                "Page_table must have shard height batch_size {} equal to Q on {} cores",
+                B,
+                num_cores);
+        } else {
+            TT_FATAL(page_table_shape[0] == B, "Page_table must have batch size equal to Q");
+        }
 
         TT_FATAL(k_shape[2] == v_shape[2], "K and V must have same block size");
         TT_FATAL(k_shape[3] == v_shape[3] && k_shape[3] == q_shape[3], "Q, K, V must have same hidden size");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -390,6 +390,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     const bool use_half_tile =
         (is_causal and num_q_heads <= 16 and q_df == tt::DataFormat::Float16_b and
          device->arch() == tt::ARCH::WORMHOLE_B0);
+
     if (use_half_tile) {
         q_tile = half_tile;
         mask_tile = half_tile;
@@ -415,6 +416,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
     uint32_t pos_tensor_tile_size = 0;
     uint32_t index_stick_size = 0;
+    bool is_cur_pos_tensor_sharded = false;
+    CBHandle cb_in8_id = 0;
     if (use_cur_pos_tensor) {
         auto pos_buffer = cur_pos_tensor.value().buffer();
         tt::DataFormat pos_df = tt_metal::datatype_to_dataformat_converter(cur_pos_tensor.value().dtype());
@@ -422,21 +425,33 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         index_stick_size = pos_buffer->aligned_page_size();
 
         // cb pos
-        auto c_in8_config = CircularBufferConfig(pos_tensor_tile_size, {{CBIndex::c_8, pos_df}})
-                                .set_page_size(CBIndex::c_8, pos_tensor_tile_size);
-        CreateCircularBuffer(program, core_grid, c_in8_config);
+        auto c_in8_config = CircularBufferConfig(index_stick_size, {{CBIndex::c_8, pos_df}})
+                                .set_page_size(CBIndex::c_8, index_stick_size);
+        if (cur_pos_tensor.value().is_sharded()) {
+            is_cur_pos_tensor_sharded = true;
+            c_in8_config.set_globally_allocated_address(*pos_buffer);
+        }
+        cb_in8_id = CreateCircularBuffer(program, core_grid, c_in8_config);
     }
 
     uint32_t page_table_stick_size = 0;
+    uint32_t shard_size = 0;
+    bool is_page_table_sharded = false;
+    CBHandle cb_in9_id = 0;
     if (is_paged_attention) {
         auto page_table_buffer = page_table_tensor.value().buffer();
+        is_page_table_sharded = page_table_tensor.value().is_sharded();
         tt::DataFormat page_table_df = tt_metal::datatype_to_dataformat_converter(page_table_tensor.value().dtype());
         page_table_stick_size = page_table_buffer->aligned_page_size();
-
+        shard_size = is_page_table_sharded ? B * page_table_stick_size : page_table_stick_size;
         // cb page_table
-        auto c_in9_config = CircularBufferConfig(page_table_stick_size, {{CBIndex::c_9, page_table_df}})
+        auto c_in9_config = CircularBufferConfig(shard_size, {{CBIndex::c_9, page_table_df}})
                                 .set_page_size(CBIndex::c_9, page_table_stick_size);
-        CreateCircularBuffer(program, core_grid, c_in9_config);
+
+        if (is_page_table_sharded) {
+            c_in9_config.set_globally_allocated_address(*page_table_buffer);
+        }
+        cb_in9_id = CreateCircularBuffer(program, core_grid, c_in9_config);
     }
 
     log_debug(tt::LogOp, "q_data_format: {}", q_df);
@@ -497,10 +512,11 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     CreateCircularBuffer(program, core_grid, c_in7_config);
 
     // tilizedQ input
-    auto c_in8_config = CircularBufferConfig(q_tiles * q_tile_size, {{CBIndex::c_10, q_df}})
-                            .set_page_size(CBIndex::c_10, q_tile_size)
-                            .set_tile_dims(CBIndex::c_10, q_tile);
-    CreateCircularBuffer(program, core_grid, c_in8_config);
+
+    auto c_tilized_q_config = CircularBufferConfig(q_tiles * q_tile_size, {{CBIndex::c_10, q_df}})
+                                  .set_page_size(CBIndex::c_10, q_tile_size)
+                                  .set_tile_dims(CBIndex::c_10, q_tile);
+    auto cb_tilized_q_id = CreateCircularBuffer(program, core_grid, c_tilized_q_config);
 
     // cb_col_identity
     auto col_identity_tile = full_tile;
@@ -723,7 +739,9 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         (uint32_t)use_mla,
         use_half_tile,
         q_chunk_size_bytes,
-    };
+        is_cur_pos_tensor_sharded,
+        is_page_table_sharded};
+        
     if (use_attention_sink) {
         tt_metal::TensorAccessorArgs(*attention_sink->buffer()).append_to(reader_compile_time_args_common);
     } else {
@@ -967,6 +985,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
          num_cores_per_batch,
          num_cores_per_head,
          num_output_cores,
+         cb_in8_id,
+         cb_in9_id,
          is_output_sharded,
          cb_out4_id,
          B,
@@ -990,10 +1010,16 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
             auto v_buffer = use_mla ? input_tensors.at(1).buffer() : input_tensors.at(2).buffer();
 
             auto out0_buffer = output_tensors.at(0).buffer();
+
             uint32_t q_addr = q_buffer->address();
             uint32_t k_addr = k_buffer->address();
             uint32_t v_addr = v_buffer->address();
-            uint32_t pos_addr = use_cur_pos_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
+            uint32_t out_addr = out0_buffer->address();
+
+            auto cur_pos_tensor = optional_input_tensors.at(0);
+            auto page_table_tensor = optional_input_tensors.at(1);
+            uint32_t pos_addr = use_cur_pos_tensor ? cur_pos_tensor.value().buffer()->address() : 0;
+
             uint32_t page_table_addr =
                 is_paged_attention ? optional_input_tensors.at(1).value().buffer()->address() : 0;
             uint32_t attn_mask_addr = use_attention_mask ? optional_input_tensors.at(2).value().buffer()->address() : 0;
@@ -1001,7 +1027,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
                 use_attention_sink ? optional_input_tensors.at(3).value().buffer()->address() : 0;
             auto page_table_buffer = is_paged_attention ? optional_input_tensors.at(1).value().buffer() : nullptr;
             uint32_t page_table_stick_size = is_paged_attention ? page_table_buffer->aligned_page_size() : 0;
-            uint32_t out_addr = out0_buffer->address();
 
             auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernels_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernels_id);
@@ -1067,13 +1092,16 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
                 compute_args[arg_idx++] = core_num_in_output;
                 compute_args[arg_idx++] = cur_pos;
             }
-
+            if (use_cur_pos_tensor and cur_pos_tensor.value().is_sharded()) {
+                UpdateDynamicCircularBufferAddress(program, cb_in8_id, *cur_pos_tensor.value().buffer());
+            }
+            if (is_paged_attention and page_table_tensor.value().is_sharded()) {
+                UpdateDynamicCircularBufferAddress(program, cb_in9_id, *page_table_tensor.value().buffer());
+            }
             if (is_output_sharded) {
                 UpdateDynamicCircularBufferAddress(program, cb_out4_id, *out0_buffer);
             }
         };
-
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
-
 }  // namespace ttnn::operations::transformer::detail

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -740,8 +740,9 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         use_half_tile,
         q_chunk_size_bytes,
         is_cur_pos_tensor_sharded,
-        is_page_table_sharded};
-        
+        is_page_table_sharded,
+    };
+
     if (use_attention_sink) {
         tt_metal::TensorAccessorArgs(*attention_sink->buffer()).append_to(reader_compile_time_args_common);
     } else {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -1017,8 +1017,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
             uint32_t v_addr = v_buffer->address();
             uint32_t out_addr = out0_buffer->address();
 
-            auto cur_pos_tensor = optional_input_tensors.at(0);
-            auto page_table_tensor = optional_input_tensors.at(1);
+            const auto& cur_pos_tensor = optional_input_tensors.at(0);
+            const auto& page_table_tensor = optional_input_tensors.at(1);
             uint32_t pos_addr = use_cur_pos_tensor ? cur_pos_tensor.value().buffer()->address() : 0;
 
             uint32_t page_table_addr =


### PR DESCRIPTION
### Problem description
Previously cur pos tensor and page table is always read from DRAM. This PR intializes the cur pos tensor, page table as L1 sharded on sub core grid and all ops directly read from L1. For the page table we cast the page table to uint16 to save L1 space since indices won't go above16K

### What's changed
- Updated SDPA reader, Paged cache update op, plus one op to use globally allocated L1 address of cur pos and page table tensor
- Updated text demo and demo decode to create the cur pos tensor directly on device rather on host
- `copy_host_to_device` is updated so that it can handle cases for tensors already created on device
- page table is now casted to uint16 during decode in text demo

### Perf Improvement (looking at model perf kernel durations, old taken from latest superset)
old 8650 ns -> new SDPA-model-kernel-avg: 7815.972222222223 ns
old 4450 ns -> new  PagedUpdateCache-model-kernel-avg: 3669.2673611111113 ns
old 842 ns -> new PlusOne_0-model_tail-kernel-avg: 428.71875 ns

E2E Perf: 72.6 tok/s/u -> 73.15 tok/s/u

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/17030443623) (All passing, demo failing just because throughput is too high)
- [ ] 6u [TG Pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/17030448926)