### PR TITLE
[skip ci] Reducing TG runs on labels to reduce queue times in TG pipelines

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -36,9 +36,7 @@ jobs:
         ]
     runs-on:
       - arch-wormhole_b0
-      - ${{ inputs.topology }}
-      - bare-metal
-      - pipeline-functional
+      - config-tg
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/tg-frequent-tests-impl.yaml
+++ b/.github/workflows/tg-frequent-tests-impl.yaml
@@ -35,9 +35,7 @@ jobs:
         ]
     runs-on:
       - arch-wormhole_b0
-      - ${{ inputs.topology }}
-      - bare-metal
-      - pipeline-functional
+      - config-tg
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
             name: "Galaxy CNN model perf tests",
             model-type: "CNN",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
             save-perf-data: false,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },  # Pavle Josipovic
@@ -40,7 +40,7 @@ jobs:
             if: false, #see GH issue #26295
             model-type: "Llama-70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
             save-perf-data: true,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U053W15B6JF # Djordje Ivanovic
@@ -51,7 +51,7 @@ jobs:
             cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests',
             timeout: 100,
             tracy: true,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
             save-perf-data: true,
             owner_id: U071CKL4AFK # Ammar Vora
           },
@@ -59,7 +59,7 @@ jobs:
             name: "Galaxy Llama 70B prefill perf tests",
             model-type: "Llama-70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
             save-perf-data: true,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_prefill_model_perf_tg_device --dispatch-mode ""',
             owner_id: U03PUAKE719 # Miguel Tairum
@@ -68,7 +68,7 @@ jobs:
             name: "Galaxy DiT SD3.5 model perf tests",
             model-type: "SD3.5",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
             save-perf-data: true,
             cmd: 'TT_MM_THROTTLE_PERF=5 pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "tg_cfg2_sp4_tp4"',
             owner_id: U03FJB5TM5Y # Colman Glagovich

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
             name: "Galaxy CNN model perf tests",
             model-type: "CNN",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
             save-perf-data: false,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },  # Pavle Josipovic
@@ -40,7 +40,7 @@ jobs:
             if: false, #see GH issue #26295
             model-type: "Llama-70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
             save-perf-data: true,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U053W15B6JF # Djordje Ivanovic
@@ -51,7 +51,7 @@ jobs:
             cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests',
             timeout: 100,
             tracy: true,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
             save-perf-data: true,
             owner_id: U071CKL4AFK # Ammar Vora
           },
@@ -59,7 +59,7 @@ jobs:
             name: "Galaxy Llama 70B prefill perf tests",
             model-type: "Llama-70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
             save-perf-data: true,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_prefill_model_perf_tg_device --dispatch-mode ""',
             owner_id: U03PUAKE719 # Miguel Tairum
@@ -68,7 +68,7 @@ jobs:
             name: "Galaxy DiT SD3.5 model perf tests",
             model-type: "SD3.5",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
             save-perf-data: true,
             cmd: 'TT_MM_THROTTLE_PERF=5 pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "tg_cfg2_sp4_tp4"',
             owner_id: U03FJB5TM5Y # Colman Glagovich

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -88,9 +88,7 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on:
       - arch-wormhole_b0
-      - ${{ inputs.topology }}
-      - bare-metal
-      - pipeline-functional
+      - config-tg
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image }}


### PR DESCRIPTION
### Problem description
Due to high queue times, we're removing some unnecessary runs on labels to see if that may help.

### What's changed
The runs on labels were just reduced to:
      - arch-wormhole_b0
      - config-tg
      - ${{ inputs.extra-tag }}