### PR TITLE
Generic Pool Output Shape Ceil Mode Adjustment

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -218,7 +218,7 @@ def run_avg_pool2d(
     if padding_is_4d:
         assert (
             not ceil_mode_out_shape_adj
-        ), "current test infrastructure does not support ceil mode output shapae adjustments with 4D padding"
+        ), "current test infrastructure does not support ceil mode output shape adjustments with 4D padding"
         torch_input_padded = torch.nn.functional.pad(
             torch_input,
             (pad_l, pad_r, pad_t, pad_b),  # torch is padding in the order (left, right, top, bottom)

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -150,6 +150,10 @@ def run_avg_pool2d(
     if ceil_mode:
         out_h = math.ceil((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
         out_w = math.ceil((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
+        if ((out_h - 1) * stride_h) >= (in_h + pad_t):
+            out_h -= 1
+        if ((out_w - 1) * stride_w) >= (in_w + pad_l):
+            out_w -= 1
     else:
         out_h = math.floor((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
         out_w = math.floor((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -147,12 +147,15 @@ def run_avg_pool2d(
     out_c = (
         max(in_c, 32) if dtype == ttnn.bfloat8_b else in_c
     )  # TTNN will pad the output channels to 32 for bfloat8_b only
+    ceil_mode_out_shape_adj = False
     if ceil_mode:
         out_h = math.ceil((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
         out_w = math.ceil((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
         if ((out_h - 1) * stride_h) >= (in_h + pad_t):
+            ceil_mode_out_shape_adj = True
             out_h -= 1
         if ((out_w - 1) * stride_w) >= (in_w + pad_l):
+            ceil_mode_out_shape_adj = True
             out_w -= 1
     else:
         out_h = math.floor((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
@@ -212,8 +215,10 @@ def run_avg_pool2d(
         )
 
     # apply padding manually to torch tensor since torch doesn't support asymmetric padding
-    # for avg pool we only do this when necessary as it will lead to an expensive correction process
     if padding_is_4d:
+        assert (
+            not ceil_mode_out_shape_adj
+        ), "current test infrastructure does not support ceil mode output shapae adjustments with 4D padding"
         torch_input_padded = torch.nn.functional.pad(
             torch_input,
             (pad_l, pad_r, pad_t, pad_b),  # torch is padding in the order (left, right, top, bottom)

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -186,7 +186,7 @@ def run_max_pool(
     if padding_is_4d:
         assert (
             not ceil_mode_out_shape_adj
-        ), "current test infrastructure does not support ceil mode output shapae adjustments with 4D padding"
+        ), "current test infrastructure does not support ceil mode output shape adjustments with 4D padding"
         torch_input_padded = torch.nn.functional.pad(
             torch_input,
             (pad_l, pad_r, pad_t, pad_b),  # torch is padding in the order (left, right, top, bottom)

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -113,6 +113,10 @@ def run_max_pool(
     if ceil_mode:
         out_h = math.ceil((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
         out_w = math.ceil((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
+        if ((out_h - 1) * stride_h) >= (in_h + pad_t):
+            out_h -= 1
+        if ((out_w - 1) * stride_w) >= (in_w + pad_l):
+            out_w -= 1
     else:
         out_h = math.floor((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
         out_w = math.floor((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -53,12 +53,14 @@ def run_max_pool(
     dilation_h, dilation_w = dilation
 
     # handle both 2D and 4D padding
+    padding_is_4d = False
     if len(padding) == 2:
         pad_h = int(padding[0] * 2)
         pad_w = int(padding[1] * 2)
         pad_t = pad_b = padding[0]
         pad_l = pad_r = padding[1]
     elif len(padding) == 4:
+        padding_is_4d = True
         pad_t, pad_b, pad_l, pad_r = padding
         pad_h = pad_t + pad_b
         pad_w = pad_l + pad_r
@@ -110,12 +112,15 @@ def run_max_pool(
     out_c = (
         max(in_c, 32) if dtype == ttnn.bfloat8_b else in_c
     )  # TTNN will pad the output channels to 32 for bfloat8_b only
+    ceil_mode_out_shape_adj = False
     if ceil_mode:
         out_h = math.ceil((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
         out_w = math.ceil((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
         if ((out_h - 1) * stride_h) >= (in_h + pad_t):
+            ceil_mode_out_shape_adj = True
             out_h -= 1
         if ((out_w - 1) * stride_w) >= (in_w + pad_l):
+            ceil_mode_out_shape_adj = True
             out_w -= 1
     else:
         out_h = math.floor((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
@@ -178,17 +183,25 @@ def run_max_pool(
     )
 
     # apply padding manually to torch tensor since torch doesn't support asymmetric padding
-    torch_input_padded = torch.nn.functional.pad(
-        torch_input,
-        (pad_l, pad_r, pad_t, pad_b),  # torch is padding in the order (left, right, top, bottom)
-        mode="constant",
-        value=-float("inf"),
-    )
+    if padding_is_4d:
+        assert (
+            not ceil_mode_out_shape_adj
+        ), "current test infrastructure does not support ceil mode output shapae adjustments with 4D padding"
+        torch_input_padded = torch.nn.functional.pad(
+            torch_input,
+            (pad_l, pad_r, pad_t, pad_b),  # torch is padding in the order (left, right, top, bottom)
+            mode="constant",
+            value=0,
+        )
+        torch_padding = [0, 0]  # use zero padding for torch avg pool since we are padding manually
+    else:
+        torch_input_padded = torch_input
+        torch_padding = padding
     # run torch maxpool2d
     torch_output = torch.nn.MaxPool2d(
         kernel_size=kernel_size,
         stride=stride,
-        padding=[0, 0],  # always use zero padding we are padding manually
+        padding=torch_padding,
         dilation=dilation,
         return_indices=False,
         ceil_mode=ceil_mode,

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -25,6 +25,7 @@ parameters = {
             [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, True],  # massive kernel, wide, ceil mode
             [1, 320, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, True],  # non-tile multiple NHW, ceil mode
             [1, 32, 6, 6, 3, 3, 1, 1, 1, 1, 1, 1, False],  # partial grid on WH to use noop cores
+            [1, 32, 13, 8, 4, 3, 6, 5, 2, 1, 1, 1, True],  # ceil mode output shape adjustment edge case
             # requires reversed local reads on some cores, and forward reads on others
             [8, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, True],
             # requires reversed local reads on some cores, and forward reads on others, large kernel

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -89,6 +89,21 @@ ttnn::Shape SlidingWindowConfig::get_output_shape() const {
     if (ceil_mode) {
         output_h = std::ceil(output_h_float) + 1;
         output_w = std::ceil(output_w_float) + 1;
+        // adjust the output shape if the last kernel position is in the padding region
+        // note there is a bug in PyTorch's adjustment for maxpool where they use
+        // > instead of >= for this condition resulting in one padding position being
+        // included in the output.  For instance, using:
+        // [n,  c, h, w, k_h, k_w, s_h, s_w, p_h, p_w, d_h, d_w, ceil_mode] =
+        // [1, 32, 7, 7,   4,   4,   3,   3,   2,   2,   1,   1,      True]
+        // torch get's an output shape of [1, 32, 4, 4] rather than the expected [1, 32, 3, 3]
+        // so they have 1 row/column of padding values in the output.  This is not an issue
+        // for average pool
+        if (((output_h - 1) * stride_hw.first) >= (input_hw.first + padding[0])) {
+            output_h--;
+        }
+        if (((output_w - 1) * stride_hw.second) >= (input_hw.second + padding[2])) {
+            output_w--;
+        }
     } else {
         output_h = std::floor(output_h_float) + 1;
         output_w = std::floor(output_w_float) + 1;
@@ -116,9 +131,13 @@ uint32_t SlidingWindowConfig::get_pad_w() const { return padding[2] + padding[3]
 uint32_t SlidingWindowConfig::get_ceil_pad_h() const {
     uint32_t ceil_padding_h = 0;
     if (ceil_mode) {
-        ttnn::Shape output_shape = get_output_shape();
-        // extra_padding=stride×(out_size−1)+kernel_size−input_size−2×padding
-        ceil_padding_h = stride_hw.first * (output_shape[1] - 1) + window_hw.first - input_hw.first - get_pad_h();
+        // Calculate the output size using the original ceil formula (before adjustment)
+        float output_h_float =
+            (float)(input_hw.first + get_pad_h() - dilation_hw.first * (window_hw.first - 1) - 1) / stride_hw.first;
+        uint32_t output_h = std::ceil(output_h_float) + 1;
+
+        // extra_padding = ceil size - non ceil size
+        ceil_padding_h = stride_hw.first * (output_h - 1) + window_hw.first - input_hw.first - get_pad_h();
     }
 
     return ceil_padding_h;
@@ -127,9 +146,13 @@ uint32_t SlidingWindowConfig::get_ceil_pad_h() const {
 uint32_t SlidingWindowConfig::get_ceil_pad_w() const {
     uint32_t ceil_padding_w = 0;
     if (ceil_mode) {
-        ttnn::Shape output_shape = get_output_shape();
-        // extra_padding=stride×(out_size−1)+kernel_size−input_size−2×padding
-        ceil_padding_w = stride_hw.second * (output_shape[2] - 1) + window_hw.second - input_hw.second - get_pad_w();
+        // Calculate the output size using the original ceil formula (before adjustment)
+        float output_w_float =
+            (float)(input_hw.second + get_pad_w() - dilation_hw.second * (window_hw.second - 1) - 1) / stride_hw.second;
+        uint32_t output_w = std::ceil(output_w_float) + 1;
+
+        // extra_padding = ceil size - non ceil size
+        ceil_padding_w = stride_hw.second * (output_w - 1) + window_hw.second - input_hw.second - get_pad_w();
     }
 
     return ceil_padding_w;

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -90,14 +90,6 @@ ttnn::Shape SlidingWindowConfig::get_output_shape() const {
         output_h = std::ceil(output_h_float) + 1;
         output_w = std::ceil(output_w_float) + 1;
         // adjust the output shape if the last kernel position is in the padding region
-        // note there is a bug in PyTorch's adjustment for maxpool where they use
-        // > instead of >= for this condition resulting in one padding position being
-        // included in the output.  For instance, using:
-        // [n,  c, h, w, k_h, k_w, s_h, s_w, p_h, p_w, d_h, d_w, ceil_mode] =
-        // [1, 32, 7, 7,   4,   4,   3,   3,   2,   2,   1,   1,      True]
-        // torch get's an output shape of [1, 32, 4, 4] rather than the expected [1, 32, 3, 3]
-        // so they have 1 row/column of padding values in the output.  This is not an issue
-        // for average pool
         if (((output_h - 1) * stride_hw.first) >= (input_hw.first + padding[0])) {
             output_h--;
         }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When ceiling mode is enabled the output shape may need to be adjusted for both max and average pool if the last kernel position would land in the padded region.

### What's changed
The output shape is now adjusted in sliding window as well as in the generic pool tests.  Also a test case has been added to ensure this edge case is not missed in the future.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788678635
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788680925
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788697682
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788694879
Failing on main, this PR hits unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788689673
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788683416
Failing on main, this PR hits unrelated error
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16788692460
- [x] New/Existing tests provide coverage for changes