### PR TITLE
Improve MoE gate accuracy with fallbacks

### DIFF
--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -401,7 +401,9 @@ class MoEGate(nn.Module):
         if self.topk_method == "noaux_tc":
             assert not self.training
             scores_for_choice = scores.view(bsz * seq_len, -1) + self.e_score_correction_bias.unsqueeze(0)
-            group_scores = topk_bitonic(scores_for_choice.view(bsz * seq_len, self.n_group, -1), k=2, dim=-1)[0].sum(
+            group_scores = self.topk_fn(
+                scores_for_choice.view(bsz * seq_len, self.n_group, -1), k=2, dim=-1, sorted=True
+            )[0].sum(
                 dim=-1
             )  # [n, n_group]
 

--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -357,7 +357,7 @@ class DeepseekV3MLP(nn.Module):
 
 
 class MoEGate(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config, use_bitonic_sort=True):
         super().__init__()
         self.config = config
         self.top_k = config.num_experts_per_tok
@@ -377,7 +377,7 @@ class MoEGate(nn.Module):
             self.e_score_correction_bias = nn.Parameter(torch.empty((self.n_routed_experts)))
         self.reset_parameters()
         # initatialize whether to use bitonic topk or torch.topk
-        self.use_bitonic_sort = True
+        self.use_bitonic_sort = use_bitonic_sort
         self.topk_fn = torch.topk
         if self.use_bitonic_sort:
             self.topk_fn = topk_bitonic

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -12,13 +12,14 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tt.moe import MoE
 from models.demos.deepseek_v3.utils.run_config import create_run_config
-from models.demos.deepseek_v3.utils.test_utils import get_model_config, run_module_forward
+from models.demos.deepseek_v3.utils.test_utils import assert_hidden_dim_pcc, get_model_config, run_module_forward
 
 
 @pytest.fixture
 def reference_model(hf_config):
     """Get the actual DeepSeek MLP model using local implementation."""
     torch.manual_seed(5)
+    torch.use_deterministic_algorithms(True)
     # Note : Running Reference MoE without shared experts
     hf_config.n_shared_experts = None
     return DeepseekV3MoE(hf_config)
@@ -34,7 +35,7 @@ def reference_model(hf_config):
 @pytest.mark.parametrize(
     "mode,seq_len",
     [
-        ("decode", 32),
+        ("decode", 128),
         ("prefill", 2048),
     ],
 )
@@ -54,10 +55,13 @@ def test_forward_pass(
     hf_state_dict = reference_model.state_dict()
 
     # Create input tensor
-    torch_input = torch.randn(batch_size, seq_len, hf_config.hidden_size)
+    torch_input = torch.randn(batch_size, seq_len, hf_config.hidden_size, dtype=torch.bfloat16)
 
     # Reference forward pass
-    reference_output = reference_model(torch_input)
+    reference_model.eval()
+    reference_model.to(torch.bfloat16)
+    with torch.no_grad():
+        reference_output = reference_model(torch_input)
 
     # Setup: Convert weights and get weight_config
     weight_config = MoE.convert_weights(hf_config, hf_state_dict, tmp_path, mesh_device)
@@ -90,13 +94,13 @@ def test_forward_pass(
     actual_output_memory_config = tt_output.memory_config()
     assert (
         actual_output_memory_config == expected_output_memory_config
-    ), f"TopK experts weights memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+    ), f"MoE output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
     # Convert output back to torch
     tt_output_torch = ttnn.to_torch(
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
-    )[0]
+    )
 
     # Cleanup
     ttnn.deallocate(tt_input)
@@ -104,8 +108,7 @@ def test_forward_pass(
 
     # Compare outputs using utility function
     logger.info(f"Mode: {mode}, Seq len: {seq_len}")
-    # TODO: test PCC using real weights, currently failing due to topk mismatch
-    # assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tt/moe_gate.py
+++ b/models/demos/deepseek_v3/tt/moe_gate.py
@@ -4,19 +4,23 @@
 from pathlib import Path
 
 import torch
+from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from models.demos.deepseek_v3.reference.reference_utils import topk_bitonic
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import (
     BinaryOpConfig,
     FromWeightConfig,
     LinearConfig,
+    LinearFallbackConfig,
     MeshDeviceStub,
     MulConfig,
     ReshapeConfig,
     ScatterConfig,
     TopKConfig,
+    TopKFallbackConfig,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_HIFI2,
@@ -59,7 +63,7 @@ class MoEGate(AbstractModule):
             state_dict[f"{prefix}e_score_correction_bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0),
             device=mesh_device,
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.bfloat16,
+            dtype=ttnn.float32,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
@@ -187,11 +191,11 @@ class MoEGate(AbstractModule):
             ),
             "topk_within_expert_groups": TopKConfig(
                 k=2,  # no hf config for this
-                dim=3,
+                dim=-1,
             ),
             "topk_expert_groups": TopKConfig(
                 k=hf_config.topk_group,
-                dim=3,
+                dim=-1,
             ),
             "scatter_top_expert_groups": ScatterConfig(
                 input=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
@@ -209,8 +213,21 @@ class MoEGate(AbstractModule):
             ),
             "topk_experts": TopKConfig(
                 k=hf_config.num_experts_per_tok,
-                dim=3,
+                dim=-1,
             ),
+            "topk_fallback": True,
+            "topk_fallback_config": TopKFallbackConfig(
+                mesh_device=mesh_device,
+                dtype=ttnn.bfloat16,
+                memory_config=memory_config,
+                use_bitonic_sort=True,
+            ),
+            "linear_fallback": False,
+            "linear_fallback_config": LinearFallbackConfig(
+                mesh_device=mesh_device,
+                dtype=ttnn.bfloat16,
+            ),
+            "mesh_device": mesh_device,
             "input_memory_config": memory_config,
             "output_memory_config": memory_config,
         }
@@ -228,7 +245,10 @@ class MoEGate(AbstractModule):
         assert x.memory_config() == cfg["input_memory_config"]
 
         # Gate projections
-        logits = ttnn.linear(x, **cfg["gate_proj"])
+        if cfg["linear_fallback"]:
+            logits = cls.linear_fallback_op(x, **cfg["linear_fallback_config"], **cfg["gate_proj"])
+        else:
+            logits = ttnn.linear(x, **cfg["gate_proj"])
         # Sigmoid activation
         scores = ttnn.sigmoid(logits)
         ttnn.deallocate(logits)
@@ -247,17 +267,22 @@ class MoEGate(AbstractModule):
         expert_scores_grouped = ttnn.reshape(scores_with_bias, **cfg["reshape_scores"])
         num_experts_per_group = expert_scores_grouped.shape[3]
 
-        if expert_scores_grouped.shape[3] < TOPK_MIN_WIDTH:
-            # Pad to 64 for topk op
-            expert_scores_grouped = ttnn.pad(
-                expert_scores_grouped,
-                [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_scores_grouped.shape[3])],
-                value=-float("inf"),
-            )
         # calculate top-2 scores with expert groups
-        topk_scores_within_expert_groups, topk_indices_within_expert_groups = ttnn.topk(
-            expert_scores_grouped, **cfg["topk_within_expert_groups"]
-        )
+        if cfg["topk_fallback"]:
+            topk_scores_within_expert_groups, topk_indices_within_expert_groups = cls.topk_fallback_op(
+                expert_scores_grouped, **cfg["topk_fallback_config"], **cfg["topk_within_expert_groups"]
+            )
+        else:
+            if expert_scores_grouped.shape[3] < TOPK_MIN_WIDTH:
+                # Pad to 64 for topk op
+                expert_scores_grouped = ttnn.pad(
+                    expert_scores_grouped,
+                    [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_scores_grouped.shape[3])],
+                    value=-float("inf"),
+                )
+            topk_scores_within_expert_groups, topk_indices_within_expert_groups = ttnn.topk(
+                expert_scores_grouped, **cfg["topk_within_expert_groups"]
+            )
         ttnn.deallocate(expert_scores_grouped)
         ttnn.deallocate(topk_indices_within_expert_groups)
         # sum top-2 scores within expert groups
@@ -266,16 +291,21 @@ class MoEGate(AbstractModule):
         # reshape to 4D tensor
         expert_group_scores = ttnn.unsqueeze(expert_group_scores, dim=0)
 
-        if expert_group_scores.shape[3] < TOPK_MIN_WIDTH:
-            expert_group_scores = ttnn.pad(
-                expert_group_scores,
-                [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_group_scores.shape[3])],
-                value=-float("inf"),
-            )
         # calculate top-k expert groups
-        topk_expert_groups_scores, topk_expert_groups_indices = ttnn.topk(
-            expert_group_scores, **cfg["topk_expert_groups"]
-        )
+        if cfg["topk_fallback"]:
+            topk_expert_groups_scores, topk_expert_groups_indices = cls.topk_fallback_op(
+                expert_group_scores, **cfg["topk_fallback_config"], **cfg["topk_expert_groups"]
+            )
+        else:
+            if expert_group_scores.shape[3] < TOPK_MIN_WIDTH:
+                expert_group_scores = ttnn.pad(
+                    expert_group_scores,
+                    [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_group_scores.shape[3])],
+                    value=-float("inf"),
+                )
+            topk_expert_groups_scores, topk_expert_groups_indices = ttnn.topk(
+                expert_group_scores, **cfg["topk_expert_groups"]
+            )
         ttnn.deallocate(expert_group_scores)
         ttnn.deallocate(topk_expert_groups_scores)
 
@@ -306,7 +336,14 @@ class MoEGate(AbstractModule):
         ttnn.deallocate(active_experts_mask)
 
         # calculate top-k experts
-        topk_experts_scores_with_bias, topk_experts_indices = ttnn.topk(active_experts_scores, **cfg["topk_experts"])
+        if cfg["topk_fallback"]:
+            topk_experts_scores_with_bias, topk_experts_indices = cls.topk_fallback_op(
+                active_experts_scores, **cfg["topk_fallback_config"], **cfg["topk_experts"]
+            )
+        else:
+            topk_experts_scores_with_bias, topk_experts_indices = ttnn.topk(
+                active_experts_scores, **cfg["topk_experts"]
+            )
         ttnn.deallocate(active_experts_scores)
         ttnn.deallocate(topk_experts_scores_with_bias)
 
