### PR TITLE
Reenable SD perf test that used to hang

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -239,7 +239,6 @@ def test_stable_diffusion_vae_trace(device):
     ), f"Inference time with trace is {inference_time}s, while expected time is {expected_inference_time}s"
 
 
-@pytest.mark.skip("#25836: ND Hangs, team will need to investigate")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 21 * 4096, "trace_region_size": 789321728}], indirect=True)
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25836

### Problem description
- This test was disabled due to the ND hangs mentioned in the issue that caused CI to fail non deterministically.
- The other pipelines that run the stable diffusion demo test show stability after merging the throttle PR ->
this test should be enabled

### What's changed
- reenabled test
- Switched to using throttle level 5 instead of slow matmuls in https://github.com/tenstorrent/tt-metal/pull/26052
- tested on n300 test on repeat with throttle, test did not hang even after 16h
- if the test hangs again, will disable it