### PR TITLE
Low-overhead profiler for device trace replays

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -49,6 +49,7 @@ def set_env_vars(**kwargs):
         "doDispatchCores": "TT_METAL_DEVICE_PROFILER_DISPATCH=1 ",
         "slowDispatch": "TT_METAL_SLOW_DISPATCH_MODE=1 ",
         "enable_noc_tracing": "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1 ",
+        "doDeviceTrace": "TT_METAL_TRACE_PROFILER=1 ",
     }
     envVarsStr = " "
     for arg, argVal in kwargs.items():
@@ -77,6 +78,7 @@ def run_gtest_profiler_test(testbin, testname, doSync=False, enable_noc_tracing=
 def run_device_profiler_test(
     testName=None,
     setupAutoExtract=False,
+    doDeviceTrace=False,
     slowDispatch=False,
     doSync=False,
     doDispatchCores=False,
@@ -86,7 +88,12 @@ def run_device_profiler_test(
     if testName:
         testCommand = testName
     clear_profiler_runtime_artifacts()
-    envVars = set_env_vars(slowDispatch=slowDispatch, doSync=doSync, doDispatchCores=doDispatchCores)
+    envVars = set_env_vars(
+        doDeviceTrace=doDeviceTrace,
+        slowDispatch=slowDispatch,
+        doSync=doSync,
+        doDispatchCores=doDispatchCores,
+    )
     testCommand = f"cd {TT_METAL_HOME} && {envVars} {testCommand}"
     print()
     logger.info(f"Running: {testCommand}")
@@ -212,45 +219,75 @@ def test_full_buffer():
         assert stats[statName]["stats"]["Count"] in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong Marker Repeat count"
 
 
+def verify_stats(devicesData, statTypes, allowedRange, refCountDict):
+    verifiedStat = []
+    for _, deviceData in devicesData["data"]["devices"].items():
+        for ref, counts in refCountDict.items():
+            if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
+                verifiedStat.append(ref)
+                res = False
+                readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
+                for count in counts:
+                    if count - allowedRange <= readCount <= count + allowedRange:
+                        res = True
+                        break
+                assert (
+                    res
+                ), f"Wrong tensix zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+
+    statTypesSet = set(statTypes)
+    for statType in statTypes:
+        for stat in verifiedStat:
+            if statType in stat and statType in statTypesSet:
+                statTypesSet.remove(statType)
+    assert (
+        len(statTypesSet) == 0
+    ), f"Not all required stats (i.e. {statTypesSet}) were found in the device stats (i.e. {verifiedStat})"
+
+
+def test_device_trace_run():
+    verify_stats(
+        run_device_profiler_test(
+            testName=f"pytest {TRACY_TESTS_DIR}/test_trace_runs.py::test_with_ops",
+            setupAutoExtract=False,
+            doDeviceTrace=True,
+        ),
+        statTypes=["kernel", "fw"],
+        allowedRange=0,
+        refCountDict={
+            "trace_fw_duration": [5],
+            "trace_kernel_duration": [5],
+        },
+    )
+    verify_stats(
+        run_device_profiler_test(
+            testName=f"pytest {TRACY_TESTS_DIR}/test_trace_runs.py::test_with_ops_single_core",
+            setupAutoExtract=False,
+            doDeviceTrace=True,
+        ),
+        statTypes=["kernel", "fw"],
+        allowedRange=0,
+        refCountDict={
+            "trace_fw_duration": [5],
+            "trace_kernel_duration": [5],
+        },
+    )
+
+
 @skip_for_blackhole()
 def test_dispatch_cores():
-    OP_COUNT = 1
-    RISC_COUNT = 1
-    ZONE_COUNT = 37
     REF_COUNT_DICT = {
         "Tensix CQ Dispatch": [600, 760, 1310, 2330],
         "Tensix CQ Prefetch": [900, 1440, 3870, 5000],
-        "dispatch_total_cq_cmd_op_time": [103],
-        "dispatch_go_send_wait_time": [103],
+        "dispatch_total_cq_cmd_op_time": [206],
+        "dispatch_go_send_wait_time": [206],
     }
-
-    def verify_stats(devicesData, statTypes, allowedRange):
-        verifiedStat = []
-        for device, deviceData in devicesData["data"]["devices"].items():
-            for ref, counts in REF_COUNT_DICT.items():
-                if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
-                    verifiedStat.append(ref)
-                    res = False
-                    readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
-                    for count in counts:
-                        if count - allowedRange <= readCount <= count + allowedRange:
-                            res = True
-                            break
-                    assert (
-                        res
-                    ), f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
-
-        statTypesSet = set(statTypes)
-        for statType in statTypes:
-            for stat in verifiedStat:
-                if statType in stat and statType in statTypesSet:
-                    statTypesSet.remove(statType)
-        assert len(statTypesSet) == 0
 
     verify_stats(
         run_device_profiler_test(setupAutoExtract=True, doDispatchCores=True),
         statTypes=["Dispatch", "Prefetch"],
         allowedRange=150,
+        refCountDict=REF_COUNT_DICT,
     )
 
     verify_stats(
@@ -261,6 +298,7 @@ def test_dispatch_cores():
         ),
         statTypes=["Dispatch", "Prefetch"],
         allowedRange=1000,
+        refCountDict=REF_COUNT_DICT,
     )
 
     verify_stats(
@@ -271,6 +309,7 @@ def test_dispatch_cores():
         ),
         statTypes=["Dispatch", "Prefetch"],
         allowedRange=1000,
+        refCountDict=REF_COUNT_DICT,
     )
 
     verify_stats(
@@ -281,6 +320,7 @@ def test_dispatch_cores():
         ),
         statTypes=["dispatch_total_cq_cmd_op_time", "dispatch_go_send_wait_time"],
         allowedRange=0,  # This test is basically counting ops and should be exact regardless of changes to dispatch code or harvesting.
+        refCountDict=REF_COUNT_DICT,
     )
 
 

--- a/tests/ttnn/tracy/test_trace_runs.py
+++ b/tests/ttnn/tracy/test_trace_runs.py
@@ -38,3 +38,34 @@ def test_with_ops(device):
     for i in range(5):
         ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
     ttnn.release_trace(device, tid)
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 1996800, "dispatch_core_type": ttnn.DispatchCoreType.WORKER}], indirect=True
+)
+def test_with_ops_single_core(device):
+    torch.manual_seed(0)
+    m = 1024
+    k = 1024
+    n = 1024
+    torch_a = torch.randn((m, k), dtype=torch.bfloat16)
+    torch_b = torch.randn((k, n), dtype=torch.bfloat16)
+
+    a = ttnn.from_torch(torch_a)
+    b = ttnn.from_torch(torch_b)
+
+    a = ttnn.to_device(a, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    b = ttnn.to_device(b, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    a = ttnn.to_layout(a, ttnn.TILE_LAYOUT)
+    b = ttnn.to_layout(b, ttnn.TILE_LAYOUT)
+
+    ttnn.matmul(a, b, core_grid=ttnn.CoreGrid(y=1, x=1))
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    for i in range(100):
+        ttnn.matmul(a, b, core_grid=ttnn.CoreGrid(y=1, x=1))
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    for i in range(5):
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    ttnn.release_trace(device, tid)

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -10,7 +10,7 @@ namespace tt::tt_metal {
 
 enum class ProfilerReadState { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_READ };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
-enum class ProfilerDataBufferSource { L1, DRAM };
+enum class ProfilerDataBufferSource { L1, DRAM, DRAM_AND_L1 };
 
 struct DeviceProgramId {
     uint32_t base_program_id = 0;

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -446,6 +446,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
 }
 
 void FDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    ZoneScopedN("FDMeshCommandQueue::finish_nolock");
     auto event = this->enqueue_record_event_to_host_nolock(sub_device_ids);
 
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -876,6 +876,7 @@ void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
 }
 
 void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
+    ZoneScoped;
     TracyTTMetalReplayMeshTrace(this->get_device_ids(), *trace_id);
     auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
     const auto& trace_buffer = active_sub_device_manager->get_trace(trace_id);

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -6,7 +6,8 @@
 
 #include <cstdint>
 
-#define PROFILER_OPT_DO_DISPATCH_CORES 2
+#define PROFILER_OPT_DO_DISPATCH_CORES (1 << 1)
+#define PROFILER_OPT_DO_TRACE_ONLY (1 << 2)
 
 namespace kernel_profiler {
 
@@ -52,6 +53,7 @@ enum ControlBuffer {
     CORE_COUNT_PER_DRAM,
     DROPPED_ZONES,
     PROFILER_DONE,
+    CURRENT_TRACE_ID
 };
 
 enum PacketTypes { ZONE_START, ZONE_END, ZONE_TOTAL, TS_DATA, TS_EVENT };

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -85,6 +85,7 @@ uint32_t wIndex __attribute__((used));
 uint32_t stackSize __attribute__((used));
 uint32_t sums[SUM_COUNT] __attribute__((used));
 uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+uint32_t traceCount __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 
@@ -357,6 +358,7 @@ int main() {
     uint8_t prev_noc_mode = DM_DEDICATED_NOC;
     trigger_sync_register_init();
 
+    DeviceProfilerInit();
     while (1) {
         WAYPOINT("GW");
         uint8_t go_message_signal = RUN_MSG_DONE;
@@ -376,6 +378,7 @@ int main() {
                 // Set the rd_ptr on workers to specified value
                 mailboxes->launch_msg_rd_ptr = 0;
                 if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
+                    DeviceTraceProfilerInit();
                     uint32_t go_message_index = mailboxes->go_message_index;
                     // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently
                     // guaranteed to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -106,6 +106,7 @@ void __attribute__((noinline)) Application(void) {
     WAYPOINT("RED");
 
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
+    DeviceProfilerInit();
     while (routing_info->routing_enabled) {
         // FD: assume that no more host -> remote writes are pending
         uint8_t go_message_signal = mailboxes->go_messages[0].signal;

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
@@ -136,6 +136,7 @@ int main() {
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
     // Cleanup profiler buffer incase we never get the go message
 
+    DeviceProfilerInit();
     while (1) {
         init_sync_registers();
         // Wait...

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
 
     signal_ncrisc_completion();
 
-    // Cleanup profiler buffer incase we never get the go message
+    DeviceProfilerInit();
     while (1) {
         WAYPOINT("W");
         notify_brisc_and_wait();

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
     *trisc_run = RUN_SYNC_MSG_DONE;
 
-    // Cleanup profiler buffer incase we never get the go message
+    DeviceProfilerInit();
     while (1) {
         WAYPOINT("W");
         while (*trisc_run != RUN_SYNC_MSG_GO) {

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -51,6 +51,9 @@ struct pair_hash {
     }
 };
 
+constexpr uint32_t TRACE_RISC_ID = 6;
+constexpr uint32_t ERISC_RISC_ID = 5;
+
 // defined locally in profiler.cpp
 class FabricRoutingLookup;
 
@@ -69,6 +72,12 @@ struct ZoneDetails {
     enum class ZoneNameKeyword : uint16_t {
         BRISC_FW,
         ERISC_FW,
+        NCRISC_FW,
+        TRISC_FW,
+        BRISC_KERNEL,
+        ERISC_KERNEL,
+        NCRISC_KERNEL,
+        TRISC_KERNEL,
         SYNC_ZONE,
         PROFILER,
         DISPATCH,
@@ -82,6 +91,12 @@ struct ZoneDetails {
     static inline std::unordered_map<std::string, ZoneNameKeyword> zone_name_keywords_map = {
         {"BRISC-FW", ZoneNameKeyword::BRISC_FW},
         {"ERISC-FW", ZoneNameKeyword::ERISC_FW},
+        {"NCRISC-FW", ZoneNameKeyword::NCRISC_FW},
+        {"TRISC-FW", ZoneNameKeyword::TRISC_FW},
+        {"BRISC-KERNEL", ZoneNameKeyword::BRISC_KERNEL},
+        {"ERISC-KERNEL", ZoneNameKeyword::ERISC_KERNEL},
+        {"NCRISC-KERNEL", ZoneNameKeyword::NCRISC_KERNEL},
+        {"TRISC-KERNEL", ZoneNameKeyword::TRISC_KERNEL},
         {"SYNC-ZONE", ZoneNameKeyword::SYNC_ZONE},
         {"PROFILER", ZoneNameKeyword::PROFILER},
         {"DISPATCH", ZoneNameKeyword::DISPATCH},

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -754,7 +754,11 @@ void ReadDeviceProfilerResults(
             !tt::tt_metal::MetalContext::instance().dprint_server(),
             "Debug print server is running, cannot read device profiler data");
 
-        profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+            profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM_AND_L1, metadata);
+        } else {
+            profiler.readResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
+        }
     }
 #endif
 }
@@ -776,7 +780,11 @@ void ProcessDeviceProfilerResults(
             return;
         }
 
-        profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+            profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM_AND_L1, metadata);
+        } else {
+            profiler.processResults(device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
+        }
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {
             profiler.pushTracyDeviceResults();
         }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -171,12 +171,14 @@ void JitBuildEnv::init(
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
 
     if (tt::tt_metal::getDeviceProfilerState()) {
+        uint32_t profiler_options = 1;
         if (rtoptions.get_profiler_do_dispatch_cores()) {
-            // TODO(MO): Standard bit mask for device side profiler options
-            this->defines_ += "-DPROFILE_KERNEL=2 ";
-        } else {
-            this->defines_ += "-DPROFILE_KERNEL=1 ";
+            profiler_options |= PROFILER_OPT_DO_DISPATCH_CORES;
         }
+        if (rtoptions.get_profiler_trace_only()) {
+            profiler_options |= PROFILER_OPT_DO_TRACE_ONLY;
+        }
+        this->defines_ += "-DPROFILE_KERNEL=" + std::to_string(profiler_options) + " ";
     }
     if (rtoptions.get_profiler_noc_events_enabled()) {
         // force profiler on if noc events are being profiled

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -97,6 +97,7 @@ RunTimeOptions::RunTimeOptions() {
     profiler_sync_enabled = false;
     profiler_mid_run_tracy_push = false;
     profiler_buffer_usage_enabled = false;
+    profiler_trace_profiler = false;
 #if defined(TRACY_ENABLE)
     const char* profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
     if (profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1') {
@@ -106,12 +107,15 @@ RunTimeOptions::RunTimeOptions() {
             profile_dispatch_cores = true;
         }
         const char* profiler_sync_enabled_str = std::getenv("TT_METAL_PROFILER_SYNC");
-        if (profiler_enabled && profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
+        if (profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
             profiler_sync_enabled = true;
         }
+        const char* profiler_trace_profiler_str = std::getenv("TT_METAL_TRACE_PROFILER");
+        if (profiler_trace_profiler_str != nullptr && profiler_trace_profiler_str[0] == '1') {
+            profiler_trace_profiler = true;
+        }
         const char* profiler_force_push_enabled_str = std::getenv("TT_METAL_TRACY_MID_RUN_PUSH");
-        if (profiler_enabled && profiler_force_push_enabled_str != nullptr &&
-            profiler_force_push_enabled_str[0] == '1') {
+        if (profiler_force_push_enabled_str != nullptr && profiler_force_push_enabled_str[0] == '1') {
             profiler_mid_run_tracy_push = true;
         }
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -128,6 +128,7 @@ class RunTimeOptions {
     bool profile_dispatch_cores = false;
     bool profiler_sync_enabled = false;
     bool profiler_mid_run_tracy_push = false;
+    bool profiler_trace_profiler = false;
     bool profiler_buffer_usage_enabled = false;
     bool profiler_noc_events_enabled = false;
     std::string profiler_noc_events_report_path;
@@ -385,6 +386,7 @@ public:
     inline bool get_profiler_enabled() const { return profiler_enabled; }
     inline bool get_profiler_do_dispatch_cores() const { return profile_dispatch_cores; }
     inline bool get_profiler_sync_enabled() const { return profiler_sync_enabled; }
+    inline bool get_profiler_trace_only() const { return profiler_trace_profiler; }
     inline bool get_profiler_tracy_mid_run_push() const { return profiler_mid_run_tracy_push; }
     inline bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
     inline bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -21,9 +21,34 @@ class default_setup(metaclass=MergeMetaclass):
         "NCRISC",
         "TRISC",
         "ERISC",
+        "CORE_AGG",
     ]
 
     timerAnalysis = {
+        "trace_fw_duration": {
+            "across": "ops",
+            "type": "op_first_last",
+            "start": {"core": "ANY", "risc": "CORE_AGG", "zone_name": "TRACE-FW"},
+            "end": {"core": "ANY", "risc": "CORE_AGG", "zone_name": "TRACE-FW"},
+        },
+        "trace_kernel_duration": {
+            "across": "ops",
+            "type": "op_first_last",
+            "start": {"core": "ANY", "risc": "CORE_AGG", "zone_name": "TRACE-KERNEL"},
+            "end": {"core": "ANY", "risc": "CORE_AGG", "zone_name": "TRACE-KERNEL"},
+        },
+        "trace2trace - FW": {
+            "across": "device",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "ANY", "zone_phase": "ZONE_END", "zone_name": "TRACE-FW"},
+            "end": {"core": "ANY", "risc": "ANY", "zone_phase": "ZONE_START", "zone_name": "TRACE-FW"},
+        },
+        "trace2trace - kernel": {
+            "across": "device",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "ANY", "zone_phase": "ZONE_END", "zone_name": "TRACE-KERNEL"},
+            "end": {"core": "ANY", "risc": "ANY", "zone_phase": "ZONE_START", "zone_name": "TRACE-KERNEL"},
+        },
         "op2op": {
             "across": "core",
             "type": "adjacent",

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -33,11 +33,12 @@
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
 
 #if defined(PROFILE_KERNEL) && \
-    (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)))
+    (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES)))
 namespace kernel_profiler {
 
 extern uint32_t wIndex;
 extern uint32_t stackSize;
+extern uint32_t traceCount;
 
 extern uint32_t sums[SUM_COUNT];
 extern uint32_t sumIDs[SUM_COUNT];
@@ -46,6 +47,15 @@ constexpr uint32_t QUICK_PUSH_MARKER_COUNT = 2;
 constexpr uint32_t DISPATCH_META_DATA_COUNT = 2;
 constexpr uint32_t DISPATCH_META_DATA_UINT32_SIZE = 4;
 constexpr uint32_t DISPATCH_PARENT_ZONE_MARKER_COUNT = 2;
+
+#if (PROFILE_KERNEL & PROFILER_OPT_DO_TRACE_ONLY) && !(defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+constexpr bool TRACE_ON_TENSIX = true;
+#else
+constexpr bool TRACE_ON_TENSIX = false;
+#endif
+constexpr uint32_t TRACE_MARK_FW_START = (1 << 31);
+constexpr uint32_t TRACE_MARK_KERNEL_START = (1 << 30);
+constexpr uint32_t TRACE_MARK_ALL_ENDS = (1 << 29);
 // Space has to be left in the buffer in order to guarantee
 // that the next dispatch command can make it fully populated
 // with its meta data (op id + command type)
@@ -63,9 +73,8 @@ volatile tt_l1_ptr uint32_t (*profiler_data_buffer)[kernel_profiler::PROFILER_L1
     reinterpret_cast<volatile tt_l1_ptr uint32_t (*)[kernel_profiler::PROFILER_L1_VECTOR_SIZE]>(
         GET_MAILBOX_ADDRESS_DEV(profiler.buffer));
 
-#if defined(COMPILE_FOR_BRISC)
-constexpr uint32_t myRiscID = 0;
-#elif defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+#if (PROFILE_KERNEL & PROFILER_OPT_DO_TRACE_ONLY) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
+    defined(COMPILE_FOR_IDLE_ERISC)
 constexpr uint32_t myRiscID = 0;
 #elif defined(COMPILE_FOR_NCRISC)
 constexpr uint32_t myRiscID = 1;
@@ -193,7 +202,7 @@ inline __attribute__((always_inline)) void risc_finished_profiling() {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
     defined(COMPILE_FOR_IDLE_ERISC)
 
-#if (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
+#if (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES))
 
 // Saves several NoC register states that may be setup by dispatch kernels and restores them
 // when the NocDestinationStateSaver is destroyed
@@ -351,9 +360,6 @@ __attribute__((noinline)) void quick_push() {
 
     uint64_t dram_bank_dst_noc_addr = s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
 
-    mark_time_at_index_inlined(wIndex, get_const_id(hash, ZONE_END));
-    wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
-
     for (uint32_t i = 0; i < (wIndex % NOC_ALIGNMENT_FACTOR); i++) {
         mark_padding();
     }
@@ -373,6 +379,9 @@ __attribute__((noinline)) void quick_push() {
     }
 
     wIndex = CUSTOM_MARKERS;
+
+    mark_time_at_index_inlined(wIndex, get_const_id(hash, ZONE_END));
+    wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
 
 #endif
 }
@@ -431,15 +440,54 @@ struct profileScopeGuaranteed {
     static_assert(start_index < CUSTOM_MARKERS);
     static_assert(end_index < CUSTOM_MARKERS);
     inline __attribute__((always_inline)) profileScopeGuaranteed() {
-        if constexpr (index == 0) {
-            init_profiler();
+        if constexpr (TRACE_ON_TENSIX) {
+            uint32_t trace_controls = profiler_control_buffer[CURRENT_TRACE_ID];
+            if constexpr (index == 0) {
+#if !defined(COMPILE_FOR_TRISC)
+                if (trace_controls & TRACE_MARK_FW_START) {
+                    mark_time_at_index_inlined(start_index, get_const_id(timer_id, ZONE_START));
+                    profiler_control_buffer[CURRENT_TRACE_ID] = TRACE_MARK_KERNEL_START;
+                } else if (trace_controls == 0) {
+                    mark_time_at_index_inlined(start_index, get_const_id(timer_id, ZONE_START));
+                    wIndex = CUSTOM_MARKERS;
+                }
+#endif
+            } else {
+                if (trace_controls & TRACE_MARK_KERNEL_START) {
+                    mark_time_at_index_inlined(start_index, get_const_id(timer_id, ZONE_START));
+                    profiler_control_buffer[CURRENT_TRACE_ID] = TRACE_MARK_ALL_ENDS;
+                } else if (trace_controls == 0) {
+                    mark_time_at_index_inlined(start_index, get_const_id(timer_id, ZONE_START));
+                }
+            }
+        } else {
+            if constexpr (index == 0) {
+                init_profiler();
+            }
+            mark_time_at_index_inlined(start_index, get_const_id(timer_id, ZONE_START));
         }
-        mark_time_at_index_inlined(start_index, timer_id);
     }
     inline __attribute__((always_inline)) ~profileScopeGuaranteed() {
-        mark_time_at_index_inlined(end_index, get_const_id(timer_id, ZONE_END));
-        if constexpr (index == 0) {
-            finish_profiler();
+        if constexpr (TRACE_ON_TENSIX) {
+            if (profiler_control_buffer[CURRENT_TRACE_ID] == TRACE_MARK_ALL_ENDS) {
+                mark_time_at_index_inlined(end_index, get_const_id(timer_id, ZONE_END));
+#if defined(COMPILE_FOR_BRISC)
+                // Validate profiler_data_buffer in L1
+                profiler_data_buffer[myRiscID][ID_HH] = 0x0;
+#endif
+            } else if (
+                profiler_control_buffer[CURRENT_TRACE_ID] == 0 &&
+                profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER] == 0) {
+                mark_time_at_index_inlined(end_index, get_const_id(timer_id, ZONE_END));
+            }
+            if constexpr (index == 0) {
+                profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER] = wIndex;
+            }
+        } else {
+            mark_time_at_index_inlined(end_index, get_const_id(timer_id, ZONE_END));
+            if constexpr (index == 0) {
+                finish_profiler();
+            }
         }
     }
 };
@@ -483,6 +531,22 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
         wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
     }
 }
+
+__attribute__((noinline)) void trace_init() {
+    if constexpr (TRACE_ON_TENSIX) {
+        if (traceCount > 0) {
+            quick_push();
+        }
+        traceCount++;
+        set_host_counter(traceCount);
+        profiler_control_buffer[CURRENT_TRACE_ID] = TRACE_MARK_FW_START;
+        // Invalidate profiler_data_buffer in L1
+        // As the start of profiler buffer ID_HH = 0x0
+        // indicates valid profiler data
+        profiler_data_buffer[myRiscID][ID_HH] = 0x80000000;
+    }
+}
+
 }  // namespace kernel_profiler
 
 #include "noc_event_profiler.hpp"
@@ -505,7 +569,7 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 #define DeviceRecordEvent(event_id) kernel_profiler::recordEvent(event_id);
 
 // Dispatch and enabled
-#elif (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
+#elif (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES))
 
 #define DeviceZoneScopedN(name)                                                         \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                         \
@@ -555,7 +619,17 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     kernel_profiler::profileScopeAccumulate<hash, 1> zone = kernel_profiler::profileScopeAccumulate<hash, 1>();
 
-#define DeviceZoneSetCounter(counter) kernel_profiler::set_host_counter(counter);
+#define DeviceZoneSetCounter(counter)                  \
+    if constexpr (!kernel_profiler::TRACE_ON_TENSIX) { \
+        kernel_profiler::set_host_counter(counter);    \
+    }
+
+#define DeviceProfilerInit()                          \
+    if constexpr (kernel_profiler::TRACE_ON_TENSIX) { \
+        kernel_profiler::init_profiler();             \
+    }
+
+#define DeviceTraceProfilerInit() kernel_profiler::trace_init();
 
 #else
 
@@ -571,11 +645,15 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 
 #define DeviceZoneScopedSumN2(name)
 
+#define DeviceTraceProfilerInit()
+
 #define DeviceZoneSetCounter(counter)
 
 #define DeviceTimestampedData(data_id, data)
 
 #define DeviceRecordEvent(event_id)
+
+#define DeviceProfilerInit()
 
 // null macros when noc tracing is disabled
 #define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -229,8 +229,14 @@ def get_ops(timeseries):
             if len(ts) == 5:
                 timerID, tsValue, attachedData, risc, core = ts
                 if opCores[core]:
-                    if (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_START") or (
-                        risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_START"
+                    if (
+                        (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_START")
+                        or (risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_START")
+                        or (
+                            risc == "CORE_AGG"
+                            and timerID["zone_name"] == "TRACE-FW"
+                            and timerID["type"] == "ZONE_START"
+                        )
                     ):
                         if len(opCores[core]) == 2:
                             corruption = False
@@ -248,8 +254,10 @@ def get_ops(timeseries):
                             False
                         ), f"Unexpected FW start, core {core}, risc {risc} is reporting a second start of FW for op {opID}. {assertMsg}"
 
-                    elif (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_END") or (
-                        risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_END"
+                    elif (
+                        (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_END")
+                        or (risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_END")
+                        or (risc == "CORE_AGG" and timerID["zone_name"] == "TRACE-FW" and timerID["type"] == "ZONE_END")
                     ):
                         assert (
                             len(opCores[core]) == 1
@@ -261,14 +269,22 @@ def get_ops(timeseries):
                                 opIsDone = False
                                 break
                 else:
-                    if (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_START") or (
-                        risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_START"
+                    if (
+                        (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_START")
+                        or (risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_START")
+                        or (
+                            risc == "CORE_AGG"
+                            and timerID["zone_name"] == "TRACE-FW"
+                            and timerID["type"] == "ZONE_START"
+                        )
                     ):
                         opCores[core] = (timerID,)
             if len(ts) == 4:
                 timerID, tsValue, attachedData, risc = ts
-                if (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_END") or (
-                    risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_END"
+                if (
+                    (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_END")
+                    or (risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_END")
+                    or (risc == "CORE_AGG" and timerID["zone_name"] == "TRACE-FW" and timerID["type"] == "ZONE_END")
                 ):
                     opIsDone = True
             ops[-1]["timeseries"].append(ts)
@@ -541,7 +557,9 @@ def op_core_first_last_analysis(riscData, analysis):
         else:
             core_ops[core] = [ts]
     for core, timeseries in core_ops.items():
-        durations.append(first_last_analysis(timeseries, analysis)[0])
+        ret = first_last_analysis(timeseries, analysis)
+        if len(ret) > 0:
+            durations.append(ret[0])
 
     return durations
 

--- a/tt_metal/tools/profiler/tt_metal_tracy.hpp
+++ b/tt_metal/tools/profiler/tt_metal_tracy.hpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <tt_metal_profiler.hpp>
+
 #if defined(TRACY_ENABLE)
 
 #define TracyTTMetalBeginTrace(device_id, trace_id)                                                 \

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -71,6 +71,13 @@ def main():
         default=False,
     )
     parser.add_option(
+        "--device-trace-profiler",
+        dest="device_trace_profiler",
+        action="store_true",
+        help="Profile device side trace durations",
+        default=[],
+    )
+    parser.add_option(
         "--push-device-data-mid-run",
         dest="mid_run_device_data",
         action="store_true",
@@ -152,6 +159,9 @@ def main():
 
     if options.sync_host_device:
         os.environ["TT_METAL_PROFILER_SYNC"] = "1"
+
+    if options.device_trace_profiler:
+        os.environ["TT_METAL_TRACE_PROFILER"] = "1"
 
     if options.collect_noc_traces:
         os.environ["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"


### PR DESCRIPTION
### Ticket
#19304 

### Problem description

Device profiler does a NOC push to DRAM after each op. In trace runs where dispatch overhead is down to minimum, the overhead becomes significant and results in inaccurate trace start to end measurements. 

### What's changed

We only measure the beginning of the trace FW and Kernel once as the first op in the trace starts. 

We don't know when trace end is coming so all FW and kernel ends for all ops after first op are marked as the end of trace. End marker rewrite over the same location.  Storing all end is very low over head of around 30-20 cycles per op during the time that you still have to wait for the next go msg to come even in the most optimized FD trace replay paths.

When trace is done, we have the duration of the TRACE FW and Kernel recorded in L1.  


Below are tracy runs of normal profiler device profiling vs trace only profiling.

5.91ms normal run
<img width="2131" height="382" alt="Screenshot 2025-08-07 at 9 45 22 AM" src="https://github.com/user-attachments/assets/096fecf5-a527-4f09-90a5-9c3677f0d9ae" />

5.83ms trace only run
<img width="1189" height="266" alt="Screenshot 2025-08-07 at 9 44 35 AM" src="https://github.com/user-attachments/assets/1fd11081-5521-4d6f-b53a-d01c99728fa1" />

That is 80us of difference. The trace is 100 matmuls so that leave **800ns** per op of overhead when cores try to push profiler results though NOC. The init and finish process for profiling each op is also avoided which is also contributing to this number.  

Note that in normal profiler runs kernel and FW duration are still accurate. These overheads all contribute to op2op gap.
### Checklist

- [x] [All post commit - profiler](https://github.com/tenstorrent/tt-metal/actions/runs/16910584885)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16779354940)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/16910591654)
- [x] [Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/16773871787) (Red but nothing regressed because of this commit)
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16761335856)
- [x] [TG Perf](https://github.com/tenstorrent/tt-metal/actions/runs/16658181779)
- [x] [uBench](https://github.com/tenstorrent/tt-metal/actions/runs/16805011500)
