### PR TITLE
Re-enable int32 Transpose tests

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -85,12 +85,12 @@ def test_fold_transpose(device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
     ],
 )
@@ -127,12 +127,12 @@ def test_transpose_wh_bfp4(device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
     ],
 )
@@ -165,12 +165,12 @@ def test_transpose_hc_program_cache(dtype, device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
     ],
 )
@@ -194,13 +194,13 @@ def test_transpose_cn_program_cache(dtype, device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
         ttnn.bfloat8_b,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
         "bfloat8_b",
     ],
@@ -236,12 +236,12 @@ def test_transpose_wh_program_cache(dtype, device):
     "dtype",
     (
         ttnn.bfloat8_b,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat8_b",
-        # "int32",
+        "int32",
         "float",
     ],
 )
@@ -678,12 +678,12 @@ def test_transpose_bfloat8_b(device, shape, swap_dims):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
     ],
 )
@@ -701,12 +701,12 @@ def test_transpose_hc(dtype, shape, device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
     ],
 )
@@ -734,12 +734,12 @@ def test_transpose_2D(dtype, shape, layout, device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32, issue 24704
+        ttnn.int32,
         ttnn.float32,
     ),
     ids=[
         "bfloat16",
-        # "int32",
+        "int32",
         "float",
     ],
 )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24727)

### Problem description
LLK race condition fixed, transpose tests need to be reenabled

### What's changed
Just uncommented the now passing tests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16816910098) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16816913942) CI with demo tests passes (if applicable)
