### PR TITLE
#25975: Finish porting all element-wise kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "binary_ng_utils.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/cb_utils.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/eltwise/binary/common/binary_op_utils.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 
@@ -674,11 +675,62 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             operation_attributes.subtile_broadcast_type, reader_defines);
         writer_kernel = KernelName::WriterNoBcastNg;
     }
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        get_kernel_file_path(writer_kernel, is_sfpu_op),
-        all_device_cores,
-        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram, has_sharding}, std::move(writer_defines)));
+    tt::tt_metal::KernelHandle writer_kernel_id;
+    if (b.has_value()) {
+        std::vector<uint32_t> writer_compile_time_args;
+        if (writer_kernel == CMAKE_UNIQUE_NAMESPACE::KernelName::WriterNoBcastNg) {
+            tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
+            writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
+        } else {
+            writer_compile_time_args = {
+                static_cast<uint32_t>(b_is_dram),
+                static_cast<uint32_t>(c_is_dram),
+                static_cast<uint32_t>(has_sharding)};
+        }
+        writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            get_kernel_file_path(writer_kernel, is_sfpu_op),
+            all_device_cores,
+            tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
+    } else {
+        std::vector<uint32_t> writer_compile_time_args;
+        // Choose compile-time args based on selected writer kernel
+        switch (writer_kernel) {
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar:
+                // Only destination tensor TA
+                tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
+                break;
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalarBcast:
+                // Source (A) then destination (C)
+                tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(writer_compile_time_args);
+                tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
+                break;
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::WriterNoBcast:
+                // Source (A), destination (C), then has_sharding flag
+                tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(writer_compile_time_args);
+                tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
+                writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
+                break;
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::WriterRowBcast:
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::WriterColBcast:
+                // Source (A) then destination (C)
+                tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(writer_compile_time_args);
+                tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
+                break;
+            default:
+                // Fallback to previous behavior if an unexpected kernel is selected
+                writer_compile_time_args = {
+                    static_cast<uint32_t>(b_is_dram),
+                    static_cast<uint32_t>(c_is_dram),
+                    static_cast<uint32_t>(has_sharding)};
+                break;
+        }
+        writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            get_kernel_file_path(writer_kernel, is_sfpu_op),
+            all_device_cores,
+            tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
+    }
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
@@ -730,11 +782,38 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             .defines = std::move(compute_kernel_defines)});
 
     // READER KERNEL
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op),
-        all_device_cores,
-        tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding, b_is_dram}, std::move(reader_defines)));
+    tt::tt_metal::KernelHandle reader_kernel_id;
+    if (b.has_value()) {
+        reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op),
+            all_device_cores,
+            tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding, b_is_dram}, std::move(reader_defines)));
+    } else {
+        std::vector<uint32_t> reader_compile_time_args;
+        switch (kernel_config.reader_kernel) {
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::ReaderNoBcast:
+                reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
+                tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(reader_compile_time_args);
+                break;
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::ReaderRowBcast:
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::ReaderColBcast:
+            case CMAKE_UNIQUE_NAMESPACE::KernelName::ReaderScalarBcast:
+                tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(reader_compile_time_args);
+                break;
+            default:
+                reader_compile_time_args = {
+                    static_cast<uint32_t>(a_is_dram),
+                    static_cast<uint32_t>(has_sharding),
+                    static_cast<uint32_t>(b_is_dram)};
+                break;
+        }
+        reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op),
+            all_device_cores,
+            tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
+    }
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
     const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t onetile = 1;
 
@@ -46,9 +46,7 @@ void kernel_main() {
     constexpr auto cb_id_src = tt::CBIndex::c_0;
 #if !SRC_SHARDED
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     // this is the INPUT tile offset
     uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -30,13 +30,10 @@ void kernel_main() {
     cb_push_back(cb_id_src, src_num_tiles);
 #else
     constexpr uint32_t onetile = 1;
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<1>();
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
-
-    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -30,8 +30,8 @@ void kernel_main() {
     cb_push_back(cb_id_src, src_num_tiles);
 #else
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = get_compile_time_arg_val(0) == 1;
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr bool has_sharding = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
     const uint32_t HtWt = Ht * Wt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
@@ -25,15 +25,13 @@ void kernel_main() {
     const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     const uint32_t tiles_per_n = C * HtWt;
     const uint32_t tiles_per_d = N * tiles_per_n;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -25,15 +25,13 @@ void kernel_main() {
     const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     const uint32_t tiles_per_n = C * HtWt;
     const uint32_t tiles_per_d = N * tiles_per_n;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
@@ -43,8 +43,8 @@ void kernel_main() {
     uint32_t start_tw = offset_c % Wt;
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
-#if !SRC_SHARDED
     constexpr auto src_args = TensorAccessorArgs<0>();
+#if !SRC_SHARDED
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
@@ -56,8 +56,8 @@ void kernel_main() {
 #endif
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 #if !DST_SHARDED
-    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
@@ -44,12 +44,9 @@ void kernel_main() {
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
 #if !SRC_SHARDED
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     // this is the INPUT tile offset
     uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
@@ -60,12 +57,9 @@ void kernel_main() {
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 #if !DST_SHARDED
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 #endif
 
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
@@ -31,22 +31,16 @@ void kernel_main() {
     cb_reserve_back(cb_id_src, src_num_tiles);
     cb_push_back(cb_id_src, src_num_tiles);
 #else
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 #endif
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 #if !DST_SHARDED
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 #endif
 
 #if !SRC_SHARDED || !DST_SHARDED

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
@@ -27,24 +27,25 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
 #if SRC_SHARDED
     cb_reserve_back(cb_id_src, src_num_tiles);
     cb_push_back(cb_id_src, src_num_tiles);
 #else
-    constexpr auto src_args = TensorAccessorArgs<0>();
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 #endif
 
-    constexpr auto cb_id_dst = tt::CBIndex::c_2;
 #if !DST_SHARDED
-    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 #endif
 
 #if !SRC_SHARDED || !DST_SHARDED
-    constexpr bool has_sharding = get_compile_time_arg_val(2) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
@@ -28,20 +28,14 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     const uint32_t tiles_per_n = C * HtWt;
     const uint32_t tiles_per_d = N * tiles_per_n;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -26,12 +26,9 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
 #if !DST_SHARDED
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<0>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 #endif
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
@@ -29,20 +29,14 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     const uint32_t tiles_per_n = C * HtWt;
     const uint32_t tiles_per_d = N * tiles_per_n;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -32,19 +32,15 @@ void kernel_main() {
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 #if !SRC_SHARDED
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 #endif
 #if !SRC_SHARDED_B
-    constexpr bool src_is_dram_b = get_compile_time_arg_val(2) == 1;
     const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
-    const DataFormat src_data_format_b = get_dataformat(cb_id_src_b);
-    const InterleavedAddrGenFast<src_is_dram_b> src_b = {
-        .bank_base_address = src_addr_b, .page_size = src_tile_bytes_b, .data_format = src_data_format_b};
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
     constexpr uint32_t onetile = 1;
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
     const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -32,25 +32,21 @@ void kernel_main() {
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 #if SRC_SHARDED
     cb_reserve_back(cb_id_src, src_num_tiles);
     cb_push_back(cb_id_src, src_num_tiles);
 #else
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 #endif
 #if SRC_SHARDED_B
     cb_reserve_back(cb_id_src_b, src_num_tiles_b);
     cb_push_back(cb_id_src_b, src_num_tiles_b);
 #else
-    constexpr bool src_is_dram_b = get_compile_time_arg_val(2) == 1;
     const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
-    const DataFormat src_data_format_b = get_dataformat(cb_id_src_b);
-    const InterleavedAddrGenFast<src_is_dram_b> src_b = {
-        .bank_base_address = src_addr_b, .page_size = src_tile_bytes_b, .data_format = src_data_format_b};
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -32,19 +32,15 @@ void kernel_main() {
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 #if !SRC_SHARDED
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 #endif
 #if !SRC_SHARDED_B
-    constexpr bool src_is_dram_b = get_compile_time_arg_val(2) == 1;
     const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
-    const DataFormat src_data_format_b = get_dataformat(cb_id_src_b);
-    const InterleavedAddrGenFast<src_is_dram_b> src_b = {
-        .bank_base_address = src_addr_b, .page_size = src_tile_bytes_b, .data_format = src_data_format_b};
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
     constexpr uint32_t onetile = 1;
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
     const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -32,19 +32,15 @@ void kernel_main() {
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 #if !SRC_SHARDED
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 #endif
 #if !SRC_SHARDED_B
-    constexpr bool src_is_dram_b = get_compile_time_arg_val(2) == 1;
     const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
-    const DataFormat src_data_format_b = get_dataformat(cb_id_src_b);
-    const InterleavedAddrGenFast<src_is_dram_b> src_b = {
-        .bank_base_address = src_addr_b, .page_size = src_tile_bytes_b, .data_format = src_data_format_b};
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
     constexpr uint32_t onetile = 1;
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
     const auto src_b = TensorAccessor(src_b_args, src_addr_b, src_tile_bytes_b);
 #endif
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
@@ -28,16 +28,13 @@ void kernel_main() {
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 #if !DST_SHARDED
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<0>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 #endif
 
 #if !DST_SHARDED
-    constexpr bool has_sharding = get_compile_time_arg_val(2) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
Refactored all of the eltwise kernels to use TensorAccessor

This PR was generated by AI: Cursor + GPT5-Max using this [prompt](https://gist.github.com/sminakov-tt/4a781b688d9bc679c78e431df3148feb).

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16843397809)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/16843400185)
- [x] New/Existing tests provide coverage for changes