### PR TITLE
fix profiler tests

### DIFF
--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -276,6 +276,10 @@ def get_updated_device_params(device_params):
     if "TT_TEST_USE_WORKER_DISPATCH" in os.environ:
         dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
 
+    # Special env to force ethernet dispatch to test dispatch from ethernet cores
+    if "TT_TEST_USE_ETH_DISPATCH" in os.environ:
+        dispatch_core_type = ttnn.device.DispatchCoreType.ETH
+
     if ttnn.device.is_blackhole() and dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
         logger.warning("blackhole arch does not support DispatchCoreAxis.ROW, using DispatchCoreAxis.COL instead.")
         dispatch_core_axis = ttnn.DispatchCoreAxis.COL

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -50,6 +50,7 @@ def set_env_vars(**kwargs):
         "slowDispatch": "TT_METAL_SLOW_DISPATCH_MODE=1 ",
         "dispatchFromWorker": "TT_TEST_USE_WORKER_DISPATCH=1 ",
         "enable_noc_tracing": "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1 ",
+        "dispatchFromEth": "TT_TEST_USE_ETH_DISPATCH=1 ",
     }
     envVarsStr = " "
     for arg, argVal in kwargs.items():
@@ -82,6 +83,7 @@ def run_device_profiler_test(
     doSync=False,
     doDispatchCores=False,
     dispatchFromWorker=False,
+    dispatchFromEth=False,
 ):
     name = inspect.stack()[1].function
     testCommand = f"build/{PROG_EXMP_DIR}/{name}"
@@ -89,7 +91,11 @@ def run_device_profiler_test(
         testCommand = testName
     clear_profiler_runtime_artifacts()
     envVars = set_env_vars(
-        slowDispatch=slowDispatch, doSync=doSync, doDispatchCores=doDispatchCores, dispatchFromWorker=dispatchFromWorker
+        slowDispatch=slowDispatch,
+        doSync=doSync,
+        doDispatchCores=doDispatchCores,
+        dispatchFromWorker=dispatchFromWorker,
+        dispatchFromEth=dispatchFromEth,
     )
     testCommand = f"cd {TT_METAL_HOME} && {envVars} {testCommand}"
     print()
@@ -300,6 +306,7 @@ def test_ethernet_dispatch_cores():
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
         setupAutoExtract=True,
         doDispatchCores=True,
+        dispatchFromEth=True,
     )
     for device, deviceData in devicesData["data"]["devices"].items():
         for ref, counts in REF_COUNT_DICT.items():
@@ -319,6 +326,7 @@ def test_ethernet_dispatch_cores():
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_all_devices",
         setupAutoExtract=True,
         doDispatchCores=True,
+        dispatchFromEth=True,
     )
     for device, deviceData in devicesData["data"]["devices"].items():
         for ref, counts in REF_COUNT_DICT.items():


### PR DESCRIPTION
### Problem description
N150 profiler regression tests were failing after #26061  https://github.com/tenstorrent/tt-metal/actions/runs/16726232868/job/47356336883

### What's changed
Profiler tests were missing a flag to force ethernet dispatch on N150. This was added as an env var (`TT_TEST_USE_ETH_DISPATCH`) which is picked up by conftest in `tests/scripts/common.py` like the worker dispatch flag `TT_TEST_USE_WORKER_DISPATCH`.

APC pipeline:  https://github.com/tenstorrent/tt-metal/actions/runs/16734966452
T3K profiler pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/16749865064

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes