### PR TITLE
Revert "Reapply "Replace truncating fp32->bf16 with tie-to-even rounding"

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, divup, assert_equal
+from tests.ttnn.utils_for_testing import assert_with_pcc, divup
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,7 @@ def test_zeros_like(device, input_shape):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -50,7 +50,7 @@ def test_ones_like(device, input_shape):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -73,7 +73,7 @@ def test_full_like(device, input_shape, fill_value):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -96,7 +96,7 @@ def test_full_like_bf8b(device, input_shape, fill_value):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor).to(torch.bfloat16)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -136,7 +136,7 @@ def test_full_like_opt_tensor(device, input_shape, fill_value, layout):
     opt_tensor = ttnn.from_device(opt_tensor)
     opt_tensor = ttnn.to_torch(opt_tensor)
 
-    assert_equal(torch_output_tensor, opt_tensor)
+    assert_with_pcc(torch_output_tensor, opt_tensor, 0.9999)
     assert torch.allclose(torch_output_tensor, opt_tensor)
 
 
@@ -154,7 +154,7 @@ def test_ones(device, input_shape):
     assert ttnn.is_tensor_storage_on_device(tensor)
     tensor = ttnn.to_torch(tensor)
 
-    assert_equal(torch_tensor, tensor)
+    assert_with_pcc(torch_tensor, tensor, 0.9999)
     assert torch.allclose(torch_tensor, tensor)
 
 
@@ -172,7 +172,7 @@ def test_zeros(device, input_shape):
     assert ttnn.is_tensor_storage_on_device(tensor)
     tensor = ttnn.to_torch(tensor)
 
-    assert_equal(torch_tensor, tensor)
+    assert_with_pcc(torch_tensor, tensor, 0.9999)
     assert torch.allclose(torch_tensor, tensor)
 
 
@@ -199,7 +199,7 @@ def test_full(device, input_shape, fill_value, layout):
     assert ttnn.is_tensor_storage_on_device(tensor)
     tensor = ttnn.to_torch(tensor)
 
-    assert_equal(torch_tensor, tensor)
+    assert_with_pcc(torch_tensor, tensor, 0.9999)
     assert torch.allclose(torch_tensor, tensor)
 
 
@@ -233,7 +233,7 @@ def test_full_with_opt_tensor(device, input_shape, layout, fill_value):
     assert ttnn.is_tensor_storage_on_device(opt_tensor)
     opt_tensor = ttnn.to_torch(opt_tensor)
 
-    assert_equal(torch_tensor, opt_tensor)
+    assert_with_pcc(torch_tensor, opt_tensor, 0.9999)
     assert torch.allclose(torch_tensor, opt_tensor)
 
 
@@ -260,7 +260,7 @@ def test_full_multi_device(mesh_device, input_shape, fill_value, layout):
     assert ttnn.is_tensor_storage_on_device(tensor)
     output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor.cpu())]
     for output_tensor in output_tensors:
-        assert_equal(torch_tensor, output_tensor)
+        assert_with_pcc(torch_tensor, output_tensor, 0.9999)
         assert torch.allclose(torch_tensor, output_tensor)
 
 
@@ -300,7 +300,8 @@ def test_arange_tile_layout(device, start, end, step):
     if (start > end and step > 0) or (start < end and step < 0) or (step == 0):
         pytest.skip(f"Skipping invalid case: start={start}, end={end}, step={step}")
 
