### PR TITLE
Delete checks for hugepages in tt::Cluster

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -243,29 +243,6 @@ void Cluster::generate_cluster_descriptor() {
             this->cluster_desc_->get_noc_translation_table_en().at(0),
             "Running Metal on Blackhole requires FW >= 80.18.0.0");
     }
-
-    uint32_t total_num_hugepages = tt::umd::get_num_hugepages();
-    if (this->cluster_type_ == tt::tt_metal::ClusterType::TG) {
-        // TODO: don't think this check is correct, we want to have total num hugepages == num chips even for Galaxy
-        TT_FATAL(
-            this->arch_ == tt::ARCH::BLACKHOLE or
-                total_num_hugepages >= this->driver_->get_target_device_ids().size() / 4,
-            "Machine setup error: Insufficient number of hugepages available, expected >= {} for {} devices but have "
-            "{}. "
-            "Increase number of hugepages!",
-            this->driver_->get_target_device_ids().size() / 4,
-            this->driver_->get_target_device_ids().size(),
-            total_num_hugepages);
-    } else {
-        // TODO (abhullar): ignore hugepage set up for BH bringup
-        TT_FATAL(
-            this->arch_ == tt::ARCH::BLACKHOLE or total_num_hugepages >= this->driver_->get_target_device_ids().size(),
-            "Machine setup error: Insufficient number of hugepages available, expected one per device ({}) but have "
-            "{}. "
-            "Increase number of hugepages!",
-            this->driver_->get_target_device_ids().size(),
-            total_num_hugepages);
-    }
 }
 
 void Cluster::validate_harvesting_masks() const {


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/26194

### Problem description
Hugepages are no longer a requirement for systems with IOMMU enabled.  The check produces false positive on systems with IOMMU but without enough hugepages.

### What's changed

Deleted the check.  I tested on a system with IOMMU disabled & hugepage disabled, without the check, the program fails at: https://github.com/tenstorrent/tt-umd/blob/44bd946b34318915b57aadabb509145cde560d6f/device/chip/local_chip.cpp#L163, so it's won't fail silently.

The check is already a no-op for BH, so deleting it does not affect BH.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16736215972) CI passes (ttnn and profiler failures should be unrelated)