### PR TITLE
#25196: [skip ci] Single-card demo tests workflow: add options to select certain models via JSON array + make perf tests optional on workflow_dispatch.

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -123,6 +123,7 @@ jobs:
           echo "[info] run-perf-tests: $run_perf_tests"
 
           if [[ "$requested_models" != "all" ]]; then
+            jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests"
             requested_demo_tests=$(jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests")
             echo "[info] after filtering for requested models: ${requested_demo_tests"
           fi

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -119,6 +119,9 @@ jobs:
 
           echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 
+          echo "[info] Showing GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
   single-card-demo-tests:
     needs: define-demo-tests
     strategy:

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -117,7 +117,7 @@ jobs:
           echo $default_demo_tests | jq
           requested_demo_tests=$default_demo_tests
 
-          echo "demo-tests=$(echo $requested_demo_tests | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 
   single-card-demo-tests:
     needs: define-demo-tests

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -111,7 +111,7 @@ jobs:
           set -euo pipefail
 
           echo "[info] Outputing default values"
-          default_demo_tests=${{ toJSON(matrix.default-demo-tests) }}
+          default_demo_tests='${{ toJSON(matrix.default-demo-tests) }}'
           echo $default_demo_tests
           echo "[info] Outputing default values via jq"
           echo $default_demo_tests | jq

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -176,8 +176,6 @@ jobs:
         timeout-minutes: 10
         with:
           name: ${{ inputs.build-artifact-name }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 16847523376
       - name: Extract files
         run: tar -xvf ttm_any.tar
       - name: ⬇️ Download Wheel
@@ -185,8 +183,6 @@ jobs:
         timeout-minutes: 10
         with:
           name: ${{ inputs.wheel-artifact-name }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 16847523376
       - name: Check for invalid performance + civ2-compatible combination
         if: ${{ matrix.test-group.performance && matrix.test-group.civ2-compatible }}
         run: |

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -125,11 +125,11 @@ jobs:
           if [[ "$requested_models" != "all" ]]; then
             jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests"
             requested_demo_tests=$(jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests")
-            echo "[info] after filtering for requested models: ${requested_demo_tests"
+            echo "[info] after filtering for requested models: $requested_demo_tests"
           fi
 
           # Check that we have a valid test list that's not empty
-          # echo "$requested_demo_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
+          echo "$requested_demo_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
 
           echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -117,7 +117,7 @@ jobs:
           echo $default_demo_tests | jq
           requested_demo_tests=$default_demo_tests
 
-          echo "demo-tests=$requested_demo_tests" >> "$GITHUB_OUTPUT"
+          echo "demo-tests=$(echo $requested_demo_tests | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
   single-card-demo-tests:
     needs: define-demo-tests

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -152,6 +152,8 @@ jobs:
         timeout-minutes: 10
         with:
           name: ${{ inputs.build-artifact-name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: 16847523376
       - name: Extract files
         run: tar -xvf ttm_any.tar
       - name: ⬇️ Download Wheel
@@ -159,6 +161,8 @@ jobs:
         timeout-minutes: 10
         with:
           name: ${{ inputs.wheel-artifact-name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: 16847523376
       - name: Check for invalid performance + civ2-compatible combination
         if: ${{ matrix.test-group.performance && matrix.test-group.civ2-compatible }}
         run: |

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -30,7 +30,7 @@ jobs:
   define-demo-tests:
     runs-on: ubuntu-latest
     outputs:
-      demo-tests: ${{ steps.compute-tests.demo-tests }}
+      demo-tests: ${{ steps.compute-tests.outputs.demo-tests }}
     strategy:
       matrix:
         default-demo-tests: [

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -129,7 +129,7 @@ jobs:
           fi
 
           # Check that we have a valid test list that's not empty
-          echo "$requested_demo_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
+          # echo "$requested_demo_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
 
           echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -111,7 +111,7 @@ jobs:
           set -euo pipefail
 
           echo "[info] Outputing default values"
-          default_demo_tests=${{ matrix.default-demo-tests }}
+          default_demo_tests=${{ toJSON(matrix.default-demo-tests) }}
           echo $default_demo_tests
           echo "[info] Outputing default values via jq"
           echo $default_demo_tests | jq

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -19,13 +19,24 @@ on:
         required: false
         type: string
         default: "in-service"
+      requested-models:
+        required: true
+        default: "all"
+        type: string
+      run-perf-tests:
+        required: true
+        type: boolean
+        default: true
 
 jobs:
-  single-card-demo-tests:
+  define-demo-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      demo-tests: ${{ steps.compute-tests.demo-tests }}
     strategy:
-      fail-fast: false
       matrix:
-        test-group: [
+        default-demo-tests: [
+          [
                     { name: "falcon7b", runner-label: "N150", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
                     { name: "llama3", runner-label: "N150", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
                     { name: "vgg", runner-label: "N150", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
@@ -93,6 +104,26 @@ jobs:
                     # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
                     { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_func, owner_id: U07RY6B5FLJ},  #Gongyu Wang
         ]
+      ]
+    steps:
+      - name: Compute tests
+        shell: bash
+        id: compute-tests
+        run: |
+          set -euo pipefail
+
+          echo "[info] Outputing default values"
+          default_demo_tests=${{ matrix.default-demo-tests }}
+          echo $default_demo_tests
+          echo "[info] Outputing default values via jq"
+          echo $default_demo_tests | jq
+
+  single-card-demo-tests:
+    needs: define-demo-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJSON(needs.compute-tests.outputs.demo-tests) }}
     name: ${{ matrix.test-group.name }}-${{ matrix.test-group.runner-label }}-${{ (matrix.test-group.performance && 'perf') || 'func' }}
     env:
       LOGURU_LEVEL: INFO

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJSON(needs.compute-tests.outputs.demo-tests) }}
+        test-group: ${{ fromJSON(needs.define-demo-tests.outputs.demo-tests) }}
     name: ${{ matrix.test-group.name }}-${{ matrix.test-group.runner-label }}-${{ (matrix.test-group.performance && 'perf') || 'func' }}
     env:
       LOGURU_LEVEL: INFO

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -20,11 +20,9 @@ on:
         type: string
         default: "in-service"
       requested-models:
-        required: true
         default: "all"
         type: string
       run-perf-tests:
-        required: true
         type: boolean
         default: true
 

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -123,9 +123,15 @@ jobs:
           echo "[info] run-perf-tests: $run_perf_tests"
 
           if [[ "$requested_models" != "all" ]]; then
-            jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests"
             requested_demo_tests=$(jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests")
             echo "[info] after filtering for requested models: $requested_demo_tests"
+          fi
+
+          # By default, test list includes perf tests. If we don't want to run perf tests,
+          # filter them out
+          if [[ "$run_perf_tests" == "false" ]]; then
+            requested_demo_tests=$(jq '[.[] | select(.performance == false)]' <<< "$requested_demo_tests")
+            echo "[info] after filtering filtering out perf tests: $requested_demo_tests"
           fi
 
           # Check that we have a valid test list that's not empty

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -117,8 +117,18 @@ jobs:
           echo $default_demo_tests | jq
           requested_demo_tests=$default_demo_tests
 
-          echo "[info] requested-models: ${{ toJSON(inputs.requested-models) }}"
-          echo "[info] run-perf-tests: ${{ inputs.run-perf-tests }}"
+          requested_models=${{ toJSON(inputs.requested-models) }}
+          echo "[info] requested-models: $requested_models"
+          run_perf_tests=${{ inputs.run-perf-tests }}
+          echo "[info] run-perf-tests: $run_perf_tests"
+
+          if [[ "$requested_models" != "all" ]]; then
+            requested_demo_tests=$(jq --argjson requested_models "$requested_models" '[.[] | select(.name | IN($requested_models[]))]' <<< "$requested_demo_tests")
+            echo "[info] after filtering for requested models: ${requested_demo_tests"
+          fi
+
+          # Check that we have a valid test list that's not empty
+          echo "$requested_demo_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
 
           echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -117,7 +117,7 @@ jobs:
           echo $default_demo_tests | jq
           requested_demo_tests=$default_demo_tests
 
-          echo "[info] requested-models: ${{ inputs.requested-models }}"
+          echo "[info] requested-models: ${{ toJSON(inputs.requested-models) }}"
           echo "[info] run-perf-tests: ${{ inputs.run-perf-tests }}"
 
           echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -115,6 +115,9 @@ jobs:
           echo $default_demo_tests
           echo "[info] Outputing default values via jq"
           echo $default_demo_tests | jq
+          requested_demo_tests=$default_demo_tests
+
+          echo "demo-tests=$requested_demo_tests" >> "$GITHUB_OUTPUT"
 
   single-card-demo-tests:
     needs: define-demo-tests

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -117,6 +117,9 @@ jobs:
           echo $default_demo_tests | jq
           requested_demo_tests=$default_demo_tests
 
+          echo "[info] requested-models: ${{ inputs.requested-models }}"
+          echo "[info] run-perf-tests: ${{ inputs.run-perf-tests }}"
+
           echo "demo-tests=$(echo $requested_demo_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 
           echo "[info] Showing GITHUB_OUTPUT"

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -2,6 +2,15 @@ name: "(Single-card) Demo tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      requested-models:
+        description: "List of requested models as JSON array. Default is 'all'"
+        default: "all"
+        type: string
+      run-perf-tests:
+        description: "Run perf variants"
+        type: boolean
+        default: true
   schedule:
     - cron: "0 */6 * * 1,2,3,4,5"
     - cron: "0 */4 * * 0,6"
@@ -15,3 +24,5 @@ jobs:
       build-artifact-name: TTMetal_build_any_22.04_amd64_x86_64-linux-clang-17-libstdcpp
       wheel-artifact-name: eager-dist-cp310-ubuntu-22.04-any
       arch: wormhole_b0
+      requested-models: ${{ inputs.requested-models || 'all' }}
+      run-perf-tests: ${{ inputs.run-perf-tests || true }}

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -16,13 +16,22 @@ on:
     - cron: "0 */4 * * 0,6"
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-wheel: true
+      version: 22.04
   single-card-demo-tests:
+    needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml
     with:
-      docker-image: "ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:3a6f3289447c0320d0d176a087255518186f1fc5"
-      build-artifact-name: TTMetal_build_any_22.04_amd64_x86_64-linux-clang-17-libstdcpp
-      wheel-artifact-name: eager-dist-cp310-ubuntu-22.04-any
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       arch: wormhole_b0
       requested-models: ${{ inputs.requested-models || 'all' }}
       # Using || true after is dangerous since that will always be passed in if first value is falsy

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -2,7 +2,6 @@ name: "(Single-card) Demo tests"
 
 on:
   workflow_dispatch:
-  workflow_call:
   schedule:
     - cron: "0 */6 * * 1,2,3,4,5"
     - cron: "0 */4 * * 0,6"

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -25,4 +25,7 @@ jobs:
       wheel-artifact-name: eager-dist-cp310-ubuntu-22.04-any
       arch: wormhole_b0
       requested-models: ${{ inputs.requested-models || 'all' }}
-      run-perf-tests: ${{ inputs.run-perf-tests || true }}
+      # Using || true after is dangerous since that will always be passed in if first value is falsy
+      # which it can be if inputs.run-perf-tests isn't clicked. So, scope the default true to only
+      # when we're not using workflow_dispatch and can't possibly have an input anyway
+      run-perf-tests: ${{ inputs.run-perf-tests || (github.event_name != 'workflow_dispatch' && true) }}

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -7,20 +7,11 @@ on:
     - cron: "0 */4 * * 0,6"
 
 jobs:
-  build-artifact:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-wheel: true
-      version: 22.04
   single-card-demo-tests:
-    needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      docker-image: "ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:3a6f3289447c0320d0d176a087255518186f1fc5"
+      build-artifact-name: TTMetal_build_any_22.04_amd64_x86_64-linux-clang-17-libstdcpp
+      wheel-artifact-name: eager-dist-cp310-ubuntu-22.04-any
       arch: wormhole_b0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 timeout = 300
 minversion = 7.2
-addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml
+addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml --collect-only
 empty_parameter_set_mark = skip
 markers =
     post_commit: mark tests to run on post-commit

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 timeout = 300
 minversion = 7.2
-addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml --collect-only
+addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml
 empty_parameter_set_mark = skip
 markers =
     post_commit: mark tests to run on post-commit


### PR DESCRIPTION
### Ticket

#25196 

### Problem description

Everyone loves their demo tests
But not everyone needs to run everything

### What's changed

Use juicy `strategy: matrix: ...: ${{ fromJSON(...) }}` tricks to be able to filter out a test config.

### Checklist
- [ ] all, but no perf: https://github.com/tenstorrent/tt-metal/actions/runs/16853021170
- [ ] falcon7b + yolov7 + perf: https://github.com/tenstorrent/tt-metal/actions/runs/16853025658
- [ ] falcon7b + yolov7, but no perf: https://github.com/tenstorrent/tt-metal/actions/runs/16853032677

<img width="419" height="344" alt="image" src="https://github.com/user-attachments/assets/d44f3a9e-6f1b-4f0f-9aa8-fea1c97cd20a" />

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes