### PR TITLE
Add optional barrier to `all_broadcast_async`

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async.cpp
@@ -16,9 +16,16 @@ std::vector<ttnn::Tensor> ExecuteAllBroadcastAsync::invoke(
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const ttnn::ccl::Topology topology,
-    std::optional<tt::tt_metal::SubDeviceId> subdevice_id) {
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<GlobalSemaphore>& barrier_semaphore) {
     return ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor, multi_device_global_semaphore, num_links, memory_config, topology, subdevice_id);
+        input_tensor,
+        multi_device_global_semaphore,
+        num_links,
+        memory_config,
+        topology,
+        subdevice_id,
+        barrier_semaphore);
 }
 
 std::vector<ttnn::Tensor> ExecuteAllBroadcastAsync::invoke(
@@ -30,7 +37,8 @@ std::vector<ttnn::Tensor> ExecuteAllBroadcastAsync::invoke(
     const std::optional<ttnn::Tensor>& persistent_output_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<size_t> num_preferred_links,
-    std::optional<tt::tt_metal::SubDeviceId> subdevice_id) {
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const std::optional<GlobalSemaphore>& barrier_semaphore) {
     return ttnn::operations::experimental::ccl::all_broadcast_async(
         input_tensor,
         cluster_axis,
@@ -40,7 +48,8 @@ std::vector<ttnn::Tensor> ExecuteAllBroadcastAsync::invoke(
         persistent_output_tensor,
         memory_config,
         num_preferred_links,
-        subdevice_id);
+        subdevice_id,
+        barrier_semaphore);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async.hpp
@@ -18,7 +18,8 @@ struct ExecuteAllBroadcastAsync {
         uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
-        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt);
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
     static std::vector<ttnn::Tensor> invoke(
         const ttnn::Tensor& input_tensor,
@@ -29,7 +30,8 @@ struct ExecuteAllBroadcastAsync {
         const std::optional<ttnn::Tensor>& persistent_output_tensor = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<size_t> num_preferred_links = std::nullopt,
-        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt);
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async_pybind.cpp
@@ -32,9 +32,16 @@ void bind_all_broadcast_async(pybind11::module& module, const ccl_operation_t& o
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const ttnn::ccl::Topology topology,
-               std::optional<tt::tt_metal::SubDeviceId> subdevice_id) -> std::vector<ttnn::Tensor> {
+               std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+               const std::optional<GlobalSemaphore>& barrier_semaphore) -> std::vector<ttnn::Tensor> {
                 return self(
-                    input_tensor, multi_device_global_semaphore, num_links, memory_config, topology, subdevice_id);
+                    input_tensor,
+                    multi_device_global_semaphore,
+                    num_links,
+                    memory_config,
+                    topology,
+                    subdevice_id,
+                    barrier_semaphore);
             },
             py::arg("input_tensor"),
             py::arg("multi_device_global_semaphore"),
@@ -42,7 +49,8 @@ void bind_all_broadcast_async(pybind11::module& module, const ccl_operation_t& o
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
             py::arg("topology") = ttnn::ccl::Topology::Linear,
-            py::arg("subdevice_id") = std::nullopt},
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("barrier_semaphore") = std::nullopt},
 
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
@@ -54,7 +62,8 @@ void bind_all_broadcast_async(pybind11::module& module, const ccl_operation_t& o
                const std::optional<ttnn::Tensor>& persistent_output_tensor,
                const std::optional<size_t> num_preferred_links,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<tt::tt_metal::SubDeviceId> subdevice_id) -> std::vector<ttnn::Tensor> {
+               std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+               const std::optional<GlobalSemaphore>& barrier_semaphore) -> std::vector<ttnn::Tensor> {
                 return self(
                     input_tensor,
                     cluster_axis,
@@ -64,7 +73,8 @@ void bind_all_broadcast_async(pybind11::module& module, const ccl_operation_t& o
                     persistent_output_tensor,  // = std::nullopt,
                     memory_config,             // = std::nullopt,
                     num_preferred_links,       // = std::nullopt,
-                    subdevice_id);             // = std::nullopt
+                    subdevice_id,              // = std::nullopt
+                    barrier_semaphore);        // = std::nullopt
             },
             py::arg("input_tensor"),
             py::arg("cluster_axis"),
@@ -75,7 +85,8 @@ void bind_all_broadcast_async(pybind11::module& module, const ccl_operation_t& o
             py::arg("persistent_output_tensor") = std::nullopt,
             py::arg("num_links") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("subdevice_id") = std::nullopt});
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("barrier_semaphore") = std::nullopt});
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.hpp
@@ -34,6 +34,7 @@ struct AllBroadcastAsync {
     const GlobalSemaphore semaphore;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
     std::optional<uint32_t> cluster_axis;
+    const std::optional<GlobalSemaphore>& barrier_semaphore;
 
     AllBroadcastAsync(
         std::vector<IDevice*> devices,
@@ -43,7 +44,8 @@ struct AllBroadcastAsync {
         ccl::Topology topology,
         GlobalSemaphore semaphore,
         std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-        std::optional<uint32_t> cluster_axis) :
+        std::optional<uint32_t> cluster_axis,
+        const std::optional<GlobalSemaphore>& barrier_semaphore) :
         devices(std::move(devices)),
         num_links(num_links),
         ring_size(ring_size),
@@ -51,7 +53,8 @@ struct AllBroadcastAsync {
         topology(topology),
         semaphore(semaphore),
         sub_device_id(sub_device_id),
-        cluster_axis(cluster_axis) {}
+        cluster_axis(cluster_axis),
+        barrier_semaphore(barrier_semaphore) {}
 
     // Add attributes method for reflection
     auto attributes() const {
@@ -64,6 +67,7 @@ struct AllBroadcastAsync {
         attrs.emplace_back("topology", topology);
         attrs.emplace_back("semaphore", semaphore);
         attrs.emplace_back("cluster_axis", cluster_axis);
+        attrs.emplace_back("barrier_semaphore", barrier_semaphore);
         return attrs;
     }
 
@@ -92,7 +96,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     uint32_t ring_index,
     ccl::Topology topology,
     const GlobalSemaphore& semaphore,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<GlobalSemaphore>& barrier_semaphore);
 
 namespace operations::experimental::ccl {
 
@@ -102,7 +107,8 @@ std::vector<Tensor> all_broadcast_async(
     uint32_t num_links = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
-    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt);
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
 std::vector<Tensor> all_broadcast_async(
     const Tensor& input_tensor,
@@ -113,7 +119,8 @@ std::vector<Tensor> all_broadcast_async(
     const std::optional<ttnn::Tensor>& persistent_output_tensor = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<size_t> num_preferred_links = std::nullopt,
-    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt);
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
 }  // namespace operations::experimental::ccl
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -49,7 +49,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     const uint32_t ring_index,
     ccl::Topology topology,
     const GlobalSemaphore& semaphore,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<GlobalSemaphore>& barrier_semaphore) {
     tt::tt_metal::Program program{};
 
     auto mesh_device = input_tensor.mesh_device();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_writer.cpp
@@ -55,6 +55,10 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    bool use_barrier = get_arg_val<uint32_t>(arg_idx++);
+    size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t arg_for_fab = arg_idx;
 
 #ifdef SHARDED
@@ -97,6 +101,9 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_seminc =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
+
     pkt_hdr_forward->to_chip_multicast(
         tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
     pkt_hdr_backward->to_chip_multicast(
@@ -104,6 +111,35 @@ void kernel_main() {
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open();
+    }
+
+    if (use_barrier) {
+        uint32_t num_total_targets = num_targets_forward_direction + num_targets_backward_direction;
+
+        uint64_t barrier_sem_noc_addr_in_pkt =
+            safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
+        pkt_hdr_seminc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+            barrier_sem_noc_addr_in_pkt,
+            static_cast<uint16_t>(1),  // increment 1
+            32});
+
+        if (num_targets_forward_direction) {
+            fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+            pkt_hdr_seminc->to_chip_multicast(
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+            fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+        }
+        if (num_targets_backward_direction) {
+            pkt_hdr_seminc->to_chip_multicast(
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+            fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+            fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+                packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+        }
+
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
     // 1. mcast via fabric to remote tensor addresses
@@ -137,22 +173,21 @@ void kernel_main() {
     // 2. mcast output ready semaphore
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
-    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
-    pkt_hdr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+    pkt_hdr_seminc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
         out_ready_sem_noc_addr_in_pkt,
         static_cast<uint16_t>(1),  // increment 1
         32});
     // Write the mcast packet (forward)
     if (fabric_connection.has_forward_connection()) {
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr->to_chip_multicast(
+        pkt_hdr_seminc->to_chip_multicast(
             tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_forward)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
-        pkt_hdr->to_chip_multicast(
+        pkt_hdr_seminc->to_chip_multicast(
             tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_backward)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_writer.cpp
@@ -53,6 +53,10 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    bool use_barrier = get_arg_val<uint32_t>(arg_idx++);
+    size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t arg_for_fab = arg_idx;
 
 #ifdef SHARDED
@@ -97,6 +101,9 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_seminc =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
+
     pkt_hdr_forward->to_chip_multicast(
         tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
     pkt_hdr_backward->to_chip_multicast(
@@ -104,6 +111,35 @@ void kernel_main() {
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open();
+    }
+
+    if (use_barrier) {
+        uint32_t num_total_targets = num_targets_forward_direction + num_targets_backward_direction;
+
+        uint64_t barrier_sem_noc_addr_in_pkt =
+            safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
+        pkt_hdr_seminc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+            barrier_sem_noc_addr_in_pkt,
+            static_cast<uint16_t>(1),  // increment 1
+            32});
+
+        if (num_targets_forward_direction) {
+            fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+            pkt_hdr_seminc->to_chip_multicast(
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+            fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+        }
+        if (num_targets_backward_direction) {
+            pkt_hdr_seminc->to_chip_multicast(
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+            fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+            fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+                packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+        }
+
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
     // 1. mcast via fabric to remote tensor addresses
@@ -138,22 +174,21 @@ void kernel_main() {
     // 2. mcast output ready semaphore
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
-    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
-    pkt_hdr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+    pkt_hdr_seminc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
         out_ready_sem_noc_addr_in_pkt,
         static_cast<uint16_t>(1),  // increment 1
         32});
     // Write the mcast packet (forward)
     if (fabric_connection.has_forward_connection()) {
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr->to_chip_multicast(
+        pkt_hdr_seminc->to_chip_multicast(
             tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_forward)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
-        pkt_hdr->to_chip_multicast(
+        pkt_hdr_seminc->to_chip_multicast(
             tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_backward)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(


### PR DESCRIPTION
### What's changed
- Add optional barrier semaphore for pre-ccl synchronization to `all_broadcast_async`
- Required so that we can use `all_broadcast_async` in composite RS & AG ops, which are needed to handle weird shapes for the training team

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16819908941
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes