### PR TITLE
Int32 support for squared_difference

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -36,6 +36,7 @@ import ttnn
         ttnn.logical_and,
         ttnn.add,
         ttnn.sub,
+        ttnn.squared_difference,
     ],
 )
 def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, device):
@@ -102,6 +103,7 @@ def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, devic
         ttnn.add,
         ttnn.sub,
         ttnn.mul,
+        ttnn.squared_difference,
     ],
 )
 def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
@@ -174,7 +176,9 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         block_sharded_memory_config,
     ],
 )
-@pytest.mark.parametrize("ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul"))
+@pytest.mark.parametrize(
+    "ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul", "squared_difference")
+)
 def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
     ttnn_op = getattr(ttnn, ttnn_fn)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2101,7 +2101,7 @@ void py_module(py::module& module) {
         R"doc(Computes squared difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}} = \verb|squared_difference|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
         ". ",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
     detail::bind_binary_operation(
         module,
@@ -2436,13 +2436,13 @@ void py_module(py::module& module) {
         ttnn::squared_difference_,
         R"doc(Performs squared_difference in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
         R"doc(\verb|squared_difference|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
     detail::bind_inplace_operation(
         module,
         ttnn::divide_,
         R"doc(Performs division in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
-        R"doc(\verb|squared_difference|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc");
+        R"doc(\verb|divide|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc");
 
     detail::bind_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -321,7 +321,11 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "mul_binary_tile";
             break;
         case BinaryOpType::SQUARED_DIFFERENCE:
-            op_name = "sub_binary_tile";
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "sub_int32_tile";
+            } else {
+                op_name = "sub_binary_tile";
+            }
             new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst1));
             break;
         case BinaryOpType::BIAS_GELU:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -31,11 +31,11 @@ namespace utils {
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:
         case BinaryOpType::LDEXP:
-        case BinaryOpType::SQUARED_DIFFERENCE:
         case BinaryOpType::BIAS_GELU: return (a == DataType::FLOAT32 && b == DataType::FLOAT32);
         case BinaryOpType::LOGICAL_AND:
         case BinaryOpType::LOGICAL_OR:
         case BinaryOpType::LOGICAL_XOR:
+        case BinaryOpType::SQUARED_DIFFERENCE:
         case BinaryOpType::GT:
         case BinaryOpType::LT:
         case BinaryOpType::GE:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -24,11 +24,11 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LOGADDEXP:
         case LOGADDEXP2:
         case LDEXP:
-        case SQUARED_DIFFERENCE:
         case BIAS_GELU: return (a == FLOAT32 && b == FLOAT32);
         case LOGICAL_AND:
         case LOGICAL_OR:
         case LOGICAL_XOR:
+        case SQUARED_DIFFERENCE:
         case GT:
         case LT:
         case GE:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -70,9 +70,6 @@ struct OpConfig {
         DEQUANT,
         MAXIMUM,
         MINIMUM,
-        LOGICAL_AND,
-        LOGICAL_OR,
-        LOGICAL_XOR,
         XLOGY
     };
 


### PR DESCRIPTION
### Ticket
#24609 

### Problem description
ttnn.squared_difference has only float support now. Need to provide int32 support.

### What's changed
Added int32 support in binary and binary_ng infra.
**Perf for a single tile [1, 1, 32, 32]: 6711 ns**

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16797132056) - same as main (latest run: https://github.com/tenstorrent/tt-metal/actions/runs/16822438950)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16797144887)
- [x] New/Existing tests provide coverage for changes