### PR TITLE
Update LLK compute API for Reduce with full fp32 accumulation

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -16,9 +16,9 @@ template <
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false,
-    bool fp32_transpose = false>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
@@ -28,18 +28,24 @@ template <
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false,
-    bool fp32_transpose = false>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
-template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    int num_fidelity_phases = 0,
+    bool enforce_fp32_accumulation = false /*unused*/>
 inline void llk_math_reduce_init(
     const std::uint32_t within_face_16x16_transpose =
         0) {  // within_face_16x16_transpose used for unpack, ignored by math
-    _llk_math_reduce_init_<type, dim, num_fidelity_phases>(within_face_16x16_transpose);
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>(
+        within_face_16x16_transpose);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -85,7 +85,7 @@ inline void llk_unpack_AB(
     WAYPOINT("UABD");
 }
 
-template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE, bool fp32_transpose = false>
+template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -98,7 +98,7 @@ inline void llk_unpack_AB_reduce_init(
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
 
-    if constexpr (fp32_transpose) {
+    if constexpr (enforce_fp32_accumulation) {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
         _llk_unpack_dbg_feature_disable_();
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -16,9 +16,9 @@ template <
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false,
-    bool fp32_transpose = false>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
@@ -28,17 +28,23 @@ template <
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false,
-    bool fp32_transpose = false>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
-template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    int num_fidelity_phases = 0,
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce_init(
     const std::uint32_t within_face_16x16_transpose =
         0) {  // within_face_16x16_transpose used for unpack, ignored by math
-    _llk_math_reduce_init_<type, dim, num_fidelity_phases>(within_face_16x16_transpose);
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>(
+        within_face_16x16_transpose);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -85,7 +85,7 @@ inline void llk_unpack_AB(
     WAYPOINT("UABD");
 }
 
-template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE, bool fp32_transpose = false>
+template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -98,7 +98,7 @@ inline void llk_unpack_AB_reduce_init(
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
 
-    if constexpr (fp32_transpose) {
+    if constexpr (enforce_fp32_accumulation) {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
         _llk_unpack_dbg_feature_disable_();
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -35,20 +35,20 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Param Type | Name           | Description                                                     | Type      | Valid Range                                    | Required |
- * |------------|----------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
- * | Template   | reduce_type    | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
- * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
- * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
- * | Function   | icb            | The identifier of the circular buffer (CB) containing operand A | uint32_t  | 0 to 31                                        | True     |
- * | Function   | icb_scaler     | CB holding scaling factors (see above)                          | uint32_t  | 0 to 31                                        | True     |
- * | Function   | ocb            | The identifier of the output circular buffer (CB)               | uint32_t  | 0 to 31                                        | True     |
+ * | Param Type | Name                      | Description                                                                             | Type      | Valid Range                                    | Required |
+ * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool      | {true, false}                                  | True     |
+ * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | icb_scaler                | CB holding scaling factors (see above)                                                  | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
+template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
-    UNPACK((llk_unpack_AB_reduce_init<reduce_dim, BroadcastType::NONE, fp32_transpose>(icb, icb_scaler)));
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
+    UNPACK((llk_unpack_AB_reduce_init<reduce_dim, BroadcastType::NONE, enforce_fp32_accumulation>(icb, icb_scaler)));
+    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, enforce_fp32_accumulation>()));
     PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
 }
 
@@ -92,41 +92,41 @@ ALWI void reduce_uninit() { PACK((llk_pack_reduce_mask_clear())); }
  * NOTE: For other valid ways of populating the `icb_scaler`, refer to the ISA documentation.
  * Return value: None
  *
- * | Param Type | Name           | Description                                                     | Type      | Valid Range                                    | Required |
- * |------------|----------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
- * | Template   | reduce_type    | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
- * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
- * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
- * | Function   | icb            | The identifier of the circular buffer (CB) containing operand A | uint32_t  | 0 to 31                                        | True     |
- * | Function   | icb_scaler     | CB holding scaling factors (see above)                          | uint32_t  | 0 to 31                                        | True     |
- * | Function   | itile          | The index of the tile within the first CB                       | uint32_t  | Must be less than the size of the CB           | True     |
- * | Function   | itile_sclaer   | The index of the tile within the scaling factor CB.             | uint32_t  | Must be less than the size of the CB           | True     |
- * | Function   | idst           | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
+ * | Param Type | Name                      | Description                                                                             | Type      | Valid Range                                    | Required |
+ * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool      | {true, false}                                  | True     |
+ * | Function   | icb                       | The identifier of the circular buffer (CB) containing operand A                         | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | icb_scaler                | CB holding scaling factors (see above)                                                  | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | itile                     | The index of the tile within the first CB                                               | uint32_t  | Must be less than the size of the CB           | True     |
+ * | Function   | itile_scaler              | The index of the tile within the scaling factor CB.                                     | uint32_t  | Must be less than the size of the CB           | True     |
+ * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
-ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_sclaer, uint32_t idst) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, fp32_transpose>(
+template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
+ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_scaler, uint32_t idst) {
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
         icb, icb_scaler, idst)));
-    UNPACK((llk_unpack_AB(icb, icb_scaler, itile, itile_sclaer)));
+    UNPACK((llk_unpack_AB(icb, icb_scaler, itile, itile_scaler)));
 }
 
 // clang-format off
 /**
  * Performs a math-only reduction operation on a tile in the DST register. Assumes that source tiles are already in source registers.
  *
- * | Param Type | Name           | Description                                                     | Type      | Valid Range                                    | Required |
- * |------------|----------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
- * | Template   | reduce_type    | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
- * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
- * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
- * | Function   | idst           | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
- * | Function   | num_faces      | Number of faces to reduce (optional, default 4)                 | uint32_t  | 1 to 4                                         | False    |
+ * | Param Type | Name                      | Description                                                                             | Type      | Valid Range                                    | Required |
+ * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type               | The type of reduce op - sum, average or maximum                                         | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim                | The dimension of reduce op - row, column or both                                        | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | enforce_fp32_accumulation | Enable accumulation of reduction in full FP32 precision (Requires DST_ACCUM_MODE==true) | bool      | {true, false}                                  | True     |
+ * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
+ * | Function   | num_faces                 | Number of faces to reduce (optional, default 4)                                         | uint32_t  | 1 to 4                                         | False    |
  */
 // clang-format on
-template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
+template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_tile_math(uint32_t idst, uint32_t num_faces = 4) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, fp32_transpose>(
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
         idst, num_faces)));
 }
 

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -74,7 +74,7 @@ ALWI void tilizeA_B_reduce_init(
     UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true, false, zero_srcA_reduce>(
         icb0, icb1_scaler, block, num_faces, face_r_dim, 1)));
 
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, MATH_FIDELITY>()));
+    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure_disaggregated(icb0, icb1_scaler)));
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25266)

### Problem description
Reduce init function was not configuring the ALU Format for SrcA, so if it was set to Tf32 the kernel would not work correctly.

### What's changed
Passing down all the necessary parameters for the LLK init to correctly config the HW.
Also renaming the related flag from `fp32_transpose` to `enforce_fp32_accumulation` for greater clarity.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16833535686) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16833537470) CI with demo tests passes (if applicable)