### PR TITLE
#26510: Update logical to physical mapping for 1D MGD

### DIFF
--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -28,6 +28,9 @@ echo "Running fabric unit tests now...";
 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
 
+# Host side tests: Topology Mapping in Control Plane
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*LogicalToPhysicalConversionFixture*"
+
 #############################################
 # FABRIC SANITY TESTS                       #
 #############################################

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -55,6 +55,8 @@ run_t3000_ttfabric_tests() {
 
   # originally were in TT-NN, now promoted to TT-Metal (Fabric)
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*WorkerFabricEdmDatapath*:*EdmFabric*"
+  # Instantiate a 1x8 Mesh on a T3K with 2D Fabric
+  TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2DFixture.TestUnicast*"
 
   # TODO (issue: #24335) disabled slow dispatch tests for now, need to re-evaluate if need to add in a different pool
   #TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"

--- a/tests/tt_metal/tt_fabric/fabric_router/test_control_plane_logical_to_physical.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_control_plane_logical_to_physical.cpp
@@ -381,6 +381,37 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds1x8Mesh) {
         });
 }
 
+TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds1x8MeshOn2x4Physical) {
+    // Test 1x8 large 1D mesh shape
+    // Shape: 4-0-3-6
+    //        | | | |
+    //        5-1-2-7
+    test_adjacency_map = {
+        {0, {1, 4, 3}},
+        {1, {0, 2, 5}},
+        {2, {1, 7, 3}},
+        {3, {0, 2, 6}},
+        {4, {0, 5}},
+        {5, {4, 1}},
+        {6, {7, 3}},
+        {7, {6, 2}}};
+
+    std::set<chip_id_t> user_chip_ids = {0, 1, 2, 3, 4, 5, 6, 7};
+    tt::tt_metal::distributed::MeshShape mesh_shape(1, 8);
+
+    auto topology_info = build_mesh_adjacency_map(
+        user_chip_ids, mesh_shape, [this](chip_id_t chip_id) { return this->get_adjacent_chips(chip_id); });
+
+    auto physical_chip_ids = convert_1d_mesh_adjacency_to_row_major_vector(topology_info);
+
+    // Verify all chip mappings for 1x8 mesh
+    verify_physical_chip_ids(
+        physical_chip_ids,
+        8,
+        {
+            {0, 0}, {1, 4}, {2, 5}, {3, 1}, {4, 2}, {5, 7}, {6, 6}, {7, 3}  // horizontal line
+        });
+}
 // Torus and ring support?
 TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsLooped1DMesh) {
     GTEST_SKIP() << "Ring topology currently not supported";

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -40,11 +40,6 @@ void get_optimal_noc_for_edm(
     uint32_t num_links,
     Topology topology);
 
-// Helper: BFS distance map from a start chip to all reachable chips using the
-// provided adjacency map. Returned distances are expressed in hop count.
-std::unordered_map<chip_id_t, std::uint32_t> compute_distances(
-    chip_id_t start_chip, const std::unordered_map<chip_id_t, std::vector<chip_id_t>>& adjacency_map);
-
 // Helper: Build adjacency map and discover corners/edges using BFS
 struct IntraMeshAdjacencyMap {
     std::unordered_map<chip_id_t, std::vector<chip_id_t>> adjacency_map;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26510)

### Problem description
- Mapping a 1D MGD to a higher dimensional physical cluster (ex: T3K) is currently broken
- This is because this mapping relies on the concept of corners and edges. Corners are defined as chips which have a single neighbour in 1D topologies. While this works when mapping 1D logical to 1D physical, this does not work when folding 2D physical into 1D logical

### What's changed
- Use a DFS based algorithm for mapping logical Fabric Nodes to Physical chips instead.
- This algorithm should be deterministic when run on the same machine multiple times
- Update testing to rely on auto-mapping for 1D topologies onto 2D clusters

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes