### PR TITLE
[skip ci] Shift models-post-commit to CIv2 on WH

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -37,7 +37,10 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true
+          || inputs.runner-label == 'N150'
+          || inputs.runner-label == 'N300')
+        && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N300's are super backlogged in CIv2.  We had previously moved TTNN tests to CIv2, but that backlogged N300's on CIv2 too much that the merge queue ground to a half, effectively.

### What's changed
Move the Models tests to CIv2.  This is a lighter load than the TTNN tests, so hopefully CIv2 can bear it while still alleviating some pressure on CIv1.