### PR TITLE
Fix deterministic hang on FlashMLA and SDPA unit tests

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -25,6 +25,10 @@
 /******************************************************************************
  *                   Generic Compute Functions                                 *
  ******************************************************************************/
+
+/**
+ * out_cb = eltwise_max(in0, in1)
+ */
 template <int vector_mode = (int)VectorMode::RC>
 void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) {
     // inputs come in full, outputs go out full
@@ -47,6 +51,9 @@ void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) 
     cb_push_back(out_cb, num_tiles);
 }
 
+/**
+ * out_cb = reduce[MAX,SUM](in0_cb * scale_cb)
+ */
 template <
     PoolType pool_type,
     ReduceDim reduce_dim,
@@ -91,6 +98,9 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
     reduce_uninit();
 }
 
+/**
+ * in_cb = 1 / in_cb
+ */
 template <int vector_mode = (int)VectorMode::RC>
 void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     // Precondition: in_cb has num_tiles produced
@@ -110,6 +120,9 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     cb_push_back(in_cb, num_tiles);
 }
 
+/**
+ * in0_cb = exp((in0_cb - in1_cb) * scale_fp32)
+ */
 template <uint32_t in0_cb, uint32_t rows, uint32_t scale_fp32, int vector_mode = (int)VectorMode::RC, uint32_t scale_cb>
 void sub_exp_block_bcast_cols_inplace_reduce(uint32_t in1_cb, uint32_t reduce_cb, uint32_t cols) {
     // Precondition: in0_cb has rows*cols produced
@@ -153,6 +166,9 @@ void sub_exp_block_bcast_cols_inplace_reduce(uint32_t in1_cb, uint32_t reduce_cb
     }
 }
 
+/**
+ * in0_cb *= in1_cb
+ */
 void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t rows, uint32_t cols) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
@@ -177,6 +193,9 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t row
     cb_pop_front(in1_cb, rows);
 }
 
+/**
+ * out_cb = in0_cb * in1_cb
+ */
 void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t rows, uint32_t cols) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
@@ -202,6 +221,9 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uin
     cb_pop_front(in1_cb, rows);
 }
 
+/**
+ * in0_cb += in1_cb
+ */
 template <bool pop_in1>
 void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
@@ -225,6 +247,9 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     }
 }
 
+/**
+ * out_cb = in0_cb + in1_cb
+ */
 void add_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: in0_cb has num_tiles produced
@@ -246,6 +271,9 @@ void add_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_t
     cb_pop_front(in1_cb, num_tiles);
 }
 
+/**
+ * in0_cb *= in1_cb
+ */
 void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: in0_cb has num_tiles produced
@@ -266,6 +294,9 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     }
 }
 
+/**
+ * out_cb = exp((in0_cb - in1_cb) * scale_fp32)
+ */
 template <uint32_t scale_fp32, int vector_mode = (int)VectorMode::RC>
 void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
@@ -291,6 +322,9 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     }
 }
 
+/**
+ * in_cb -> out_cb
+ */
 template <bool pop_in_cb>
 void move_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
     // Precondition: in_cb has num_tiles produced
@@ -316,6 +350,9 @@ void move_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
     }
 }
 
+/**
+ * out_cb = in0_cb @ in1_cb
+ */
 ALWI void cb_matmul_blocks(
     const uint32_t& in0_cb,
     const uint32_t& in1_cb,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -28,12 +28,16 @@ constexpr uint32_t MAX_PACK_UNTILIZE_WIDTH = 8;
 namespace NAMESPACE {
 
 void MAIN {
+    // Compile time arguments
+
+    // Input dimensions in tiles
     constexpr uint32_t St = get_compile_time_arg_val(0);
     constexpr uint32_t DHt = get_compile_time_arg_val(1);
     constexpr uint32_t vDHt = get_compile_time_arg_val(2);
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(3);
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
 
+    // Matmul configs
     constexpr uint32_t qk_in0_block_w = get_compile_time_arg_val(5);
     constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(6);
     constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(7);
@@ -48,6 +52,8 @@ void MAIN {
     constexpr uint32_t out_num_blocks = get_compile_time_arg_val(16);
     constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(19);
     constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(20);
+
+    // Attention-specific parameters
     constexpr bool is_causal = get_compile_time_arg_val(21) == 1;
     constexpr bool use_attention_mask = get_compile_time_arg_val(22) == 1;
     constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(23);
@@ -61,7 +67,8 @@ void MAIN {
     constexpr bool untilize_output = tilize_q;
     constexpr bool use_pack_untilize = out_chunk_tiles <= MAX_PACK_UNTILIZE_WIDTH;
 
-    constexpr uint32_t cb_q_in = tt::CBIndex::c_0;  // reuse it also for reduce input o
+    // CB index definitions
+    constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
@@ -89,6 +96,7 @@ void MAIN {
     constexpr uint32_t cb_out_l = tt::CBIndex::c_18;
     constexpr uint32_t cb_out_final = tt::CBIndex::c_20;
 
+    // Runtime arguments
     uint32_t arg_idx = 0;
     const bool do_reduce = get_arg_val<uint32_t>(arg_idx++) == 1;
     const bool apply_mask_at_last_chunk = do_reduce && is_causal;
@@ -99,7 +107,7 @@ void MAIN {
     const uint32_t core_num_in_output = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t cur_pos_arg = get_arg_val<uint32_t>(arg_idx++);
 
-    // idle core
+    // Idle core
     // get_arg_val<uint32_t>(0) can go from 0-63 for the core_num; for active cores 65 is out of range so 65 indicates
     // an idle_core
     if (get_arg_val<uint32_t>(0) == 65) {
@@ -123,28 +131,30 @@ void MAIN {
             cur_pos = index_addr_ptr[cb_get_tile_offset + (cur_batch / q_heads_parallel_factor)];
             cb_release_tile(cb_index_id);
         }
-
         if (cur_pos == UINT32_MAX) {
             // cur_pos of -1 indicates that the user should be skipped
             return;
         }
     }
 
+    // Get dynamic chunk size for K in tiles
     auto Sk_chunk_t_dynamic = get_dynamic_Sk_chunk_t<Sk_chunk_t, max_dynamic_chunk_size>(cur_pos);
     auto k_chunk_size_dynamic = Sk_chunk_t_dynamic * tt::constants::TILE_HEIGHT;
 
-    // Sequence length assignment
+    // Get the sequence length assignment
     auto [PSt, k_num_chunks, k_chunk_start, k_chunk_end] =
         get_runtime_args(cur_pos, cur_batch, core_num_in_reduce, num_cores_per_head, k_chunk_size_dynamic);
     if (k_chunk_start == k_chunk_end) {
         return;  // early exit because no computes needs to be done
     }
 
+    // Get number of worker cores to wait for
     uint32_t num_cores_to_wait = num_cores_per_head - 1;
     if (num_cores_per_head > k_num_chunks) {
         num_cores_to_wait = k_num_chunks - 1;
     }
 
+    // We tilize input Q if it is in ROW MAJOR layout
     if constexpr (tilize_q) {
         compute_kernel_hw_startup(cb_q_rm, cb_q_in);
         tilize_init(cb_q_rm, q_chunk_tiles, cb_q_in);
@@ -154,13 +164,13 @@ void MAIN {
         tilize_uninit(cb_q_rm, cb_q_in);
         cb_push_back(cb_q_in, q_chunk_tiles);
         cb_pop_front(cb_q_rm, q_chunk_tiles);
-
         mm_init_short(cb_q_in, cb_k_in);
     } else {
         mm_init(cb_q_in, cb_k_in, cb_qk_im);
     }
     cb_wait_front(cb_q_in, q_chunk_tiles);
 
+    // Define dynamic matmul configs
 #ifdef DYNAMIC_CHUNK_SIZE
     const uint32_t qk_subblock_h_dynamic = 1;
     const uint32_t qk_subblock_w_dynamic = Sk_chunk_t_dynamic;  // Guaranteed < DST
@@ -187,11 +197,13 @@ void MAIN {
     // NOTE: Using VectorMode::RC for 16x32 tiles will be correct accuracy, just slower due to unnecessary math
     constexpr int vector_mode = use_half_tile ? VectorMode::R : VectorMode::RC;
 
-    // Ping pong intermediate buffers between loops to avoid copies
+    // We set up Ping Pong intermediate buffers between loops
     uint32_t cb_cur_max = cb_max_1;
     uint32_t cb_prev_max = cb_max_2;
     uint32_t cb_cur_sum = cb_sum_1;
     uint32_t cb_prev_sum = cb_sum_2;
+
+    // Loop through all heads assigned to core
     for (uint32_t cur_head_work = 0; cur_head_work < num_heads_per_core; ++cur_head_work) {
 
         /******************************************************************************
@@ -244,13 +256,17 @@ void MAIN {
          * @param qk_chunk_tiles - Number of QK chunk tiles (dynamic)
          * @param out_chunk_tiles - Number of output chunk tiles
          */
+        /* START OF FLASH ATTENTION LOOP */
         {
             uint32_t cb_out_mm = cb_out_accumulate_im;
+
+            // Loop through all K chunks
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
-                /* QK = Q_CHUNK @ K_CHUNK */
-                reconfig_data_format(cb_q_in, cb_k_in);  // DEBUG
+                // Reconfig register DF
+                reconfig_data_format(cb_q_in, cb_k_in);
                 pack_reconfig_data_format(cb_qk_im);
 
+                // OPTIMIZATION: Add the attention mask directly on top of DST if chunk sizes are dynamic
 #ifdef DYNAMIC_CHUNK_SIZE
                 bool add_mask_fusion =
                     is_causal && k_chunk == k_chunk_end - 1 && apply_mask_at_last_chunk || use_attention_mask;
@@ -258,6 +274,7 @@ void MAIN {
                 bool add_mask_fusion = false;
 #endif
 
+                /* QK = Q_CHUNK @ K_CHUNK */
                 cb_matmul_blocks(
                     cb_q_in,
                     cb_k_in,
@@ -276,11 +293,11 @@ void MAIN {
                     cb_mask_in,
                     cb_zero_in);
 
+                /* QK += MASK */
                 if (!add_mask_fusion) {
                     if constexpr (is_causal) {
                         // For decode, we only apply mask at the last chunk for causal mode
                         if (k_chunk == k_chunk_end - 1 && apply_mask_at_last_chunk) {
-                            /* QK += MASK */
                             reconfig_data_format(cb_qk_im, cb_mask_in);
                             add_block_inplace<false>(cb_qk_im, cb_mask_in, qk_chunk_tiles_dynamic);
                         }
@@ -293,7 +310,7 @@ void MAIN {
                 }
 
                 /**
-                 * Note
+                 * OPTIMIZATION
                  * Typically, scores are multiplied by a scalar here, but an optimization was employed
                  * where the scaling is fused into exp both in exp(x - max) and exp(prev_max - cur_max).
                  * This gives us scaling for free on the performance-critical exp(x - max) computation.
@@ -301,7 +318,9 @@ void MAIN {
 
                 reconfig_data_format(cb_qk_im, cb_identity_scale_in);
                 pack_reconfig_data_format(cb_cur_max);
+
                 /**
+                 * OPTIMIZATION
                  * reduce_c can perform both reduce_max and eltwise max with previous result.
                  * if do_eltwise_max:
                  *  cur_max = eltwise_max(prev_max, max(qk, dim=-1))
@@ -315,6 +334,7 @@ void MAIN {
                 /* QK = exp(QK)*/
                 reconfig_data_format(cb_qk_im, cb_cur_max);
                 pack_reconfig_data_format(cb_qk_im);
+
                 /**
                  * sub_exp performs `QK = exp((QK - cur_max) * scale)`
                  */
@@ -326,8 +346,11 @@ void MAIN {
                     cb_identity_scale_in>(cb_cur_max, cb_cur_sum, Sk_chunk_t_dynamic);
                 cb_wait_front(cb_qk_im, qk_chunk_tiles_dynamic);
 
+                // Reconfig register DF
                 reconfig_data_format(cb_qk_im, cb_identity_scale_in);
                 pack_reconfig_data_format(cb_cur_sum);
+
+                /* reduce_c performs CUR_SUM = sum(QK, dim = -1) */
                 reduce_c<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_qk_im, cb_identity_scale_in, Sq_chunk_t, vector_mode>(
                     cb_cur_sum, cb_cur_sum, Sk_chunk_t_dynamic, false);
 
@@ -352,6 +375,7 @@ void MAIN {
                     cb_mask_in,
                     cb_zero_in);
 
+                // Reconfig register DF
                 reconfig_data_format_srca(cb_out_im);
                 cb_pop_front(cb_qk_im, qk_chunk_tiles_dynamic);
 
@@ -359,37 +383,47 @@ void MAIN {
                 if (k_chunk == k_chunk_start) {
                     cb_out_mm = cb_out_im;
                 } else {
-                    reconfig_data_format(cb_prev_max, cb_cur_max);  // DEBUG
+                    // When there is more than 1 chunk, we perform Lazy Softmax
+
+                    // Reconfig register DF
+                    reconfig_data_format(cb_prev_max, cb_cur_max);
                     pack_reconfig_data_format(cb_exp_max_diff);
-                    /* cb_exp_max_diff = torch.exp(cb_prev_max - cb_cur_max) */
+
+                    /* EXP_MAX_DIFF = exp(PREV_MAX - CUR_MAX) */
                     sub_exp_block<scale_fp32, vector_mode>(cb_prev_max, cb_cur_max, cb_exp_max_diff, Sq_chunk_t);
                     cb_pop_front(cb_prev_max, Sq_chunk_t);
 
-                    /* cb_prev_sum *= cb_exp_max_diff */
+                    /* PREV_SUM *= EXP_MAX_DIFF */
                     mul_block_inplace(cb_prev_sum, cb_exp_max_diff, Sq_chunk_t);
 
-                    /* cb_out_accumulate_im *= cb_exp_max_diff */
-                    reconfig_data_format(cb_out_accumulate_im, cb_exp_max_diff);  // DEBUG
+                    /* OUT_ACC *= EXP_MAX_DIFF */
+                    reconfig_data_format(cb_out_accumulate_im, cb_exp_max_diff);
                     pack_reconfig_data_format(cb_out_accumulate_im);
                     mul_block_bcast_cols(cb_out_accumulate_im, cb_exp_max_diff, cb_out_accumulate_im, Sq_chunk_t, vDHt);
 
-                    /* cb_cur_sum += cb_prev_sum */
-                    reconfig_data_format(cb_cur_sum, cb_prev_sum);  // DEBUG
+                    /* CUR_SUM += PREV_SUM */
+                    reconfig_data_format(cb_cur_sum, cb_prev_sum);
                     pack_reconfig_data_format(cb_cur_sum);
                     add_block_inplace<true>(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
 
-                    /* cb_out_accumulate_im += cb_out_im */
-                    reconfig_data_format(cb_out_accumulate_im, cb_out_im);  // DEBUG
+                    /* OUT_ACC += OUT_IM */
+                    reconfig_data_format(cb_out_accumulate_im, cb_out_im);
                     pack_reconfig_data_format(cb_out_accumulate_im);
                     add_block_inplace<true>(cb_out_accumulate_im, cb_out_im, out_chunk_tiles);
                 }
 
                 if (k_chunk < k_chunk_end - 1 || do_reduce) {
-                    reconfig_data_format(cb_cur_max, cb_cur_max);  // DEBUG
+                    // Move intermediate sum and max values to appropriate ping pong buffers
+                    reconfig_data_format(cb_cur_max, cb_cur_max);
                     pack_reconfig_data_format(cb_prev_max);
+
+                    // PREV_MAX <- CUR_MAX
                     move_block<true>(cb_cur_max, cb_prev_max, Sq_chunk_t);
+
+                    // PREV_SUM <- CUR_SUM
                     move_block<true>(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
                 } else {
+                    // Write results OUT_ACC, CUR_MAX, CUR_SUM to designated
                     // Write o, m, l into cb_out
                     move_block<true>(cb_out_accumulate_im, cb_out_o, out_chunk_tiles);
                     move_block<true>(cb_cur_max, cb_out_m, Sq_chunk_t);
@@ -399,57 +433,71 @@ void MAIN {
         }
         /* END OF FLASH ATTENTION LOOP */
 
-        // do reduction across intermediates from other cores if this is the reduction core
+        // Perform reduction across intermediates from other cores if this is the reduction core
         if (do_reduce) {
-            // cb_out_accumulate_im should contain o_1
-            // cb_prev_max and cb_prev_sum should contain m_1 and l_1
+            // cb_out_accumulate_im should contain o_1 (output from FA of itself's core)
+            // cb_prev_max and cb_prev_sum should contain m_1 and l_1 (max and sum of logits of itself's core)
+
             if (k_chunk_end - k_chunk_start < k_num_chunks) {
-                // This indicates that there are computes done by other workers. Needs to wait for them and send to
-                // reducer's compute
+                // This indicates that there are computes done by other workers.
+                // We need to wait for them and send to reducer's compute
+                // Iterate through each worker
+
                 for (uint32_t i = 0; i < num_cores_to_wait; i++) {
+                    // OUT_ACC_2 <- WORKER_OUT
                     move_block<true>(cb_out_o, cb_out_accumulate_im_2, out_chunk_tiles);
+
+                    // PREV_SUM_2 <- WORKER_SUM
                     move_block<true>(cb_l_in, cb_prev_sum_2, Sq_chunk_t);
+
+                    // CUR_MAX = max(PREV_MAX, WORKER_MAX)
                     max_block<vector_mode>(cb_m_in, cb_prev_max, cb_cur_max, Sq_chunk_t);  // pushed, pushed, popped
 
-                    // l = torch.exp(m_2 - m) * l_2 + torch.exp(m_1 - m) * l_1
-
-                    /// l1 = torch.exp((m_2 - m) * scale) * l_2
+                    // EXP_MAX_DIFF_2 = exp((WORKER_MAX - CUR_MAX)*scale)
+                    // PREV_SUM_2 *= EXP_MAX_DIFF_2
                     sub_exp_block<scale_fp32, vector_mode>(cb_m_in, cb_cur_max, cb_exp_max_diff_2, Sq_chunk_t);
                     mul_block_inplace(cb_prev_sum_2, cb_exp_max_diff_2, Sq_chunk_t);
 
-                    /// l2 = torch.exp((m_1 - m)  * scale) * l_1
+                    /// EXP_MAX_DIFF = exp((PREV_MAX - CUR_MAX)*scale)
+                    // PREV_SUM *= EXP_MAX_DIFF
                     sub_exp_block<scale_fp32, vector_mode>(cb_prev_max, cb_cur_max, cb_exp_max_diff, Sq_chunk_t);
                     mul_block_inplace(cb_prev_sum, cb_exp_max_diff, Sq_chunk_t);
 
-                    /// l = l1 + l2
+                    /// CUR_SUM = PREV_SUM_2 + PREV_SUM
                     add_block(cb_prev_sum_2, cb_prev_sum, cb_cur_sum, Sq_chunk_t);
 
+                    // OUT_ACC_2 *= EXP_MAX_DIFF
+                    // OUT_ACC *= EXP_MAX_DIFF_2
                     mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, vDHt);
                     mul_block_bcast_cols_inplace(cb_out_accumulate_im_2, cb_exp_max_diff_2, Sq_chunk_t, vDHt);
 
+                    // OUT_ACC = OUT_ACC + OUT_ACC_2
                     add_block_inplace<true>(cb_out_accumulate_im, cb_out_accumulate_im_2, out_chunk_tiles);
 
-                    // copy tiles
+                    // PREV_MAX <- CUR_MAX
+                    // PREV_SUM <- CUR_SUM
                     cb_pop_front(cb_prev_max, Sq_chunk_t);
                     cb_pop_front(cb_m_in, Sq_chunk_t);
                     move_block<true>(cb_cur_max, cb_prev_max, Sq_chunk_t);
                     move_block<true>(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
                 }
             }
-            /* cb_cur_sum = 1.0 / cb_cur_sum */
-            cb_push_back(cb_cur_sum, Sq_chunk_t);
 
-            reconfig_data_format(cb_cur_sum, cb_cur_sum);  // DEBUG
+            /* CUR_SUM = 1.0 / CUR_SUM */
+            cb_push_back(cb_cur_sum, Sq_chunk_t);
+            reconfig_data_format(cb_cur_sum, cb_cur_sum);
             pack_reconfig_data_format(cb_cur_sum);
             recip_block_inplace<vector_mode>(cb_cur_sum, Sq_chunk_t);
 
-            /* cb_out_accumulate_im *= cb_cur_sum */
-            reconfig_data_format(cb_out_accumulate_im, cb_cur_sum);  // DEBUG
+            /* OUT_ACC *= CUR_SUM */
+            reconfig_data_format(cb_out_accumulate_im, cb_cur_sum);
             pack_reconfig_data_format(cb_out_accumulate_im);
             mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_cur_sum, Sq_chunk_t, vDHt);
             pack_reconfig_data_format(cb_out_final);
 
+            // Untilize output to ROW MAJOR if input Q was also ROW MAJOR
             if constexpr (untilize_output) {
+                // Conditionally use pack_untilize or untilize
                 if constexpr (use_pack_untilize) {
                     pack_untilize_init<out_chunk_tiles>(cb_out_accumulate_im, cb_out_final);
                 } else {
@@ -470,12 +518,15 @@ void MAIN {
                 cb_pop_front(cb_out_accumulate_im, out_chunk_tiles);
                 cb_push_back(cb_out_final, out_chunk_tiles);
             } else {
+                // Move output to buffer for the writer
                 move_block<true>(cb_out_accumulate_im, cb_out_final, out_chunk_tiles);
             }
-            // free up cb_prev_max after K chunks
+            // Free up cb_prev_max after K chunks
             cb_pop_front(cb_prev_max, Sq_chunk_t);
         }
     }
+
+    // Free up cb_q_in after Q chunks
     cb_pop_front(cb_q_in, q_chunk_tiles);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -432,7 +432,6 @@ void MAIN {
             }
         }
         /* END OF FLASH ATTENTION LOOP */
-
         // Perform reduction across intermediates from other cores if this is the reduction core
         if (do_reduce) {
             // cb_out_accumulate_im should contain o_1 (output from FA of itself's core)
@@ -492,6 +491,7 @@ void MAIN {
             /* OUT_ACC *= CUR_SUM */
             reconfig_data_format(cb_out_accumulate_im, cb_cur_sum);
             pack_reconfig_data_format(cb_out_accumulate_im);
+
             mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_cur_sum, Sq_chunk_t, vDHt);
             pack_reconfig_data_format(cb_out_final);
 
@@ -523,6 +523,7 @@ void MAIN {
             }
             // Free up cb_prev_max after K chunks
             cb_pop_front(cb_prev_max, Sq_chunk_t);
+            cb_pop_front(cb_prev_sum, Sq_chunk_t);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -330,10 +330,8 @@ void MAIN {
 
                 reconfig_data_format(cb_qk_im, cb_identity_scale_in);
                 pack_reconfig_data_format(cb_cur_sum);
-                uint32_t cb_sum_dest = k_chunk > k_chunk_start ? cb_cur_sum : cb_prev_sum;
-
                 reduce_c<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_qk_im, cb_identity_scale_in, Sq_chunk_t, vector_mode>(
-                    cb_sum_dest, cb_sum_dest, Sk_chunk_t_dynamic, false);
+                    cb_cur_sum, cb_cur_sum, Sk_chunk_t_dynamic, false);
 
                 /* OUT_IM = QK @ V_CHUNK */
                 reconfig_data_format(cb_qk_im, cb_v_in);  // DEBUG
@@ -441,6 +439,11 @@ void MAIN {
                 }
             }
             /* cb_cur_sum = 1.0 / cb_cur_sum */
+            cb_push_back(cb_cur_sum, Sq_chunk_t);
+
+            reconfig_data_format(cb_cur_sum, cb_cur_sum);  // DEBUG
+            pack_reconfig_data_format(cb_cur_sum);
+            recip_block_inplace<vector_mode>(cb_cur_sum, Sq_chunk_t);
 
             reconfig_data_format(cb_prev_sum, cb_prev_sum);  // DEBUG
             pack_reconfig_data_format(cb_prev_sum);


### PR DESCRIPTION
### Problem description
Previously #26497 was reverted because it was failing APC tests specifically `tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py::test_flash_mla_decode_stress[32-False-q_dtype0-dtype0-0-0-64-16-16-1024-8]
` and `tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py::test_sdpa_decode[32-32-8-8192-128-grid_size3-True-False-all_bfp16]
` because there was a missing pop front on prev sum in both these test cases there is more than 1 head being assigned to each core so caused a hang when prev sum was expected to be empty. This was previously never caught by all TG tests because TG llama tests do not iterate more than once per core. I verified locally all sdpa and mla unit tests are passing, decode device perf and pcc 80L text demo was also passing 10 times exactly. really sorry for not running APC prior causing reverts ...

### What's changed
- Missing pop front

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/16870394066) All passing
- [ ] [TG Pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16870392456) Passing
