### PR TITLE
#26330: Update tanh_accurate to use where llk

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
@@ -12,6 +12,7 @@
 #include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #include "compute_kernel_api/eltwise_unary/exp.h"
 #include "compute_kernel_api/eltwise_unary/recip.h"
+#include "compute_kernel_api/eltwise_unary/where.h"
 #include "compute_kernel_api.h"
 
 namespace NAMESPACE {
@@ -23,12 +24,10 @@ void MAIN {
     constexpr auto cb_output = tt::CBIndex::c_2;  // output
 
     constexpr auto cb_tanh_lut = tt::CBIndex::c_1;   // lut tanh(x)
-    constexpr auto cb_exp_2x = tt::CBIndex::c_3;     // exp(2x) and abs(x)
+    constexpr auto cb_exp_2x = tt::CBIndex::c_3;     // exp(2x)
     constexpr auto cb_sub = tt::CBIndex::c_4;        // exp(2x) - 1
     constexpr auto cb_add = tt::CBIndex::c_5;        // recip ( exp(2x) + 1 )
     constexpr auto cb_tanh_exp = tt::CBIndex::c_6;   // tanh[x] = (exp[2x] - 1) / (exp[2x] + 1)
-    constexpr auto cb_true_val = tt::CBIndex::c_7;   // output for x > 3.5
-    constexpr auto cb_false_val = tt::CBIndex::c_8;  // output for x <= 3.5
 
     constexpr uint32_t one = 0x3f800000u;    //  1.0f
     constexpr uint32_t two = 0x40000000u;    //  2.0f
@@ -130,98 +129,33 @@ void MAIN {
             cb_pop_front(cb_sub, 1);
             cb_pop_front(cb_add, 1);
 
-            // abs(x) > 3.5f in c_3
+            // output = cb_tanh_lut if x > 3.5, otherwise cb_tanh_exp
+            cb_wait_front(cb_tanh_exp, 1);
+            cb_wait_front(cb_tanh_lut, 1);
+            cb_wait_front(cb_input, 1);
 
-            cb_reserve_back(cb_exp_2x, 1);
             tile_regs_acquire();
             copy_tile_to_dst_init_short(cb_input);
             copy_tile(cb_input, 0, 0);
-
             abs_tile_init();
             abs_tile(0);
             unary_gt_tile_init();
             unary_gt_tile(0, limit);
-
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, cb_exp_2x);
-
-            tile_regs_release();
-            cb_push_back(cb_exp_2x, 1);
-
-            cb_pop_front(cb_input, 1);
-
-            // t2 output for x > 3.5
-
-            cb_wait_front(cb_tanh_lut, 1);
-            cb_wait_front(cb_exp_2x, 1);
-            cb_reserve_back(cb_true_val, 1);
-
-            tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_exp_2x);
-            copy_tile(cb_exp_2x, 0, 0);
-
-            gtz_tile_init();
-            gtz_tile(0);
-
-            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-                cb_tanh_lut);
-            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-                cb_tanh_lut, 0, 0);
-
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, cb_true_val);
-
-            tile_regs_release();
-
-            cb_push_back(cb_true_val, 1);
-            cb_pop_front(cb_tanh_lut, 1);
-
-            // t1 output for x <= 3.5
-
-            cb_wait_front(cb_tanh_exp, 1);
-            cb_reserve_back(cb_false_val, 1);
-
-            tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_exp_2x);
-            copy_tile(cb_exp_2x, 0, 0);
-
-            lez_tile_init();
-            lez_tile(0);
-
-            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-                cb_tanh_exp);
-            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-                cb_tanh_exp, 0, 0);
-
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, cb_false_val);
-
-            tile_regs_release();
-
-            cb_push_back(cb_false_val, 1);
-            cb_pop_front(cb_exp_2x, 1);
-            cb_pop_front(cb_tanh_exp, 1);
-
-            // out = t1 + t2
-            cb_wait_front(cb_false_val, 1);
-            cb_wait_front(cb_true_val, 1);
-
-            tile_regs_acquire();
-
-            add_tiles_init(cb_true_val, cb_false_val);
-            add_tiles(cb_true_val, cb_false_val, 0, 0, 0);
-
+            copy_tile_to_dst_init_short(cb_tanh_lut);
+            copy_tile(cb_tanh_lut, 0, 1);
+            copy_tile_to_dst_init_short(cb_tanh_exp);
+            copy_tile(cb_tanh_exp, 0, 2);
+            where_tile_init();
+            where_tile(0, 1, 2);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(0, cb_output);
 
             tile_regs_release();
 
-            cb_pop_front(cb_true_val, 1);
-            cb_pop_front(cb_false_val, 1);
+            cb_pop_front(cb_tanh_exp, 1);
+            cb_pop_front(cb_tanh_lut, 1);
+            cb_pop_front(cb_input, 1);
         }
         cb_push_back(cb_output, per_core_block_dim);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
@@ -84,20 +84,6 @@ TanhAccurateProgramFactory::cached_program_t TanhAccurateProgramFactory::create(
             .set_page_size(im5_cb_index, single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im5_config);
 
-    // output for x > 3.5
-    uint32_t im6_cb_index = tt::CBIndex::c_7;
-    tt::tt_metal::CircularBufferConfig cb_im6_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im6_cb_index, cb_data_format}})
-            .set_page_size(im6_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im6_config);
-
-    // output for x <= 3.5
-    uint32_t im7_cb_index = tt::CBIndex::c_8;
-    tt::tt_metal::CircularBufferConfig cb_im7_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im7_cb_index, cb_data_format}})
-            .set_page_size(im7_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im7_config);
-
     // output buffer
     uint32_t output_cb_index = tt::CBIndex::c_2;
     uint32_t num_output_tiles = 2;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
@@ -121,10 +121,20 @@ TanhAccurateProgramFactory::cached_program_t TanhAccurateProgramFactory::create(
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (args.preserve_fp32_precision) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im1_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im2_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im3_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im4_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im5_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     bool math_approx_mode = false;
     std::map<std::string, std::string> unary_defines;
+    if (input.dtype() == DataType::FLOAT32) {
+        unary_defines["TANH_FP32"] = "1";
+    } else {
+        unary_defines["TANH_BF16"] = "1";
+    }
     auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
 
     tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
@@ -148,10 +148,20 @@ TanhAccurateShardedProgramFactory::cached_program_t TanhAccurateShardedProgramFa
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (args.preserve_fp32_precision) {
         unpack_to_dest_mode[in_cb_id] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im1_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im2_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im3_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im4_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[im5_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     bool math_approx_mode = false;
     std::map<std::string, std::string> unary_defines;
+    if (input.dtype() == DataType::FLOAT32) {
+        unary_defines["TANH_FP32"] = "1";
+    } else {
+        unary_defines["TANH_BF16"] = "1";
+    }
     auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
 
     tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
@@ -110,20 +110,6 @@ TanhAccurateShardedProgramFactory::cached_program_t TanhAccurateShardedProgramFa
             .set_page_size(im5_cb_index, in_cb_pagesize);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im5_config);
 
-    // output for x > 3.5
-    uint32_t im6_cb_index = tt::CBIndex::c_7;
-    tt::tt_metal::CircularBufferConfig cb_im6_config =
-        tt::tt_metal::CircularBufferConfig(in_cb_pagesize * in_cb_npages, {{im6_cb_index, act_df}})
-            .set_page_size(im6_cb_index, in_cb_pagesize);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im6_config);
-
-    // output for x <= 3.5
-    uint32_t im7_cb_index = tt::CBIndex::c_8;
-    tt::tt_metal::CircularBufferConfig cb_im7_config =
-        tt::tt_metal::CircularBufferConfig(in_cb_pagesize * in_cb_npages, {{im7_cb_index, act_df}})
-            .set_page_size(im7_cb_index, in_cb_pagesize);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im7_config);
-
     // output sharded CB
     uint32_t out_cb_id = tt::CBIndex::c_2;
     tt::tt_metal::CircularBufferConfig out_cb_config =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
@@ -18,10 +18,6 @@ Tensor Tanh_accurate::invoke(
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    TT_FATAL(
-        input_tensor.dtype() == DataType::BFLOAT16,
-        "Supported dtypes for tanh with accuracy mode enabled is : BFLOAT16");
-
     auto input_dtype = input_tensor.dtype();
     DataType output_dtype = input_dtype;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -891,7 +891,7 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
                * - Dtypes
                  - Layouts
                  - Ranks
-               * - BFLOAT16, BFLOAT8_B
+               * - BFLOAT16, BFLOAT8_B, FLOAT32
                  - TILE
                  - 2, 3, 4
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #26330 

### What's changed
Updated tanh_accurate to use where llk

### Performance results:

In main:
single tile            - 6760 ns
[1,1,8192,8192]  - 4944736ns

After using where LLk:
single tile            -5329ns (**~21%  faster**)
[1,1,8192,8192]  - 3687484 (**~25% faster**)
### Checklist
- [ ] All post commit
- [ ] Blackhole Post commit