### PR TITLE
MoE Decoder Functional

### DIFF
--- a/.github/workflows/tg-deepseek-tests-impl.yaml
+++ b/.github/workflows/tg-deepseek-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "Galaxy DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 90, owner_id: U03HY7MK4BT}, # Mark O'Connor
         ]
     runs-on:
       - arch-wormhole_b0

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 import pytest
+import torch
 from loguru import logger
 from transformers import AutoConfig
 
@@ -92,3 +93,13 @@ def ccl(mesh_device):
     This is used to test distributed operations in DeepSeek modules.
     """
     return CCL1D(mesh_device)
+
+
+@pytest.fixture(scope="function")
+def set_deterministic_env():
+    """
+    Fixture to set seeds and enable deterministic algorithms for DeepSeek tests.
+    This ensures reproducible results across test runs.
+    """
+    torch.manual_seed(5)
+    torch.use_deterministic_algorithms(True)

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -67,7 +67,7 @@ def test_forward_pass(
     mesh_device,
     model_path,
     ccl,
-    reset_seeds,
+    set_deterministic_env,
 ):
     mesh_shape = list(mesh_device.shape)
     num_rows, sdpa_dp_factor = mesh_shape
@@ -79,8 +79,6 @@ def test_forward_pass(
     ############################
     logger.info("Setting up reference model")
     if module_path is None:
-        # This is needed to make the reference model weights initialization deterministic
-        torch.use_deterministic_algorithms(True)
         reference_model = DeepseekV3DecoderLayer(hf_config, layer_idx=reference_layer_idx).eval()
         # This needs to be disabled as deterministic way to quantize weights is not supported
         torch.use_deterministic_algorithms(False)

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
-
 from random import randint
 
 import pytest
@@ -11,6 +10,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3DecoderLayer
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block import DecoderBlock
+from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block import MoEDecoderBlock
 from models.demos.deepseek_v3.tt.mla_1d import MLA1D
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.reference_forwards import reference_forward_decode as reference_forward
@@ -31,14 +31,6 @@ def hf_config(hf_config):
     return hf_config
 
 
-def load_reference_model(hf_config, layer_idx):
-    """Load the reference model for testing."""
-
-    model = DeepseekV3DecoderLayer(hf_config, layer_idx=layer_idx).eval()
-
-    return model
-
-
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -50,7 +42,7 @@ def load_reference_model(hf_config, layer_idx):
     "DecoderBlockClass, module_path, reference_layer_idx",
     [
         (DecoderBlock, None, 0),
-        # (MoEDecoderBlock, None, 3), # TODO: Uncomment once PCC is fixed for MoE
+        (MoEDecoderBlock, None, 3),
         # (DecoderBlock, "model.layers.0", None),
         # (MoEDecoderBlock, "model.layers.3", None), # TODO: Uncomment once PCC is fixed for MoE
     ],
@@ -75,6 +67,7 @@ def test_forward_pass(
     mesh_device,
     model_path,
     ccl,
+    reset_seeds,
 ):
     mesh_shape = list(mesh_device.shape)
     num_rows, sdpa_dp_factor = mesh_shape
@@ -86,7 +79,11 @@ def test_forward_pass(
     ############################
     logger.info("Setting up reference model")
     if module_path is None:
-        reference_model = load_reference_model(hf_config, reference_layer_idx)
+        # This is needed to make the reference model weights initialization deterministic
+        torch.use_deterministic_algorithms(True)
+        reference_model = DeepseekV3DecoderLayer(hf_config, layer_idx=reference_layer_idx).eval()
+        # This needs to be disabled as deterministic way to quantize weights is not supported
+        torch.use_deterministic_algorithms(False)
         state_dict = add_inv_scale_to_state_dict(
             reference_model.to(torch.bfloat16).state_dict(),
             block_shape=hf_config.quantization_config["weight_block_size"],

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -51,9 +51,16 @@ class DeepseekV3LMHead(nn.Module):
         ("prefill", 2048),
     ],
 )
-def test_forward_pass(mode: str, seq_len: int, hf_config: Any, tmp_path: Path, mesh_device: ttnn.Device, ccl: CCL1D):
+def test_forward_pass(
+    mode: str,
+    seq_len: int,
+    hf_config: Any,
+    tmp_path: Path,
+    mesh_device: ttnn.Device,
+    ccl: CCL1D,
+    set_deterministic_env: Any,
+):
     assert mesh_device.get_num_devices() == 32, "Mesh device must have 32 devices for this test."
-    torch.manual_seed(0)
 
     reference_model = DeepseekV3LMHead(hf_config).eval()
     state_dict = reference_model.state_dict()

--- a/models/demos/deepseek_v3/tests/test_mlp_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mlp_1d.py
@@ -140,6 +140,7 @@ def test_forward_pass(
     mesh_device,
     model_path,
     ccl,
+    reset_seeds,
 ):
     num_module_layers, _ = mesh_device.shape
 

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -41,7 +41,7 @@ def reference_model(hf_config):
 def test_forward_pass(
     mode,
     seq_len,
-    use_deterministic_env,
+    set_deterministic_env,
     reference_model,
     hf_config,
     tmp_path,

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -41,7 +41,7 @@ def reference_model(hf_config):
 def test_forward_pass(
     mode,
     seq_len,
-    reset_seeds,
+    use_deterministic_env,
     reference_model,
     hf_config,
     tmp_path,

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -18,7 +18,6 @@ from models.demos.deepseek_v3.utils.test_utils import assert_hidden_dim_pcc, get
 @pytest.fixture
 def reference_model(hf_config):
     """Get the actual DeepSeek MLP model using local implementation."""
-    torch.manual_seed(5)
     torch.use_deterministic_algorithms(True)
     # Note : Running Reference MoE without shared experts
     hf_config.n_shared_experts = None
@@ -42,6 +41,7 @@ def reference_model(hf_config):
 def test_forward_pass(
     mode,
     seq_len,
+    reset_seeds,
     reference_model,
     hf_config,
     tmp_path,
@@ -82,7 +82,7 @@ def test_forward_pass(
     tt_input = ttnn.from_torch(
         torch_input.unsqueeze(1),
         device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=tuple(mesh_device.shape)),
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
         dtype=ttnn.bfloat16,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -118,9 +118,9 @@ def test_forward_pass(
     weight_type: str,
     module_path: str,
     model_path: Path,
+    reset_seeds: Any,
 ):
     batch_size = 1
-    torch.manual_seed(0)
 
     reference_model = get_reference_model(weight_type, hf_config, module_path, model_path)
     torch_input = get_reference_input(batch_size, seq_len, hf_config)

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -39,7 +39,7 @@ def reference_model(hf_config, use_bitonic_sort):
 def test_forward_pass(
     mode,
     seq_len,
-    reset_seeds,
+    use_deterministic_env,
     reference_model,
     hf_config,
     topk_fallback,

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -19,7 +19,6 @@ from tests.ttnn.utils_for_testing import comp_pcc
 @pytest.fixture
 def reference_model(hf_config, use_bitonic_sort):
     """Get the actual DeepSeek MLP model using local implementation."""
-    torch.manual_seed(5)
     torch.use_deterministic_algorithms(True)
     return ReferenceMoEGate(hf_config, use_bitonic_sort).eval()
 
@@ -40,6 +39,7 @@ def reference_model(hf_config, use_bitonic_sort):
 def test_forward_pass(
     mode,
     seq_len,
+    reset_seeds,
     reference_model,
     hf_config,
     topk_fallback,

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -39,7 +39,7 @@ def reference_model(hf_config, use_bitonic_sort):
 def test_forward_pass(
     mode,
     seq_len,
-    use_deterministic_env,
+    set_deterministic_env,
     reference_model,
     hf_config,
     topk_fallback,

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -56,7 +56,7 @@ def test_forward_pass(
     tmp_path,
     mesh_device,
     ccl,
-    reset_seeds,
+    set_deterministic_env,
 ):
     num_module_layers, _ = mesh_device.shape
 

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -56,6 +56,7 @@ def test_forward_pass(
     tmp_path,
     mesh_device,
     ccl,
+    reset_seeds,
 ):
     num_module_layers, _ = mesh_device.shape
 

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
@@ -12,6 +12,8 @@ from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_base import DecoderBlockBase
 from models.demos.deepseek_v3.tt.mlp.shared_expert import SharedExpert
 from models.demos.deepseek_v3.tt.moe import MoE
+from models.demos.deepseek_v3.utils.config_dataclass import AllGatherAsyncConfig
+from models.demos.deepseek_v3.utils.config_helpers import even_int_div, sub_state_dicts
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -37,15 +39,15 @@ class MoEDecoderBlock(DecoderBlockBase):
         ), "Number of state dicts must match the number of mesh device rows"
         return {
             "shared_expert": SharedExpert.convert_weights(
-                hf_config, state_dicts, output_path / "shared_expert", mesh_device
+                hf_config, sub_state_dicts(state_dicts, "shared_experts."), output_path / "shared_experts", mesh_device
             ),
             "moe": [
                 (
-                    MoE.convert_weights(hf_config, [state_dict], output_path / "moe", mesh_device)
+                    MoE.convert_weights(hf_config, [state_dict], output_path / f"moe_{i}", mesh_device)
                     if state_dict is not None
                     else None
                 )
-                for state_dict in state_dicts
+                for i, state_dict in enumerate(state_dicts)
             ],
         }
 
@@ -60,9 +62,26 @@ class MoEDecoderBlock(DecoderBlockBase):
         assert mesh_device.shape[0] == len(
             is_padding_layer
         ), "Number of mesh device rows must match the number of padding or non-padding layers"
-        return [
-            None if is_padding else MoE.prefill_model_config(hf_config, mesh_device) for is_padding in is_padding_layer
-        ]
+        return {
+            "shared_expert": SharedExpert.prefill_model_config(hf_config, mesh_device),
+            "moe": [
+                None if is_padding else MoE.prefill_model_config(hf_config, mesh_device)
+                for is_padding in is_padding_layer
+            ],
+            "apply_dp": {
+                "mesh_shape": tuple(mesh_device.shape),
+                "dim": -2,
+                "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+                "cluster_axis": 0,
+            },
+            "revert_dp": AllGatherAsyncConfig(
+                mesh_device=mesh_device,
+                dim=-2,  # Batch dimension
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cluster_axis=0,
+                topology=ttnn.Topology.Linear,
+            ),
+        }
 
     @classmethod
     @abstractmethod
@@ -75,9 +94,27 @@ class MoEDecoderBlock(DecoderBlockBase):
         assert mesh_device.shape[0] == len(
             is_padding_layer
         ), "Number of mesh device rows must match the number of padding or non-padding layers"
-        return [
-            None if is_padding else MoE.decode_model_config(hf_config, mesh_device) for is_padding in is_padding_layer
-        ]
+        return {
+            "shared_expert": SharedExpert.decode_model_config(hf_config, mesh_device),
+            "moe": [
+                None if is_padding else MoE.decode_model_config(hf_config, mesh_device)
+                for is_padding in is_padding_layer
+            ],
+            "apply_dp": {
+                "mesh_shape": tuple(mesh_device.shape),
+                "dim": -2,
+                "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+                "cluster_axis": 0,
+            },
+            "revert_dp": AllGatherAsyncConfig(
+                mesh_device=mesh_device,
+                dim=-2,  # Batch dimension
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cluster_axis=0,
+                topology=ttnn.Topology.Linear,
+                num_links=3,
+            ),
+        }
 
     @classmethod
     @abstractmethod
@@ -88,9 +125,85 @@ class MoEDecoderBlock(DecoderBlockBase):
         is_padding_layer: tuple[bool, ...],
         ccl: CCL1D,
     ) -> ModelState:
-        return [
-            None if is_padding else MoE.create_state(hf_config, mesh_device, ccl) for is_padding in is_padding_layer
-        ]
+        return {
+            "moe": [
+                None if is_padding else MoE.create_state(hf_config, mesh_device, ccl) for is_padding in is_padding_layer
+            ],
+            "shared_expert": SharedExpert.create_state(hf_config, mesh_device, ccl),
+            "apply_dp": {
+                "semaphore": ccl.get_semaphore(0),
+            },
+            "revert_dp": {
+                "multi_device_global_semaphore": ccl.get_semaphore(0),
+            },
+        }
+
+    @classmethod
+    def apply_data_parallelism(
+        cls,
+        x: ttnn.Tensor,
+        row_idx: int,
+        mesh_shape: tuple[int, int],
+        dim: int,
+        memory_config: ttnn.MemoryConfig,
+        cluster_axis: int = 0,
+        semaphore=None,
+    ) -> ttnn.Tensor:
+        """Apply data parallelism by broadcasting from source row and partitioning across mesh."""
+        # First broadcast from row_idx to all rows in the mesh
+        x_broadcasted = cls._broadcast_row_to_mesh(x, mesh_shape, row_idx, semaphore)
+
+        # Then partition the batch across the mesh
+        x_partitioned = cls._partition_batch_on_mesh(x_broadcasted, dim, memory_config, cluster_axis)
+
+        return x_partitioned
+
+    @classmethod
+    def _broadcast_row_to_mesh(
+        cls, tt_input: ttnn.Tensor, mesh_shape: tuple[int, int], src_row: int, semaphore
+    ) -> ttnn.Tensor:
+        """Broadcast data from a source row to all other rows in the mesh."""
+        # Broadcast from src_row to mesh
+        # Loop over rows, skip src_row
+        for row_dim_idx in range(mesh_shape[0]):
+            if row_dim_idx == src_row:
+                continue
+
+            # Do p2p transfer from nodes in src_row to other nodes in that column
+            for col_dim_idx in range(mesh_shape[1]):
+                source_coord = ttnn.MeshCoordinate(src_row, col_dim_idx)
+                dest_coord = ttnn.MeshCoordinate(row_dim_idx, col_dim_idx)
+
+                ttnn.point_to_point(
+                    tt_input,
+                    dest_coord,
+                    source_coord,
+                    ttnn.Topology.Linear,
+                    semaphore,
+                    optional_output_tensor=tt_input,
+                )
+
+        return tt_input
+
+    @classmethod
+    def _partition_batch_on_mesh(
+        cls, tt_input: ttnn.Tensor, dim: int, memory_config: ttnn.MemoryConfig, cluster_axis: int = 0
+    ) -> ttnn.Tensor:
+        """Partition tensor along specified dimension across mesh cluster axis."""
+        tt_out_tensor = ttnn.mesh_partition(
+            tt_input,
+            dim,
+            cluster_axis=cluster_axis,
+            memory_config=memory_config,
+        )
+        return tt_out_tensor
+
+    @classmethod
+    def revert_data_parallelism(cls, x: ttnn.Tensor, row_idx: int, **cfg) -> ttnn.Tensor:
+        """Revert data parallelism by gathering partitioned tensor back to original form."""
+        # Gather tensor along specified dimension across mesh cluster axis
+        tt_out_tensor = ttnn.experimental.all_gather_async(x, **cfg)
+        return tt_out_tensor
 
     @classmethod
     @abstractmethod
@@ -100,20 +213,44 @@ class MoEDecoderBlock(DecoderBlockBase):
         mesh_device: ttnn.MeshDevice,
         is_padding_layer: tuple[bool, ...],
     ) -> ModelState:
-        return [
-            None if is_padding else MoE.create_shared_state(hf_config, mesh_device) for is_padding in is_padding_layer
-        ]
+        return {
+            "moe": [
+                None if is_padding else MoE.create_shared_state(hf_config, mesh_device)
+                for is_padding in is_padding_layer
+            ],
+            "shared_expert": {},
+        }
 
     @classmethod
     @abstractmethod
     def forward_mlp_prefill(cls, x: ttnn.Tensor, row_idx: int, cfg: RunPrefillConfig) -> ttnn.Tensor:
-        mlp_out = MoE.forward_prefill(x, cfg["moe"][row_idx])
+        num_tokens_to_route = x.shape[-3] * x.shape[-2]
+        DP_FACTOR = cfg["moe"][row_idx]["num_dispatch_devices"]
+        DP_SIZE = even_int_div(num_tokens_to_route, DP_FACTOR)
+        # Apply data parallelism only if the number of tokens per dispatch device is a multiple of the tile size
+        apply_dp = DP_SIZE % ttnn.TILE_SIZE == 0
+        if apply_dp:
+            x_dp = cls.apply_data_parallelism(x, row_idx, **cfg["apply_dp"])
+        mlp_out = MoE.forward_prefill(x_dp if apply_dp else x, cfg["moe"][row_idx])
+        if apply_dp:
+            ttnn.deallocate(x_dp)
+            mlp_out = cls.revert_data_parallelism(mlp_out, row_idx, **cfg["revert_dp"])
         mlp_out += SharedExpert.forward_prefill(x, cfg["shared_expert"])
         return mlp_out
 
     @classmethod
     @abstractmethod
     def forward_mlp_decode(cls, x: ttnn.Tensor, row_idx: int, cfg: RunDecodeConfig) -> ttnn.Tensor:
-        mlp_out = MoE.forward_decode(x, cfg["moe"][row_idx])
+        num_tokens_to_route = x.shape[-3] * x.shape[-2]
+        DP_FACTOR = cfg["moe"][row_idx]["num_dispatch_devices"]
+        DP_SIZE = even_int_div(num_tokens_to_route, DP_FACTOR)
+        # Apply data parallelism only if the number of tokens per dispatch device is a multiple of the tile size
+        apply_dp = DP_SIZE % ttnn.TILE_SIZE == 0
+        if apply_dp:
+            x_dp = cls.apply_data_parallelism(x, row_idx, **cfg["apply_dp"])
+        mlp_out = MoE.forward_decode(x_dp if apply_dp else x, cfg["moe"][row_idx])
+        if apply_dp:
+            ttnn.deallocate(x_dp)
+            mlp_out = cls.revert_data_parallelism(mlp_out, row_idx, **cfg["revert_dp"])
         mlp_out += SharedExpert.forward_decode(x, cfg["shared_expert"])
         return mlp_out

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -13,6 +13,7 @@ from models.demos.deepseek_v3.tt.experts import Experts as MoEExperts
 from models.demos.deepseek_v3.tt.moe_gate import MoEGate
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import (
+    AllGatherAsyncConfig,
     AllToAllCombineConfig,
     AllToAllDispatchConfig,
     MulConfig,
@@ -104,6 +105,10 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "to_remote_multi_device_global_semaphore": ccl.get_semaphore(1),
                 "num_links": ccl.get_max_links(1),
             },
+            "revert_tp": {
+                "multi_device_global_semaphore": ccl.get_semaphore(1),
+                "num_links": ccl.get_max_links(1),
+            },
         }
 
     @classmethod
@@ -157,6 +162,13 @@ class MoE(SharedStateAddOn, AbstractModule):
                 memory_config=memory_config,
                 topology=ttnn.Topology.Linear,
             ),
+            "revert_tp": AllGatherAsyncConfig(
+                mesh_device=mesh_device,
+                dim=-1,  # Last dimension
+                memory_config=memory_config,
+                cluster_axis=1,
+                topology=ttnn.Topology.Linear,
+            ),
         }
 
     @classmethod
@@ -206,7 +218,8 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
-        assert x.memory_config() == cfg["input_memory_config"]
+        x = ttnn.experimental.all_gather_async(x, **cfg["revert_tp"])
+
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
         batch_size_per_device = x.shape[
             -2

--- a/models/demos/deepseek_v3/utils/reference_forwards.py
+++ b/models/demos/deepseek_v3/utils/reference_forwards.py
@@ -152,6 +152,20 @@ def reference_forward_decode(
     # Generate the cache
     cache = DynamicCache()
 
+    # Pre-populate cache with dummy entries for layers before the target layer
+    # This is necessary when testing a single layer in isolation
+    layer_idx = reference_model.self_attn.layer_idx
+    if layer_idx > 0 and len(cache.key_cache) < layer_idx:
+        # For DeepSeek v3 MLA, cache entries have shape [bsz, 1, 0, kv_lora_rank + qk_rope_head_dim]
+        # where the sequence length is 0 initially
+        cache_head_dim = reference_model.self_attn.kv_lora_rank + reference_model.self_attn.qk_rope_head_dim
+        dummy_key_value = torch.zeros(bsz, 1, 0, cache_head_dim, dtype=torch.float32)
+
+        # Only add dummy entries for missing layers
+        for i in range(len(cache.key_cache), layer_idx):
+            cache.key_cache.append(dummy_key_value.clone())
+            cache.value_cache.append(dummy_key_value.clone())
+
     # Padding for decode mode
     if mode == "decode":
         assert q_len == 1, "Decode mode should have sequence length of 1"

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -14,7 +14,6 @@ from loguru import logger
 
 from models.demos.deepseek_v3.scripts.generate_test_inputs_outputs import __file__ as REFERENCE_IO_SCRIPT_NAME
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
-from models.demos.deepseek_v3.utils.config_helpers import dequantize
 from models.utility_functions import comp_pcc
 
 # Constant for testing
@@ -63,19 +62,8 @@ def add_inv_scale_to_state_dict(
             output_state_dict[name] = tensor
             continue
 
-        dequant_scale = torch.randn(
-            (
-                *tensor.shape[: -len(block_shape)],
-                *(
-                    (tensor.shape[-len(block_shape) + idx] + block_dim - 1) // block_dim
-                    for idx, block_dim in enumerate(block_shape)
-                ),
-            ),
-            dtype=torch.float32,
-        )
-
-        tensor_quant = dequantize(tensor.to(torch.float8_e4m3fn), 1.0 / dequant_scale, block_shape)
-        output_state_dict[name] = tensor_quant.to(torch.float8_e4m3fn)
+        tensor_quant, dequant_scale = quantize_fp8_blockwise(tensor, block_shape)
+        output_state_dict[name] = tensor_quant
         output_state_dict[name + "_scale_inv"] = dequant_scale
 
     return output_state_dict


### PR DESCRIPTION
Decoder Block with MoE is functional.
`2025-08-08 02:42:40.125 | INFO     | models.demos.deepseek_v3.tests.test_decoder_block:test_forward_pass:254 - PCC for MoEDecoderBlock in decode mode: 0.9910413918076039  `

Key Changes
1. moe_decoder_block.py filled up with all the required ccl helpers
2. Fixed reference_forward dynamic caching when decoder is tested on any layer_num > 0
3. Cherry-picked all_gather on MoE input. [Feel free to optimize that and make it common for both shared experts and MoE]
4. Added weight config caching in test_decoder_block.py. [Not necessary to do the same way, it is for my testing convenience]




### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16821291351) CI passes
- [x] [Deepseek TG](https://github.com/tenstorrent/tt-metal/actions/runs/17071151057) CI 