### PR TITLE
Mpise/22336 4gb tensor gets filled with zeros

### DIFF
--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -28,6 +28,7 @@ jobs:
           { name: "t3k_ccl_2d_tests", arch: wormhole_b0, cmd: TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml pytest -n auto tests/nightly/t3000/2d_ccl, timeout: 10, owner_id: U013121KDH9}, # Austin Ho
           { name: "t3k_ccl_legacy_tests", arch: wormhole_b0, cmd: pytest -n auto tests/nightly/t3000/ccl_legacy, timeout: 180, owner_id: ULMEPM2MA}, # Sean Nijjar
           { name: "t3k_fabric_unit_tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 180, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
+          { name: "t3k_dispatch_unit_tests", arch: wormhole_b0, cmd: build/test/tt_metal/unit_tests_dispatch --gtest_filter="Large*.DRAMReadback/*", timeout: 15, owner_id: U07R05K4WGJ}, # John Bauman
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(
     unit_tests_dispatch_slow
     PRIVATE
         dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp # FIXME: Fix the heap-buffer-overflow in here and see if it's fast enough for Basic
+        dispatch_buffer/test_large_mesh_buffer.cpp
         dispatch_program/test_EnqueueProgram.cpp
         dispatch_trace/test_EnqueueTrace.cpp
 )

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
@@ -1,0 +1,386 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <tt-metalium/distributed.hpp>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include "env_lib.hpp"
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/shape2d.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "impl/context/metal_context.hpp"
+#include <tt-metalium/util.hpp>
+#include "tt_metal/api/tt-metalium/math.hpp"
+#include <enchantum/enchantum.hpp>
+
+namespace tt::tt_metal::distributed::test {
+namespace {
+
+using MeshBufferTest2x4 = MeshDevice2x4Fixture;
+using MeshBufferTestSuite = GenericMeshDeviceFixture;
+using ElementType = uint64_t;
+constexpr uint32_t ElementSize = sizeof(ElementType);
+
+constexpr auto KB{1ul << 10};
+constexpr auto MB{1ul << 20};
+constexpr auto GB{1ul << 30};
+class LargeMeshBufferTestSuiteBase : public MeshBufferTestSuite {
+protected:
+    static constexpr uint64_t max_num_elements_ = (12 * GB) / ElementSize;
+    // A large datatype is used to reduce random shuffle time
+    inline static std::vector<ElementType> src_vec_;
+
+    LargeMeshBufferTestSuiteBase() {
+        if (src_vec_.empty()) {
+            log_info(tt::LogTest, "LargeMeshBufferTestSuiteBase ctor: initializing src_vec_");
+            src_vec_.resize(max_num_elements_);
+            std::iota(src_vec_.begin(), src_vec_.end(), 0);
+            std::shuffle(src_vec_.begin(), src_vec_.end(), std::mt19937(std::random_device{}()));
+        }
+    }
+};
+
+bool validate_interleaved_test_inputs(size_t size, MeshDevice& mesh_device) {
+    const size_t num_dram_channels = mesh_device.num_dram_channels();
+    const size_t dram_size_per_channel = mesh_device.dram_size_per_channel();
+    const size_t dram_size = num_dram_channels * dram_size_per_channel;
+    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+    const DeviceAddr bank_offset = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+
+    bool result{true};
+    auto allocation_size_per_bank = (size + num_dram_channels - 1) / num_dram_channels;
+    result = result and allocation_size_per_bank <= dram_size_per_channel - bank_offset;
+    if (not result) {
+        log_info(
+            tt::LogTest,
+            "Skipping because requested size, size/bank ({:X}, {:X}) is greater than available "
+            "size/bank, #banks ({:X}, {})",
+            size,
+            allocation_size_per_bank,
+            dram_size_per_channel - bank_offset,
+            num_dram_channels);
+        return result;
+    }
+
+    return result;
+}
+
+class InterleavedMeshBufferTestSuite : public LargeMeshBufferTestSuiteBase,
+                                       public testing::WithParamInterface<std::tuple<uint64_t, uint32_t>> {};
+
+TEST_P(InterleavedMeshBufferTestSuite, DRAMReadback) {
+    // - REPLICATED layout for writing, SHARDED with ROW_MAJOR for reading
+    // - DRAM, bottom up allocation
+    auto [tensor_size, page_size] = GetParam();
+    if (!validate_interleaved_test_inputs(tensor_size, *mesh_device_)) {
+        GTEST_SKIP();
+    }
+
+    const DeviceLocalBufferConfig device_local_config{
+        .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+    log_info(tt::LogTest, "page_size: {}, tensor_size/device (MB): {}", page_size, tensor_size / (1 << 20));
+
+    const ReplicatedBufferConfig buffer_config{.size = tensor_size};
+
+    // Create replicated buffer for writing with specific address 32
+    auto mesh_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+    // Verify buffer properties
+    EXPECT_EQ(mesh_buffer->size(), tensor_size);
+    EXPECT_EQ(mesh_buffer->global_layout(), MeshBufferLayout::REPLICATED);
+    EXPECT_EQ(mesh_buffer->device_local_size(), tensor_size);
+    EXPECT_TRUE(mesh_buffer->is_allocated());
+
+    // Create test data - use uint16_t for easy verification
+    auto num_elements = tensor_size / ElementSize;
+    ASSERT_TRUE(num_elements <= max_num_elements_);
+    std::vector<ElementType> src_vec(src_vec_.begin(), src_vec_.begin() + num_elements);
+
+    distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+    auto mesh_size = coord_range.shape().mesh_size();
+    std::vector<MeshCommandQueue::ShardDataTransfer> input_shards = {};
+    input_shards.reserve(mesh_size);
+    for (auto& coord : coord_range) {
+        input_shards.emplace_back(coord, src_vec.data());
+    }
+
+    std::unordered_map<distributed::MeshCoordinate, std::vector<ElementType>> dst_vec = {};
+    std::vector<MeshCommandQueue::ShardDataTransfer> output_shards = {};
+    output_shards.reserve(mesh_size);
+    for (auto& coord : coord_range) {
+        dst_vec[coord] = std::vector<ElementType>(num_elements, 0);
+        output_shards.emplace_back(coord, dst_vec[coord].data());
+    }
+
+    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
+    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+
+    for (auto& dst : dst_vec) {
+        EXPECT_EQ(dst.second, src_vec);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LargeInterleavedReadback,
+    InterleavedMeshBufferTestSuite,
+    ::testing::Combine(
+        ::testing::Values(2 * GB, 4 * GB, 8 * GB, 12 * GB),  // tensor sizes
+        ::testing::Values(4 * KB, 16 * KB, 1 * MB)           // page sizes
+        ));
+
+bool validate_sharded_test_inputs(
+    CoreCoord grid_size, Shape2D tensor_shape, MeshDevice& mesh_device, uint32_t element_sizeB) {
+    CoreCoord available_grid_size = mesh_device.dram_grid_size();
+    bool result{true};
+    result = result and available_grid_size.x >= grid_size.x and available_grid_size.y >= grid_size.y;
+    if (not result) {
+        log_info(
+            tt::LogTest,
+            "Skipping test because required grid {} is incompatible with available grid {}",
+            grid_size,
+            available_grid_size);
+    }
+
+    // Determine if required allocation per bank can fit
+    const size_t num_dram_channels = mesh_device.num_dram_channels();
+    const size_t dram_size_per_channel = mesh_device.dram_size_per_channel();
+    const DeviceAddr bank_offset = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+    uint32_t shard_height = tensor_shape.height() / grid_size.y;
+    uint32_t shard_width = tensor_shape.width() / grid_size.x;
+    size_t shard_sizeB = size_t(shard_height) * shard_width * element_sizeB;
+
+    result = result and shard_sizeB <= dram_size_per_channel - bank_offset;
+    if (not result) {
+        log_info(
+            tt::LogTest,
+            "Skipping because required shard size/bank (tensor shape: {}, grid shape: {}, derived shard size: {:X}) is "
+            "greater than available "
+            "size/bank: {:X}, #banks: {})",
+            tensor_shape,
+            grid_size,
+            shard_sizeB,
+            dram_size_per_channel - bank_offset,
+            num_dram_channels);
+        return result;
+    }
+
+    return result;
+}
+
+class ShardedMeshBufferTestSuite
+    : public LargeMeshBufferTestSuiteBase,
+      public testing::WithParamInterface<std::tuple<std::pair<Shape2D, CoreCoord>, uint32_t>> {};
+
+TEST_P(ShardedMeshBufferTestSuite, DRAMReadback) {
+    // shard_shape: shape on device (elements)
+    // page_size: (bytes)
+    auto [tensor_and_grid, page_size] = GetParam();
+    auto [device_tensor_shape, core_grid_size] = tensor_and_grid;
+    uint64_t device_tensor_size = device_tensor_shape.height() * device_tensor_shape.width() * ElementSize;
+
+    if (!validate_sharded_test_inputs(core_grid_size, device_tensor_shape, *mesh_device_, ElementSize)) {
+        GTEST_SKIP();
+    }
+
+    uint32_t num_pages = static_cast<uint32_t>(device_tensor_size / page_size);
+    if (uint64_t(num_pages) * page_size != device_tensor_size) {
+        TT_THROW(
+            "Check test parameters: shard shape:{}, page size:{} are incompatible (shard size:{}, #pages:{})",
+            device_tensor_shape,
+            page_size,
+            device_tensor_size,
+            num_pages);
+    }
+
+    CoreCoord start(0, 0);
+    CoreCoord end(core_grid_size.x - 1, core_grid_size.y - 1);
+    CoreRange cores(start, end);
+
+    constexpr auto tile_height{constants::TILE_HEIGHT};
+    constexpr auto tile_width{constants::TILE_WIDTH};
+    constexpr auto tile_area{tile_height * tile_width};
+    // Ensure buffer dimensions are divisible by tile dimensions
+    ASSERT_TRUE(device_tensor_shape.height() % tile_height == 0);
+    ASSERT_TRUE(device_tensor_shape.width() % tile_width == 0);
+
+    auto test_helper_factor_area = [](uint32_t area, int32_t& height, int32_t& width) {
+        // Find all factors of area
+        std::vector<uint32_t> factors{1};
+        auto temp = area;
+        auto f = 2;
+        while (f < temp) {
+            if (temp % f == 0) {
+                factors.push_back(f);
+                temp /= f;
+            } else {
+                f++;
+            }
+        }
+        factors.push_back(temp);
+        // Start with last factor vs product of rest
+        int split_idx = factors.size() - 1;
+        height = 1, width = area;
+        int32_t temp_height, temp_width;
+        int32_t min_diff = std::abs(width - height);
+        while (split_idx > 0) {
+            temp_height = std::accumulate(factors.begin(), factors.begin() + split_idx, 1, std::multiplies<uint32_t>());
+            temp_width = std::accumulate(factors.begin() + split_idx, factors.end(), 1, std::multiplies<uint32_t>());
+            auto temp_diff = std::abs(height - width);
+            if (temp_diff > min_diff) {
+                break;
+            }
+            height = temp_height;
+            width = temp_width;
+            min_diff = temp_diff;
+            split_idx--;
+        }
+    };
+
+    // Determine page shape in elements
+    uint32_t page_area = page_size / ElementSize;
+    int32_t page_height;
+    int32_t page_width;
+    if (page_area >= tile_area) {
+        // Calculate page dims in terms of number of tiles in a page
+        if ((page_area / tile_area) * tile_area != page_area) {
+            TT_THROW("page size elements {} is incompatible with tile size {}", page_area, tile_area);
+        }
+        test_helper_factor_area(page_area / tile_area, page_height, page_width);
+        page_height *= tile_height;
+        page_width *= tile_width;
+    } else {
+        // calculate page dims in terms of number of pages per tile
+        if ((tile_area / page_area) * page_area != tile_area) {
+            TT_THROW("page size elements {} is incompatible with tile size {}", page_area, tile_area);
+        }
+        int32_t tile_height_pages, tile_width_pages;
+        test_helper_factor_area(tile_area / page_area, tile_height_pages, tile_width_pages);
+        page_height = tile_height / tile_height_pages;
+        page_width = tile_width / tile_width_pages;
+    }
+    if (page_height * page_width != page_area) {
+        TT_THROW("Incorrectly derived page dims: {} {} {}", page_area, page_height, page_width);
+    }
+    Shape2D page_shape{page_height, page_width};
+    // Device tensor shape in pages
+    uint32_t device_tensor_height_pages = device_tensor_shape.height() / page_height;
+    uint32_t device_tensor_width_pages = device_tensor_shape.width() / page_width;
+    if (device_tensor_height_pages * page_height != device_tensor_shape.height()) {
+        TT_THROW(
+            "Shard height {} on device cannot fit integral # pages heightwise {}",
+            device_tensor_shape.height(),
+            page_height);
+    }
+    if (device_tensor_width_pages * page_width != device_tensor_shape.width()) {
+        TT_THROW(
+            "Shard width {} on device cannot fit integral # pages widthwise {}",
+            device_tensor_shape.width(),
+            page_width);
+    }
+    Shape2D device_tensor_shape_pages{device_tensor_height_pages, device_tensor_width_pages};
+
+    // Derive shard dimensions (elements) for core grid. A shard is an on core memory block and must be in whole pages.
+    uint32_t shard_height = device_tensor_shape.height() / core_grid_size.y;
+    uint32_t shard_width = device_tensor_shape.width() / core_grid_size.x;
+    Shape2D shard_shape{shard_height, shard_width};
+    if (((shard_height / page_height) * page_height != shard_height) or
+        ((shard_width / page_width) * page_width != shard_width)) {
+        TT_THROW("Shard shape {} not an integral multiple of page shape {}", shard_shape, page_shape);
+    }
+    auto tensor_layout = TensorMemoryLayout::BLOCK_SHARDED;
+    if (device_tensor_shape.height() == shard_shape.height() and device_tensor_shape.width() > shard_shape.width()) {
+        tensor_layout = TensorMemoryLayout::WIDTH_SHARDED;
+    } else if (
+        device_tensor_shape.width() == shard_shape.width() and device_tensor_shape.height() > shard_shape.height()) {
+        tensor_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    }
+    auto shard_orientation = ShardOrientation::ROW_MAJOR;
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = page_size,
+        .buffer_type = BufferType::DRAM,
+        .sharding_args = BufferShardingArgs(
+            ShardSpecBuffer{CoreRangeSet(cores), shard_shape, shard_orientation, page_shape, device_tensor_shape_pages},
+            tensor_layout),
+        .bottom_up = true};
+
+    auto num_elements = device_tensor_size / ElementSize;
+    log_info(
+        tt::LogTest,
+        "Core grid size:{}, device tensor: size:{} MB, shape:{} pages, shape:{} elements, shard shape:{} elements, "
+        "page shape:{} elements, page_size:{} KB, tensor layout:{}",
+        core_grid_size,
+        device_tensor_size >> 20,
+        device_tensor_shape_pages,
+        device_tensor_shape,
+        shard_shape,
+        page_shape,
+        page_size >> 10,
+        reflect::enum_name(tensor_layout));
+
+    uint32_t device_rows = mesh_device_->num_rows();
+    uint32_t device_cols = mesh_device_->num_cols();
+    uint32_t num_devices = device_rows * device_cols;
+    uint64_t tensor_size = num_devices * device_tensor_size;
+    const ReplicatedBufferConfig buffer_config{.size = tensor_size};
+    auto mesh_buffer = MeshBuffer::create(buffer_config, per_device_buffer_config, mesh_device_.get());
+    distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+
+    std::vector<ElementType> src_vec(src_vec_.begin(), src_vec_.begin() + num_elements);
+    if (num_elements > max_num_elements_) {
+        TT_THROW("Buffer size {} elements exceeds test vector {} elements", num_elements, max_num_elements_);
+    }
+    auto mesh_size = coord_range.shape().mesh_size();
+    std::vector<MeshCommandQueue::ShardDataTransfer> input_shards = {};
+    input_shards.reserve(mesh_size);
+    for (auto& coord : coord_range) {
+        input_shards.emplace_back(coord, src_vec.data());
+    }
+
+    std::unordered_map<distributed::MeshCoordinate, std::vector<ElementType>> dst_vec = {};
+    std::vector<MeshCommandQueue::ShardDataTransfer> output_shards = {};
+    output_shards.reserve(mesh_size);
+    for (auto& coord : coord_range) {
+        dst_vec[coord] = std::vector<ElementType>(device_tensor_size / ElementSize, 0);
+        output_shards.emplace_back(coord, dst_vec[coord].data());
+    }
+
+    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
+    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+
+    for (auto& dst : dst_vec) {
+        EXPECT_EQ(dst.second, src_vec);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LargeShardedReadback,
+    ShardedMeshBufferTestSuite,
+    ::testing::Combine(
+        // shard_shape (elements), page_size (bytes)
+        ::testing::Values(
+            std::make_pair(Shape2D((1 << 14), (1 << 14)), CoreCoord(8, 1)),   // 2 GB with uint64_t
+            std::make_pair(Shape2D((1 << 14), (1 << 15)), CoreCoord(8, 1)),   // 4 GB with uint64_t
+            std::make_pair(Shape2D((1 << 14), (3 << 14)), CoreCoord(12, 1)),  // 6 GB with uint64_t
+            std::make_pair(Shape2D((1 << 15), (1 << 15)), CoreCoord(8, 1))),  // 8 GB with uint64_t
+        ::testing::Values(4096, 16 << 10, 1 << 20)                            // page size
+        ));
+
+}  // namespace
+}  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -74,9 +74,6 @@ using std::chrono::microseconds;
 //     --bypass-check (set to bypass checking performance criteria fulfillment)
 ////////////////////////////////////////////////////////////////////////////////
 
-inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
-    uint64_t num_bytes, int rand_max_float, int seed, float offset = 0.0f);
-
 template <typename T>
 std::vector<T> slice_vec(std::vector<T> const& v, int m, int n);
 
@@ -257,7 +254,8 @@ int main(int argc, char** argv) {
             tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
             tt_metal::distributed::Finish(device->mesh_command_queue());
         } else {
-            for (uint32_t i = 0, input_offset = 0; i < num_cores; ++i) {
+            uint64_t input_offset = 0;
+            for (uint32_t i = 0; i < num_cores; ++i) {
                 CoreCoord core = {i / num_cores_y, i % num_cores_y};
                 uint32_t num_tiles_per_core = 0;
                 if (core_group_1.contains(core)) {
@@ -377,7 +375,7 @@ inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
 
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         float num_1_float = rand_float() + offset;
         float num_2_float = rand_float() + offset;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -325,7 +325,7 @@ void add_prefetcher_linear_read_cmd(IDevice* device,
     cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR;
 
     cmd.relay_linear.pad1 = 0;
-    cmd.relay_linear.pad2 = 0;
+    cmd.relay_linear.length_hi = 0;
     cmd.relay_linear.noc_xy_addr =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
     cmd.relay_linear.addr = addr;

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -53,32 +53,32 @@ uint32_t pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16> two_bfloats
 
 std::pair<bfloat16, bfloat16> unpack_two_bfloat16_from_uint32(uint32_t uint32_data);
 
-std::vector<std::uint32_t> create_arange_vector_of_bfloat16(uint32_t num_bytes, bool print = true);
+std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bytes, bool print = true);
 
 std::vector<bfloat16> create_random_vector_of_bfloat16_native(
-    uint32_t num_bytes, float rand_max_float, int seed, float offset = 0.0f);
+    size_t num_bytes, float rand_max_float, int seed, float offset = 0.0f);
 
 void print_golden_metalium_vectors(std::vector<bfloat16>& golden_vec, std::vector<bfloat16>& result_vec);
 
 std::vector<std::uint32_t> create_random_vector_of_bfloat16(
-    uint32_t num_bytes, int rand_max_float, int seed, float offset = 0.0f);
+    size_t num_bytes, int rand_max_float, int seed, float offset = 0.0f);
 
-std::vector<std::uint32_t> create_random_vector_of_bfloat16_1_1(uint32_t num_bytes, int seed);
+std::vector<std::uint32_t> create_random_vector_of_bfloat16_1_1(size_t num_bytes, int seed);
 
-std::vector<std::uint32_t> create_random_vector_of_bfloat16_0_2(uint32_t num_bytes, int seed);
+std::vector<std::uint32_t> create_random_vector_of_bfloat16_0_2(size_t num_bytes, int seed);
 
 /*
  * rk: Still won't handle the case where the number of elements is odd, except
  * if it's 1. Whatever, for now.
  */
-std::vector<std::uint32_t> create_constant_vector_of_bfloat16(uint32_t num_bytes, float value);
+std::vector<std::uint32_t> create_constant_vector_of_bfloat16(size_t num_bytes, float value);
 
 // creates a bfloat16 identity matrix with dims (rows x cols)
 // each 2 cols will be packed as a single uint32_t
 std::vector<bfloat16> create_identity_matrix(int rows, int cols, int num_ones);
 
 // TODO(AP): duplication with above
-std::vector<uint32_t> create_random_binary_vector_of_bfloat16(uint32_t num_bytes, int seed);
+std::vector<uint32_t> create_random_binary_vector_of_bfloat16(size_t num_bytes, int seed);
 
 std::vector<uint16_t> u16_from_u32_vector(const std::vector<uint32_t>& in);
 

--- a/tt_metal/api/tt-metalium/tt_align.hpp
+++ b/tt_metal/api/tt-metalium/tt_align.hpp
@@ -5,9 +5,16 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 namespace tt {
 
-inline constexpr uint32_t align(uint32_t addr, uint32_t alignment) { return ((addr - 1) | (alignment - 1)) + 1; }
+template <typename T1, typename T2>
+inline constexpr std::common_type_t<T1, T2> align(T1 addr, T2 alignment) {
+    static_assert(std::is_integral<T1>::value, "align() requires integral types");
+    static_assert(std::is_integral<T2>::value, "align() requires integral types");
+    using T = std::common_type_t<T1, T2>;
+    return ((static_cast<T>(addr) - 1) | (static_cast<T>(alignment) - 1)) + 1;
+}
 
 }  // namespace tt

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -113,9 +113,9 @@ void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
     auto shard_shape = buffer.physical_shard_shape();
     auto datum_size_bytes = buffer.datum_size_bytes();
 
-    auto stride_size_bytes = datum_size_bytes * global_buffer_shape.width();
-    auto single_write_size = datum_size_bytes * shard_shape.width();
-    auto total_write_size_per_shard = single_write_size * shard_shape.height();
+    const auto stride_size_bytes = datum_size_bytes * global_buffer_shape.width();
+    const auto single_write_size = datum_size_bytes * shard_shape.width();
+    const uint64_t total_write_size_per_shard = single_write_size * shard_shape.height();
     auto num_shards_x = global_buffer_shape.width() / shard_shape.width();
     auto num_shards_y = global_buffer_shape.height() / shard_shape.height();
     uint32_t num_devices_x = buffer.device()->num_cols();
@@ -135,8 +135,8 @@ void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
                 /*region=*/std::nullopt,
                 num_txns_per_device);
             this->submit_memcpy_request(num_txns_per_device, true);
-            uint32_t write_offset = shard_x * single_write_size + shard_y * stride_size_bytes * shard_shape.height();
-            uint32_t size_to_write = total_write_size_per_shard;
+            uint64_t write_offset = shard_x * single_write_size + shard_y * stride_size_bytes * shard_shape.height();
+            uint64_t size_to_write = total_write_size_per_shard;
             uint32_t local_offset = 0;
             while (size_to_write) {
                 std::memcpy(

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -84,12 +84,7 @@ uint32_t BankManager::num_banks() const { return bank_id_to_bank_offset_.size();
 
 DeviceAddr BankManager::bank_size() const {
     TT_ASSERT(bool(allocator_), "Allocator not initialized!");
-    DeviceAddr max_size_bytes_u64 = allocator_->max_size_bytes();
-    if (max_size_bytes_u64 > std::numeric_limits<DeviceAddr>::max()) {
-        TT_THROW("Bank size {} overflows DeviceAddr", max_size_bytes_u64);
-    }
-    DeviceAddr max_size_bytes = (DeviceAddr)max_size_bytes_u64;
-    return max_size_bytes;
+    return allocator_->max_size_bytes();
 }
 
 int64_t BankManager::bank_offset(uint32_t bank_id) const {
@@ -134,11 +129,12 @@ uint64_t BankManager::allocate_buffer(
     if (not address.has_value()) {
         TT_THROW(
             "Out of Memory: Not enough space to allocate {} B {} buffer across {} banks, where each bank needs to "
-            "store {} B",
+            "store {} B, but bank size is only {} B",
             size,
             enchantum::to_string(buffer_type_),
             num_banks,
-            size_per_bank);
+            size_per_bank,
+            bank_size());
     }
     allocated_buffers_.insert(address.value());
     return address.value();

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -35,14 +35,14 @@ struct ReadBufferDescriptor {
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping;
     const BufferCorePageMapping* core_page_mapping;
     void* dst;
-    uint32_t dst_offset;
+    uint64_t dst_offset;
     uint32_t num_pages_read;
 
     ReadBufferDescriptor(
         uint32_t page_size,
         uint32_t padded_page_size,
         void* dst,
-        uint32_t dst_offset,
+        uint64_t dst_offset,
         uint32_t num_pages_read,
         const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping = nullptr,
         const BufferCorePageMapping* core_page_mapping = nullptr) :

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -67,9 +67,9 @@ std::pair<bfloat16, bfloat16> unpack_two_bfloat16_from_uint32(uint32_t uint32_da
     return two_bfloats;
 }
 
-std::vector<std::uint32_t> create_arange_vector_of_bfloat16(uint32_t num_bytes, bool print) {
+std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bytes, bool print) {
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         float num_1_float = i * 2;
         float num_2_float = i * 2 + 1;
 
@@ -91,11 +91,11 @@ std::vector<std::uint32_t> create_arange_vector_of_bfloat16(uint32_t num_bytes, 
 }
 
 std::vector<bfloat16> create_random_vector_of_bfloat16_native(
-    uint32_t num_bytes, float rand_max_float, int seed, float offset) {
+    size_t num_bytes, float rand_max_float, int seed, float offset) {
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
 
     std::vector<bfloat16> vec(num_bytes / sizeof(bfloat16), 0);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         float num_1_float = rand_float() + offset;
         vec[i] = bfloat16(num_1_float);
     }
@@ -104,7 +104,7 @@ std::vector<bfloat16> create_random_vector_of_bfloat16_native(
 
 void print_golden_metalium_vectors(std::vector<bfloat16>& golden_vec, std::vector<bfloat16>& result_vec) {
     std::cout << "-- index -- golden -- metalium --" << std::endl;
-    for (int i = 0; i < result_vec.size(); i++) {
+    for (size_t i = 0; i < result_vec.size(); i++) {
         float a1 = golden_vec[i].to_float();
         float a2 = result_vec[i].to_float();
         if (i % 128 == 0) {
@@ -114,11 +114,11 @@ void print_golden_metalium_vectors(std::vector<bfloat16>& golden_vec, std::vecto
 }
 
 std::vector<std::uint32_t> create_random_vector_of_bfloat16(
-    uint32_t num_bytes, int rand_max_float, int seed, float offset) {
+    size_t num_bytes, int rand_max_float, int seed, float offset) {
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
 
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         float num_1_float = rand_float() + offset;
         float num_2_float = rand_float() + offset;
 
@@ -136,11 +136,11 @@ std::vector<std::uint32_t> create_random_vector_of_bfloat16(
     return vec;
 }
 
-std::vector<std::uint32_t> create_random_vector_of_bfloat16_1_1(uint32_t num_bytes, int seed) {
+std::vector<std::uint32_t> create_random_vector_of_bfloat16_1_1(size_t num_bytes, int seed) {
     return create_random_vector_of_bfloat16(num_bytes, 2.0f, seed, -1.0f);  // -1.0..1.0
 }
 
-std::vector<std::uint32_t> create_random_vector_of_bfloat16_0_2(uint32_t num_bytes, int seed) {
+std::vector<std::uint32_t> create_random_vector_of_bfloat16_0_2(size_t num_bytes, int seed) {
     return create_random_vector_of_bfloat16(num_bytes, 2.0f, seed);  // 0.0f..2.0f
 }
 
@@ -148,11 +148,10 @@ std::vector<std::uint32_t> create_random_vector_of_bfloat16_0_2(uint32_t num_byt
  * rk: Still won't handle the case where the number of elements is odd, except
  * if it's 1. Whatever, for now.
  */
-std::vector<std::uint32_t> create_constant_vector_of_bfloat16(uint32_t num_bytes, float value) {
-    const uint32_t num_elements_vec = std::max(
-        static_cast<uint32_t>(1), static_cast<uint32_t>(num_bytes / sizeof(std::uint32_t)));  // always at least have 1
+std::vector<std::uint32_t> create_constant_vector_of_bfloat16(size_t num_bytes, float value) {
+    const size_t num_elements_vec = std::max<size_t>(1ul, num_bytes / sizeof(std::uint32_t));  // always at least have 1
     std::vector<std::uint32_t> vec(num_elements_vec, 0);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         bfloat16 num_1_bfloat16 = bfloat16(value);
 
         bfloat16 num_2_bfloat16 = num_elements_vec == 1 ? bfloat16(static_cast<float>(0.0)) : bfloat16(value);
@@ -174,11 +173,11 @@ std::vector<bfloat16> create_identity_matrix(int rows, int cols, int num_ones) {
 }
 
 // TODO(AP): duplication with above
-std::vector<uint32_t> create_random_binary_vector_of_bfloat16(uint32_t num_bytes, int seed) {
+std::vector<uint32_t> create_random_binary_vector_of_bfloat16(size_t num_bytes, int seed) {
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, 1), std::mt19937(seed));
 
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         float num_1_float = rand_float();
         float num_2_float = rand_float();
 
@@ -195,7 +194,7 @@ std::vector<uint32_t> create_random_binary_vector_of_bfloat16(uint32_t num_bytes
 
 std::vector<uint16_t> u16_from_u32_vector(const std::vector<uint32_t>& in) {
     std::vector<uint16_t> result(in.size() * 2);
-    for (int i = 0; i < in.size(); i++) {
+    for (size_t i = 0; i < in.size(); i++) {
         uint32_t val = in.at(i);
         auto two_bfloats = unpack_two_bfloat16_from_uint32(val);
         result[i * 2] = two_bfloats.first.to_uint16();
@@ -207,7 +206,7 @@ std::vector<uint16_t> u16_from_u32_vector(const std::vector<uint32_t>& in) {
 std::vector<uint32_t> u32_from_u16_vector(const std::vector<uint16_t>& in) {
     std::vector<uint32_t> result(in.size() / 2);
     TT_ASSERT(in.size() % 2 == 0);
-    for (auto i = 0; i < in.size(); i += 2) {
+    for (size_t i = 0; i < in.size(); i += 2) {
         auto val1 = bfloat16(in.at(i));
         auto val2 = bfloat16(in.at(i + 1));
         auto packed = pack_two_bfloat16_into_uint32(std::make_pair(val1, val2));
@@ -278,7 +277,7 @@ bfloat16 bfloat16_identity_transform(const bfloat16& input) { return input; }
 std::vector<bfloat16> unpack_uint32_vec_into_bfloat16_vec(
     const std::vector<std::uint32_t>& data, const std::function<bfloat16(const bfloat16&)>& transform) {
     std::vector<bfloat16> result;
-    for (auto i = 0; i < data.size(); i++) {
+    for (size_t i = 0; i < data.size(); i++) {
         auto unpacked = unpack_two_bfloat16_from_uint32(data[i]);
         result.push_back(transform(unpacked.first));
         result.push_back(transform(unpacked.second));
@@ -347,7 +346,7 @@ bool packed_uint32_t_vector_comparison(
         return false;
     }
 
-    for (int i = 0; i < vec_a.size(); i++) {
+    for (size_t i = 0; i < vec_a.size(); i++) {
         std::pair<bfloat16, bfloat16> as = unpack_two_bfloat16_from_uint32(vec_a.at(i));
         std::pair<bfloat16, bfloat16> bs = unpack_two_bfloat16_from_uint32(vec_b.at(i));
 

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -230,10 +230,11 @@ uint32_t dump_prefetch_cmd(CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream&
         switch (cmd_id) {
             case CQ_PREFETCH_CMD_RELAY_LINEAR:
                 iq_file << fmt::format(
-                    " (noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
+                    " (noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x}, length_hi={:#010x})",
                     val(cmd->relay_linear.noc_xy_addr),
                     val(cmd->relay_linear.addr),
-                    val(cmd->relay_linear.length));
+                    val(cmd->relay_linear.length),
+                    val(cmd->relay_linear.length_hi));
                 break;
             case CQ_PREFETCH_CMD_RELAY_PAGED:
                 iq_file << fmt::format(

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -57,7 +57,7 @@ public:
 
     void add_dispatch_wait_with_prefetch_stall(uint32_t flags, uint32_t address, uint32_t stream, uint32_t count);
 
-    void add_prefetch_relay_linear(uint32_t noc_xy_addr, uint32_t lengthB, uint32_t addr);
+    void add_prefetch_relay_linear(uint32_t noc_xy_addr, DeviceAddr lengthB, uint32_t addr);
 
     void add_prefetch_relay_paged(
         uint8_t is_dram,
@@ -111,7 +111,7 @@ public:
         const void* data = nullptr);
 
     template <bool inline_data = false>
-    void add_dispatch_write_host(bool flush_prefetch, uint32_t data_sizeB, bool is_event, const void* data = nullptr);
+    void add_dispatch_write_host(bool flush_prefetch, uint64_t data_sizeB, bool is_event, const void* data = nullptr);
 
     void add_prefetch_exec_buf(uint32_t base_addr, uint32_t log_page_size, uint32_t pages);
 

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -87,11 +87,11 @@ struct CQPrefetchBaseCmd {
 
 // Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH)
 struct CQPrefetchRelayLinearCmd {
-    uint8_t pad1;
-    uint16_t pad2;
+    uint16_t pad1;
+    uint8_t length_hi;
+    uint32_t length;
     uint32_t noc_xy_addr;
     uint32_t addr;
-    uint32_t length;
 } __attribute__((packed));
 
 // Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH). Must be only
@@ -217,8 +217,7 @@ struct CQDispatchWriteHostCmd {
     uint8_t is_event;  // one flag, false=read buffer
     uint16_t pad1;
     uint32_t pad2;
-    uint32_t pad3;
-    uint32_t length;
+    uint64_t length;
 } __attribute__((packed));
 
 constexpr uint16_t CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX = 0xFFFF;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -237,84 +237,90 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
     uint32_t completion_write_ptr;
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
-    uint32_t length = cmd->write_linear_host.length;
+    uint64_t wlength = cmd->write_linear_host.length;
     // DPRINT << "process_write_host_h: " << length << ENDL();
     uint32_t data_ptr = cmd_ptr;
 #if !defined(FABRIC_RELAY)
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
 #endif
-    while (length != 0) {
-        // Get a page if needed
-        if (cb_fence == data_ptr) {
-            // Check for block completion
-            if (cb_fence == block_next_start_addr[rd_block_idx]) {
-                // Check for dispatch_cb wrap
-                if (rd_block_idx == dispatch_cb_blocks - 1) {
-                    cb_fence = dispatch_cb_base;
-                    data_ptr = dispatch_cb_base;
+    constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
+    while (wlength != 0) {
+        uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(wlength);
+        wlength -= length;
+        while (length != 0) {
+            // Get a page if needed
+            if (cb_fence == data_ptr) {
+                // Check for block completion
+                if (cb_fence == block_next_start_addr[rd_block_idx]) {
+                    // Check for dispatch_cb wrap
+                    if (rd_block_idx == dispatch_cb_blocks - 1) {
+                        cb_fence = dispatch_cb_base;
+                        data_ptr = dispatch_cb_base;
+                    }
+                    if constexpr (is_h_variant && is_d_variant) {
+                        move_rd_to_next_block_and_release_pages<
+                            upstream_noc_index,
+                            upstream_noc_xy,
+                            upstream_dispatch_cb_sem_id,
+                            dispatch_cb_pages_per_block,
+                            dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                    } else {
+                        move_rd_to_next_block_and_release_pages_remote<
+                            upstream_noc_index,
+                            upstream_noc_xy,
+                            upstream_dispatch_cb_sem_id,
+                            dispatch_cb_pages_per_block,
+                            dispatch_cb_blocks>(relay_client, block_noc_writes_to_clear, rd_block_idx);
+                    }
                 }
-                if constexpr (is_h_variant && is_d_variant) {
-                    move_rd_to_next_block_and_release_pages<
-                        upstream_noc_index,
-                        upstream_noc_xy,
-                        upstream_dispatch_cb_sem_id,
-                        dispatch_cb_pages_per_block,
-                        dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
-                } else {
-                    move_rd_to_next_block_and_release_pages_remote<
-                        upstream_noc_index,
-                        upstream_noc_xy,
-                        upstream_dispatch_cb_sem_id,
-                        dispatch_cb_pages_per_block,
-                        dispatch_cb_blocks>(relay_client, block_noc_writes_to_clear, rd_block_idx);
-                }
-            }
-            // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
-            uint32_t n_pages = cb_acquire_pages<my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
+                // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
+                uint32_t n_pages = cb_acquire_pages<my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
+                    cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
 
-            cb_fence += n_pages * dispatch_cb_page_size;
-        }
-        uint32_t available_data = cb_fence - data_ptr;
-        uint32_t xfer_size = (length > available_data) ? available_data : length;
-        uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
-        completion_queue_reserve_back(npages);
-        uint32_t completion_queue_write_addr = cq_write_interface.completion_fifo_wr_ptr << 4;
-        // completion_queue_write_addr will never be equal to completion_queue_end_addr due to
-        // completion_queue_push_back wrap logic so we don't need to handle this case explicitly to avoid 0 sized
-        // transactions
-        if (completion_queue_write_addr + xfer_size > completion_queue_end_addr) {
-            uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
+                cb_fence += n_pages * dispatch_cb_page_size;
+            }
+            uint32_t available_data = cb_fence - data_ptr;
+            uint32_t xfer_size = (length > available_data) ? available_data : length;
+            uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
+            completion_queue_reserve_back(npages);
+            uint32_t completion_queue_write_addr = cq_write_interface.completion_fifo_wr_ptr << 4;
+            // completion_queue_write_addr will never be equal to completion_queue_end_addr due to
+            // completion_queue_push_back wrap logic so we don't need to handle this case explicitly to avoid 0 sized
+            // transactions
+            if (completion_queue_write_addr + xfer_size > completion_queue_end_addr) {
+                uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
 #if defined(FABRIC_RELAY)
-            noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
+                noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
 #else
-            cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, last_chunk_size);
-            uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
+                cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, last_chunk_size);
+                uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
+                noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
+                noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
+#endif
+                completion_queue_write_addr = completion_queue_base_addr;
+                data_ptr += last_chunk_size;
+                length -= last_chunk_size;
+                xfer_size -= last_chunk_size;
+            }
+#if defined(FABRIC_RELAY)
+            noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
+#else
+            cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
+            // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets
+            // written
+            uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
             noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
             noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
 #endif
-            completion_queue_write_addr = completion_queue_base_addr;
-            data_ptr += last_chunk_size;
-            length -= last_chunk_size;
-            xfer_size -= last_chunk_size;
+
+            // This will update the write ptr on device and host
+            // We flush to ensure the ptr has been read out of l1 before we update it again
+            completion_queue_push_back(npages);
+
+            length -= xfer_size;
+            data_ptr += xfer_size;
+            noc_async_writes_flushed();
         }
-#if defined(FABRIC_RELAY)
-        noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
-#else
-        cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
-        // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets written
-        uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
-        noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
-        noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
-#endif
-
-        // This will update the write ptr on device and host
-        // We flush to ensure the ptr has been read out of l1 before we update it again
-        completion_queue_push_back(npages);
-
-        length -= xfer_size;
-        data_ptr += xfer_size;
-        noc_async_writes_flushed();
     }
     cmd_ptr = data_ptr;
 }
@@ -337,10 +343,10 @@ void process_exec_buf_end_h() {
 // This means the downstream buffers are always page aligned, simplifies wrap handling
 template <uint32_t preamble_size>
 void relay_to_next_cb(
-    uint32_t data_ptr, uint32_t length, uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
+    uint32_t data_ptr, uint64_t wlength, uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
     static_assert(preamble_size == 0, "Dispatcher preamble size must be 0. This is not supported anymore with Fabric");
 
-    // DPRINT << "relay_to_next_cb: " << data_ptr << " " << cb_fence << " " << length << ENDL();
+    // DPRINT << "relay_to_next_cb: " << data_ptr << " " << cb_fence << " " << wlength << ENDL();
 
     // First page should be valid since it has the command
     ASSERT(data_ptr <= dispatch_cb_end - dispatch_cb_page_size);
@@ -352,78 +358,87 @@ void relay_to_next_cb(
     relay_client.init_write_state_only<my_noc_index, NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0));
     relay_client.init_inline_write_state_only<my_noc_index>(get_noc_addr_helper(downstream_noc_xy, 0));
 
-    while (length > 0) {
-        ASSERT(downstream_cb_end > downstream_cb_data_ptr);
+    constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
+    while (wlength != 0) {
+        uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(wlength);
+        wlength -= length;
+        while (length > 0) {
+            ASSERT(downstream_cb_end > downstream_cb_data_ptr);
 
-        cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(1);
+            cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(1);
 
-        uint32_t xfer_size;
-        bool not_end_of_cmd;
-        if (length > dispatch_cb_page_size - preamble_size) {
-            xfer_size = dispatch_cb_page_size - preamble_size;
-            not_end_of_cmd = true;
-        } else {
-            xfer_size = length;
-            not_end_of_cmd = false;
-        }
-
-        if constexpr (preamble_size > 0) {
-            uint32_t flag;
-            relay_client.write_inline<my_noc_index>(
-                get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr),
-                xfer_size + preamble_size + not_end_of_cmd);
-            downstream_cb_data_ptr += preamble_size;
-            ASSERT(downstream_cb_data_ptr < downstream_cb_end);
-        }
-        // Get a page if needed
-        if (data_ptr + xfer_size > cb_fence) {
-            // Check for block completion
-            if (cb_fence == block_next_start_addr[rd_block_idx]) {
-                uint32_t orphan_size = cb_fence - data_ptr;
-                // No more writes from this block. Decrement the number of writes
-                // since they were all accounted for.
-                // Check for dispatch_cb wrap
-                if (rd_block_idx == dispatch_cb_blocks - 1) {
-                    ASSERT(cb_fence == dispatch_cb_end);
-                    if (orphan_size != 0) {
-                        relay_client.write<my_noc_index, true, NCRISC_WR_CMD_BUF>(
-                            data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), orphan_size);
-                        length -= orphan_size;
-                        xfer_size -= orphan_size;
-                        downstream_cb_data_ptr += orphan_size;
-                        if (downstream_cb_data_ptr == downstream_cb_end) {
-                            downstream_cb_data_ptr = downstream_cb_base;
-                        }
-                        // All writes from this block have completed.
-                        orphan_size = 0;
-                    }
-                    cb_fence = dispatch_cb_base;
-                    data_ptr = dispatch_cb_base;
-                }
-
-                move_rd_to_next_block_and_release_pages<
-                    upstream_noc_index,
-                    upstream_noc_xy,
-                    upstream_dispatch_cb_sem_id,
-                    dispatch_cb_pages_per_block,
-                    dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+            uint32_t xfer_size;
+            bool not_end_of_cmd;
+            if (length > dispatch_cb_page_size - preamble_size) {
+                xfer_size = dispatch_cb_page_size - preamble_size;
+                not_end_of_cmd = true;
+            } else {
+                xfer_size = length;
+                not_end_of_cmd = false;
             }
 
-            // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
-            uint32_t n_pages = cb_acquire_pages<my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
-            cb_fence += n_pages * dispatch_cb_page_size;
-        }
+            if constexpr (preamble_size > 0) {
+                uint32_t flag;
+                relay_client.write_inline<my_noc_index>(
+                    get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr),
+                    xfer_size + preamble_size + not_end_of_cmd);
+                downstream_cb_data_ptr += preamble_size;
+                ASSERT(downstream_cb_data_ptr < downstream_cb_end);
+            }
+            // Get a page if needed
+            if (data_ptr + xfer_size > cb_fence) {
+                // Check for block completion
+                if (cb_fence == block_next_start_addr[rd_block_idx]) {
+                    uint32_t orphan_size = cb_fence - data_ptr;
+                    // No more writes from this block. Decrement the number of writes
+                    // since they were all accounted for.
+                    // Check for dispatch_cb wrap
+                    if (rd_block_idx == dispatch_cb_blocks - 1) {
+                        ASSERT(cb_fence == dispatch_cb_end);
+                        if (orphan_size != 0) {
+                            relay_client.write<my_noc_index, true, NCRISC_WR_CMD_BUF>(
+                                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), orphan_size);
+                            length -= orphan_size;
+                            xfer_size -= orphan_size;
+                            downstream_cb_data_ptr += orphan_size;
+                            if (downstream_cb_data_ptr == downstream_cb_end) {
+                                downstream_cb_data_ptr = downstream_cb_base;
+                            }
+                            // All writes from this block have completed.
+                            orphan_size = 0;
+                        }
+                        cb_fence = dispatch_cb_base;
+                        data_ptr = dispatch_cb_base;
+                    }
 
-        relay_client
-            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
+                    move_rd_to_next_block_and_release_pages<
+                        upstream_noc_index,
+                        upstream_noc_xy,
+                        upstream_dispatch_cb_sem_id,
+                        dispatch_cb_pages_per_block,
+                        dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                }
+
+                // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
+                uint32_t n_pages = cb_acquire_pages<my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
+                    cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
+                cb_fence += n_pages * dispatch_cb_page_size;
+            }
+
+            relay_client.write_atomic_inc_any_len<
+                my_noc_index,
+                downstream_noc_xy,
+                downstream_cb_sem_id,
+                true,
+                NCRISC_WR_CMD_BUF>(
                 data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), xfer_size, 1);
 
-        length -= xfer_size;
-        data_ptr += xfer_size;
-        downstream_cb_data_ptr += xfer_size;
-        if (downstream_cb_data_ptr == downstream_cb_end) {
-            downstream_cb_data_ptr = downstream_cb_base;
+            length -= xfer_size;
+            data_ptr += xfer_size;
+            downstream_cb_data_ptr += xfer_size;
+            if (downstream_cb_data_ptr == downstream_cb_end) {
+                downstream_cb_data_ptr = downstream_cb_base;
+            }
         }
     }
 
@@ -439,7 +454,7 @@ void relay_to_next_cb(
 void process_write_host_d(uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
     volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
     // Remember: host transfer command includes the command in the payload, don't add it here
-    uint32_t length = cmd->write_linear_host.length;
+    uint64_t length = cmd->write_linear_host.length;
     uint32_t data_ptr = cmd_ptr;
 
     relay_to_next_cb<split_dispatch_page_preamble_size>(
@@ -549,7 +564,7 @@ void process_write_paged(uint32_t& block_noc_writes_to_clear, uint32_t block_nex
     uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
     uint32_t write_length = pages * page_size;
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
-    uint64_t dst_addr_offset = 0;  // Offset into page.
+    uint32_t dst_addr_offset = 0;  // Offset into page.
 
     // DPRINT << "process_write_paged - pages: " << pages << " page_size: " << page_size
     //        << " dispatch_cb_page_size: " << dispatch_cb_page_size << ENDL();

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -372,8 +372,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
     stall_state = static_cast<StallState>(stall_flag << 1);  // NOT_STALLED -> STALL_NEXT if stall_flag is set
 
     if (fetch_size != 0 && pending_read_size == 0) {
-        pending_read_size = read_from_pcie<preamble_size>(
-            prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+        pending_read_size = read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
         if (stall_state == STALL_NEXT && pending_read_size != 0) {
             // No pending reads -> stall_state can be set to STALLED, since the read to the cmd
             // that initiated the stall has been issued.
@@ -575,8 +574,8 @@ uint32_t process_relay_paged_cmd_large(
     // First step - read into DB0
     uint32_t scratch_read_addr = scratch_db_top[0];
     uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-    uint32_t write_length = pages * page_size - length_adjust;
-    uint32_t read_length;
+    uint64_t write_length = (uint64_t)pages * page_size - length_adjust;
+    uint64_t read_length;
     uint32_t amt_read;
     if (scratch_db_half_size >= write_length) {
         amt_read = write_length;
@@ -699,9 +698,9 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_pt
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
 
     // First step - read into DB0
-    uint32_t read_length = pages * page_size;
+    uint64_t read_wlength = (uint64_t)pages * page_size;
     uint32_t scratch_read_addr = scratch_db_top[0];
-    uint32_t amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+    uint32_t amt_to_read = (scratch_db_half_size > read_wlength) ? read_wlength : scratch_db_half_size;
     uint32_t amt_read = 0;
     while (amt_to_read >= page_size) {
         uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
@@ -711,42 +710,54 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_pt
         amt_to_read -= page_size;
         amt_read += page_size;
     }
+    // The fences are to prevent any compiler reordering of instructions around the division. The latency of the
+    // division is hidden by the latency of the noc_async_read_barrier().
+    std::atomic_signal_fence(std::memory_order_acq_rel);
+    const uint32_t max_batch_size = read_wlength > std::numeric_limits<uint32_t>::max()
+                                        ? (std::numeric_limits<uint32_t>::max() / page_size) * page_size
+                                        : read_wlength;
+    std::atomic_signal_fence(std::memory_order_acq_rel);
     noc_async_read_barrier();
 
     // Second step - read into DB[x], write from DB[x], toggle x, iterate
     // Writes are fast, reads are slow
     uint32_t db_toggle = 0;
     uint32_t scratch_write_addr;
-    read_length -= amt_read;
-    while (read_length != 0) {
-        // This ensures that writes from prior iteration are done
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_writes_flushed();
+    read_wlength -= amt_read;
+    while (read_wlength != 0) {
+        uint32_t read_length = (read_wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(read_wlength);
+        read_wlength -= read_length;
+        while (read_length != 0) {
+            // This ensures that writes from prior iteration are done
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_writes_flushed();
 
-        db_toggle ^= 1;
-        scratch_read_addr = scratch_db_top[db_toggle];
-        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+            db_toggle ^= 1;
+            scratch_read_addr = scratch_db_top[db_toggle];
+            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
 
-        uint32_t amt_to_write = amt_read;
-        amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
-        amt_read = 0;
-        while (amt_to_read >= page_size) {
-            uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-            noc_async_read(noc_addr, scratch_read_addr, page_size);
-            scratch_read_addr += page_size;
-            page_id++;
-            amt_to_read -= page_size;
-            amt_read += page_size;
+            uint32_t amt_to_write = amt_read;
+            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            amt_read = 0;
+            while (amt_to_read >= page_size) {
+                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+                noc_async_read(noc_addr, scratch_read_addr, page_size);
+                scratch_read_addr += page_size;
+                page_id++;
+                amt_to_read -= page_size;
+                amt_read += page_size;
+            }
+
+            // Third step - write from DB
+            uint32_t npages =
+                write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+            cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
+
+            read_length -= amt_read;
+
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_read_barrier();
         }
-
-        // Third step - write from DB
-        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
-
-        read_length -= amt_read;
-
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_read_barrier();
     }
 
     // Third step - write from DB
@@ -925,47 +936,52 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     uint32_t noc_xy_addr = cmd->relay_linear.noc_xy_addr;
     uint32_t read_addr = cmd->relay_linear.addr;
-    uint32_t length = cmd->relay_linear.length;
-    uint32_t read_length = length;
-    // DPRINT << "relay_linear: " << cmd_ptr << " " << length << " " << read_addr << " " << noc_xy_addr << ENDL();
+    uint64_t wlength = cmd->relay_linear.length | ((uint64_t)cmd->relay_linear.length_hi << 32);
+    // DPRINT << "relay_linear: " << cmd_ptr << " " << wlength << " " << read_addr << " " << noc_xy_addr << ENDL();
 
     // First step - read into DB0
     uint32_t scratch_read_addr = scratch_db_top[0];
-    uint32_t amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+    uint32_t amt_to_read = (scratch_db_half_size > wlength) ? wlength : scratch_db_half_size;
     uint64_t noc_addr = get_noc_addr_helper(noc_xy_addr, read_addr);
     noc_async_read(noc_addr, scratch_read_addr, amt_to_read);
     read_addr += amt_to_read;
+    wlength -= amt_to_read;
     noc_async_read_barrier();
 
     // Second step - read into DB[x], write from DB[x], toggle x, iterate
     // Writes are fast, reads are slow
     uint32_t db_toggle = 0;
     uint32_t scratch_write_addr;
-    read_length -= amt_to_read;
-    while (read_length != 0) {
-        // This ensures that writes from prior iteration are done
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_writes_flushed();
+    constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
+    while (wlength != 0) {
+        uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;
+        wlength -= read_length;
+        while (read_length != 0) {
+            // This ensures that writes from prior iteration are done
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_writes_flushed();
 
-        db_toggle ^= 1;
-        scratch_read_addr = scratch_db_top[db_toggle];
-        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+            db_toggle ^= 1;
+            scratch_read_addr = scratch_db_top[db_toggle];
+            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
 
-        uint32_t amt_to_write = amt_to_read;
-        amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
-        noc_addr = get_noc_addr_helper(noc_xy_addr, read_addr);
-        noc_async_read(noc_addr, scratch_read_addr, amt_to_read);
-        read_addr += amt_to_read;
+            uint32_t amt_to_write = amt_to_read;
+            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            noc_addr = get_noc_addr_helper(noc_xy_addr, read_addr);
+            noc_async_read(noc_addr, scratch_read_addr, amt_to_read);
+            read_addr += amt_to_read;
 
-        // Third step - write from DB
-        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+            // Third step - write from DB
+            uint32_t npages =
+                write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 
-        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
+            cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
-        read_length -= amt_to_read;
+            read_length -= amt_to_read;
 
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_read_barrier();
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_read_barrier();
+        }
     }
 
     // Third step - write from DB

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -639,7 +639,7 @@ void read_pages_to_host_helper(
     const uint32_t& host_page_id,
     const uint32_t& core_page_id,
     const uint32_t& bank_id) {
-    uint32_t host_buffer_start = host_page_id * page_size;
+    uint64_t host_buffer_start = uint64_t(host_page_id) * page_size;
     if (dev_buffer.is_l1()) {
         auto core_coordinates =
             device->worker_core_from_logical_core(dev_buffer.allocator()->get_logical_core_from_bank_id(bank_id));


### PR DESCRIPTION
### Ticket
[22336](https://github.com/tenstorrent/tt-metal/issues/22336)

### Problem description
>= 4 GB (> 32 bits addressing) buffers write and read to device memory does not work correctly. This PR addresses the integer overflow and inadequate width integer types for addressing and offsetting into the buffers encountered in Metal code.

### What's changed
Investigate the call flows, identify the problematic codes and fix them (could be by accumulating intermediate results in `uint64_t` or increasing the integer type width from `uint32_t` to `uint64_t`).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes