### PR TITLE
[DM] Add performance tests for noc one_packet_state APIs

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -14,6 +14,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/all_to_all/test_all_to_all.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_from_all/test_all_from_all.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/interleaved/test_interleaved.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/one_packet/test_one_packet.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
@@ -1,0 +1,33 @@
+# One Packet Data Movement Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a sender and a receiver Tensix core using the one_packet APIs.
+
+## Test Flow
+Runs either the reader kernel or the writer kernel on the master core.
+
+If the reader kernel is run, data is written directly into the L1 memory of the subordinate core, and the kernel issues NOC instructions to read this data into the L1 address of the master core using the one_packet APIs. A read barrier is placed after these transactions in order to ensure data validity.
+
+If the writer kernel is run, data is written directly into the L1 memory of the master core, and the kernel issues NOC instructions to write this data into the L1 address of the subordinate core using the one_packet APIs. A write barrier is placed after these transactions in order to ensure data validity.
+
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+
+Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| master_core_coord         | CoreCoord             | Logical coordinates for the master core. |
+| subordinate_core_coord    | CoreCoord             | Logical coordinates for the subordinate core. |
+| num_packets               | uint32_t              | Number of packet transactions. |
+| packet_size_bytes         | uint32_t              | Size of a packet in bytes (Max 8kB for Wormhole, 16kB for Blackhole). |
+| read                      | bool                  | True if the reader kernel is enabled, false if the writer kernel is enabled. |
+
+## Test Cases
+Each test case uses bfloat16 as L1 data format.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. One Packet Read Sizes: Tests packet reading over varying packet sizes and number of packets.
+2. One Packet Write Sizes: Tests packet writing over varying packet sizes and number of packets.
+3. One Packet Read Directed Ideal: Tests the most optimal transactions for reading packets by maximizing the number of packets and packet size to amortize initialization overhead and saturate the bandwidth.
+4. One Packet Write Directed Ideal: Tests the most optimal transactions for writing packets by maximizing the number of packets and packet size to amortize initialization overhead and saturate the bandwidth.

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/read_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/read_one_packet.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint_pages.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    constexpr uint32_t num_packets = get_compile_time_arg_val(0);
+    constexpr uint32_t packet_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+
+    uint32_t master_l1_addr = get_arg_val<uint32_t>(0);
+    uint32_t subordinate_l1_addr = get_arg_val<uint32_t>(1);
+    uint32_t responder_x_coord = get_arg_val<uint32_t>(2);
+    uint32_t responder_y_coord = get_arg_val<uint32_t>(3);
+
+    DeviceTimestampedData("Number of transactions", num_packets);
+    DeviceTimestampedData("Transaction size in bytes", packet_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        uint64_t src_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, subordinate_l1_addr);
+        noc_async_read_one_packet_set_state(src_noc_addr, packet_size_bytes);
+        for (uint32_t i = 0; i < num_packets; i++) {
+            noc_async_read_one_packet_with_state<true>(subordinate_l1_addr, master_l1_addr);
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/write_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/write_one_packet.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint_pages.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    constexpr uint32_t num_packets = get_compile_time_arg_val(0);
+    constexpr uint32_t packet_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+
+    uint32_t master_l1_addr = get_arg_val<uint32_t>(0);
+    uint32_t subordinate_l1_addr = get_arg_val<uint32_t>(1);
+    uint32_t responder_x_coord = get_arg_val<uint32_t>(2);
+    uint32_t responder_y_coord = get_arg_val<uint32_t>(3);
+
+    DeviceTimestampedData("Number of transactions", num_packets);
+    DeviceTimestampedData("Transaction size in bytes", packet_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        uint64_t dst_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, subordinate_l1_addr);
+        noc_async_write_one_packet_set_state(dst_noc_addr, packet_size_bytes);
+        for (uint32_t i = 0; i < num_packets; i++) {
+            noc_async_write_one_packet_with_state<true>(master_l1_addr, subordinate_l1_addr);
+        }
+        noc_async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "dm_common.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::one_packet {
+// Test config, i.e. test parameters
+struct OnePacketConfig {
+    uint32_t test_id = 0;
+    CoreCoord master_core_coord = CoreCoord();
+    CoreCoord subordinate_core_coord = CoreCoord();
+    uint32_t num_packets = 0;
+    uint32_t packet_size_bytes = 0;
+    bool read = true;
+};
+
+/// @brief Does OneToOne or OneFromOne but with one_packet read/write
+/// @param device
+/// @param test_config - Configuration of the test -- see struct
+/// @return
+bool run_dm(IDevice* device, const OnePacketConfig& test_config) {
+    // Program
+    Program program = CreateProgram();
+
+    // (Logical) Core Coordinates and ranges
+    CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
+
+    // Obtain L1 Address for Storing Data
+    // NOTE: We don't know if the whole block of memory is actually available.
+    //       This is something that could probably be checked
+    L1AddressInfo master_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+    L1AddressInfo subordinate_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.subordinate_core_coord);
+    // Checks that both master and subordinate cores have the same L1 base address and size
+    if (master_l1_info.base_address != subordinate_l1_info.base_address ||
+        master_l1_info.size != subordinate_l1_info.size) {
+        log_error(tt::LogTest, "Mismatch in L1 address or size between master and subordinate cores");
+        return false;
+    }
+    // Check if the L1 size is sufficient for the test configuration
+    if (master_l1_info.size < test_config.packet_size_bytes) {
+        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+
+    uint32_t master_l1_address = master_l1_info.base_address;
+    uint32_t subordinate_l1_address = subordinate_l1_info.base_address;
+
+    // Compile-time arguments for kernels
+    vector<uint32_t> compile_args = {
+        (uint32_t)test_config.num_packets, (uint32_t)test_config.packet_size_bytes, (uint32_t)test_config.test_id};
+
+    // Kernel
+    tt::tt_metal::KernelHandle kernel;
+    if (test_config.read) {
+        kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/data_movement/one_packet/kernels/read_one_packet.cpp",
+            master_core_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = compile_args});
+    } else {
+        kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/data_movement/one_packet/kernels/write_one_packet.cpp",
+            master_core_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = compile_args});
+    }
+
+    // Runtime Arguments
+    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+    SetRuntimeArgs(
+        program,
+        kernel,
+        master_core_set,
+        {master_l1_address, subordinate_l1_address, physical_subordinate_core.x, physical_subordinate_core.y});
+
+    // Assign unique id
+    log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    // Input
+    vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f,
+        100.0f,
+        test_config.packet_size_bytes / bfloat16::SIZEOF,
+        chrono::system_clock::now().time_since_epoch().count());
+
+    // Golden output
+    vector<uint32_t> packed_golden = packed_input;
+    vector<uint32_t> packed_output;
+
+    // Launch program and record outputs
+    if (test_config.read) {
+        detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, subordinate_l1_address, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        detail::LaunchProgram(device, program);
+        detail::ReadFromDeviceL1(
+            device, test_config.master_core_coord, master_l1_address, test_config.packet_size_bytes, packed_output);
+    } else {
+        detail::WriteToDeviceL1(device, test_config.master_core_coord, master_l1_address, packed_input);
+        MetalContext::instance().get_cluster().l1_barrier(device->id());
+        detail::LaunchProgram(device, program);
+        detail::ReadFromDeviceL1(
+            device,
+            test_config.subordinate_core_coord,
+            subordinate_l1_address,
+            test_config.packet_size_bytes,
+            packed_output);
+    }
+
+    // Results comparison
+    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
+        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+
+    if (!pcc) {
+        log_error(tt::LogTest, "PCC Check failed");
+        log_info(tt::LogTest, "Golden vector");
+        print_vector<uint32_t>(packed_golden);
+        log_info(tt::LogTest, "Output vector");
+        print_vector<uint32_t>(packed_output);
+    }
+
+    return pcc;
+}
+}  // namespace unit_tests::dm::one_packet
+
+/* ========== Test case for reading varying number of packets and packet sizes; Test id = 80 ========== */
+TEST_F(DeviceFixture, TensixDataMovementOnePacketReadSizes) {
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    // Parameters
+    uint32_t max_packet_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;  // 16 kB for BH, 8 kB for WH
+    uint32_t max_packets = 256;
+
+    // Cores
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 1};
+
+    for (uint32_t num_packets = 1; num_packets <= max_packets; num_packets *= 4) {
+        for (uint32_t packet_size_bytes = page_size_bytes; packet_size_bytes <= max_packet_size_bytes;
+             packet_size_bytes *= 2) {
+            // Test config
+            unit_tests::dm::one_packet::OnePacketConfig test_config = {
+                .test_id = 80,
+                .master_core_coord = master_core_coord,
+                .subordinate_core_coord = subordinate_core_coord,
+                .num_packets = num_packets,
+                .packet_size_bytes = packet_size_bytes,
+                .read = true,
+            };
+
+            // Run
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+            }
+        }
+    }
+}
+
+/* ========== Test case for writing varying number of packets and packet sizes; Test id = 81 ========== */
+TEST_F(DeviceFixture, TensixDataMovementOnePacketWriteSizes) {
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    // Parameters
+    uint32_t max_packet_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;  // 16 kB for BH, 8 kB for WH
+    uint32_t max_packets = 256;
+    // Cores
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 1};
+
+    for (uint32_t num_packets = 1; num_packets <= max_packets; num_packets *= 4) {
+        for (uint32_t packet_size_bytes = page_size_bytes; packet_size_bytes <= max_packet_size_bytes;
+             packet_size_bytes *= 2) {
+            // Test config
+            unit_tests::dm::one_packet::OnePacketConfig test_config = {
+                .test_id = 81,
+                .master_core_coord = master_core_coord,
+                .subordinate_core_coord = subordinate_core_coord,
+                .num_packets = num_packets,
+                .packet_size_bytes = packet_size_bytes,
+                .read = false,
+            };
+
+            // Run
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+            }
+        }
+    }
+}
+
+/* ========== Directed Ideal Test Case; Test id = 82 ========== */
+TEST_F(DeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal) {
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    // Parameters
+    uint32_t packet_size_bytes = page_size_bytes * 256;  // max packet size = 256 flits
+    uint32_t num_packets = max_transmittable_bytes / packet_size_bytes;
+
+    // Cores
+    /*
+        Any two cores that are next to each other on the torus
+         - May be worth considering the performance of this test with different pairs of adjacent cores
+    */
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 1};
+
+    // Test Config
+    unit_tests::dm::one_packet::OnePacketConfig test_config = {
+        .test_id = 82,
+        .master_core_coord = master_core_coord,
+        .subordinate_core_coord = subordinate_core_coord,
+        .num_packets = num_packets,
+        .packet_size_bytes = packet_size_bytes,
+        .read = true,
+    };
+
+    // Run
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
+
+/* ========== Directed Ideal Test Case; Test id = 83 ========== */
+TEST_F(DeviceFixture, TensixDataMovementOnePacketWriteDirectedIdeal) {
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    // Parameters
+    uint32_t packet_size_bytes = page_size_bytes * 256;  // max packet size = 256 flits
+    uint32_t num_packets = max_transmittable_bytes / packet_size_bytes;
+
+    // Cores
+    /*
+        Any two cores that are next to each other on the torus
+         - May be worth considering the performance of this test with different pairs of adjacent cores
+    */
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 1};
+
+    // Test Config
+    unit_tests::dm::one_packet::OnePacketConfig test_config = {
+        .test_id = 83,
+        .master_core_coord = master_core_coord,
+        .subordinate_core_coord = subordinate_core_coord,
+        .num_packets = num_packets,
+        .packet_size_bytes = packet_size_bytes,
+        .read = false,
+    };
+
+    // Run
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -60,6 +60,46 @@
     riscv_1:
       bandwidth: 60
 
