### PR TITLE
Add enum for inline writes to specify dst type + add watcher assert when inline writing to stream reg 

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     // Write to stream register at `reg_addr` on core [target_noc_x, target_noc_y]
     uint32_t reg_addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
     uint64_t dest_addr = NOC_XY_ADDR(target_noc_x, target_noc_y, reg_addr);
-    noc_inline_dw_write<true>(dest_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+    noc_inline_dw_write<InlineWriteDst::REG>(dest_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
 
     if (target_core_value) {
         while (target_core_value != (NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX) &

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     // Write to stream register at `reg_addr` on core [target_noc_x, target_noc_y]
     uint32_t reg_addr = STREAM_REG_ADDR(stream_id, stream_reg);
     uint64_t dest_addr = NOC_XY_ADDR(target_noc_x, target_noc_y, reg_addr);
-    noc_inline_dw_write<true>(dest_addr, value_to_write);
+    noc_inline_dw_write<InlineWriteDst::REG>(dest_addr, value_to_write);
     noc_async_write_barrier();
 
     // Read back value that was written, store in L1 of this core for host to validate

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -390,13 +390,13 @@ struct WorkerToFabricEdmSenderImpl {
                 offsetof(tt::tt_fabric::EDMChannelWorkerLocationInfo, worker_semaphore_address));
         // write the address of our local copy of read counter (that EDM is supposed to update)
         if constexpr (!I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
-            noc_inline_dw_write<false, posted>(
+            noc_inline_dw_write<InlineWriteDst::DEFAULT, posted>(
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(from_remote_buffer_free_slots_ptr),
                 0xf,
                 WORKER_HANDSHAKE_NOC);
         } else {
-            noc_inline_dw_write<false, posted>(
+            noc_inline_dw_write<InlineWriteDst::DEFAULT, posted>(
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
@@ -406,7 +406,7 @@ struct WorkerToFabricEdmSenderImpl {
             dest_noc_addr_coord_only |
             reinterpret_cast<uint64_t>(&(worker_location_info_ptr->worker_teardown_semaphore_address));
         // Write our local teardown ack address to EDM
-        noc_inline_dw_write<false, posted>(
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, posted>(
             edm_teardown_semaphore_address_address,
             reinterpret_cast<size_t>(worker_teardown_addr),
             0xf,
@@ -414,7 +414,7 @@ struct WorkerToFabricEdmSenderImpl {
         // Write out core noc-xy coord to EDM
         const uint64_t connection_worker_xy_address =
             dest_noc_addr_coord_only | reinterpret_cast<uint64_t>(&(worker_location_info_ptr->worker_xy));
-        noc_inline_dw_write<false, posted>(
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, posted>(
             connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, WORKER_HANDSHAKE_NOC);
     }
 
@@ -443,7 +443,7 @@ struct WorkerToFabricEdmSenderImpl {
         tt::tt_fabric::EDMChannelWorkerLocationInfo* worker_location_info_ptr =
             reinterpret_cast<tt::tt_fabric::EDMChannelWorkerLocationInfo*>(edm_worker_location_info_addr);
 
-        noc_inline_dw_write<false, posted>(
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, posted>(
             edm_connection_handshake_noc_addr, open_connection_value, 0xf, WORKER_HANDSHAKE_NOC);
         *this->worker_teardown_addr = 0;
         if constexpr (!USER_DEFINED_NUM_BUFFER_SLOTS) {
@@ -563,7 +563,7 @@ private:
         } else {
             const uint64_t noc_sem_addr =
                 get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_remote_free_slots_update_addr, noc);
-            noc_inline_dw_write<true>(noc_sem_addr, (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC, 0xf, noc);
+            noc_inline_dw_write<InlineWriteDst::REG>(noc_sem_addr, (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC, 0xf, noc);
         }
         if constexpr (I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             // Write to the atomic increment stream register (write of -1 will subtract 1)

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -166,7 +166,7 @@ FORCE_INLINE
         case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE: {
             const auto dest_address = header.command_fields.unicast_inline_write.noc_address;
             const auto value = header.command_fields.unicast_inline_write.value;
-            noc_inline_dw_write<false, true>(
+            noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
                 dest_address,
                 value,
                 0xF,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -202,7 +202,7 @@ struct EdmChannelWorkerInterface {
     // Only used for persistent connections (i.e. upstream is EDM)
     template <bool enable_ring_support>
     FORCE_INLINE void update_persistent_connection_copy_of_free_slots(int32_t inc_val) {
-        noc_inline_dw_write<true, true>(
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
             this->cached_worker_semaphore_address,
             inc_val << REMOTE_DEST_BUF_WORDS_FREE_INC,
             0xf,
@@ -210,7 +210,7 @@ struct EdmChannelWorkerInterface {
     }
 
     FORCE_INLINE void notify_worker_of_read_counter_update() {
-        noc_inline_dw_write<true, true>(
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
             this->cached_worker_semaphore_address,
             local_read_counter.counter,
             0xf,

--- a/tt_metal/fabric/hw/inc/tt_fabric.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric.h
@@ -600,7 +600,7 @@ struct fvc_inbound_push_state_t {
             advance_remote_wrptr(1, remote_wrptr_direction);
             advance_out_rdptr<fvc_mode>(1);
             uint64_t push_addr = get_noc_addr_helper(dest_addr, router_push_addr);
-            noc_inline_dw_write<true, true>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+            noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
 
             *update_router_space = (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC;
             uint32_t words_available = packet_words_remaining;
@@ -642,7 +642,7 @@ struct fvc_inbound_push_state_t {
         noc_async_write_one_packet(get_local_buffer_read_addr(), buffer_wr_addr, FABRIC_ROUTER_BUF_SLOT_SIZE);
         advance_remote_wrptr(1, direction);
         uint64_t push_addr = get_noc_addr_helper(mcast_router_noc_xy[direction], router_push_addr);
-        noc_inline_dw_write<true, true>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
         *update_router_space = (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC;
     }
 
@@ -771,7 +771,7 @@ struct fvc_inbound_push_state_t {
         advance_remote_wrptr(1);
         advance_out_rdptr<fvc_mode>(1);
         uint64_t push_addr = get_noc_addr_helper(dest_addr, router_push_addr);
-        noc_inline_dw_write<true>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+        noc_inline_dw_write<InlineWriteDst::DEFAULT>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
 
         *update_router_space = (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC;
         uint32_t words_available = packet_words_remaining;

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -563,7 +563,7 @@ inline void fabric_client_connect(
     router_addr += direction * sizeof(uint64_t);
     // stream register to receive router buffer space available updates.
     uint64_t xy_local_addr = get_noc_addr(0);
-    noc_inline_dw_write<true>(
+    noc_inline_dw_write<InlineWriteDst::REG>(
         router_addr,
         (STREAM_REG_ADDR(
             STREAM_ID_NOC_RECEIVER_BUFFER_SPACE, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX)));
@@ -591,7 +591,7 @@ inline void fabric_client_disconnect(volatile tt_l1_ptr fabric_push_client_inter
     uint64_t client_q_addr = get_noc_addr_helper(client_interface->router_addr_h, FABRIC_ROUTER_CLIENT_QUEUE_START);
 
     // update wr ptr for the next client
-    noc_inline_dw_write<true>(
+    noc_inline_dw_write<InlineWriteDst::DEFAULT>(
         client_q_addr + offsetof(fabric_push_client_queue_t, router_wr_ptr), client_interface->wr_ptr);
 
     // update curr client index so that the next client in the queue can connect
@@ -630,7 +630,7 @@ inline void fabric_async_write_push_data(
         size -= PACKET_HEADER_SIZE_BYTES;
     }
     noc_async_write_one_packet(src_addr, buffer_wr_addr, size, noc_index);
-    noc_inline_dw_write<true>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+    noc_inline_dw_write<InlineWriteDst::DEFAULT>(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
     client_interface->wr_ptr++;
     *(volatile uint32_t*)client_interface->update_router_space = (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC;
     if (client_interface->wr_ptr >= client_interface->buffer_size) {

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -659,7 +659,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopbac
 }
 
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
-inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
+inline __attribute__((always_inline)) void noc_fast_spoof_write_dw_inline(
     uint32_t noc,
     uint32_t cmd_buf,
     uint32_t val,
@@ -668,6 +668,58 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
     uint32_t static_vc,
     bool mcast,
     bool posted = false) {
+    // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
+    // time. If one port on the receipient has back-pressure then the transaction will hang because there is no
+    // mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate inline writes on
+    // Blackhole by writing the value to be written to local L1 first and then issue a noc async write.
+    ASSERT((dest_addr & 0x3) == 0);
+    uint32_t src_addr = noc_get_interim_inline_value_addr(noc, dest_addr);
+
+    // Flush to make sure write left L1 before updating it
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc));
+    } else {
+        while (!ncrisc_noc_nonposted_writes_sent(noc));
+    }
+
+    volatile tt_l1_ptr uint32_t* interim_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
+    *interim_addr_ptr = val;
+
+// Copied from dataflow_cmd_bufs.h
+#if defined(COMPILE_FOR_BRISC)
+    constexpr uint32_t write_cmd_buf = noc_mode == DM_DEDICATED_NOC ? BRISC_WR_CMD_BUF : DYNAMIC_NOC_BRISC_WR_CMD_BUF;
+#elif defined(COMPILE_FOR_NCRISC)
+    constexpr uint32_t write_cmd_buf = noc_mode == DM_DEDICATED_NOC ? NCRISC_WR_CMD_BUF : DYNAMIC_NOC_NCRISC_WR_CMD_BUF;
+#else
+    constexpr uint32_t write_cmd_buf = NCRISC_WR_CMD_BUF;
+#endif
+
+    ncrisc_noc_fast_write<noc_mode>(
+        noc,
+        write_cmd_buf,
+        src_addr,
+        dest_addr,
+        4,
+        static_vc,
+        false,  // mcast
+        false,  // linked
+        1,      // num_dests
+        true,   // multicast_path_reserve
+        posted  // posted
+    );
+}
+
+template <uint8_t noc_mode = DM_DEDICATED_NOC>
+inline __attribute__((always_inline)) void noc_fast_default_write_dw_inline(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint32_t val,
+    uint64_t dest_addr,
+    uint32_t be,
+    uint32_t static_vc,
+    bool mcast,
+    bool posted = false) {
+    ASSERT(be == 0xF);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
@@ -703,6 +755,30 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
             noc_nonposted_writes_num_issued[noc] += 1;
             noc_nonposted_writes_acked[noc] += 1;
         }
+    }
+}
+
+template <uint8_t noc_mode = DM_DEDICATED_NOC, InlineWriteDst dst_type = InlineWriteDst::DEFAULT>
+inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint32_t val,
+    uint64_t dest_addr,
+    uint32_t be,
+    uint32_t static_vc,
+    bool mcast,
+    bool posted = false) {
+    if constexpr (dst_type == InlineWriteDst::DEFAULT) {
+        if ((dest_addr & 0xFFFFFFFF) >= NOC_REG_SPACE_START_ADDR) {
+            noc_fast_default_write_dw_inline<noc_mode>(noc, cmd_buf, val, dest_addr, be, static_vc, mcast, posted);
+        } else {
+            noc_fast_spoof_write_dw_inline<noc_mode>(noc, cmd_buf, val, dest_addr, be, static_vc, mcast, posted);
+        }
+    } else if constexpr (dst_type == InlineWriteDst::L1) {
+        noc_fast_spoof_write_dw_inline<noc_mode>(noc, cmd_buf, val, dest_addr, be, static_vc, mcast, posted);
+    } else {
+        ASSERT((dest_addr & 0xFFFFFFFF) >= NOC_REG_SPACE_START_ADDR);
+        noc_fast_default_write_dw_inline<noc_mode>(noc, cmd_buf, val, dest_addr, be, static_vc, mcast, posted);
     }
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1616,59 +1616,24 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
  * | be                                       | Byte-enable                                                | uint8_t  | 0x1-0xF                          | False    |
  * | noc                                      | NOC to use for the transaction                             | uint8_t  | 0 or 1                           | False    |
  * | vc                                       | Virtual channel to use for the transaction                 | uint8_t  | 0-3 (Unicast VCs)                | False    |
- * | write_to_stream_reg (template parameter) | Whether to write to a stream register instead of L1 memory | bool     | true or false                    | False    |
+ * | InlineWriteDst (template parameter)      | Whether the write is targeting L1 or a Stream Register     | InlineWriteDst     | DEFAULT, L1, REG       | False    |
  * | posted              (template parameter) | Whether the call is posted (i.e. ack requirement)          | bool     | true or false                    | False    |
  */
 // clang-format on
-template <bool write_to_stream_reg = false, bool posted = false>
+template <InlineWriteDst dst_type = InlineWriteDst::DEFAULT, bool posted = false>
 FORCE_INLINE void noc_inline_dw_write(
     uint64_t addr, uint32_t val, uint8_t be = 0xF, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NWIW");
     DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
     DEBUG_SANITIZE_NO_DRAM_ADDR(noc, addr, 4);
-#ifdef ARCH_BLACKHOLE
-    // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
-    // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
-    // mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate inline writes on
-    // Blackhole by writing the value to be written to local L1 first and then issue a noc async write.
-    ASSERT((addr & 0x3) == 0);
-    if constexpr (write_to_stream_reg) {
-        noc_fast_write_dw_inline<noc_mode>(
-            noc,
-            write_at_cmd_buf,
-            val,
-            addr,
-            be,  // byte-enable
-            vc,
-            false,  // mcast
-            posted  // posted
-        );
-        WAYPOINT("NWID");
-        return;
+#if defined(ARCH_BLACKHOLE) && defined(WATCHER_ENABLED)
+    if constexpr (dst_type == InlineWriteDst::L1) {
+        uint32_t src_addr = noc_get_interim_inline_value_addr(noc, addr);
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, addr, src_addr, 4);
     }
+#endif
 
-    ASSERT(be == 0xF);
-    uint32_t src_addr = noc_get_interim_inline_value_addr(noc, addr);
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, addr, src_addr, 4);
-    noc_async_writes_flushed(noc);
-    volatile tt_l1_ptr uint32_t* interim_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
-    *interim_addr_ptr = val;
-    ncrisc_noc_fast_write_any_len<noc_mode>(
-        noc,
-        write_cmd_buf,
-        src_addr,
-        addr,
-        4,
-        vc,
-        false,  // mcast
-        false,  // linked
-        1,      // num_dests
-        true,   // multicast_path_reserve
-        posted  // posted
-    );
-    noc_async_writes_flushed(noc);
-#else
-    noc_fast_write_dw_inline<noc_mode>(
+    noc_fast_write_dw_inline<noc_mode, dst_type>(
         noc,
         write_at_cmd_buf,
         val,
@@ -1678,7 +1643,6 @@ FORCE_INLINE void noc_inline_dw_write(
         false,  // mcast
         posted  // posted
     );
-#endif
     WAYPOINT("NWID");
 }
 

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -52,6 +52,12 @@ inline uint32_t READ_REG(uint32_t addr) {
     return ptr[0];
 }
 
+// This enum is used to specify the dest location type for inline writes.
+// It is needed because inline writes use all 4 memory ports and may hang on Blackhole when there is back-pressure.
+// This hang only manifests when the inline writes are issued to a L1 location. The workaround on BH is for inline
+// writes to L1 to use noc async writes.
+enum class InlineWriteDst : uint8_t { DEFAULT = 0, L1 = 1, REG = 2 };
+
 inline uint32_t dram_io_incr_ptr(uint32_t curr_ptr, uint32_t incr, uint32_t buf_size_q_slots) {
     uint32_t next_ptr = curr_ptr + incr;
     uint32_t double_buf_size_q_slots = 2 * buf_size_q_slots;

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -568,7 +568,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopbac
         noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve);
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC>
+// `dst_type` is "Don't care" on Wormhole, it's required on Blackhole to workaround bug that manifests with noc
+// transactions using all 4 memory ports. Issuing inline writes and atomics requires all 4 memory ports to accept the
+// transaction at the same time. If one port on the receipient has no back-pressure then the transaction will hang
+// because there is no mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate
+// inline writes on Blackhole by writing the value to be written to local L1 first and then issue a noc async write.
+template <uint8_t noc_mode = DM_DEDICATED_NOC, InlineWriteDst dst_type = InlineWriteDst::DEFAULT>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
     uint32_t noc,
     uint32_t cmd_buf,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25348
This pr won't necessarily close above issue

### Problem description
Workaround to handle inline writes on BH wasn't robust to caller errors could easily repro the same hang signature which requires rebooting a machine.

### What's changed
- Add a default fallback for inline writes that uses noc async write if the dest addr is not in register addr space
- Add watcher assert when user specifies write targets register
- Lowered inline write handling to arch specific noc header
- Made fabric apis use default path for inline writes. **Note: This might degrade perf while Fabric devs scrub through and figure out when reg write should be specified**

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16756051307) CI passes (profiler error seems unrelated - run on main https://github.com/tenstorrent/tt-metal/actions/runs/16751476908/job/47435286796 also has same issue)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16734641352) CI passes
- [x] [Blackhole LLM unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16731409469)
- [x] [Blackhole LLM demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16731412519)