-    torch_output_tensor = torch.arange(start, end, step).bfloat16()
+    golden_arange = ttnn.get_golden_function(ttnn.arange)
+    torch_output_tensor = golden_arange(start, end, step)
 
     output_tensor = ttnn.arange(start, end, step, device=device, layout=ttnn.TILE_LAYOUT)
     width_dim = int(((abs(end - start) + abs(step) - 1) // abs(step)))
@@ -313,10 +314,7 @@ def test_arange_tile_layout(device, start, end, step):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    if torch_output_tensor.numel() == 0:
-        assert output_tensor.numel() == 0
-    else:
-        assert_equal(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
 @pytest.mark.parametrize(
@@ -335,20 +333,14 @@ def test_arange(device, start, end, step):
     if (start > end and step > 0) or (start < end and step < 0) or (step == 0):
         pytest.skip(f"Skipping invalid case: start={start}, end={end}, step={step}")
 
-    # torch.arange has worse accuracy for bf16 than ttnn for some reason:
-    # https://github.com/tenstorrent/tt-metal/pull/19882#issuecomment-2772903175
-    torch_output_tensor_int = torch.arange(start, end, step, dtype=torch.int32)
-    torch_output_tensor = torch_output_tensor_int.to(torch.bfloat16)
+    torch_output_tensor = torch.arange(start, end, step)
 
     output_tensor = ttnn.arange(start, end, step, dtype=ttnn.bfloat16, device=device)
     assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    if torch_output_tensor.numel() == 0:
-        assert output_tensor.numel() == 0
-    else:
-        assert_equal(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
 @pytest.mark.parametrize(
@@ -366,10 +358,7 @@ def test_arange(device, start, end, step):
 def test_arange_multi_device(mesh_device, start, end, step):
     if (start > end and step > 0) or (start < end and step < 0) or (step == 0):
         pytest.skip(f"Skipping invalid case: start={start}, end={end}, step={step}")
-    # torch.arange has worse accuracy for bf16 than ttnn for some reason:
-    # https://github.com/tenstorrent/tt-metal/pull/19882#issuecomment-2772903175
-    torch_output_tensor_int = torch.arange(start, end, step, dtype=torch.int32)
-    torch_output_tensor = torch_output_tensor_int.to(torch.bfloat16)
+    torch_output_tensor = torch.arange(start, end, step)
 
     output_tensor = ttnn.arange(
         start,
@@ -383,10 +372,7 @@ def test_arange_multi_device(mesh_device, start, end, step):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(output_tensor.cpu())]
     for output_tensor in output_tensors:
-        if torch_output_tensor.numel() == 0:
-            assert output_tensor.numel() == 0
-        else:
-            assert_equal(torch_output_tensor, output_tensor)
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_full.py
+++ b/tests/ttnn/unit_tests/operations/test_full.py
@@ -15,12 +15,10 @@ from tests.ttnn.utils_for_testing import assert_equal, tt_dtype_to_torch_dtype
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [],  # single tile with rank 0
         [3],  # single tile with rank 1
         [1, 3],  # single tile
         [32, 32],  # single tile
         [5, 17, 31],  # multiple tiles
-        [3, 300, 1, 300],  # multiple tiles not aligned by 32
     ],
 )
 @pytest.mark.parametrize(
@@ -41,12 +39,10 @@ def test_full_int(device, input_shape, fill_value):
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [],  # single tile with rank 0
         [3],  # single tile with rank 1
         [1, 3],  # single tile
         [32, 32],  # single tile
         [5, 96, 64],  # multiple tiles
-        [3, 300, 1, 300],  # multiple tiles not aligned by 32
     ],
 )
 @pytest.mark.parametrize(
@@ -57,7 +53,6 @@ def test_full_int(device, input_shape, fill_value):
         2.00830080,  # mantissa: 0000 0001 0001, bf16 round up test
         2.02343750,  # mantissa: 0000 0011, bf16 round up test
         -3.9921875,  # test mantissa overflow. answer should be 4
-        1e-8,  # Casted to different values in fp32->bf16 truncate vs round
     ],
 )
 @pytest.mark.parametrize(
@@ -75,7 +70,11 @@ def test_full_float(device, input_shape, fill_value, tt_dtype):
     assert ttnn.is_tensor_storage_on_device(tt_output)
     tt_output_cpu = ttnn.to_torch(tt_output)
 
-    assert torch.equal(torch_output, tt_output_cpu)
+    # TODO (issue #16579): Investigate why ttnn.full isn't exact match while ttnn.moreh_full is correct for ttnn.bfloat16
+    if tt_dtype == ttnn.bfloat16:
+        pytest.xfail("ttnn.full does not have exact match if dtype is ttnn.bfloat16")
+    else:
+        assert torch.equal(torch_output, tt_output_cpu)
 
 
 # TODO (issue #16579): Add program cache test when ttnn.full is run on device

--- a/tt-train/tests/ops/layer_norm_op_test.cpp
+++ b/tt-train/tests/ops/layer_norm_op_test.cpp
@@ -189,7 +189,7 @@ TEST_F(LayerNormOpTest, CompositeLayerNormOp_backward) {
     std::vector<float> expected_beta_grad{-0.8165, 0.0000, 2.4495};
     for (uint32_t i = 0; i < features; ++i) {
         EXPECT_NEAR(beta_grad[i], expected_beta_grad[i], 3e-2);
-        EXPECT_NEAR(gamma_grad[i], expected_gamma_grad[i], 4.2e-2);
+        EXPECT_NEAR(gamma_grad[i], expected_gamma_grad[i], 3e-2);
         EXPECT_NEAR(tensor_grad[i], expected_tensor_grad[i], 6e-2);
     }
 }

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -341,7 +341,7 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
     EXPECT_EQ(result_composite_xtensor.shape(), x_data.shape());
 
     // Compare forward results
-    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_composite_xtensor, 4e-2F, 3e-2F));
+    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_composite_xtensor, 1.0e-3F, 3e-2F));
     EXPECT_TRUE(xt::all(xt::isfinite(result_kernel_xtensor)));
     EXPECT_TRUE(xt::all(xt::isfinite(result_composite_xtensor)));
 

