### PR TITLE
Fix packer cb_reserve_back when tiles_received wraps

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -155,4 +155,17 @@ TEST_F(DeviceFixture, TensixTestCreateCircularBufferAtOverlappingIndex) {
     EXPECT_ANY_THROW(CreateCircularBuffer(program, cr_set, config2));
 }
 
+TEST_F(DeviceFixture, TensixTestCreateCircularBufferWithTooManyPages) {
+    Program program;
+    CBConfig cb_config;
+
+    CoreRange cr({0, 0}, {1, 1});
+    CoreRangeSet cr_set({cr});
+
+    CircularBufferConfig config = CircularBufferConfig(cb_config.page_size * (1 << 16), {{0, cb_config.data_format}})
+                                       .set_page_size(0, cb_config.page_size);
+
+    EXPECT_ANY_THROW(CreateCircularBuffer(program, cr_set, config));
+}
+
 }  // end namespace basic_tests::circular_buffer

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -163,7 +163,7 @@ TEST_F(DeviceFixture, TensixTestCreateCircularBufferWithTooManyPages) {
     CoreRangeSet cr_set({cr});
 
     CircularBufferConfig config = CircularBufferConfig(cb_config.page_size * (1 << 16), {{0, cb_config.data_format}})
-                                       .set_page_size(0, cb_config.page_size);
+                                      .set_page_size(0, cb_config.page_size);
 
     EXPECT_ANY_THROW(CreateCircularBuffer(program, cr_set, config));
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -35,7 +35,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     std::int32_t free_tiles;
     do {
         std::uint16_t tiles_acked = (std::uint16_t)reg_read((std::uint32_t)tiles_acked_ptr);
-        // Perform 16-bit subtractions because inputs are 16 bits and map wrap due to overflow.
+        // Perform 16-bit subtractions because inputs are 16 bits and may wrap due to overflow.
         std::uint16_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -32,11 +32,12 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     // that is, don't do this: uint32_t tiles_received = tiles_received_ptr[0];
     uint16_t tiles_received = get_local_cb_interface(output).tiles_received;
 
-    std::int16_t free_tiles;
+    std::int32_t free_tiles;
     do {
         std::uint16_t tiles_acked = (std::uint16_t)reg_read((std::uint32_t)tiles_acked_ptr);
+        // Perform 16-bit subtractions because inputs are 16 bits and map wrap due to overflow.
         std::uint16_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
-        free_tiles = (std::int16_t)free_tiles_wrap;
+        free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -30,13 +30,13 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     // updated by packer here we don't synchronize with packer, so if we use tiles_received_ptr could case a data race
     // alternatively we could sync with packer, but that's slower and more complex code
     // that is, don't do this: uint32_t tiles_received = tiles_received_ptr[0];
-    uint32_t tiles_received = get_local_cb_interface(output).tiles_received;
+    uint16_t tiles_received = get_local_cb_interface(output).tiles_received;
 
-    std::int32_t free_tiles;
+    std::int16_t free_tiles;
     do {
         std::uint16_t tiles_acked = (std::uint16_t)reg_read((std::uint32_t)tiles_acked_ptr);
-        std::uint32_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
-        free_tiles = (std::int32_t)free_tiles_wrap;
+        std::uint16_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
+        free_tiles = (std::int16_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -35,7 +35,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     std::int32_t free_tiles;
     do {
         std::uint16_t tiles_acked = (std::uint16_t)reg_read((std::uint32_t)tiles_acked_ptr);
-        // Perform 16-bit subtractions because inputs are 16 bits and map wrap due to overflow.
+        // Perform 16-bit subtractions because inputs are 16 bits and may wrap due to overflow.
         std::uint16_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -32,11 +32,12 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     // that is, don't do this: uint32_t tiles_received = tiles_received_ptr[0];
     uint16_t tiles_received = get_local_cb_interface(output).tiles_received;
 
-    std::int16_t free_tiles;
+    std::int32_t free_tiles;
     do {
         std::uint16_t tiles_acked = (std::uint16_t)reg_read((std::uint32_t)tiles_acked_ptr);
+        // Perform 16-bit subtractions because inputs are 16 bits and map wrap due to overflow.
         std::uint16_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
-        free_tiles = (std::int16_t)free_tiles_wrap;
+        free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -30,13 +30,13 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     // updated by packer here we don't synchronize with packer, so if we use tiles_received_ptr could case a data race
     // alternatively we could sync with packer, but that's slower and more complex code
     // that is, don't do this: uint32_t tiles_received = tiles_received_ptr[0];
-    uint32_t tiles_received = get_local_cb_interface(output).tiles_received;
+    uint16_t tiles_received = get_local_cb_interface(output).tiles_received;
 
-    std::int32_t free_tiles;
+    std::int16_t free_tiles;
     do {
         std::uint16_t tiles_acked = (std::uint16_t)reg_read((std::uint32_t)tiles_acked_ptr);
-        std::uint32_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
-        free_tiles = (std::int32_t)free_tiles_wrap;
+        std::uint16_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
+        free_tiles = (std::int16_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
 }
 

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -91,11 +91,12 @@ void CircularBuffer::validate_set_config_attributes() {
         if (ps_set) {
             // Validate number of pages is not too large.
             uint32_t num_pages = this->size() / this->page_size(buffer_index);
-            // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the number
-            // of pages would cause overflow.
+            // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the
+            // number of pages would cause overflow.
             TT_FATAL(
                 num_pages <= max_num_cb_pages,
-                "For buffer index {}, number of CB pages {} is greater than {}. Would cause wraparound in the CB calculations.",
+                "For buffer index {}, number of CB pages {} is greater than {}. Would cause wraparound in the CB "
+                "calculations.",
                 buffer_index,
                 num_pages,
                 max_num_cb_pages);
@@ -130,7 +131,11 @@ uint32_t CircularBuffer::page_size(uint32_t buffer_index) const {
 
 uint32_t CircularBuffer::num_pages(uint32_t buffer_index) const {
     uint32_t num_pages = this->size() / this->page_size(buffer_index);
-    TT_ASSERT(num_pages <= max_num_cb_pages, "Number of CB pages {} is greater than {}. Would cause wraparound in the CB calculations.", num_pages, max_num_cb_pages);
+    TT_ASSERT(
+        num_pages <= max_num_cb_pages,
+        "Number of CB pages {} is greater than {}. Would cause wraparound in the CB calculations.",
+        num_pages,
+        max_num_cb_pages);
     return num_pages;
 }
 

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -115,7 +115,13 @@ uint32_t CircularBuffer::page_size(uint32_t buffer_index) const {
     return page_size;
 }
 
-uint32_t CircularBuffer::num_pages(uint32_t buffer_index) const { return this->size() / this->page_size(buffer_index); }
+uint32_t CircularBuffer::num_pages(uint32_t buffer_index) const {
+        uint32_t num_pages = this->size() / this->page_size(buffer_index);
+        // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the number of pages would cause overflow.
+        constexpr uint32_t max_num_pages = (1 << 16) - 1;
+        TT_FATAL(num_pages <= max_num_pages, "Number of pages {} is greater than {}. Would cause wraparound in the CB calculations.", num_pages, max_num_pages);
+        return num_pages;
+}
 
 DataFormat CircularBuffer::data_format(uint32_t buffer_index) const {
     if (not this->uses_buffer_index(buffer_index)) {

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -90,16 +90,7 @@ void CircularBuffer::validate_set_config_attributes() {
         }
         if (ps_set) {
             // Validate number of pages is not too large.
-            uint32_t num_pages = this->size() / this->page_size(buffer_index);
-            // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the
-            // number of pages would cause overflow.
-            TT_FATAL(
-                num_pages <= max_num_cb_pages,
-                "For buffer index {}, number of CB pages {} is greater than {}. Would cause wraparound in the CB "
-                "calculations.",
-                buffer_index,
-                num_pages,
-                max_num_cb_pages);
+            this->num_pages(buffer_index);
         }
     }
 }
@@ -131,9 +122,13 @@ uint32_t CircularBuffer::page_size(uint32_t buffer_index) const {
 
 uint32_t CircularBuffer::num_pages(uint32_t buffer_index) const {
     uint32_t num_pages = this->size() / this->page_size(buffer_index);
-    TT_ASSERT(
+    // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the
+    // number of pages would cause overflow.
+    TT_FATAL(
         num_pages <= max_num_cb_pages,
-        "Number of CB pages {} is greater than {}. Would cause wraparound in the CB calculations.",
+        "For buffer index {}, number of CB pages {} is greater than {}. Would cause wraparound in the CB "
+        "calculations.",
+        buffer_index,
         num_pages,
         max_num_cb_pages);
     return num_pages;

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -15,6 +15,7 @@
 namespace tt {
 
 namespace tt_metal {
+static constexpr uint32_t max_num_cb_pages = (1 << 16) - 1;
 
 // Dynamic CBs will be created with address_ initialized to globally allocated address
 // Static CBs will not have address set until their owning Program allocates them
@@ -87,6 +88,18 @@ void CircularBuffer::validate_set_config_attributes() {
                 df_set_str,
                 ps_set_str);
         }
+        if (ps_set) {
+            // Validate number of pages is not too large.
+            uint32_t num_pages = this->size() / this->page_size(buffer_index);
+            // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the number
+            // of pages would cause overflow.
+            TT_FATAL(
+                num_pages <= max_num_cb_pages,
+                "For buffer index {}, number of CB pages {} is greater than {}. Would cause wraparound in the CB calculations.",
+                buffer_index,
+                num_pages,
+                max_num_cb_pages);
+        }
     }
 }
 
@@ -117,14 +130,7 @@ uint32_t CircularBuffer::page_size(uint32_t buffer_index) const {
 
 uint32_t CircularBuffer::num_pages(uint32_t buffer_index) const {
     uint32_t num_pages = this->size() / this->page_size(buffer_index);
-    // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the number
-    // of pages would cause overflow.
-    constexpr uint32_t max_num_pages = (1 << 16) - 1;
-    TT_FATAL(
-        num_pages <= max_num_pages,
-        "Number of pages {} is greater than {}. Would cause wraparound in the CB calculations.",
-        num_pages,
-        max_num_pages);
+    TT_ASSERT(num_pages <= max_num_cb_pages, "Number of CB pages {} is greater than {}. Would cause wraparound in the CB calculations.", num_pages, max_num_cb_pages);
     return num_pages;
 }
 

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -15,7 +15,9 @@
 namespace tt {
 
 namespace tt_metal {
-static constexpr uint32_t max_num_cb_pages = (1 << 16) - 1;
+// We use 16 bits to store tiles_received and tiles_acked.
+static constexpr uint32_t cb_page_count_bits = 16;
+static constexpr uint32_t max_num_cb_pages = (1 << cb_page_count_bits) - 1;
 
 // Dynamic CBs will be created with address_ initialized to globally allocated address
 // Static CBs will not have address set until their owning Program allocates them

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -116,11 +116,16 @@ uint32_t CircularBuffer::page_size(uint32_t buffer_index) const {
 }
 
 uint32_t CircularBuffer::num_pages(uint32_t buffer_index) const {
-        uint32_t num_pages = this->size() / this->page_size(buffer_index);
-        // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the number of pages would cause overflow.
-        constexpr uint32_t max_num_pages = (1 << 16) - 1;
-        TT_FATAL(num_pages <= max_num_pages, "Number of pages {} is greater than {}. Would cause wraparound in the CB calculations.", num_pages, max_num_pages);
-        return num_pages;
+    uint32_t num_pages = this->size() / this->page_size(buffer_index);
+    // LocalCBInterface.tiles_acked and LocalCBInterface.tiles_received are 16 bits, so we need to check if the number
+    // of pages would cause overflow.
+    constexpr uint32_t max_num_pages = (1 << 16) - 1;
+    TT_FATAL(
+        num_pages <= max_num_pages,
+        "Number of pages {} is greater than {}. Would cause wraparound in the CB calculations.",
+        num_pages,
+        max_num_pages);
+    return num_pages;
 }
 
 DataFormat CircularBuffer::data_format(uint32_t buffer_index) const {


### PR DESCRIPTION
### Ticket
#26452 

### Problem description
When tiles_received wraps (in 16 bits), the 32-bit arithmetic we use causes the free_tiles calculation to be incorrect, which can cause cb_reserve_back to return early when it shouldn't.
Eg. if tiles_received = 0x10020, tiles_acked = 0xffc0, and fifo_num_pages=96, the real free_tiles_wrap should be 0, but the value we get is 65536 with 32-bit arithmetic

### What's changed
Convert to use 16-bit arithmetic (this matches the implementation in dataflow_api.h).

Also check that fifo_page_num is never >= 65536, as that would break this wrapping calculations.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes