### PR TITLE
#25975: Add CI check to prevent adding new InterleavedAddrGen usages in the codebase

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -116,7 +116,7 @@ jobs:
             BASE_REF="HEAD^"
           fi
 
-                    # Find all changed C++ files in the current PR/commit
+          # Find all changed C++ files in the current PR/commit
           CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD | grep -E '\.(cpp|hpp|h|cc|cxx)$' || true)
 
           # Check if any changed C++ files contain new InterleavedAddrGen usages

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -116,10 +116,10 @@ jobs:
             BASE_REF="HEAD^"
           fi
 
-          # Find all changed files in the current PR/commit
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD)
+          # Find all changed C++ files in the current PR/commit
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD | grep -E '\.(cpp|hpp|h|cc|cxx)$')
 
-          # Check if any changed files contain new InterleavedAddrGen usages
+          # Check if any changed C++ files contain new InterleavedAddrGen usages
           NEW_USAGE_FOUND=0
           for file in $CHANGED_FILES; do
             if [ -f "$file" ]; then

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -116,22 +116,26 @@ jobs:
             BASE_REF="HEAD^"
           fi
 
-          # Find all changed C++ files in the current PR/commit
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD | grep -E '\.(cpp|hpp|h|cc|cxx)$')
+                    # Find all changed C++ files in the current PR/commit
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD | grep -E '\.(cpp|hpp|h|cc|cxx)$' || true)
 
           # Check if any changed C++ files contain new InterleavedAddrGen usages
           NEW_USAGE_FOUND=0
-          for file in $CHANGED_FILES; do
-            if [ -f "$file" ]; then
-              # Check for InterleavedAddrGen, InterleavedAddrGenFast, InterleavedPow2AddrGen, or get_interleaved_addr_gen
-              if git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen" > /dev/null; then
-                echo "❌ Found new InterleavedAddrGen usage in: $file"
-                echo "Added lines:"
-                git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen"
-                NEW_USAGE_FOUND=1
+          if [ -n "$CHANGED_FILES" ]; then
+            for file in $CHANGED_FILES; do
+              if [ -f "$file" ]; then
+                # Check for InterleavedAddrGen, InterleavedAddrGenFast, InterleavedPow2AddrGen, or get_interleaved_addr_gen
+                if git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen" > /dev/null; then
+                  echo "❌ Found new InterleavedAddrGen usage in: $file"
+                  echo "Added lines:"
+                  git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen"
+                  NEW_USAGE_FOUND=1
+                fi
               fi
-            fi
-          done
+            done
+          else
+            echo "No C++ files changed in this PR."
+          fi
 
           if [ $NEW_USAGE_FOUND -eq 1 ]; then
             echo ""

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -101,6 +101,44 @@ jobs:
         run: |
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
+  check-interleaved-addr-gen-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for new InterleavedAddrGen usages in changed files
+        run: |
+          # Get the base branch for comparison
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="HEAD^"
+          fi
+
+          # Find all changed files in the current PR/commit
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD)
+
+          # Check if any changed files contain new InterleavedAddrGen usages
+          NEW_USAGE_FOUND=0
+          for file in $CHANGED_FILES; do
+            if [ -f "$file" ]; then
+              # Check for InterleavedAddrGen, InterleavedAddrGenFast, InterleavedPow2AddrGen, or get_interleaved_addr_gen
+              if git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen" > /dev/null; then
+                echo "❌ Found new InterleavedAddrGen usage in: $file"
+                echo "Added lines:"
+                git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen"
+                NEW_USAGE_FOUND=1
+              fi
+            fi
+          done
+
+          if [ $NEW_USAGE_FOUND -eq 1 ]; then
+            echo ""
+            echo "❌ New InterleavedAddrGen usages detected!"
+            echo "Please use TensorAccessor instead."
+            exit 1
+          else
+            echo "✅ No new InterleavedAddrGen usages found in changed files."
+          fi
   check-sweeps-workflow:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -105,11 +105,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git diff comparison
       - name: Check for new InterleavedAddrGen usages in changed files
         run: |
           # Get the base branch for comparison
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="${{ github.event.pull_request.base.sha }}"
+            BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
           else
             BASE_REF="HEAD^"
           fi


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We're working on migrating all usages of InterleavedAddrGen to TensorAccessor.
This PR adds a CI check to prevent adding new usages of InterleavedAddrGen

### What's changed
Added CI check to prevent new usages of InterleavedAddrGen

### Checklist
- [x] No code changes