### PR TITLE
conv3.0 reuse

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.utility_functions import run_for_blackhole
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10113.0],
-        [32, "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 11842.0],
+        [16, "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10193.0],
+        [32, "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 12000.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_model_utils import get_conv_input_memory_config
-from models.utility_functions import _nearest_y, is_blackhole, is_single_chip, is_wormhole_b0
+from models.utility_functions import _nearest_y, is_blackhole, is_wormhole_b0
 
 hardcoded_matmul_config_linear = {
     8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
@@ -581,7 +581,8 @@ class resnet50:
             enable_split_reader=True,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,
-            enable_activation_reuse=is_single_chip(),
+            # otherwise act block h is not big enough for the reuse
+            enable_activation_reuse=not is_wormhole_b0() or device.get_num_devices() <= 8,
         )
         self.conv1_compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_model_utils import get_conv_input_memory_config
-from models.utility_functions import _nearest_y, is_blackhole, is_wormhole_b0
+from models.utility_functions import _nearest_y, is_blackhole, is_single_chip, is_wormhole_b0
 
 hardcoded_matmul_config_linear = {
     8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
@@ -581,7 +581,7 @@ class resnet50:
             enable_split_reader=True,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,
-            enable_activation_reuse=True,
+            enable_activation_reuse=is_single_chip(),
         )
         self.conv1_compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -581,6 +581,7 @@ class resnet50:
             enable_split_reader=True,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,
+            enable_activation_reuse=True,
         )
         self.conv1_compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,7 +13,7 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5713.0],
+        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5780.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -35,7 +35,7 @@ def test_unet_model(batch, groups, device, iterations, reset_seeds):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1589.0),),
+    ((1, 4, 1658.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -35,7 +35,7 @@ def test_unet_model(batch, groups, device, iterations, reset_seeds):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1658.0),),
+    ((1, 4, 1632.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -7,6 +7,7 @@ import ttnn
 
 from typing import Literal
 
+from ttnn.device import is_wormhole_b0
 from ttnn.model_preprocessing import infer_ttnn_module_args
 
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -65,6 +66,7 @@ def create_unet_model_parameters(
     parameters.c1["conv_blocking_and_parallelization_config_override"] = None
     parameters.c1["use_split_reader"] = True
     parameters.c1["use_activation_double_buffer"] = True
+    parameters.c1["enable_activation_reuse"] = True
     parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
     parameters.c1_2["use_split_reader"] = True
     parameters.c1_2["use_activation_double_buffer"] = True
@@ -72,21 +74,26 @@ def create_unet_model_parameters(
     parameters.c2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c2["use_split_reader"] = True
     parameters.c2["use_activation_double_buffer"] = True
+    parameters.c2["enable_activation_reuse"] = True
     parameters.c2_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c2_2["use_split_reader"] = True
     parameters.c2_2["use_activation_double_buffer"] = True
+    parameters.c2_2["enable_activation_reuse"] = True
 
     parameters.c3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c3["use_split_reader"] = True
     parameters.c3["use_activation_double_buffer"] = True
+    parameters.c3["enable_activation_reuse"] = is_wormhole_b0(device)
     parameters.c3_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c3_2["use_split_reader"] = True
     parameters.c3_2["use_activation_double_buffer"] = True
 
     parameters.c4["conv_blocking_and_parallelization_config_override"] = None
     parameters.c4["use_activation_double_buffer"] = True
+    parameters.c4["enable_activation_reuse"] = is_wormhole_b0(device)
     parameters.c4_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c4_2["use_activation_double_buffer"] = True
+    parameters.c4_2["enable_activation_reuse"] = is_wormhole_b0(device)
 
     parameters.bnc["conv_blocking_and_parallelization_config_override"] = None
     parameters.bnc["use_activation_double_buffer"] = False
@@ -116,9 +123,11 @@ def create_unet_model_parameters(
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
     parameters.c7_2["use_activation_double_buffer"] = True
+    parameters.c7_2["enable_activation_reuse"] = True
     parameters.c7_3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_3["use_split_reader"] = True
     parameters.c7_3["use_activation_double_buffer"] = True
+    parameters.c7_3["enable_activation_reuse"] = True
 
     parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
     parameters.c8["use_activation_double_buffer"] = True

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -174,7 +174,7 @@ class UNetConv2D:
             weights_dtype=weights_dtype,
             shard_layout=shard_layout,
             deallocate_activation=True,
-            enable_act_double_buffer=False,
+            enable_act_double_buffer=True,
             enable_split_reader=(conv.use_split_reader if "use_split_reader" in conv else False),
             activation=activation,
             output_layout=output_layout,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -142,6 +142,7 @@ class UNetConv2D:
         reallocate_halo_output=False,
         override_core_grid=None,
         mesh_mapper=None,
+        enable_activation_reuse=False,
     ):
         assert is_valid_device_for_unet(device), "UNet Shallow requires an 8x8 grid on WH or 10x13/10x11 on BH"
 
@@ -173,15 +174,14 @@ class UNetConv2D:
             weights_dtype=weights_dtype,
             shard_layout=shard_layout,
             deallocate_activation=True,
-            enable_act_double_buffer=(
-                conv.use_activation_double_buffer if "use_activation_double_buffer" in conv else False
-            ),
+            enable_act_double_buffer=False,
             enable_split_reader=(conv.use_split_reader if "use_split_reader" in conv else False),
             activation=activation,
             output_layout=output_layout,
             reshard_if_not_optimal=reshard_if_not_optimal,
             reallocate_halo_output=reallocate_halo_output,
             enable_weights_double_buffer=True,
+            enable_activation_reuse=enable_activation_reuse,
         )
 
         if override_core_grid is not None:
@@ -275,6 +275,8 @@ class UNetDownblock:
         mesh_mapper=None,
         reshard_if_not_optimal=True,
         override_core_grid=None,
+        first_conv_reuse=False,
+        second_conv_reuse=False,
     ):
         self.conv1 = UNetConv2D(
             conv1,
@@ -283,8 +285,11 @@ class UNetDownblock:
             reshard_if_not_optimal=reshard_if_not_optimal,
             mesh_mapper=mesh_mapper,
             override_core_grid=override_core_grid,
+            enable_activation_reuse=first_conv_reuse,
         )
-        self.conv2 = UNetConv2D(conv2, bn=bn2, device=device, mesh_mapper=mesh_mapper)
+        self.conv2 = UNetConv2D(
+            conv2, bn=bn2, device=device, mesh_mapper=mesh_mapper, enable_activation_reuse=second_conv_reuse
+        )
         self.pool1 = UNetMaxPool2D(pool, conv2.out_channels, device=device)
 
     def __call__(self, x):
@@ -317,6 +322,9 @@ class UNetUpblock:
         reshard_if_not_optimal=True,
         final_block=False,
         override_core_grid=None,
+        first_conv_reuse=False,
+        second_conv_reuse=False,
+        third_conv_reuse=False,
     ):
         self.final_block = final_block
         self.device = device
@@ -329,9 +337,10 @@ class UNetUpblock:
             mesh_mapper=mesh_mapper,
             reallocate_halo_output=True,
             override_core_grid=override_core_grid,
+            enable_activation_reuse=first_conv_reuse,
         )
-        self.conv2 = UNetConv2D(conv2, bn2, device, mesh_mapper=mesh_mapper)
-        self.conv3 = UNetConv2D(conv3, bn3, device, mesh_mapper=mesh_mapper)
+        self.conv2 = UNetConv2D(conv2, bn2, device, mesh_mapper=mesh_mapper, enable_activation_reuse=second_conv_reuse)
+        self.conv3 = UNetConv2D(conv3, bn3, device, mesh_mapper=mesh_mapper, enable_activation_reuse=third_conv_reuse)
 
         self.batch_size = conv1.batch_size
         self.input_height = conv1.input_height
@@ -413,6 +422,7 @@ class UNet:
             override_core_grid=63 if is_wormhole_b0(self.device) else None,
             reshard_if_not_optimal=not is_wormhole_b0(self.device),
             mesh_mapper=mesh_mapper,
+            first_conv_reuse=True,
         )
         self.downblock2 = UNetDownblock(
             parameters.c2,
@@ -423,6 +433,8 @@ class UNet:
             device,
             reshard_if_not_optimal=False,
             mesh_mapper=mesh_mapper,
+            first_conv_reuse=True,
+            second_conv_reuse=True,
         )
         self.downblock3 = UNetDownblock(
             parameters.c3,
@@ -432,6 +444,7 @@ class UNet:
             parameters.p3,
             device,
             mesh_mapper=mesh_mapper,
+            first_conv_reuse=True,
         )
         self.downblock4 = UNetDownblock(
             parameters.c4,
@@ -441,6 +454,8 @@ class UNet:
             parameters.p4,
             device,
             mesh_mapper=mesh_mapper,
+            first_conv_reuse=True,
+            second_conv_reuse=True,
         )
 
         self.bnc = UNetConv2D(
@@ -491,6 +506,8 @@ class UNet:
             reshard_if_not_optimal=not is_wormhole_b0(self.device),
             final_block=False,
             mesh_mapper=mesh_mapper,
+            second_conv_reuse=True,
+            third_conv_reuse=True,
         )
         self.upblock4 = UNetUpblock(
             parameters.c8,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -173,7 +173,9 @@ class UNetConv2D:
             weights_dtype=weights_dtype,
             shard_layout=shard_layout,
             deallocate_activation=True,
-            enable_act_double_buffer=True,
+            enable_act_double_buffer=(
+                conv.use_activation_double_buffer if "use_activation_double_buffer" in conv else False
+            ),
             enable_split_reader=(conv.use_split_reader if "use_split_reader" in conv else False),
             activation=activation,
             output_layout=output_layout,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -444,7 +444,7 @@ class UNet:
             parameters.p3,
             device,
             mesh_mapper=mesh_mapper,
-            first_conv_reuse=True,
+            first_conv_reuse=is_wormhole_b0(self.device),
         )
         self.downblock4 = UNetDownblock(
             parameters.c4,
@@ -454,8 +454,8 @@ class UNet:
             parameters.p4,
             device,
             mesh_mapper=mesh_mapper,
-            first_conv_reuse=True,
-            second_conv_reuse=True,
+            first_conv_reuse=is_wormhole_b0(self.device),
+            second_conv_reuse=is_wormhole_b0(self.device),
         )
 
         self.bnc = UNetConv2D(

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4653,7 +4653,7 @@ def test_conv2d_activation_reuse(
 
 
 @skip_for_blackhole()
-@pytest.mark.parametrize("enable_activation_reuse", [True])
+@pytest.mark.parametrize("enable_activation_reuse", [False, True])
 @pytest.mark.parametrize("enable_split_reader", [False, True])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4605,7 +4605,7 @@ def test_conv2d_activation_reuse(
     enable_split_reader,
     enable_activation_reuse,
 ):
-    if batch == 16 and is_wormhole():
+    if batch == 16 and is_wormhole_b0():
         # not enough memory on WH for this case
         act_block_h_override = 32*4
 

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4562,13 +4562,13 @@ def test_conv_bs_grid(
 
 
 # fmt: off
-@pytest.mark.parametrize("enable_activation_reuse", [True])
-@pytest.mark.parametrize("enable_split_reader", [True])
+@pytest.mark.parametrize("enable_activation_reuse", [False, True])
+@pytest.mark.parametrize("enable_split_reader", [False, True])
 @pytest.mark.parametrize(
     "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, input_dtype, input_layout, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc",
     (
         # model kiwi new convs
-        # ( 1,  4,    32, 1024,   128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
+        ( 1,  4,    32, 1024,   128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
         ( 1,  32,   32, 512,    40, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
         ( 1,  3,    45, 512,    60, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
         ( 1,  7,    32, 1024,   140, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (4, 4), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4573,7 +4573,7 @@ def test_conv_bs_grid(
         ( 1,  3,    45, 512,    60, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
         ( 1,  7,    32, 1024,   140, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (4, 4), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
         ( 4,  32,   32,  256,   32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (3, 3), (1, 1), [1, 1, 1, 1], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
-        (16,  48,   56,  256,   32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (3, 3), (1, 1), [1, 1, 1, 1], (1, 1), True, 32*4, True, ttnn.MathFidelity.LoFi, False, False),
+        (16,  48,   56,  256,   32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (3, 3), (1, 1), [1, 1, 1, 1], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
     ),
 )
  #fmt: on
@@ -4605,6 +4605,10 @@ def test_conv2d_activation_reuse(
     enable_split_reader,
     enable_activation_reuse,
 ):
+    if batch == 16 and is_wormhole():
+        # not enough memory on WH for this case
+        act_block_h_override = 32*4
+
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
 

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -229,7 +229,6 @@ def run_conv(
 
     requires_device_placement = input_dtype == ttnn.bfloat8_b or sharded_cfg is not None
 
-    tt_input_tensor = None
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         input_dtype,
@@ -4645,7 +4644,7 @@ def test_conv2d_activation_reuse(
         output_mesh_composer=None,
         enable_split_reader=enable_split_reader,
         input_layout= input_layout,
-        activation="relu",
+        activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
         enable_act_double_buffer=True,  # will be disabled if activation reuse is enabled
         input_dtype = input_dtype,
         enable_activation_reuse=enable_activation_reuse
@@ -4710,7 +4709,6 @@ def test_conv2d_activation_reuse_unet_conv_group_4(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, ttnn.ShardSpec(input_core_grid, (2688, input_channels), ttnn.ShardOrientation.ROW_MAJOR)
     )
 
-    # run conv
     run_conv(
         device,
         torch_tensor_map,
@@ -4736,7 +4734,7 @@ def test_conv2d_activation_reuse_unet_conv_group_4(
         deallocate_activation=True,
         enable_act_double_buffer=True, # will be disabled if activation reuse is enabled
         enable_weights_double_buffer=True,
-        activation="relu",
+        activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
         input_dtype=ttnn.bfloat16,
         sharded_cfg=memory_config,
         enable_split_reader=enable_split_reader,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -125,7 +125,6 @@ def run_conv(
     sharded_cfg=None,
     throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
     enable_activation_reuse=False,
-    prepared_input_tensor=None,
 ):
     if isinstance(device, ttnn.MeshDevice) and len(device.get_device_ids()) > 1:
         assert input_mesh_mapper is not None, "Expected mesh mapper for input tensor when running on multiple devices"
@@ -231,19 +230,16 @@ def run_conv(
     requires_device_placement = input_dtype == ttnn.bfloat8_b or sharded_cfg is not None
 
     tt_input_tensor = None
-    if prepared_input_tensor is None:
-        tt_input_tensor = ttnn.from_torch(
-            torch_input_tensor,
-            input_dtype,
-            mesh_mapper=input_mesh_mapper,
-            layout=input_layout,
-            device=device if requires_device_placement else None,
-        )
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        input_dtype,
+        mesh_mapper=input_mesh_mapper,
+        layout=input_layout,
+        device=device if requires_device_placement else None,
+    )
 
-        if sharded_cfg:
-            tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, sharded_cfg)
-    else:
-        tt_input_tensor = prepared_input_tensor
+    if sharded_cfg:
+        tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, sharded_cfg)
 
     conv_config = ttnn.Conv2dConfig(
         weights_dtype=weights_dtype,
@@ -4697,16 +4693,8 @@ def test_conv2d_activation_reuse_unet_conv_group_4(
 ):
     batch_size = 1
     groups = 4
-
-    # prepare input tensor
     input_channels = groups * input_channels
     output_channels = groups * output_channels
-
-    conv_input_shape = (batch_size, input_channels, input_height, input_width)
-    torch_input_tensor_nchw = randomize_torch_tensor(torch_tensor_map, conv_input_shape)
-    torch_input_tensor_nchw_reshaped = torch_input_tensor_nchw.reshape(
-        [1, 1, input_channels, input_height * input_width]
-    )
 
     input_core_grid = ttnn.CoreRangeSet(
         {
@@ -4714,18 +4702,8 @@ def test_conv2d_activation_reuse_unet_conv_group_4(
             ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
         }
     )
-    input_sharded_memory_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, ttnn.ShardSpec(input_core_grid, (16, 2688), ttnn.ShardOrientation.ROW_MAJOR)
-    )
-    tt_input_tensor = ttnn.from_torch(
-        torch_input_tensor_nchw_reshaped, dtype=ttnn.bfloat16, device=device, memory_config=input_sharded_memory_config
-    )
-
     memory_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, ttnn.ShardSpec(input_core_grid, (2688, input_channels), ttnn.ShardOrientation.ROW_MAJOR)
-    )
-    tt_input_tensor = ttnn.experimental.convert_to_hwc(
-        tt_input_tensor, memory_config=memory_config, dtype=ttnn.bfloat16
     )
 
     # run conv
@@ -4756,7 +4734,7 @@ def test_conv2d_activation_reuse_unet_conv_group_4(
         enable_weights_double_buffer=True,
         activation="relu",
         input_dtype=ttnn.bfloat16,
-        prepared_input_tensor=tt_input_tensor,
+        sharded_cfg=memory_config,
         enable_split_reader=enable_split_reader,
         enable_activation_reuse=enable_activation_reuse
     )

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -124,6 +124,8 @@ def run_conv(
     bs_full_inner_dim=False,
     sharded_cfg=None,
     throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
+    enable_activation_reuse=False,
+    prepared_input_tensor=None,
 ):
     if isinstance(device, ttnn.MeshDevice) and len(device.get_device_ids()) > 1:
         assert input_mesh_mapper is not None, "Expected mesh mapper for input tensor when running on multiple devices"
@@ -227,16 +229,21 @@ def run_conv(
         )
 
     requires_device_placement = input_dtype == ttnn.bfloat8_b or sharded_cfg is not None
-    tt_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
-        input_dtype,
-        mesh_mapper=input_mesh_mapper,
-        layout=input_layout,
-        device=device if requires_device_placement else None,
-    )
 
-    if sharded_cfg:
-        tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, sharded_cfg)
+    tt_input_tensor = None
+    if prepared_input_tensor is None:
+        tt_input_tensor = ttnn.from_torch(
+            torch_input_tensor,
+            input_dtype,
+            mesh_mapper=input_mesh_mapper,
+            layout=input_layout,
+            device=device if requires_device_placement else None,
+        )
+
+        if sharded_cfg:
+            tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, sharded_cfg)
+    else:
+        tt_input_tensor = prepared_input_tensor
 
     conv_config = ttnn.Conv2dConfig(
         weights_dtype=weights_dtype,
@@ -251,6 +258,7 @@ def run_conv(
         in_place=in_place,
         enable_kernel_stride_folding=enable_kernel_stride_folding,
         full_inner_dim=bs_full_inner_dim,
+        enable_activation_reuse=enable_activation_reuse,
     )
 
     compute_config = ttnn.init_device_compute_kernel_config(
@@ -4553,5 +4561,202 @@ def test_conv_bs_grid(
         None,
         shard_layout=BS,
         has_bias=False,
+        input_dtype=ttnn.bfloat16
+    )
+
+
+# fmt: off
+@pytest.mark.parametrize("enable_activation_reuse", [True])
+@pytest.mark.parametrize("enable_split_reader", [True])
+@pytest.mark.parametrize(
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, input_dtype, input_layout, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc",
+    (
+        # model kiwi new convs
+        # ( 1,  4,    32, 1024,   128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
+        ( 1,  32,   32, 512,    40, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
+        ( 1,  3,    45, 512,    60, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (5, 5), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
+        ( 1,  7,    32, 1024,   140, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (4, 4), (1, 1), [2, 2, 2, 2], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
+        ( 4,  32,   32,  256,   32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (3, 3), (1, 1), [1, 1, 1, 1], (1, 1), True, 0, True, ttnn.MathFidelity.LoFi, False, False),
+        (16,  48,   56,  256,   32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 1, (3, 3), (1, 1), [1, 1, 1, 1], (1, 1), True, 32*4, True, ttnn.MathFidelity.LoFi, False, False),
+    ),
+)
+ #fmt: on
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384*2}], indirect=True)
+def test_conv2d_activation_reuse(
+    device,
+    torch_tensor_map,
+    batch,
+    input_channels,
+    output_channels,
+    input_height,
+    input_width,
+    weights_dtype,
+    output_dtype,
+    groups,
+    kernel,
+    stride,
+    padding,
+    dilation,
+    auto_shard,
+    act_block_h_override,
+    deallocate_activation,
+    math_fidelity,
+    fp32_accum,
+    packer_l1_acc,
+    input_dtype,
+    input_layout,
+    enable_split_reader,
+    enable_activation_reuse,
+):
+    config_override = {}
+    config_override["act_block_h"] = act_block_h_override
+
+    run_conv(
+        device=device,
+        torch_tensor_map=torch_tensor_map,
+        math_fidelity=math_fidelity,
+        output_dtype=output_dtype,
+        weights_dtype=weights_dtype,
+        batch_size=batch,
+        output_channels=output_channels,
+        input_channels=input_channels,
+        input_height=input_height,
+        input_width=input_width,
+        filter_height=kernel[0],
+        filter_width=kernel[1],
+        stride_h=stride[0],
+        stride_w=stride[1],
+        padding=(padding[0], padding[1], padding[2], padding[3]),
+        config_override=config_override,
+        dilation_h=dilation[0],
+        dilation_w=dilation[1],
+        fp32_accum=fp32_accum,
+        packer_l1_acc=packer_l1_acc,
+        output_layout=ttnn.TILE_LAYOUT,
+        deallocate_activation=deallocate_activation,
+        groups=groups,
+        has_bias=True,
+        shard_layout=None,
+        auto_shard=auto_shard,
+        memory_config=None,
+        input_mesh_mapper=None,
+        weight_mesh_mapper=None,
+        output_mesh_composer=None,
+        enable_split_reader=enable_split_reader,
+        input_layout= input_layout,
+        activation="relu",
+        enable_act_double_buffer=True,  # will be disabled if activation reuse is enabled
+        input_dtype = input_dtype,
+        enable_activation_reuse=enable_activation_reuse
+    )
+
+
+@skip_for_blackhole()
+@pytest.mark.parametrize("enable_activation_reuse", [True])
+@pytest.mark.parametrize("enable_split_reader", [False, True])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, in_place",
+    (
+        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, None, False),
+    ),
+)
+@pytest.mark.parametrize(
+    "weights_dtype",
+    [ttnn.bfloat8_b],
+)
+@pytest.mark.parametrize(
+    "output_dtype",
+    [ttnn.bfloat8_b],
+)
+@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
+@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
+def test_conv2d_activation_reuse_unet_conv_group_4(
+    device,
+    torch_tensor_map,
+    math_fidelity,
+    output_dtype,
+    weights_dtype,
+    output_channels,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    shard_layout,
+    config_override,
+    output_layout,
+    in_place,
+    enable_split_reader,
+    enable_activation_reuse,
+):
+    batch_size = 1
+    groups = 4
+
+    # prepare input tensor
+    input_channels = groups * input_channels
+    output_channels = groups * output_channels
+
+    conv_input_shape = (batch_size, input_channels, input_height, input_width)
+    torch_input_tensor_nchw = randomize_torch_tensor(torch_tensor_map, conv_input_shape)
+    torch_input_tensor_nchw_reshaped = torch_input_tensor_nchw.reshape(
+        [1, 1, input_channels, input_height * input_width]
+    )
+
+    input_core_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
+            ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
+        }
+    )
+    input_sharded_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, ttnn.ShardSpec(input_core_grid, (16, 2688), ttnn.ShardOrientation.ROW_MAJOR)
+    )
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor_nchw_reshaped, dtype=ttnn.bfloat16, device=device, memory_config=input_sharded_memory_config
+    )
+
+    memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, ttnn.ShardSpec(input_core_grid, (2688, input_channels), ttnn.ShardOrientation.ROW_MAJOR)
+    )
+    tt_input_tensor = ttnn.experimental.convert_to_hwc(
+        tt_input_tensor, memory_config=memory_config, dtype=ttnn.bfloat16
+    )
+
+    # run conv
+    run_conv(
+        device,
+        torch_tensor_map,
+        math_fidelity,
+        output_dtype,
+        weights_dtype,
+        batch_size,
+        output_channels,
+        input_channels,
+        input_height,
+        input_width,
+        filter_height,
+        filter_width,
+        stride_h,
+        stride_w,
+        (pad_h, pad_w),
+        config_override,
+        shard_layout=shard_layout,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        output_layout=output_layout,
+        groups=groups,
+        in_place=in_place,
+        deallocate_activation=True,
+        enable_act_double_buffer=True, # will be disabled if activation reuse is enabled
+        enable_weights_double_buffer=True,
+        activation="relu",
         input_dtype=ttnn.bfloat16,
+        prepared_input_tensor=tt_input_tensor,
+        enable_split_reader=enable_split_reader,
+        enable_activation_reuse=enable_activation_reuse
     )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -556,6 +556,16 @@ Result conv2d_L1(
         kernel_size = folding_result.kernel_size;
         mm_conv = folding_result.mm_conv;
     }
+
+    if (conv_config.enable_activation_reuse) {
+        if (conv_config.enable_act_double_buffer) {
+            conv_config.enable_act_double_buffer = false;
+            log_warning(
+                tt::LogOp,
+                "Activation double buffering is currently not supported when activation reuse optimization is enabled, "
+                "disabling double buffering.");
+        }
+    }
     auto [output_height, output_width] =
         calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
 
@@ -646,6 +656,7 @@ Result conv2d_L1(
         true,  // parameters_on_device
         conv_config.enable_kernel_stride_folding,
         conv_config.full_inner_dim,
+        conv_config.enable_activation_reuse,
         kernel_size,
         orig_stride,
         padding_n4);
@@ -775,7 +786,8 @@ Result conv2d_L1(
             conv_config.enable_act_double_buffer,
             conv_config.enable_weights_double_buffer,
             conv_config.full_inner_dim,
-            enable_split_reader);
+            enable_split_reader,
+            conv_config.enable_activation_reuse);
 
         if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
             conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -70,6 +70,7 @@ std::vector<CBInfo> get_cb_info(
     DataType input_datatype,
     DataType output_datatype,
     std::array<uint32_t, 2> conv_input_shard_shape,
+    uint32_t output_image_width,
     bool enable_bias,
     bool is_1d_depthwise_conv,
     bool skip_act_cb_create);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -198,6 +198,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("conv_weight_tensor").noconvert(),
         py::arg("in1_block_h"),
         py::arg("in1_block_w"),
+        py::arg("enable_activation_reuse") = false,
         py::arg("output_dtype").noconvert() = std::nullopt);
 
     module.def(
@@ -317,6 +318,7 @@ void py_bind_conv2d(py::module& module) {
             bool,
             bool,
             bool,
+            bool,
             bool>(),
         py::kw_only(),
         py::arg("weights_dtype") = std::nullopt,
@@ -336,7 +338,8 @@ void py_bind_conv2d(py::module& module) {
         py::arg("full_inner_dim") = false,
         py::arg("enable_split_reader") = false,
         py::arg("in_place") = false,
-        py::arg("enable_kernel_stride_folding") = false);
+        py::arg("enable_kernel_stride_folding") = false,
+        py::arg("enable_activation_reuse") = false);
     py_conv_config.def_readwrite("weights_dtype", &Conv2dConfig::weights_dtype, R"doc(
         Optional argument which specifies the data type of the preprocessed weights & bias tensor if the Conv2D op is responsible for preparing the weights.
         Supports ttnn.bfloat16 and ttnn.bfloat8_b.
@@ -463,6 +466,15 @@ void py_bind_conv2d(py::module& module) {
 
         ===============================================================
         )doc");
+    py_conv_config.def_readwrite("enable_activation_reuse", &Conv2dConfig::enable_activation_reuse, R"doc(
+        ===================== EXPERIMENTAL FEATURE ======================
+
+        Enables reusing data between consecutive image rows.
+        It can be enabled for height sharding only and boosts image2column performance,
+        so its meant to be used for reader-bound convolutions.
+
+        ===============================================================
+    )doc");
 
     py_conv_config.def("__repr__", [](const Conv2dConfig& config) { return fmt::format("{}", config); });
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -875,7 +875,8 @@ Conv2dConfig determine_conv_config_for_auto_shard(
         Conv2dConfig conv_config = conv_config_in;
         conv_config.shard_layout = shard_layout;
         // Set act_block_h_override to min value to be conservative with L1 memory usage;
-        // With activation reuse, the CB usage is constant regardless of the act block h, so we can keep override to 0
+        // When activation reuse is enabled, the activation CB usage is constant regardless of the act_block_h_override
+        // and the bigger the act block height the better the reuse since we apply optimization within single act block
         if (conv_config.act_block_h_override == 0 && !conv_config.enable_activation_reuse) {
             conv_config.act_block_h_override = tt::constants::TILE_HEIGHT;
             // Split reader is currently only supported for height sharded convs that are not 1d deptwise.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -398,7 +398,7 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
         }
     }
 
-    if (enable_activation_reuse) {
+    if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED && enable_activation_reuse) {
         const uint32_t output_image_width_ntiles = div_up(output_width, tt::constants::TILE_HEIGHT);
         TT_FATAL(
             act_block_h_ntiles > output_image_width_ntiles,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -364,8 +364,10 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     uint32_t act_block_w_div,
     uint32_t window_h,
     uint32_t window_w,
+    uint32_t output_width,
     bool fp32_accum,
-    bool full_inner_dim) {
+    bool full_inner_dim,
+    bool enable_activation_reuse) {
     if (act_block_h_override > 0) {
         TT_ASSERT(
             act_block_h_override % 32 == 0,
@@ -396,11 +398,23 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
         }
     }
 
+    if (enable_activation_reuse) {
+        const uint32_t output_image_width_ntiles = div_up(output_width, tt::constants::TILE_HEIGHT);
+        TT_FATAL(
+            act_block_h_ntiles > output_image_width_ntiles,
+            "Activation reuse needs act block h ({}) to be bigger than output image width in tiles ({}) for the "
+            "optimization to give boost",
+            act_block_h_ntiles,
+            output_image_width_ntiles);
+    }
+
     uint32_t act_c_num_blocks = get_num_cores_channels_from_parallel_config(parallel_config);
     TT_ASSERT(padded_in_channels % act_c_num_blocks == 0);
     uint32_t act_block_w = 0;
     if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
-        act_block_w = tt::round_up(padded_in_channels * window_w, tt::constants::TILE_WIDTH);
+        act_block_w = enable_activation_reuse
+                          ? tt::round_up(padded_in_channels * window_h * window_w, tt::constants::TILE_WIDTH)
+                          : tt::round_up(padded_in_channels * window_w, tt::constants::TILE_WIDTH);
     } else if (parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
         act_block_w = tt::round_up(
             padded_in_channels / act_c_num_blocks * window_w * (full_inner_dim ? window_h : 1),
@@ -860,9 +874,9 @@ Conv2dConfig determine_conv_config_for_auto_shard(
                                          const Conv2dConfig& conv_config_in) -> core_count_and_size {
         Conv2dConfig conv_config = conv_config_in;
         conv_config.shard_layout = shard_layout;
-        if (conv_config.act_block_h_override == 0) {
-            // Set act_block_h_override to min value to
-            // be conservative with L1 memory usage.
+        // Set act_block_h_override to min value to be conservative with L1 memory usage;
+        // With activation reuse, the CB usage is constant regardless of the act block h, so we can keep override to 0
+        if (conv_config.act_block_h_override == 0 && !conv_config.enable_activation_reuse) {
             conv_config.act_block_h_override = tt::constants::TILE_HEIGHT;
             // Split reader is currently only supported for height sharded convs that are not 1d deptwise.
             if (conv_config.enable_split_reader && shard_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
@@ -935,6 +949,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
             conv_config,
             input_datatype,
             output_datatype,
+            output_width,
             enable_bias,
             conv_is_1d_deptwise);
 
@@ -1038,8 +1053,10 @@ std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryC
         conv_config.act_block_w_div,
         kernel_size[0],
         kernel_size[1],
+        output_width,
         get_fp32_dest_acc_en(compute_config),
-        conv_config.full_inner_dim);
+        conv_config.full_inner_dim,
+        conv_config.enable_activation_reuse);
     return {opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config};
 }
 
@@ -1193,7 +1210,8 @@ uint32_t calculate_conv_dram_slice_L1_usage(
             conv_config,
             params.input_datatype,
             params.output_datatype,
-            params.enable_bias,
+            output_slice_width,
+        params.enable_bias,
             false);
 
         auto shard_shape = sliced_input_tensor_memory_config.shard_spec().value().shape;
@@ -1351,6 +1369,7 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
     const Conv2dConfig& conv_config,
     const DataType input_datatype,
     const DataType output_datatype,
+    const uint32_t output_image_width,
     const bool enable_bias,
     bool is_1d_depthwise_conv,
     bool skip_act_cb_create) {
@@ -1366,6 +1385,7 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
         input_datatype,
         output_datatype,
         dummy_input_shard_shape,
+        output_image_width,
         enable_bias,
         is_1d_depthwise_conv,
         skip_act_cb_create);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -399,7 +399,7 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     }
 
     if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED && enable_activation_reuse) {
-        const uint32_t output_image_width_ntiles = div_up(output_width, tt::constants::TILE_HEIGHT);
+        const uint32_t output_image_width_ntiles = tt::div_up(output_width, tt::constants::TILE_HEIGHT);
         TT_FATAL(
             act_block_h_ntiles > output_image_width_ntiles,
             "Activation reuse needs act block h ({}) to be bigger than output image width in tiles ({}) for the "

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -121,8 +121,10 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     uint32_t act_block_w_div,
     uint32_t window_h,
     uint32_t window_w,
+    uint32_t output_width,
     bool fp32_accum,
-    bool full_inner_dim);
+    bool full_inner_dim,
+    bool enable_activation_reuse = false);
 
 std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryConfig> get_conv_configs(
     const Conv2dConfig& conv_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -44,7 +44,8 @@ Tensor optimized_conv_new(
     bool enable_act_double_buffer,
     bool enable_weights_double_buffer,
     bool full_inner_dim,
-    bool enable_split_reader) {
+    bool enable_split_reader,
+    bool enable_activation_reuse) {
     TT_FATAL(b.layout() == Layout::TILE,
              "Weights should be in TILE layout.");  // Weights should already be formatted
     const auto& ashape = input_tensor_shape;
@@ -58,6 +59,7 @@ Tensor optimized_conv_new(
         input_bias_format_params = {
             .pad_shape = bias.value().padded_shape(), .pad_value = 0, .target_layout = Layout::TILE};
     }
+
     auto optimized_conv_op = OptimizedConvNew(
         sliding_window_config,
         output_channels,
@@ -74,7 +76,8 @@ Tensor optimized_conv_new(
         enable_act_double_buffer,
         enable_weights_double_buffer,
         full_inner_dim,
-        enable_split_reader);
+        enable_split_reader,
+        enable_activation_reuse);
     IDevice* device = a.device();
 
     optimized_conv_op.pre_op_l1_allocation_size_bytes =
@@ -251,7 +254,8 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             enable_act_double_buffer,
             enable_weights_double_buffer,
             enable_split_reader,
-            full_inner_dim);
+            full_inner_dim,
+            enable_activation_reuse);
     }
 
     const uint32_t post_op_l1_allocation_size =
@@ -263,6 +267,7 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
         std::array<uint32_t, 2>({sliding_window_config.window_hw.first, sliding_window_config.window_hw.second});
 
     const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, memory_config.memory_layout());
+    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
     conv_op_l1_usage l1_usage = calculate_L1_usage(
         compute_kernel_config,
         block_config,
@@ -275,17 +280,14 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
             .enable_act_double_buffer = enable_act_double_buffer,
             .enable_weights_double_buffer = enable_weights_double_buffer,
-            .enable_split_reader = enable_split_reader},
+            .enable_split_reader = enable_split_reader,
+            .enable_activation_reuse = enable_activation_reuse},
         input_tensor_a.dtype(),
         this->dtype,
+        output_image_width,
         has_bias,
         is_1d_deptwise_conv(
-            groups,
-            input_tensor_shape[3],
-            output_channels,
-            kernel_dims[1],
-            sliding_window_config.get_output_shape()[2],
-            has_bias),
+            groups, input_tensor_shape[3], output_channels, kernel_dims[1], output_image_width, has_bias),
         skip_mcast.skip_activation_mcast);
 
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -103,6 +103,11 @@ struct Conv2dConfig {
     //    5. Input tensor data type is not BFLOAT8_B.
 
     bool enable_kernel_stride_folding = false;
+
+    // Activation reuse is a feature that enables reusing data between consecutive image rows.
+    // It can be enabled for height sharding only and boosts im2col performance,
+    // so its meant to be used for reader-bound convolutions.
+    bool enable_activation_reuse = false;
     // ===============================================================
 
     static constexpr auto attribute_names = std::make_tuple(
@@ -123,7 +128,8 @@ struct Conv2dConfig {
         "full_inner_dim",
         "enable_split_reader",
         "in_place",
-        "enable_kernel_stride_folding");
+        "enable_kernel_stride_folding",
+        "enable_activation_reuse");
     auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->weights_dtype),
@@ -143,7 +149,8 @@ struct Conv2dConfig {
             std::cref(this->full_inner_dim),
             std::cref(this->enable_split_reader),
             std::cref(this->in_place),
-            std::cref(this->enable_kernel_stride_folding));
+            std::cref(this->enable_kernel_stride_folding),
+            std::cref(this->enable_activation_reuse));
     }
 };
 
@@ -227,7 +234,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_act_double_buffer,
     bool enable_weights_double_buffer,
     bool enable_split_reader,
-    bool full_inner_dim);
+    bool full_inner_dim,
+    bool enable_activation_reuse);
 
 // new micro op
 struct OptimizedConvNew {
@@ -246,6 +254,7 @@ struct OptimizedConvNew {
     bool enable_weights_double_buffer;
     bool full_inner_dim;
     bool enable_split_reader;
+    bool enable_activation_reuse;
     uint32_t pre_op_l1_allocation_size_bytes{};
     OptimizedConvNew(
         const sliding_window::SlidingWindowConfig& sliding_window_config,
@@ -263,7 +272,8 @@ struct OptimizedConvNew {
         bool enable_act_double_buffer,
         bool enable_weights_double_buffer,
         bool full_inner_dim,
-        bool enable_split_reader) :
+        bool enable_split_reader,
+        bool enable_activation_reuse) :
         output_channels(output_channels),
         groups(groups),
         sliding_window_config(sliding_window_config),
@@ -279,7 +289,8 @@ struct OptimizedConvNew {
         enable_act_double_buffer(enable_act_double_buffer),
         enable_weights_double_buffer(enable_weights_double_buffer),
         full_inner_dim(full_inner_dim),
-        enable_split_reader(enable_split_reader) {}
+        enable_split_reader(enable_split_reader),
+        enable_activation_reuse(enable_activation_reuse) {}
 
     void validate(
         const std::vector<Tensor>& input_tensors,
@@ -309,7 +320,8 @@ struct OptimizedConvNew {
         "input_tensor_shape",
         "enable_act_double_buffer",
         "enable_weights_double_buffer",
-        "enable_split_reader");
+        "enable_split_reader",
+        "enable_activation_reuse");
     auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->parallelization_config),
@@ -325,7 +337,8 @@ struct OptimizedConvNew {
             std::cref(this->input_tensor_shape),
             std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_weights_double_buffer),
-            std::cref(this->enable_split_reader));
+            std::cref(this->enable_split_reader),
+            std::cref(this->enable_activation_reuse));
     }
 };
 
@@ -347,7 +360,8 @@ Tensor optimized_conv_new(
     bool enable_act_double_buffer = false,
     bool enable_weights_double_buffer = false,
     bool full_inner_dim = false,
-    bool enable_split_reader = false);
+    bool enable_split_reader = false,
+    bool enable_activation_reuse = false);
 
 // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
 // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
@@ -373,6 +387,7 @@ conv_op_l1_usage calculate_L1_usage(
     const Conv2dConfig& conv_config,
     tt::tt_metal::DataType input_datatype,
     tt::tt_metal::DataType output_datatype,
+    uint32_t output_image_width,
     bool enable_bias,
     bool is_1d_depthwise_conv,
     bool skip_act_cb_create = false);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -565,9 +565,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
     const bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
+    const uint32_t batch = sliding_window_config.get_output_shape()[0];
     const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
     const uint32_t output_image_height = sliding_window_config.get_output_shape()[1];
-    const uint32_t output_matrix_height_tiles = (output_image_height * output_image_width) / tt::constants::TILE_HEIGHT;
+    const uint32_t output_matrix_height_tiles =
+        (batch * output_image_height * output_image_width) / tt::constants::TILE_HEIGHT;
 
     Conv2dConfig conv_config = Conv2dConfig{
         .weights_dtype = b.dtype(),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -51,7 +51,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_act_double_buffer,
     bool enable_weights_double_buffer,
     bool enable_split_reader,
-    bool full_inner_dim) {
+    bool full_inner_dim,
+    bool enable_activation_reuse) {
     distributed::MeshDevice* device = a.device();
     TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
@@ -68,6 +69,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     const bool skip_weights_mcast = skip_mcast.skip_weights_mcast;
 
     const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const tt::DataFormat act_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -116,7 +118,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     const uint32_t per_core_out_matrix_width_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
     const uint32_t per_core_out_matrix_height_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
 
-    const bool slice_inner_dim = height_sharded || !full_inner_dim;
+    const bool slice_inner_dim = (height_sharded && !enable_activation_reuse) || (block_sharded && !full_inner_dim);
 
     uint32_t conv_act_c_blocks = 1;
     uint32_t out_conv_c_blocks = 1;
@@ -147,12 +149,20 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
     const uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
     const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw.first;
     const uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw.second;
 
     if (sliding_window_config.is_transpose) {
         auto input_shape = sliding_window_config.get_transposed_full_input_shape();
         conv_act_size_w = input_shape[2];
         pad_w = 0;
+    }
+
+    // Activation reuse validation
+    if (enable_activation_reuse) {
+        TT_FATAL(!block_sharded, "Activation data reuse is not supported for block sharded");
+        TT_FATAL(dilation_h == 1 && dilation_w == 1, "Activation data reuse is not supported for dilation > 1");
+        TT_FATAL(stride_h == 1 && stride_w == 1, "Activation data reuse is not supported for stride > 1");
     }
 
     const bool is_conv_1d_depthwise_conv =
@@ -469,6 +479,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
     const bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
+    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
+    const uint32_t output_image_height = sliding_window_config.get_output_shape()[1];
+    const uint32_t output_matrix_height_tiles = (output_image_height * output_image_width) / tt::constants::TILE_HEIGHT;
 
     Conv2dConfig conv_config = Conv2dConfig{
         .weights_dtype = b.dtype(),
@@ -476,7 +489,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
         .enable_act_double_buffer = enable_act_double_buffer,
         .enable_weights_double_buffer = enable_weights_double_buffer,
-        .enable_split_reader = enable_split_reader};
+        .enable_split_reader = enable_split_reader,
+        .enable_activation_reuse = enable_activation_reuse};
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -487,6 +501,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         a.dtype(),
         output.dtype(),
         shard_shape,
+        output_image_width,
         has_bias,
         is_conv_1d_depthwise_conv,
         skip_activation_mcast);
@@ -537,6 +552,71 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t reader_arg_act_block_h_datums = (enable_split_reader ? act_block_h_datums_split : act_block_h_datums);
     TT_FATAL(reader_arg_act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
 
+    // reader kernel args
+    uint32_t image_width_tiles = 0, image_width_mod_tile = 0, act_cb_num_tiles_split = 0,
+             act_cb_num_tiles_split_last = 0, reuse_window_offset = 0;
+    bool readers_process_full_image_widths = false;
+
+    // compute kernel args
+    uint32_t tilized_cb_row_offset = 0, tilized_cb_second_reader_offset = 0;
+
+    uint32_t total_remaining_tiles_to_push = 0, cores_pushing_remaining_tiles = 0, partial_core_remaining_tiles = 0;
+    uint32_t last_core_with_work = 0;
+
+    if (enable_activation_reuse) {
+        // Calculate compile time args needed for activation reuse feature
+        image_width_tiles = (output_image_width + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
+        image_width_mod_tile = output_image_width % tt::constants::TILE_HEIGHT;
+        const uint32_t image_width_tile_leftover =
+            image_width_mod_tile == 0 ? 0 : tt::constants::TILE_HEIGHT - image_width_mod_tile;
+
+        // We rely that double buffering is turned off here
+        // TODO(sjovic): avoid this assumption
+        act_cb_num_tiles_split = access_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages;
+        if (enable_split_reader) {
+            act_cb_num_tiles_split_last = access_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).num_pages;
+        }
+
+        // Number of bytes to move the CB read pointer when passing on to the new output image row;
+        // We need to skip the first kernel_w*in_channels_padded elements
+        reuse_window_offset = filter_w * conv_act_c_read_bytes;
+        // In case the output image width is not a multiple of the tile height, we need to skip the additional elements
+        // we read to fill in the tile height
+        if (image_width_tile_leftover) {
+            reuse_window_offset += (filter_w * filter_h * conv_act_c_read_bytes + act_block_w_extra_align_bytes) *
+                                   image_width_tile_leftover;
+        }
+
+        // Precompute happy path for the feature - if each reader processes full image rows only, we can skip many if
+        // conditions in the kernel. There are two cases which can affect this:
+        // - shards are split in such way that one shard ends in the middle of the image width
+        // - shards contain full image widths only, but split reader splits shard in the middle of the image width
+        // - output image width is not a multiple of the tile height, so we need to process more than one image width at
+        // once
+        readers_process_full_image_widths = act_block_h_nsubblocks_split % image_width_tiles == 0 &&
+                                            act_block_h_nsubblocks_split_last % image_width_tiles == 0;
+        readers_process_full_image_widths = readers_process_full_image_widths && image_width_tile_leftover == 0;
+
+        // Compute kernel interleaves tilizing data coming from two readers so it needs to calculate the address in the
+        // tilized CB
+        tilized_cb_row_offset = (tilized_act_tile_size * act_block_w_ntiles);
+        tilized_cb_second_reader_offset = (tilized_act_tile_size * act_block_h_nsubblocks_split * act_block_w_ntiles);
+
+        // Last cores sometime have less work to do, but we still need to push the same number of tiles
+        // to avoid blocking compute kernels; Here we compute how many cores will be pushing the remaining tiles
+        total_remaining_tiles_to_push = act_block_h_ntiles * total_active_num_cores - output_matrix_height_tiles;
+        if (total_remaining_tiles_to_push > 0) {
+            cores_pushing_remaining_tiles =
+                (total_remaining_tiles_to_push + act_block_h_ntiles - 1) / act_block_h_ntiles;  // Ceiling division
+
+            partial_core_remaining_tiles = total_remaining_tiles_to_push % act_block_h_ntiles;
+            if (partial_core_remaining_tiles == 0) {
+                partial_core_remaining_tiles = act_block_h_ntiles;
+            }
+        }
+    }
+
+
     std::vector<uint32_t> reader_compile_time_args = {
         (uint32_t)dilation_h,
         (uint32_t)dilation_w,
@@ -565,8 +645,21 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
-    };
+        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index};
+
+    if (enable_activation_reuse) {
+        std::vector<uint32_t> activation_reuse_args = {
+            act_cb_num_tiles_split,
+            act_block_w_ntiles,
+            static_cast<uint32_t>(readers_process_full_image_widths),
+            image_width_tiles,
+            output_image_width,
+            reuse_window_offset,
+            static_cast<uint32_t>(total_remaining_tiles_to_push != 0)};
+
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
+    }
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -593,8 +686,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
 
     if (enable_split_reader) {
-        reader_defines["SPLIT_READER"] = "1";
         compute_defines["SPLIT_READER"] = "1";
+        reader_defines["SPLIT_READER"] = "1";
+        if (conv_act_c_read_bytes > 0) {
+            writer_mcast_sender_defines["SPLIT_READER"] = "1";
+            writer_defines["SPLIT_READER"] = "1";
+        }
     }
 
     if (packer_l1_acc_en) {
@@ -603,6 +700,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     if (weight_block_w_ntiles <= 8) {
         compute_defines["PACKER_UNTILIZE"] = "1";
     }
+
+    if (enable_activation_reuse) {
+        compute_defines["ACTIVATION_REUSE"] = "1";
+        reader_defines["ACTIVATION_REUSE"] = "1";
+        writer_mcast_sender_defines["ACTIVATION_REUSE"] = "1";
+        writer_defines["ACTIVATION_REUSE"] = "1";
+    }
+
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), total_num_cores, compute_defines, ttnn::get_throttle_level(compute_kernel_config));
 
@@ -636,7 +741,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     if (height_sharded) {
         if (enable_split_reader) {
             std::vector<uint32_t> split_reader_args = {
-                (uint32_t)(conv_act_c_read_bytes > 0),
                 (uint32_t)act_block_num_tiles_split_last / conv_act_c_blocks,
                 (uint32_t)conv_act_c_read_bytes,
                 (uint32_t)filter_w,                       // weight_size_w
@@ -646,10 +750,20 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 (uint32_t)dilation_h,
                 (uint32_t)dilation_w,
                 (uint32_t)stride_w};
-            writer_compile_time_args.insert(
-                writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
-        } else {
-            std::vector<uint32_t> split_reader_args(10, 0);
+
+            if (enable_activation_reuse) {
+                std::vector<uint32_t> activation_reuse_args = {
+                    filter_h,
+                    act_cb_num_tiles_split_last,
+                    act_block_w_ntiles,
+                    static_cast<uint32_t>(readers_process_full_image_widths),
+                    image_width_tiles,
+                    output_image_width,
+                    reuse_window_offset,
+                    static_cast<uint32_t>(total_remaining_tiles_to_push != 0)};
+                split_reader_args.insert(
+                    split_reader_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
+            }
             writer_compile_time_args.insert(
                 writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
         }
@@ -689,12 +803,21 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
         get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
-
         get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
         get_cb_info_by_name(cb_info, Conv2dCb::TEMP_SUM).index,
         partials_cb_uses_output,
         conv_act_c_blocks,
         check_skip_compute};
+
+    if (enable_activation_reuse) {
+        compute_kernel_args.push_back(image_width_tiles);
+        // offsets divided with 16 due to the compute kernel addressing mode
+        compute_kernel_args.push_back(reuse_window_offset / 16);
+        if (enable_split_reader) {
+            compute_kernel_args.push_back(tilized_cb_row_offset / 16);
+            compute_kernel_args.push_back(tilized_cb_second_reader_offset / 16);
+        }
+    }
 
     const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(device->arch());
     const tt::tt_metal::NOC reader_noc =
@@ -749,8 +872,43 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                         : std::vector<uint32_t>{end_x, end_y, start_x, start_y};
     };
 
+    // Last cores sometime have less work to do, but we still need to push the same number of tiles
+    // to avoid blocking compute kernels
+    std::vector<uint32_t> reader_remaining_tiles_to_push_args;
+    std::vector<uint32_t> writer_remaining_tiles_to_push_args;
+    if (enable_activation_reuse) {
+        int reader_remaining_tiles_to_push = 0;
+        int writer_remaining_tiles_to_push = 0;
+        for (uint32_t core_i = 0; core_i < total_active_num_cores; core_i++) {
+            // Core pushing at least 1 tile in height of real data
+            if (core_i == total_active_num_cores - cores_pushing_remaining_tiles) {
+                reader_remaining_tiles_to_push = partial_core_remaining_tiles;
+                if (enable_split_reader) {
+                    if (partial_core_remaining_tiles > act_block_h_nsubblocks_split_last) {
+                        writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
+                        reader_remaining_tiles_to_push =
+                            partial_core_remaining_tiles - act_block_h_nsubblocks_split_last;
+                    } else {
+                        writer_remaining_tiles_to_push = partial_core_remaining_tiles;
+                        reader_remaining_tiles_to_push = 0;
+                    }
+                }
+                // Cores with no meaningful work
+            } else if (core_i > total_active_num_cores - cores_pushing_remaining_tiles) {
+                reader_remaining_tiles_to_push = act_block_h_ntiles;
+                if (enable_split_reader) {
+                    reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
+                    writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
+                }
+            }
+
+            reader_remaining_tiles_to_push_args.push_back(reader_remaining_tiles_to_push);
+            writer_remaining_tiles_to_push_args.push_back(writer_remaining_tiles_to_push);
+        }
+    }
+
+    // Setup reader runtime arguments
     if (block_sharded) {
-        // Setup reader runtime arguments
         const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
         const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
         std::vector<uint32_t> act_mcast_noc_y;
@@ -807,10 +965,20 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 SetRuntimeArgs(program, reader_id, core, reader_rt_args);
             }
         }
+    } else if (enable_activation_reuse) {
+        uint32_t core_i = 0;
+        for (const CoreRange& core_range : all_cores.ranges()) {
+            for (const CoreCoord& core : core_range) {
+                std::vector<uint32_t> reader_rt_args{reader_remaining_tiles_to_push_args[core_i]};
+                SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+                core_i++;
+            }
+        }
     }
 
     // Setup writer mcast arguments
     // Setup sender args first
+    uint32_t core_i = 0;
     for (const CoreCoord& core : mcast_sender_cores) {
         // Calculate weight slice indices
         uint32_t weight_slice_i = (block_sharded && transpose_mcast || !block_sharded) ? core.y : core.x;
@@ -823,6 +991,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             "bias_tile_offset {} should be less than bias_ntiles {}",
             bias_tile_offset,
             bias_ntiles);
+
 
         std::vector<uint32_t> sender_rt_args = {
             weight_dram_addr, bias_dram_addr, out_start_tile_id_w, bias_tile_offset};
@@ -886,10 +1055,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                  total_num_cores - 1,  // mcast_num_dests, mcast_num_cores
                  weights_mcast_sender_semaphore_id,
                  weights_mcast_receiver_semaphore_id});
+            if (enable_split_reader && enable_activation_reuse) {
+                sender_rt_args.push_back(writer_remaining_tiles_to_push_args[core_i]);
+            }
             SetRuntimeArgs(program, writer_mcast_sender_id, core, sender_rt_args);
         }
     }
 
+    core_i++;
     // Setup receiver args second
     for (const CoreRange& core_range : mcast_receiver_cores.ranges()) {
         // Helper lambda to create receiver runtime args
@@ -918,8 +1091,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                     top_left_core_physical.y,
                     weights_mcast_sender_semaphore_id,
                     weights_mcast_receiver_semaphore_id};
+                if (enable_split_reader && enable_activation_reuse) {
+                    receiver_args.push_back(writer_remaining_tiles_to_push_args[core_i]);
+                }
             }
             SetRuntimeArgs(program, writer_mcast_receiver_id, core, receiver_args);
+
+            core_i++;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -364,6 +364,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         log_debug(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
     }
 
+    const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
     Conv2dConfig conv_config = Conv2dConfig{
         .weights_dtype = b.dtype(),
         .shard_layout = a.memory_config().memory_layout(),
@@ -380,6 +381,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         a.dtype(),
         output.dtype(),
         a.memory_config().shard_spec().value().shape,
+        output_image_width,
         has_bias,
         false,
         skip_activation_mcast);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -43,6 +43,132 @@ void tilize_in(
     }
 }  // tilize_in()
 
