### PR TITLE
#26445: [skip ci] Handle non-beta tt-ubuntu civ2 runners

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -208,11 +208,12 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         ubuntu_version = None
 
     # Clean up ephemeral runner names
-    if host_name and host_name.startswith("tt-beta"):
+    if host_name and (host_name.startswith("tt-beta") or host_name.startswith("tt-ubuntu")):
         parts = host_name.split("-")
         # Issue: https://github.com/tenstorrent/tt-metal/issues/21694
-        # Remove non-constant ephemeral runner suffix from tt-beta runner names only if the second last part is "runner"
-        # We don't want to remove the suffix for non-ephemeral tt-beta runners (e.g. tt-beta-ubuntu-2204-xlarge)
+        # Issue: https://github.com/tenstorrent/tt-metal/issues/26445
+        # Remove non-constant ephemeral runner suffix from tt-beta/tt-ubuntu runner names only if the second last part is "runner"
+        # We don't want to remove the suffix for non-ephemeral runners (e.g. tt-beta-ubuntu-2204-xlarge)
         # E.g. tt-beta-ubuntu-2204-n150-large-stable-nk6pd-runner-5g5f9 -> tt-beta-ubuntu-2204-n150-large-stable-nk6pd
         if len(parts) >= 2 and parts[-2] == "runner":
             host_name = "-".join(parts[:-1])


### PR DESCRIPTION
### Ticket
Fixes #26445 

### Problem description
We have new CIv2 runners without the `tt-beta` prefix

### What's changed
Add support for `tt-ubuntu` runners

### Checklist
- [ ] New/Existing tests provide coverage for changes