### PR TITLE
#25975: Finalize porting all data movement kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -33,8 +33,8 @@ void kernel_main() {
     constexpr uint32_t selected_experts_k = get_compile_time_arg_val(4);
     constexpr uint32_t num_local_experts = get_compile_time_arg_val(5);
     constexpr uint32_t output_page_size_bytes = get_compile_time_arg_val(6);  // num_local_experts * datum size
-    constexpr uint32_t output_is_dram = get_compile_time_arg_val(7);
-    constexpr uint32_t datum_size_bytes = get_compile_time_arg_val(8);
+    constexpr uint32_t datum_size_bytes = get_compile_time_arg_val(7);
+    constexpr auto dst_args = TensorAccessorArgs<8>();
 
     using data_addr_t = detail::DataTypeHolder<datum_size_bytes>::type;
 
@@ -42,8 +42,7 @@ void kernel_main() {
     const auto start_idx = get_arg_val<uint32_t>(1);
     const auto end_idx = get_arg_val<uint32_t>(2);
 
-    InterleavedAddrGen<output_is_dram> output_addrgen{
-        .bank_base_address = output_base_addr, .page_size = output_page_size_bytes};
+    const auto output_addrgen = TensorAccessor(dst_args, output_base_addr, output_page_size_bytes);
 
     // scratch space
     cb_reserve_back(output_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
@@ -82,22 +82,6 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     const uint32_t& source_stick_size_bytes = source_stick_size * source_datum_size;
     const uint32_t& output_stick_size_bytes = output_stick_size * output_datum_size;
 
-    // check if row byte sizes are at least 32 and a power of 2 (for InterleavedAddrGen)
-    const uint32_t is_input_stick_size_bytes_pow2_min_32 = is_pow2_min32(input_stick_size_bytes);
-    const uint32_t is_index_stick_size_bytes_pow2_min_32 = is_pow2_min32(index_stick_size_bytes);
-    const uint32_t is_source_stick_size_bytes_pow2_min_32 = is_pow2_min32(source_stick_size_bytes);
-    const uint32_t is_output_stick_size_bytes_pow2_min_32 = is_pow2_min32(output_stick_size_bytes);
-
-    // for InterleavedAddrGen
-    const uint32_t input_stick_size_bytes_log2 =
-        is_input_stick_size_bytes_pow2_min_32 ? std::log2(input_stick_size_bytes) : 0;
-    const uint32_t index_stick_size_bytes_log2 =
-        is_index_stick_size_bytes_pow2_min_32 ? std::log2(index_stick_size_bytes) : 0;
-    const uint32_t source_stick_size_bytes_log2 =
-        is_source_stick_size_bytes_pow2_min_32 ? std::log2(source_stick_size_bytes) : 0;
-    const uint32_t output_stick_size_bytes_log2 =
-        is_output_stick_size_bytes_pow2_min_32 ? std::log2(output_stick_size_bytes) : 0;
-
     // maximal input/index/source/output chunk size, divisible by 32, calculated as follows:
     // BH available L1 mem size of nearly 1.5 MB...
     // ... divided by 4 to be able to allocate four equally long row chunks (coming from input/index/source/output


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

This PR finalized porting all data movement kernels to TensorAccessor

### What's changed
Ported moe_expert_token_remap kernels to use TensorAccessor

### Checklist
- [x] [T3K frequent CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16795194937)
- [x] New/Existing tests provide coverage for changes