### PR TITLE
Fix memory initialization bug in DeviceOperation

### DIFF
--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -952,7 +952,7 @@ public:
     ~DeviceOperation() { this->destruct(); }
 
 private:
-    storage_t type_erased_storage{};
+    alignas(max_align_t) storage_t type_erased_storage{};
     void* pointer = nullptr;
 
     void (*delete_storage)(storage_t&) = nullptr;

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -953,7 +953,7 @@ public:
 
 private:
     alignas(32) void* pointer = nullptr;
-    alignas(32) storage_t type_erased_storage;
+    alignas(32) storage_t type_erased_storage{};
 
     void (*delete_storage)(storage_t&) = nullptr;
     void* (*copy_storage)(storage_t& storage, const void*) = nullptr;

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -952,8 +952,8 @@ public:
     ~DeviceOperation() { this->destruct(); }
 
 private:
-    alignas(32) void* pointer = nullptr;
     alignas(32) storage_t type_erased_storage{};
+    alignas(32) void* pointer = nullptr;
 
     void (*delete_storage)(storage_t&) = nullptr;
     void* (*copy_storage)(storage_t& storage, const void*) = nullptr;

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -952,8 +952,8 @@ public:
     ~DeviceOperation() { this->destruct(); }
 
 private:
-    alignas(32) storage_t type_erased_storage{};
-    alignas(32) void* pointer = nullptr;
+    storage_t type_erased_storage{};
+    void* pointer = nullptr;
 
     void (*delete_storage)(storage_t&) = nullptr;
     void* (*copy_storage)(storage_t& storage, const void*) = nullptr;


### PR DESCRIPTION
### Ticket
Addressing failure exposed by #26175

### Problem description
`type_erased_storage` was not always being initialized.  But when updated to guarantee initialization [this test](https://github.com/tenstorrent/tt-metal/actions/runs/16809798874/job/47613083228#step:7:116) would fail.
This was a result of the copy c'tor processing the storage when initializing `pointer`, which is done before the storage is initialized.  The results in the initialization of storage clobbering the copied value.

### What's changed
Guarantee initialization of `type_erased_storage`, but also ensure that its initialization always comes _before_ `pointer`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16816384469)