### PR TITLE
#25975: Port embedding and embedding_backward kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -223,13 +223,13 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_fused(
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)src2_cb_index,
-        (std::uint32_t)in0_is_dram,
         (std::uint32_t)input_page_size,
-        (std::uint32_t)weights_is_dram,
         (std::uint32_t)weight_page_size,
         (std::uint32_t)weight_block_size,
         (std::uint32_t)num_tiles_per_block,
         (std::uint32_t)input_block_size_bytes};
+    TensorAccessorArgs(*a.buffer()).append_to(embedding_compile_time_args);
+    TensorAccessorArgs(*weights.buffer()).append_to(embedding_compile_time_args);
 
     std::map<std::string, std::string> embedding_defines = {
         {enchantum::to_string(embeddings_type).data(), "1"},
@@ -495,12 +495,12 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
         (std::uint32_t)out_cb_index,
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)src2_cb_index,
-        (std::uint32_t)in0_is_dram,
         (std::uint32_t)input_page_size,
-        (std::uint32_t)weights_is_dram,
         (std::uint32_t)weight_page_size,
         (std::uint32_t)block_height,
         (std::uint32_t)block_height * input_element_size_bytes};
+    TensorAccessorArgs(*a.buffer()).append_to(embedding_compile_time_args);
+    TensorAccessorArgs(*weights.buffer()).append_to(embedding_compile_time_args);
 
     EmbeddingsIndexType embeddings_index_type;
     if (a.dtype() == DataType::BFLOAT16) {
@@ -715,12 +715,12 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_tilized_indices(
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)src2_cb_index,
-        (std::uint32_t)in0_is_dram,
         (std::uint32_t)input_page_size,
-        (std::uint32_t)weights_is_dram,
         (std::uint32_t)weight_page_size,
         (std::uint32_t)a.logical_shape()[-1],  // width/length of a row
         (std::uint32_t)FACE_HEIGHT};
