### PR TITLE
Add DeepSeek-R1-Distill-Qwen-14B as a supported model in tt-transformers

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -113,6 +113,7 @@ jobs:
   #          # Moved to t3k tests until OOM on single card runners resolved
             # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
             { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_func, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+            { name: "ds_r1_qwen", runner-label: "N300", performance: true, cmd: run_ds_r1_qwen_func, owner_id: U07RY6B5FLJ},  #Gongyu Wang
             { name: "gemma3", runner-label: "N150", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews
             { name: "gemma3", runner-label: "N300", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews
           ]]

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -587,6 +587,7 @@ class ModelArgs:
                 "Qwen2.5-VL-3B": {"N150": 128, "N300": 128, "T3K": None, "TG": None, "P150x4": None},
                 "Qwen2.5-VL-32B": {"N150": None, "N300": None, "T3K": 64, "TG": None, "P150x4": None},
                 "Qwen2.5-VL-72B": {"N150": None, "N300": None, "T3K": 32, "TG": None, "P150x4": None},
+                "DeepSeek-R1-Distill-Qwen-14B": {"N150": 4, "N300": 64, "T3K": 128, "TG": None, "P150x4": None},
                 "Phi-3.5-mini-instruct": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Phi-3-mini-128k-instruct": {"N150": 32, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
                 "QwQ-32B": {"N150": None, "N300": None, "T3K": 64, "TG": 128, "P150x4": 128},

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -53,6 +53,14 @@ run_qwen25_vl_func() {
   fi
 }
 
+run_ds_r1_qwen_func() {
+
+  ds_r1_qwen=deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
+  qwen_cache=$TT_CACHE_HOME/$ds_r1_qwen
+  HF_MODEL=$ds_r1_qwen TT_CACHE_PATH=$qwen_cache MESH_DEVICE=N300 pytest -n auto models/tt_transformers/demo/simple_text_demo.py -k performance-ci-1 --timeout 1800
+
+}
+
 run_gemma3_func() {
   HF_MODEL=/mnt/MLPerf/tt_dnn-models/google/gemma-3-4b-it pytest models/demos/gemma3/demo/text_demo.py -k "ci-token-matching"
   echo "LOG_METAL: Gemma3 4B accuracy tests completed (text only)"


### PR DESCRIPTION
### Ticket
#25398

### Problem description
TT-Transformers doesn't have support for DeepSeek-R1-Distill-Qwen-14B model

### What's changed
Add one line in tt/model_config.py

### Checklist
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes 
