### PR TITLE
Fixing T3k multiprocess tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
@@ -137,7 +137,7 @@ Tests:
     defaults:
       ftype: unicast
     patterns:
-      - type: all_to_all_unicast
+      - type: all_to_all
         iterations: 2
   # ======================================================================================
   # Test 4: Parameterized Unicast Test


### PR DESCRIPTION
### Ticket
No Ticket

### Problem description
T3k Unit tests are currently broken in test suite `t3k tt_metal multiprocess tests` due to [this PR](https://github.com/tenstorrent/tt-metal/pull/25743), which changed some yaml test syntax for `all_to_all`.  

### What's changed
Changed the test to match new syntax.

### Checklist
- [ ] [t3k unit](https://github.com/tenstorrent/tt-metal/actions/runs/16735109393)