### PR TITLE
#26128 Track user-requested devices to catch re-opens

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -673,7 +673,7 @@ static int pgm_dispatch(T& state, TestInfo info) {
         // Run benchmark timing loop
         run_benchmark_timing_loop(state, info, mesh_cq, executor, tid, mesh_device);
 
-        pass &= mesh_device->close();
+        mesh_device->close();
     } catch (const std::exception& e) {
         pass = false;
         mesh_device->close();

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -174,7 +174,7 @@ public:
     virtual void configure_fabric() = 0;
     virtual void init_fabric() = 0;
     // Puts device into reset
-    virtual bool close() = 0;
+    virtual void close() = 0;
 
     // Program cache interface. Syncrhonize with worker worker threads before querying or
     // modifying this structure, since worker threads use this for compiling ops

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -55,8 +55,8 @@ public:
 
     tt_metal::IDevice* get_active_device(chip_id_t device_id) const;
     std::vector<tt_metal::IDevice*> get_all_active_devices() const;
-    bool close_device(chip_id_t device_id);
-    bool close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
+    void close_device(chip_id_t device_id);
+    void close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
     bool is_device_active(chip_id_t id) const;
     // True if dispatch firmware is active on this device pool
     bool is_dispatch_firmware_active() const;
@@ -82,7 +82,8 @@ private:
     bool dispatch_firmware_active_ = false;
 
     std::mutex lock;
-    std::vector<std::unique_ptr<tt_metal::IDevice>> devices;
+    ttsl::SmallVector<std::unique_ptr<tt_metal::IDevice>> devices_;
+    ttsl::SmallVector<bool> user_requested_devices_;
 
     bool skip_remote_devices;
     // Issue #19729: use_max_eth_core_count_on_all_devices_ is a workaround

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -224,7 +224,7 @@ public:
     bool compile_fabric() override;
     void configure_fabric() override;
     void init_fabric() override;
-    bool close() override;
+    void close() override;
     void enable_program_cache() override;
     void clear_program_cache() override;
     void disable_and_clear_program_cache() override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -574,7 +574,7 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
     view_ = std::move(new_view);
 }
 
-bool MeshDevice::close() {
+void MeshDevice::close() {
     ZoneScoped;
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
@@ -589,7 +589,6 @@ bool MeshDevice::close() {
     sub_device_manager_tracker_.reset();
     scoped_devices_.reset();
     parent_mesh_.reset();
-    return true;
 }
 
 std::string MeshDevice::to_string() const {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -467,11 +467,9 @@ bool Device::initialize(
     return true;
 }
 
-bool Device::close() {
+void Device::close() {
     log_trace(tt::LogMetal, "Closing device {}", this->id_);
-    if (not this->initialized_) {
-        TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
-    }
+    TT_FATAL(this->initialized_, "Cannot close device {} that has not been initialized!", this->id_);
 
     this->disable_and_clear_program_cache();
     this->set_program_cache_misses_allowed(true);
@@ -485,8 +483,6 @@ bool Device::close() {
     this->command_queues_.clear();
     this->sysmem_manager_.reset();
     this->initialized_ = false;
-
-    return true;
 }
 
 Device::~Device() {

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -144,7 +144,7 @@ public:
     void configure_fabric() override;
     void init_fabric() override;
     // Puts device into reset
-    bool close() override;
+    void close() override;
 
     // Program cache interface. Synchronize with worker worker threads before querying or
     // modifying this structure, since worker threads use this for compiling ops

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -258,7 +258,11 @@ void DevicePool::initialize(
 
     // Record IDs that the user requested to be opened.
     for (auto dev_id : device_ids) {
-        TT_FATAL(!_inst->user_requested_devices_[dev_id], "Device {} already opened", dev_id);
+        // Device can be active but not user requested if it was opened by DevicePool automatically.
+        TT_FATAL(
+            !_inst->is_device_active(dev_id) || !_inst->user_requested_devices_[dev_id],
+            "Device {} already opened",
+            dev_id);
         _inst->user_requested_devices_[dev_id] = true;
     }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -243,6 +243,9 @@ void DevicePool::initialize(
         static DevicePool device_pool{};
         _inst = &device_pool;
     }
+
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
     _inst->l1_small_size = l1_small_size;
     _inst->trace_region_size = trace_region_size;
     _inst->worker_l1_size = worker_l1_size;
@@ -251,10 +254,17 @@ void DevicePool::initialize(
     _inst->init_profiler_ = init_profiler;
     _inst->initialize_fabric_and_dispatch_fw_ = initialize_fabric_and_dispatch_fw;
     _inst->using_fast_dispatch = tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
+    _inst->user_requested_devices_.resize(cluster.number_of_devices());
+
+    // Record IDs that the user requested to be opened.
+    for (auto dev_id : device_ids) {
+        TT_FATAL(!_inst->user_requested_devices_[dev_id], "Device {} already opened", dev_id);
+        _inst->user_requested_devices_[dev_id] = true;
+    }
 
     std::vector<chip_id_t> device_ids_to_open = device_ids;
     // Never skip for TG Cluster
-    bool is_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
+    bool is_galaxy = cluster.is_galaxy_cluster();
     bool skip = !is_galaxy;
     bool any_remote_devices = false;
 
@@ -264,8 +274,7 @@ void DevicePool::initialize(
         // Check if fabric needs to be enabled (any remote devices).
         // Note, all devices must be open to use fabric. This check will happen in add_devices_to_pool.
         for (auto dev_id : device_ids_to_open) {
-            any_remote_devices =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id) != dev_id;
+            any_remote_devices = cluster.get_associated_mmio_device(dev_id) != dev_id;
             if (any_remote_devices) {
                 break;
             }
@@ -276,7 +285,7 @@ void DevicePool::initialize(
         // Must open all devices in cluster to use fabric
         if (any_remote_devices) {
             device_ids_to_open.clear();
-            for (int id = 0; id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); ++id) {
+            for (int id = 0; id < cluster.number_of_devices(); ++id) {
                 device_ids_to_open.push_back(id);
             }
         }
@@ -285,19 +294,17 @@ void DevicePool::initialize(
     std::vector<chip_id_t> target_mmio_ids;
     for (const auto& device_id : device_ids_to_open) {
         TT_FATAL(
-            tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids().find(device_id) !=
-                tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids().end(),
+            cluster.all_chip_ids().find(device_id) != cluster.all_chip_ids().end(),
             "Device index {} out of range. There are {} devices available.",
             device_id,
-            tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices());
-        const auto& mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+            cluster.number_of_devices());
+        const auto mmio_device_id = cluster.get_associated_mmio_device(device_id);
         if (std::find(target_mmio_ids.begin(), target_mmio_ids.end(), mmio_device_id) == target_mmio_ids.end()) {
             target_mmio_ids.push_back(mmio_device_id);
         }
         skip &= (device_id == mmio_device_id);
     }
-    if (target_mmio_ids.size() != tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices()) {
+    if (target_mmio_ids.size() != cluster.number_of_pci_devices()) {
         log_warning(
             tt::LogMetal,
             "Opening subset of mmio devices slows down UMD read/write to remote chips. If opening more devices, "
@@ -491,15 +498,13 @@ void DevicePool::activate_device(chip_id_t id) {
         id,
         tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices());
     const std::lock_guard<std::mutex> lock(this->lock);
-    if (this->devices.size() < id + 1) {
-        this->devices.reserve(id + 1);
-    }
-    auto device = get_device(id);
+    devices_.reserve(id + 1);
+    auto* device = get_device(id);
     if (!device) {
         log_debug(tt::LogMetal, "DevicePool new device {}", id);
         int worker_core_thread_core = this->worker_thread_to_cpu_core_map.at(id);
         int completion_queue_reader_core = this->completion_queue_reader_to_cpu_core_map.at(id);
-        device = new Device(
+        devices_.emplace_back(std::make_unique<Device>(
             id,
             this->num_hw_cqs,
             this->l1_small_size,
@@ -508,35 +513,23 @@ void DevicePool::activate_device(chip_id_t id) {
             false,
             worker_core_thread_core,
             completion_queue_reader_core,
-            this->worker_l1_size);
-        this->devices.emplace_back(std::unique_ptr<IDevice>(device));
+            this->worker_l1_size));
     } else {
         log_debug(tt::LogMetal, "DevicePool re-initialize device {}", id);
-        if (not device->is_initialized()) {
-            device->initialize(
-                num_hw_cqs, this->l1_small_size, this->trace_region_size, this->worker_l1_size, this->l1_bank_remap);
-        } else {
-            TT_THROW("Cannot re-initialize device {}, must first call close()", id);
-        }
+        TT_FATAL(!device->is_initialized(), "Cannot re-initialize device {}, must first call close()", id);
+        device->initialize(
+            num_hw_cqs, this->l1_small_size, this->trace_region_size, this->worker_l1_size, this->l1_bank_remap);
     }
 }
 
 bool DevicePool::is_device_active(chip_id_t id) const {
-    auto device = get_device(id);
-    if (!device) {
-        return false;
-    }
-
-    return device->is_initialized();
+    auto* device = get_device(id);
+    return device != nullptr && device->is_initialized();
 }
 
 IDevice* DevicePool::get_device(chip_id_t id) const {
-    auto it = std::find_if(devices.begin(), devices.end(), [&id](const auto& device) { return device->id() == id; });
-    if (it == devices.end()) {
-        return nullptr;
-    }
-
-    return it->get();
+    auto it = std::find_if(devices_.begin(), devices_.end(), [&id](const auto& device) { return device->id() == id; });
+    return it == devices_.end() ? nullptr : it->get();
 }
 
 std::size_t DevicePool::get_max_num_eth_cores_across_all_devices() const {
@@ -549,7 +542,7 @@ std::size_t DevicePool::get_max_num_eth_cores_across_all_devices() const {
     // available and will dispatch to/wait on the correct number of cores (effectively ignoring the
     // value host dispatch provides, if its incorrect).
     std::size_t max_eth_core_count = 0;
-    for (const auto& device : this->devices) {
+    for (const auto& device : devices_) {
         max_eth_core_count = std::max(
             MetalContext::instance()
                 .get_control_plane()
@@ -584,7 +577,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     }
 
     for (const auto& device_id : devices_to_activate) {
-        if (not this->is_device_active(device_id)) {
+        if (!this->is_device_active(device_id)) {
             this->activate_device(device_id);
         }
     }
@@ -613,9 +606,7 @@ void DevicePool::wait_for_fabric_router_sync() const {
     const auto& fabric_context = control_plane.get_fabric_context();
 
     auto wait_for_handshake = [&](IDevice* dev) {
-        if (!dev) {
-            TT_THROW("Fabric router sync on null device. All devices must be opened for Fabric.");
-        }
+        TT_FATAL(dev, "Fabric router sync on null device. All devices must be opened for Fabric.");
         if (fabric_context.get_num_fabric_initialized_routers(dev->id()) == 0) {
             return;
         }
@@ -721,7 +712,7 @@ IDevice* DevicePool::get_active_device(chip_id_t device_id) const {
 
 std::vector<IDevice* > DevicePool::get_all_active_devices() const {
     std::vector<IDevice*> user_devices;
-    for (const auto& device : this->devices) {
+    for (const auto& device : devices_) {
         if (device && device->is_initialized()) {
             user_devices.push_back(device.get());
         }
@@ -749,7 +740,7 @@ void DevicePool::teardown_fd(const std::unordered_set<chip_id_t>& devices_to_clo
 
 bool DevicePool::is_dispatch_firmware_active() const { return this->dispatch_firmware_active_; }
 
-bool DevicePool::close_device(chip_id_t device_id) {
+void DevicePool::close_device(chip_id_t device_id) {
     // Sync and close one device
     // Currently can only call this on mmio chips, once we split dispatch kernel shutdown
     // from device close, we can call this on remote devices too
@@ -767,7 +758,7 @@ bool DevicePool::close_device(chip_id_t device_id) {
     return close_devices(devices_to_close);
 }
 
-bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_synchronize) {
+void DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_synchronize) {
     ZoneScoped;
 
     // Ordered, because we need to shutdown tunnels from the farthest to the closest.
@@ -874,19 +865,17 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
 
     detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
 
-    bool pass = true;
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
-        pass &= dev->close();
+        dev->close();
+        user_requested_devices_[dev_id] = false;
     }
 
     tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
-
-    return pass;
 }
 
 DevicePool::~DevicePool() {
-    for (const auto& dev : this->devices) {
+    for (const auto& dev : devices_) {
         if (dev != nullptr and dev->is_initialized()) {
             // TODO: #13876, Was encountering issues with the DispatchMemMap being destroyed before the DevicePool
             // destructor, which leads to device->close() hitting asserts. We need to move the ownership of
@@ -894,7 +883,8 @@ DevicePool::~DevicePool() {
             dev->close();
         }
     }
-    this->devices.clear();
+    devices_.clear();
+    user_requested_devices_.clear();
 }
 
 }  // namespace tt

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -998,7 +998,8 @@ IDevice* CreateDeviceMinimal(
 bool CloseDevice(IDevice* device) {
     ZoneScoped;
     auto device_id = device->id();
-    return tt::DevicePool::instance().close_device(device_id);
+    tt::DevicePool::instance().close_device(device_id);
+    return true;
 }
 
 Program CreateProgram() { return Program(); }

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -46,7 +46,7 @@ void ttnn_device(py::module& module) {
         py::arg("worker_l1_size") = DEFAULT_WORKER_L1_SIZE,
         py::return_value_policy::reference,
         R"doc(
-            Open a device with the given device_id. If the device is already open, return the existing device.
+            Open a device with the given device_id. If the device is already open, throws an exception.
 
             Keyword Args:
                 device_id (int): The device ID to open.


### PR DESCRIPTION
### Ticket
#26128

### Problem description
Trying to re-open the same device ID causes an error with unclear message.

### What's changed
* In `DevicePool`, track device IDs that were explicitly requested. Check if there is an attempt to use the same ID and throw with a more clear error message.
* Some refactoring. Why does close device returns a boolean?

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16783037373)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16777960914)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes