### PR TITLE
Update 2D Mcast setup in test

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -273,8 +273,27 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
 
     std::vector<uint32_t> mcast_header_rtas(4, 0);
     for (const auto& routing_info : mcast_routing_info) {
+        auto axis_hops = routing_info.num_mcast_hops;
+        if (spine_hops) {
+            // hops here include the mcast origin device.
+            // i.e mcast_routing_info specifies the size of mcast group, which included the mcast
+            // origin device.
+            // For example, if north is set to 4, it implies origin device + 3 north neighbors.
+            // Therefore, if there is an mcast trunk, decrement the trunk hop count by 1 to discount the origin
+            // device.
+            if (routing_info.mcast_dir == RoutingDirection::N or routing_info.mcast_dir == RoutingDirection::S) {
+                // Decrement the hop to account for mcast origin device.
+                axis_hops--;
+            }
+            // Also, if there is a a trunk present, we do not decrement the branch axis size.
+        } else {
+            // There is no Trunk, i.e branch line mcast.
+            // In this case decrement the branch axis hop count, because, origin devices counts as first
+            // mcast receiver device.
+            axis_hops--;
+        }
         mcast_header_rtas[static_cast<uint32_t>(
-            control_plane.routing_direction_to_eth_direction(routing_info.mcast_dir))] = routing_info.num_mcast_hops;
+            control_plane.routing_direction_to_eth_direction(routing_info.mcast_dir))] = axis_hops;
     }
     sender_runtime_args.insert(sender_runtime_args.end(), mcast_header_rtas.begin(), mcast_header_rtas.end());
     // append the EDM connection rt args

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_line_mcast_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_line_mcast_tx.cpp
@@ -80,28 +80,6 @@ void kernel_main() {
     fwd_packet_header = PacketHeaderPool::allocate_header();
     zero_l1_buf((uint32_t*)fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
 
-    // the hop counts passed down by the test include the mcast start device.
-    // To account for the starting device, decrement respecive direction count by 1.
-    if (num_hops_n) {
-        // line mcast north, or trunk of 2D mcast.
-        // decrement line/trunk hop by 1.
-        // east/west hops stay intact since mcast is not starting on east/west device.
-        num_hops_n--;
-    } else if (num_hops_s) {
-        // line mcast south, or trunk of 2D mcast.
-        // decrement line/trunk hop by 1.
-        // east/west hops stay intact since mcast is not starting on east/west device.
-        num_hops_s--;
-    } else if (num_hops_e) {
-        // not a 2D mcast.
-        // mcast start device is east of sender, so decrement east hop by 1.
-        num_hops_e--;
-    } else if (num_hops_w) {
-        // not a 2D mcast.
-        // mcast start device is west of sender, so decrement west hop by 1.
-        num_hops_w--;
-    }
-
     fabric_set_mcast_route(
         (MeshPacketHeader*)fwd_packet_header, fwd_dev_id, fwd_mesh_id, num_hops_e, num_hops_w, num_hops_n, num_hops_s);
 


### PR DESCRIPTION
Properly set the 2d mcast size in the test instead of modifying hop counts in the tx kernel.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes