### PR TITLE
changed conftest - is_galaxy(), is_6U()

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -70,7 +70,10 @@ def galaxy_type():
 def is_galaxy():
     import ttnn
 
-    return ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
+    return (
+        ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
+        or ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.TG
+    )
 
 
 # TODO: Remove this when TG clusters are deprecated.
@@ -78,7 +81,7 @@ def is_6u():
     import ttnn
 
     # 6U has 32 PCIe devices
-    return is_galaxy() and ttnn.GetNumPCIeDevices() == SIX_U_NUM_PCIE_DEVICES
+    return ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
 
 
 # TODO: Remove this when TG clusters are deprecated.

--- a/conftest.py
+++ b/conftest.py
@@ -80,7 +80,6 @@ def is_galaxy():
 def is_6u():
     import ttnn
 
-    # 6U has 32 PCIe devices
     return ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
 
 
@@ -88,7 +87,6 @@ def is_6u():
 def is_tg_cluster():
     import ttnn
 
-    # TG has 4 PCIe devices
     return ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.TG
 
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26502)

### Problem description
is_galaxy() from conftest returns False on 4U Galaxy

### What's changed
changed is_galaxy() and is_6u() in conftest.py

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16830384834) CI failed - fail unrelated to galaxy
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16830476424) passes
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/16830474567) passes