### PR TITLE
Enable int32 on repeat

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -14,7 +14,13 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 layouts = [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT]
 
-dtypes = [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16), (torch.bfloat16, ttnn.bfloat8_b)]
+dtypes = [
+    (torch.float32, ttnn.float32),
+    (torch.bfloat16, ttnn.bfloat16),
+    (torch.bfloat16, ttnn.bfloat8_b),
+    (torch.int32, ttnn.int32),
+    (torch.int32, ttnn.uint32),
+]
 shapes = [(1,), (2,), (2, 3), (4, 16, 3, 1), (4, 3, 1, 2, 2)]
 repeat_shapes = [
     (1,),

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -21,8 +21,9 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
     TT_FATAL(
         input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "Can only work with bfloat16/float32 or uint32 tensors");
+            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32 or
+            input_tensor_a.dtype() == tt::tt_metal::DataType::INT32,
+        "Can only work with bfloat16/float32 or int32/uint32 tensors");
     // is this relevant?
     TT_FATAL(
         this->m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),


### PR DESCRIPTION
### Ticket
#24749 
#25695 

### Problem description
Repeat should have int32/uint32 enabled and supported

### What's changed
Enabled int32 and added unit tests/sweeps

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16837299446) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16837319400) CI with demo tests passes (if applicable)
