### PR TITLE
Optimize profiler python post-processing scripts

### DIFF
--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -39,7 +39,6 @@ void RunCustomCycle(tt_metal::IDevice* device, int fastDispatch) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args});
 
     for (int i = 0; i < fastDispatch; i++) {
-        program.set_runtime_id(i + 1);
         EnqueueProgram(device->command_queue(), program, false);
     }
 }

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -39,6 +39,7 @@ void RunCustomCycle(tt_metal::IDevice* device, int fastDispatch) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args});
 
     for (int i = 0; i < fastDispatch; i++) {
+        program.set_runtime_id(i + 1);
         EnqueueProgram(device->command_queue(), program, false);
     }
 }

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -199,7 +199,6 @@ def import_device_profile_log(logPath):
                 for risc, riscData in coreData["riscs"].items():
                     riscData["timeseries"].sort(key=lambda x: x[1])
                     for marker, timestamp, attachedData in riscData["timeseries"]:
-                        shiftedTS = timestamp - globalMinTS
                         # ERISC dispatch is EOL, some models still use it. Need to check and drop it here until it is fully removed.
                         if (
                             "CQ-DISPATCH" in marker["zone_name"] or "CQ-PREFETCH" in marker["zone_name"]
@@ -401,7 +400,6 @@ def risc_to_core_timeseries(devicesData, detectOps):
     for chipID, deviceData in devicesData["devices"].items():
         for core, coreData in deviceData["cores"].items():
             tmpTimeseries = []
-            tmpDurations = []
             for risc, riscData in coreData["riscs"].items():
                 for ts in riscData["timeseries"]:
                     tmpTimeseries.append(ts + (risc,))

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -178,12 +178,12 @@ def import_device_profile_log(logPath):
             for core, coreData in deviceData["cores"].items():
                 for risc, riscData in coreData["riscs"].items():
                     riscData["timeseries"].sort(key=lambda x: x[1])
-                    for marker, timestamp, attachedData in riscData["timeseries"]:
+                    for marker, _, _ in riscData["timeseries"]:
                         # ERISC dispatch is EOL, some models still use it. Need to check and drop it here until it is fully removed.
                         if (
                             "CQ-DISPATCH" in marker["zone_name"] or "CQ-PREFETCH" in marker["zone_name"]
                         ) and "ERISC" not in risc:
-                            dispatchCores.add((chipID, core, risc))
+                            dispatchCores.add((chipID, core))
 
     # Sort all timeseries
     sort_timeseries(devicesData)
@@ -343,7 +343,7 @@ def get_dispatch_core_ops(timeseries):
 
 def get_dispatch_core_ops_core_to_device(chipID, deviceData):
     deviceDispatchCores = set()
-    for chip, core, risc in dispatchCores:
+    for chip, core in dispatchCores:
         if chip == chipID:
             deviceDispatchCores.add(core)
 
@@ -358,10 +358,6 @@ def get_dispatch_core_ops_core_to_device(chipID, deviceData):
 
 
 def risc_to_core_timeseries(devicesData, detectOps):
-    dispatchCoresNoRisc = set()
-    for chip, core, risc in dispatchCores:
-        dispatchCoresNoRisc.add((chip, core))
-
     for chipID, deviceData in devicesData["devices"].items():
         for core, coreData in deviceData["cores"].items():
             tmpTimeseries = []
@@ -373,7 +369,7 @@ def risc_to_core_timeseries(devicesData, detectOps):
 
             ops = []
             if detectOps:
-                if (chipID, core) in dispatchCoresNoRisc:
+                if (chipID, core) in dispatchCores:
                     ops = get_dispatch_core_ops(tmpTimeseries)
                 else:
                     ops = get_ops(tmpTimeseries)

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -173,54 +173,20 @@ def import_device_profile_log(logPath):
                 "cores": {core: {"riscs": {risc: {"timeseries": [(timerID, timeData, attachedData)]}}}}
             }
 
-    def sort_timeseries_and_find_min(devicesData):
-        globalMinTS = (1 << 64) - 1
-        globalMinRisc = "BRISC"
-        globalMinCore = (0, 0)
-
-        foundRange = set()
-        for chipID, deviceData in devicesData["devices"].items():
-            for core, coreData in deviceData["cores"].items():
-                for risc, riscData in coreData["riscs"].items():
-                    riscData["timeseries"].sort(key=lambda x: x[1])
-                    firstTimeID, firsTimestamp, firstStatData = riscData["timeseries"][0]
-                    if globalMinTS > firsTimestamp:
-                        globalMinTS = firsTimestamp
-                        globalMinCore = core
-                        globalMinRisc = risc
-            deviceData.update(
-                dict(metadata=dict(global_min=dict(ts=globalMinTS, risc=globalMinRisc, core=globalMinCore)))
-            )
-
+    def sort_timeseries(devicesData):
         for chipID, deviceData in devicesData["devices"].items():
             for core, coreData in deviceData["cores"].items():
                 for risc, riscData in coreData["riscs"].items():
                     riscData["timeseries"].sort(key=lambda x: x[1])
                     for marker, timestamp, attachedData in riscData["timeseries"]:
-                        shiftedTS = timestamp - globalMinTS
                         # ERISC dispatch is EOL, some models still use it. Need to check and drop it here until it is fully removed.
                         if (
                             "CQ-DISPATCH" in marker["zone_name"] or "CQ-PREFETCH" in marker["zone_name"]
                         ) and "ERISC" not in risc:
                             dispatchCores.add((chipID, core, risc))
-                    riscData["timeseries"].insert(
-                        0,
-                        (
-                            {"id": 0, "zone_name": "", "type": "", "src_line": "", "src_file": ""},
-                            deviceData["metadata"]["global_min"]["ts"],
-                            0,
-                        ),
-                    )
 
-        if foundRange:
-            for chipID, deviceData in devicesData["devices"].items():
-                for core, coreData in deviceData["cores"].items():
-                    for risc, riscData in coreData["riscs"].items():
-                        if (chipID, core, risc) not in foundRange:
-                            riscData["timeseries"] = []
-
-    # Sort all timeseries and find global min timestamp
-    sort_timeseries_and_find_min(devicesData)
+    # Sort all timeseries
+    sort_timeseries(devicesData)
 
     return devicesData
 
@@ -422,10 +388,7 @@ def core_to_device_timeseries(devicesData, detectOps):
         for core, coreData in deviceData["cores"].items():
             for risc, riscData in coreData["riscs"].items():
                 for ts in riscData["timeseries"]:
-                    timerID, timestamp, *metadata = ts
                     tsCore = ts + (core,)
-                    if timerID["id"] == 0:
-                        tsCore = ts + (deviceData["metadata"]["global_min"]["core"],)
                     if risc in tmpTimeseries["riscs"]:
                         tmpTimeseries["riscs"][risc]["timeseries"].append(tsCore)
                     else:

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -133,11 +133,11 @@ def import_tracy_op_logs(logFolder):
                         jsonStr = tmpStrs[-1]
                         opData = json.loads(jsonStr)
                         opData["metal_trace_id"] = None
-                        if "op_hash" in opData.keys():
-                            assert "device_id" in opData.keys()
+                        if "op_hash" in opData:
+                            assert "device_id" in opData
                             deviceID = int(opData["device_id"])
                             opHash = int(opData["op_hash"])
-                            if deviceID in cached_ops.keys():
+                            if deviceID in cached_ops:
                                 cached_ops[deviceID][opHash] = opData.copy()
                             else:
                                 cached_ops[deviceID] = {opHash: opData.copy()}
@@ -150,8 +150,8 @@ def import_tracy_op_logs(logFolder):
                         opHash = int(opDataList[1])
                         deviceID = int(opDataList[2])
                         opID = int(opDataList[3])
-                        assert deviceID in cached_ops.keys(), "Expected hashed op info is not found"
-                        assert opHash in cached_ops[deviceID].keys(), "Expected hashed op info is not found"
+                        assert deviceID in cached_ops, "Expected hashed op info is not found"
+                        assert opHash in cached_ops[deviceID], "Expected hashed op info is not found"
                         opData = cached_ops[deviceID][opHash].copy()
                         opData["global_call_count"] = opID
                         opData["metal_trace_id"] = None
@@ -201,15 +201,15 @@ def import_tracy_op_logs(logFolder):
     for op in tracyOpTimesData:
         if "TT_DNN" in op["name"] or "TT_METAL" in op["name"]:
             opID = int(op["zone_text"].split(":")[-1])
-            assert opID in ops.keys(), f"Op time for op {opID} must present"
+            assert opID in ops, f"Op time for op {opID} must present"
             ops[opID]["host_time"] = op
 
     for op in tracyOpTimesData:
         if op["special_parent_text"] and "id:" in op["special_parent_text"]:
             parentOpID = int(op["special_parent_text"].split(":")[-1])
 
-            if "child_calls" in ops[parentOpID].keys():
-                if op["name"] in ops[parentOpID]["child_calls"].keys():
+            if "child_calls" in ops[parentOpID]:
+                if op["name"] in ops[parentOpID]["child_calls"]:
                     ops[parentOpID]["child_calls"][op["name"]] += int(op["exec_time_ns"])
                 else:
                     ops[parentOpID]["child_calls"][op["name"]] = int(op["exec_time_ns"])
@@ -253,13 +253,13 @@ def get_device_op_data(ops):
     deviceOps = {}
     hasTraceRuns = False
     for opID, opData in ops.items():
-        if "device_id" in opData.keys():
+        if "device_id" in opData:
             deviceID = opData["device_id"]
-            if deviceID not in deviceOps.keys():
+            if deviceID not in deviceOps:
                 deviceOps[deviceID] = [opData]
             else:
                 deviceOps[deviceID].append(opData)
-        if "metal_trace_id" in opData.keys() and opData["metal_trace_id"] is not None:
+        if "metal_trace_id" in opData and opData["metal_trace_id"] is not None:
             hasTraceRuns = True
 
     for deviceID in deviceOps:
@@ -295,7 +295,7 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
             allAnalysis = setup.timerAnalysis
             pickedAnalysis = {}
             for analysis in device_analysis_types:
-                assert analysis in allAnalysis.keys(), f" {analysis} is not calculated in device analysis"
+                assert analysis in allAnalysis, f" {analysis} is not calculated in device analysis"
                 pickedAnalysis[analysis] = allAnalysis[analysis]
 
             setup.timerAnalysis = pickedAnalysis
@@ -303,7 +303,7 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
         deviceData = import_log_run_stats(setup)
         freq = deviceData["deviceInfo"]["freq"]
         for device in devicesOps:
-            assert device in deviceData["devices"].keys()
+            assert device in deviceData["devices"]
             deviceOpsTime = deviceData["devices"][device]["cores"]["DEVICE"]["riscs"]["TENSIX"]["ops"]
             deviceDispatchOpsTime = deviceData["devices"][device]["cores"]["DEVICE"]["riscs"]["TENSIX"]["dispatch_ops"]
             deviceOpsTime.sort(key=device_op_compare_time)
@@ -321,7 +321,7 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
                 for deviceOpTime in deviceOpsTime:
                     if len(deviceOpTime["timeseries"]) > 0:
                         timeID, ts, statData, risc, core = deviceOpTime["timeseries"][0]
-                        assert "run_host_id" in timeID.keys(), "Device op ID missing: Device data must provide op ID"
+                        assert "run_host_id" in timeID, "Device op ID missing: Device data must provide op ID"
                         deviceOpID = timeID["run_host_id"]
                         assert (
                             deviceOpID in opIDHostDataDict
@@ -373,8 +373,8 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
                 for deviceOp, deviceOpTime in zip(devicesOps[device], deviceOpsTime):
                     if len(deviceOpTime["timeseries"]) > 0:
                         timeID, ts, statData, risc, core = deviceOpTime["timeseries"][0]
-                        if "zone_name" in timeID.keys() and "FW" in timeID["zone_name"]:
-                            if "run_host_id" in timeID.keys():
+                        if "zone_name" in timeID and "FW" in timeID["zone_name"]:
+                            if "run_host_id" in timeID:
                                 if timeID["run_host_id"] != deviceOp["global_call_count"]:
                                     deviceOPId = timeID["run_host_id"]
                                     hostOPId = deviceOp["global_call_count"]
@@ -393,8 +393,8 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
             for deviceOp, deviceOpTime in zip(devicesOps[device], deviceOpsTime):
                 cores = set()
                 for timeID, ts, statData, risc, core in deviceOpTime["timeseries"]:
-                    if "zone_name" in timeID.keys() and "FW" in timeID["zone_name"]:
-                        if "run_host_id" in timeID.keys():
+                    if "zone_name" in timeID and "FW" in timeID["zone_name"]:
+                        if "run_host_id" in timeID:
                             assert (
                                 timeID["run_host_id"] == deviceOp["global_call_count"]
                             ), f"op id {timeID['run_host_id']} reported by device {device} is not matching assigned op id {deviceOp['global_call_count']}"
@@ -413,7 +413,7 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
             # Tag trace ops with a UID
             for device in devicesOps:
                 for deviceOp in devicesOps[device]:
-                    if "metal_trace_replay_session_id" in deviceOp.keys():
+                    if "metal_trace_replay_session_id" in deviceOp:
                         deviceOp["global_call_count"] = (
                             deviceOp["global_call_count"]
                             | deviceOp["metal_trace_replay_session_id"] << TRACE_OP_ID_BITSHIFT
@@ -487,7 +487,7 @@ def get_device_data_generate_report(
             allAnalysis = setup.timerAnalysis
             pickedAnalysis = {}
             for analysis in device_analysis_types:
-                assert analysis in allAnalysis.keys(), f" {analysis} is not calculated in device analysis"
+                assert analysis in allAnalysis, f" {analysis} is not calculated in device analysis"
                 pickedAnalysis[analysis] = allAnalysis[analysis]
 
             setup.timerAnalysis = pickedAnalysis
@@ -503,7 +503,7 @@ def get_device_data_generate_report(
                 deviceOp = {}
                 cores = set()
                 for timeID, ts, statData, risc, core in deviceOpTime["timeseries"]:
-                    if "zone_name" in timeID.keys() and "FW" in timeID["zone_name"]:
+                    if "zone_name" in timeID and "FW" in timeID["zone_name"]:
                         if core not in cores:
                             cores.add(core)
                 deviceOp["core_usage"] = {"count": len(cores), "cores": [str(core) for core in cores]}
@@ -512,7 +512,7 @@ def get_device_data_generate_report(
                     for analysis, data in deviceOpTime["analysis"].items()
                 }
 
-                if "run_host_id" in timeID.keys():
+                if "run_host_id" in timeID:
                     deviceOp["global_call_count"] = timeID["run_host_id"]
                 else:
                     deviceOp["global_call_count"] = i
@@ -541,7 +541,7 @@ def get_device_data_generate_report(
                         rowDict["DEVICE FW START CYCLE"] = analysisData[0]["start_cycle"]
                         rowDict["DEVICE FW END CYCLE"] = analysisData[0]["end_cycle"]
                     if analysis == "device_kernel_duration":
-                        if device in devicePreOpTime.keys():
+                        if device in devicePreOpTime:
                             rowDict["OP TO OP LATENCY [ns]"] = round(
                                 1000 * (analysisData[0]["start_cycle"] - devicePreOpTime[device]) / freq
                             )
@@ -549,7 +549,7 @@ def get_device_data_generate_report(
                             rowDict["OP TO OP LATENCY [ns]"] = 0
                         devicePreOpTime[device] = analysisData[0]["end_cycle"]
                     if analysis == "device_kernel_duration_dm_start":
-                        if device in devicePreOpDMStartTime.keys():
+                        if device in devicePreOpDMStartTime:
                             rowDict["OP TO OP LATENCY BR/NRISC START [ns]"] = round(
                                 1000 * (analysisData[0]["start_cycle"] - devicePreOpDMStartTime[device]) / freq
                             )
@@ -561,7 +561,7 @@ def get_device_data_generate_report(
             def get_core_str_format(core):
                 return f"{core[0]}; {core[1]} [ns]"
 
-            allCores = list(deviceData["devices"][device]["cores"].keys())
+            allCores = list(deviceData["devices"][device]["cores"])
             allCores.remove("DEVICE")
             allCores.sort()
             for core in allCores:
@@ -607,7 +607,7 @@ def get_device_data_generate_report(
 
         rowDictHeaders = set()
         for row in rowDicts:
-            for k in row.keys():
+            for k in row:
                 rowDictHeaders.add(k)
         if export_csv:
             with open(allOpsCSVPath, "w") as allOpsCSV:
@@ -692,7 +692,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
             if ioField == "shape":
                 for field in ["W", "Z", "Y", "X"]:
                     headers.append(field)
-                    assert field in ioData.keys(), "Wrong io tensor shape data format"
+                    assert field in ioData, "Wrong io tensor shape data format"
                     data[field] = ioData[field]
             elif ioField == "dtype":
                 headers = ["DATATYPE"]
@@ -705,12 +705,12 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                 if type(ioData) == str:
                     data["MEMORY"] = ioData
                 else:
-                    assert "device_id" in ioData.keys(), "Wrong io tensor memory data format"
+                    assert "device_id" in ioData, "Wrong io tensor memory data format"
                     deviceID = ioData["device_id"]
-                    assert "memory_config" in ioData.keys(), "Wrong io tensor memory data format"
-                    assert "buffer_type" in ioData["memory_config"].keys(), "Wrong io tensor memory data format"
+                    assert "memory_config" in ioData, "Wrong io tensor memory data format"
+                    assert "buffer_type" in ioData["memory_config"], "Wrong io tensor memory data format"
                     bufferType = ioData["memory_config"]["buffer_type"].upper()
-                    assert "memory_layout" in ioData["memory_config"].keys(), "Wrong io tensor memory data format"
+                    assert "memory_layout" in ioData["memory_config"], "Wrong io tensor memory data format"
                     memoryLayout = ioData["memory_config"]["memory_layout"].upper()
                     data["MEMORY"] = f"DEV_{deviceID}_{bufferType}_{memoryLayout}"
 
@@ -720,7 +720,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
             ioFields = ["shape", "layout", "dtype", "storage_type"]
             for count, tensor in enumerate(tensors):
                 for ioField in ioFields:
-                    assert ioField in tensor.keys(), "Wrong io tensor fields"
+                    assert ioField in tensor, "Wrong io tensor fields"
                     ioData = tensor[ioField]
                     fields, data = io_tensor_to_csv(ioField, ioData)
                     for field in fields:
@@ -743,7 +743,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
             ret = int(ret)
             return ret
 
-        rowKeys = list(ops.keys()) + list(traceOps.keys()) + list(signposts.keys())
+        rowKeys = list(ops) + list(traceOps) + list(signposts)
         rowKeys.sort(key=row_compare)
         childCallKeys = set()
         for row in rowKeys:
@@ -752,7 +752,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                     opData = traceOps[row]
                 else:
                     opData = ops[row]
-                if "child_calls" in opData.keys():
+                if "child_calls" in opData:
                     for childCall in opData["child_calls"]:
                         childCallKeys.add(f"{childCall}_TT_HOST_FUNC [ns]")
 
@@ -773,7 +773,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                 else:
                     opData = ops[op]
                     opData["metal_trace_replay_session_id"] = ""
-                    if "trac_id" not in opData.keys() or opData["metal_trace_id"] is None:
+                    if "trac_id" not in opData or opData["metal_trace_id"] is None:
                         opData["metal_trace_id"] = ""
 
                 for field, fieldData in opData.items():
@@ -781,7 +781,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                     if headerField in OPS_CSV_HEADER:
                         rowDict[headerField] = fieldData
 
-                assert "host_time" in opData.keys(), "Corrupted op data"
+                assert "host_time" in opData, "Corrupted op data"
                 rowDict["HOST START TS"] = int(opData["host_time"]["ns_since_start"])
                 rowDict["HOST END TS"] = int(opData["host_time"]["ns_since_start"]) + int(
                     opData["host_time"]["exec_time_ns"]
@@ -795,7 +795,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                 if "NPE CONG IMPACT (%)" in opData:
                     rowDict["NPE CONG IMPACT (%)"] = opData.get("NPE CONG IMPACT (%)")
 
-                if "kernel_info" in opData.keys():
+                if "kernel_info" in opData:
                     rowDict["COMPUTE KERNEL SOURCE"] = []
                     rowDict["COMPUTE KERNEL HASH"] = []
                     rowDict["DATA MOVEMENT KERNEL SOURCE"] = []
@@ -812,11 +812,11 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                     for kernel, kernelSize in opData["kernel_info"]["kernel_sizes"].items():
                         rowDict[kernel.upper().replace("_", " ") + " [B]"] = kernelSize
 
-                if "core_usage" in opData.keys():
+                if "core_usage" in opData:
                     rowDict["CORE COUNT"] = opData["core_usage"]["count"]
 
-                if "device_time" in opData.keys():
-                    assert "device_id" in opData.keys(), "Op has device data without device_id"
+                if "device_time" in opData:
+                    assert "device_id" in opData, "Op has device data without device_id"
                     deviceID = opData["device_id"]
                     for analysis, data in opData["device_time"].items():
                         analysisData = data["series"]
@@ -838,7 +838,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                             rowDict["DEVICE FW START CYCLE"] = analysisData[0]["start_cycle"]
                             rowDict["DEVICE FW END CYCLE"] = analysisData[0]["end_cycle"]
                         if analysis == "device_kernel_duration":
-                            if deviceID in devicePreOpTime.keys():
+                            if deviceID in devicePreOpTime:
                                 rowDict["OP TO OP LATENCY [ns]"] = round(
                                     (analysisData[0]["start_cycle"] - devicePreOpTime[deviceID]) / freq
                                 )
@@ -846,7 +846,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                                 rowDict["OP TO OP LATENCY [ns]"] = 0
                             devicePreOpTime[deviceID] = analysisData[0]["end_cycle"]
                         if analysis == "device_kernel_duration_dm_start":
-                            if deviceID in devicePreOpDMStartTime.keys():
+                            if deviceID in devicePreOpDMStartTime:
                                 rowDict["OP TO OP LATENCY BR/NRISC START [ns]"] = round(
                                     (analysisData[0]["start_cycle"] - devicePreOpDMStartTime[deviceID]) / freq
                                 )
@@ -854,21 +854,21 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                                 rowDict["OP TO OP LATENCY BR/NRISC START [ns]"] = 0
                             devicePreOpDMStartTime[deviceID] = analysisData[0]["end_cycle"]
 
-                if "child_calls" in opData.keys():
+                if "child_calls" in opData:
                     for childCall, duration in opData["child_calls"].items():
                         headerField = f"{childCall}_TT_HOST_FUNC [ns]"
                         rowDict[headerField] = f"{duration:.0f}"
 
-                assert "input_tensors" in opData.keys(), "Ops must have input tensors"
-                if "optional_input_tensors" in opData.keys():
+                assert "input_tensors" in opData, "Ops must have input tensors"
+                if "optional_input_tensors" in opData:
                     add_io_data(opData["input_tensors"] + opData["optional_input_tensors"], "INPUT")
                 else:
                     add_io_data(opData["input_tensors"], "INPUT")
 
-                if "output_tensors" in opData.keys():
+                if "output_tensors" in opData:
                     add_io_data(opData["output_tensors"], "OUTPUT")
 
-                if "performance_model" in opData.keys():
+                if "performance_model" in opData:
                     rowDict["PM IDEAL [ns]"] = opData["performance_model"]["ideal_ns"]
                     rowDict["PM COMPUTE [ns]"] = opData["performance_model"]["compute_ns"]
                     rowDict["PM BANDWIDTH [ns]"] = opData["performance_model"]["bandwidth_ns"]


### PR DESCRIPTION
#25439 

This PR optimizes the `process_device_log.py` and `process_ops_logs.py` profiler post-processing scripts.

### Key changes
 - Removed unnecessary calls to `keys()`
 - Deleted logic for determining the global minimum
 - `import_device_profile_log()` uses `pandas` to parse the CSV file
 - The `tracyOpTimesLog` file is read from disk only once now instead of twice

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16786871996)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16786874641)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16786902931)
- [x] [TG model perf] (https://github.com/tenstorrent/tt-metal/actions/runs/16786863958)
- [x] New/Existing tests provide coverage for changes