### PR TITLE
#26215: ttnn.gather cached run fix.

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_gather.py
@@ -170,3 +170,30 @@ def test_gather_long_tensor(input_shape, index_shape, dim, device):
 
     assert ttnn_gather.shape == index.shape
     assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+
+
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, runs",
+    [
+        ([1, 1, 512, 64], [1, 1, 512, 32], -1, 3),
+        ([1, 1, 32, 2048 * TILE_HEIGHT], [1, 1, 32, 2048 * TILE_HEIGHT], -1, 2),
+        ([1, 32, 1, 128], [1, 32, 1, 128], -1, 2),
+    ],
+)
+def test_gather_cache_run(input_shape, index_shape, dim, runs, device):
+    torch.manual_seed(0)
+
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(input_shape, dtype=torch_dtype)
+    index = torch.randint(0, input_shape[dim], index_shape, dtype=torch.int64)
+
+    torch_gather = torch.gather(input, dim, index)
+
+    ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    ttnn_index = ttnn.from_torch(index, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
+
+    for _ in range(runs):
+        ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
+        assert ttnn_gather.shape == index.shape
+        assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))

--- a/tests/ttnn/unit_tests/operations/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_gather.py
@@ -175,9 +175,9 @@ def test_gather_long_tensor(input_shape, index_shape, dim, device):
 @pytest.mark.parametrize(
     "input_shape, index_shape, dim, runs",
     [
-        ([1, 1, 512, 64], [1, 1, 512, 32], -1, 3),
+        ([64, 64], [64, 32], -1, 10),
         ([1, 1, 32, 2048 * TILE_HEIGHT], [1, 1, 32, 2048 * TILE_HEIGHT], -1, 2),
-        ([1, 32, 1, 128], [1, 32, 1, 128], -1, 2),
+        ([32, 128], [32, 128], -1, 5),
     ],
 )
 def test_gather_cache_run(input_shape, index_shape, dim, runs, device):

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -216,7 +216,7 @@ void GatherProgramFactorySingleRowSingleCore::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
     auto input_tensor_buffer = tensor_args.input_tensor.buffer();
-    auto input_index_tensor_buffer = tensor_args.input_tensor.buffer();
+    auto input_index_tensor_buffer = tensor_args.input_index_tensor.buffer();
     auto output_tensor_buffer = output_tensor.buffer();
 
     const auto input_index_shape = tensor_args.input_index_tensor.padded_shape();
@@ -458,7 +458,7 @@ void GatherProgramFactorySingleRowMultiCore::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
     auto input_tensor_buffer = tensor_args.input_tensor.buffer();
-    auto input_index_tensor_buffer = tensor_args.input_tensor.buffer();
+    auto input_index_tensor_buffer = tensor_args.input_index_tensor.buffer();
     auto output_tensor_buffer = output_tensor.buffer();
 
     const auto input_index_shape = tensor_args.input_index_tensor.padded_shape();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26215

### Problem description
- ttnn.gather returned inconsistent outputs on repeated calls with same inputs.

### What's changed
- Fixed small bug in override runtime args,
- Added test for multi run with the same input.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16742943250
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16746349238
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes