### PR TITLE
Fabric connection open API

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_atomic_inc_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_atomic_inc_sender.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
 
     auto route_id = PacketHeaderPool::allocate_header_n(num_send_dir);
     tt::tt_fabric::WorkerToFabricEdmSender connections[num_send_dir] = {};
-    open_connections(connections, num_send_dir, rt_arg_idx);
+    open_connections(connections, rt_arg_idx);
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -126,7 +126,7 @@ void kernel_main() {
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
-    close_connections(connections, num_send_dir);
+    close_connections(connections);
 
     noc_async_write_barrier();
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_atomic_inc_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_atomic_inc_sender.cpp
@@ -47,13 +47,9 @@ void kernel_main() {
         }
     }
 
-    tt::tt_fabric::WorkerToFabricEdmSender connections[num_send_dir] = {};
     auto route_id = PacketHeaderPool::allocate_header_n(num_send_dir);
-    for (uint32_t i = 0; i < num_send_dir; i++) {
-        connections[i] =
-            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_arg_idx);
-        connections[i].open();
-    }
+    tt::tt_fabric::WorkerToFabricEdmSender connections[num_send_dir] = {};
+    open_connections(connections, num_send_dir, rt_arg_idx);
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -130,9 +126,7 @@ void kernel_main() {
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
-    for (uint32_t i = 0; i < num_send_dir; i++) {
-        connections[i].close();
-    }
+    close_connections(connections, num_send_dir);
 
     noc_async_write_barrier();
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
@@ -47,13 +47,9 @@ void kernel_main() {
         }
     }
 
-    tt::tt_fabric::WorkerToFabricEdmSender connections[num_send_dir] = {};
     auto route_id = PacketHeaderPool::allocate_header_n(num_send_dir);
-    for (uint32_t i = 0; i < num_send_dir; i++) {
-        connections[i] =
-            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_arg_idx);
-        connections[i].open();
-    }
+    tt::tt_fabric::WorkerToFabricEdmSender connections[num_send_dir] = {};
+    open_connections(connections, num_send_dir, rt_arg_idx);
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -146,9 +142,7 @@ void kernel_main() {
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
-    for (uint32_t i = 0; i < num_send_dir; i++) {
-        connections[i].close();
-    }
+    close_connections(connections, num_send_dir);
 
     noc_async_write_barrier();
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
 
     auto route_id = PacketHeaderPool::allocate_header_n(num_send_dir);
     tt::tt_fabric::WorkerToFabricEdmSender connections[num_send_dir] = {};
-    open_connections(connections, num_send_dir, rt_arg_idx);
+    open_connections(connections, rt_arg_idx);
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -142,7 +142,7 @@ void kernel_main() {
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
-    close_connections(connections, num_send_dir);
+    close_connections(connections);
 
     noc_async_write_barrier();
 

--- a/tt_metal/fabric/hw/inc/linear/api.h
+++ b/tt_metal/fabric/hw/inc/linear/api.h
@@ -13,6 +13,21 @@
 
 namespace tt::tt_fabric::linear::experimental {
 
+FORCE_INLINE void open_connections(
+    tt::tt_fabric::WorkerToFabricEdmSender* client_interfaces, uint8_t num_send_dir, size_t& rt_arg_idx) {
+    for (uint8_t i = 0; i < num_send_dir; i++) {
+        client_interfaces[i] =
+            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_arg_idx);
+        client_interfaces[i].open();
+    }
+}
+
+FORCE_INLINE void close_connections(tt::tt_fabric::WorkerToFabricEdmSender* client_interfaces, uint8_t num_send_dir) {
+    for (uint8_t i = 0; i < num_send_dir; i++) {
+        client_interfaces[i].close();
+    }
+}
+
 FORCE_INLINE void fabric_unicast_noc_unicast_write(
     tt_l1_ptr tt::tt_fabric::WorkerToFabricEdmSender* client_interface,
     volatile PACKET_HEADER_TYPE* packet_header,

--- a/tt_metal/fabric/hw/inc/linear/api.h
+++ b/tt_metal/fabric/hw/inc/linear/api.h
@@ -13,17 +13,19 @@
 
 namespace tt::tt_fabric::linear::experimental {
 
+template <size_t num_send_dir>
 FORCE_INLINE void open_connections(
-    tt::tt_fabric::WorkerToFabricEdmSender* client_interfaces, uint8_t num_send_dir, size_t& rt_arg_idx) {
-    for (uint8_t i = 0; i < num_send_dir; i++) {
+    tt::tt_fabric::WorkerToFabricEdmSender (&client_interfaces)[num_send_dir], size_t& rt_arg_idx) {
+    for (size_t i = 0; i < num_send_dir; i++) {
         client_interfaces[i] =
             tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_arg_idx);
         client_interfaces[i].open();
     }
 }
 
-FORCE_INLINE void close_connections(tt::tt_fabric::WorkerToFabricEdmSender* client_interfaces, uint8_t num_send_dir) {
-    for (uint8_t i = 0; i < num_send_dir; i++) {
+template <size_t num_send_dir>
+FORCE_INLINE void close_connections(tt::tt_fabric::WorkerToFabricEdmSender (&client_interfaces)[num_send_dir]) {
+    for (size_t i = 0; i < num_send_dir; i++) {
         client_interfaces[i].close();
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24883

### Problem description
Wanted to reduce developer's burden to explicitly open connection for each direction

### What's changed
wrap the loop in API

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes