### PR TITLE
set dispatch core type to worker t3k mesh partition tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py
@@ -245,6 +245,7 @@ def run_mesh_partition_test(
     [
         {
             "trace_region_size": 10000,
+            "dispatch_core_type": ttnn.DispatchCoreType.WORKER,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
         }
     ],
@@ -301,6 +302,7 @@ def test_mesh_partition(
     [
         {
             "trace_region_size": 16384,
+            "dispatch_core_type": ttnn.DispatchCoreType.WORKER,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
         }
     ],


### PR DESCRIPTION
### Problem description
tteager tests were failing on T3K frequent tests pipeline https://github.com/tenstorrent/tt-metal/actions/runs/16728157184/job/47350037299

### What's changed
tteager tests never specified ethernet dispatch so we have moved the failing tests on to worker dispatch explicitly 

APC: https://github.com/tenstorrent/tt-metal/actions/runs/16777621040
BH APC: https://github.com/tenstorrent/tt-metal/actions/runs/16777623579
T3K frequent tests pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/16772308179/job/47490634742

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
