### PR TITLE
Hotfix for T3K eager tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_mesh_partition_t3000.py
@@ -244,7 +244,7 @@ def run_mesh_partition_test(
     "device_params",
     [
         {
-            "trace_region_size": 10000,
+            "trace_region_size": 18432,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
         }
     ],
@@ -300,7 +300,7 @@ def test_mesh_partition(
     "device_params",
     [
         {
-            "trace_region_size": 16384,
+            "trace_region_size": 18432,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
         }
     ],


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Seems like there was a change to slice that caused trace buffer region sizes to increase in mesh_partition.

### What's changed
Update buffer region

T3K frequent:
https://github.com/tenstorrent/tt-metal/actions/runs/16780697434
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes