### PR TITLE
#24171: Add tensor placement information to TensorTopology

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(
         core/distributed/api.cpp
         core/distributed/distributed_tensor.cpp
         core/distributed/distributed_tensor_config.cpp
+        core/distributed/distributed_configs.cpp
         core/distributed/tensor_topology.cpp
         core/events.cpp
         core/global_circular_buffer.cpp

--- a/ttnn/api/ttnn/distributed/distributed_configs.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_configs.hpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <ostream>
+#include <variant>
+#include <tt_stl/small_vector.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+
+namespace tt::tt_metal::distributed {
+
+struct MeshMapperConfig {
+    // Specifies the tensor should be replicated across devices.
+    struct Replicate {
+        bool operator==(const Replicate&) const = default;
+    };
+
+    // Specifies the tensor should be sharded along the specified dimension.
+    struct Shard {
+        int dim = 0;
+        bool operator==(const Shard&) const = default;
+    };
+
+    // Specifies placements for each dimension of the shape.
+    // The size of `placements` must match the dimensions of the shape.
+    //
+    // For example, sharding a 2x8 tensor over 2x2 mesh with {Replicate(), Shard{1}} will yield the following result:
+    //
+    //    Input Tensor [2, 8]:
+    // +----+----+----+----+----+----+---+-----+
+    // |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |
+    // |----+----+----+----+----+----+---+-----+
+    // |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 |
+    // +----+----+----+----+----+----+---+-----+
+    //
+    //    Shape [2, 2]:
+    // +-------+-------+
+    // | (0,0) | (0,1) |
+    // +-------+-------+
+    // | (1,0) | (1,1) |
+    // +-------+-------+
+    //
+    // Distributed Tensor on Mesh (placements = {Replicate{}, Shard{1}}):
+    //
+    // +-----------------------------+-----------------------------+
+    // |     (0,0)                   |     (0,1)                   |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  0 |  1 |  2 |  3 |    |    |  4 |  5 |  6 |  7 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  8 |  9 | 10 | 11 |    |    | 12 | 13 | 14 | 15 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // +-----------------------------+-----------------------------+
+    // |     (1,0)                   |     (1,1)                   |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  0 |  1 |  2 |  3 |    |    |  4 |  5 |  6 |  7 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  8 |  9 | 10 | 11 |    |    | 12 | 13 | 14 | 15 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // +-----------------------------+-----------------------------+
+    //
+
+    using Placement = std::variant<Replicate, Shard>;
+    tt::stl::SmallVector<Placement> placements;
+
+    // If provided, the sharding will be performed according to this shape, but re-mapped to the mesh device shape in
+    // either row-major order, or preserving the original coordinates (if the shape fits within the mesh device
+    // entirely).
+    std::optional<tt::tt_metal::distributed::MeshShape> mesh_shape_override = std::nullopt;
+};
+
+bool operator==(const MeshMapperConfig::Placement& lhs, const MeshMapperConfig::Placement& rhs);
+std::ostream& operator<<(std::ostream& os, const MeshMapperConfig::Placement& placement);
+std::ostream& operator<<(std::ostream& os, const MeshMapperConfig& config);
+
+struct MeshComposerConfig {
+    // Specifies dimension of the tensor to concatenate.
+    tt::stl::SmallVector<int> dims;
+
+    // If provided, the concatenation will be performed according to this shape, but re-mapped to the mesh device shape
+    // in either row-major order, or preserving the original coordinates (if the shape fits within the mesh device
+    // entirely).
+    std::optional<tt::tt_metal::distributed::MeshShape> mesh_shape_override = std::nullopt;
+};
+
+std::ostream& operator<<(std::ostream& os, const MeshComposerConfig& config);
+
+}  // namespace tt::tt_metal::distributed

--- a/ttnn/api/ttnn/distributed/tensor_topology.hpp
+++ b/ttnn/api/ttnn/distributed/tensor_topology.hpp
@@ -6,19 +6,26 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 
+#include "ttnn/distributed/distributed_configs.hpp"
+
 namespace tt::tt_metal {
 class TensorTopology {
 public:
     TensorTopology() :
         mesh_shape_(tt::tt_metal::distributed::MeshShape{1}),
+        placements_({tt::tt_metal::distributed::MeshMapperConfig::Replicate{}}),
         mesh_coords_({tt::tt_metal::distributed::MeshCoordinate{0}}) {}
 
     TensorTopology(
         tt::tt_metal::distributed::MeshShape mesh_shape,
+        tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements,
         std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords) :
-        mesh_shape_(std::move(mesh_shape)), mesh_coords_(std::move(mesh_coords)) {}
+        mesh_shape_(std::move(mesh_shape)), placements_(std::move(placements)), mesh_coords_(std::move(mesh_coords)) {}
 
     const tt::tt_metal::distributed::MeshShape& mesh_shape() const { return mesh_shape_; }
+    const tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>& placements() const {
+        return placements_;
+    }
     const std::vector<tt::tt_metal::distributed::MeshCoordinate>& mesh_coords() const { return mesh_coords_; }
 
     tt::tt_metal::distributed::MeshCoordinate get_neighbor(
@@ -35,6 +42,7 @@ public:
 
 private:
     tt::tt_metal::distributed::MeshShape mesh_shape_;
+    tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements_;
     std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords_;
 };
 

--- a/ttnn/core/distributed/distributed_configs.cpp
+++ b/ttnn/core/distributed/distributed_configs.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/distributed/distributed_configs.hpp"
+#include <tt_stl/overloaded.hpp>
+
+namespace tt::tt_metal::distributed {
+
+std::ostream& operator<<(std::ostream& os, const MeshMapperConfig::Placement& placement) {
+    std::visit(
+        tt::stl::overloaded{
+            [&](const MeshMapperConfig::Replicate& replicate) { os << "PlacementReplicate()"; },
+            [&](const MeshMapperConfig::Shard& shard) { os << "PlacementShard(" << shard.dim << ")"; },
+        },
+        placement);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const MeshMapperConfig& config) {
+    os << "MeshMapperConfig(";
+    os << "placements: [";
+    for (int i = 0; i < config.placements.size(); ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        os << config.placements[i];
+    }
+    os << "]";
+    if (config.mesh_shape_override.has_value()) {
+        os << ", mesh_shape_override=" << *config.mesh_shape_override;
+    }
+    os << ")";
+    return os;
+}
+
+bool operator==(const MeshMapperConfig::Placement& lhs, const MeshMapperConfig::Placement& rhs) {
+    return std::visit(
+        tt::stl::overloaded{
+            [&](const MeshMapperConfig::Replicate& l, const MeshMapperConfig::Replicate& r) { return l == r; },
+            [&](const MeshMapperConfig::Shard& l, const MeshMapperConfig::Shard& r) { return l == r; },
+            [&](const auto&, const auto&) { return false; },  // Different types are never equal
+        },
+        lhs,
+        rhs);
+}
+
+std::ostream& operator<<(std::ostream& os, const MeshComposerConfig& config) {
+    os << "MeshComposerConfig(";
+    os << "dims: [";
+    for (int i = 0; i < config.dims.size(); ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        os << config.dims[i];
+    }
+    os << "]";
+    if (config.mesh_shape_override.has_value()) {
+        os << ", mesh_shape_override=" << *config.mesh_shape_override;
+    }
+    os << ")";
+    return os;
+}
+
+}  // namespace tt::tt_metal::distributed


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24171)

### Problem description
Lowering `MeshMapperConfig` to metal so that we can add it as a property of `TensorTopology`. This helps describe full topology metadata for created tensors.

### What's changed
- Move MeshMapperConfig to tt::tt_metal namespace
- Add comparator operator for MeshMapperConfig::Placement
- Update tests to check placements for TensorTopology

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16814034210
  - [ ] T3k: https://github.com/tenstorrent/tt-metal/actions/runs/16814039844
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes