### PR TITLE
#25975: Port Moreh kernels to use TensorAccessor, part 1

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp
@@ -21,13 +21,9 @@ void kernel_main() {
     const auto cb_id_mask_w = cb_id++;
 
     const uint32_t input_tile_bytes = get_tile_size(cb_id_input);
-    const auto input_data_format = get_dataformat(cb_id_input);
 
-    const InterleavedAddrGenFast<true> dram_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
-
-    const InterleavedAddrGenFast<false> l1_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    constexpr auto input_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     Scalar one;
     one.f = 1.0f;
@@ -49,11 +45,7 @@ void kernel_main() {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             const auto tile_idx = start_tile_idx + row_idx * Wt + col_idx;
             cb_reserve_back(cb_id_input, 1);
-            if (input_is_dram) {
-                noc_async_read_tile(tile_idx, dram_input_addrg, input_l1_write_ptr);
-            } else {
-                noc_async_read_tile(tile_idx, l1_input_addrg, input_l1_write_ptr);
-            }
+            noc_async_read_tile(tile_idx, s, input_l1_write_ptr);
             noc_async_read_barrier();
             cb_push_back(cb_id_input, 1);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/writer_moreh_abs_pow.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/writer_moreh_abs_pow.cpp
@@ -18,13 +18,9 @@ void kernel_main() {
     const auto cb_id_output = cb_id++;
 
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     const auto start_tile_idx = tile_offset;
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
@@ -33,11 +29,7 @@ void kernel_main() {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             const auto tile_idx = start_tile_idx + row_idx * Wt + col_idx;
             cb_wait_front(cb_id_output, 1);
-            if (output_is_dram) {
-                noc_async_write_tile(tile_idx, dram_output_addrg, output_l1_read_addr);
-            } else {
-                noc_async_write_tile(tile_idx, l1_output_addrg, output_l1_read_addr);
-            }
+            noc_async_write_tile(tile_idx, s, output_l1_read_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_id_output, 1);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "moreh_abs_pow_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_abs_pow {
 MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation::MorehAbsPowFactory::create(
@@ -98,8 +99,12 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
         "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/"
         "writer_moreh_abs_pow.cpp";
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores);
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
+    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/writer_moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/writer_moreh_adam.cpp
@@ -17,39 +17,24 @@ void kernel_main() {
     constexpr uint32_t cb_id_exp_avg_sq = tt::CBIndex::c_18;
 
     const uint32_t param_tile_bytes = get_tile_size(cb_id_param);
-    const auto param_data_format = get_dataformat(cb_id_param);
-
     const uint32_t exp_avg_tile_bytes = get_tile_size(cb_id_exp_avg);
-    const auto exp_avg_data_format = get_dataformat(cb_id_exp_avg);
-
     const uint32_t exp_avg_sq_tile_bytes = get_tile_size(cb_id_exp_avg_sq);
-    const auto exp_avg_sq_data_format = get_dataformat(cb_id_exp_avg_sq);
 
-    constexpr bool param_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool exp_avg_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool exp_avg_sq_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool max_exp_avg_sq_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr auto param_args = TensorAccessorArgs<0>();
+    constexpr auto exp_avg_args = TensorAccessorArgs<param_args.next_compile_time_args_offset()>();
+    constexpr auto exp_avg_sq_args = TensorAccessorArgs<exp_avg_args.next_compile_time_args_offset()>();
 
-    const InterleavedAddrGenFast<param_is_dram> param_addrg = {
-        .bank_base_address = param_addr, .page_size = param_tile_bytes, .data_format = param_data_format};
-
-    const InterleavedAddrGenFast<exp_avg_is_dram> exp_avg_addrg = {
-        .bank_base_address = exp_avg_addr, .page_size = exp_avg_tile_bytes, .data_format = exp_avg_data_format};
-
-    const InterleavedAddrGenFast<exp_avg_sq_is_dram> exp_avg_sq_addrg = {
-        .bank_base_address = exp_avg_sq_addr,
-        .page_size = exp_avg_sq_tile_bytes,
-        .data_format = exp_avg_sq_data_format};
+    const auto param_addrg = TensorAccessor(param_args, param_addr, param_tile_bytes);
+    const auto exp_avg_addrg = TensorAccessor(exp_avg_args, exp_avg_addr, exp_avg_tile_bytes);
+    const auto exp_avg_sq_addrg = TensorAccessor(exp_avg_sq_args, exp_avg_sq_addr, exp_avg_sq_tile_bytes);
 
 #ifdef AMSGRAD
     constexpr uint32_t cb_id_max_exp_avg_sq = tt::CBIndex::c_19;
     const auto max_exp_avg_sq_addr = get_arg_val<uint32_t>(3);
     const uint32_t max_exp_avg_sq_tile_bytes = get_tile_size(cb_id_max_exp_avg_sq);
-    const auto max_exp_avg_sq_data_format = get_dataformat(cb_id_max_exp_avg_sq);
-    const InterleavedAddrGenFast<max_exp_avg_sq_is_dram> max_exp_avg_sq_addrg = {
-        .bank_base_address = max_exp_avg_sq_addr,
-        .page_size = max_exp_avg_sq_tile_bytes,
-        .data_format = max_exp_avg_sq_data_format};
+    constexpr auto max_exp_avg_sq_args = TensorAccessorArgs<exp_avg_sq_args.next_compile_time_args_offset()>();
+    const auto max_exp_avg_sq_addrg =
+        TensorAccessor(max_exp_avg_sq_args, max_exp_avg_sq_addr, max_exp_avg_sq_tile_bytes);
 #endif
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_adam {
 MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::ProgramFactory::create(
@@ -93,18 +94,22 @@ MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::Program
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
 
-    const std::vector<uint32_t> reader_compile_time_args{
-        static_cast<uint32_t>(is_dram(param_in)),
-        static_cast<uint32_t>(is_dram(grad)),
-        static_cast<uint32_t>(is_dram(exp_avg_in)),
-        static_cast<uint32_t>(is_dram(exp_avg_sq_in)),
-        static_cast<uint32_t>(is_dram(max_exp_avg_sq_in))};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*param_in.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*exp_avg_in.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*exp_avg_sq_in.buffer()).append_to(reader_compile_time_args);
+    if (max_exp_avg_sq_in.has_value()) {
+        TensorAccessorArgs(*max_exp_avg_sq_in.value().buffer()).append_to(reader_compile_time_args);
+    }
 
-    const std::vector<uint32_t> writer_compile_time_args{
-        static_cast<uint32_t>(is_dram(param_out)),
-        static_cast<uint32_t>(is_dram(exp_avg_out)),
-        static_cast<uint32_t>(is_dram(exp_avg_sq_out)),
-        static_cast<uint32_t>(max_exp_avg_sq_out.has_value() ? is_dram(max_exp_avg_sq_out.value()) : false)};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*param_out.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*exp_avg_out.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*exp_avg_sq_out.buffer()).append_to(writer_compile_time_args);
+    if (max_exp_avg_sq_out.has_value()) {
+        TensorAccessorArgs(*max_exp_avg_sq_out.value().buffer()).append_to(writer_compile_time_args);
+    }
 
     const auto reader_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/"

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
@@ -41,45 +41,26 @@ void kernel_main() {
     constexpr uint32_t cb_beta2_exponent = tt::CBIndex::c_29;
 
     const uint32_t param_tile_bytes = get_tile_size(cb_id_param);
-    const auto param_data_format = get_dataformat(cb_id_param);
-
     const uint32_t grad_tile_bytes = get_tile_size(cb_id_grad);
-    const auto grad_data_format = get_dataformat(cb_id_grad);
-
     const uint32_t exp_avg_tile_bytes = get_tile_size(cb_id_exp_avg);
-    const auto exp_avg_data_format = get_dataformat(cb_id_exp_avg);
-
     const uint32_t exp_avg_sq_tile_bytes = get_tile_size(cb_id_exp_avg_sq);
-    const auto exp_avg_sq_data_format = get_dataformat(cb_id_exp_avg_sq);
 
-    constexpr bool param_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool grad_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool exp_avg_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool exp_avg_sq_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr bool max_exp_avg_sq_is_dram = get_compile_time_arg_val(4) == 1;
+    constexpr auto param_args = TensorAccessorArgs<0>();
+    constexpr auto grad_args = TensorAccessorArgs<param_args.next_compile_time_args_offset()>();
+    constexpr auto exp_avg_args = TensorAccessorArgs<grad_args.next_compile_time_args_offset()>();
+    constexpr auto exp_avg_sq_args = TensorAccessorArgs<exp_avg_args.next_compile_time_args_offset()>();
 
-    const InterleavedAddrGenFast<param_is_dram> param_addrg = {
-        .bank_base_address = param_addr, .page_size = param_tile_bytes, .data_format = param_data_format};
-
-    const InterleavedAddrGenFast<grad_is_dram> grad_addrg = {
-        .bank_base_address = grad_addr, .page_size = grad_tile_bytes, .data_format = grad_data_format};
-
-    const InterleavedAddrGenFast<exp_avg_is_dram> exp_avg_addrg = {
-        .bank_base_address = exp_avg_addr, .page_size = exp_avg_tile_bytes, .data_format = exp_avg_data_format};
-
-    const InterleavedAddrGenFast<exp_avg_sq_is_dram> exp_avg_sq_addrg = {
-        .bank_base_address = exp_avg_sq_addr,
-        .page_size = exp_avg_sq_tile_bytes,
-        .data_format = exp_avg_sq_data_format};
+    const auto param_addrg = TensorAccessor(param_args, param_addr, param_tile_bytes);
+    const auto grad_addrg = TensorAccessor(grad_args, grad_addr, grad_tile_bytes);
+    const auto exp_avg_addrg = TensorAccessor(exp_avg_args, exp_avg_addr, exp_avg_tile_bytes);
+    const auto exp_avg_sq_addrg = TensorAccessor(exp_avg_sq_args, exp_avg_sq_addr, exp_avg_sq_tile_bytes);
 
 #ifdef AMSGRAD
     constexpr uint32_t cb_id_max_exp_avg_sq = tt::CBIndex::c_4;
     const uint32_t max_exp_avg_sq_tile_bytes = get_tile_size(cb_id_max_exp_avg_sq);
-    const auto max_exp_avg_sq_data_format = get_dataformat(cb_id_max_exp_avg_sq);
-    const InterleavedAddrGenFast<max_exp_avg_sq_is_dram> max_exp_avg_sq_addrg = {
-        .bank_base_address = max_exp_avg_sq_addr,
-        .page_size = max_exp_avg_sq_tile_bytes,
-        .data_format = max_exp_avg_sq_data_format};
+    constexpr auto max_exp_avg_sq_args = TensorAccessorArgs<exp_avg_sq_args.next_compile_time_args_offset()>();
+    const auto max_exp_avg_sq_addrg =
+        TensorAccessor(max_exp_avg_sq_args, max_exp_avg_sq_addr, max_exp_avg_sq_tile_bytes);
 #endif
 
     fill_cb_with_value(cb_scalar_args, lr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/writer_moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/writer_moreh_adamw.cpp
@@ -19,38 +19,23 @@ void kernel_main() {
     constexpr uint32_t cb_id_exp_avg_sq = tt::CBIndex::c_18;
 
     const uint32_t param_tile_bytes = get_tile_size(cb_id_param);
-    const auto param_data_format = get_dataformat(cb_id_param);
-
     const uint32_t exp_avg_tile_bytes = get_tile_size(cb_id_exp_avg);
-    const auto exp_avg_data_format = get_dataformat(cb_id_exp_avg);
-
     const uint32_t exp_avg_sq_tile_bytes = get_tile_size(cb_id_exp_avg_sq);
-    const auto exp_avg_sq_data_format = get_dataformat(cb_id_exp_avg_sq);
 
-    constexpr bool param_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool exp_avg_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool exp_avg_sq_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr bool max_exp_avg_sq_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr auto param_args = TensorAccessorArgs<0>();
+    constexpr auto exp_avg_args = TensorAccessorArgs<param_args.next_compile_time_args_offset()>();
+    constexpr auto exp_avg_sq_args = TensorAccessorArgs<exp_avg_args.next_compile_time_args_offset()>();
 
-    const InterleavedAddrGenFast<param_is_dram> param_addrg = {
-        .bank_base_address = param_addr, .page_size = param_tile_bytes, .data_format = param_data_format};
-
-    const InterleavedAddrGenFast<exp_avg_is_dram> exp_avg_addrg = {
-        .bank_base_address = exp_avg_addr, .page_size = exp_avg_tile_bytes, .data_format = exp_avg_data_format};
-
-    const InterleavedAddrGenFast<exp_avg_sq_is_dram> exp_avg_sq_addrg = {
-        .bank_base_address = exp_avg_sq_addr,
-        .page_size = exp_avg_sq_tile_bytes,
-        .data_format = exp_avg_sq_data_format};
+    const auto param_addrg = TensorAccessor(param_args, param_addr, param_tile_bytes);
+    const auto exp_avg_addrg = TensorAccessor(exp_avg_args, exp_avg_addr, exp_avg_tile_bytes);
+    const auto exp_avg_sq_addrg = TensorAccessor(exp_avg_sq_args, exp_avg_sq_addr, exp_avg_sq_tile_bytes);
 
 #ifdef AMSGRAD
     constexpr uint32_t cb_id_max_exp_avg_sq = tt::CBIndex::c_19;
     const uint32_t max_exp_avg_sq_tile_bytes = get_tile_size(cb_id_max_exp_avg_sq);
-    const auto max_exp_avg_sq_data_format = get_dataformat(cb_id_max_exp_avg_sq);
-    const InterleavedAddrGenFast<max_exp_avg_sq_is_dram> max_exp_avg_sq_addrg = {
-        .bank_base_address = max_exp_avg_sq_addr,
-        .page_size = max_exp_avg_sq_tile_bytes,
-        .data_format = max_exp_avg_sq_data_format};
+    constexpr auto max_exp_avg_sq_args = TensorAccessorArgs<exp_avg_sq_args.next_compile_time_args_offset()>();
+    const auto max_exp_avg_sq_addrg =
+        TensorAccessor(max_exp_avg_sq_args, max_exp_avg_sq_addr, max_exp_avg_sq_tile_bytes);
 #endif
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -7,6 +7,7 @@
 #include "moreh_adamw_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_adamw {
 MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation::MultiCore::create(
@@ -95,18 +96,22 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> reader_compile_time_args{
-        static_cast<uint32_t>(is_dram(param_in)),
-        static_cast<uint32_t>(is_dram(grad)),
-        static_cast<uint32_t>(is_dram(exp_avg_in)),
-        static_cast<uint32_t>(is_dram(exp_avg_sq_in)),
-        static_cast<uint32_t>(max_exp_avg_sq_in.has_value() ? is_dram(max_exp_avg_sq_in.value()) : false)};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*param_in.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*exp_avg_in.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*exp_avg_sq_in.buffer()).append_to(reader_compile_time_args);
+    if (max_exp_avg_sq_in.has_value()) {
+        TensorAccessorArgs(*max_exp_avg_sq_in.value().buffer()).append_to(reader_compile_time_args);
+    }
 
-    const std::vector<uint32_t> writer_compile_time_args{
-        static_cast<uint32_t>(is_dram(param_out)),
-        static_cast<uint32_t>(is_dram(exp_avg_out)),
-        static_cast<uint32_t>(is_dram(exp_avg_sq_out)),
-        static_cast<uint32_t>(max_exp_avg_sq_out.has_value() ? is_dram(max_exp_avg_sq_out.value()) : false)};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*param_out.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*exp_avg_out.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*exp_avg_sq_out.buffer()).append_to(writer_compile_time_args);
+    if (max_exp_avg_sq_out.has_value()) {
+        TensorAccessorArgs(*max_exp_avg_sq_out.value().buffer()).append_to(writer_compile_time_args);
+    }
 
     const auto reader_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/"

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange.cpp
@@ -17,10 +17,10 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
     uint32_t num_bytes_per_tile = get_tile_size(cb_out);
 
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = num_bytes_per_tile};
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(dst_args, dst_addr, num_bytes_per_tile);
 
     union value {
         float f;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange_rm.cpp
@@ -18,10 +18,10 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
     uint32_t num_bytes_per_tile = TILE_WIDTH * element_size;
 
-    const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = num_bytes_per_tile};
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(dst_args, dst_addr, num_bytes_per_tile);
 
     union value {
         float f;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_arange_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
@@ -43,14 +44,16 @@ MorehArangeOperation::ProgramFactory::cached_program_t MorehArangeOperation::Pro
         default: break;
     }
 
-    uint32_t dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
     auto kernel_id = CreateWriteKernel(
         program,
         operation_attributes.untilize_out
             ? "ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange_rm.cpp"
             : "ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange.cpp",
         all_cores,
-        {dst_is_dram},
+        writer_compile_time_args,
         writer_defines);
 
     // Set runtime arguments

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/reader_moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/reader_moreh_clip_grad_norm_step1.cpp
@@ -7,7 +7,6 @@
 void kernel_main() {
     int i{0};
     const auto input_addr = get_arg_val<uint32_t>(i++);
-    const bool input_is_dram = get_arg_val<uint32_t>(i++) == 1;
     const auto num_tiles = get_arg_val<uint32_t>(i++);
     const auto decimal = get_arg_val<uint32_t>(i++);
     const auto origin_h = get_arg_val<uint32_t>(i++);
@@ -20,13 +19,9 @@ void kernel_main() {
     const auto cb_id_mask_h_w = cb_id++;
 
     const uint32_t input_tile_bytes = get_tile_size(cb_id_input);
-    const auto input_data_format = get_dataformat(cb_id_input);
 
-    const InterleavedAddrGenFast<true> dram_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
-
-    const InterleavedAddrGenFast<false> l1_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    constexpr auto input_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     union {
         float f;
@@ -42,11 +37,7 @@ void kernel_main() {
     const auto input_l1_write_ptr = get_write_ptr(cb_id_input);
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
         cb_reserve_back(cb_id_input, onetile);
-        if (input_is_dram) {
-            noc_async_read_tile(tile_idx, dram_input_addrg, input_l1_write_ptr);
-        } else {
-            noc_async_read_tile(tile_idx, l1_input_addrg, input_l1_write_ptr);
-        }
+        noc_async_read_tile(tile_idx, s, input_l1_write_ptr);
         noc_async_read_barrier();
         cb_push_back(cb_id_input, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/writer_moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/writer_moreh_clip_grad_norm_step1.cpp
@@ -7,29 +7,20 @@
 void kernel_main() {
     int i{0};
     const auto output_addr = get_arg_val<uint32_t>(i++);
-    const bool output_is_dram = get_arg_val<uint32_t>(i++) == 1;
     const auto tile_offset = get_arg_val<uint32_t>(i++);
 
     constexpr uint32_t cb_id_output = 16;
 
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     constexpr uint32_t onetile = 1;
 
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
     cb_wait_front(cb_id_output, onetile);
-    if (output_is_dram) {
-        noc_async_write_tile(tile_offset, dram_output_addrg, output_l1_read_addr);
-    } else {
-        noc_async_write_tile(tile_offset, l1_output_addrg, output_l1_read_addr);
-    }
+    noc_async_write_tile(tile_offset, s, output_l1_read_addr);
     noc_async_write_barrier();
     cb_pop_front(cb_id_output, onetile);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -118,12 +118,10 @@ MorehClipGradNormStep1Operation::ProgramFactory::create(
         "writer_moreh_clip_grad_norm_step1.cpp";
 
     std::vector<uint32_t> reader_ct_args = {};
-    // input accessor
     TensorAccessorArgs(*inputs.at(0).buffer()).append_to(reader_ct_args);
     const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, core_group_1, reader_ct_args);
 
     std::vector<uint32_t> writer_ct_args = {};
-    // output accessor (tmp_pow_sum)
     TensorAccessorArgs(*tmp_pow_sum.buffer()).append_to(writer_ct_args);
     const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, core_group_1, writer_ct_args);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_clip_grad_norm_step1 {
 
@@ -116,8 +117,15 @@ MorehClipGradNormStep1Operation::ProgramFactory::create(
         "ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/"
         "writer_moreh_clip_grad_norm_step1.cpp";
 
-    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, core_group_1);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, core_group_1);
+    std::vector<uint32_t> reader_ct_args = {};
+    // input accessor
+    TensorAccessorArgs(*inputs.at(0).buffer()).append_to(reader_ct_args);
+    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, core_group_1, reader_ct_args);
+
+    std::vector<uint32_t> writer_ct_args = {};
+    // output accessor (tmp_pow_sum)
+    TensorAccessorArgs(*tmp_pow_sum.buffer()).append_to(writer_ct_args);
+    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, core_group_1, writer_ct_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
@@ -151,17 +159,11 @@ MorehClipGradNormStep1Operation::ProgramFactory::create(
 
         // reader
         const std::array reader_runtime_args{
-            input_addr,
-            static_cast<uint32_t>(input.buffer()->is_dram()),
-            num_tiles,
-            *reinterpret_cast<uint32_t*>(&decimal),
-            origin_h,
-            origin_w};
+            input_addr, num_tiles, *reinterpret_cast<uint32_t*>(&decimal), origin_h, origin_w};
         SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
 
         // writer
-        const std::array writer_runtime_args{
-            output_addr, static_cast<uint32_t>(tmp_pow_sum.buffer()->is_dram()), tile_offset};
+        const std::array writer_runtime_args{output_addr, tile_offset};
         SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
 
         // compute
@@ -204,7 +206,7 @@ void MorehClipGradNormStep1Operation::ProgramFactory::override_runtime_arguments
         {
             auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = tensor_args.inputs.at(i).buffer()->address();
-            runtime_args[3] = *reinterpret_cast<uint32_t*>(&decimal);
+            runtime_args[2] = *reinterpret_cast<uint32_t*>(&decimal);
         }
 
         {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/writer_moreh_clip_grad_norm_step2.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/writer_moreh_clip_grad_norm_step2.cpp
@@ -7,28 +7,19 @@
 void kernel_main() {
     int i{0};
     const auto output_addr = get_arg_val<uint32_t>(i++);
-    const bool output_is_dram = get_arg_val<uint32_t>(i++) == 1;
 
     constexpr uint32_t cb_id_output = 16;
 
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     constexpr uint32_t onetile = 1;
 
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
     cb_wait_front(cb_id_output, onetile);
-    if (output_is_dram) {
-        noc_async_write_tile(0, dram_output_addrg, output_l1_read_addr);
-    } else {
-        noc_async_write_tile(0, l1_output_addrg, output_l1_read_addr);
-    }
+    noc_async_write_tile(0, s, output_l1_read_addr);
     noc_async_write_barrier();
     cb_pop_front(cb_id_output, onetile);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/reader_moreh_clip_grad_norm_step3.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/reader_moreh_clip_grad_norm_step3.cpp
@@ -7,9 +7,7 @@
 void kernel_main() {
     int i{0};
     const auto input_addr = get_arg_val<uint32_t>(i++);
-    const bool input_is_dram = get_arg_val<uint32_t>(i++) == 1;
     const auto clip_coef_clamped_addr = get_arg_val<uint32_t>(i++);
-    const bool clip_coef_clamped_is_dram = get_arg_val<uint32_t>(i++) == 1;
     const auto num_tiles = get_arg_val<uint32_t>(i++);
 
     uint32_t cb_id{0};
@@ -20,34 +18,18 @@ void kernel_main() {
 
     // input
     const uint32_t input_tile_bytes = get_tile_size(cb_id_input);
-    const auto input_data_format = get_dataformat(cb_id_input);
-
-    const InterleavedAddrGenFast<true> dram_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
-    const InterleavedAddrGenFast<false> l1_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    constexpr auto input_args = TensorAccessorArgs<0>();
+    const auto input_addrg = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     // clip_coef_clamped
     const uint32_t clip_coef_clamped_tile_bytes = get_tile_size(cb_id_clip_coef_clamped);
-    const auto clip_coef_clamped_data_format = get_dataformat(cb_id_clip_coef_clamped);
-
-    const InterleavedAddrGenFast<true> dram_clip_coef_clamped_addrg = {
-        .bank_base_address = clip_coef_clamped_addr,
-        .page_size = clip_coef_clamped_tile_bytes,
-        .data_format = clip_coef_clamped_data_format};
-    const InterleavedAddrGenFast<false> l1_clip_coef_clamped_addrg = {
-        .bank_base_address = clip_coef_clamped_addr,
-        .page_size = clip_coef_clamped_tile_bytes,
-        .data_format = clip_coef_clamped_data_format};
+    constexpr auto coef_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    const auto coef_addrg = TensorAccessor(coef_args, clip_coef_clamped_addr, clip_coef_clamped_tile_bytes);
 
     // clip_coef_clamped
     const auto clip_coef_clamped_l1_write_ptr = get_write_ptr(cb_id_clip_coef_clamped);
     cb_reserve_back(cb_id_clip_coef_clamped, onetile);
-    if (clip_coef_clamped_is_dram) {
-        noc_async_read_tile(0, dram_clip_coef_clamped_addrg, clip_coef_clamped_l1_write_ptr);
-    } else {
-        noc_async_read_tile(0, l1_clip_coef_clamped_addrg, clip_coef_clamped_l1_write_ptr);
-    }
+    noc_async_read_tile(0, coef_addrg, clip_coef_clamped_l1_write_ptr);
     noc_async_read_barrier();
     cb_push_back(cb_id_clip_coef_clamped, onetile);
 
@@ -55,11 +37,7 @@ void kernel_main() {
     const auto input_l1_write_ptr = get_write_ptr(cb_id_input);
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
         cb_reserve_back(cb_id_input, onetile);
-        if (input_is_dram) {
-            noc_async_read_tile(tile_idx, dram_input_addrg, input_l1_write_ptr);
-        } else {
-            noc_async_read_tile(tile_idx, l1_input_addrg, input_l1_write_ptr);
-        }
+        noc_async_read_tile(tile_idx, input_addrg, input_l1_write_ptr);
         noc_async_read_barrier();
         cb_push_back(cb_id_input, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/writer_moreh_clip_grad_norm_step3.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/writer_moreh_clip_grad_norm_step3.cpp
@@ -7,7 +7,6 @@
 void kernel_main() {
     int i{0};
     const auto output_addr = get_arg_val<uint32_t>(i++);
-    const bool output_is_dram = get_arg_val<uint32_t>(i++) == 1;
     const auto num_tiles = get_arg_val<uint32_t>(i++);
 
     constexpr uint32_t cb_id_output = 16;
@@ -16,22 +15,15 @@ void kernel_main() {
 
     // output
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     // output
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
         cb_wait_front(cb_id_output, onetile);
-        if (output_is_dram) {
-            noc_async_write_tile(tile_idx, dram_output_addrg, output_l1_read_addr);
-        } else {
-            noc_async_write_tile(tile_idx, l1_output_addrg, output_l1_read_addr);
-        }
+        noc_async_write_tile(tile_idx, s, output_l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id_output, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_clip_grad_norm_step3 {
 
@@ -88,8 +89,13 @@ MorehClipGradNormStep3Operation::ProgramFactory::create(
         "ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/"
         "writer_moreh_clip_grad_norm_step3.cpp";
 
-    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, core_group_1);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, core_group_1);
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*inputs.at(0).buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*clip_coef_clamped.buffer()).append_to(reader_ct_args);
+    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, core_group_1, reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*inputs.at(0).buffer()).append_to(writer_ct_args);
+    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, core_group_1, writer_ct_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
@@ -114,16 +120,11 @@ MorehClipGradNormStep3Operation::ProgramFactory::create(
         const auto num_tiles = static_cast<uint32_t>(input.physical_volume()) / tt::constants::TILE_HW;
 
         // reader
-        const std::array reader_runtime_args{
-            input_addr,
-            static_cast<uint32_t>(input.buffer()->is_dram()),
-            clip_coef_clamped_addr,
-            static_cast<uint32_t>(clip_coef_clamped.buffer()->is_dram()),
-            num_tiles};
+        const std::array reader_runtime_args{input_addr, clip_coef_clamped_addr, num_tiles};
         SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
 
         // writer
-        const std::array writer_runtime_args{input_addr, static_cast<uint32_t>(input.buffer()->is_dram()), num_tiles};
+        const std::array writer_runtime_args{input_addr, num_tiles};
         SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
 
         // compute
@@ -154,7 +155,7 @@ void MorehClipGradNormStep3Operation::ProgramFactory::override_runtime_arguments
         {
             auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = inputs.at(i).buffer()->address();
-            runtime_args[2] = clip_coef_clamped_address;
+            runtime_args[1] = clip_coef_clamped_address;
         }
 
         {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp
@@ -12,21 +12,21 @@ void kernel_main() {
     uint32_t num_cols = get_arg_val<uint32_t>(3);  // number of cols to read
     uint32_t mask_h = get_arg_val<uint32_t>(4);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t Wt = get_compile_time_arg_val(2);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(2);
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    constexpr auto src_args = TensorAccessorArgs<3>();
 
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
-    constexpr uint32_t scaler = get_compile_time_arg_val(4);
+    constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
     cb_reserve_back(cb_id_in2, 1);
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
@@ -57,8 +57,7 @@ void kernel_main() {
     generate_mask_h(cb_id_mask_h, mask_h);
 #endif
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     uint32_t w = curr_col_in_batch;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
@@ -12,7 +12,7 @@ void kernel_main() {
     const auto num_output_tiles = get_arg_val<uint32_t>(i++);
     const auto input_tile_stride = get_arg_val<uint32_t>(i++);
     const auto start_id = get_arg_val<uint32_t>(i++);
-    const auto input_is_dram = (get_arg_val<uint32_t>(i++) == 1);
+    // removed input_is_dram runtime flag; TensorAccessorArgs encodes location
     const auto HtWt = get_arg_val<uint32_t>(i++);
     const auto inner_size = get_arg_val<uint32_t>(i++);
 
@@ -33,11 +33,8 @@ void kernel_main() {
 
     uint32_t l1_write_addr_in0;
     uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
-    const auto input_data_format = get_dataformat(cb_id_in0);
-    const InterleavedAddrGenFast<true> dram_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
-    const InterleavedAddrGenFast<false> l1_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    constexpr auto input_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
         uint32_t hw_tile_id = i % HtWt;
@@ -48,11 +45,7 @@ void kernel_main() {
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
             cb_reserve_back(cb_id_in0, onetile);
             l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-            if (input_is_dram) {
-                noc_async_read_tile(read_tile_id, dram_input_addrg, l1_write_addr_in0);
-            } else {
-                noc_async_read_tile(read_tile_id, l1_input_addrg, l1_write_addr_in0);
-            }
+            noc_async_read_tile(read_tile_id, s, l1_write_addr_in0);
             noc_async_read_barrier();
             cb_push_back(cb_id_in0, onetile);
             read_tile_id += input_tile_stride;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp
@@ -12,7 +12,6 @@ void kernel_main() {
     const auto num_output_tiles = get_arg_val<uint32_t>(i++);
     const auto input_tile_stride = get_arg_val<uint32_t>(i++);
     const auto start_id = get_arg_val<uint32_t>(i++);
-    // removed input_is_dram runtime flag; TensorAccessorArgs encodes location
     const auto HtWt = get_arg_val<uint32_t>(i++);
     const auto inner_size = get_arg_val<uint32_t>(i++);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
@@ -10,8 +10,8 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
     uint32_t mask_w = get_arg_val<uint32_t>(3);
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
 
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
     generate_mm_scaler(cb_id_in2, scaler);
@@ -26,10 +26,8 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
@@ -10,15 +10,13 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include "moreh_mean_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -77,8 +78,9 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
     float scaler = 1.0f / origin_H;
     bfloat16 bfloat_scaler_value(scaler);
     auto packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(is_dram(input)), Ht, Wt, HtWt, packed_scaler_value};
+    std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    reader_compile_time_args.push_back(packed_scaler_value);
 
     std::map<std::string, std::string> reader_defines;
     reader_defines["REDUCE_SCALER"] = "1";
@@ -92,8 +94,8 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
         reader_compile_time_args,
         reader_defines);
 
-    std::vector<uint32_t> writer_compile_time_args = {
-        static_cast<uint32_t>(CBIndex::c_16), static_cast<uint32_t>(is_dram(output))};
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
     const auto writer_kernel_id = CreateWriteKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -148,15 +148,10 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
              units_per_core,
              input_tile_stride,
              tile_offset,
-             static_cast<uint32_t>(is_dram(input)),
              HtWt,
              inner_size});
 
-        SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            {output.buffer()->address(), units_per_core, tile_offset, static_cast<uint32_t>(is_dram(output))});
+        SetRuntimeArgs(program, writer_kernel_id, core, {output.buffer()->address(), units_per_core, tile_offset});
 
         tile_offset += units_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include "moreh_mean_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -88,6 +89,8 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> reader_compile_time_args;
     std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
     const auto reader_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp";
     const auto writer_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp";
     const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/writer_moreh_norm_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/writer_moreh_norm_h.cpp
@@ -17,24 +17,16 @@ void kernel_main() {
     const auto cb_id_output = cb_id++;
 
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
 
     auto output_tile_idx = tile_offset;
     for (uint32_t idx = 0; idx < num_cols_per_core; ++idx) {
         cb_wait_front(cb_id_output, 1);
-        if (output_is_dram) {
-            noc_async_write_tile(output_tile_idx, dram_output_addrg, output_l1_read_addr);
-        } else {
-            noc_async_write_tile(output_tile_idx, l1_output_addrg, output_l1_read_addr);
-        }
+        noc_async_write_tile(output_tile_idx, s, output_l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id_output, 1);
         output_tile_idx++;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/reader_moreh_norm_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/reader_moreh_norm_nc.cpp
@@ -19,13 +19,9 @@ void kernel_main() {
     const auto cb_id_one = cb_id++;
 
     const uint32_t input_tile_bytes = get_tile_size(cb_id_input);
-    const auto input_data_format = get_dataformat(cb_id_input);
 
-    const InterleavedAddrGenFast<true> dram_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
-
-    const InterleavedAddrGenFast<false> l1_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    constexpr auto input_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     Scalar one;
     one.f = 1.0f;
@@ -42,11 +38,7 @@ void kernel_main() {
         auto input_tile_idx = outer_idx * outer_stride + inner_idx;
         for (uint32_t d = 0; d < num_reduced_tiles_along_dim; ++d) {
             cb_reserve_back(cb_id_input, 1);
-            if (input_is_dram) {
-                noc_async_read_tile(input_tile_idx, dram_input_addrg, input_l1_write_ptr);
-            } else {
-                noc_async_read_tile(input_tile_idx, l1_input_addrg, input_l1_write_ptr);
-            }
+            noc_async_read_tile(input_tile_idx, s, input_l1_write_ptr);
             noc_async_read_barrier();
             cb_push_back(cb_id_input, 1);
             input_tile_idx += inner_stride;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/writer_moreh_norm_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/writer_moreh_norm_nc.cpp
@@ -17,24 +17,16 @@ void kernel_main() {
     const auto cb_id_output = cb_id++;
 
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
 
     auto output_tile_idx = tile_offset;
     for (uint32_t idx = 0; idx < num_output_tiles_per_core; ++idx) {
         cb_wait_front(cb_id_output, 1);
-        if (output_is_dram) {
-            noc_async_write_tile(output_tile_idx, dram_output_addrg, output_l1_read_addr);
-        } else {
-            noc_async_write_tile(output_tile_idx, l1_output_addrg, output_l1_read_addr);
-        }
+        noc_async_write_tile(output_tile_idx, s, output_l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id_output, 1);
         output_tile_idx++;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_norm {
@@ -93,8 +94,12 @@ MorehNormOperation::ProgramFactoryHOther::cached_program_t MorehNormOperation::P
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/"
         "writer_moreh_norm_h.cpp";
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores);
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
+    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_norm {
@@ -96,8 +97,12 @@ MorehNormOperation::ProgramFactoryNCOther::cached_program_t MorehNormOperation::
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/"
         "writer_moreh_norm_nc.cpp";
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores);
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
+    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_norm {
@@ -96,8 +97,12 @@ MorehNormOperation::ProgramFactoryWOther::cached_program_t MorehNormOperation::P
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/"
         "writer_moreh_norm_w.cpp";
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores);
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
+    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/reader_moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/reader_moreh_norm_w.cpp
@@ -19,13 +19,9 @@ void kernel_main() {
     const auto cb_id_mask_w = cb_id++;
 
     const uint32_t input_tile_bytes = get_tile_size(cb_id_input);
-    const auto input_data_format = get_dataformat(cb_id_input);
 
-    const InterleavedAddrGenFast<true> dram_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
-
-    const InterleavedAddrGenFast<false> l1_input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    constexpr auto input_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     Scalar one;
     one.f = 1.0f;
@@ -46,11 +42,7 @@ void kernel_main() {
         for (uint32_t col_idx = 0; col_idx < Wt; ++col_idx) {
             const auto tile_idx = start_tile_idx + row_idx * Wt + col_idx;
             cb_reserve_back(cb_id_input, 1);
-            if (input_is_dram) {
-                noc_async_read_tile(tile_idx, dram_input_addrg, input_l1_write_ptr);
-            } else {
-                noc_async_read_tile(tile_idx, l1_input_addrg, input_l1_write_ptr);
-            }
+            noc_async_read_tile(tile_idx, s, input_l1_write_ptr);
             noc_async_read_barrier();
             cb_push_back(cb_id_input, 1);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/writer_moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/writer_moreh_norm_w.cpp
@@ -18,13 +18,9 @@ void kernel_main() {
     const auto cb_id_output = cb_id++;
 
     const uint32_t output_tile_bytes = get_tile_size(cb_id_output);
-    const auto output_data_format = get_dataformat(cb_id_output);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    constexpr auto output_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     const auto start_tile_idx = tile_offset / Wt;
     const auto output_l1_read_addr = get_read_ptr(cb_id_output);
@@ -32,11 +28,7 @@ void kernel_main() {
     for (uint32_t row_idx = 0; row_idx < num_rows_per_core; ++row_idx) {
         const auto tile_idx = start_tile_idx + row_idx;
         cb_wait_front(cb_id_output, 1);
-        if (output_is_dram) {
-            noc_async_write_tile(tile_idx, dram_output_addrg, output_l1_read_addr);
-        } else {
-            noc_async_write_tile(tile_idx, l1_output_addrg, output_l1_read_addr);
-        }
+        noc_async_write_tile(tile_idx, s, output_l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id_output, 1);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/writer_moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/writer_moreh_norm_backward.cpp
@@ -8,7 +8,7 @@
 
 void kernel_main() {
     // compile time args
-    constexpr bool input_grad_is_dram = (get_compile_time_arg_val(0) == 1);
+    constexpr auto input_grad_args = TensorAccessorArgs<0>();
 
     int i{0};
     const auto input_grad_addr = get_arg_val<uint32_t>(i++);
@@ -20,12 +20,7 @@ void kernel_main() {
 
     // input_grad
     const uint32_t input_grad_tile_bytes = get_tile_size(cb_id_input_grad);
-    const auto input_grad_data_format = get_dataformat(cb_id_input_grad);
-
-    const InterleavedAddrGenFast<input_grad_is_dram> input_grad_addrg = {
-        .bank_base_address = input_grad_addr,
-        .page_size = input_grad_tile_bytes,
-        .data_format = input_grad_data_format};
+    const auto input_grad_addrg = TensorAccessor(input_grad_args, input_grad_addr, input_grad_tile_bytes);
 
     auto input_grad_tile_idx = tile_offset;
     for (uint32_t idx = 0; idx < num_input_tiles_per_core; ++idx) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "moreh_norm_backward_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_norm_backward {
 
@@ -164,12 +165,12 @@ MorehNormBackwardOperation::ProgramFactory::cached_program_t MorehNormBackwardOp
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/"
         "writer_moreh_norm_backward.cpp";
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(is_dram(input)),
-        static_cast<uint32_t>(is_dram(output)),
-        static_cast<uint32_t>(is_dram(output_grad)),
-        static_cast<uint32_t>(input_grad_rank)};
-    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(is_dram(input_grad))};
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(input_grad_rank)};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
     const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
     const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp
@@ -19,12 +19,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
-    const DataFormat src_in_data_format = get_dataformat(cb_in);
 
-    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<in_is_dram> src_in = {
-        .bank_base_address = src_addr, .page_size = src_in_tile_bytes, .data_format = src_in_data_format};
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
@@ -22,12 +22,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
-    const DataFormat src_in_data_format = get_dataformat(cb_in);
 
-    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<in_is_dram> src_in = {
-        .bank_base_address = src_addr, .page_size = src_in_tile_bytes, .data_format = src_in_data_format};
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
@@ -22,12 +22,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
-    const DataFormat src_in_data_format = get_dataformat(cb_in);
 
-    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<in_is_dram> src_in = {
-        .bank_base_address = src_addr, .page_size = src_in_tile_bytes, .data_format = src_in_data_format};
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
@@ -21,12 +21,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
-    const DataFormat src_in_data_format = get_dataformat(cb_in);
 
-    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<in_is_dram> src_in = {
-        .bank_base_address = src_addr, .page_size = src_in_tile_bytes, .data_format = src_in_data_format};
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
@@ -21,12 +21,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
-    const DataFormat src_in_data_format = get_dataformat(cb_in);
 
-    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<in_is_dram> src_in = {
-        .bank_base_address = src_addr, .page_size = src_in_tile_bytes, .data_format = src_in_data_format};
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp
@@ -17,12 +17,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t dst_out_tile_bytes = get_tile_size(cb_out);
-    const DataFormat dst_out_data_format = get_dataformat(cb_out);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> dst_out = {
-        .bank_base_address = dst_addr, .page_size = dst_out_tile_bytes, .data_format = dst_out_data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto dst_out = TensorAccessor(out_args, dst_addr, dst_out_tile_bytes);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp
@@ -15,11 +15,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const DataFormat data_format = get_dataformat(cb_id_out);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp
@@ -15,11 +15,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const DataFormat data_format = get_dataformat(cb_id_out);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 
     uint32_t blk = 1;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp
@@ -14,11 +14,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const DataFormat data_format = get_dataformat(cb_id_out);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < N; i++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp
@@ -14,11 +14,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const DataFormat data_format = get_dataformat(cb_id_out);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 
     uint32_t blk = 1;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax {
@@ -62,23 +63,27 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
+    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp",
         all_cores,
-        {src_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp",
         all_cores,
-        {dst_is_dram},
+        writer_ct_args,
         writer_defines);
 
     auto outer_stride = Ht * Wt;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -63,8 +63,6 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax {
@@ -63,23 +64,27 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
+    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels//reader_moreh_softmax_h_large.cpp",
         all_cores,
-        {src_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp",
         all_cores,
-        {dst_is_dram},
+        writer_ct_args,
         writer_defines);
 
     std::map<std::string, std::string> compute_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -64,8 +64,6 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax {
@@ -64,23 +65,27 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
+    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp",
         all_cores,
-        {src_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp",
         all_cores,
-        {dst_is_dram},
+        writer_ct_args,
         writer_defines);
 
     std::map<std::string, std::string> compute_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -65,8 +65,6 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax {
@@ -64,23 +65,27 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
+    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp",
         all_cores,
-        {src_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp",
         all_cores,
-        {dst_is_dram},
+        writer_ct_args,
         writer_defines);
 
     std::map<std::string, std::string> compute_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -65,8 +65,6 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax {
@@ -64,23 +65,27 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
+    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp",
         all_cores,
-        {src_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp",
         all_cores,
-        {dst_is_dram},
+        writer_ct_args,
         writer_defines);
 
     std::map<std::string, std::string> compute_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -65,8 +65,6 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
         });
 
     // create read/wrtie kernel
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
-    bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp
@@ -23,19 +23,12 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     uint32_t y_tile_bytes = get_tile_size(cb_y);
-    const DataFormat y_data_format = get_dataformat(cb_y);
-
     uint32_t dy_tile_bytes = get_tile_size(cb_dy);
-    const DataFormat dy_data_format = get_dataformat(cb_dy);
 
-    constexpr bool y_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool dy_is_dram = get_compile_time_arg_val(1) == 1;
-
-    const InterleavedAddrGenFast<y_is_dram> y_in = {
-        .bank_base_address = y_addr, .page_size = y_tile_bytes, .data_format = y_data_format};
-
-    const InterleavedAddrGenFast<dy_is_dram> dy_in = {
-        .bank_base_address = dy_addr, .page_size = dy_tile_bytes, .data_format = dy_data_format};
+    constexpr auto y_args = TensorAccessorArgs<0>();
+    constexpr auto dy_args = TensorAccessorArgs<y_args.next_compile_time_args_offset()>();
+    const auto y_in = TensorAccessor(y_args, y_addr, y_tile_bytes);
+    const auto dy_in = TensorAccessor(dy_args, dy_addr, dy_tile_bytes);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp
@@ -26,19 +26,12 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t y_tile_bytes = get_tile_size(cb_y);
-    const DataFormat y_data_format = get_dataformat(cb_y);
-
     uint32_t dy_tile_bytes = get_tile_size(cb_dy);
-    const DataFormat dy_data_format = get_dataformat(cb_dy);
 
-    constexpr bool y_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool dy_is_dram = get_compile_time_arg_val(1) == 1;
-
-    const InterleavedAddrGenFast<y_is_dram> y_in = {
-        .bank_base_address = y_addr, .page_size = y_tile_bytes, .data_format = y_data_format};
-
-    const InterleavedAddrGenFast<dy_is_dram> dy_in = {
-        .bank_base_address = dy_addr, .page_size = dy_tile_bytes, .data_format = dy_data_format};
+    constexpr auto y_args = TensorAccessorArgs<0>();
+    constexpr auto dy_args = TensorAccessorArgs<y_args.next_compile_time_args_offset()>();
+    const auto y_in = TensorAccessor(y_args, y_addr, y_tile_bytes);
+    const auto dy_in = TensorAccessor(dy_args, dy_addr, dy_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h_large.cpp
@@ -26,19 +26,12 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t y_tile_bytes = get_tile_size(cb_y);
-    const DataFormat y_data_format = get_dataformat(cb_y);
-
     uint32_t dy_tile_bytes = get_tile_size(cb_dy);
-    const DataFormat dy_data_format = get_dataformat(cb_dy);
 
-    constexpr bool y_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool dy_is_dram = get_compile_time_arg_val(1) == 1;
-
-    const InterleavedAddrGenFast<y_is_dram> y_in = {
-        .bank_base_address = y_addr, .page_size = y_tile_bytes, .data_format = y_data_format};
-
-    const InterleavedAddrGenFast<dy_is_dram> dy_in = {
-        .bank_base_address = dy_addr, .page_size = dy_tile_bytes, .data_format = dy_data_format};
+    constexpr auto y_args = TensorAccessorArgs<0>();
+    constexpr auto dy_args = TensorAccessorArgs<y_args.next_compile_time_args_offset()>();
+    const auto y_in = TensorAccessor(y_args, y_addr, y_tile_bytes);
+    const auto dy_in = TensorAccessor(dy_args, dy_addr, dy_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp
@@ -25,19 +25,12 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t y_tile_bytes = get_tile_size(cb_y);
-    const DataFormat y_data_format = get_dataformat(cb_y);
-
     uint32_t dy_tile_bytes = get_tile_size(cb_dy);
-    const DataFormat dy_data_format = get_dataformat(cb_dy);
 
-    constexpr bool y_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool dy_is_dram = get_compile_time_arg_val(1) == 1;
-
-    const InterleavedAddrGenFast<y_is_dram> y_in = {
-        .bank_base_address = y_addr, .page_size = y_tile_bytes, .data_format = y_data_format};
-
-    const InterleavedAddrGenFast<dy_is_dram> dy_in = {
-        .bank_base_address = dy_addr, .page_size = dy_tile_bytes, .data_format = dy_data_format};
+    constexpr auto y_args = TensorAccessorArgs<0>();
+    constexpr auto dy_args = TensorAccessorArgs<y_args.next_compile_time_args_offset()>();
+    const auto y_in = TensorAccessor(y_args, y_addr, y_tile_bytes);
+    const auto dy_in = TensorAccessor(dy_args, dy_addr, dy_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w_large.cpp
@@ -25,19 +25,12 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t y_tile_bytes = get_tile_size(cb_y);
-    const DataFormat y_data_format = get_dataformat(cb_y);
-
     uint32_t dy_tile_bytes = get_tile_size(cb_dy);
-    const DataFormat dy_data_format = get_dataformat(cb_dy);
 
-    constexpr bool y_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool dy_is_dram = get_compile_time_arg_val(1) == 1;
-
-    const InterleavedAddrGenFast<y_is_dram> y_in = {
-        .bank_base_address = y_addr, .page_size = y_tile_bytes, .data_format = y_data_format};
-
-    const InterleavedAddrGenFast<dy_is_dram> dy_in = {
-        .bank_base_address = dy_addr, .page_size = dy_tile_bytes, .data_format = dy_data_format};
+    constexpr auto y_args = TensorAccessorArgs<0>();
+    constexpr auto dy_args = TensorAccessorArgs<y_args.next_compile_time_args_offset()>();
+    const auto y_in = TensorAccessor(y_args, y_addr, y_tile_bytes);
+    const auto dy_in = TensorAccessor(dy_args, dy_addr, dy_tile_bytes);
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     generate_bcast_scaler(cb_scaler, scaler);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp
@@ -17,12 +17,9 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t dst_out_tile_bytes = get_tile_size(cb_out);
-    const DataFormat dst_out_data_format = get_dataformat(cb_out);
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> dst_out = {
-        .bank_base_address = dst_addr, .page_size = dst_out_tile_bytes, .data_format = dst_out_data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto dst_out = TensorAccessor(out_args, dst_addr, dst_out_tile_bytes);
 
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp
@@ -15,11 +15,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const DataFormat data_format = get_dataformat(cb_id_out);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 
     uint32_t blk = 1;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp
@@ -14,11 +14,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const DataFormat data_format = get_dataformat(cb_id_out);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 
     uint32_t blk = 1;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -62,9 +62,6 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
@@ -61,9 +62,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
+    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
+    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -84,17 +85,22 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp",
         all_cores,
-        {y_is_dram, dy_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp",
         all_cores,
-        {dx_is_dram},
+        writer_ct_args,
         writer_defines);
 
     auto outer_stride = Ht * Wt;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
@@ -66,9 +67,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
+    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
+    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -88,18 +89,23 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
         "reader_moreh_softmax_backward_h_large.cpp",
         all_cores,
-        {y_is_dram, dy_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp",
         all_cores,
-        {dx_is_dram},
+        writer_ct_args,
         writer_defines);
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -67,9 +67,6 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -64,9 +64,6 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
@@ -63,24 +64,29 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
+    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
+    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp",
         all_cores,
-        {y_is_dram, dy_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp",
         all_cores,
-        {dx_is_dram},
+        writer_ct_args,
         writer_defines);
 
     std::map<std::string, std::string> compute_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -67,9 +67,6 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
@@ -66,9 +67,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
         });
 
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
+    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
+    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -88,18 +89,23 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
         "reader_moreh_softmax_backward_w_large.cpp",
         all_cores,
-        {y_is_dram, dy_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp",
         all_cores,
-        {dx_is_dram},
+        writer_ct_args,
         writer_defines);
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
@@ -62,24 +63,29 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
             {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
         });
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
+    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
+    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
+    std::vector<uint32_t> reader_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp",
         all_cores,
-        {y_is_dram, dy_is_dram},
+        reader_ct_args,
         reader_defines);
+    std::vector<uint32_t> writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
     auto writer_kernel_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp",
         all_cores,
-        {dx_is_dram},
+        writer_ct_args,
         writer_defines);
 
     std::map<std::string, std::string> compute_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -63,9 +63,6 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
             {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
         });
     // create read/wrtie kernel
-    bool y_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;        // unused after TA
-    bool dy_is_dram = output_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;  // unused after TA
-    bool dx_is_dram = input_grad.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;   // unused after TA
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "moreh_sum_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/util.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
@@ -80,8 +81,10 @@ MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::Mor
             {tt::CBIndex::c_16, out0_t},       // output
         });
 
-    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(is_dram(input))};
-    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(is_dram(output))};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
     const auto reader_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp";
     const auto writer_kernel_file =

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
@@ -13,21 +13,20 @@ void kernel_main() {
     uint32_t num_cols = get_arg_val<uint32_t>(3);  // number of cols to read
     uint32_t mask_h = get_arg_val<uint32_t>(4);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t Wt = get_compile_time_arg_val(2);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(2);
 
     constexpr uint32_t cb_id_in0 = 0;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
 
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_id_in2 = 2;
-    constexpr uint32_t scaler = get_compile_time_arg_val(4);
+    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
     generate_reduce_scaler(cb_id_in2, scaler);
 #endif
 
@@ -36,8 +35,7 @@ void kernel_main() {
     generate_mask_h(cb_id_mask_h, mask_h);
 #endif
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     uint32_t w = curr_col_in_batch;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp
@@ -10,15 +10,13 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp
@@ -11,7 +11,7 @@ inline uint32_t get_read_tile_id(uint32_t output_tile_id, uint32_t reduce_tile_s
 
 void kernel_main() {
     // compile-time args
-    constexpr bool input_is_dram = (get_compile_time_arg_val(0) == 1);
+    constexpr auto input_args = TensorAccessorArgs<0>();
 
     // runtime args
     ArgFetcher arg_fetcher;
@@ -34,9 +34,7 @@ void kernel_main() {
 
     uint32_t l1_write_addr_in0;
     uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
-    const auto input_data_format = get_dataformat(cb_id_in0);
-    const InterleavedAddrGenFast<input_is_dram> input_addrg = {
-        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    const auto input_addrg = TensorAccessor(input_args, input_addr, input_tile_bytes);
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
         auto read_tile_id = (dim == 0) ? (i) : (get_read_tile_id(i, reduce_tile_size, inner_tile_size));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp
@@ -6,7 +6,7 @@
 
 void kernel_main() {
     // compile-time args
-    constexpr bool output_is_dram = (get_compile_time_arg_val(0) == 1);
+    constexpr auto output_args = TensorAccessorArgs<0>();
 
     // runtime args
     ArgFetcher arg_fetcher;
@@ -18,10 +18,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     uint32_t output_tile_bytes = get_tile_size(cb_id_out);
-    const auto output_data_format = get_dataformat(cb_id_out);
-
-    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    const auto output_addrg = TensorAccessor(output_args, output_addr, output_tile_bytes);
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "moreh_sum_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -81,10 +82,12 @@ MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehS
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(is_dram(input))};
+    std::vector<uint32_t> reader_compile_time_args = {};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
     std::map<std::string, std::string> reader_defines;
     reader_defines["USE_FPU"] = "1";
-    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(is_dram(output))};
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
     const auto reader_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp";
     const auto writer_kernel_file =

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
@@ -10,8 +10,8 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
     uint32_t mask_w = get_arg_val<uint32_t>(3);
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
 
     constexpr uint32_t cb_id_in2 = 2;
     generate_mm_scaler(cb_id_in2, scaler);
@@ -26,10 +26,8 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp
@@ -10,15 +10,13 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
Refactored a bunch of Moreh kernels to use TensorAccessor

This PR was generated by AI: Cursor + GPT5-Max using this [prompt](https://gist.github.com/sminakov-tt/4a781b688d9bc679c78e431df3148feb).

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16842078586)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/16842081913)
- [x] New/Existing tests provide coverage for changes