### PR TITLE
#21824: Add uint16 support for zero comp ops

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -114,6 +114,7 @@ class TtMoeLayer(LightweightModule):
             topk_values, topk_indices = ttnn.topk(gate_logits_1SB8, 32)
             topk_values = ttnn.add(topk_values, self.top2_mask_11BB)
             mask_B2 = ttnn.eqz(topk_indices)
+            mask_B2 = ttnn.typecast(mask_B2, topk_values.get_dtype())
             weights_1SB1 = ttnn.sum(ttnn.softmax(topk_values, dim=-1) * mask_B2, dim=3, keepdim=True)
 
             topk_values.deallocate(True)

--- a/models/experimental/grok/tt/grok_moe.py
+++ b/models/experimental/grok/tt/grok_moe.py
@@ -120,6 +120,7 @@ class TtMoeLayer(LightweightModule):
         # tlog('our_topk_indices', ttl_topk_indices)
         ttl_topk_values = ttl_topk_values * self.top2_mask_11BB  # masked unwanted ones to 0
         mask_B2 = ttnn.eq(self.expert_mask_11BB, ttl_topk_indices)  # Each device masks for its own expert index 1-8
+        mask_B2 = ttnn.typecast(mask_B2, ttl_topk_values.get_dtype())
         weights_1SB1 = ttnn.sum(ttl_topk_values * mask_B2, dim=3, keepdim=True)
 
         # MLP and masking

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -582,11 +582,13 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [
-        torch.Size([1, 1, 32, 32]),
-        torch.Size([1, 1, 320, 384]),
-        torch.Size([1, 3, 320, 384]),
-    ],
+    (
+        (torch.Size([100])),
+        (torch.Size([32, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
 )
 @pytest.mark.parametrize(
     "low, high",
@@ -604,44 +606,10 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
 )
 def test_unary_zero_comp_uint16_ttnn(input_shapes, low, high, ttnn_function, device):
     in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
-    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
-
-    cq_id = 0
-    output_tensor = ttnn_function(input_tensor, queue_id=cq_id)
-    golden_function = ttnn.get_golden_function(ttnn_function)
-    golden_tensor = golden_function(in_data)
-
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert torch.equal(golden_tensor, output_tensor)
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    [
-        torch.Size([1, 1, 32, 32]),
-        torch.Size([1, 1, 320, 384]),
-    ],
-)
-@pytest.mark.parametrize(
-    "ttnn_function",
-    [
-        ttnn.eqz,
-        ttnn.nez,
-    ],
-)
-def test_unary_zero_comp_with_majority_zeros(input_shapes, ttnn_function, device):
-    rows, cols = input_shapes[-2], input_shapes[-1]
-    total_elements = rows * cols
-    num_zeros = total_elements * 3 // 4
-    num_nonzeros = total_elements - num_zeros
-
-    flat_tensor = torch.zeros(total_elements, dtype=torch.int32)
-    random_ints = torch.randint(0, 100, (num_nonzeros,), dtype=torch.int32)
-    flat_tensor[:num_nonzeros] = random_ints
-    flat_tensor = flat_tensor[torch.randperm(total_elements)]
-
-    in_data = flat_tensor.reshape(input_shapes)
+    zeroize_prob = 0.50
+    if zeroize_prob > 0:
+        zero_mask = torch.rand(in_data.shape) < zeroize_prob
+        in_data = in_data.masked_fill(zero_mask, 0)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
 
     cq_id = 0

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -576,8 +576,82 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
-    assert pcc == 1
+
+    assert torch.equal(golden_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([1, 1, 32, 32]),
+        torch.Size([1, 1, 320, 384]),
+        torch.Size([1, 3, 320, 384]),
+    ],
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (0, 2),  # Small range
+        (0, 65535),  # Full uint16 range
+    ],
+)
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.eqz,
+        ttnn.nez,
+    ],
+)
+def test_unary_zero_comp_uint16_ttnn(input_shapes, low, high, ttnn_function, device):
+    in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    cq_id = 0
+    output_tensor = ttnn_function(input_tensor, queue_id=cq_id)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    golden_tensor = golden_function(in_data)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(golden_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([1, 1, 32, 32]),
+        torch.Size([1, 1, 320, 384]),
+    ],
+)
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.eqz,
+        ttnn.nez,
+    ],
+)
+def test_unary_zero_comp_with_majority_zeros(input_shapes, ttnn_function, device):
+    rows, cols = input_shapes[-2], input_shapes[-1]
+    total_elements = rows * cols
+    num_zeros = total_elements * 3 // 4
+    num_nonzeros = total_elements - num_zeros
+
+    flat_tensor = torch.zeros(total_elements, dtype=torch.int32)
+    random_ints = torch.randint(0, 100, (num_nonzeros,), dtype=torch.int32)
+    flat_tensor[:num_nonzeros] = random_ints
+    flat_tensor = flat_tensor[torch.randperm(total_elements)]
+
+    in_data = flat_tensor.reshape(input_shapes)
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    cq_id = 0
+    output_tensor = ttnn_function(input_tensor, queue_id=cq_id)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    golden_tensor = golden_function(in_data)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(golden_tensor, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -620,8 +694,7 @@ def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
-    assert pcc == 1
+    assert torch.equal(golden_tensor, output_tensor)
 
 
 def is_int32_overflow(tensor, scalar):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -120,6 +120,35 @@ inline void calculate_comp_int() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
+inline void calculate_comp_uint16() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        static_assert(COMP_MODE == SfpuType::equal_zero or COMP_MODE == SfpuType::not_equal_zero);
+        constexpr int check = COMP_MODE == SfpuType::equal_zero ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0;
+
+        // full tile size
+        constexpr int tile_size = 64;
+        // location of conditional value tile
+        constexpr int cond_val_idx = 0 * tile_size;  // tile 0
+        // location of output tile
+        constexpr int output_idx = 0 * tile_size;  // tile 0
+        // load in conditional uint16 value
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, cond_val_idx);
+        // initially put 0 into output
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+        // if (REG0 == 0)
+        TTI_SFPSETCC(0, 0, 0, check);
+        // load in (int) 1
+        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0x0001);
+        // end_if
+        TTI_SFPENCC(0, 0, 0, 0);
+        // store result
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, output_idx);
+
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_unary_int(int scalar) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -121,10 +121,9 @@ inline void calculate_comp_int() {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_uint16() {
+    static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
+    constexpr int check = ((COMP_MODE == SfpuType::equal_zero) ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0);
     for (int d = 0; d < ITERATIONS; d++) {
-        static_assert(COMP_MODE == SfpuType::equal_zero or COMP_MODE == SfpuType::not_equal_zero);
-        constexpr int check = COMP_MODE == SfpuType::equal_zero ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0;
-
         // full tile size
         constexpr int tile_size = 64;
         // location of conditional value tile
@@ -132,18 +131,17 @@ inline void calculate_comp_uint16() {
         // location of output tile
         constexpr int output_idx = 0 * tile_size;  // tile 0
         // load in conditional uint16 value
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, cond_val_idx);
+        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_7, cond_val_idx);
         // initially put 0 into output
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
         // if (REG0 == 0)
         TTI_SFPSETCC(0, 0, 0, check);
         // load in (int) 1
-        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0x0001);
+        TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x0001);
         // end_if
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, output_idx);
-
+        TTI_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_3, output_idx);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -27,7 +27,7 @@ inline void llk_math_eltwise_unary_sfpu_eqz_int32(uint dst_index, int vector_mod
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_eqz_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::equal_zero>, dst_index, vector_mode);
 }
 
@@ -51,7 +51,7 @@ inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mod
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -26,6 +26,12 @@ inline void llk_math_eltwise_unary_sfpu_eqz_int32(uint dst_index, int vector_mod
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_eqz_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_eqz_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::equal_zero, APPROXIMATE>();
 }
@@ -41,6 +47,12 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_nez_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -142,10 +142,9 @@ inline void calculate_comp_int() {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_uint16() {
+    static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
+    constexpr int check = ((COMP_MODE == SfpuType::equal_zero) ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0);
     for (int d = 0; d < ITERATIONS; d++) {
-        static_assert(COMP_MODE == SfpuType::equal_zero or COMP_MODE == SfpuType::not_equal_zero);
-        constexpr int check = COMP_MODE == SfpuType::equal_zero ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0;
-
         // full tile size
         constexpr int tile_size = 64;
         // location of conditional value tile
@@ -153,18 +152,17 @@ inline void calculate_comp_uint16() {
         // location of output tile
         constexpr int output_idx = 0 * tile_size;  // tile 0
         // load in conditional uint16 value
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, cond_val_idx);
+        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_3, cond_val_idx);
         // initially put 0 into output
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
         // if (REG0 == 0)
         TTI_SFPSETCC(0, 0, 0, check);
         // load in (int) 1
-        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0x0001);
+        TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x0001);
         // end_if
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, output_idx);
-
+        TTI_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_3, output_idx);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -141,6 +141,35 @@ inline void calculate_comp_int() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
+inline void calculate_comp_uint16() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        static_assert(COMP_MODE == SfpuType::equal_zero or COMP_MODE == SfpuType::not_equal_zero);
+        constexpr int check = COMP_MODE == SfpuType::equal_zero ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0;
+
+        // full tile size
+        constexpr int tile_size = 64;
+        // location of conditional value tile
+        constexpr int cond_val_idx = 0 * tile_size;  // tile 0
+        // location of output tile
+        constexpr int output_idx = 0 * tile_size;  // tile 0
+        // load in conditional uint16 value
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, cond_val_idx);
+        // initially put 0 into output
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+        // if (REG0 == 0)
+        TTI_SFPSETCC(0, 0, 0, check);
+        // load in (int) 1
+        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0x0001);
+        // end_if
+        TTI_SFPENCC(0, 0, 0, 0);
+        // store result
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, output_idx);
+
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_unary_int(int scalar) {
     // Convert both operands to two's complement format
     //

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -26,6 +26,12 @@ inline void llk_math_eltwise_unary_sfpu_eqz_int32(uint dst_index, int vector_mod
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_eqz_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_eqz_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::equal_zero, APPROXIMATE>();
 }
@@ -41,6 +47,12 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_nez_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/comp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/comp.h
@@ -466,6 +466,22 @@ ALWI void eqz_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz<APPROX
 // clang-format on
 ALWI void eqz_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz_int32<APPROX>(idst))); }
 
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element of a equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void eqz_tile_uint16(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz_uint16<APPROX>(idst))); }
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -502,6 +518,22 @@ ALWI void lez_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_lez<APPROX
  */
 // clang-format on
 ALWI void lez_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_lez_int32<APPROX>(idst))); }
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is not equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void nez_tile_uint16(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_nez_uint16<APPROX>(idst))); }
 
 /**
  * Please refer to documentation for any_init.

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/comp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/comp.h
@@ -436,7 +436,7 @@ ALWI void ltz_tile_init() { MATH((llk_math_eltwise_unary_sfpu_ltz_init<APPROX>()
 
 // clang-format off
 /**
- * Will store in the output of the compute core True if each element of a equal to zero.
+ * Will store in the output of the compute core True if each element of a tile is equal to zero.
  * The DST register buffer must be in acquired state via *acquire_dst* call.
  * This call is blocking and is only
  * available on the compute engine.
@@ -452,7 +452,7 @@ ALWI void eqz_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz<APPROX
 
 // clang-format off
 /**
- * Will store in the output of the compute core True if each element of a equal to zero.
+ * Will store in the output of the compute core True if each element of a tile is equal to zero.
  * The DST register buffer must be in acquired state via *acquire_dst* call.
  * This call is blocking and is only
  * available on the compute engine.
@@ -468,7 +468,7 @@ ALWI void eqz_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz_
 
 // clang-format off
 /**
- * Will store in the output of the compute core True if each element of a equal to zero.
+ * Will store in the output of the compute core True if each element of a tile is equal to zero.
  * The DST register buffer must be in acquired state via *acquire_dst* call.
  * This call is blocking and is only
  * available on the compute engine.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -471,7 +471,8 @@ BinaryNgDeviceOperation::invoke(
             std::nullopt,
             memory_config.value_or(
                 output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config()),
-            input_tensor_a.dtype(),
+            input_tensor_a.dtype(),  // TODO: For mixed dtypes we need to set this value to the appropriate dtype
+                                     // depending on which LLK is meant to be used.
             output_dtype,
             get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor),
             std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -495,6 +495,9 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     const auto& b = tensor_args.input_tensor_b;
     const bool is_sfpu_op = operation_attributes.is_sfpu;
     const bool is_quant_op = operation_attributes.is_quant_op;
+    // TODO: For mixed dtypes we need to set this value to the appropriate dtype depending on which LLK is meant to be
+    // used.
+    const auto input_dtype = operation_attributes.input_dtype;
     if (is_quant_op) {
         TT_FATAL(is_sfpu_op, "Quantization op is SFPU-only");
     }
@@ -575,10 +578,10 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
                 compute_kernel_defines["QUANT_ZERO_POINT_RT_ARGS_IDX"] = "3";
                 unary::utils::update_macro_defines(unary::UnaryOpType::ZERO_POINT, compute_kernel_defines);
             } else {
-                add_activation_defines(compute_kernel_defines, post_activations, "POST", c.dtype());
+                add_activation_defines(compute_kernel_defines, post_activations, "POST", input_dtype);
             }
         } else {
-            add_activation_defines(compute_kernel_defines, post_activations, "POST", c.dtype());
+            add_activation_defines(compute_kernel_defines, post_activations, "POST", input_dtype);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -495,6 +495,8 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype.value() == DataType::INT32) {
                 op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile_int32({});", idst)};
+            } else if (input_dtype.value() == DataType::UINT16) {
+                op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile_uint16({});", idst)};
             } else {
                 op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile({});", idst)};
             }
@@ -504,6 +506,8 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile_int32({});", idst)};
+            } else if (input_dtype == DataType::UINT16) {
+                op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile_uint16({});", idst)};
             } else {
                 op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)};
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1739,7 +1739,7 @@ void py_module(py::module& module) {
         ttnn::eqz,
         R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ == 0}}))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT16)doc");
     bind_unary_operation(
         module,
         ttnn::ceil,
@@ -1862,7 +1862,7 @@ void py_module(py::module& module) {
         ttnn::nez,
         R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ != 0}}))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT16)doc");
 
     bind_unary_operation_overload_complex_return_complex(
         module,


### PR DESCRIPTION
### Ticket
Link to Github Issue #21824 

### Problem description
 Zero-comparison operations are not supported for uint16.
 
### What's changed
Added uint16 for eqz and nez.

### Reason for adding typecast:
https://github.com/tenstorrent/tt-metal/issues/21824#issuecomment-3160169403
### Checklist
- [x] [All post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/16956196769)
- [x] [Black post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/16879848240)