### PR TITLE
#21212: Fix softmax_in_place golden func

### DIFF
--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -20,6 +20,8 @@ def find_closest_largest_divisor(num: int, start_divisor: int):
 def _golden_function(input_tensor: ttnn.Tensor, dim: Optional[int] = None, **_):
     import torch
 
+    dim = dim or -1
+
     return torch.nn.Softmax(dim)(input_tensor)
 
 


### PR DESCRIPTION
### Ticket
#21212

### Problem description
The `ttnn.softmax_in_place` function from SD 1.4 has PCC issues when comparison mode is enabled.

### What's changed
In softmax calls, dim defaults to -1 if not specified. Do the same for the golden implementation. Add a test that references this golden implementation too.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16799059623) tt-train tests are failing on the main, unrelated issue