### PR TITLE
#25126: [skip ci] Enable autodetect in didt test for multidevice

### DIFF
--- a/.github/workflows/didt-tests.yaml
+++ b/.github/workflows/didt-tests.yaml
@@ -53,13 +53,13 @@ jobs:
       - name: Run di/dt Tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and 1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and 1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -29,12 +29,12 @@ test_suite_bh_single_pcie_small_ml_model_tests() {
     pytest models/demos/blackhole/resnet50/tests/upstream_pipeline
 }
 
-test_suite_bh_single_pcie_didt_tests() {
+test_suite_bh_pcie_didt_tests() {
     echo "[upstream-tests] Running BH upstream didt tests"
-    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "all" --didt-workload-iterations 200 --determinism-check-interval 1
-    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 200 --determinism-check-interval 1
-    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 200 --determinism-check-interval 1
-    pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 200 --determinism-check-interval 1
+    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
 }
 
 verify_llama_dir_() {
@@ -174,25 +174,28 @@ declare -A hw_topology_test_suites
 # Store test suites as newline-separated lists
 hw_topology_test_suites["blackhole"]="test_suite_bh_single_pcie_python_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests
-test_suite_bh_single_pcie_didt_tests
+test_suite_bh_pcie_didt_tests
 test_suite_bh_single_pcie_small_ml_model_tests
 test_suite_bh_single_pcie_llama_demo_tests" # NOTE: This test MUST be last because of the requirements install currently in the llama tests
 
 hw_topology_test_suites["blackhole_no_models"]="test_suite_bh_single_pcie_python_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests
-test_suite_bh_single_pcie_didt_tests"
+test_suite_bh_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
+test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_deskbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
+test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_pcie_didt_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
+test_suite_bh_multi_pcie_llama_demo_tests
+test_suite_bh_pcie_didt_tests"
 
 
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -195,7 +195,6 @@ test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
-test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -31,10 +31,10 @@ test_suite_bh_single_pcie_small_ml_model_tests() {
 
 test_suite_bh_single_pcie_didt_tests() {
     echo "[upstream-tests] Running BH upstream didt tests"
-    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and 1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and 1chips" --didt-workload-iterations 100 --determinism-check-interval 1
-    pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "1chips" --didt-workload-iterations 100 --determinism-check-interval 1
+    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "all" --didt-workload-iterations 200 --determinism-check-interval 1
+    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 200 --determinism-check-interval 1
+    pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 200 --determinism-check-interval 1
+    pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 200 --determinism-check-interval 1
 }
 
 verify_llama_dir_() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -172,30 +172,32 @@ test_suite_wh_6u_llama_long_stress_tests() {
 declare -A hw_topology_test_suites
 
 # Store test suites as newline-separated lists
-hw_topology_test_suites["blackhole"]="test_suite_bh_single_pcie_python_unit_tests
-test_suite_bh_single_pcie_metal_unit_tests
+hw_topology_test_suites["blackhole"]="
 test_suite_bh_pcie_didt_tests
+test_suite_bh_single_pcie_python_unit_tests
+test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_single_pcie_small_ml_model_tests
 test_suite_bh_single_pcie_llama_demo_tests" # NOTE: This test MUST be last because of the requirements install currently in the llama tests
 
-hw_topology_test_suites["blackhole_no_models"]="test_suite_bh_single_pcie_python_unit_tests
-test_suite_bh_single_pcie_metal_unit_tests
-test_suite_bh_pcie_didt_tests"
+hw_topology_test_suites["blackhole_no_models"]="
+test_suite_bh_pcie_didt_tests
+test_suite_bh_single_pcie_python_unit_tests
+test_suite_bh_single_pcie_metal_unit_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests
-test_suite_bh_pcie_didt_tests"
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_deskbox"]="
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests
-test_suite_bh_pcie_didt_tests"
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_rackbox"]="
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_multi_pcie_llama_demo_tests
-test_suite_bh_pcie_didt_tests"
+test_suite_bh_multi_pcie_llama_demo_tests"
 
 
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests

--- a/tests/didt/README.md
+++ b/tests/didt/README.md
@@ -14,11 +14,13 @@ Resnet Convolution: `pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k 
 
 ### Supported systems
 
-We support N150, N300, T3000, 6U Galaxy systems, and single chip Blackhole. To choose the system, pass in the following parametrization ids (as shown in the example commands):
+We support N150, N300, T3000, 6U Galaxy systems, and single/multi chip Blackhole. To choose the system, pass in the following parametrization ids (as shown in the example commands):
 - 1chips
 - 2chips
 - 8chips
 - galaxy
+
+Alternatively, running with `all` will run the test on as many devices as are detected on the system.
 
 ### Targetting specific device
 

--- a/tests/didt/test_ff1_matmul.py
+++ b/tests/didt/test_ff1_matmul.py
@@ -10,6 +10,10 @@ from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole, skip_for_wormhole_b0
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 class FF1Test(OpTestBase):
     def __init__(
@@ -67,6 +71,7 @@ GELU_FIDELITY_PARAMETRIZATION_IDS = ["without_gelu", "with_gelu"]
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
@@ -78,9 +83,6 @@ def test_ff1_matmul(
     determinism_check_interval,
     grid_size=(8, 8),
 ):
-    if is_blackhole() and mesh_device.get_num_devices() > 1:
-        pytest.skip("Multi-chip Blackhole has not been tested")
-
     per_core_M = 4
     per_core_N = 72
 
@@ -160,7 +162,6 @@ def test_ff1_matmul(
     ff1_test.run_op_test()
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize(
     "gelu, math_fidelity",
     GELU_FIDELITY_PARAMETRIZATION,

--- a/tests/didt/test_lm_head_matmul.py
+++ b/tests/didt/test_lm_head_matmul.py
@@ -10,6 +10,10 @@ from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole, skip_for_wormhole_b0
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 class LMHeadTest(OpTestBase):
     def __init__(
@@ -61,13 +65,11 @@ class LMHeadTest(OpTestBase):
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
 def test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval, grid_size=(8, 8)):
-    if is_blackhole() and mesh_device.get_num_devices() > 1:
-        pytest.skip("Multi-chip Blackhole has not been tested")
-
     # Initialize input configurations
     in0_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
     in1_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
@@ -139,7 +141,6 @@ def test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check
     lm_head_test.run_op_test()
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize("logical_chip_id", range(32), ids=[f"logical_chip_{i}_" for i in range(32)])
 @pytest.mark.parametrize(
     "mesh_device",

--- a/tests/didt/test_mm_after_non_mm.py
+++ b/tests/didt/test_mm_after_non_mm.py
@@ -10,6 +10,10 @@ from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole, skip_for_wormhole_b0
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 # This test was created to perform temperature readings on BH chip
 # The workload starts with loops of a non-matmul OP to bring the chip to
@@ -109,6 +113,7 @@ GELU_FIDELITY_PARAMETRIZATION_IDS = ["without_gelu", "with_gelu"]
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
@@ -126,9 +131,6 @@ def test_ff1_matmul(
     loop_counts,
     grid_size=(8, 8),
 ):
-    if is_blackhole() and mesh_device.get_num_devices() > 1:
-        pytest.skip("Multi-chip Blackhole has not been tested")
-
     per_core_M = 4
     per_core_N = 72
 

--- a/tests/didt/test_resnet_conv.py
+++ b/tests/didt/test_resnet_conv.py
@@ -11,6 +11,10 @@ from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 class ResnetConvTest(OpTestBase):
     def __init__(
@@ -153,6 +157,7 @@ class ResnetConvTest(OpTestBase):
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
@@ -253,7 +258,6 @@ def test_resnet_conv(mesh_device, didt_workload_iterations, determinism_check_in
     resnetConvTest.run_op_test()
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize("logical_chip_id", range(32), ids=[f"logical_chip_{i}_" for i in range(32)])
 @pytest.mark.parametrize(
     "mesh_device",

--- a/tests/didt/test_sdxl_conv.py
+++ b/tests/didt/test_sdxl_conv.py
@@ -12,6 +12,10 @@ import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 class SdxlConvTest(OpTestBase):
     def __init__(
@@ -311,6 +315,7 @@ conv_test_cases = [
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
@@ -424,7 +429,6 @@ def test_sdxl_conv(mesh_device, didt_workload_iterations, determinism_check_inte
     sdxlConvTest.run_op_test()
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize("test_config", conv_test_cases, ids=[c["id"] for c in conv_test_cases])
 @pytest.mark.parametrize("logical_chip_id", range(32), ids=[f"logical_chip_{i}_" for i in range(32)])
 @pytest.mark.parametrize(

--- a/tests/didt/test_sdxl_conv_1280x1280_upsample.py
+++ b/tests/didt/test_sdxl_conv_1280x1280_upsample.py
@@ -12,6 +12,10 @@ import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 class SdxlConvTest(OpTestBase):
     def __init__(
@@ -169,6 +173,7 @@ class SdxlConvTest(OpTestBase):
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
@@ -274,7 +279,6 @@ def test_sdxl_conv(mesh_device, didt_workload_iterations, determinism_check_inte
     sdxlConvTest.run_op_test()
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize("logical_chip_id", range(32), ids=[f"logical_chip_{i}_" for i in range(32)])
 @pytest.mark.parametrize(
     "mesh_device",

--- a/tests/didt/test_sdxl_matmul.py
+++ b/tests/didt/test_sdxl_matmul.py
@@ -10,6 +10,10 @@ from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
 from models.utility_functions import skip_for_blackhole, is_blackhole, skip_for_wormhole_b0
 
+NUM_DEVICES = ttnn.distributed.get_num_devices()
+MESH_X = NUM_DEVICES if NUM_DEVICES <= 8 else 8
+MESH_Y = 1 if NUM_DEVICES <= 8 else NUM_DEVICES / MESH_X
+
 
 class SdxlMmTest(OpTestBase):
     def __init__(
@@ -160,6 +164,7 @@ mm_test_cases = [
         pytest.param(2, id="2chips"),
         pytest.param(8, id="8chips"),
         pytest.param((8, 4), id="galaxy"),
+        pytest.param((MESH_X, MESH_Y), id="all"),  # run on all available devices
     ],
     indirect=["mesh_device"],
 )
@@ -170,9 +175,6 @@ def test_sdxl_matmul(
     test_config,
     grid_size=(8, 8),
 ):
-    if is_blackhole() and mesh_device.get_num_devices() > 1:
-        pytest.skip("Multi-chip Blackhole has not been tested")
-
     # Initialize input configurations
     if is_blackhole():
         compute_grid = get_blackhole_grid_size(mesh_device)
@@ -246,7 +248,6 @@ def test_sdxl_matmul(
     sdxl_matmul_test.run_op_test()
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize("test_config", mm_test_cases, ids=[c["id"] for c in mm_test_cases])
 @pytest.mark.parametrize("logical_chip_id", range(32), ids=[f"logical_chip_{i}_" for i in range(32)])
 @pytest.mark.parametrize(

--- a/tests/didt/test_sharded_ff1.py
+++ b/tests/didt/test_sharded_ff1.py
@@ -30,12 +30,9 @@ GELU = True
     indirect=["mesh_device"],
 )
 def test_reproduce_matmul_2d_hang(mesh_device, ff1_hang_dummy_param, didt_workload_iterations):
-    if is_blackhole() and mesh_device.get_num_devices() > 1:
-        pytest.skip("Multi-chip Blackhole has not been tested")
     test_ff1_matmul(mesh_device, GELU, MATH_FIDELITY, didt_workload_iterations, -1)
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize(
     "logical_chip_index",
     [0, 1, 2, 3, 4, 5, 6, 7],
@@ -66,16 +63,12 @@ def test_specific_chip_reproduce_matmul_2d_hang(mesh_device, logical_chip_index,
     indirect=["mesh_device"],
 )
 def test_determinism(mesh_device, didt_workload_iterations, determinism_check_interval):
-    if is_blackhole() and mesh_device.get_num_devices() > 1:
-        pytest.skip("Multi-chip Blackhole has not been tested")
-
     if determinism_check_interval == -1:
         determinism_check_interval = 1
 
     test_ff1_matmul(mesh_device, GELU, MATH_FIDELITY, didt_workload_iterations, determinism_check_interval, False)
 
 
-@skip_for_blackhole("Multi-chip Blackhole has not been tested")
 @pytest.mark.parametrize(
     "logical_chip_index",
     [0, 1, 2, 3, 4, 5, 6, 7],


### PR DESCRIPTION
### Ticket
Need to enable didt testing on BH QB upstreaming tests

### Problem description
Didt tests can be run on variable number of devices, but setting this requires a different command for each device.

### What's changed
Autodetect the number of devices that are available and run the didt test on all of them if using the "all" flag. Still maintains all of the old options (1chip, 2chip, galaxy, etc.) but adds this feature which works on all configs (except for rackbox for now but this will be revisited shortly)

### Checklist
- [x] upstreaming tests pass : https://github.com/tenstorrent/tt-metal/actions/runs/16780799039/job/47521591812 (same failure as on main, didt tests pass)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16787253183) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16787256679) CI with demo tests passes (if applicable)
- [x] l2 nightly didt tests : https://github.com/tenstorrent/tt-metal/actions/runs/16787266257
- [x] New/Existing tests provide coverage for changes