### PR TITLE
Removed warmup run from stable_diffusion device perf test

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -416,7 +416,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     if is_wormhole_b0():
         os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
-    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=False)
+    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
     prep_device_perf_report(
         model_name=f"stable_diffusion_{batch}batch",

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -416,7 +416,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     if is_wormhole_b0():
         os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
-    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
+    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=False)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
     prep_device_perf_report(
         model_name=f"stable_diffusion_{batch}batch",

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -112,6 +112,13 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
     encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device, memory_config=ttnn.L1_MEMORY_CONFIG)
     model = UNet2D(device, parameters, batch_size, input_height, input_width)
 
+    use_signpost = True
+    try:
+        from tracy import signpost
+    except ModuleNotFoundError:
+        use_signpost = False
+    if use_signpost:
+        signpost(header="start")
     ttnn_output = model(
         input,
         timestep=ttnn_timestep,
@@ -122,6 +129,8 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
         return_dict=return_dict,
         config=config,
     )
+    if use_signpost:
+        signpost(header="stop")
 
     ttnn_output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_output, ttnn_output, 0.995)

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import time
 
 import pytest
 import torch
@@ -113,30 +112,6 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
     encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device, memory_config=ttnn.L1_MEMORY_CONFIG)
     model = UNet2D(device, parameters, batch_size, input_height, input_width)
 
-    first_iter = time.time()
-    use_signpost = True
-    try:
-        from tracy import signpost
-    except ModuleNotFoundError:
-        use_signpost = False
-    if use_signpost:
-        signpost(header="start")
-    ttnn_output_ = model(
-        input,
-        timestep=ttnn_timestep,
-        encoder_hidden_states=encoder_hidden_states,
-        class_labels=class_labels,
-        attention_mask=attention_mask,
-        cross_attention_kwargs=cross_attention_kwargs,
-        return_dict=return_dict,
-        config=config,
-    )
-    if use_signpost:
-        signpost(header="stop")
-    first_iter = time.time() - first_iter
-    print(f"First iteration took {first_iter} seconds")
-
-    second_iter = time.time()
     ttnn_output = model(
         input,
         timestep=ttnn_timestep,
@@ -147,8 +122,6 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
         return_dict=return_dict,
         config=config,
     )
-    second_iter = time.time() - second_iter
-    print(f"Second iteration took {second_iter} seconds")
 
     ttnn_output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_output, ttnn_output, 0.995)


### PR DESCRIPTION
### Problem description
Warmup model run is not needed when running device perf.
It increases the test time without any gain and increases device perf report generation duration.

### What's changed
Removed warmup run from `models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py:: test_unet_2d_condition_model_512x512`