### PR TITLE
ghci#984: [DO NOT MERGE, TRYING TO TEST] Try running on runners that solely use IOMMU, no hugepages available at all through our custom systemd service

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   metalium-basic:
-    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner) }}
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-next', inputs.runner) }}
     container:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-next', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -164,7 +164,7 @@ jobs:
     name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
     timeout-minutes: 100
-    runs-on: tt-beta-ubuntu-2204-large
+    runs-on: tt-ubuntu-2204-xlarge-next
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:
       packages-artifact-name: ${{ steps.set-artifact-name.outputs.name }}
@@ -327,7 +327,7 @@ jobs:
     name: 🐍 Build wheel (Python ${{ inputs.version == '22.04' && '3.10' || '3.12' }})
     needs: build-docker-image
     timeout-minutes: 30
-    runs-on: tt-beta-ubuntu-2204-large
+    runs-on: tt-ubuntu-2204-xlarge-next
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -164,7 +164,7 @@ jobs:
     needs: check-docker-images
     if: needs.check-docker-images.outputs.dev-exists != 'true' || needs.check-docker-images.outputs.basic-dev-exists != 'true' || needs.check-docker-images.outputs.manylinux-exists != 'true'
     timeout-minutes: 90
-    runs-on: tt-beta-ubuntu-2204-large
+    runs-on: tt-ubuntu-2204-xlarge-next
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: >-
       ${{
         (startsWith(inputs.runner-label, 'tt-beta-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)))
-        || (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        || (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     steps:

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -36,8 +36,8 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-ubuntu-2204-{0}-next', inputs.runner-label))
+        || github.event.pull_request.head.repo.fork == true && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -44,7 +44,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-next', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -32,20 +32,6 @@ on:
     branches:
       - main # Builds on main will populate the shared ccache to speed up builds on branches
 
-concurrency:
-  # Groups to control cancelling of obsolete runs.
-  # main (or any protected branch): run_id (ie: never cancel other jobs)
-  # PRs: PR #
-  # Merge Queue: branch name; will be paired with the 'destroyed' trigger to cause a cancel when it leaves or moves in the queue.
-  #              See https://github.com/orgs/community/discussions/137976#discussioncomment-14004793
-  # All others: branch name (ie: one run per branch)
-  group: >-
-    ${{ github.workflow }}-
-    ${{ (github.ref_protected && github.run_id)
-        || github.event.pull_request.number
-        || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -40,7 +40,7 @@ jobs:
         (github.event.pull_request.head.repo.fork == true
           || inputs.runner-label == 'N150'
           || inputs.runner-label == 'N300')
-        && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-next', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -24,7 +24,7 @@ jobs:
   smoke:
     runs-on: >-
       ${{
-        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b' || contains(inputs.runner, 'viommu')) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner))
+        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b' || contains(inputs.runner, 'viommu')) && format('tt-ubuntu-2204-{0}-next', inputs.runner))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner))
       }}
     container:

--- a/.github/workflows/tt-cnn-post-commit.yaml
+++ b/.github/workflows/tt-cnn-post-commit.yaml
@@ -70,7 +70,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -33,7 +33,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        github.event.pull_request.head.repo.fork == true && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -101,7 +101,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/ttnn-tutorials-post-commit.yaml
+++ b/.github/workflows/ttnn-tutorials-post-commit.yaml
@@ -59,7 +59,7 @@ jobs:
     name: TTNN tutorials ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-next', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
+# REVERT MEEEEEE
+# Just to force a build and run
+
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")


### PR DESCRIPTION
### Ticket

tenstorrent/github-ci-infra#984 , implemented in https://github.com/tenstorrent/github-ci-infra/pull/999

### Problem description

Before, even though we weren't mounting the hugetlbfs, we had some hugepages allocated because the systemd service for `tenstorrent-hugepages.service` was turned on.

This caused some parts of the SW to still think it had to use HPs.

### What's changed

Some SW fixes for that logic since when in, and now we want to test runners that solely use iommu, no HPs at all.

### Checklist
- [ ] merge gate spam https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml?query=branch%3Arkim%2Fghci-984-no-hp-systemd
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16853239667
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16853241227
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes