### PR TITLE
Fixed the db report for memory buffers to show correct info

### DIFF
--- a/ttnn/api/ttnn/reports.hpp
+++ b/ttnn/api/ttnn/reports.hpp
@@ -43,6 +43,7 @@ struct BufferInfo {
     uint32_t address;
     uint32_t max_size_per_bank;
     tt::tt_metal::BufferType buffer_type;
+    tt::tt_metal::TensorMemoryLayout buffer_layout;
 };
 
 std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices);

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -72,14 +72,15 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
                 const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();
                 for (size_t core_index = 0; core_index < buffer_page_mapping.all_cores.size(); core_index++) {
                     auto core = buffer_page_mapping.all_cores[core_index];
-                    // For future devs reading this code, I asserted the number of bank_ids_from_logical_core and is
-                    // always 1
-                    auto bank_id = device->allocator()->get_bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
-                    uint32_t bank_num_pages = 0;
-                    for (const auto& core_page_mapping : buffer_page_mapping.core_page_mappings[core_index]) {
-                        bank_num_pages = std::max(bank_num_pages, core_page_mapping.num_pages);
+                    auto banks_per_core =
+                        device->allocator()->get_bank_ids_from_logical_core(buffer->buffer_type(), core);
+                    for (auto bank_id : banks_per_core) {
+                        uint32_t bank_num_pages = 0;
+                        for (const auto& core_page_mapping : buffer_page_mapping.core_page_mappings[core_index]) {
+                            bank_num_pages = std::max(bank_num_pages, core_page_mapping.num_pages);
+                        }
+                        bank_to_num_pages[bank_id] = bank_num_pages;
                     }
-                    bank_to_num_pages[bank_id] = bank_num_pages;
                 }
             }
 

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -72,11 +72,12 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
                 const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();
                 for (size_t core_index = 0; core_index < buffer_page_mapping.all_cores.size(); core_index++) {
                     auto core = buffer_page_mapping.all_cores[core_index];
+                    // For future devs reading this code, I asserted the number of bank_ids_from_logical_core and is
+                    // always 1
                     auto bank_id = device->allocator()->get_bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
                     uint32_t bank_num_pages = 0;
                     for (const auto& core_page_mapping : buffer_page_mapping.core_page_mappings[core_index]) {
-                        bank_num_pages =
-                            std::max(bank_num_pages, core_page_mapping.device_start_page + core_page_mapping.num_pages);
+                        bank_num_pages = std::max(bank_num_pages, core_page_mapping.num_pages);
                     }
                     bank_to_num_pages[bank_id] = bank_num_pages;
                 }
@@ -92,6 +93,7 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
             buffer_info.address = address;
             buffer_info.max_size_per_bank = (*max_num_pages).second * page_size;
             buffer_info.buffer_type = buffer->buffer_type();
+            buffer_info.buffer_layout = buffer->buffer_layout();
             buffer_infos.push_back(buffer_info);
         }
     }

--- a/ttnn/cpp/ttnn-pybind/reports.cpp
+++ b/ttnn/cpp/ttnn-pybind/reports.cpp
@@ -28,8 +28,9 @@ void py_module(py::module& module) {
         .def_property_readonly("address", [](const ttnn::reports::BufferInfo& self) { return self.address; })
         .def_property_readonly(
             "max_size_per_bank", [](const ttnn::reports::BufferInfo& self) { return self.max_size_per_bank; })
-        .def_property_readonly("buffer_type", [](const ttnn::reports::BufferInfo& self) { return self.buffer_type; });
-
+        .def_property_readonly("buffer_type", [](const ttnn::reports::BufferInfo& self) { return self.buffer_type; })
+        .def_property_readonly(
+            "buffer_layout", [](const ttnn::reports::BufferInfo& self) { return self.buffer_layout; });
     module.def("get_buffers", &get_buffers, py::arg("devices"));
     module.def("get_buffers", [](MeshDevice* device) { return get_buffers({device}); }, py::arg("device"));
 

--- a/ttnn/ttnn/database.py
+++ b/ttnn/ttnn/database.py
@@ -55,6 +55,7 @@ class Buffer:
     address: int
     max_size_per_bank: int
     buffer_type: ttnn.BufferType
+    buffer_layout: ttnn.TensorMemoryLayout
 
     def __post_init__(self):
         self.buffer_type = ttnn.BufferType(self.buffer_type) if self.buffer_type is not None else None
@@ -199,7 +200,7 @@ def get_or_create_sqlite_db(report_path):
     )
     cursor.execute(
         """CREATE TABLE IF NOT EXISTS buffers
-                (operation_id int, device_id int, address int, max_size_per_bank int, buffer_type int)"""
+                (operation_id int, device_id int, address int, max_size_per_bank int, buffer_type int, buffer_layout int)"""
     )
     cursor.execute(
         """CREATE TABLE IF NOT EXISTS buffer_pages
@@ -401,7 +402,8 @@ def insert_buffers(report_path, operation_id, devices):
                 {buffer.device_id},
                 {buffer.address},
                 {buffer.max_size_per_bank},
-                {buffer.buffer_type.value}
+                {buffer.buffer_type.value},
+                {buffer.buffer_layout.value if buffer.buffer_layout is not None else 'NULL'}
             )"""
         )
     sqlite_connection.commit()


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/20846)

### Problem description
The calculation of memory for sharded layout was adding the first page address + the page size, giving some numbers that were outside of the range of the memory available

### What's changed
Corrected the max size per bank calculation by removing the addition of the first page address. Also Included a new set of registers in the database to helping developers to identify easily what kind of memory they are dealing with

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes