### PR TITLE
Skipping galaxy llama 70b model perf tests on TG Model Perf Pipeline

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -37,6 +37,7 @@ jobs:
           },  # Pavle Josipovic
           {
             name: "Galaxy Llama 70B model perf tests",
+            if: false, #see GH issue #26295
             model-type: "Llama-70B",
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],


### PR DESCRIPTION
### Ticket
[#26295](https://github.com/tenstorrent/tt-metal/issues/26295)

### Problem description
We've observed this test failing multiple times over the past several weeks. We have commented out the test for now for the devs to fix the error. First observed failure: https://github.com/tenstorrent/tt-metal/actions/runs/16524022176/job/46733193541#step:9:1244

### What's changed
Just skips over the galaxy llama 70b model perf tests on TG model perf pipeline

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16761260039)