+#ifdef ACTIVATION_REUSE
+template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
+inline void tilize_single_block() {
+    cb_wait_front(in_cb_id, in_block_w);
+    fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
+    cb_pop_front(in_cb_id, in_block_w);
+}
+
+template <uint32_t in_cb_id, uint32_t window_reuse_offset>
+inline void update_in_cb(uint32_t& in_cb_addr) {
+    UNPACK((get_local_cb_interface(in_cb_id).fifo_rd_ptr = in_cb_addr));
+    in_cb_addr += window_reuse_offset;
+}
+
+template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id, uint32_t tilized_cb_row_offset>
+inline void tilize_single_block_with_out_cb_update(uint32_t& out_cb_addr) {
+    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
+    PACK((out_cb_addr += tilized_cb_row_offset));
+    tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
+}
+
+template <
+    uint32_t in_cb_id,
+    uint32_t in_block_w,
+    uint32_t in_num_subblocks,
+    uint32_t out_cb_id,
+    uint32_t window_reuse_offset,
+    uint32_t image_width_in_tiles>
+inline void tilize_in_reuse(uint32_t in_cb_start_addr) {
+    fast_tilize_init_with_dt(in_cb_id, in_block_w, out_cb_id);
+
+    constexpr uint32_t num_image_rows = in_num_subblocks / image_width_in_tiles;
+    constexpr uint32_t last_row_columns = in_num_subblocks % image_width_in_tiles;
+    uint32_t in_cb_addr = in_cb_start_addr;
+
+    // full image rows
+    for (uint32_t image_row = 0; image_row < num_image_rows; ++image_row) {
+        update_in_cb<in_cb_id, window_reuse_offset>(in_cb_addr);
+        for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
+            cb_reserve_back(out_cb_id, in_block_w);
+            tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
+            cb_push_back(out_cb_id, in_block_w);
+        }
+    }
+
+    // partial last image row
+    update_in_cb<in_cb_id, window_reuse_offset>(in_cb_addr);
+    for (uint32_t image_col = 0; image_col < last_row_columns; ++image_col) {
+        cb_reserve_back(out_cb_id, in_block_w);
+        tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
+        cb_push_back(out_cb_id, in_block_w);
+    }
+
+    fast_tilize_uninit(in_cb_id, out_cb_id);
+}
+
+template <
+    uint32_t in1_cb_id,
+    uint32_t in2_cb_id,
+    uint32_t in_block_w,
+    uint32_t in1_num_subblocks,
+    uint32_t in2_num_subblocks,
+    uint32_t out_cb_id,
+    uint32_t out_cb_tiles,
+    uint32_t window_reuse_offset,
+    uint32_t tilized_cb_row_offset,
+    uint32_t tilized_cb_second_reader_offset,
+    uint32_t image_width_in_tiles>
+inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t act_cb_second_reader_start_address) {
+    cb_reserve_back(out_cb_id, out_cb_tiles);
+    fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
+
+    uint32_t in1_cb_addr = act_cb_start_address;
+    uint32_t in2_cb_addr = act_cb_second_reader_start_address;
+
+    uint32_t out_cb_addr, out_cb_addr_second_reader;
+    PACK((out_cb_addr = get_local_cb_interface(out_cb_id).fifo_wr_ptr));
+    PACK((out_cb_addr_second_reader = out_cb_addr + tilized_cb_second_reader_offset));
+
+    constexpr uint32_t min_num_subblocks =
+        in1_num_subblocks > in2_num_subblocks ? in2_num_subblocks : in1_num_subblocks;
+    constexpr uint32_t min_num_image_rows = min_num_subblocks / image_width_in_tiles;
+    constexpr uint32_t leftover_in1 = in1_num_subblocks - min_num_image_rows * image_width_in_tiles;
+    constexpr uint32_t leftover_in2 = in2_num_subblocks - min_num_image_rows * image_width_in_tiles;
+    constexpr uint32_t max_leftover = leftover_in1 > leftover_in2 ? leftover_in1 : leftover_in2;
+
+    // full image rows
+    for (uint32_t image_row = 0; image_row < min_num_image_rows; ++image_row) {
+        update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+        update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+        for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
+            tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                out_cb_addr);
+            tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                out_cb_addr_second_reader);
+        }
+    }
+
+    // partial last image row
+    update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+    update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+    for (uint32_t image_col = 0; image_col < max_leftover; ++image_col) {
+        if (image_col < leftover_in1) {
+            tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                out_cb_addr);
+
+            if (image_col == image_width_in_tiles - 1) {
+                update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+            }
+        }
+
+        if (image_col < leftover_in2) {
+            tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                out_cb_addr_second_reader);
+
+            if (image_col == image_width_in_tiles - 1) {
+                update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+            }
+        }
+    }
+
+    cb_push_back(out_cb_id, out_cb_tiles);
+    fast_tilize_uninit(in2_cb_id, out_cb_id);
+}
+#endif
+
 template <uint32_t out_subblock_w, uint32_t out_block_w>
 inline void reblock_and_untilize(
     uint32_t num_out_subblocks_in_col,
@@ -107,6 +233,15 @@ void MAIN {
     constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(27);
     constexpr bool check_skip_compute = get_compile_time_arg_val(28);
 
+#ifdef ACTIVATION_REUSE
+    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(30);
+#ifdef SPLIT_READER
+    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(31);
+    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(32);
+#endif
+#endif
+
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     constexpr uint32_t out_block_w = in1_block_w;
     constexpr bool spill = in0_num_blocks_w > 1;
@@ -141,6 +276,14 @@ void MAIN {
     if constexpr (check_skip_compute) {
         skip_compute = (bool)get_arg_val<uint32_t>(0);
     }
+#ifdef ACTIVATION_REUSE
+    uint32_t act_cb_start_address = get_local_cb_interface(in0_cb_id).fifo_rd_ptr;
+#ifdef SPLIT_READER
+    const uint32_t out_cb_tiles = in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last);
+    const uint32_t tilized_cb_start_address = get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr;
+    const uint32_t act_cb_second_reader_start_address = get_local_cb_interface(in0_cb_second_reader_id).fifo_rd_ptr;
+#endif
+#endif
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -148,7 +291,6 @@ void MAIN {
 #endif
     UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
     PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
-
     // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
@@ -201,10 +343,37 @@ void MAIN {
                     pack_reconfig_data_format(curr_matmul_out_cb, tilized_in0_cb_id);
                     pack_reconfig_l1_acc(0);
 #endif
+
+#ifndef ACTIVATION_REUSE
                     tilize_in<true, !split_reader>(in0_cb_id, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
 #ifdef SPLIT_READER
                     tilize_in<false, true>(
                         in0_cb_second_reader_id, in0_block_w, in0_num_subblocks_read_last, tilized_in0_cb_id);
+#endif
+#else
+#ifndef SPLIT_READER
+                    tilize_in_reuse<
+                        in0_cb_id,
+                        in0_block_w,
+                        in0_num_subblocks_read,
+                        tilized_in0_cb_id,
+                        window_reuse_offset,
+                        image_width_in_tiles>(act_cb_start_address);
+#else
+                    PACK((get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr = tilized_cb_start_address));
+                    tilize_in_reuse_split_reader<
+                        in0_cb_id,
+                        in0_cb_second_reader_id,
+                        in0_block_w,
+                        in0_num_subblocks_read,
+                        in0_num_subblocks_read_last,
+                        tilized_in0_cb_id,
+                        out_cb_tiles,
+                        window_reuse_offset,
+                        tilized_cb_row_offset,
+                        tilized_cb_second_reader_offset,
+                        image_width_in_tiles>(act_cb_start_address, act_cb_second_reader_start_address);
+#endif
 #endif
 
                     mm_block_init_short_with_both_dt(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -65,3 +65,239 @@ FORCE_INLINE void read_sticks(
     }
     reader_idx++;
 }
+
+#ifdef ACTIVATION_REUSE
+template <uint32_t cb_id_act, uint32_t act_cb_tiles, uint32_t window_reuse_offset>
+FORCE_INLINE void pass_to_the_next_image_width(
+    uint32_t& l1_write_addr_act, uint32_t cb_start_addr, uint32_t& pixel_row, uint32_t& pixel_column) {
+    pixel_column = 0;
+    pixel_row++;
+    cb_reserve_back(cb_id_act, act_cb_tiles);
+    l1_write_addr_act = cb_start_addr + pixel_row * window_reuse_offset;
+    get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+}
+
+template <uint32_t coalesced_read_bytes, uint32_t stride_h_bytes>
+FORCE_INLINE void read_kernel_w(uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+    l1_write_addr_act += coalesced_read_bytes;
+    act_l1_offset += stride_h_bytes;
+}
+
+template <uint32_t cb_id_act, uint32_t act_cb_w_tiles>
+FORCE_INLINE void push_full_tile_height() {
+    noc_async_read_barrier();
+    cb_push_back(cb_id_act, act_cb_w_tiles);
+}
+
+// Function to read the windows in the first output image row where we don't reuse anything
+template <
+    uint32_t coalesced_read_bytes,
+    uint32_t stride_h_bytes,
+    uint32_t window_outer,
+    uint32_t cb_id_act,
+    uint32_t act_cb_w_tiles,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes>
+FORCE_INLINE void read_first_image_row_window(
+    uint32_t& l1_write_addr_act, uint32_t reader_offset, uint16_t ind, uint32_t& pixel_column) {
+    uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+    for (uint32_t outer = 0; outer < window_outer; outer++) {
+        // read full inner dim at once
+        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+    }
+    l1_write_addr_act += act_block_w_extra_align_bytes;
+
+    pixel_column++;
+    // if full tile, push back
+    if ((pixel_column & 31) == 0) {
+        push_full_tile_height<cb_id_act, act_cb_w_tiles>();
+    }
+}
+
+template <
+    uint32_t coalesced_read_bytes,
+    uint32_t stride_h_bytes,
+    uint32_t outer_coalesced_read_bytes,
+    uint32_t outer_stride_h_bytes>
+FORCE_INLINE void read_image_row_window_with_reuse(uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+    l1_write_addr_act += outer_coalesced_read_bytes;
+    act_l1_offset += outer_stride_h_bytes;
+    read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+}
+
+template <
+    uint32_t coalesced_read_bytes,
+    uint32_t conv_act_c_read_bytes,
+    uint32_t act_block_w_extra_align_bytes,
+    uint32_t stride_h_bytes,
+    uint32_t window_inner,
+    uint32_t stride_w,
+    uint32_t window_outer,
+    uint32_t cb_id_act,
+    uint32_t act_cb_tiles,
+    uint32_t act_cb_w_tiles,
+    bool readers_process_full_image_widths,
+    uint32_t image_width_tiles,
+    uint32_t output_image_width,
+    uint32_t window_reuse_offset,
+    bool need_to_push_remaining_tiles>
+FORCE_INLINE void read_sticks_activation_reuse(
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
+    uint32_t reader_offset,
+    uint32_t& l1_write_addr_act,
+    uint32_t& reader_idx,
+    uint32_t cb_start_addr,
+    uint32_t remaining_tiles_to_push) {
+    constexpr uint32_t image_width_padded_to_tile = image_width_tiles * 32;
+    constexpr uint32_t output_image_width_full_tile = output_image_width == image_width_padded_to_tile;
+    constexpr uint32_t reuse_outer = window_outer - 1;
+    constexpr uint32_t outer_coalesced_read_bytes = reuse_outer * coalesced_read_bytes;
+    constexpr uint32_t outer_stride_h_bytes = reuse_outer * stride_h_bytes;
+
+    uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    uint32_t pixel_row = 0, pixel_column = 0;
+
+    cb_reserve_back(cb_id_act, act_cb_tiles);
+
+    reader_idx++;
+    uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+
+    // ------ HANDLE FIRST OUTPUT IMAGE WIDTH SEPARATELY, WHERE WE NEED TO READ THE FULL WINDOW ------
+    for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+        read_first_image_row_window<
+            coalesced_read_bytes,
+            stride_h_bytes,
+            window_outer,
+            cb_id_act,
+            act_cb_w_tiles,
+            conv_act_c_read_bytes,
+            act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
+    }
+
+    num_elems--;
+    reader_idx++;
+    start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+
+    if constexpr (!readers_process_full_image_widths) {
+        if (num_elems) {
+            // The first image width might be split between two rows
+            uint16_t leftover_row_width = image_width_padded_to_tile - pixel_column;
+            uint16_t second_row_width = leftover_row_width, third_row_width = 0;
+            if constexpr (!output_image_width_full_tile) {
+                // If the output image width is not a multiple of the tile width, the first 'image width' might be split
+                // between three rows since we padd image width to tile size; otherwise, it is always split between
+                // maximum two rows
+                const uint16_t interval_width = end_ind - start_ind + 1;
+                if (leftover_row_width > interval_width) {
+                    second_row_width = interval_width;
+                    third_row_width = leftover_row_width - second_row_width;
+                }
+            }
+
+            for (uint16_t ind = start_ind; ind < start_ind + second_row_width; ind += stride_w) {
+                read_first_image_row_window<
+                    coalesced_read_bytes,
+                    stride_h_bytes,
+                    window_outer,
+                    cb_id_act,
+                    act_cb_w_tiles,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
+            }
+
+            start_ind = start_ind + second_row_width;
+
+            if constexpr (!output_image_width_full_tile) {
+                if (third_row_width > 0) {
+                    num_elems--;
+                    reader_idx++;
+                    start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+                    end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+
+                    for (uint16_t ind = start_ind; ind < start_ind + third_row_width; ind += stride_w) {
+                        read_first_image_row_window<
+                            coalesced_read_bytes,
+                            stride_h_bytes,
+                            window_outer,
+                            cb_id_act,
+                            act_cb_w_tiles,
+                            conv_act_c_read_bytes,
+                            act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
+                    }
+
+                    start_ind = start_ind + third_row_width;
+                }
+            }
+        }
+    }
+    // Move on to the next output image width
+    pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
+        l1_write_addr_act, cb_start_addr, pixel_row, pixel_column);
+
+    // ------ HANDLE REMAINING INPUT, WHERE WE READ JUST THE LAST KERNEL WIDTH OF THE WINDOW ------
+    while (num_elems--) {
+        for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+            uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+            if constexpr (output_image_width_full_tile) {
+                // In this case, everything is reused after the first image width
+                read_image_row_window_with_reuse<
+                    coalesced_read_bytes,
+                    stride_h_bytes,
+                    outer_coalesced_read_bytes,
+                    outer_stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+            } else {
+                // In this case, we need to check if we are in the limits of image width since we pad it to tile size
+                if (pixel_column < output_image_width) {
+                    read_image_row_window_with_reuse<
+                        coalesced_read_bytes,
+                        stride_h_bytes,
+                        outer_coalesced_read_bytes,
+                        outer_stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+                } else {
+                    for (uint32_t outer = 0; outer < window_outer; outer++) {
+                        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+                    }
+                }
+            }
+
+            l1_write_addr_act += act_block_w_extra_align_bytes;
+
+            pixel_column++;
+            if ((pixel_column & 31) == 0) {
+                push_full_tile_height<cb_id_act, act_cb_w_tiles>();
+
+                // Move on to the next output image width
+                if constexpr (!readers_process_full_image_widths) {
+                    if (pixel_column == image_width_padded_to_tile) {
+                        pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
+                            l1_write_addr_act, cb_start_addr, pixel_row, pixel_column);
+                    }
+                }
+            }
+        }
+
+        if constexpr (readers_process_full_image_widths) {
+            // Move on to the next output image width
+            pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
+                l1_write_addr_act, cb_start_addr, pixel_row, pixel_column);
+        }
+
+        reader_idx++;
+        start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+        end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+    }
+
+    // Last core sometimes has less work to do, but we still need to push the same number of tiles
+    // to avoid blocking compute kernels
+    if constexpr (need_to_push_remaining_tiles) {
+        constexpr uint32_t tiles_to_push = image_width_tiles * act_cb_w_tiles;
+        for (uint32_t i = 0; i < remaining_tiles_to_push; i += image_width_tiles) {
+            get_local_cb_interface(cb_id_act).fifo_wr_ptr = cb_start_addr;
+            cb_push_back(cb_id_act, tiles_to_push);
+        }
+    }
+}
+#endif

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -26,13 +26,6 @@ FORCE_INLINE void zero_out_tiles() {
     noc_async_read_barrier();
 }
 
-template <uint32_t coalesced_read_bytes, uint32_t stride_h_bytes>
-FORCE_INLINE void read_kernel_w(uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
-    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-    l1_write_addr_act += coalesced_read_bytes;
-    act_l1_offset += stride_h_bytes;
-}
-
 template <
     uint32_t dilation_w,
     uint32_t coalesced_read_bytes,
@@ -72,6 +65,13 @@ FORCE_INLINE void read_sticks(
         }
     }
     reader_idx++;
+}
+
+template <uint32_t coalesced_read_bytes, uint32_t stride_h_bytes>
+FORCE_INLINE void read_kernel_w(uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+    l1_write_addr_act += coalesced_read_bytes;
+    act_l1_offset += stride_h_bytes;
 }
 
 #ifdef ACTIVATION_REUSE

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -14,6 +14,7 @@ void kernel_main() {
     // them
     constexpr uint32_t window_outer = get_compile_time_arg_val(4);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);
     constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
     constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(9);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
