### PR TITLE
[skip ci] Fail fast when the Clang Tidy check fails

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -72,6 +72,8 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     needs: [code-analysis]
+    permissions:
+      actions: write
     steps:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -70,6 +70,7 @@ jobs:
 
   fail-fast:
     if: failure()
+    runs-on: ubuntu-latest
     needs: [code-analysis]
     steps:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -68,6 +68,12 @@ jobs:
     with:
       version: 22.04
 
+  fail-fast:
+    if: failure()
+    needs: [code-analysis]
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
   find-changes:
     if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -58,7 +58,7 @@ size_t get_tt_fabric_max_payload_size_bytes();
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const FabricNodeId& dst_fabric_node_id,
-    uint32_t link_idx,
+    const uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -58,7 +58,7 @@ size_t get_tt_fabric_max_payload_size_bytes();
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const FabricNodeId& dst_fabric_node_id,
-    const uint32_t link_idx,
+    uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some PRs fail the Clang Tidy check, but the workflow continues on for what is sometimes many many many extra minutes before it finally reports a failure for the MQ to evict the PR and re-start all the subsequent ones.  Each minute is wasted resources times the number of queued up jobs, whose subsequent runs will not only start later, but will be further behind in the job queue causing even longer delays and making the MQ pile up even further.

### What's changed
Fail fast.

### Extra thought
It could be limited to only fail fast in the MQ.  Either way is fine.