### PR TITLE
#0: Add pci slot and distinguish external connectors between qsfp and tfly

### DIFF
--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -26,7 +26,7 @@ struct UbbId {
     std::uint32_t asic_id;
 };
 
-enum class ConnectorType { EXTERNAL, TRACE, LK1, LK2, LK3 };
+enum class ConnectorType { UNUSED, QSFP, TFLY, TRACE, LK1, LK2, LK3 };
 
 enum class LinkingBoardType {
     A,
@@ -62,10 +62,10 @@ UbbId get_ubb_id(chip_id_t chip_id) {
 
 ConnectorType get_connector_type(chip_id_t chip_id, CoreCoord eth_core, uint32_t chan, ClusterType cluster_type) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    if (cluster.is_external_cable(chip_id, eth_core)) {
-        return ConnectorType::EXTERNAL;
-    }
     if (cluster_type == ClusterType::GALAXY) {
+        if (cluster.is_external_cable(chip_id, eth_core)) {
+            return ConnectorType::QSFP;
+        }
         auto ubb_id = get_ubb_id(chip_id);
         if ((ubb_id.asic_id == 5 || ubb_id.asic_id == 6) && (12 <= chan && chan <= 15)) {
             return ConnectorType::LK1;
@@ -77,7 +77,32 @@ ConnectorType get_connector_type(chip_id_t chip_id, CoreCoord eth_core, uint32_t
             return ConnectorType::TRACE;
         }
     } else {
-        return ConnectorType::TRACE;
+        if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
+            auto mmio_device_id = cluster.get_associated_mmio_device(chip_id);
+            if (mmio_device_id == chip_id) {
+                if (chan == 14 || chan == 15) {
+                    return ConnectorType::TFLY;
+                } else if (chan == 0 || chan == 1 || chan == 6 || chan == 7) {
+                    return ConnectorType::QSFP;
+                } else if ((chan == 8 || chan == 9) && cluster.get_board_type(chip_id) == tt::umd::BoardType::N300) {
+                    return ConnectorType::TRACE;
+                }
+                return ConnectorType::UNUSED;
+            } else {
+                if (chan == 6 || chan == 7) {
+                    return ConnectorType::TFLY;
+                } else if (chan == 0 || chan == 1) {
+                    return ConnectorType::TRACE;
+                }
+                return ConnectorType::UNUSED;
+            }
+            // TODO: Need to add proper support for other architectures
+        } else {
+            if (cluster.is_external_cable(chip_id, eth_core)) {
+                return ConnectorType::QSFP;
+            }
+            return ConnectorType::TRACE;
+        }
     }
 }
 
@@ -120,12 +145,31 @@ std::string get_ubb_id_str(chip_id_t chip_id) {
     return "Tray: " + std::to_string(ubb_id.tray_id) + " N" + std::to_string(ubb_id.asic_id);
 }
 
+std::string get_physical_slot_str(chip_id_t chip_id) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto physical_slot = cluster.get_physical_slot(chip_id);
+    if (physical_slot.has_value()) {
+        return "Physical Slot: " + std::to_string(*physical_slot);
+    }
+    return "";
+}
+
+std::string get_physical_loc_str(chip_id_t chip_id, ClusterType cluster_type) {
+    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+        return get_ubb_id_str(chip_id);
+    } else {
+        return get_physical_slot_str(chip_id);
+    }
+}
+
 std::string get_connector_str(chip_id_t chip_id, CoreCoord eth_core, uint32_t channel, ClusterType cluster_type) {
     auto connector = get_connector_type(chip_id, eth_core, channel, cluster_type);
     std::stringstream str;
     str << "(";
     switch (connector) {
-        case ConnectorType::EXTERNAL: str << "external connector"; break;
+        case ConnectorType::UNUSED: str << "unused"; break;
+        case ConnectorType::QSFP: str << "QSFP"; break;
+        case ConnectorType::TFLY: str << "TFLY"; break;
         case ConnectorType::TRACE: str << "internal trace"; break;
         case ConnectorType::LK1:
         case ConnectorType::LK2:
@@ -213,11 +257,15 @@ TEST(Cluster, ReportSystemHealth) {
         const auto& soc_desc = cluster.get_soc_desc(chip_id);
         std::stringstream chip_id_ss;
         chip_id_ss << std::dec << "Chip: " << chip_id << " Unique ID: " << std::hex << unique_chip_id;
-        if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
-            chip_id_ss << " " << get_ubb_id_str(chip_id);
+        auto physical_loc = get_physical_loc_str(chip_id, cluster_type);
+        if (not physical_loc.empty()) {
+            chip_id_ss << " " << physical_loc;
         }
         ss << chip_id_ss.str() << std::endl;
         for (const auto& [eth_core, chan] : soc_desc.logical_eth_core_to_chan_map) {
+            if (get_connector_type(chip_id, eth_core, chan, cluster_type) == ConnectorType::UNUSED) {
+                continue;
+            }
             tt_cxy_pair virtual_eth_core(
                 chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
             std::stringstream eth_ss;
@@ -232,31 +280,33 @@ TEST(Cluster, ReportSystemHealth) {
                 cluster.read_core(&uncorr_val_hi, sizeof(uint32_t), virtual_eth_core, uncorr_addr);
                 cluster.read_core(&uncorr_val_lo, sizeof(uint32_t), virtual_eth_core, uncorr_addr + 4);
             }
-            eth_ss << " eth channel " << std::dec << (uint32_t)chan << " " << eth_core.str();
+            eth_ss << " eth channel " << std::dec << (uint32_t)chan << " core " << eth_core.str();
             std::string connection_type = get_connector_str(chip_id, eth_core, chan, cluster_type);
             if (cluster.is_ethernet_link_up(chip_id, eth_core)) {
+                eth_ss << " link UP " << connection_type;
+                CoreCoord connected_eth_core = CoreCoord{0, 0};
                 if (eth_connections.at(chip_id).find(chan) != eth_connections.at(chip_id).end()) {
-                    const auto& [connected_chip_id, connected_eth_core] =
+                    chip_id_t connected_chip_id = 0;
+                    std::tie(connected_chip_id, connected_eth_core) =
                         cluster.get_connected_ethernet_core(std::make_tuple(chip_id, eth_core));
-                    eth_ss << " link UP " << connection_type << ", retrain: " << read_vec[0] << ", connected to chip "
-                           << connected_chip_id;
-                    if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
-                        eth_ss << "\n\tCRC Errors: 0x" << std::hex << crc_error_val << " ";
-                        eth_ss << "Corrected Codewords: 0x" << std::hex << cw_pair_to_full(corr_val_hi, corr_val_lo)
-                               << " Uncorrected Codewords: 0x" << std::hex
-                               << cw_pair_to_full(uncorr_val_hi, uncorr_val_lo);
+                    eth_ss << ", connected to Chip " << connected_chip_id;
+                    auto connected_physical_loc = get_physical_loc_str(connected_chip_id, cluster_type);
+                    if (not connected_physical_loc.empty()) {
+                        eth_ss << " " << connected_physical_loc;
                     }
-                    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
-                        eth_ss << " " << get_ubb_id_str(connected_chip_id);
-                    }
-                    eth_ss << " " << connected_eth_core.str();
                 } else {
-                    const auto& [connected_chip_unique_id, connected_eth_core] =
+                    uint64_t connected_chip_unique_id = 0;
+                    std::tie(connected_chip_unique_id, connected_eth_core) =
                         cluster.get_connected_ethernet_core_to_remote_mmio_device(std::make_tuple(chip_id, eth_core));
-                    eth_ss << " link UP " << connection_type << ", retrain: " << read_vec[0] << ", connected to chip "
-                           << std::hex << connected_chip_unique_id;
-                    // Cannot use get_ubb_id_str here as connected_chip_unique_id is on other host
-                    eth_ss << " " << connected_eth_core.str();
+                    eth_ss << ", connected to Unique ID: " << std::hex << connected_chip_unique_id;
+                    // Cannot use get_physical_loc_str here as connected_chip_unique_id is on other host
+                }
+                eth_ss << " core " << connected_eth_core.str();
+                eth_ss << "\n\tRetrain count: " << read_vec[0];
+                if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
+                    eth_ss << " CRC Errors: 0x" << std::hex << crc_error_val;
+                    eth_ss << " Corrected Codewords: 0x" << std::hex << cw_pair_to_full(corr_val_hi, corr_val_lo)
+                           << " Uncorrected Codewords: 0x" << std::hex << cw_pair_to_full(uncorr_val_hi, uncorr_val_lo);
                 }
                 if (read_vec[0] > 0) {
                     unexpected_system_states.push_back(chip_id_ss.str() + eth_ss.str());
@@ -383,8 +433,9 @@ TEST(Cluster, TestMeshFullConnectivity) {
     for (const auto& [chip, connections] : eth_connections) {
         std::stringstream chip_ss;
         chip_ss << "Chip " << chip;
-        if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
-            chip_ss << " " << get_ubb_id_str(chip);
+        auto physical_loc = get_physical_loc_str(chip, cluster_type);
+        if (not physical_loc.empty()) {
+            chip_ss << " " << physical_loc;
         }
         const auto& soc_desc = cluster.get_soc_desc(chip);
         std::map<chip_id_t, int> num_connections_to_chip;
@@ -438,8 +489,9 @@ TEST(Cluster, TestMeshFullConnectivity) {
         for (const auto& [other_chip, count] : num_connections_to_chip) {
             std::stringstream other_chip_ss;
             other_chip_ss << "Chip " << other_chip;
-            if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
-                other_chip_ss << " " << get_ubb_id_str(other_chip);
+            auto other_physical_loc = get_physical_loc_str(other_chip, cluster_type);
+            if (not other_physical_loc.empty()) {
+                other_chip_ss << " " << other_physical_loc;
             }
             if (num_target_connections > 0) {
                 EXPECT_GE(count, num_target_connections)

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -134,6 +134,10 @@ public:
         return this->driver_->get_chip(chip)->get_tt_device()->get_pci_device()->get_device_info().pci_bus;
     }
 
+    std::optional<int> get_physical_slot(chip_id_t chip) const {
+        return this->driver_->get_chip(chip)->get_tt_device()->get_pci_device()->get_device_info().physical_slot;
+    }
+
     //! device driver and misc apis
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We provide physical information, ex tray + N id for ubbs, but no information on regular card systems like N300/T3K.
We also didn't distinguish external connector types which could be QSFP or TFLY.
We were also printing out eth channels that aren't exposed/can't be connected to as down/unconnected. These prints are somewhat useless and adds noise to the report.

### What's changed
Uplift UMD to get physical slot information.
Update health check to print physical slot on non-galaxy systems if available.
Add checks for whether connections are qsfp, tfly, or unused for WH systems.

Example output:
```
Chip: 0 Unique ID: 26190e02a Physical Slot: 4
 eth channel 0 core (x=0,y=0) link UP (QSFP), connected to Chip 3 Physical Slot: 6 core (x=0,y=0)
        Retrain count: 0 CRC Errors: 0x0 Corrected Codewords: 0x489 Uncorrected Codewords: 0x0
 eth channel 1 core (x=0,y=1) link UP (QSFP), connected to Chip 3 Physical Slot: 6 core (x=0,y=1)
        Retrain count: 0 CRC Errors: 0x0 Corrected Codewords: 0x1d9 Uncorrected Codewords: 0x0
 eth channel 6 core (x=0,y=6) link DOWN/unconnected (QSFP)
 eth channel 7 core (x=0,y=7) link DOWN/unconnected (QSFP)
 eth channel 8 core (x=0,y=8) link UP (internal trace), connected to Chip 4 Physical Slot: 4 core (x=0,y=0)
        Retrain count: 0 CRC Errors: 0x0 Corrected Codewords: 0x456 Uncorrected Codewords: 0x0
 eth channel 9 core (x=0,y=9) link UP (internal trace), connected to Chip 4 Physical Slot: 4 core (x=0,y=1)
        Retrain count: 0 CRC Errors: 0x0 Corrected Codewords: 0x1798d1 Uncorrected Codewords: 0x0
 eth channel 14 core (x=0,y=14) link UP (TFLY), connected to Chip 1 Physical Slot: 2 core (x=0,y=14)
        Retrain count: 0 CRC Errors: 0x0 Corrected Codewords: 0x869 Uncorrected Codewords: 0x0
 eth channel 15 core (x=0,y=15) link UP (TFLY), connected to Chip 1 Physical Slot: 2 core (x=0,y=15)
        Retrain count: 0 CRC Errors: 0x0 Corrected Codewords: 0x0 Uncorrected Codewords: 0x0

 (test_system_health.cpp:323)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 3 Unique ID: 26190e08e Physical Slot: 6 eth channel 6 core (x=0,y=6) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 3 Unique ID: 26190e08e Physical Slot: 6 eth channel 7 core (x=0,y=7) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 2 Unique ID: 26190e06e Physical Slot: 8 eth channel 0 core (x=0,y=0) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 2 Unique ID: 26190e06e Physical Slot: 8 eth channel 1 core (x=0,y=1) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 1 Unique ID: 26190e068 Physical Slot: 2 eth channel 0 core (x=0,y=0) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 1 Unique ID: 26190e068 Physical Slot: 2 eth channel 1 core (x=0,y=1) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 0 Unique ID: 26190e02a Physical Slot: 4 eth channel 6 core (x=0,y=6) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
2025-08-08 18:21:03.520 | warning  |            Test | Chip: 0 Unique ID: 26190e02a Physical Slot: 4 eth channel 7 core (x=0,y=7) link DOWN/unconnected (QSFP) (test_system_health.cpp:327)
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16837827624
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16837842847
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/16837862887
BH LLMBox: https://github.com/tenstorrent/tt-metal/actions/runs/16837858979