### PR TITLE
Update Docs for Reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -39,8 +39,8 @@ void bind_reduction_cumprod_operation(py::module& module) {
             ttnn.Tensor: the output tensor.
 
         Example:
-            >>> input_tensor = ttnn.rand((N, N), device=device)
-            >>> output_tensor = ttnn.cumprod(input_tensor, dim=0)
+            input_tensor = ttnn.rand((N, N), device=device)
+            output_tensor = ttnn.cumprod(input_tensor, dim=0)
 
         Note:
             If both `dtype` and `output` are specified then `output.dtype` must match `dtype`.

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -21,7 +21,10 @@ void bind_reduction_cumprod_operation(py::module& module) {
         R"doc(
         Returns cumulative product of `input` along dimension `dim`
         For a given `input` of size N, the `output` will also contain N elements and be such that:
-        This function is fundamentally identical to `torch.cumprod()`
+
+        .. math::
+            \mathrm{{output}}_i = \mathrm{{input}}_1 \times \mathrm{{input}}_2 \times \cdots \times \mathrm{{input}}_i
+
 
         Args:
             input (ttnn.Tensor): input tensor
@@ -35,8 +38,12 @@ void bind_reduction_cumprod_operation(py::module& module) {
         Returns:
             ttnn.Tensor: the output tensor.
 
+        Example:
+            >>> input_tensor = ttnn.rand((N, N), device=device)
+            >>> output_tensor = ttnn.cumprod(input_tensor, dim=0)
+
         Note:
-            If both `dtype` and `output` are specified then `output.dtype` must be `dtype`)
+            If both `dtype` and `output` are specified then `output.dtype` must match `dtype`.
 
             Supported dtypes, layout, ranks and `dim` values:
 
@@ -60,12 +67,10 @@ void bind_reduction_cumprod_operation(py::module& module) {
 
         .. code-block:: python
 
-            import torch
             import ttnn
 
             # Create tensor
-            torch_input = torch.rand([2, 3, 4])
-            tensor_input = ttnn.from_torch(torch_input, device=device)
+            tensor_input = ttnn.rand((2,3,4), device=device)
 
             # Apply ttnn.cumprod() on dim=0
             tensor_output = ttnn.cumprod(tensor_input, dim=0)

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -27,7 +27,6 @@ void bind_reduction_cumsum_operation(py::module& module) {
         .. math::
             \mathrm{{output}}_i = \mathrm{{input}}_1 + \mathrm{{input}}_2 + \cdots + \mathrm{{input}}_i
 
-
         Args:
             input (ttnn.Tensor): input tensor
             dim (int): dimension along which to compute cumulative sum
@@ -39,7 +38,6 @@ void bind_reduction_cumsum_operation(py::module& module) {
 
         Returns:
             ttnn.Tensor: the output tensor.
-
 
 
         Note:

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -21,8 +21,8 @@ namespace py = pybind11;
 void bind_reduction_cumsum_operation(py::module& module) {
     auto docstring =
         R"doc(
-        Returns cumulative sum of `input` along dimension `dim`
-        For a given `input` of size N, the `output` will also contain N elements and be such that:
+        Returns cumulative sum of :attr:`input` along dimension :attr:`dim`
+        For a given :attr:`input` of size N, the :attr:`output` will also contain N elements and be such that:
 
         .. math::
             \mathrm{{output}}_i = \mathrm{{input}}_1 + \mathrm{{input}}_2 + \cdots + \mathrm{{input}}_i
@@ -43,7 +43,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
 
 
         Note:
-            If both `dtype` and `output` are specified then `output.dtype` must match `dtype`.
+            If both :attr:`dtype` and :attr:`output` are specified then :attr:`output.dtype` must match :attr:`dtype`.
 
             Supported dtypes, layout, ranks and `dim` values:
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -23,14 +23,17 @@ void bind_reduction_cumsum_operation(py::module& module) {
         R"doc(
         Returns cumulative sum of `input` along dimension `dim`
         For a given `input` of size N, the `output` will also contain N elements and be such that:
-        This function is fundamentally identical to `torch.cumsum()`
+
+        .. math::
+            \mathrm{{output}}_i = \mathrm{{input}}_1 + \mathrm{{input}}_2 + \cdots + \mathrm{{input}}_i
+
 
         Args:
             input (ttnn.Tensor): input tensor
             dim (int): dimension along which to compute cumulative sum
 
         Keyword Args:
-            dtype (ttnn.DataType, optional): desired output type. If specified then input tensor will be casted to `dtype` before processing.
+            dtype (ttnn.DataType, optional): desired output type. If specified then input tensor will be cast to `dtype` before processing.
             reverse_order (bool, optional, default False): whether to perform accumulation from the end to the beginning of accumulation axis.
             out (ttnn.Tensor, optional): preallocated output. If specified, `out` must have same shape as `input`, and must be on the same device.
 
@@ -40,7 +43,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
 
 
         Note:
-            If both `dtype` and `output` are specified then `output.dtype` must be `dtype`)
+            If both `dtype` and `output` are specified then `output.dtype` must match `dtype`.
 
             Supported dtypes, layout, ranks and `dim` values:
 
@@ -64,12 +67,10 @@ void bind_reduction_cumsum_operation(py::module& module) {
 
         .. code-block:: python
 
-            import torch
             import ttnn
 
             # Create tensor
-            torch_input = torch.rand([2, 3, 4])
-            tensor_input = ttnn.from_torch(torch_input, device=device)
+            tensor_input = ttnn.rand((2, 3, 4), device=device)
 
             # Apply ttnn.cumsum() on dim=0
             tensor_output = ttnn.cumsum(tensor_input, dim=0)

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -40,8 +40,8 @@ void bind_reduction_argmax_operation(py::module& module) {
                 List of ttnn.Tensor: the output tensor.
 
             Example:
-                >>> input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
-                >>> output = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
+                input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+                output = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
         )doc";
 
     using OperationType = decltype(ttnn::argmax);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -16,13 +16,13 @@ void bind_reduction_argmax_operation(py::module& module) {
     auto doc =
         R"doc(
 
-            Returns the indices of the maximum value of elements in the ``input`` tensor
-            If no ``dim`` is provided, it will return the indices of maximum value of all elements in given ``input``
+            Returns the indices of the maximum value of elements in the :attr:`input_tensor`.
+            If no :attr:`dim` is provided, it will return the indices of maximum value of all elements in given :attr:`input_tensor`.
 
             The input tensor must be in ROW_MAJOR layout.
             Currently this op only supports dimension-specific reduction on the last dimension.
 
-            Input tensor support bfloat16, float32, uint32, int32, uint16 data types and ROW_MAJOR layout.
+            Input tensor supports bfloat16, float32, uint32, int32, uint16 data types, and ROW_MAJOR layout.
 
             Output tensor will have UINT32 data type.
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -19,13 +19,6 @@ void bind_reduction_argmax_operation(py::module& module) {
             Returns the indices of the maximum value of elements in the :attr:`input_tensor`.
             If no :attr:`dim` is provided, it will return the indices of maximum value of all elements in given :attr:`input_tensor`.
 
-            The input tensor must be in ROW_MAJOR layout.
-            Currently this op only supports dimension-specific reduction on the last dimension.
-
-            Input tensor supports bfloat16, float32, uint32, int32, uint16 data types, and ROW_MAJOR layout.
-
-            Output tensor will have UINT32 data type.
-
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
 
@@ -37,11 +30,49 @@ void bind_reduction_argmax_operation(py::module& module) {
                 queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
-                List of ttnn.Tensor: the output tensor.
+                ttnn.Tensor: Output tensor containing the indices of the maximum value.
+
+            Note:
+                The input tensor supports the following data types and layouts:
+
+                .. list-table:: Input Tensor
+                    :header-rows: 1
+
+                    * - dtype
+                        - layout
+                    * - FLOAT32
+                        - ROW_MAJOR
+                    * - BFLOAT16
+                        - ROW_MAJOR
+                    * - UINT32
+                        - ROW_MAJOR
+                    * - INT32
+                        - ROW_MAJOR
+                    * - UINT16
+                        - ROW_MAJOR
+
+                The output tensor will be of the following data type and layout:
+
+                .. list-table:: Output Tensor
+                    :header-rows: 1
+
+                    * - dtype
+                        - layout
+                    * - UINT32
+                        - ROW_MAJOR
+
+            Limitations:
+                Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
 
             Example:
                 input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
-                output = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
+
+                # Last dim reduction yields shape of [1, 1, 32, 1]
+                output_onedim = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
+
+                # All dim reduction yields shape of []
+                output_alldim = ttnn.argmax(input_tensor)
+
         )doc";
 
     using OperationType = decltype(ttnn::argmax);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -18,19 +18,13 @@ void bind_reduction_argmax_operation(py::module& module) {
 
             Returns the indices of the maximum value of elements in the ``input`` tensor
             If no ``dim`` is provided, it will return the indices of maximum value of all elements in given ``input``
-            If no ``keepdim`` is provided, it will default to `False`.
 
-            Currently this op only support dimension-specific reduction on last dimension.
+            The input tensor must be in ROW_MAJOR layout.
+            Currently this op only supports dimension-specific reduction on the last dimension.
 
             Input tensor support bfloat16, float32, uint32, int32, uint16 data types and ROW_MAJOR layout.
 
             Output tensor will have UINT32 data type.
-
-            Equivalent pytorch code:
-
-            .. code-block:: python
-
-                return torch.argmax(input_tensor, dim=dim, keepdim=keepdim)
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
@@ -45,6 +39,9 @@ void bind_reduction_argmax_operation(py::module& module) {
             Returns:
                 List of ttnn.Tensor: the output tensor.
 
+            Example:
+                >>> input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+                >>> output = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
         )doc";
 
     using OperationType = decltype(ttnn::argmax);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -18,7 +18,7 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
         R"doc(
         {0}
 
-        Computes the {0} of the input tensor along the specified dimension.
+        Computes the {0} of the input tensor :attr:`input_a` along the specified dimension :attr:`dim`.
         If no dimension is provided, {0} is computed over all dimensions yielding a single value.
 
             Args:

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -35,6 +35,27 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
             Returns:
                 ttnn.Tensor: the output tensor.
 
+            Note:
+                The input tensor supports the following data types and layouts:
+
+                .. list-table:: Input Tensor
+                    :header-rows: 1
+
+                    * - dtype
+                        - layout
+                    * - FLOAT32
+                        - ROW_MAJOR, TILE
+                    * - BFLOAT16
+                        - ROW_MAJOR, TILE
+                    * - BFLOAT8_B
+                        - ROW_MAJOR, TILE
+                    * - INT32
+                        - ROW_MAJOR, TILE
+                    * - UINT32
+                        - ROW_MAJOR, TILE
+
+                The output tensor will match the data type and layout of the input tensor.
+
             Example:
 
                 input_a = ttnn.rand(1, 2), dtype=torch.bfloat16, device=device)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -37,8 +37,8 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
 
             Example:
 
-                >>> input_a = ttnn.rand(1, 2), dtype=torch.bfloat16, device=device)
-                >>> output = {1}(input_a, dim, memory_config)
+                input_a = ttnn.rand(1, 2), dtype=torch.bfloat16, device=device)
+                output = {1}(input_a, dim, memory_config)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -16,23 +16,32 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
     namespace py = pybind11;
     auto doc = fmt::format(
         R"doc(
+        {0}
+
+        Computes the {0} of the input tensor along the specified dimension.
+        If no dimension is provided, {0} is computed over all dimensions yielding a single value.
 
             Args:
                 input_a (ttnn.Tensor): the input tensor.
-                dim (number): dimension value .
+                dim (number): dimension value to reduce over.
+                keepdim (bool, optional): keep original dimension size. Defaults to `False`.
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+                compute_kernel_config (ttnn.ComputeKernelConfig, optional): Compute kernel configuration for the operation. Defaults to `None`.
+                scalar (float, optional): A scaling factor to be applied to the input tensor. Defaults to `1.0`.
+                correction (bool, optional): Applies only to std - whether to apply Bessel's correction (i.e. N-1). Defaults to `True`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
 
             Example:
 
-                >>> input_a = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-                >>> output = ttnn.{0}(input_a, dim, memory_config)
+                >>> input_a = ttnn.rand(1, 2), dtype=torch.bfloat16, device=device)
+                >>> output = {1}(input_a, dim, memory_config)
         )doc",
-        operation.base_name());
+        operation.base_name(),
+        operation.python_fully_qualified_name());
 
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -21,10 +21,6 @@ void bind_reduction_moe_operation(py::module& module) {
         R"doc(moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> ttnn.Tensor
 
             Returns the weight of the zero-th MoE expert.
-            :attr:`input_tensor` must have BFLOAT16 data type and TILE_LAYOUT layout.
-            :attr:`expert_mask_tensor` and :attr:`topk_mask_tensor` must have BFLOAT16 data type and TILE_LAYOUT layout.
-
-            Output value tensor will have the same data type as :attr:`input_tensor` and :attr:`output_tensor`.
 
             Equivalent PyTorch code:
 
@@ -43,15 +39,40 @@ void bind_reduction_moe_operation(py::module& module) {
                 * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensors
                 * :attr:`queue_id` (Optional[uint8]): command queue id
 
+            Returns:
+                ttnn.Tensor: the output tensor.
+
+            Note:
+                The :attr:`input_tensor`, :attr:`expert_mask_tensor`, and :attr:`topk_mask_tensor` must match the following data type and layout:
+
+                    .. list-table::
+                        :header-rows: 1
+
+                        * - dtype
+                            - layout
+                        * - BFLOAT16
+                            - TILE
+
+                The output tensor will match the data type and layout of the input tensor.
+
+            Limitations:
+                - Tensors must be 4D.
+                - For the :attr:`input_tensor`, N*C*H must be a multiple of 32. The last dimension must be a power of two and ≥64.
+                - :attr:`k` must be exactly 32.
+                - For the :attr:`topk_mask_tensor`, H must be 32 and W must match :attr:`k` (i.e. 32).
+                - For the :attr:`expert_mask_tensor`, H must be 32 and W must match W of the :attr:`input_tensor`.
+                - All of the shape validations are performed on padded shapes.
+
             Example:
                 N, C, H, W = 1, 1, 32, 64
                 k = 32
 
-                input_tensor = ttnn.rand([N, C, H, W], device=device)
-                expert_mask = ttnn.zeros([N, C, 1, W], device=device)
-                topE_mask = ttnn.zeros([N, C, 1, k],  device=device)
+                input_tensor = ttnn.rand([N, C, H, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+                expert_mask = ttnn.zeros([N, C, 1, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+                topE_mask = ttnn.zeros([N, C, 1, k], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
-                ttnn.moe(input_tensor, expert_mask, topE_mask, k)
+                ttnn_output = ttnn.moe(input_tensor, expert_mask, topE_mask, k)
+
         )doc";
 
     using OperationType = decltype(ttnn::moe);

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -21,12 +21,12 @@ void bind_reduction_moe_operation(py::module& module) {
         R"doc(moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> ttnn.Tensor
 
             Returns the weight of the zero-th MoE expert.
-            Input tensor must have BFLOAT16 data type and TILE_LAYOUT layout.
-            expert_mask_tensor and topk_mask_tensor must have BFLOAT16 data type and TILE_LAYOUT layout.
+            :attr:`input_tensor` must have BFLOAT16 data type and TILE_LAYOUT layout.
+            :attr:`expert_mask_tensor` and :attr:`topk_mask_tensor` must have BFLOAT16 data type and TILE_LAYOUT layout.
 
-            Output value tensor will have the same data type as input tensor and output.
+            Output value tensor will have the same data type as :attr:`input_tensor` and :attr:`output_tensor`.
 
-            Equivalent pytorch code:
+            Equivalent PyTorch code:
 
             .. code-block:: python
                 val, ind = torch.topk(input_tensor + expert_mask_tensor, k)

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -44,14 +44,14 @@ void bind_reduction_moe_operation(py::module& module) {
                 * :attr:`queue_id` (Optional[uint8]): command queue id
 
             Example:
-                >>> N, C, H, W = 1, 1, 32, 64
-                >>> k = 32
+                N, C, H, W = 1, 1, 32, 64
+                k = 32
 
-                >>> input_tensor = ttnn.rand([N, C, H, W], device=device)
-                >>> expert_mask = ttnn.zeros([N, C, 1, W], device=device)
-                >>> topE_mask = ttnn.zeros([N, C, 1, k],  device=device)
+                input_tensor = ttnn.rand([N, C, H, W], device=device)
+                expert_mask = ttnn.zeros([N, C, 1, W], device=device)
+                topE_mask = ttnn.zeros([N, C, 1, k],  device=device)
 
-                >>> ttnn.moe(input_tensor, expert_mask, topE_mask, k)
+                ttnn.moe(input_tensor, expert_mask, topE_mask, k)
         )doc";
 
     using OperationType = decltype(ttnn::moe);

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -21,7 +21,7 @@ void bind_reduction_moe_operation(py::module& module) {
         R"doc(moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> ttnn.Tensor
 
             Returns the weight of the zero-th MoE expert.
-            Input tensor must have BBFLOAT16 data type and TILE_LAYOUT layout.
+            Input tensor must have BFLOAT16 data type and TILE_LAYOUT layout.
             expert_mask_tensor and topk_mask_tensor must have BFLOAT16 data type and TILE_LAYOUT layout.
 
             Output value tensor will have the same data type as input tensor and output.
@@ -42,6 +42,16 @@ void bind_reduction_moe_operation(py::module& module) {
                 * :attr:`memory_config`: Memory Config of the output tensors
                 * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensors
                 * :attr:`queue_id` (Optional[uint8]): command queue id
+
+            Example:
+                >>> N, C, H, W = 1, 1, 32, 64
+                >>> k = 32
+
+                >>> input_tensor = ttnn.rand([N, C, H, W], device=device)
+                >>> expert_mask = ttnn.zeros([N, C, 1, W], device=device)
+                >>> topE_mask = ttnn.zeros([N, C, 1, k],  device=device)
+
+                >>> ttnn.moe(input_tensor, expert_mask, topE_mask, k)
         )doc";
 
     using OperationType = decltype(ttnn::moe);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -40,9 +40,9 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                 List of ttnn.Tensor: the output tensor.
 
             Example::
-                >>> tensor = ttnn.rand((1,2), device=device)
-                >>> output = {1}(tensor, dim=0)
-                >>> output_all_dims = {1}(tensor)
+                tensor = ttnn.rand((1,2), device=device)
+                output = {1}(tensor, dim=0)
+                output_all_dims = {1}(tensor)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -22,11 +22,9 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
             Computes the product of all elements on specified :attr:`dim` of the :attr:`input_tensor` tensor.
 
             If no :attr:`dim` is provided (or :attr:`dim` is set to `None`), it will compute the full product of every element in the :attr:`input_tensor` tensor.
-            When using this full-product mode, the input tensor must be bfloat16.
 
             If :attr:`keepdim` is `True`, the resulting tensor will have the same rank as the :attr:`input_tensor` tensor, but with the specified :attr:`dim` reduced to 1.
             Otherwise, the target :attr:`dim` will be squeezed, resulting in an output tensor with one less dimension than the :attr:`input_tensor` tensor.
-            Setting :attr:`keepdim` to `True` is not supported when computing the full product, as this operation results in a scalar.
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
@@ -38,6 +36,30 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
 
             Returns:
                 List of ttnn.Tensor: the output tensor.
+
+            Note:
+                The :attr:`input_tensor` supports the following data type and layout:
+
+                .. list-table:: input_tensor
+                    :header-rows: 1
+
+                    * - dtype
+                        - layout
+                    * - BFLOAT16
+                        - TILE, ROW_MAJOR
+
+                The :attr:`output_tensor` will be in the following data type and layout:
+
+                .. list-table:: output_tensor
+                    :header-rows: 1
+
+                    * - dtype
+                        - layout
+                    * - BFLOAT16
+                        - TILE
+
+            Limitations:
+                - When :attr:`dim` is not specified (i.e. full product), the :attr:`input_tensor` must be bfloat16, and keepdim=True is not supported  (as this operation results in a scalar).
 
             Example::
                 tensor = ttnn.rand((1,2), device=device)

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -19,14 +19,14 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
     auto doc = fmt::format(
         R"doc(
 
-            Computes the product of all elements on specified ``dim`` of the ``input`` tensor.
+            Computes the product of all elements on specified :attr:`dim` of the :attr:`input_tensor` tensor.
 
-            If no ``dim`` is provided (or ``dim`` is set to `None`), it will compute the full product of every element in the ``input`` tensor.
+            If no :attr:`dim` is provided (or :attr:`dim` is set to `None`), it will compute the full product of every element in the :attr:`input_tensor` tensor.
             When using this full-product mode, the input tensor must be bfloat16.
 
-            If ``keepdim`` is `True`, the resulting tensor will have a similar shape as the ``input`` tensor, but with the specified ``dim`` reduced to 1.
-            Otherwise, the target ``dim`` will be squeezed, resulting in an output tensor with one less dimension than the ``input`` tensor.
-            Setting ``keepdim`` to `True` is not supported when computing the full product, as this operation results in a scalar.
+            If :attr:`keepdim` is `True`, the resulting tensor will have the same rank as the :attr:`input_tensor` tensor, but with the specified :attr:`dim` reduced to 1.
+            Otherwise, the target :attr:`dim` will be squeezed, resulting in an output tensor with one less dimension than the :attr:`input_tensor` tensor.
+            Setting :attr:`keepdim` to `True` is not supported when computing the full product, as this operation results in a scalar.
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -21,9 +21,12 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
 
             Computes the product of all elements on specified ``dim`` of the ``input`` tensor.
 
-            If no ``dim`` is provided (or ``dim`` is set to `None`), it will compute the product of all elements in the ``input`` tensor.
-            If ``keepdim`` is `True`, the resulting tensor will have a similar shape as the ``input`` tensor, but with the specified ``dim`` reduced to 1. This is not supported when taking the product across all dimensions.
+            If no ``dim`` is provided (or ``dim`` is set to `None`), it will compute the full product of every element in the ``input`` tensor.
+            When using this full-product mode, the input tensor must be bfloat16.
+
+            If ``keepdim`` is `True`, the resulting tensor will have a similar shape as the ``input`` tensor, but with the specified ``dim`` reduced to 1.
             Otherwise, the target ``dim`` will be squeezed, resulting in an output tensor with one less dimension than the ``input`` tensor.
+            Setting ``keepdim`` to `True` is not supported when computing the full product, as this operation results in a scalar.
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
@@ -37,8 +40,7 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                 List of ttnn.Tensor: the output tensor.
 
             Example::
-
-                >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+                >>> tensor = ttnn.rand((1,2), device=device)
                 >>> output = {1}(tensor, dim=0)
                 >>> output_all_dims = {1}(tensor)
         )doc",

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -15,13 +15,13 @@ namespace py = pybind11;
 void bind_reduction_sampling_operation(py::module& module) {
     auto doc =
         R"doc(
-            Samples from the input tensor based on provided top-k and top-p constraints.
+            Samples from the :attr:`input_values_tensor` based on provided top-k and top-p constraints.
 
-            This operation samples values from the  `input_values_tensor` based on the provided thresholds `k` (top-k sampling)
-            and `p` (top-p nucleus sampling). The operation uses the `input_indices_tensor` for indexing and applies sampling
+            This operation samples values from the :attr:`input_values_tensor` based on the provided thresholds :attr:`k` (top-k sampling)
+            and :attr:`p` (top-p nucleus sampling). The operation uses the :attr:`input_indices_tensor` for indexing and applies sampling
             under the given seed for reproducibility.
 
-            The op first converts the input_values_tensor into probabilities by doing a softmax.
+            The op first converts the :attr:`input_values_tensor` into probabilities by doing a softmax.
 
             In top-k sampling, the op considers only the k highest-probability values from the input distribution. The remaining values are ignored, regardless of their probabilities.
             In top-p sampling, the op selects values from the input distribution such that the cumulative probability mass is less than or equal to a threshold p.

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -44,7 +44,7 @@ void bind_reduction_sampling_operation(py::module& module) {
                     - Must have `ROW_MAJOR` layout.
                     - Must have the same shape as `input_values_tensor`.
                 - `k`:
-                    - Must have `BFLOAT16` data type.
+                    - Must have `UINT32` data type.
                     - Must have `ROW_MAJOR` layout.
                     - Must have `INTERLEAVED` memory layout.
                     - Must contain 32 elements.
@@ -92,6 +92,16 @@ void bind_reduction_sampling_operation(py::module& module) {
 
             Returns:
                 ttnn.Tensor: The output tensor containing sampled indices.
+
+            Example:
+                >>> input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
+                >>> input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                >>> k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                >>> p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                >>> temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+                >>> output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
+
         )doc";
 
     using OperationType = decltype(ttnn::sampling);

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -17,7 +17,7 @@ void bind_reduction_sampling_operation(py::module& module) {
         R"doc(
             Samples from the input tensor based on provided top-k and top-p constraints.
 
-            This operation samples values from the input tensor `input_values_tensor` based on the provided thresholds `k` (top-k sampling)
+            This operation samples values from the  `input_values_tensor` based on the provided thresholds `k` (top-k sampling)
             and `p` (top-p nucleus sampling). The operation uses the `input_indices_tensor` for indexing and applies sampling
             under the given seed for reproducibility.
 
@@ -94,13 +94,13 @@ void bind_reduction_sampling_operation(py::module& module) {
                 ttnn.Tensor: The output tensor containing sampled indices.
 
             Example:
-                >>> input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
-                >>> input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                >>> k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                >>> p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                >>> temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
+                input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-                >>> output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
+                output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -49,6 +49,10 @@ void bind_reduction_topk_operation(py::module& module) {
             Returns:
                 List of ttnn.Tensor: the output tensor.
 
+            Example:
+                >>> input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)
+                >>> topk_values, topk_indices = ttnn.topk(input_tensor, k=32, dim=-1, largest=True, sorted=True)
+
         )doc";
 
     using OperationType = decltype(ttnn::topk);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -50,8 +50,8 @@ void bind_reduction_topk_operation(py::module& module) {
                 List of ttnn.Tensor: the output tensor.
 
             Example:
-                >>> input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)
-                >>> topk_values, topk_indices = ttnn.topk(input_tensor, k=32, dim=-1, largest=True, sorted=True)
+                input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)
+                topk_values, topk_indices = ttnn.topk(input_tensor, k=32, dim=-1, largest=True, sorted=True)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -22,10 +22,6 @@ void bind_reduction_topk_operation(py::module& module) {
 
             The boolean option :attr:`sorted` if True, will make sure that the returned :attr:`k` elements are sorted.
 
-            :attr:`input_tensor` must have BFLOAT8 or BFLOAT16 data type and TILE_LAYOUT layout.
-
-            :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
-
             Equivalent PyTorch code:
 
             .. code-block:: python
@@ -48,6 +44,25 @@ void bind_reduction_topk_operation(py::module& module) {
 
             Returns:
                 List of ttnn.Tensor: the output tensor.
+
+            Note:
+                The :attr:`input_tensor` supports the following data type and layout:
+
+                .. list-table:: input_tensor
+                    :header-rows: 1
+
+                    * - dtype
+                        - layout
+                    * - BFLOAT8, BFLOAT16
+                        - TILE
+
+                The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
+
+            Limitations:
+                - :attr:`input_tensor` must be 4D
+                - For :attr:`input_tensor`, N*C*H must be a multiple of 32 and W must be ≥64.
+                - To enable multicore execution, the width of :attr:`input_tensor` along :attr:`dim` must be ≥8192 and <65536, and :attr:`k` must be ≤64.
+                - All shape validations are performed on padded shapes.
 
             Example:
                 input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -14,19 +14,19 @@ void bind_reduction_topk_operation(py::module& module) {
     auto doc =
         R"doc(topk(input_tensor: ttnn.Tensor, k: int, dim: int, largest: bool, sorted: bool, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> Tuple[ttnn.Tensor, ttnn.Tensor]
 
-            Returns the ``k`` largest or ``k`` smallest elements of the given input tensor along a given dimension.
+            Returns the :attr:`k` largest or :attr:`k` smallest elements of the :attr:`input_tensor` along a given dimension :attr:`dim`.
 
-            If ``dim`` is not provided, the last dimension of the input tensor is used.
+            If :attr:`dim` is not provided, the last dimension of the :attr:`input_tensor` is used.
 
-            If ``largest`` is True, the k largest elements are returned. Otherwise, the k smallest elements are returned.
+            If :attr:`largest` is True, the :attr:`k` largest elements are returned. Otherwise, the :attr:`k` smallest elements are returned.
 
-            The boolean option ``sorted`` if True, will make sure that the returned k elements are sorted.
+            The boolean option :attr:`sorted` if True, will make sure that the returned :attr:`k` elements are sorted.
 
-            Input tensor must have BFLOAT8 or BFLOAT16 data type and TILE_LAYOUT layout.
+            :attr:`input_tensor` must have BFLOAT8 or BFLOAT16 data type and TILE_LAYOUT layout.
 
-            Output value tensor will have the same data type as input tensor and output index tensor will have UINT16 data type.
+            :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
 
-            Equivalent pytorch code:
+            Equivalent PyTorch code:
 
             .. code-block:: python
 


### PR DESCRIPTION
### Ticket
#25635 

Updating the documentation for the Reduce ops, mostly to provide pure TTNN examples and clarify some limitations


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes