### PR TITLE
[skip ci] DM: Adding codeowners for data movement docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -281,6 +281,7 @@ models/experimental/vovnet @ssinghalTT @tenstorrent/cse-developer-ttnn
 # docs
 docs/Makefile @tenstorrent/metalium-developers-infra
 docs/source/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @aczajkowskiTT
+docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/ @pgkeller @abhullar-tt @rtawfik01 @vvukomanovicTT @atatuzunerTT
 
 # misc
 dockerfile/upstream_test_images/ @tenstorrent/metalium-developers-infra


### PR DESCRIPTION
### Problem description
Docs folder doesn't have specific codeowners for each directory.

### What's changed
Added codeowners for the data movement directory.