### PR TITLE
Adding mesh_device support to Embedding1D

### DIFF
--- a/models/demos/deepseek_v3/tests/test_embedding_1d.py
+++ b/models/demos/deepseek_v3/tests/test_embedding_1d.py
@@ -41,7 +41,7 @@ def test_embedding_forward_pass(
     seq_len,
     generate_reference_io,
     tmp_path,
-    mesh_row,
+    mesh_device,
     model_path,
 ):
     module_path = "model.embed_tokens"
@@ -63,16 +63,16 @@ def test_embedding_forward_pass(
         reference_output.unsqueeze_(0)
 
     # Generate module configs and state
-    weight_config = Embedding1D.convert_weights(hf_config, state_dict, tmp_path, mesh_row)
-    model_config = get_model_config(Embedding1D, mode, hf_config, mesh_row)
-    model_state = Embedding1D.create_state(hf_config, mesh_row)
+    weight_config = Embedding1D.convert_weights(hf_config, state_dict, tmp_path, mesh_device)
+    model_config = get_model_config(Embedding1D, mode, hf_config, mesh_device)
+    model_state = Embedding1D.create_state(hf_config, mesh_device)
     run_config = create_run_config(model_config, weight_config, model_state)
 
     # Convert input to TTNN
     tt_input_ids = ttnn.from_torch(
         torch_input,
-        device=mesh_row,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_row),
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         dtype=ttnn.uint32,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -85,11 +85,11 @@ def test_embedding_forward_pass(
     tt_output_torch = ttnn.to_torch(
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(
-            mesh_row,
-            dims=(-2, -1),
-            mesh_shape=tuple(mesh_row.shape),
+            mesh_device,
+            dims=(0, -1),
+            mesh_shape=tuple(mesh_device.shape),
         ),
-    )
+    )[:1, ...]
 
     # Cleanup
     ttnn.deallocate(tt_input_ids)

--- a/models/demos/deepseek_v3/tt/embedding_1d.py
+++ b/models/demos/deepseek_v3/tt/embedding_1d.py
@@ -45,7 +45,7 @@ class Embedding1D(AbstractModule):
             torch_weight,
             dtype=ttnn.bfloat8_b,
             device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=[-2, -1], mesh_shape=list(mesh_device.shape)),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=[None, -1], mesh_shape=list(mesh_device.shape)),
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )


### PR DESCRIPTION
### Ticket
- #23022 

### Problem description
Embedding1D module currently only supports `mesh_row` fixture which gives a (1, 8) mesh device. But, we require a (4, 8).

### What's changed
- Use `mesh_device`
- Only shard the weights on the outer dim
- Note: Cannot shard on inner dim because it's an embedding table, not a normal matmul

### Checklist
- [ ] New/Existing tests provide coverage for changes