### PR TITLE
#26377: [skip ci] Add CIv2 model jobs for (Single-card) Frequent model and ttnn tests

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -153,3 +153,45 @@ jobs:
         with:
           path: generated/test_reports/
           prefix: "test_reports_"
+  nightly-wh-models-civ2:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        card: [N150, N300]
+        model: [yolov8s]
+    name: Nightly CIv2-compatible ${{ matrix.card }} ${{ matrix.model }}
+    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.card) }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: wormhole_b0
+        GTEST_OUTPUT: xml:/work/generated/test_reports/
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Run frequent reg tests scripts
+        timeout-minutes: ${{ matrix.timeout || 30 }}
+        run: |
+          pytest tests/nightly/single_card/${{ matrix.model }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"

--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -17,142 +17,142 @@ on:
         type: string
         default: "in-service"
 jobs:
-  # nightly-wh-models:
-  #   strategy:
-  #     # Do not fail-fast because we need to ensure all tests go to completion
-  #     # so we try not to get hanging machines
-  #     fail-fast: false
-  #     matrix:
-  #       card: [N150, N300]
-  #       model: [common_models, functional_unet, ttt-llama3.2-1B, qwen25_vl-3B, resnet50, whisper, openpdn_mnist, vit, sentence_bert, yolov7, swin_s, yolov6l, swin_v2, mobilenetv2, segformer, vgg_unet, yolov10x, yolov11, yolov8s, yolov8s_world, yolov8x, yolov9c, vanilla_unet, yolov5x, efficientnetb0, vovnet, ufld_v2, yolov12x, vadv2]
-  #       # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
-  #       # ttt-mistral-7B-v0.3 issue #25861: https://github.com/tenstorrent/tt-metal/issues/25861
-  #       include:
-  #         - model: stable_diffusion_xl_base
-  #           card: N150
-  #           timeout: 45
-  #         - model: stable_diffusion_xl_base
-  #           card: N300
-  #           timeout: 45
-  #   name: Nightly ${{ matrix.card }} ${{ matrix.model }}
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
-  #   steps:
-  #     - name: ⬇️ Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #     - name: ⬇️ Download Build
-  #       uses: actions/download-artifact@v4
-  #       timeout-minutes: 10
-  #       with:
-  #         name: ${{ inputs.build-artifact-name }}
-  #     - name: Extract files
-  #       run: tar -xvf ttm_any.tar
-  #     - name: ⬇️ Download Wheel
-  #       uses: actions/download-artifact@v4
-  #       timeout-minutes: 10
-  #       with:
-  #         name: ${{ inputs.wheel-artifact-name }}
-  #     - uses: ./.github/actions/ensure-active-weka-mount
-  #     - name: Run frequent reg tests scripts
-  #       timeout-minutes: ${{ matrix.timeout || 30 }}
-  #       uses: ./.github/actions/docker-run
-  #       with:
-  #         docker_image: ${{ inputs.docker-image }}
-  #         docker_password: ${{ secrets.GITHUB_TOKEN }}
-  #         install_wheel: true
-  #         docker_opts: |
-  #           -v /mnt/MLPerf:/mnt/MLPerf:ro
-  #           -e TT_METAL_HOME=${{ github.workspace }}
-  #           -e ARCH_NAME=wormhole_b0
-  #           -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-  #           -e GTEST_OUTPUT=xml:generated/test_reports/
-  #           ${{ matrix.model == 'stable_diffusion_xl_base' && '-e HF_HOME=/mnt/MLPerf/tt_dnn-models/hf_home' || '' }}
-  #         # TT-Transformer models have a single ci-dispatch test that contains all tests.
-  #         # Due to host OOM issues in CI vm, we currently only run llama-1B (on TT-Transformers) in the model matrix.
-  #         run_args: |
-  #           if [[ "${{ matrix.model }}" == *"ttt"* ]]; then
-  #             pytest tests/nightly/single_card/tt_transformers -k ${{ matrix.model }}
-  #           elif [[ "${{ matrix.model }}" == *"qwen25_vl"* ]]; then
-  #             pytest tests/nightly/single_card/qwen25_vl -k ${{ matrix.model }}
-  #           else
-  #             pytest tests/nightly/single_card/${{ matrix.model }}
-  #           fi
-  #     - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-  #       timeout-minutes: 10
-  #       if: ${{ !cancelled() }}
-  #       with:
-  #         path: generated/test_reports/
-  #         prefix: "test_reports_"
-  # nightly-wh-unstable-models:
-  #   strategy:
-  #     # Do not fail-fast because we need to ensure all tests go to completion
-  #     # so we try not to get hanging machines
-  #     fail-fast: false
-  #     matrix:
-  #       test-config:
-  #         - model: "stable_diffusion"
-  #           cmd: TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
-  #             # Skipping due to issue #15932
-  #             # - model: "mamba 1"
-  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1
-  #             # - model: "mamba 2"
-  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 2
-  #             # - model: "mamba 3"
-  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 3
-  #             # - model: "mamba 4"
-  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 4
-  #         - model: "mamba 5"
-  #           cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 5
-  #             # - model: "mamba 6"
-  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 6
-  #       card: [N150, N300]
-  #   name: "[Unstable] Nightly ${{ matrix.card }} ${{ matrix.test-config.model }}"
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
-  #   steps:
-  #     - name: ⬇️ Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #     - name: ⬇️ Download Build
-  #       uses: actions/download-artifact@v4
-  #       timeout-minutes: 10
-  #       with:
-  #         name: ${{ inputs.build-artifact-name }}
-  #     - name: Extract files
-  #       run: tar -xvf ttm_any.tar
-  #     - name: ⬇️ Download Wheel
-  #       uses: actions/download-artifact@v4
-  #       timeout-minutes: 10
-  #       with:
-  #         name: ${{ inputs.wheel-artifact-name }}
-  #     - uses: ./.github/actions/ensure-active-weka-mount
-  #     - name: Run frequent reg tests scripts
-  #       timeout-minutes: 60
-  #       uses: ./.github/actions/docker-run
-  #       with:
-  #         docker_image: ${{ inputs.docker-image }}
-  #         docker_password: ${{ secrets.GITHUB_TOKEN }}
-  #         install_wheel: true
-  #         docker_opts: |
-  #           -v /mnt/MLPerf:/mnt/MLPerf:ro
-  #           -e TT_METAL_HOME=${{ github.workspace }}
-  #           -e ARCH_NAME=wormhole_b0
-  #           -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-  #           -e GTEST_OUTPUT=xml:generated/test_reports/
-  #         run_args: ${{ matrix.test-config.cmd }}
-  #     - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-  #       timeout-minutes: 10
-  #       if: ${{ !cancelled() }}
-  #       with:
-  #         path: generated/test_reports/
-  #         prefix: "test_reports_"
+  nightly-wh-models:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        card: [N150, N300]
+        model: [common_models, functional_unet, ttt-llama3.2-1B, qwen25_vl-3B, resnet50, whisper, openpdn_mnist, vit, sentence_bert, yolov7, swin_s, yolov6l, swin_v2, mobilenetv2, segformer, vgg_unet, yolov10x, yolov11, yolov8s, yolov8s_world, yolov8x, yolov9c, vanilla_unet, yolov5x, efficientnetb0, vovnet, ufld_v2, yolov12x, vadv2]
+        # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
+        # ttt-mistral-7B-v0.3 issue #25861: https://github.com/tenstorrent/tt-metal/issues/25861
+        include:
+          - model: stable_diffusion_xl_base
+            card: N150
+            timeout: 45
+          - model: stable_diffusion_xl_base
+            card: N300
+            timeout: 45
+    name: Nightly ${{ matrix.card }} ${{ matrix.model }}
+    defaults:
+      run:
+        shell: bash
+    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.build-artifact-name }}
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
+      - uses: ./.github/actions/ensure-active-weka-mount
+      - name: Run frequent reg tests scripts
+        timeout-minutes: ${{ matrix.timeout || 30 }}
+        uses: ./.github/actions/docker-run
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          install_wheel: true
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            ${{ matrix.model == 'stable_diffusion_xl_base' && '-e HF_HOME=/mnt/MLPerf/tt_dnn-models/hf_home' || '' }}
+          # TT-Transformer models have a single ci-dispatch test that contains all tests.
+          # Due to host OOM issues in CI vm, we currently only run llama-1B (on TT-Transformers) in the model matrix.
+          run_args: |
+            if [[ "${{ matrix.model }}" == *"ttt"* ]]; then
+              pytest tests/nightly/single_card/tt_transformers -k ${{ matrix.model }}
+            elif [[ "${{ matrix.model }}" == *"qwen25_vl"* ]]; then
+              pytest tests/nightly/single_card/qwen25_vl -k ${{ matrix.model }}
+            else
+              pytest tests/nightly/single_card/${{ matrix.model }}
+            fi
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: generated/test_reports/
+          prefix: "test_reports_"
+  nightly-wh-unstable-models:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-config:
+          - model: "stable_diffusion"
+            cmd: TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
+              # Skipping due to issue #15932
+              # - model: "mamba 1"
+              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1
+              # - model: "mamba 2"
+              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 2
+              # - model: "mamba 3"
+              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 3
+              # - model: "mamba 4"
+              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 4
+          - model: "mamba 5"
+            cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 5
+              # - model: "mamba 6"
+              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 6
+        card: [N150, N300]
+    name: "[Unstable] Nightly ${{ matrix.card }} ${{ matrix.test-config.model }}"
+    defaults:
+      run:
+        shell: bash
+    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.build-artifact-name }}
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
+      - uses: ./.github/actions/ensure-active-weka-mount
+      - name: Run frequent reg tests scripts
+        timeout-minutes: 60
+        uses: ./.github/actions/docker-run
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          install_wheel: true
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+          run_args: ${{ matrix.test-config.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: generated/test_reports/
+          prefix: "test_reports_"
   nightly-wh-models-civ2:
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion

--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -17,142 +17,142 @@ on:
         type: string
         default: "in-service"
 jobs:
-  nightly-wh-models:
-    strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
-      fail-fast: false
-      matrix:
-        card: [N150, N300]
-        model: [common_models, functional_unet, ttt-llama3.2-1B, qwen25_vl-3B, resnet50, whisper, openpdn_mnist, vit, sentence_bert, yolov7, swin_s, yolov6l, swin_v2, mobilenetv2, segformer, vgg_unet, yolov10x, yolov11, yolov8s, yolov8s_world, yolov8x, yolov9c, vanilla_unet, yolov5x, efficientnetb0, vovnet, ufld_v2, yolov12x, vadv2]
-        # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
-        # ttt-mistral-7B-v0.3 issue #25861: https://github.com/tenstorrent/tt-metal/issues/25861
-        include:
-          - model: stable_diffusion_xl_base
-            card: N150
-            timeout: 45
-          - model: stable_diffusion_xl_base
-            card: N300
-            timeout: 45
-    name: Nightly ${{ matrix.card }} ${{ matrix.model }}
-    defaults:
-      run:
-        shell: bash
-    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
-    steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@v4
-        timeout-minutes: 10
-        with:
-          name: ${{ inputs.build-artifact-name }}
-      - name: Extract files
-        run: tar -xvf ttm_any.tar
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@v4
-        timeout-minutes: 10
-        with:
-          name: ${{ inputs.wheel-artifact-name }}
-      - uses: ./.github/actions/ensure-active-weka-mount
-      - name: Run frequent reg tests scripts
-        timeout-minutes: ${{ matrix.timeout || 30 }}
-        uses: ./.github/actions/docker-run
-        with:
-          docker_image: ${{ inputs.docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          install_wheel: true
-          docker_opts: |
-            -v /mnt/MLPerf:/mnt/MLPerf:ro
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/
-            ${{ matrix.model == 'stable_diffusion_xl_base' && '-e HF_HOME=/mnt/MLPerf/tt_dnn-models/hf_home' || '' }}
-          # TT-Transformer models have a single ci-dispatch test that contains all tests.
-          # Due to host OOM issues in CI vm, we currently only run llama-1B (on TT-Transformers) in the model matrix.
-          run_args: |
-            if [[ "${{ matrix.model }}" == *"ttt"* ]]; then
-              pytest tests/nightly/single_card/tt_transformers -k ${{ matrix.model }}
-            elif [[ "${{ matrix.model }}" == *"qwen25_vl"* ]]; then
-              pytest tests/nightly/single_card/qwen25_vl -k ${{ matrix.model }}
-            else
-              pytest tests/nightly/single_card/${{ matrix.model }}
-            fi
-      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
-        if: ${{ !cancelled() }}
-        with:
-          path: generated/test_reports/
-          prefix: "test_reports_"
-  nightly-wh-unstable-models:
-    strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
-      fail-fast: false
-      matrix:
-        test-config:
-          - model: "stable_diffusion"
-            cmd: TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
-              # Skipping due to issue #15932
-              # - model: "mamba 1"
-              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1
-              # - model: "mamba 2"
-              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 2
-              # - model: "mamba 3"
-              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 3
-              # - model: "mamba 4"
-              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 4
-          - model: "mamba 5"
-            cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 5
-              # - model: "mamba 6"
-              # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 6
-        card: [N150, N300]
-    name: "[Unstable] Nightly ${{ matrix.card }} ${{ matrix.test-config.model }}"
-    defaults:
-      run:
-        shell: bash
-    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
-    steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@v4
-        timeout-minutes: 10
-        with:
-          name: ${{ inputs.build-artifact-name }}
-      - name: Extract files
-        run: tar -xvf ttm_any.tar
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@v4
-        timeout-minutes: 10
-        with:
-          name: ${{ inputs.wheel-artifact-name }}
-      - uses: ./.github/actions/ensure-active-weka-mount
-      - name: Run frequent reg tests scripts
-        timeout-minutes: 60
-        uses: ./.github/actions/docker-run
-        with:
-          docker_image: ${{ inputs.docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          install_wheel: true
-          docker_opts: |
-            -v /mnt/MLPerf:/mnt/MLPerf:ro
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/
-          run_args: ${{ matrix.test-config.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
-        if: ${{ !cancelled() }}
-        with:
-          path: generated/test_reports/
-          prefix: "test_reports_"
+  # nightly-wh-models:
+  #   strategy:
+  #     # Do not fail-fast because we need to ensure all tests go to completion
+  #     # so we try not to get hanging machines
+  #     fail-fast: false
+  #     matrix:
+  #       card: [N150, N300]
+  #       model: [common_models, functional_unet, ttt-llama3.2-1B, qwen25_vl-3B, resnet50, whisper, openpdn_mnist, vit, sentence_bert, yolov7, swin_s, yolov6l, swin_v2, mobilenetv2, segformer, vgg_unet, yolov10x, yolov11, yolov8s, yolov8s_world, yolov8x, yolov9c, vanilla_unet, yolov5x, efficientnetb0, vovnet, ufld_v2, yolov12x, vadv2]
+  #       # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
+  #       # ttt-mistral-7B-v0.3 issue #25861: https://github.com/tenstorrent/tt-metal/issues/25861
+  #       include:
+  #         - model: stable_diffusion_xl_base
+  #           card: N150
+  #           timeout: 45
+  #         - model: stable_diffusion_xl_base
+  #           card: N300
+  #           timeout: 45
+  #   name: Nightly ${{ matrix.card }} ${{ matrix.model }}
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
+  #   steps:
+  #     - name: ⬇️ Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #     - name: ⬇️ Download Build
+  #       uses: actions/download-artifact@v4
+  #       timeout-minutes: 10
+  #       with:
+  #         name: ${{ inputs.build-artifact-name }}
+  #     - name: Extract files
+  #       run: tar -xvf ttm_any.tar
+  #     - name: ⬇️ Download Wheel
+  #       uses: actions/download-artifact@v4
+  #       timeout-minutes: 10
+  #       with:
+  #         name: ${{ inputs.wheel-artifact-name }}
+  #     - uses: ./.github/actions/ensure-active-weka-mount
+  #     - name: Run frequent reg tests scripts
+  #       timeout-minutes: ${{ matrix.timeout || 30 }}
+  #       uses: ./.github/actions/docker-run
+  #       with:
+  #         docker_image: ${{ inputs.docker-image }}
+  #         docker_password: ${{ secrets.GITHUB_TOKEN }}
+  #         install_wheel: true
+  #         docker_opts: |
+  #           -v /mnt/MLPerf:/mnt/MLPerf:ro
+  #           -e TT_METAL_HOME=${{ github.workspace }}
+  #           -e ARCH_NAME=wormhole_b0
+  #           -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+  #           -e GTEST_OUTPUT=xml:generated/test_reports/
+  #           ${{ matrix.model == 'stable_diffusion_xl_base' && '-e HF_HOME=/mnt/MLPerf/tt_dnn-models/hf_home' || '' }}
+  #         # TT-Transformer models have a single ci-dispatch test that contains all tests.
+  #         # Due to host OOM issues in CI vm, we currently only run llama-1B (on TT-Transformers) in the model matrix.
+  #         run_args: |
+  #           if [[ "${{ matrix.model }}" == *"ttt"* ]]; then
+  #             pytest tests/nightly/single_card/tt_transformers -k ${{ matrix.model }}
+  #           elif [[ "${{ matrix.model }}" == *"qwen25_vl"* ]]; then
+  #             pytest tests/nightly/single_card/qwen25_vl -k ${{ matrix.model }}
+  #           else
+  #             pytest tests/nightly/single_card/${{ matrix.model }}
+  #           fi
+  #     - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+  #       timeout-minutes: 10
+  #       if: ${{ !cancelled() }}
+  #       with:
+  #         path: generated/test_reports/
+  #         prefix: "test_reports_"
+  # nightly-wh-unstable-models:
+  #   strategy:
+  #     # Do not fail-fast because we need to ensure all tests go to completion
+  #     # so we try not to get hanging machines
+  #     fail-fast: false
+  #     matrix:
+  #       test-config:
+  #         - model: "stable_diffusion"
+  #           cmd: TT_MM_THROTTLE_PERF=5 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
+  #             # Skipping due to issue #15932
+  #             # - model: "mamba 1"
+  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1
+  #             # - model: "mamba 2"
+  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 2
+  #             # - model: "mamba 3"
+  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 3
+  #             # - model: "mamba 4"
+  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 4
+  #         - model: "mamba 5"
+  #           cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 5
+  #             # - model: "mamba 6"
+  #             # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 6
+  #       card: [N150, N300]
+  #   name: "[Unstable] Nightly ${{ matrix.card }} ${{ matrix.test-config.model }}"
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
+  #   steps:
+  #     - name: ⬇️ Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #     - name: ⬇️ Download Build
+  #       uses: actions/download-artifact@v4
+  #       timeout-minutes: 10
+  #       with:
+  #         name: ${{ inputs.build-artifact-name }}
+  #     - name: Extract files
+  #       run: tar -xvf ttm_any.tar
+  #     - name: ⬇️ Download Wheel
+  #       uses: actions/download-artifact@v4
+  #       timeout-minutes: 10
+  #       with:
+  #         name: ${{ inputs.wheel-artifact-name }}
+  #     - uses: ./.github/actions/ensure-active-weka-mount
+  #     - name: Run frequent reg tests scripts
+  #       timeout-minutes: 60
+  #       uses: ./.github/actions/docker-run
+  #       with:
+  #         docker_image: ${{ inputs.docker-image }}
+  #         docker_password: ${{ secrets.GITHUB_TOKEN }}
+  #         install_wheel: true
+  #         docker_opts: |
+  #           -v /mnt/MLPerf:/mnt/MLPerf:ro
+  #           -e TT_METAL_HOME=${{ github.workspace }}
+  #           -e ARCH_NAME=wormhole_b0
+  #           -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+  #           -e GTEST_OUTPUT=xml:generated/test_reports/
+  #         run_args: ${{ matrix.test-config.cmd }}
+  #     - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+  #       timeout-minutes: 10
+  #       if: ${{ !cancelled() }}
+  #       with:
+  #         path: generated/test_reports/
+  #         prefix: "test_reports_"
   nightly-wh-models-civ2:
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/26377

### Problem description
Model developers are moving to CIv2 compatible downloads, we should be running (Single-card) Frequent model and ttnn tests using CIv2

### What's changed
Add a separate job for CIv2 compatible models using containerization (starting with yolov8s)

### Checklist
- [x] (Single-card) Frequent model and ttnn tests: https://github.com/tenstorrent/tt-metal/actions/runs/16788082934