@@ -355,3 +392,94 @@ class MoEGate(AbstractModule):
     @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         return cls.forward(x, cfg)
+
+    @classmethod
+    def topk_fallback_op(
+        cls,
+        input: ttnn.Tensor,
+        mesh_device: ttnn.Device,
+        dtype: ttnn.DataType,
+        memory_config: ttnn.MemoryConfig,
+        k: int,
+        dim: int,
+        largest: bool,
+        sorted: bool,
+        use_bitonic_sort: bool,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        # convert ttnn mesh tensor to torch tensor
+        logger.info(f"topk_fallback_op: input shape: {input.shape}")
+        torch_input = ttnn.to_torch(
+            input,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
+        )[0].unsqueeze(0)
+
+        if use_bitonic_sort:
+            topk_fn = topk_bitonic
+        else:
+            topk_fn = torch.topk
+
+        torch_topk_scores, torch_topk_indices = topk_fn(torch_input, k=k, dim=dim, largest=largest, sorted=sorted)
+
+        ttnn_topk_scores = ttnn.from_torch(
+            torch_topk_scores,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=tuple(mesh_device.shape)),
+            dtype=dtype,
+            memory_config=memory_config,
+            layout=ttnn.TILE_LAYOUT,
+        )
+
+        ttnn_topk_indices = ttnn.from_torch(
+            torch_topk_indices,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=tuple(mesh_device.shape)),
+            dtype=ttnn.uint16,
+            memory_config=memory_config,
+            layout=ttnn.TILE_LAYOUT,
+        )
+
+        return ttnn_topk_scores, ttnn_topk_indices
+
+    @classmethod
+    def linear_fallback_op(
+        cls,
+        input_tensor: ttnn.Tensor,
+        input_tensor_b: ttnn.Tensor,
+        mesh_device: ttnn.Device,
+        dtype: ttnn.DataType,
+        memory_config: ttnn.MemoryConfig,
+        compute_kernel_config=None,
+    ) -> ttnn.Tensor:
+        """Linear fallback operation using torch.nn.functional.linear"""
+        # convert ttnn mesh tensors to torch tensors
+        logger.info(f"linear_fallback_op: input shape: {input_tensor.shape}, weight shape: {input_tensor_b.shape}")
+
+        torch_input = ttnn.to_torch(
+            input_tensor,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
+        )[0].unsqueeze(0)
+
+        torch_weight = ttnn.to_torch(
+            input_tensor_b,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 0), mesh_shape=tuple(mesh_device.shape)),
+        )[0][0]
+
+        torch_input_2d = torch_input.squeeze(0).squeeze(0)  # [seq_len, hidden_dim]
+        torch_weight_2d = torch_weight.T  # [output_dim, hidden_dim]
+
+        # use torch linear: input @ weight.T
+        torch_output = torch.nn.functional.linear(torch_input_2d, torch_weight_2d)
+
+        # Restore dimensions and convert back to ttnn
+        torch_output = torch_output.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_len, output_dim]
+
+        ttnn_output = ttnn.from_torch(
+            torch_output,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=tuple(mesh_device.shape)),
+            dtype=dtype,
+            memory_config=memory_config,
+            layout=ttnn.TILE_LAYOUT,
+        )
+
+        return ttnn_output

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -263,3 +263,21 @@ class RepeatConfig(OpConfigBase):
     """Common parameters for a ttnn.repeat op"""
 
     repeat_dims: ttnn.Shape
+
+
+@dataclass
+class TopKFallbackConfig(OpConfigBase):
+    """Common parameters for a ttnn.topk_fallback op"""
+
+    mesh_device: ttnn.Device
+    dtype: ttnn.DataType
+    memory_config: ttnn.MemoryConfig
+    use_bitonic_sort: bool = False
+
+
+@dataclass
+class LinearFallbackConfig(OpConfigBase):
+    """Common parameters for a ttnn.linear_fallback op"""
+
+    mesh_device: ttnn.Device
+    dtype: ttnn.DataType


### PR DESCRIPTION
This pull request introduces a fallback mechanism for TopK and Linear operations in the `MoEGate` module, enhancing accuracy and testability for both the reference and TTNN implementations. 

**Current Accuracy Updates**
```
TopK Weights PCC: 0.995
TopK Indices PCC: 1.0
```
**Key Requirements**
1. Changed the dtype of `e_score_correction_bias` in weight conversion from `bfloat16` to `float32`. [very very essential]
2. ttnn.topK fallback in torch.topK

With fp32 bias but without topk fallback 
```
TopK weights PCC : 0.955
TopK Indices PCC : 0.034
```

With topK and linear fallbacks
```
TopK weights PCC : 0.9995
TopK Indices PCC : 1.0
```

**Major highlights:**
- Adds fallback implementations for TopK
- Adds fallback implementations for TopK and Linear operations, configurable via model config.
- Adjusts tensor data types for improved accuracy and compatibility.
- Refactors tests and enable pcc check

**Key changes:**

* Added `TopKFallbackConfig` and `LinearFallbackConfig` dataclasses for configuring fallback operations, and extended `model_config` in `moe_gate.py` to support fallback toggles and their configs. 
* Implemented `topk_fallback_op` and `linear_fallback_op` methods in `MoEGate` to enable fallback to PyTorch/bitonic sort for TopK and to PyTorch linear for Linear operations, used conditionally in the forward pass. 
* Updated `test_moe_gate.py` to use deterministic algorithms, set appropriate tensor dtypes (`bfloat16`), and leverage new utility functions for model config and forward passes, ensuring more accurate and robust test comparisons. 
* Changed the dtype of `e_score_correction_bias` in weight conversion from `bfloat16` to `float32` for improved numerical stability. (`models/demos/deepseek_v3/tt/moe_gate.py`)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes