### PR TITLE
remove env vars for dispatch cores

### DIFF
--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -272,13 +272,6 @@ def get_updated_device_params(device_params):
 
     dispatch_core_axis = new_device_params.pop("dispatch_core_axis", None)
     dispatch_core_type = new_device_params.pop("dispatch_core_type", None)
-    # Special env to force worker dispatch to test dispatch from worker cores
-    if "TT_TEST_USE_WORKER_DISPATCH" in os.environ:
-        dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
-
-    # Special env to force ethernet dispatch to test dispatch from ethernet cores
-    if "TT_TEST_USE_ETH_DISPATCH" in os.environ:
-        dispatch_core_type = ttnn.device.DispatchCoreType.ETH
 
     if ttnn.device.is_blackhole() and dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
         logger.warning("blackhole arch does not support DispatchCoreAxis.ROW, using DispatchCoreAxis.COL instead.")

--- a/tests/ttnn/tracy/test_dispatch_profiler.py
+++ b/tests/ttnn/tracy/test_dispatch_profiler.py
@@ -9,6 +9,11 @@ from loguru import logger
 import ttnn
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_type": ttnn.DispatchCoreType.WORKER}, {"dispatch_core_type": ttnn.DispatchCoreType.ETH}],
+    indirect=True,
+)
 def test_with_ops(device):
     torch.manual_seed(0)
 
@@ -39,8 +44,14 @@ def test_with_ops(device):
 
 
 @pytest.mark.parametrize("num_devices", [(8)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_type": ttnn.DispatchCoreType.WORKER}, {"dispatch_core_type": ttnn.DispatchCoreType.ETH}],
+    indirect=True,
+)
 def test_all_devices(
     all_devices,
     num_devices,
+    device_params,
 ):
     logger.debug("Testing All Devices")

--- a/tests/ttnn/tracy/test_trace_runs.py
+++ b/tests/ttnn/tracy/test_trace_runs.py
@@ -9,7 +9,9 @@ from loguru import logger
 import ttnn
 
 
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 1996800}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 1996800, "dispatch_core_type": ttnn.DispatchCoreType.WORKER}], indirect=True
+)
 def test_with_ops(device):
     torch.manual_seed(0)
     m = 1024


### PR DESCRIPTION
### Problem description
Tests no longer rely on env vars like WH_ARCH_YAML to set dispatch core type, instead the defaults are used unless overridden by the `device_params` pytest fixture. For worker and ethernet dispatch profiler tests we were using special env vars to override.


### What's changed
Changed the tests to be in line with expected usage of `device_params` and filter tests accordingly for the regular and ethernet dispatch profiler tests.


Pipelines:
APC: https://github.com/tenstorrent/tt-metal/actions/runs/16779595270
BH APC: https://github.com/tenstorrent/tt-metal/actions/runs/16783572300)
T3K: https://github.com/tenstorrent/tt-metal/actions/runs/16779611927 (1 failure - seen on main e.g https://github.com/tenstorrent/tt-metal/actions/runs/16792873580/job/47558312780)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)