### PR TITLE
Only call ReadMeshDeviceProfilerResults() in MeshDevice::close() if the mesh device object is initialized

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -578,7 +578,9 @@ bool MeshDevice::close() {
     ZoneScoped;
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
-    ReadMeshDeviceProfilerResults(*this, ProfilerReadState::LAST_FD_READ);
+    if (this->is_initialized()) {
+        ReadMeshDeviceProfilerResults(*this, ProfilerReadState::LAST_FD_READ);
+    }
 
     // TODO #20966: Remove these calls
     for (auto device : view_->get_devices()) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -821,6 +821,8 @@ void ReadDeviceProfilerResults(
     ZoneScoped;
 
     if (getDeviceProfilerState()) {
+        TT_ASSERT(device->is_initialized());
+
         auto profiler_it = tt_metal_device_profiler_map.find(device->id());
         TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
         DeviceProfiler& profiler = profiler_it->second;
@@ -879,6 +881,8 @@ void ReadMeshDeviceProfilerResults(
     ZoneScoped;
 
     if (getDeviceProfilerState()) {
+        TT_ASSERT(mesh_device.is_initialized());
+
         if (useFastDispatch(&mesh_device)) {
             for (IDevice* device : mesh_device.get_devices()) {
                 auto profiler_it = detail::tt_metal_device_profiler_map.find(device->id());


### PR DESCRIPTION
#26276 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16786924734)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16782225375)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16782243761)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16782252465)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16782270281)
- [x] [T3K profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/16782290535)
- [x] [TG model perf] (https://github.com/tenstorrent/tt-metal/actions/runs/16782302822)
- [x] [Metal microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/16782323396)
- [x] New/Existing tests provide coverage for changes