+    TensorAccessorArgs(*a.buffer()).append_to(embedding_compile_time_args);
+    TensorAccessorArgs(*weights.buffer()).append_to(embedding_compile_time_args);
 
     EmbeddingsIndexType embeddings_index_type;
     if (a.dtype() == DataType::BFLOAT16) {

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
@@ -20,16 +20,15 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
 
-    constexpr bool input_in_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
-    const auto input = get_interleaved_addr_gen<input_in_dram, input_page_size>(input_buffer_src_addr);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t weight_stick_size = get_compile_time_arg_val(4);
+    constexpr uint32_t row_length = get_compile_time_arg_val(5);
+    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(6);
 
-    constexpr bool weight_in_dram = get_compile_time_arg_val(5) == 1;
-    constexpr uint32_t weight_stick_size = get_compile_time_arg_val(6);
-    const auto weights = get_interleaved_addr_gen<weight_in_dram, weight_stick_size>(weight_buffer_src_addr);
-
-    constexpr uint32_t row_length = get_compile_time_arg_val(7);
-    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(8);
+    constexpr auto input_args = TensorAccessorArgs<7>();
+    constexpr auto weights_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    const auto input = TensorAccessor(input_args, input_buffer_src_addr, input_page_size);
+    const auto weights = TensorAccessor(weights_args, weight_buffer_src_addr, weight_stick_size);
 
     constexpr uint32_t face_size = 16;
     constexpr uint32_t tile_height = 32;
@@ -39,7 +38,6 @@ void kernel_main() {
     cb_reserve_back(cb_id_in1, 1);
     uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
     const uint32_t tile_size_bytes = get_tile_size(cb_id_in1);
-    const DataFormat data_format = get_dataformat(cb_id_in1);
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
     auto read_block = [&](const uint32_t& token_idx, const uint32_t& width_size, const uint32_t& offset = 0) {
@@ -85,11 +83,7 @@ void kernel_main() {
     bool read_indices = true;
     uint32_t col_offset = curr_col;
     uint32_t tiles_per_row = (row_length + tile_height - 1) / tile_height;
-    const InterleavedAddrGenFast<true> s = {
-        .bank_base_address = input_buffer_src_addr,
-        .page_size = tile_size_bytes,
-        .data_format = data_format,
-    };
+    const auto s = TensorAccessor(input_args, input_buffer_src_addr, tile_size_bytes);
 
     for (uint32_t i = 0; i < num_rows; ++i) {
         if (read_indices) {

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
@@ -18,16 +18,16 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
 
-    constexpr bool input_in_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
-    const auto input = get_interleaved_addr_gen<input_in_dram, input_page_size>(input_buffer_src_addr);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t weight_stick_size = get_compile_time_arg_val(4);
 
-    constexpr bool weight_in_dram = get_compile_time_arg_val(5) == 1;
-    constexpr uint32_t weight_stick_size = get_compile_time_arg_val(6);
-    const auto weights = get_interleaved_addr_gen<weight_in_dram, weight_stick_size>(weight_buffer_src_addr);
+    constexpr uint32_t rows_per_block = get_compile_time_arg_val(5);  // Input elems per block
+    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(6);
 
-    constexpr uint32_t rows_per_block = get_compile_time_arg_val(7);  // Input elems per block
-    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(8);
+    constexpr auto input_args = TensorAccessorArgs<7>();
+    constexpr auto weights_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    const auto input = TensorAccessor(input_args, input_buffer_src_addr, input_page_size);
+    const auto weights = TensorAccessor(weights_args, weight_buffer_src_addr, weight_stick_size);
 
     prepare_local_cache(cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
 

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -17,17 +17,16 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
 
-    constexpr bool input_in_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
-    auto input = get_interleaved_addr_gen<input_in_dram, input_page_size>(input_buffer_src_addr);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t weight_stick_size = get_compile_time_arg_val(4);
+    constexpr uint32_t weight_block_size = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(6);
+    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(7);
 
-    constexpr bool weight_in_dram = get_compile_time_arg_val(5) == 1;
-    constexpr uint32_t weight_stick_size = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_size = get_compile_time_arg_val(7);
-    auto weights = get_interleaved_addr_gen<weight_in_dram, weight_stick_size>(weight_buffer_src_addr + weight_offset);
-
-    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(8);
-    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(9);
+    constexpr auto input_args = TensorAccessorArgs<8>();
+    constexpr auto weights_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    auto input = TensorAccessor(input_args, input_buffer_src_addr, input_page_size);
+    auto weights = TensorAccessor(weights_args, weight_buffer_src_addr + weight_offset, weight_stick_size);
 
     prepare_local_cache(cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6);
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
 
 using namespace tt;
@@ -103,22 +104,17 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
 
     // reader
 
-    bool index_stick_size_is_power_of_two = is_power_of_two_at_least_32(index_page_size);
-    uint32_t index_log2_stick_size = index_stick_size_is_power_of_two ? std::log2(index_page_size) : 0;
-
     std::vector<uint32_t> reader_compile_time_args = {
-        grad_is_dram,
-        index_is_dram,
-        out_is_dram,
-        index_page_size,
-        index_stick_size_is_power_of_two,
-        index_log2_stick_size,
-        index_tensor.dtype() == DataType::BFLOAT16,  // TODO: Only supports either BFLOAT16 or UINT32
-        output.dtype() == DataType::BFLOAT16,        // TODO: Only supports either BFLOAT16 or BFLOAT8_B
-        max_tiles_per_core,
-        batch_size,
-        seq_len_tiles,
-        num_embeddings_tiles};
+        (uint32_t)max_tiles_per_core,
+        (uint32_t)batch_size,
+        (uint32_t)seq_len_tiles,
+        (uint32_t)num_embeddings_tiles,
+        (uint32_t)index_page_size,
+        (uint32_t)(index_tensor.dtype() == DataType::BFLOAT16),
+        (uint32_t)(output.dtype() == DataType::BFLOAT16)};
+    TensorAccessorArgs(*grad_tensor_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*index_tensor_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*out_buffer).append_to(reader_compile_time_args);
 
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
Refactored embedding and embedding_backward kernels to use TensorAccessor

This PR was generated by AI: Cursor + GPT5-Max using this [prompt](https://gist.github.com/sminakov-tt/4a781b688d9bc679c78e431df3148feb).

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16817227917)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/16817232867)
- [x] New/Existing tests provide coverage for changes