### PR TITLE
Refactor ResNet50 performance tests to use TT-CNN

### DIFF
--- a/models/demos/mobilenetv2/demo/demo.py
+++ b/models/demos/mobilenetv2/demo/demo.py
@@ -19,7 +19,11 @@ from models.demos.mobilenetv2.tt.model_preprocessing import (
     get_mesh_mappers,
 )
 from models.demos.ttnn_resnet.tests.demo_utils import get_data_loader
-from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
+from models.tt_cnn.tt.pipeline import (
+    PipelineConfig,
+    create_pipeline_from_config,
+    get_memory_config_for_persistent_dram_tensor,
+)
 from models.utility_functions import profiler, run_for_wormhole_b0
 
 NUM_VALIDATION_IMAGES_IMAGENET = 49920
@@ -56,15 +60,11 @@ def run_mobilenetv2_imagenet_demo(
             batch=batch_size, input_height=224, input_width=224, pad_channels=16, mesh_mapper=inputs_mesh_mapper
         )
 
-        dram_cores = 10
-        assert host_input_tensor.shape[-2] % dram_cores == 0, "Expecting even sharding on DRAM input tensor"
-        dram_shard_spec = ttnn.ShardSpec(
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_cores - 1, 0))}),
-            [host_input_tensor.shape[-2] // dram_cores, host_input_tensor.shape[-1]],
-            ttnn.ShardOrientation.ROW_MAJOR,
+        input_dram_mem_config = get_memory_config_for_persistent_dram_tensor(
+            host_input_tensor.shape, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, device.dram_grid_size()
         )
-        input_dram_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+        logger.info(
+            f"Auto-selected persistent DRAM tensor memory config: shape={host_input_tensor.shape}, shard_shape={input_dram_mem_config.shard_spec.shape}, grid={input_dram_mem_config.shard_spec.grid}"
         )
 
         input_l1_core_grid = ttnn.CoreGrid(x=8, y=8)
@@ -79,16 +79,13 @@ def run_mobilenetv2_imagenet_demo(
             use_height_and_width_as_shard_shape=True,
         )
 
-        config = PipelineConfig(use_trace=True, num_command_queues=2, separate_io_queue=False)
+        config = PipelineConfig(use_trace=True, num_command_queues=2, all_transfers_on_separate_command_queue=False)
         pipe = create_pipeline_from_config(
             config,
             ttnn_model,
             device,
             dram_input_memory_config=input_dram_mem_config,
             l1_input_memory_config=input_l1_mem_config,
-            dram_output_memory_config=None,
-            output_shape=None,
-            output_dtype=None,
         )
 
         profiler.start(f"compile")

--- a/models/tt_cnn/tests/test_pipeline.py
+++ b/models/tt_cnn/tests/test_pipeline.py
@@ -10,11 +10,16 @@ import torch
 
 import ttnn
 from models.tt_cnn.tt.executor import (
-    MultiCQTracedModelExecutor,
-    MultiCQTracedModelWithSeparateIOExecutor,
+    ModelExecutor,
+    MultiCQTracedModelOverlappedInputExecutor,
+    MultiCQTracedModelPipelinedIOExecutor,
     TracedModelExecutor,
 )
-from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
+from models.tt_cnn.tt.pipeline import (
+    PipelineConfig,
+    create_pipeline_from_config,
+    get_memory_config_for_persistent_dram_tensor,
+)
 from tests.ttnn.utils_for_testing import assert_equal
 
 
@@ -73,37 +78,48 @@ def create_test_model(input_shape, should_deallocate_input_tensor=True):
 @dataclass
 class ExecutorTestConfig:
     name: str
+    use_trace: bool
     num_command_queues: int
-    separate_io_queue: bool = False
+    all_transfers_on_separate_command_queue: bool = False
     requires_output_config: bool = False
+    requires_dram_output_config: bool = False
     requires_minimum_inputs: int = 1
     expected_executor_type: type = None
 
 
 EXECUTOR_CONFIGS = [
     ExecutorTestConfig(
-        name="TracedModelExecutor",
+        name="ModelExecutor",
+        use_trace=False,
         num_command_queues=1,
-        separate_io_queue=False,
-        requires_output_config=False,
+        all_transfers_on_separate_command_queue=False,
+        requires_minimum_inputs=1,
+        expected_executor_type=ModelExecutor,
+    ),
+    ExecutorTestConfig(
+        name="TracedModelExecutor",
+        use_trace=True,
+        num_command_queues=1,
+        all_transfers_on_separate_command_queue=False,
         requires_minimum_inputs=1,
         expected_executor_type=TracedModelExecutor,
     ),
     ExecutorTestConfig(
-        name="MultiCQTracedModelExecutor",
+        name="MultiCQTracedModelOverlappedInputExecutor",
+        use_trace=True,
         num_command_queues=2,
-        separate_io_queue=False,
-        requires_output_config=False,
+        all_transfers_on_separate_command_queue=False,
         requires_minimum_inputs=1,
-        expected_executor_type=MultiCQTracedModelExecutor,
+        expected_executor_type=MultiCQTracedModelOverlappedInputExecutor,
     ),
     ExecutorTestConfig(
-        name="MultiCQTracedModelWithSeparateIOExecutor",
+        name="MultiCQTracedModelPipelinedIOExecutor",
+        use_trace=True,
         num_command_queues=2,
-        separate_io_queue=True,
+        all_transfers_on_separate_command_queue=True,
         requires_output_config=True,
-        requires_minimum_inputs=2,  # Separate I/O requires at least 2 inputs to enable overlapping of input transfer with model execution
-        expected_executor_type=MultiCQTracedModelWithSeparateIOExecutor,
+        requires_minimum_inputs=2,  # Pipelined I/O requires at least 2 inputs to enable overlapping of input transfer with model execution
+        expected_executor_type=MultiCQTracedModelPipelinedIOExecutor,
     ),
 ]
 
@@ -144,14 +160,19 @@ def create_memory_configs(input_shape, dram_cores, l1_cores):
 
 
 def create_pipeline_for_executor_config(
-    executor_config: ExecutorTestConfig, model, device, input_shape, dram_cores, l1_cores
+    executor_config: ExecutorTestConfig,
+    model,
+    device,
+    input_shape,
+    dram_cores,
+    l1_cores,
 ):
     dram_memory_config, l1_memory_config = create_memory_configs(input_shape, dram_cores, l1_cores)
 
     config = PipelineConfig(
-        use_trace=True,
+        use_trace=executor_config.use_trace,
         num_command_queues=executor_config.num_command_queues,
-        separate_io_queue=executor_config.separate_io_queue,
+        all_transfers_on_separate_command_queue=executor_config.all_transfers_on_separate_command_queue,
     )
 
     pipeline_args = {
@@ -160,16 +181,8 @@ def create_pipeline_for_executor_config(
         "device": device,
         "dram_input_memory_config": dram_memory_config,
         "l1_input_memory_config": l1_memory_config,
+        "dram_output_memory_config": dram_memory_config,
     }
-
-    if executor_config.requires_output_config:
-        pipeline_args.update(
-            {
-                "dram_output_memory_config": dram_memory_config,
-                "output_shape": input_shape,
-                "output_dtype": ttnn.bfloat16,
-            }
-        )
 
     return create_pipeline_from_config(**pipeline_args)
 
@@ -328,3 +341,25 @@ def test_executor_with_preallocated_outputs(
             ttnn.to_torch(output),
             reference_output,
         )
+
+
+@pytest.mark.parametrize(
+    "shard_strategy", [ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.TensorMemoryLayout.HEIGHT_SHARDED]
+)
+def test_get_memory_config_for_persistent_dram_tensor(shard_strategy):
+    dram_grid_size = ttnn.CoreCoord(2, 1)
+    shape = (1, 1, 64, 64)
+    dram_memory_config = get_memory_config_for_persistent_dram_tensor(shape, shard_strategy, dram_grid_size)
+    assert dram_memory_config.buffer_type == ttnn.BufferType.DRAM
+    assert (
+        dram_memory_config.shard_spec.shape == [64, 32]
+        if shard_strategy == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+        else [32, 64]
+    )
+
+
+def test_get_dram_sharded_memory_config_for_tensor_invalid_grid_size():
+    dram_grid_size = ttnn.CoreCoord(2, 2)
+    shape = (1, 1, 64, 64)
+    with pytest.raises(ValueError):
+        get_memory_config_for_persistent_dram_tensor(shape, ttnn.TensorMemoryLayout.WIDTH_SHARDED, dram_grid_size)

--- a/models/tt_cnn/tt/executor.py
+++ b/models/tt_cnn/tt/executor.py
@@ -10,7 +10,7 @@ import ttnn
 
 class Executor(ABC):
     @abstractmethod
-    def compile(self, sample_input):
+    def compile(self, host_input):
         pass
 
     @abstractmethod
@@ -23,6 +23,43 @@ class Executor(ABC):
 
     @abstractmethod
     def get_read_cq(self) -> int:
+        pass
+
+
+class ModelExecutor(Executor):
+    def __init__(self, model: Callable, device, l1_input_memory_config, cq_id=0):
+        self.model = model
+        self.device = device
+        self.cq_id = cq_id
+        self.l1_input_memory_config = l1_input_memory_config
+
+    def get_read_cq(self):
+        return self.cq_id
+
+    def compile(self, host_input):
+        """
+        Compiles the model by running it once and then captures a trace.
+        """
+        self._validate_input(host_input)
+        self._execute_single(host_input)
+        ttnn.synchronize_device(self.device)
+
+    def _validate_input(self, host_input):
+        if host_input.storage_type() != ttnn.StorageType.HOST:
+            raise ValueError("Input tensor must be on host")
+
+    def _execute_single(self, input_tensor):
+        l1_input_tensor = ttnn.to_device(input_tensor, device=self.device, memory_config=self.l1_input_memory_config)
+        output_tensor = self.model(l1_input_tensor)
+        if l1_input_tensor.is_allocated():
+            ttnn.deallocate(l1_input_tensor, force=True)
+        return output_tensor
+
+    def execute(self, host_inputs: list) -> Iterable[ttnn.Tensor]:
+        for host_input in host_inputs:
+            yield self._execute_single(host_input)
+
+    def cleanup(self):
         pass
 
 
@@ -46,7 +83,9 @@ class TracedModelExecutor(Executor):
         self.l1_input_memory_config = l1_input_memory_config
 
         self.dram_input_tensor = None
+        self.l1_input_tensor = None
         self.output_tensor = None
+        self._compilation_output_tensor = None
 
         self.trace_id = None
         self.input_trace_addr = None
@@ -60,11 +99,8 @@ class TracedModelExecutor(Executor):
         """
         self._validate_input(host_input)
         self._allocate_persistent_tensors(host_input)
-
         self._run_model_for_compilation(host_input)
-
         self._capture_execution_trace(host_input)
-
         ttnn.synchronize_device(self.device)
 
     def _validate_input(self, host_input):
@@ -78,9 +114,8 @@ class TracedModelExecutor(Executor):
 
     def _run_model_for_compilation(self, host_input):
         l1_input_for_compile = self._prepare_l1_input(host_input)
-        output_for_compile = self.model(l1_input_for_compile)
+        self._compilation_output_tensor = self.model(l1_input_for_compile)
         ttnn.deallocate(l1_input_for_compile)
-        ttnn.deallocate(output_for_compile)
 
     def _capture_execution_trace(self, host_input):
         l1_input_for_trace, spec = self._prepare_input_for_trace_capture(host_input)
@@ -91,7 +126,6 @@ class TracedModelExecutor(Executor):
         ttnn.deallocate(l1_input_for_trace)
 
         self._validate_trace_address_consistency(spec)
-
         ttnn.end_trace_capture(self.device, self.trace_id, cq_id=self.cq_id)
 
     def _prepare_input_for_trace_capture(self, host_input):
@@ -99,9 +133,7 @@ class TracedModelExecutor(Executor):
         self.input_trace_addr = l1_input_for_trace.buffer_address()
         spec = l1_input_for_trace.spec
 
-        # Clean up compilation output tensor if it exists to ensure correct memory allocation order for persistent tensors
-        if hasattr(self, "_compilation_output_tensor"):
-            self._compilation_output_tensor.deallocate(force=True)
+        self._compilation_output_tensor.deallocate(force=True)
 
         return l1_input_for_trace, spec
 
@@ -110,8 +142,8 @@ class TracedModelExecutor(Executor):
         Validates that allocating a persistent L1 tensor will use the expected address
         that was captured during trace recording.
         """
-        l1_input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
-        actual_addr = l1_input_tensor.buffer_address()
+        self.l1_input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
+        actual_addr = self.l1_input_tensor.buffer_address()
 
         if self.input_trace_addr != actual_addr:
             raise RuntimeError(
@@ -141,10 +173,12 @@ class TracedModelExecutor(Executor):
         """
         # Transfer input to device and reshard to L1
         ttnn.copy_host_to_device_tensor(input_tensor, self.dram_input_tensor, cq_id=self.cq_id)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+
+        # Reuse persistent L1 tensor by resharding in-place
+        self.l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor)
 
         # Validate address consistency with captured trace
-        actual_addr = l1_input_tensor.buffer_address()
+        actual_addr = self.l1_input_tensor.buffer_address()
         if actual_addr != self.input_trace_addr:
             raise RuntimeError(
                 f"L1 input tensor address mismatch during execution: "
@@ -166,14 +200,17 @@ class TracedModelExecutor(Executor):
             ttnn.release_trace(self.device, self.trace_id)
 
 
-class MultiCQTracedModelExecutor(Executor):
+class MultiCQTracedModelOverlappedInputExecutor(Executor):
     """
-    Multi-command queue traced model executor that uses separate queues for input writes
-    and operations/output reads to enable parallel execution and improved throughput.
+    Multi-command queue traced model executor that overlaps input transfers with model execution
+    for improved throughput.
 
     Uses two command queues:
     - CQ_OPS_AND_OUTPUT_READ (0): Model operations and output reading
     - CQ_INPUT_WRITE (1): Input tensor writing to device
+
+    This executor can transfer the next input while the model is processing the current input,
+    reducing the impact of input transfer latency on overall throughput.
     """
 
     CQ_OPS_AND_OUTPUT_READ = 0
@@ -336,7 +373,7 @@ class MultiCQTracedModelExecutor(Executor):
             ttnn.release_trace(self.device, self.trace_id)
 
 
-class MultiCQTracedModelWithSeparateIOExecutor(Executor):
+class MultiCQTracedModelPipelinedIOExecutor(Executor):
     """
     Multi-command queue traced model executor that uses separate queues for I/O and operations.
 
@@ -359,8 +396,6 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
         dram_input_memory_config,
         l1_input_memory_config,
         dram_output_memory_config,
-        output_shape,
-        output_dtype,
     ):
         self.model = model
         self.device = device
@@ -368,9 +403,6 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
         self.dram_input_memory_config = dram_input_memory_config
         self.l1_input_memory_config = l1_input_memory_config
         self.dram_output_memory_config = dram_output_memory_config
-
-        self.output_shape = output_shape
-        self.output_dtype = output_dtype
 
         self.dram_input_tensor = None
         self.dram_output_tensor = None
@@ -389,18 +421,25 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
 
     def compile(self, host_input):
         """
-        Compiles the model with separate I/O pipeline by running it once to generate kernels,
+        Compiles the model with pipelined I/O by running it once to generate kernels,
         then capturing a trace for efficient repeated execution using multi-command queue
-        synchronization with separate I/O operations.
+        synchronization with pipelined I/O operations.
         """
         self._validate_input(host_input)
-        self._allocate_persistent_tensors(host_input)
+        self._allocate_persistent_input_tensor(host_input)
 
         first_op_event, read_event = self._initialize_synchronization_events()
 
-        first_op_event, write_event, last_op_event = self._run_model_for_compilation_with_io(
-            host_input, first_op_event, read_event
-        )
+        (
+            first_op_event,
+            write_event,
+            last_op_event,
+            output_shape,
+            output_dtype,
+        ) = self._run_model_for_compilation_with_io(host_input, first_op_event, read_event)
+
+        # Allocate output tensor based on inferred shape and dtype from compilation run
+        self._allocate_persistent_output_tensor(output_shape, output_dtype)
 
         self._capture_execution_trace_with_io(host_input, first_op_event, write_event)
 
@@ -412,13 +451,16 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
         if host_input.storage_type() != ttnn.StorageType.HOST:
             raise ValueError("Input tensor must be on host")
 
-    def _allocate_persistent_tensors(self, host_input):
-        """Allocates persistent DRAM input and output tensors for reuse across executions."""
+    def _allocate_persistent_input_tensor(self, host_input):
+        """Allocates persistent DRAM input tensor for reuse across executions."""
         self.dram_input_tensor = ttnn.allocate_tensor_on_device(
             host_input.shape, host_input.dtype, host_input.layout, self.device, self.dram_input_memory_config
         )
+
+    def _allocate_persistent_output_tensor(self, output_shape, output_dtype):
+        """Allocates persistent DRAM output tensor based on inferred shape and dtype."""
         self.dram_output_tensor = ttnn.allocate_tensor_on_device(
-            self.output_shape, self.output_dtype, ttnn.ROW_MAJOR_LAYOUT, self.device, self.dram_output_memory_config
+            output_shape, output_dtype, ttnn.ROW_MAJOR_LAYOUT, self.device, self.dram_output_memory_config
         )
 
     def _initialize_synchronization_events(self):
@@ -429,15 +471,17 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
     def _run_model_for_compilation_with_io(self, host_input, first_op_event, read_event):
         """
         Runs the model once for compilation using the I/O pipeline pattern.
-        Returns updated events for subsequent trace capture.
+        Returns updated events and output tensor shape/dtype for subsequent trace capture.
         """
         # Transfer input using I/O queue
         write_event = self._transfer_input_for_compilation(host_input, first_op_event)
 
         # Execute model and transfer output using ops queue
-        first_op_event, last_op_event = self._execute_model_and_transfer_output(write_event, read_event)
+        first_op_event, last_op_event, output_shape, output_dtype = self._execute_model_and_transfer_output(
+            write_event, read_event
+        )
 
-        return first_op_event, write_event, last_op_event
+        return first_op_event, write_event, last_op_event, output_shape, output_dtype
 
     def _transfer_input_for_compilation(self, host_input, first_op_event):
         """Transfers input from host to device DRAM using I/O queue."""
@@ -448,7 +492,7 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
     def _execute_model_and_transfer_output(self, write_event, read_event):
         """
         Executes model operations and transfers output to DRAM using ops queue.
-        Returns updated synchronization events.
+        Returns updated synchronization events and output tensor shape/dtype.
         """
         # Execute model operations
         ttnn.wait_for_event(self.CQ_OPS, write_event)
@@ -463,11 +507,15 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
         )
         last_op_event = ttnn.record_event(self.device, self.CQ_OPS)
 
+        # Extract output info before cleanup
+        output_shape = self._compilation_output_tensor.shape
+        output_dtype = self._compilation_output_tensor.dtype
+
         # Cleanup compilation tensors
         ttnn.deallocate(l1_input_tensor)
         ttnn.deallocate(self._compilation_output_tensor)
 
-        return first_op_event, last_op_event
+        return first_op_event, last_op_event, output_shape, output_dtype
 
     def _capture_execution_trace_with_io(self, host_input, first_op_event, write_event):
         """
@@ -593,16 +641,11 @@ class MultiCQTracedModelWithSeparateIOExecutor(Executor):
         """
         num_inputs = len(host_inputs)
         if num_inputs < 2:
-            raise ValueError(f"Separate I/O executor requires at least 2 inputs for pipelining (got {num_inputs})")
+            raise ValueError(f"Pipelined I/O executor requires at least 2 inputs for pipelining (got {num_inputs})")
 
-        # Transfer the first input to start the pipeline
         self._transfer_first_input(host_inputs[0])
-
-        # Process inputs 1 to N-1 with pipelining
         for i in range(1, num_inputs):
             yield self._issue_input_and_get_prev_output(host_inputs[i])
-
-        # Process the final input
         yield self._get_last_output()
 
     def _transfer_first_input(self, first_input):

--- a/models/tt_cnn/tt/executor.py
+++ b/models/tt_cnn/tt/executor.py
@@ -28,6 +28,9 @@ class Executor(ABC):
 
 class ModelExecutor(Executor):
     def __init__(self, model: Callable, device, l1_input_memory_config, cq_id=0):
+        """
+        Executor that runs a model on a single command-queue.
+        """
         self.model = model
         self.device = device
         self.cq_id = cq_id
@@ -38,7 +41,7 @@ class ModelExecutor(Executor):
 
     def compile(self, host_input):
         """
-        Compiles the model by running it once and then captures a trace.
+        Compiles the model by running it once.
         """
         self._validate_input(host_input)
         self._execute_single(host_input)

--- a/models/tt_cnn/tt/pipeline.py
+++ b/models/tt_cnn/tt/pipeline.py
@@ -5,21 +5,79 @@
 from dataclasses import dataclass
 from typing import Callable, Optional
 
+from loguru import logger
+
 import ttnn
 
 from .executor import (
     Executor,
-    MultiCQTracedModelExecutor,
-    MultiCQTracedModelWithSeparateIOExecutor,
+    ModelExecutor,
+    MultiCQTracedModelOverlappedInputExecutor,
+    MultiCQTracedModelPipelinedIOExecutor,
     TracedModelExecutor,
 )
+
+
+def _determine_num_cores_for_even_sharding(shard_dim: int, max_cores: int):
+    number_of_cores = max_cores
+    while shard_dim % number_of_cores != 0:
+        assert number_of_cores > 0, "Unable to find core grid"
+        number_of_cores = number_of_cores - 1
+    return number_of_cores
+
+
+def get_memory_config_for_persistent_dram_tensor(shape, shard_strategy, dram_grid_size):
+    if len(shape) < 2:
+        raise ValueError("Shape must be 2D or higher (was {shape})")
+    if dram_grid_size.y != 1:
+        raise ValueError(f"Only 1D DRAM grid is supported (was {dram_grid_size})")
+
+    # Force even shards because uneven width-sharding is not supported properly transferring from host (#22396)
+    total_number_of_dram_cores = dram_grid_size.x
+    shard_dim = shape[-1] if shard_strategy == ttnn.TensorMemoryLayout.WIDTH_SHARDED else shape[-2]
+    dram_cores_for_even_sharding = _determine_num_cores_for_even_sharding(shard_dim, total_number_of_dram_cores)
+
+    if shard_dim % dram_cores_for_even_sharding != 0:
+        raise ValueError(
+            f"Number of DRAM cores must evenly divide sharded tensor (was {shard_dim} and {dram_cores_for_even_sharding})"
+        )
+
+    if shard_strategy == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+        output_dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_cores_for_even_sharding - 1, 0))}
+            ),
+            [shape[-2], shape[-1] // dram_cores_for_even_sharding],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, output_dram_shard_spec)
+    elif shard_strategy == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+        output_dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_cores_for_even_sharding - 1, 0))}
+            ),
+            [shape[-2] // dram_cores_for_even_sharding, shape[-1]],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, output_dram_shard_spec)
+    else:
+        raise ValueError(f"Unsupported shard strategy: {shard_strategy}")
 
 
 @dataclass
 class PipelineConfig:
     use_trace: bool = True
     num_command_queues: int = 1
-    separate_io_queue: bool = False
+    all_transfers_on_separate_command_queue: bool = False
+
+    def __str__(self):
+        return (
+            f"PipelineConfig(\n"
+            f"    use_trace: {self.use_trace}\n"
+            f"    num_command_queues: {self.num_command_queues}\n"
+            f"    all_transfers_on_separate_command_queue: {self.all_transfers_on_separate_command_queue}\n"
+            f")"
+        )
 
 
 class Pipeline:
@@ -29,6 +87,7 @@ class Pipeline:
         self.preallocated_output_tensors = False
 
     def compile(self, host_input):
+        logger.debug(f"Compiling pipeline model with input_shape={list(host_input.shape)}")
         self.executor.compile(host_input)
         return self
 
@@ -54,6 +113,7 @@ class Pipeline:
     def preallocate_output_tensors_on_host(
         self, number_of_tensors_to_allocate, output_shape, output_dtype, output_layout
     ):
+        logger.debug(f"Preallocating memory for {number_of_tensors_to_allocate} output tensors on host")
         self.preallocated_output_tensors = True
         if not isinstance(output_shape, ttnn.Shape):
             output_shape = ttnn.Shape(output_shape)
@@ -79,42 +139,50 @@ def create_pipeline_from_config(
     config: PipelineConfig,
     model: Callable,
     device,
-    dram_input_memory_config: ttnn.MemoryConfig,
     l1_input_memory_config: ttnn.MemoryConfig,
+    dram_input_memory_config: ttnn.MemoryConfig = None,
     dram_output_memory_config: Optional[ttnn.MemoryConfig] = None,
-    output_shape: Optional[tuple] = None,
-    output_dtype: Optional[ttnn.DataType] = None,
 ):
-    if not config.use_trace:
-        raise NotImplementedError(
-            "Non-traced executor is not currently implemented. All executors require trace=True in the current version."
-        )
+    logger.debug(f"Creating pipeline from config:\n{config}")
 
     executor = None
     if config.num_command_queues == 1:
-        executor = TracedModelExecutor(
-            model,
-            device,
-            dram_input_memory_config=dram_input_memory_config,
-            l1_input_memory_config=l1_input_memory_config,
-        )
-    elif config.num_command_queues == 2:
-        if config.separate_io_queue:
-            if not all([dram_output_memory_config, output_shape, output_dtype]):
+        if config.use_trace:
+            if not dram_input_memory_config:
                 raise ValueError(
-                    "dram_output_memory_config, output_shape, and output_dtype must be provided for separate IO queue configuration."
+                    "dram_input_memory_config must be provided when using trace all_transfers_on_separate_command_queue=True."
                 )
-            executor = MultiCQTracedModelWithSeparateIOExecutor(
+            logger.debug("Creating TracedModelExecutor with single command queue")
+            executor = TracedModelExecutor(
+                model,
+                device,
+                dram_input_memory_config=dram_input_memory_config,
+                l1_input_memory_config=l1_input_memory_config,
+            )
+        else:
+            logger.debug("Creating ModelExecutor with single command queue")
+            executor = ModelExecutor(
+                model,
+                device,
+                l1_input_memory_config=l1_input_memory_config,
+            )
+    elif config.num_command_queues == 2:
+        if not config.use_trace:
+            raise ValueError("Non-traced runs not supported when using multiple command queues")
+        if config.all_transfers_on_separate_command_queue:
+            if not dram_output_memory_config:
+                raise ValueError(
+                    "dram_output_memory_config must be provided when all_transfers_on_separate_command_queue=True."
+                )
+            executor = MultiCQTracedModelPipelinedIOExecutor(
                 model,
                 device,
                 dram_input_memory_config=dram_input_memory_config,
                 l1_input_memory_config=l1_input_memory_config,
                 dram_output_memory_config=dram_output_memory_config,
-                output_shape=output_shape,
-                output_dtype=output_dtype,
             )
         else:
-            executor = MultiCQTracedModelExecutor(
+            executor = MultiCQTracedModelOverlappedInputExecutor(
                 model,
                 device,
                 dram_input_memory_config=dram_input_memory_config,
@@ -126,4 +194,5 @@ def create_pipeline_from_config(
     if executor is None:
         raise ValueError(f"Could not create executor for configuration: {config}")
 
+    logger.debug(f"Created executor with type={type(executor).__name__}")
     return pipeline(executor)


### PR DESCRIPTION
### What's changed?
- Automatically determine output tensor metadata during the compile run to reduce the number of places the user can make mistakes
- Add helpers for picking persistent DRAM tensor memory configs; hides current limitation with using uneven width-shaded inputs by avoiding uneven shards
- Refactor ResNet50 end-to-end performance tests to use the TT-CNN Pipeline construct
- Add a ModelExecutor to handle case where CQ=1 and tracing=False

### Next steps
- Eliminate "resnet50_2cq" by supporting 2CQ-only executors (or just remove the test case entirely) so we can refactor away the rest of the ResNet50-specific tracing and 2CQ code
- Refactor the ResNet50 demo to use TT-CNN

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16886697982
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16886700306
- [x] Single-card Model perf regression: https://github.com/tenstorrent/tt-metal/actions/runs/16886708274
- [x] T3K Model perf regression: https://github.com/tenstorrent/tt-metal/actions/runs/16886712755
- [x] TG Model perf regression: https://github.com/tenstorrent/tt-metal/actions/runs/16886717594