### PR TITLE
[skip ci] Remove 'nice' relic from the past

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -264,7 +264,7 @@ jobs:
       - name: 🛠️ Compile
         run: |
           # --target install is for the tarball that should get replaced by proper packaging later
-          nice -19 cmake --build build --target install
+          cmake --build build --target install
 
       - name: 🛠️ Profile
         if: ${{ inputs.profile }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: 🛠️ Baseline Build
         if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
         run: |
-          nice -n 19 cmake --build --preset clang-tidy
+          cmake --build --preset clang-tidy
 
       - name: Publish Ccache summary
         if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: 🔍 Analyze code with clang-tidy
         run: |
-          nice -n 19 cmake --build --preset clang-tidy
+          cmake --build --preset clang-tidy
 
       - name: Publish Ccache summary
         run: |


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Previously CI squatted on some Dev machines and we tried to be a background task.
Now we have dedicated machines and we are the main event.

### What's changed
Stop nice'ing our build jobs.