### PR TITLE
Update compute core grid for row dispatch Galaxy config

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
             model-type: "CNN",
             arch: wormhole_b0,
             save-perf-data: false,
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
+            cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="7,7" ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },  # Pavle Josipovic
           {
             name: "Galaxy Llama 70B model perf tests", #see GH issue #26295

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -10,7 +10,7 @@ galaxy:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 7]
+        end: [7, 8]
 
       storage_cores:
         []
@@ -24,7 +24,7 @@ galaxy:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 7]
+        end: [7, 8]
 
       storage_cores:
         []

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
@@ -10,7 +10,7 @@ galaxy:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 7]
+        end: [7, 9]
 
       storage_cores:
         []
@@ -24,7 +24,7 @@ galaxy:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 7]
+        end: [7, 9]
 
       storage_cores:
         []

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -38,6 +38,10 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_70(uint32_t n) {
     return (((uint64_t)n * 0xEA0EA0EB) >> 32) >> 6;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_72(uint32_t n) {
+    return (((uint64_t)n * 0x38E38E39) >> 32) >> 4;
+}
+
 inline __attribute__((always_inline)) uint32_t fast_udiv_80(uint32_t n) {
     return (((uint64_t)n * 0xCCCCCCCD) >> 32) >> 6;
 }
@@ -86,6 +90,8 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
         return fast_udiv_56(n);
     } else if constexpr (d == 70) {
         return fast_udiv_70(n);
+    } else if constexpr (d == 72) {
+        return fast_udiv_72(n);
     } else if constexpr (d == 80) {
         return fast_udiv_80(n);
     } else if constexpr (d == 94) {

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -34,7 +34,7 @@ void validate_num_banks(uint32_t num_banks, const BufferType& buffer_type, bool 
     // address gen For non pow2 num banks, special cases need to be added to avoid falling back to generic
     // implementation. See https://github.com/tenstorrent/tt-metal/issues/3321
     std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {
-        7, 12, 20, 48, 56, 63, 70, 80, 94, 110, 120, 124, 130, 140};
+        7, 12, 20, 48, 56, 63, 70, 72, 80, 94, 110, 120, 124, 130, 140};
     bool custom_mod_bank_id_calculation_exists = acceptable_num_non_pow2_mem_banks.count(num_banks) > 0;
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Saw that row dispatch for Galaxy was specifying the wrong compute grid size. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17223340468) CI 
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/runs/17223336535) CI 
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/17223333061)
- [ ] [Galaxy demo](https://github.com/tenstorrent/tt-metal/actions/runs/17223322621) -- failing in the same way as [main](https://github.com/tenstorrent/tt-metal/actions/runs/16791662853/job/47554586926)
- [ ] [Galaxy frequent](https://github.com/tenstorrent/tt-metal/actions/runs/17223317863) -- failing in the same way as [main](https://github.com/tenstorrent/tt-metal/actions/runs/16766858574/job/47473893423)
- [ ] [Galaxy unit](https://github.com/tenstorrent/tt-metal/actions/runs/17223313239) -- failing in the same way as [main](https://github.com/tenstorrent/tt-metal/actions/runs/16788537921)
- [ ] [Galaxy model perf](https://github.com/tenstorrent/tt-metal/actions/runs/17223272213)
