### PR TITLE
Throw an exception when using the wrong CreateDevice / CloseDevice API

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -148,9 +148,7 @@ int main(int argc, char** argv) {
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::DevicePool::initialize(
-            ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, tt_metal::DispatchCoreConfig{});
-        auto devices = tt::DevicePool::instance().get_all_active_devices();
+        auto devices = tt::tt_metal::detail::CreateDevices(ids);
         std::vector<tt_metal::Program> programs;
         // kernel->binaries() returns 32B aligned binaries
         std::map<uint32_t, std::vector<ll_api::memory const*>> compute_binaries;
@@ -312,10 +310,7 @@ int main(int argc, char** argv) {
                 th.join();
             }
         }
-        for (auto dev : devices) {
-            pass &= tt_metal::CloseDevice(dev);
-        }
-
+        tt::tt_metal::detail::CloseDevices(devices);
     } catch (const std::exception& e) {
         pass = false;
         // Capture the exception error message


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26128

### Problem description
- CloseDevice / CreateDevice should only be used for MMIO capable devices
- Trying to use these APIs for remote devices will lead to a hang
  - for example on N300: CloseDevice(0) but device 1 is still active will lead to a hang. This is "expected" because device 0 is needed to access device 1

### What's changed
- Throw an exception to tell users to use CloseDevices / CreateDevices APIs instead which are intended to be used with multi chip devices.
- Only found 1 test case that was using this API improperly and updated it to use the correct API

### Checklist
Blackhole
https://github.com/tenstorrent/tt-metal/actions/runs/16796904853
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16796903086