--- a/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
@@ -43,7 +43,7 @@ TEST_F(ReduceOpTest, TestMeanDim0) {
     auto mean_ttnn = ttml::core::to_xtensor(ttnn_mean_dim0);
     auto mean_moreh = ttml::core::to_xtensor(moreh_mean_dim0);
 
-    EXPECT_TRUE(xt::allclose(mean_ttnn, mean_moreh, /*rtol=*/7e-2, /*atol=*/1e-3));
+    EXPECT_TRUE(xt::allclose(mean_ttnn, mean_moreh, /*rtol=*/1e-4, /*atol=*/1e-3));
     EXPECT_TRUE(xt::allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2));
     EXPECT_TRUE(xt::allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2));
 }

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -20,16 +20,20 @@ public:
     static constexpr size_t SIZEOF = 2;
     bfloat16() = default;
 
-    // create from float: tie-to-even rounding
-    bfloat16(float float_num);
+    // create from float: no rounding, just truncate
+    bfloat16(float float_num) {
+        static_assert(sizeof float_num == 4, "float must have size 4");
+
+        uint16_data = (*reinterpret_cast<uint32_t*>(&float_num)) >> 16;
+    }
 
     // store lower 16 as 16-bit uint
-    bfloat16(uint32_t uint32_data);
+    bfloat16(uint32_t uint32_data) { uint16_data = (uint16_t)uint32_data; }
 
-    bfloat16(uint16_t uint16_data_);
+    bfloat16(uint16_t uint16_data_) { uint16_data = uint16_data_; }
 
     // store lower 16 as 16-bit uint
-    bfloat16(int int_data);
+    bfloat16(int int_data) { uint16_data = (uint16_t)int_data; }
 
     float to_float() const {
         // move lower 16 to upper 16 (of 32) and convert to float

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -13,37 +13,6 @@
 #include "assert.hpp"
 #include "tracy/Tracy.hpp"
 
-namespace {
-uint16_t fp32_to_bf16_bits_round_to_nearest_even(float val) {
-    if (std::isnan(val)) {
-        // NaN is represented when all exponent bits are 1 and mantissa is non-zero.
-        // 0x7FC0  = 0 (sign) 11111111 (exponent) 1000000 (mantissa)
-        return UINT16_C(0x7FC0);
-    } else {
-        union {
-            uint32_t U32;
-            float F32;
-        };
-
-        F32 = val;
-        // Rounding bias = 0111 1111 1111 1111 (0x7FFF) if last bit of mantissa ((U32 >> 16) & 1)
-        // is 0, otherwise 1000 0000 0000 0000 (0x8000).
-        // This ensures that we round to the nearest even number.
-        uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
-        return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
-    }
-}
-
-}  // namespace
-
-bfloat16::bfloat16(float float_num) { uint16_data = fp32_to_bf16_bits_round_to_nearest_even(float_num); }
-
-bfloat16::bfloat16(uint32_t uint32_data) { uint16_data = (uint16_t)uint32_data; }
-
-bfloat16::bfloat16(uint16_t uint16_data_) { uint16_data = uint16_data_; }
-
-bfloat16::bfloat16(int int_data) { uint16_data = (uint16_t)int_data; }
-
 std::ostream& operator<<(std::ostream& os, const bfloat16& bfp16) {
     os << bfp16.to_uint16();
     return os;
@@ -375,9 +344,4 @@ bool packed_uint32_t_vector_comparison(
     }
 
     return true;
-}
-
-uint16_t fp32_to_bf16_bits(float val) {
-    static_assert(sizeof val == 4, "float must have size 4");
-    return fp32_to_bf16_bits_round_to_nearest_even(val);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -4,7 +4,6 @@
 
 #include "binary_ng_utils.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
-#include <tt-metalium/hal.hpp>
 #include <tt-metalium/assert.hpp>
 
 #include <fmt/core.h>
@@ -520,12 +519,6 @@ uint32_t pack_scalar_runtime_arg(const float scalar, const DataType dtype, const
     }
     if (dtype == DataType::UINT32) {
         return std::bit_cast<uint32_t>(scalar);
-    }
-    // +-inf and nan, value must be truncated to make sure it's still special value in device code
-    if (scalar == tt::tt_metal::hal::get_inf() || scalar == -tt::tt_metal::hal::get_inf() ||
-        scalar == tt::tt_metal::hal::get_nan()) {
-        uint16_t bf16_bits = (*reinterpret_cast<const uint32_t*>(&scalar)) >> 16;
-        return pack_two_bfloat16_into_uint32({bf16_bits, bf16_bits});
     }
     return pack_two_bfloat16_into_uint32({scalar, scalar});
 }

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
@@ -1,14 +1,35 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/bfloat16.hpp>
 #include "full_device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 using namespace tt;
 using namespace tt::constants;
+
+// After the full modification and if there are no issues in the overall tests, it will be added to `bfloat16.hpp` and
+// applied globally.
+uint32_t get_bfloat16_rounded(const float val) {
+    uint32_t float_bits = *reinterpret_cast<const uint32_t*>(&val);
+
+    // upper 16 bits
+    uint16_t bfloat16_bits = float_bits >> 16;
+
+    // check Guard, Round, Sticky bits from lower 16 bits
+    uint32_t lower_bits = float_bits & 0xFFFF;
+    uint32_t guard_bit = (lower_bits >> 15) & 1;
+    uint32_t round_bit = (lower_bits >> 14) & 1;
+    uint32_t sticky_bit = (lower_bits & 0x3FFF) != 0;
+
+    // Tie-to-even rounding rule
+    if (guard_bit && (round_bit || sticky_bit || (bfloat16_bits & 1))) {
+        bfloat16_bits += 1;
+    }
+
+    return static_cast<uint32_t>(bfloat16_bits) << 16;
+}
 
 union datatype {
     uint32_t u32;
@@ -56,7 +77,7 @@ FullOperation::ProgramFactory::cached_program_t FullOperation::ProgramFactory::c
     } else if (std::holds_alternative<float>(fill_value)) {
         auto float_fill_value = std::get<float>(fill_value);
         if (dtype == DataType::BFLOAT16) {
-            u.u32 = static_cast<uint32_t>(bfloat16(float_fill_value).to_uint16()) << 16;
+            u.u32 = get_bfloat16_rounded(float_fill_value);
         } else {
             u.f32 = float_fill_value;
         }


### PR DESCRIPTION
This reverts commit efcf08339a78f619ec06933e6e345bb24fd412b1.

### Problem description
PR breaks PCC for stable_diffusion and stable_diffusion_xl https://github.com/tenstorrent/tt-metal/actions/runs/16732954313