### PR TITLE
hotfix for galaxy quick failures

### DIFF
--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -276,7 +276,7 @@ def get_updated_device_params(device_params):
     if "TT_TEST_USE_WORKER_DISPATCH" in os.environ:
         dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
 
-    if is_blackhole() and dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
+    if ttnn.device.is_blackhole() and dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
         logger.warning("blackhole arch does not support DispatchCoreAxis.ROW, using DispatchCoreAxis.COL instead.")
         dispatch_core_axis = ttnn.DispatchCoreAxis.COL
 


### PR DESCRIPTION
### Problem description
Galaxy quick pipeline was failing after #26061 

### What's changed
Quick fix to call `ttnn.device.is_blackhole()` instead of pytest fixture `tests/scripts/common.py::is_blackhole()` 

Is there any reason these functions still exist? Should we move everything over to the `ttnn.device` API? 

Fixed pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/16731312637/job/47360323327
### Checklist
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
