### PR TITLE
Fix combined.py in face of upstream HF change

### DIFF
--- a/models/demos/qwen25_vl/tt/model.py
+++ b/models/demos/qwen25_vl/tt/model.py
@@ -198,6 +198,10 @@ class DropInVisionTransformer(torch.nn.Module):
     def dtype(self):
         return self.reference_model.dtype
 
+    @property
+    def spatial_merge_size(self):
+        return self.model_args.hf_config.vision_config.spatial_merge_size
+
     def forward(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
         """
         Forward pass mimicking the Qwen2_5_VisionTransformerPretrainedModel interface.

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -35,7 +35,7 @@ run_qwen25_vl_func() {
   # todo)) Qwen2.5-VL-7B-Instruct
 
   # simple generation-accuracy tests for qwen25_vl_3b
-  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 600 || fail=1
+  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 900 || fail=1
   echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
 
   # complete demo tests

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -114,6 +114,7 @@ run_t3000_qwen25_vl_tests() {
   qwen25_vl_72b=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2.5-VL-72B-Instruct/
 
   for qwen_dir in "$qwen25_vl_32b" "$qwen25_vl_72b"; do
+    MESH_DEVICE=T3K HF_MODEL=$qwen_dir pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 900 || fail=1
     MESH_DEVICE=T3K HF_MODEL=$qwen_dir pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
     echo "LOG_METAL: Tests for $qwen_dir on T3K completed"
   done

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -114,7 +114,6 @@ run_t3000_qwen25_vl_tests() {
   qwen25_vl_72b=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2.5-VL-72B-Instruct/
 
   for qwen_dir in "$qwen25_vl_32b" "$qwen25_vl_72b"; do
-    MESH_DEVICE=T3K HF_MODEL=$qwen_dir pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 900 || fail=1
     MESH_DEVICE=T3K HF_MODEL=$qwen_dir pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
     echo "LOG_METAL: Tests for $qwen_dir on T3K completed"
   done


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
HF Qwen2.5-VL has changes its API where `.visual` has become a read-only property.

### What's changed
Change the code to use the new API `.mode.visual` to overwrite the vision model for combined demo.

### Checklist
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes 
  - https://github.com/tenstorrent/tt-metal/actions/runs/16792726697
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes 
  - https://github.com/tenstorrent/tt-metal/actions/runs/16794254655