### PR TITLE
#26278: Adopt ttsl::overloaded

### DIFF
--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(
         hw
         fmt::fmt-header-only
         umd::device
+        TT::STL
         tt-logger::tt-logger
 )
 
@@ -62,6 +63,7 @@ target_link_libraries(
         hw
         fmt::fmt-header-only
         umd::device
+        TT::STL
         tt-logger::tt-logger
 )
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -22,6 +22,8 @@
 
 #include "tt_memory.h"
 
+#include <tt_stl/overloaded.hpp>
+
 enum class CoreType;
 enum class AddressableCoreType : uint8_t;
 
@@ -162,7 +164,7 @@ private:
     bool coordinate_virtualization_enabled_;
     uint32_t virtual_worker_start_x_;
     uint32_t virtual_worker_start_y_;
-    bool eth_fw_is_cooperative_ = false;  // set when eth riscs have to context switch
+    bool eth_fw_is_cooperative_ = false;        // set when eth riscs have to context switch
     bool intermesh_eth_links_enabled_ = false;  // set when an architecture enable intermesh routing
     std::unordered_set<AddressableCoreType> virtualized_core_types_;
     HalTensixHarvestAxis tensix_harvest_axis_;
@@ -303,36 +305,31 @@ inline uint32_t Hal::get_programmable_core_type_count() const { return core_info
 
 inline uint32_t Hal::get_processor_classes_count(
     std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type) const {
-    return std::visit(
-        [&](auto&& core_type_specifier) -> uint32_t {
-            using T = std::decay_t<decltype(core_type_specifier)>;
-            uint32_t index = this->core_info_.size();
-            if constexpr (std::is_same_v<T, HalProgrammableCoreType>) {
-                index = utils::underlying_type<HalProgrammableCoreType>(core_type_specifier);
-            } else if constexpr (std::is_same_v<T, uint32_t>) {
-                index = core_type_specifier;
-            }
-            TT_ASSERT(index < this->core_info_.size());
-            return this->core_info_[index].get_processor_classes_count();
+    // TODO extract as reusable function like `to_index(programmable_core_type)`
+    uint32_t index = std::visit(
+        ttsl::overloaded{
+            [](HalProgrammableCoreType core_type_specifier) -> uint32_t {
+                return utils::underlying_type(core_type_specifier);
+            },
+            [](uint32_t core_type_specifier) { return core_type_specifier; },
         },
         programmable_core_type);
+    TT_ASSERT(index < this->core_info_.size());
+    return this->core_info_[index].get_processor_classes_count();
 }
 
 inline uint32_t Hal::get_processor_types_count(
     std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type, uint32_t processor_class_idx) const {
-    return std::visit(
-        [&](auto&& core_type_specifier) -> uint32_t {
-            using T = std::decay_t<decltype(core_type_specifier)>;
-            uint32_t index = this->core_info_.size();
-            if constexpr (std::is_same_v<T, HalProgrammableCoreType>) {
-                index = utils::underlying_type<HalProgrammableCoreType>(core_type_specifier);
-            } else if constexpr (std::is_same_v<T, uint32_t>) {
-                index = core_type_specifier;
-            }
-            TT_ASSERT(index < this->core_info_.size());
-            return this->core_info_[index].get_processor_types_count(processor_class_idx);
+    uint32_t index = std::visit(
+        ttsl::overloaded{
+            [](HalProgrammableCoreType core_type_specifier) -> uint32_t {
+                return utils::underlying_type(core_type_specifier);
+            },
+            [](uint32_t core_type_specifier) { return core_type_specifier; },
         },
         programmable_core_type);
+    TT_ASSERT(index < this->core_info_.size());
+    return this->core_info_[index].get_processor_types_count(processor_class_idx);
 }
 
 inline HalProgrammableCoreType Hal::get_programmable_core_type(uint32_t core_type_index) const {
@@ -458,16 +455,16 @@ inline uint32_t Hal::get_eth_fw_mailbox_arg_count() const {
 }  // namespace tt_metal
 }  // namespace tt
 
-#define HAL_MEM_L1_BASE                                               \
-    ::tt::tt_metal::MetalContext::instance().hal().get_dev_addr(      \
+#define HAL_MEM_L1_BASE                                          \
+    ::tt::tt_metal::MetalContext::instance().hal().get_dev_addr( \
         ::tt::tt_metal::HalProgrammableCoreType::TENSIX, ::tt::tt_metal::HalL1MemAddrType::BASE)
-#define HAL_MEM_L1_SIZE                                               \
-    ::tt::tt_metal::MetalContext::instance().hal().get_dev_size(      \
+#define HAL_MEM_L1_SIZE                                          \
+    ::tt::tt_metal::MetalContext::instance().hal().get_dev_size( \
         ::tt::tt_metal::HalProgrammableCoreType::TENSIX, ::tt::tt_metal::HalL1MemAddrType::BASE)
 
-#define HAL_MEM_ETH_BASE                                              \
-    ::tt::tt_metal::MetalContext::instance().hal().get_dev_addr(      \
+#define HAL_MEM_ETH_BASE                                         \
+    ::tt::tt_metal::MetalContext::instance().hal().get_dev_addr( \
         ::tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, ::tt::tt_metal::HalL1MemAddrType::BASE)
-#define HAL_MEM_ETH_SIZE                                              \
-    ::tt::tt_metal::MetalContext::instance().hal().get_dev_size(      \
+#define HAL_MEM_ETH_SIZE                                         \
+    ::tt::tt_metal::MetalContext::instance().hal().get_dev_size( \
         ::tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, ::tt::tt_metal::HalL1MemAddrType::BASE)


### PR DESCRIPTION
### Ticket
#26278

### Problem description
Cleaning up error-prone pattern with `std::visit`.

### What's changed
Refactored files under `tt_metal` to avoid this pattern.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16759097876) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes