### PR TITLE
#26442: Skip Fabric1DFixture.TestLinearFabricUnicastNocInlineWrite1D for BH LLMBox tests

### DIFF
--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -31,7 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*-Fabric1DFixture.TestLinearFabricUnicast*" },
+          # Skip TestLinearFabricUnicastNocInlineWrite1D due to hang in CI: https://github.com/tenstorrent/tt-metal/issues/26442
+          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*-Fabric1DFixture.TestLinearFabricUnicastNocInlineWrite1D*" },
           {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
           {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
           {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },

--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -33,10 +33,10 @@ jobs:
         test-group: [
           # Skip TestLinearFabricUnicastNocInlineWrite1D due to hang in CI: https://github.com/tenstorrent/tt-metal/issues/26442
           {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*-Fabric1DFixture.TestLinearFabricUnicastNocInlineWrite1D*" },
-          # {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
-          # {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
-          # {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
-          # {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },
+          {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
+          {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
+          {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
+          {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },
           # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}

--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*" },
+          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*-Fabric1DFixture.TestLinearFabricUnicast*" },
           {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
           {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
           {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },

--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -33,10 +33,10 @@ jobs:
         test-group: [
           # Skip TestLinearFabricUnicastNocInlineWrite1D due to hang in CI: https://github.com/tenstorrent/tt-metal/issues/26442
           {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*-Fabric1DFixture.TestLinearFabricUnicastNocInlineWrite1D*" },
-          {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
-          {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
-          {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
-          {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },
+          # {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
+          # {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
+          # {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
+          # {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },
           # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -75,7 +75,7 @@ test_suite_bh_multi_pcie_metal_unit_tests() {
     echo "[upstream-tests] Running BH LLMBox metal unit tests"
 
     ./build/test/tt_metal/tt_fabric/test_system_health
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*-Fabric1DFixture.TestLinearFabricUnicastNocInlineWrite1D*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/unit_tests_eth
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26442)

### Problem description
Test is hanging on BH nightly and upstream tests

### What's changed
Test skipped

### Checklist
- [x] BH LLMBox unit test: https://github.com/tenstorrent/tt-metal/actions/runs/16813137518/job/47624710229