### PR TITLE
cleanup fabric addrgen APIs to remove duplicate implementation

### DIFF
--- a/tt_metal/fabric/hw/inc/linear/addrgen_api.h
+++ b/tt_metal/fabric/hw/inc/linear/addrgen_api.h
@@ -27,13 +27,13 @@ uint32_t get_page_size(const InterleavedAddrGenFast<DRAM>& s) {
 
 // Placeholder max page size for the addrgen until the page size is properly visible by the worker
 // https://github.com/tenstorrent/tt-metal/issues/25966
-static constexpr uint32_t max_fabric_addrgen_page_size = 2048;
+static constexpr uint32_t max_fabric_addrgen_page_size = 4532;
 
-FORCE_INLINE void validate_max_page_size(uint32_t page_size) {
+FORCE_INLINE void validate_max_payload_size(uint32_t payload_size) {
     ASSERT((page_size > max_fabric_addrgen_page_size));
-    if ((page_size > max_fabric_addrgen_page_size)) {
+    if ((payload_size > max_fabric_addrgen_page_size)) {
         WAYPOINT("HUNG");
-        // hang to promopt investigation
+        // hang to prompt investigation
         while (1) {
         }
     }
@@ -42,13 +42,11 @@ FORCE_INLINE void validate_max_page_size(uint32_t page_size) {
 template <typename AddrGenType>
 FORCE_INLINE void to_noc_unicast_write(
     volatile PACKET_HEADER_TYPE* pkt_hdr, const uint32_t id, const AddrGenType& d, uint32_t offset = 0) {
-    pkt_hdr->noc_send_type = NOC_UNICAST_WRITE;
-
-    pkt_hdr->command_fields.unicast_write.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
+    auto noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
     auto page_size = addrgen_detail::get_page_size(d);
-    pkt_hdr->payload_size_bytes = page_size;
+    pkt_hdr->to_noc_unicast_write(NocUnicastCommandHeader{noc_address}, page_size);
 
-    validate_max_page_size(page_size);
+    validate_max_payload_size(page_size);
 }
 
 template <typename AddrGenType>
@@ -58,18 +56,15 @@ FORCE_INLINE void to_noc_fused_unicast_write_atomic_inc(
     const uint32_t id,
     const AddrGenType& d,
     uint32_t offset = 0) {
-    pkt_hdr->noc_send_type = NOC_FUSED_UNICAST_ATOMIC_INC;
+    auto page_size = addrgen_detail::get_page_size(d);
+    auto noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
 
-    auto page_size = addrgen_detail::get_page_size(d, offset, edm_to_local_chip_noc);
-    pkt_hdr->payload_size_bytes = page_size;
+    pkt_hdr->to_noc_fused_unicast_write_atomic_inc(
+        NocUnicastAtomicIncFusedCommandHeader(
+            noc_address, atomic_inc_spec.noc_address, atomic_inc_spec.val, atomic_inc_spec.wrap, atomic_inc_spec.flush),
+        page_size);
 
-    pkt_hdr->command_fields.unicast_seminc_fused.noc_address = d.get_noc_addr(id, offset, edm_to_local_chip_noc);
-    pkt_hdr->command_fields.unicast_seminc_fused.semaphore_noc_address = atomic_inc_spec.noc_address;
-    pkt_hdr->command_fields.unicast_seminc_fused.val = atomic_inc_spec.val;
-    pkt_hdr->command_fields.unicast_seminc_fused.wrap = atomic_inc_spec.wrap;
-    pkt_hdr->command_fields.unicast_seminc_fused.flush = atomic_inc_spec.flush;
-
-    validate_max_page_size(page_size);
+    validate_max_payload_size(page_size);
 }
 
 template <typename AddrGenType>
@@ -80,17 +75,16 @@ FORCE_INLINE void to_noc_unicast_scatter_write(
     const AddrGenType& d,
     uint32_t offset0 = 0,
     uint32_t offset1 = 0) {
-    pkt_hdr->noc_send_type = NOC_UNICAST_SCATTER_WRITE;
-
     auto page_size = addrgen_detail::get_page_size(d);
     auto payload_size = page_size * 2;
-    pkt_hdr->payload_size_bytes = payload_size;
 
-    pkt_hdr->command_fields.unicast_scatter_write.noc_address[0] = d.get_noc_addr(id0, offset0, edm_to_local_chip_noc);
-    pkt_hdr->command_fields.unicast_scatter_write.noc_address[1] = d.get_noc_addr(id1, offset1, edm_to_local_chip_noc);
-    pkt_hdr->command_fields.unicast_scatter_write.chunk_size[0] = page_size;
+    auto noc_address0 = d.get_noc_addr(id0, offset0, edm_to_local_chip_noc);
+    auto noc_address1 = d.get_noc_addr(id1, offset1, edm_to_local_chip_noc);
 
-    validate_max_page_size(payload_size);
+    pkt_hdr->to_noc_unicast_scatter_write(
+        NocUnicastScatterCommandHeader({{noc_address0, noc_address1}, static_cast<uint16_t>(page_size)}), payload_size);
+
+    validate_max_payload_size(payload_size);
 }
 
 }  // namespace linear

--- a/tt_metal/fabric/hw/inc/linear/addrgen_api.h
+++ b/tt_metal/fabric/hw/inc/linear/addrgen_api.h
@@ -27,11 +27,11 @@ uint32_t get_page_size(const InterleavedAddrGenFast<DRAM>& s) {
 
 // Placeholder max page size for the addrgen until the page size is properly visible by the worker
 // https://github.com/tenstorrent/tt-metal/issues/25966
-static constexpr uint32_t max_fabric_addrgen_page_size = 4532;
+static constexpr uint32_t max_fabric_addrgen_payload_size = 4532;
 
 FORCE_INLINE void validate_max_payload_size(uint32_t payload_size) {
-    ASSERT((page_size > max_fabric_addrgen_page_size));
-    if ((payload_size > max_fabric_addrgen_page_size)) {
+    ASSERT((page_size > max_fabric_addrgen_payload_size));
+    if ((payload_size > max_fabric_addrgen_payload_size)) {
         WAYPOINT("HUNG");
         // hang to prompt investigation
         while (1) {


### PR DESCRIPTION
also fix a buggy assertion

The previous version had a bug for scatter write and also some duplicated code. This resolves both of those issues.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/16810527019
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/16810530032