@@ -23,6 +24,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+
+#ifdef ACTIVATION_REUSE
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(27);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(28);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(29) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(31);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(32);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(33) == 1;
+
+    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(0);
+#endif
 
     if constexpr (needs_act_block_zero_out) {
         zero_out_tiles<cb_id_act>();
@@ -57,11 +70,16 @@ void kernel_main() {
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     uint32_t start_reader_idx = 0;
+    const uint32_t cb_start_addr = get_write_ptr(cb_id_act);
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+#ifdef ACTIVATION_REUSE
+        uint32_t l1_write_addr_act = cb_start_addr;
+#endif
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {
             reader_idx = start_reader_idx;
 
+#ifndef ACTIVATION_REUSE
             cb_reserve_back(cb_id_act, act_block_num_tiles);
             uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
 
@@ -75,10 +93,33 @@ void kernel_main() {
                 stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
 
             noc_async_read_barrier();
-
             cb_push_back(cb_id_act, act_block_num_tiles);
-
             reader_offset += window_outer_offset;
+#else
+            read_sticks_activation_reuse<
+                coalesced_read_bytes,
+                conv_act_c_read_bytes,
+                act_block_w_extra_align_bytes,
+                window_outer_offset,
+                weight_size_w,
+                stride_w,
+                weight_size_h,
+                cb_id_act,
+                act_reuse_cb_tiles,
+                act_block_w_tiles,
+                readers_process_full_image_widths,
+                image_width_tiles,
+                output_image_width,
+                window_reuse_offset,
+                need_to_push_remaining_tiles>(
+                packed_reader_indices_ptr,
+                act_l1_read_addr,
+                l1_write_addr_act,
+                reader_idx,
+                cb_start_addr,
+                remaining_tiles_to_push);
+
+#endif
         }
 
         start_reader_idx = reader_idx;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -110,14 +110,8 @@ void kernel_main() {
                 readers_process_full_image_widths,
                 image_width_tiles,
                 output_image_width,
-                window_reuse_offset,
-                need_to_push_remaining_tiles>(
-                packed_reader_indices_ptr,
-                act_l1_read_addr,
-                l1_write_addr_act,
-                reader_idx,
-                cb_start_addr,
-                remaining_tiles_to_push);
+                window_reuse_offset>(
+                packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 
 #endif
         }
@@ -128,5 +122,14 @@ void kernel_main() {
         start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
 #endif
     }
+
+#ifdef ACTIVATION_REUSE
+    // Last core sometimes has less work to do, but we still need to push the same number of tiles
+    // to avoid blocking compute kernels
+    if constexpr (need_to_push_remaining_tiles) {
+        push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(remaining_tiles_to_push, cb_start_addr);
+    }
+#endif
+
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -142,6 +142,15 @@ void kernel_main() {
                 output_image_width,
                 window_reuse_offset>(
                 packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+
+            if constexpr (need_to_push_remaining_tiles) {
+                if (block_weight_h == num_blocks_weight_h - 1) {
+                    // Last core sometimes has less work to do, but we still need to push the same number of tiles
+                    // to avoid blocking compute kernels
+                    push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                        remaining_tiles_to_push, cb_start_addr);
+                }
+            }
 #endif
 #endif
 
@@ -185,15 +194,6 @@ void kernel_main() {
         start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
 #endif
     }  // out_num_blocks_h
-
-#if defined(SPLIT_READER) && defined(ACTIVATION_REUSE)
-    // Last core sometimes has less work to do, but we still need to push the same number of tiles
-    // to avoid blocking compute kernels
-    if constexpr (need_to_push_remaining_tiles) {
-        push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-            remaining_tiles_to_push, cb_start_addr);
-    }
-#endif
 
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -22,16 +22,28 @@ void kernel_main() {
     constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
 
     // Split reader args
-    constexpr bool split_reader = get_compile_time_arg_val(18);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(19);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(21);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(23);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(24) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(25);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
+#ifdef SPLIT_READER
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(19);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(20);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(21);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(22);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(24);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(25);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(26);
+
+#ifdef ACTIVATION_REUSE
+    constexpr uint32_t weights_size_h = get_compile_time_arg_val(27);
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(29);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(30) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(31);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(32);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(33);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(34) == 1;
+#endif
+#endif
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i++);
@@ -40,11 +52,11 @@ void kernel_main() {
         return;
     }
 
-    if constexpr (split_reader && needs_act_block_zero_out) {
+#ifdef SPLIT_READER
+    if constexpr (needs_act_block_zero_out) {
         zero_out_tiles<cb_id_act_second_reader>();
     }
-
-    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+#endif
 
     // mcast args
     const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
@@ -57,56 +69,87 @@ void kernel_main() {
     const uint64_t weights_mcast_sender_semaphore_noc_addr =
         get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
 
-    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr;
-    uint32_t reader_idx;
-    if constexpr (split_reader) {
-        packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
-        reader_idx = 0;
-    }
+#ifdef SPLIT_READER
+#ifdef ACTIVATION_REUSE
+    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(i++);
+#endif
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+    uint32_t reader_idx = 0;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+
+    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    // coalesce reads along weight_size_w
+    uint32_t start_reader_idx = (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+    const uint32_t cb_start_addr = get_write_ptr(cb_id_act_second_reader);
+#endif
 
 // read in bias if enabled (done only once for all batches)
 #ifdef FUSE_BIAS
     bool load_bias = true;
 #endif
 
-    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
-    constexpr uint32_t coalesced_read_bytes =
-        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-
-    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
-    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-    // coalesce reads along weight_size_w
-    uint32_t start_reader_idx;
-    if constexpr (split_reader) {
-        start_reader_idx = (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-    }
     for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
         // MCAST RECEIVE WEIGHTS
         // read weight blocks inner dim
         // read weight slice - 1 block of weights in width dim and full weight matrix height
         // read slice only once for all activation blocks
 
+#ifdef SPLIT_READER
+#ifdef ACTIVATION_REUSE
+        uint32_t l1_write_addr_act = cb_start_addr;
+#endif
         uint32_t reader_offset = act_l1_read_addr;
+#endif
         for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
-            if constexpr (split_reader) {
-                // Do the second half of the reads for act
-                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-                reader_idx = start_reader_idx;
-                cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-                read_sticks<
-                    dilation_w,
-                    coalesced_read_bytes,
-                    conv_act_c_read_bytes,
-                    act_block_w_extra_align_bytes,
-                    stride_w_bytes,
-                    weight_size_w,
-                    stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+#ifdef SPLIT_READER
+            // Do the second half of the reads for act
+            noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+            reader_idx = start_reader_idx;
 
-                reader_offset += window_outer_offset;
-            }
+#ifndef ACTIVATION_REUSE
+            cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
+            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+            read_sticks<
+                dilation_w,
+                coalesced_read_bytes,
+                conv_act_c_read_bytes,
+                act_block_w_extra_align_bytes,
+                stride_w_bytes,
+                weight_size_w,
+                stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+
+            reader_offset += window_outer_offset;
+#else
+            read_sticks_activation_reuse<
+                coalesced_read_bytes,
+                conv_act_c_read_bytes,
+                act_block_w_extra_align_bytes,
+                window_outer_offset,
+                weight_size_w,
+                stride_w,
+                weights_size_h,
+                cb_id_act_second_reader,
+                act_reuse_cb_tiles,
+                act_block_w_tiles,
+                readers_process_full_image_widths,
+                image_width_tiles,
+                output_image_width,
+                window_reuse_offset,
+                need_to_push_remaining_tiles>(
+                packed_reader_indices_ptr,
+                act_l1_read_addr,
+                l1_write_addr_act,
+                reader_idx,
+                cb_start_addr,
+                remaining_tiles_to_push);
+#endif
+#endif
 
             // Receive weights
             cb_reserve_back(cb_id_weight, weight_block_num_tiles);
@@ -143,10 +186,10 @@ void kernel_main() {
         }
 #endif
 
-        if constexpr (split_reader) {
-            // Increment reader index for the next number of segments (number of segments for other reader)
-            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-        }
+#ifdef SPLIT_READER
+        // Increment reader index for the next number of segments (number of segments for other reader)
+        start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+#endif
     }  // out_num_blocks_h
 
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -140,14 +140,8 @@ void kernel_main() {
                 readers_process_full_image_widths,
                 image_width_tiles,
                 output_image_width,
-                window_reuse_offset,
-                need_to_push_remaining_tiles>(
-                packed_reader_indices_ptr,
-                act_l1_read_addr,
-                l1_write_addr_act,
-                reader_idx,
-                cb_start_addr,
-                remaining_tiles_to_push);
+                window_reuse_offset>(
+                packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 #endif
 #endif
 
@@ -191,6 +185,15 @@ void kernel_main() {
         start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
 #endif
     }  // out_num_blocks_h
+
+#if defined(SPLIT_READER) && defined(ACTIVATION_REUSE)
+    // Last core sometimes has less work to do, but we still need to push the same number of tiles
+    // to avoid blocking compute kernels
+    if constexpr (need_to_push_remaining_tiles) {
+        push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+            remaining_tiles_to_push, cb_start_addr);
+    }
+#endif
 
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 #else
     constexpr uint32_t ct_arg_idx = 27;
 #endif
-#else 
+#else
     constexpr uint32_t ct_arg_idx = 18;
 #endif
 
@@ -187,14 +187,8 @@ void kernel_main() {
                 readers_process_full_image_widths,
                 image_width_tiles,
                 output_image_width,
-                window_reuse_offset,
-                need_to_push_remaining_tiles>(
-                packed_reader_indices_ptr,
-                act_l1_read_addr,
-                l1_write_addr_act,
-                reader_idx,
-                cb_start_addr,
-                remaining_tiles_to_push);
+                window_reuse_offset>(
+                packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 #endif
 #endif
 
@@ -331,4 +325,13 @@ void kernel_main() {
         start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
 #endif
     }  // out_num_blocks_h
+
+#if defined(SPLIT_READER) && defined(ACTIVATION_REUSE)
+    // Last core sometimes has less work to do, but we still need to push the same number of tiles
+    // to avoid blocking compute kernels
+    if constexpr (need_to_push_remaining_tiles) {
+        push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+            remaining_tiles_to_push, cb_start_addr);
+    }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -26,18 +26,35 @@ void kernel_main() {
 
     constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
 
-    // Split reader args
-    constexpr bool split_reader = get_compile_time_arg_val(18);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(19);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(21);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(23);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(24) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(25);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
-    constexpr auto s_weight_args = TensorAccessorArgs<28>();
+#ifdef SPLIT_READER
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(19);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(20);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(21);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(22);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(24);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(25);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(26);
+
+#ifdef ACTIVATION_REUSE
+    constexpr uint32_t weights_size_h = get_compile_time_arg_val(27);
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(29);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(30) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(31);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(32);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(33);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(34) == 1;
+    constexpr uint32_t ct_arg_idx = 35;
+#else
+    constexpr uint32_t ct_arg_idx = 27;
+#endif
+#else 
+    constexpr uint32_t ct_arg_idx = 18;
+#endif
+
+    constexpr auto s_weight_args = TensorAccessorArgs<ct_arg_idx>();
     constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
 
     uint32_t i = 0;
@@ -48,11 +65,11 @@ void kernel_main() {
     const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
     const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
 
-    if constexpr (split_reader && needs_act_block_zero_out) {
+#ifdef SPLIT_READER
+    if constexpr (needs_act_block_zero_out) {
         zero_out_tiles<cb_id_act_second_reader>();
     }
-
-    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+#endif
 
     // mcast args
     const uint32_t weights_mcast_dest_noc_start_x = get_arg_val<uint32_t>(i++);
@@ -64,12 +81,25 @@ void kernel_main() {
     const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
     const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
 
-    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr;
-    uint32_t reader_idx;
-    if constexpr (split_reader) {
-        packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
-        reader_idx = 0;
-    }
+#ifdef SPLIT_READER
+#ifdef ACTIVATION_REUSE
+    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(i++);
+#endif
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+    uint32_t reader_idx = 0;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+
+    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    // coalesce reads along weight_size_w
+    uint32_t start_reader_idx = (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1;
+    const uint32_t cb_start_addr = get_write_ptr(cb_id_act_second_reader);
+    uint32_t reader_offset = act_l1_read_addr;
+#endif
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -100,20 +130,10 @@ void kernel_main() {
     constexpr uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
     const auto s_weight = TensorAccessor(s_weight_args, weight_addr_dram_base, weight_tile_nbytes);
 
-    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
-    constexpr uint32_t coalesced_read_bytes =
-        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-
     // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
     // Write out col major blocks in row major layout to output
     constexpr uint32_t weight_inner_block_stride_h =
         weight_next_block_stride_h / weight_block_height_num_outer;  // TODO: Pass as args
-    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-    // coalesce reads along weight_size_w
-    uint32_t start_reader_idx;
-    if constexpr (split_reader) {
-        start_reader_idx = (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1;
-    }
 
     for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
         // READ WEIGHTS + MCAST SEND WEIGHTS
@@ -124,27 +144,59 @@ void kernel_main() {
 
         uint32_t weight_current_block_start_tile_id = 0;
 
+#ifdef SPLIT_READER
+#ifdef ACTIVATION_REUSE
+        uint32_t l1_write_addr_act = cb_start_addr;
+#endif
         uint32_t reader_offset = act_l1_read_addr;
-        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
-            if constexpr (split_reader) {
-                // Do the second half of the reads for act
-                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-                reader_idx = start_reader_idx;
-                cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-                read_sticks<
-                    dilation_w,
-                    coalesced_read_bytes,
-                    conv_act_c_read_bytes,
-                    act_block_w_extra_align_bytes,
-                    stride_w_bytes,
-                    weight_size_w,
-                    stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+#endif
 
-                reader_offset += window_outer_offset;
-            }
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+#ifdef SPLIT_READER
+            // Do the second half of the reads for act
+            noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+            reader_idx = start_reader_idx;
+
+#ifndef ACTIVATION_REUSE
+            cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
+            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+            read_sticks<
+                dilation_w,
+                coalesced_read_bytes,
+                conv_act_c_read_bytes,
+                act_block_w_extra_align_bytes,
+                stride_w_bytes,
+                weight_size_w,
+                stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+
+            reader_offset += window_outer_offset;
+#else
+            read_sticks_activation_reuse<
+                coalesced_read_bytes,
+                conv_act_c_read_bytes,
+                act_block_w_extra_align_bytes,
+                window_outer_offset,
+                weight_size_w,
+                stride_w,
+                weights_size_h,
+                cb_id_act_second_reader,
+                act_reuse_cb_tiles,
+                act_block_w_tiles,
+                readers_process_full_image_widths,
+                image_width_tiles,
+                output_image_width,
+                window_reuse_offset,
+                need_to_push_remaining_tiles>(
+                packed_reader_indices_ptr,
+                act_l1_read_addr,
+                l1_write_addr_act,
+                reader_idx,
+                cb_start_addr,
+                remaining_tiles_to_push);
+#endif
+#endif
 
             // Do weights read + mcast
             cb_reserve_back(cb_id_weight, weight_block_num_tiles);
@@ -274,9 +326,9 @@ void kernel_main() {
             load_bias = false;
         }
 #endif
-        if constexpr (split_reader) {
-            // Increment reader index for the next number of segments (number of segments for other reader)
-            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-        }
+#ifdef SPLIT_READER
+        // Increment reader index for the next number of segments (number of segments for other reader)
+        start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+#endif
     }  // out_num_blocks_h
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -185,9 +185,12 @@ Tensor create_tensor_from_owned_buffer(
 
 template <typename T>
 Tensor to_weight_special_padding_tile_layout(
-    const Tensor& conv_weight_tensor, uint32_t in1_block_h, uint32_t in1_block_w, DataType output_dtype) {
+    const Tensor& conv_weight_tensor,
+    uint32_t in1_block_h,
+    uint32_t in1_block_w,
+    bool enable_activation_reuse,
+    DataType output_dtype) {
     auto w_shape = conv_weight_tensor.padded_shape();
-
     uint32_t in1_block_h_datums = in1_block_h * constants::TILE_HEIGHT;
     uint32_t in1_block_w_datums = in1_block_w * constants::TILE_WIDTH;
     auto weight_matrix_cols = w_shape[0];
@@ -197,9 +200,11 @@ Tensor to_weight_special_padding_tile_layout(
             (uint32_t)std::ceil((double)weight_matrix_cols / (double)in1_block_w_datums) * in1_block_w_datums;
     }
     // height padding
-    assert(in1_block_h_datums >= w_shape[1] * w_shape[3]);
-    uint32_t block_height_padding = in1_block_h_datums - (w_shape[1] * w_shape[3]);
-    auto weight_matrix_rows = ((w_shape[1] * w_shape[3]) + block_height_padding) * w_shape[2];
+    uint32_t inner_dim = enable_activation_reuse ? w_shape[1] * w_shape[2] * w_shape[3] : w_shape[1] * w_shape[3];
+    assert(in1_block_h_datums >= inner_dim);
+    uint32_t block_height_padding = enable_activation_reuse ? 0 : in1_block_h_datums - inner_dim;
+    auto weight_matrix_rows =
+        enable_activation_reuse ? in1_block_h_datums : ((w_shape[1] * w_shape[3]) + block_height_padding) * w_shape[2];
     ttnn::Shape output_shape{1, 1, weight_matrix_rows, weight_matrix_cols};
 
     auto compute =
@@ -526,15 +531,16 @@ Tensor convert_conv_weight_tensor_to_special_padding_tiled_layout(
     const Tensor& conv_weight_tensor,
     uint32_t in1_block_h,
     uint32_t in1_block_w,
+    bool enable_activation_reuse,
     std::optional<DataType> output_dtype) {
-    const static std::unordered_map<DataType, std::function<Tensor(const Tensor&, uint32_t, uint32_t, DataType)>>
+    const static std::unordered_map<DataType, std::function<Tensor(const Tensor&, uint32_t, uint32_t, bool, DataType)>>
         to_w_tile_layout_map = {
             {DataType::BFLOAT16, &to_weight_special_padding_tile_layout<bfloat16>},
             {DataType::FLOAT32, &to_weight_special_padding_tile_layout<float>},
             {DataType::UINT32, &to_weight_special_padding_tile_layout<uint32_t>}};
 
     return convert_tensor_to_tiled_layout_common(
-        conv_weight_tensor, output_dtype, to_w_tile_layout_map, in1_block_h, in1_block_w);
+        conv_weight_tensor, output_dtype, to_w_tile_layout_map, in1_block_h, in1_block_w, enable_activation_reuse);
 }
 
 /*
@@ -991,8 +997,10 @@ static OptimizedConvBlockConfig get_opt_block_config(
         conv_config.act_block_w_div,
         kernel_size[0],
         kernel_size[1],
+        output_width,
         get_fp32_dest_acc_en(compute_config),
-        conv_config.full_inner_dim);
+        conv_config.full_inner_dim,
+        conv_config.enable_activation_reuse);
 }
 
 static uint32_t calculate_out_channels_padded(uint32_t out_channels, const ParallelConfig& output_parallel_config) {
@@ -1138,6 +1146,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
         true,  // parameters_on_device
         conv_config.enable_kernel_stride_folding,
         conv_config.full_inner_dim,
+        conv_config.enable_activation_reuse,
         kernel_size,
         orig_stride,
         padding_n4);
@@ -1208,7 +1217,11 @@ static ttnn::Tensor prepare_conv_weights_internal(
     // for conv op, pad the weights to block shape
     if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
         weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
-            weight_tensor_, params.weight_block_h_ntiles, params.weight_block_w_ntiles, weight_tensor_.dtype());
+            weight_tensor_,
+            params.weight_block_h_ntiles,
+            params.weight_block_w_ntiles,
+            params.enable_activation_reuse,
+            weight_tensor_.dtype());
     } else if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
         weight_tensor_ = convert_conv_weight_tensor_to_tiled_layout_block_sharded(
             weight_tensor_,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -57,6 +57,7 @@ Tensor convert_conv_weight_tensor_to_special_padding_tiled_layout(
     const Tensor& conv_weight_tensor,
     uint32_t in1_block_h,
     uint32_t in1_block_w,
+    bool enable_activation_reuse = false,
     std::optional<DataType> output_dtype = std::nullopt);
 
 // Converts convolution weights to grouped layout with padded zeros
@@ -127,6 +128,7 @@ struct Conv2dWeightsBiasPrepConfig {
         bool parameters_on_device_ = true,
         bool enable_kernel_stride_folding_ = false,
         bool full_inner_dim_ = false,
+        bool enable_activation_reuse_ = false,
         std::array<uint32_t, 2> kernel_size_ = {1, 1},
         std::array<uint32_t, 2> stride_ = {1, 1},
         std::array<uint32_t, 4> padding_n4_ = {0, 0, 0, 0}) :
@@ -143,6 +145,7 @@ struct Conv2dWeightsBiasPrepConfig {
         parameters_on_device(parameters_on_device_),
         enable_kernel_stride_folding(enable_kernel_stride_folding_),
         full_inner_dim(full_inner_dim_),
+        enable_activation_reuse(enable_activation_reuse_),
         kernel_size(kernel_size_),
         stride(stride_),
         padding_n4(padding_n4_) {}
@@ -160,9 +163,11 @@ struct Conv2dWeightsBiasPrepConfig {
     const bool has_bias;
     const bool parameters_on_device;
 
-    // Kernel stride folding parameters
     const bool enable_kernel_stride_folding;
     const bool full_inner_dim;
+    const bool enable_activation_reuse;
+
+    // Kernel stride folding parameters
     const std::array<uint32_t, 2> kernel_size;
     const std::array<uint32_t, 2> stride;
     const std::array<uint32_t, 4> padding_n4;

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -208,6 +208,7 @@ Result conv_transpose2d(
         conv_config.act_block_w_div,
         kernel_size[0],
         kernel_size[1],
+        output_width,
         get_fp32_dest_acc_en(compute_config),
         conv_config.full_inner_dim);
 


### PR DESCRIPTION
## Conv 3.0 optimization

[Slides with visuals for better understanding](https://docs.google.com/presentation/d/1EY3yHXriD8cqhRmkzS9gLPKSRDcKCaGjNAO_PYQgQFc/edit?slide=id.g36449711142_0_0#slide=id.g36449711142_0_0)

### Idea [[Slides 1-7](https://docs.google.com/presentation/d/1EY3yHXriD8cqhRmkzS9gLPKSRDcKCaGjNAO_PYQgQFc/edit?slide=id.g36449711142_0_0#slide=id.g36449711142_0_0)]

This optimization aims to improve the performance of image2column part that is performed by reader kernels. This is useful when we are reader bound - usually height sharded convolutions with small input channels. 
The idea behind conv 3.0 is to reuse activation data between output image rows. Readers build activation matrix of the following dimensions - [Hout * Wout, Ci * Kh * Kw]. Each row of this matrix keeps 'unrolled' Kh * Kw window of the input image.

Once we walk the sliding window to produce single output row, we move on to the next input row. In the next row, we can reuse Ci * (Kh-1) * Kw elements since we are targeting sliding windows that moved one pixel below ([see slide 3](https://docs.google.com/presentation/d/1EY3yHXriD8cqhRmkzS9gLPKSRDcKCaGjNAO_PYQgQFc/edit?slide=id.g3746b6c088a_0_21#slide=id.g3746b6c088a_0_21)). Conv 3.0 exploits this fact and writes just the missing Ci*Kw elements ([see slide 7](https://docs.google.com/presentation/d/1EY3yHXriD8cqhRmkzS9gLPKSRDcKCaGjNAO_PYQgQFc/edit?slide=id.g3746b6c088a_0_130#slide=id.g3746b6c088a_0_130)).

#### Reader changes

Most important changes are in `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp ` `read_sticks_activation_reuse` function. The window_outer loop in reader/writer kernels is run only once - we process full inner dim in the read sticks function. `reserve_back` and `push_back` were moved from the reader/writer kernel loop to be handled inside the read sticks function, while iterating over reader indices.
- `push_back` is called each time full tile height has been processed 
- `reserve_back` is called each time full output image row has been processed
Each time we are done with the full output image row, we update the writer pointer to skip the first Kw*Ci elements. 

The code in `read_sticks_activation_reuse` was written such that the first output image row is processed outside the loop - this was done to avoid if conditions that was checked for each reader index and took many cycles.


#### Compute changes

Compute is updated to call tilize for both split readers in the same loop - it waits for one tile height (which maps to 32 output pixels) and full row of the activation matrix (which maps to the Kh*Kw*Ci), and then performs tilize. 

Each time compute reaches new output image row, it updates the CB read pointer to match the reader behavior.

Since we fill tilized cb with data from both readers, we reserve back the full act block h, and then use pointer magic to fill tile row by tile row in both halves. 


#### Caveats / limitations

1. Sharding/split reader splits data accross cores/readers in the middle of the image (unet case) [[Slides 8-9](https://docs.google.com/presentation/d/1EY3yHXriD8cqhRmkzS9gLPKSRDcKCaGjNAO_PYQgQFc/edit?slide=id.g3746b6c088a_0_177#slide=id.g3746b6c088a_0_177)] - we simply take the first output_image_width even if it is broken in two rows

2. Output image width is not a tile multiple [[Slide 10](https://docs.google.com/presentation/d/1EY3yHXriD8cqhRmkzS9gLPKSRDcKCaGjNAO_PYQgQFc/edit?slide=id.g3746b6c088a_0_223#slide=id.g3746b6c088a_0_223)] - instead of synchronizing on full output image row, we take a bit more pixels to fill in the last tile height. Those filler pixels are not reused, and we read the full `kernel_h*kernel_w*in_channels` for these pixels, instead of reading just the last `kernel_w*in_channels` as we do for the rest of the reused pixels.

3. The last core has less data to read than the other ones (unet case) - we push back the rest of the tiles once we are done with im2col 

4. The feature works for both dilation and stride equals 1.

5. Activation double buffering has not been implemented to work with this optimization, in case both are turned on, dobule buffering will be disabled with a warning.

6. Weights are fully buffered since we process full inner dim at once.


### Results

- Main convolution where we needed this perf optimization is [this one](https://github.com/tenstorrent/tt-metal/blob/main/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py#L3037) - 5x5 kernel where we have 80% of data reuse + it doesn't fall into any of the caveats groups. Improvement: **135k ns -> 60k ns** 
- First unet convolution - **120k ns -> 77k ns** (this conv falls into all of the caveat categories, so the boost is smaller), whole model FPS (with some other convs using this feature) 1589 -> 1632 (**43 FPS**)
- First resnet convolution - **161k ns -> 127k ns**, whole model FPS:
  -  WH: 5713 -> 5780 (**67 FPS**)
  -  BH: 10113 -> 10193 (**80 FPS**)


### Next steps
- Check out other convs and other CNN models and see where else it can be turned on
- Update resnet ran on t3k or galaxy to use the optimization
- Update reader indices logic when the optimization is turned on to make the reader code cleaner get rid of some if conditions
- Decouple full inner dim processing with height sharding from 3.0 feature
- Currently the feature needs to be triggered manually, but the plan is to turn it on automatically when it makes sense.
- Remove the need for act block h override when the feature is enabled - activation buffer size doesn't depend on it, so we need to make the tilized CB independent as well


### CI

- [x] All post commit: https://github.com/tenstorrent/tt-metal/actions/runs/17607055325
- [x] BH post commit: https://github.com/tenstorrent/tt-metal/actions/runs/17559629415
- [x] Nightly l2: https://github.com/tenstorrent/tt-metal/actions/runs/17559645401
- [x] Frequent ttnn and models: https://github.com/tenstorrent/tt-metal/actions/runs/17575355592 
- [x] Single card device perf: https://github.com/tenstorrent/tt-metal/actions/runs/17559622033
- [x] Single card model e2e perf: https://github.com/tenstorrent/tt-metal/actions/runs/17559624906
- [x] Blackhole demos: https://github.com/tenstorrent/tt-metal/actions/runs/17575360049 
- [x] T3K Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/17607051535
- [x] Galaxy model perf: https://github.com/tenstorrent/tt-metal/actions/runs/17608076189 - resnet passing, other models failing on main as well