### PR TITLE
Successfully Skipping Galaxy LLaMA 70B Model Perf Tests on TG Model Perf Pipeline

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -35,16 +35,15 @@ jobs:
             save-perf-data: false,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },  # Pavle Josipovic
-          {
-            name: "Galaxy Llama 70B model perf tests",
-            if: false, #see GH issue #26295
-            model-type: "Llama-70B",
-            arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
-            save-perf-data: true,
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
-            owner_id: U053W15B6JF # Djordje Ivanovic
-          },
+          # {
+          #   name: "Galaxy Llama 70B model perf tests", #see GH issue #26295
+          #   model-type: "Llama-70B",
+          #   arch: wormhole_b0,
+          #   runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
+          #   save-perf-data: true,
+          #   cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
+          #   owner_id: U053W15B6JF # Djordje Ivanovic
+          # },
           {
             name: "Llama Galaxy Perf Unit Tests",
             arch: wormhole_b0,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26295

### Problem description
We've observed this test failing multiple times over the past several weeks. We have commented out the test for now for the devs to fix the error. There was another PR that tried to skip the test (https://github.com/tenstorrent/tt-metal/pull/26302) however it did not actually do as intended so this PR will now successfully get the test skipped. First observed failure: https://github.com/tenstorrent/tt-metal/actions/runs/16524022176/job/46733193541#step:9:1244

### What's changed
This change skips over the galaxy llama 70b model perf tests on TG model perf pipeline

### Checklist
- [ ] [TG model perf](https://github.com/tenstorrent/tt-metal/actions/runs/16813269119)