### PR TITLE
Move stable_diffusion into stable models

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -71,6 +71,7 @@ jobs:
             {"model":"gemma-3-4b-it"},
             {"model":"ttt-mistral-7B-v0.3"},
             {"model":"stable_diffusion_xl_base","timeout":45}
+            {"model":"stable_diffusion","timeout":45}
           ]'
 
           # Stable set (CIv2)
@@ -81,7 +82,6 @@ jobs:
 
           # Unstable set (explicit commands)
           UNSTABLE='[
-            {"model":"stable_diffusion","cmd":"TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion"},
             {"model":"mamba 1","cmd":"pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1"},
             {"model":"mamba 2","cmd":"pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 2"},
             {"model":"mamba 3","cmd":"pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 3"},
@@ -117,7 +117,6 @@ jobs:
 
             # Skipping due to issue 15932 (mamba 1, mamba 2, mamba 3, mamba 4, mamba 6)
             UNSTABLE_OUT='[
-              {"model":"stable_diffusion","cmd":"TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion"},
               {"model":"mamba 5","cmd":"pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 5"}
             ]'
 
@@ -190,6 +189,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e GTEST_OUTPUT=xml:generated/test_reports/
             ${{ matrix.test-config.model == 'stable_diffusion_xl_base' && '-e HF_HOME=/mnt/MLPerf/tt_dnn-models/hf_home -e TT_MM_THROTTLE_PERF=5' || '' }}
+            ${{ matrix.test-config.model == 'stable_diffusion' && '-e TT_MM_THROTTLE_PERF=5' || '' }}
           # TT-Transformer models have a single ci-dispatch test that contains all tests.
           # Due to host OOM issues in CI vm, we currently only run llama-1B (on TT-Transformers) in the model matrix.
           run_args: |

--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -70,7 +70,7 @@ jobs:
             {"model":"yolov12x"},
             {"model":"gemma-3-4b-it"},
             {"model":"ttt-mistral-7B-v0.3"},
-            {"model":"stable_diffusion_xl_base","timeout":45}
+            {"model":"stable_diffusion_xl_base","timeout":45},
             {"model":"stable_diffusion","timeout":45}
           ]'
 


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-metal/issues/22332

### Problem description
After switching to throttle from slow_matmuls in #26052  `stable_diffusion` model looks stable in
[(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) on main branch. Unstable tag should therefore be removed

### What's changed
- removed unstable tag from stable_diffusion while keeping `TT_MM_THROTTLE_PERF=5`

### Checklist
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17727730102)