+"DRAM Interleaved Page Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 30
+    riscv_0:
+      bandwidth: 26
+  blackhole:
+    riscv_1:
+      bandwidth: 60
+    riscv_0:
+      bandwidth: 58
+
+"L1 Interleaved Page Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 31
+    riscv_0:
+      bandwidth: 31
+  blackhole:
+    riscv_1:
+      bandwidth: 61
+    riscv_0:
+      bandwidth: 62
+
+"One Packet Read Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 28
+  blackhole:
+    riscv_1:
+      bandwidth: 61
+
+"One Packet Write Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 30
+  blackhole:
+    riscv_0:
+      bandwidth: 61
+
 # OTHER TESTS
 
 "Reshard Hardcoded Small":

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -176,6 +176,18 @@ tests:
   75:
     name: "L1 Interleaved Page Write Noc Swap"
 
+  80:
+    name: "One Packet Read Sizes"
+
+  81:
+    name: "One Packet Write Sizes"
+
+  82:
+    name: "One Packet Read Directed Ideal"
+
+  83:
+    name: "One Packet Write Directed Ideal"
+
   100:
     name: "Multicast Schemes (Loopback Enabled)"
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24084#issuecomment-3019573108)

### Problem description
DM directory currently does not have any tests for `noc_async_read_one_packet_with_state` and `noc_async_write_one_packet_with_state` APIs, and thus has no way to analyze the performance bottlenecks that can result from using these primitives in operations such as concat.

### What's changed
Tests for these APIs have been added, which run either a reader or writer kernel and sweep over varying packet sizes and number of packets. Directed ideal test cases have also been added in which demonstrate target maximum bandwidth performance.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes