### PR TITLE
revert new tests that weren't ready for primetime

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
@@ -13,6 +13,7 @@
 #include "edm_fabric_flow_control_helpers.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp"
+#include "fabric_edm_packet_header_validate.hpp"
 #include "tt_metal/hw/inc/utils/utils.h"
 #include "debug/assert.h"
 
@@ -284,6 +285,9 @@ public:
         close_start();
         close_finish();
     }
+
+    // Only for debug/watcher asserts
+    FORCE_INLINE uint32_t get_worker_credits_stream_id() const { return this->worker_credits_stream_id; }
 
 private:
     mutable uint64_t noc_sem_addr_;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2900,14 +2900,14 @@ void kernel_main() {
                 downstream_edm_noc_interfaces_vc0[0]
                     .template open<false, use_posted_writes_for_connection_open, tt::tt_fabric::worker_handshake_noc>();
                 ASSERT(
-                    get_ptr_val(downstream_edm_noc_interfaces_vc0[0].worker_credits_stream_id) ==
+                    get_ptr_val(downstream_edm_noc_interfaces_vc0[0].get_worker_credits_stream_id()) ==
                     DOWNSTREAM_SENDER_NUM_BUFFERS_VC0);
             }
             if (has_downstream_edm_vc1_buffer_connection) {
                 downstream_edm_noc_interface_vc1
                     .template open<false, use_posted_writes_for_connection_open, tt::tt_fabric::worker_handshake_noc>();
                 ASSERT(
-                    get_ptr_val(downstream_edm_noc_interface_vc1.worker_credits_stream_id) ==
+                    get_ptr_val(downstream_edm_noc_interface_vc1.get_worker_credits_stream_id()) ==
                     DOWNSTREAM_SENDER_NUM_BUFFERS_VC1);
             }
         }


### PR DESCRIPTION
Fix [regression](https://github.com/tenstorrent/tt-metal/actions/runs/16753206235/job/47429185543) in BH LLMBox pipelines. I [added new tests](https://github.com/tenstorrent/tt-metal/commit/315128fdbdc587bba9ec341401c54381d7fc0e63) and accidentally excluded them from my test list. This removes those failing tests.