### PR TITLE
ttnn.remainder fails for row and col-row bcast 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2534,23 +2534,40 @@ def test_sub_implicit_broadcast(device, shapes):
         [[8, 16, 1], [1, 1, 32]],
     ],
 )
-def test_remainder_implicit_broadcast(device, shapes):
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.int32, ttnn.int32),
+        (torch.float32, ttnn.float32),
+    ],
+)
+def test_remainder_implicit_broadcast(device, shapes, torch_dtype, ttnn_dtype):
     torch.manual_seed(0)
 
-    torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.float32)
-    torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.float32)
-    torch_output_tensor = torch.remainder(torch_input_tensor_a, torch_input_tensor_b)
+    if torch_dtype == torch.int32:
+        torch_input_tensor_a = torch.randint(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, shapes[0], dtype=torch.int32
+        )
+        torch_input_tensor_b = torch.randint(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, shapes[1], dtype=torch.int32
+        )
+    else:
+        torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.float32)
+        torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.float32)
+
+    golden_function = ttnn.get_golden_function(ttnn.remainder)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
-        dtype=ttnn.float32,
+        dtype=ttnn_dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
-        dtype=ttnn.float32,
+        dtype=ttnn_dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2552,8 +2552,12 @@ def test_remainder_implicit_broadcast(device, shapes, torch_dtype, ttnn_dtype):
             torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, shapes[1], dtype=torch.int32
         )
     else:
-        torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.float32)
-        torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.float32)
+        torch_input_tensor_a = torch.empty(shapes[0], dtype=torch.float32).uniform_(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max
+        )
+        torch_input_tensor_b = torch.empty(shapes[1], dtype=torch.float32).uniform_(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max
+        )
 
     golden_function = ttnn.get_golden_function(ttnn.remainder)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.utility_functions import torch_random
+from tests.ttnn.utils_for_testing import assert_with_pcc
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
@@ -90,3 +91,68 @@ def test_remainder_scalar(input_shapes, scalar, device):
         assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
     else:
         assert torch.allclose(output_tensor, torch_output_tensor, atol=0.001, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # no subtile bcast
+        [[1, 16, 32], [8, 16, 32]],
+        # scalar bcast
+        [[8, 16, 32], [1, 1, 1]],
+        [[1, 1, 1], [8, 16, 32]],
+        # col bcast
+        [[1, 16, 1], [8, 16, 32]],
+        [[8, 16, 32], [8, 16, 1]],
+        # row bcast
+        [[8, 16, 32], [8, 1, 32]],
+        [[8, 1, 32], [8, 16, 32]],
+        # row col mixed bcast
+        [[1, 1, 32], [8, 16, 1]],
+        [[8, 16, 1], [1, 1, 32]],
+    ],
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.int32, ttnn.int32),
+        (torch.float32, ttnn.float32),
+        (torch.int32, ttnn.float32),
+    ],
+)
+def test_remainder_implicit_broadcast(shapes, torch_dtype, ttnn_dtype, device):
+    torch.manual_seed(0)
+
+    if torch_dtype == torch.int32:
+        torch_input_tensor_a = torch.randint(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, shapes[0], dtype=torch_dtype
+        )
+        torch_input_tensor_b = torch.randint(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, shapes[1], dtype=torch_dtype
+        )
+    else:
+        torch_input_tensor_a = torch.empty(shapes[0], dtype=torch.float32).uniform_(-2147483648.0, 2147483647.0)
+        torch_input_tensor_b = torch.empty(shapes[1], dtype=torch.float32).uniform_(-2147483648.0, 2147483647.0)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.remainder)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    output_tensor = ttnn.remainder(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -405,7 +405,12 @@ Tensor run_remainder(
             input_b,
             ttnn::div(input_a, input_b, true, "floor", std::nullopt, output_mem_config),
             std::nullopt,
-            output_mem_config),
+            output_mem_config,
+            std::nullopt,
+            FusedActivations{},
+            FusedActivations{},
+            FusedActivations{},
+            false),
         std::nullopt,
         output_mem_config,
         std::nullopt,
@@ -413,8 +418,33 @@ Tensor run_remainder(
         FusedActivations{},
         FusedActivations{},
         false);
-    result = ttnn::where(ttnn::ge(result, input_b), ttnn::subtract(result, input_b), result);
-    result = ttnn::where(ttnn::ltz(input_b), ttnn::add(result, input_b), result);
+
+    result = ttnn::where(
+        ttnn::ge(result, input_b),
+        ttnn::subtract(
+            result,
+            input_b,
+            std::nullopt,
+            output_mem_config,
+            std::nullopt,
+            FusedActivations{},
+            FusedActivations{},
+            FusedActivations{},
+            false),
+        result);
+    result = ttnn::where(
+        ttnn::ltz(input_b),
+        ttnn::add(
+            result,
+            input_b,
+            std::nullopt,
+            output_mem_config,
+            std::nullopt,
+            FusedActivations{},
+            FusedActivations{},
+            FusedActivations{},
+            false),
+        result);
     result = ttnn::where(ttnn::eq(input_a, input_b, std::nullopt, output_mem_config), 0.0f, result);
     result = ttnn::where(ttnn::eqz(input_a), 0.0f, ttnn::where(ttnn::eqz(input_b), t_nan, result));
     result = ttnn::where(ttnn::logical_and(ttnn::eqz(input_a), ttnn::eqz(input_b)), t_nan, result);


### PR DESCRIPTION
### Ticket
#24635 

### Problem description
ttnn.remainder fails for row broadcast and row-col mixed broadcast when the second tensor is broadcasted.

### What's changed
Some sub-ops were calling broadcast_height_multi_core_program_factory instead of binary_ng program factory. 
Passed use_legacy = false for these ops.

### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/16777832600 (latest run: https://github.com/tenstorrent/tt-metal/actions/runs/16796316198)
- [x] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/16777818200