### PR TITLE
Spread loading vision from qwen25_vl to all multimodal

### DIFF
--- a/models/demos/qwen25_vl/tests/test_model.py
+++ b/models/demos/qwen25_vl/tests/test_model.py
@@ -14,7 +14,7 @@ from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
 from models.tt_transformers.tt.load_checkpoints import (
     convert_hf_to_meta,
     convert_rope_style_hf_to_meta,
-    standardize_hf_keys_qwen25_vl,
+    standardize_hf_keys_multimodal,
 )
 from models.utility_functions import comp_allclose, comp_pcc
 
@@ -72,7 +72,7 @@ def test_vision_model_inference(
     # reference_model = Qwen2_5_VisionTransformerPretrainedModel(model_args.hf_config.vision_config)
     # reference_model.load_state_dict(model_args.reference_vision_model().state_dict(), strict=False)
     # FIXME: state_dict = model_args.load_state_dict()
-    state_dict = standardize_hf_keys_qwen25_vl(reference_model.state_dict())
+    state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
     state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
     state_dict_prefix = model_args.get_state_dict_prefix("VisionTransformer")
     state_dict = {f"{state_dict_prefix}.{k}": v for k, v in state_dict.items()}

--- a/models/demos/qwen25_vl/tests/test_vision_attention.py
+++ b/models/demos/qwen25_vl/tests/test_vision_attention.py
@@ -15,7 +15,7 @@ from models.tt_transformers.tt.common import get_rot_transformation_mat
 from models.tt_transformers.tt.load_checkpoints import (
     convert_hf_to_meta,
     convert_rope_style_hf_to_meta,
-    standardize_hf_keys_qwen25_vl,
+    standardize_hf_keys_multimodal,
 )
 from models.tt_transformers.tt.model_config import ModelArgs
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
@@ -56,7 +56,7 @@ def test_vision_attention_inference(
     # reference_model = Qwen2_5_VLVisionAttention(model_args.hf_config.vision_config.hidden_size, model_args.hf_config.vision_config.num_heads)
     # reference_model.load_state_dict(model_args.reference_attention().state_dict())
 
-    state_dict = standardize_hf_keys_qwen25_vl(reference_model.state_dict())
+    state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
     state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
     state_dict_prefix = model_args.get_state_dict_prefix("VisionAttention", 0)
     state_dict = {f"{state_dict_prefix}.{k}": v for k, v in state_dict.items()}

--- a/models/demos/qwen25_vl/tests/test_vision_block.py
+++ b/models/demos/qwen25_vl/tests/test_vision_block.py
@@ -12,7 +12,7 @@ from models.demos.qwen25_vl.reference.functional import qwen2_5_vision_transform
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
 from models.demos.qwen25_vl.tt.vision_block import VisionBlock
 from models.tt_transformers.tt.common import get_rot_transformation_mat
-from models.tt_transformers.tt.load_checkpoints import convert_hf_to_meta, standardize_hf_keys_qwen25_vl
+from models.tt_transformers.tt.load_checkpoints import convert_hf_to_meta, standardize_hf_keys_multimodal
 from models.utility_functions import comp_allclose, comp_pcc
 
 
@@ -58,7 +58,7 @@ def test_vision_block_inference(
         reference_model = reference_whole_model.blocks[layer_num]
 
         # Get the state dict of the reference model
-        state_dict = standardize_hf_keys_qwen25_vl(reference_model.state_dict())
+        state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
         state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
         state_dict_prefix = model_args.get_state_dict_prefix("VisionBlock", layer_num)
         state_dict = {f"{state_dict_prefix}{k}": v for k, v in state_dict.items()}

--- a/models/demos/qwen25_vl/tt/model.py
+++ b/models/demos/qwen25_vl/tt/model.py
@@ -18,7 +18,7 @@ from models.tt_transformers.tt.common import get_rot_transformation_mat
 from models.tt_transformers.tt.load_checkpoints import (
     convert_hf_to_meta,
     convert_rope_style_hf_to_meta,
-    standardize_hf_keys_qwen25_vl,
+    standardize_hf_keys_multimodal,
 )
 from models.tt_transformers.tt.model import Transformer as TTTransformer
 from models.utility_functions import comp_pcc
@@ -181,7 +181,7 @@ class DropInVisionTransformer(torch.nn.Module):
         self.model_args = model_args
         self.debug = debug
 
-        state_dict = standardize_hf_keys_qwen25_vl(reference_model.state_dict())
+        state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
         state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
         state_dict_prefix = model_args.get_state_dict_prefix("VisionTransformer")
         state_dict = {f"{state_dict_prefix}.{k}": v for k, v in state_dict.items()}

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -13,17 +13,6 @@ from safetensors.torch import load_file as safetensors_load_file
 from tqdm import tqdm
 
 
-def _get_known_prefixes_mapping():
-    return {
-        # Llama Vision
-        "text_model.": "",
-        "vision_model.": "",
-        # Gemma3
-        "model.language_model.": "model.",
-        "model.vision_tower.": "model.",
-    }
-
-
 # TODO Update function for large models: For 1 layer tests we only want to load 1 checkpoint file, instead of all.
 def load_hf_state_dict(ckpt_dir):
     # First check if index file exists
@@ -57,23 +46,21 @@ def standardize_hf_keys(state_dict):
     key_meta = "lm_head.weight"
     key_hf = "model.embed_tokens.weight"
 
-    # Check if the key_meta exists with any known prefix
-    if not any(f"{prefix}{key_meta}" in state_dict for prefix in _get_known_prefixes_mapping().keys()):
-        # Assume tied to the embeddings if not present
-        for prefix in _get_known_prefixes_mapping().keys():
-            if f"{prefix}{key_hf}" in state_dict:
-                state_dict[f"{prefix}{key_meta}"] = state_dict[f"{prefix}{key_hf}"]
-                break
+    if not key_meta in state_dict:
+        state_dict[key_meta] = state_dict[key_hf]
+        del state_dict[key_hf]
 
     return state_dict
 
 
-def standardize_hf_keys_qwen25_vl(state_dict):
+def standardize_hf_keys_multimodal(state_dict):
     all_keys = tuple(state_dict.keys())
     new_state_dict = {}
     for k in all_keys:
         if "model.visual." in k:
             new_state_dict[k.replace("model.visual.", "visual.")] = state_dict[k]
+        elif "model.vision_tower.vision_model." in k:
+            new_state_dict[k.replace("model.vision_tower.vision_model.", "visual.")] = state_dict[k]
         elif "model.language_model." in k:
             new_state_dict[k.replace("model.language_model.", "model.")] = state_dict[k]
         else:

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -46,7 +46,7 @@ def standardize_hf_keys(state_dict):
     key_meta = "lm_head.weight"
     key_hf = "model.embed_tokens.weight"
 
-    if not key_meta in state_dict:
+    if not key_meta in state_dict and key_hf in state_dict:
         state_dict[key_meta] = state_dict[key_hf]
         del state_dict[key_hf]
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -31,7 +31,7 @@ from models.tt_transformers.tt.load_checkpoints import (
     load_meta_state_dict,
     reverse_permute,
     standardize_hf_keys,
-    standardize_hf_keys_qwen25_vl,
+    standardize_hf_keys_multimodal,
 )
 from models.utility_functions import is_blackhole, is_wormhole_b0, nearest_32
 
@@ -452,6 +452,8 @@ class ModelArgs:
         self.cache_hf_flag = cache_hf  # Whether to cache HF model to avoid multiple loads (uses extra memory)
         self.cached_hf_model = None  # Save any HF model object to avoid loading it multiple times for reference methods
 
+        self.rms_norm_add_unit_offset = False
+
         assert not os.getenv(
             "FAKE_DEVICE"
         ), "FAKE_DEVICE has been renamed to MESH_DEVICE for consistency with vLLM, please update your environment variables and run again."
@@ -507,7 +509,7 @@ class ModelArgs:
 
         self.instruct = instruct
         # If the weights file contain the keyword `instruct` also set self.instruct to true
-        if "instruct" in self.CKPT_DIR.lower():
+        if any(keyword in self.CKPT_DIR.lower() for keyword in ("instruct", "it")):
             self.instruct = True
 
         # Check for supported batches since previous logic that contained the check was removed because it was unused
@@ -1392,7 +1394,9 @@ class ModelArgs:
 
     def _set_model_specific_params(self):
         # Gemma3 specific params
-        self.rms_norm_add_unit_offset = "gemma-3" in self.base_model_name.lower()
+        is_gemma3 = "gemma-3" in self.base_model_name.lower()
+        if is_gemma3:
+            self.rms_norm_add_unit_offset = True
 
     def _set_params_from_dict(self, config, is_hf=False):
         # Try to get text_config, if it doesn't exist everything is text config
@@ -1499,6 +1503,7 @@ class ModelArgs:
         self.vision_in_channels = 3
 
         self.state_dict_text_prefix = self._get_text_prefix()
+        self.is_multimodal = "vision_config" in config or self.is_vision()
 
         self._set_model_specific_params()
 
@@ -1688,8 +1693,8 @@ class ModelArgs:
                 state_dict = load_hf_state_dict(self.CKPT_DIR)
 
         if self.checkpoint_type == CheckpointType.HuggingFace:
-            if "Qwen2.5-VL" in self.model_name:
-                state_dict = standardize_hf_keys_qwen25_vl(state_dict)
+            if self.is_multimodal:
+                state_dict = standardize_hf_keys_multimodal(state_dict)
             else:
                 state_dict = standardize_hf_keys(state_dict)
             state_dict = convert_hf_to_meta(state_dict, self.head_dim)


### PR DESCRIPTION
### Ticket
n/a

### Problem description
When loading Gemma3 weights I encountered issues after loading checkpoints refactor

### What's changed
Qwen 2.5 VL is multimodal, but so is Gemma3 and is Llama 3.2 11B Vision.
Have them all follow the same route to handle the nested weights (language_model, vision_tower, etc.)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16800024215) ❌ Unrelated (t3k fabric)
- [ ] [Single card Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16800043129) ❌ Unrelated (perf asserts and hangs as on main)
- [ ] [Single card Frequent](https://github.com/tenstorrent/tt-metal/actions/runs/16800052397) ❌ Unrelated (yolo)
- [ ] [T3K Unit and Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16800066409) ❌ Unrelated (perf asserts and hangs as on main)