### PR TITLE
Enable tilize_with_val_padding for int32, add tile/untile unit tests, add fatals for unsupported variants

### DIFF
--- a/tests/ttnn/unit_tests/test_tilize_untilize_2D.py
+++ b/tests/ttnn/unit_tests/test_tilize_untilize_2D.py
@@ -13,15 +13,27 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without
 from models.utility_functions import is_grayskull, is_blackhole, torch_random, skip_for_grayskull
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+def random_torch_tensor(dtype, shape):
+    if dtype == ttnn.uint16:
+        return torch.randint(0, 100, shape).to(torch.int16)
+    if dtype == ttnn.int32:
+        return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
+    return torch.rand(shape).bfloat16().float()
+
+
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
 @pytest.mark.parametrize("use_multicore", [False, True])
 @pytest.mark.parametrize("use_pack_untilize", [False, True])
 @pytest.mark.parametrize("H", [32, 512])
 @pytest.mark.parametrize("W", [1024, 256])
 def test_untilize_2D(device, in_dtype, use_multicore, use_pack_untilize, H, W):
+    if in_dtype in [ttnn.uint32, ttnn.int32] and not use_pack_untilize:
+        pytest.skip(f"Skipping: dtype {in_dtype} with use_pack_untilize=False is unsupported")
     torch_input_shape = [H, W]
 
-    torch_input = torch.randn(torch_input_shape, dtype=torch.bfloat16).bfloat16()
+    torch_input = random_torch_tensor(in_dtype, torch_input_shape)
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.TILE_LAYOUT)
 
@@ -33,14 +45,14 @@ def test_untilize_2D(device, in_dtype, use_multicore, use_pack_untilize, H, W):
     assert passing
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
 @pytest.mark.parametrize("use_multicore", [False, True])
 @pytest.mark.parametrize("H", [128, 2048])
 @pytest.mark.parametrize("W", [32, 1056])
 def test_tilize_2D(device, in_dtype, use_multicore, H, W):
     torch_input_shape = [H, W]
 
-    torch_input = torch.randn(torch_input_shape, dtype=torch.bfloat16).bfloat16()
+    torch_input = random_torch_tensor(in_dtype, torch_input_shape)
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
 
@@ -52,15 +64,18 @@ def test_tilize_2D(device, in_dtype, use_multicore, H, W):
     assert passing
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
 @pytest.mark.parametrize("use_multicore", [False, True])
+# Fails on int32 if use_pack_untilize is False AND dtype is uint32/int32
 @pytest.mark.parametrize("use_pack_untilize", [False, True])
 @pytest.mark.parametrize("H", [32, 43])
 @pytest.mark.parametrize("W", [64, 76])
 def test_untilize_with_unpadding_2D(device, in_dtype, use_multicore, use_pack_untilize, H, W):
+    if in_dtype in [ttnn.uint32, ttnn.int32] and not use_pack_untilize:
+        pytest.skip(f"Skipping: dtype {in_dtype} with use_pack_untilize=False is unsupported")
     torch_input_shape = [H, W]
 
-    torch_input = torch.randn(torch_input_shape, dtype=torch.bfloat16).bfloat16()
+    torch_input = random_torch_tensor(in_dtype, torch_input_shape)
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.TILE_LAYOUT)
 
@@ -74,7 +89,7 @@ def test_untilize_with_unpadding_2D(device, in_dtype, use_multicore, use_pack_un
     assert passing
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
 @pytest.mark.parametrize("use_multicore", [False, True])
 @pytest.mark.parametrize("pad_value", [2, 1.3])
 @pytest.mark.parametrize("H", [32, 43])
@@ -82,7 +97,7 @@ def test_untilize_with_unpadding_2D(device, in_dtype, use_multicore, use_pack_un
 def test_tilize_with_val_padding_2D(device, in_dtype, use_multicore, H, W, pad_value):
     torch_input_shape = [H, W]
 
-    torch_input = torch.randn(torch_input_shape, dtype=torch.bfloat16).bfloat16()
+    torch_input = random_torch_tensor(in_dtype, torch_input_shape)
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
 
@@ -94,14 +109,14 @@ def test_tilize_with_val_padding_2D(device, in_dtype, use_multicore, H, W, pad_v
     assert passing
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
 @pytest.mark.parametrize("use_multicore", [False, True])
 @pytest.mark.parametrize("H", [128, 98])
 @pytest.mark.parametrize("W", [78, 1024])
 def test_tilize_with_zero_padding_2D(device, in_dtype, use_multicore, H, W):
     torch_input_shape = [H, W]
 
-    torch_input = torch.randn(torch_input_shape, dtype=torch.bfloat16).bfloat16()
+    torch_input = random_torch_tensor(in_dtype, torch_input_shape)
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -33,7 +33,7 @@ uint32_t get_packed_value(const Tensor tensor, const ttnn::PadValue pad_value) {
                     TT_FATAL(
                         tensor.dtype() == DataType::FLOAT32 or tensor.dtype() == DataType::UINT32 or
                             tensor.dtype() == DataType::INT32,
-                        "only supporting bfloat16, float32, and uint32");
+                        "only supporting bfloat16, float32, and int32/uint32");
                     return (uint32_t)((pad_value));
                 }
             } else if constexpr (std::is_same_v<T, uint32_t>) {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -31,7 +31,8 @@ uint32_t get_packed_value(const Tensor tensor, const ttnn::PadValue pad_value) {
                     return pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
                 } else {
                     TT_FATAL(
-                        tensor.dtype() == DataType::FLOAT32 or tensor.dtype() == DataType::UINT32,
+                        tensor.dtype() == DataType::FLOAT32 or tensor.dtype() == DataType::UINT32 or
+                            tensor.dtype() == DataType::INT32,
                         "only supporting bfloat16, float32, and uint32");
                     return (uint32_t)((pad_value));
                 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -130,6 +130,13 @@ void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
     if (output_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         TT_FATAL(output_buffer_type == BufferType::L1, "We don't support DRAM block sharding");
     }
+
+    // Pack untilize is what allows uint32/int32 support, so if it is not enabled, we do not support uint32/int32
+    if (!this->use_pack_untilize) {
+        TT_FATAL(
+            input_tensor_a.dtype() != DataType::UINT32 && input_tensor_a.dtype() != DataType::INT32,
+            "Pack untilize must be enabled to support uint32/int32 data types");
+    }
 }
 
 std::vector<ttnn::TensorSpec> Untilize::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -66,6 +66,13 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
         TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
     }
+
+    // Pack untilize is what allows uint32/int32 support, so if it is not enabled, we do not support uint32/int32
+    if (!this->use_pack_untilize) {
+        TT_FATAL(
+            input_tensor_a.dtype() != DataType::UINT32 && input_tensor_a.dtype() != DataType::INT32,
+            "Pack untilize must be enabled to support uint32/int32 data types");
+    }
 }
 
 std::vector<ttnn::TensorSpec> UntilizeWithUnpadding::compute_output_specs(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26294)

### Problem description
Needed to make sure tilize/untilize is fully enabled for uint32/int32 as well as add unit tests to test_tilize_untilize_2d. We also want to make sure we fatal out if new pack isn't being used, as that is what enables uint32/int32

### What's changed
Enabled int32 in tilize_with_val_padding, added int32 to unit tests, added fatals when use_pack==True and dtype== unit32/int32

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16760165271) CI passes