### PR TITLE
Update Whisper codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -239,7 +239,7 @@ models/demos/t3000/llama3_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-
 models/demos/t3000/mixtral8x7b @yieldthought @mtairum @uaydonat
 models/demos/t3000/sentence_bert @atupe-tt @tenstorrent/cse-developer-ttnn
 models/demos/tg/falcon7b @skhorasganiTT @djordje-tt @uaydonat
-models/demos/whisper @skhorasganiTT @uaydonat
+models/demos/whisper @skhorasganiTT @djordje-tt @uaydonat
 models/demos/grayskull @uaydonat @yieldthought @cglagovichTT
 models/demos/yolov4 @dvartaniansTT @mbahnasTT @rdraskicTT @mbezuljTT @tenstorrent/metalium-developers-convolutions
 models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions @mradosavljevicTT


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Whisper had 2 codeowners, need 1 more for backup

### What's changed
- Added @djordje-tt as a Whisper codeowner since he is now a co-owner of the model

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes