### PR TITLE
Make ttnn.divide handle div-by-zero by default

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -1,12 +1,12 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
 import ttnn
 
 import pytest
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
 
 def test_sub_fp32(device):
@@ -95,14 +95,11 @@ def test_div_fp32(device):
     z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_div)
 
-    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
-    assert status
+    assert_allclose(z_torch, tt_out, atol=1e-10, rtol=1e-6)
 
 
-# Torch: num/ 0 = inf and 0/0  nan;
-# TT: num/ 0 = inf but 0/0= 0 not nan and 1/0 is 170141183460469231731687303715884105728.000000000000000 not inf;
-# input_b must be non-zero
-def test_div_bf16(device):
+# Test division when input_b is non-zero
+def test_div_bf16_nonzero(device):
     x_torch = torch.tensor(
         [
             [
@@ -110,9 +107,6 @@ def test_div_bf16(device):
                 -3,
                 16,
                 -5,
-                14,
-                -12,
-                0,
                 0,
                 15,
             ]
@@ -126,18 +120,15 @@ def test_div_bf16(device):
                 3,
                 -4,
                 -5,
-                0,
-                0,
-                0,
                 1,
                 10,
             ]
         ],
         dtype=torch.bfloat16,
     )
-    # torch out in ttnn TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,  1.500000000000000]],
+    # torch out in ttnn TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000, 0.000000000000000,  1.500000000000000]],
     #         dtype=torch.bfloat16)
-    # tt out in torch TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,  0.000000000000000,  0.000000000000000,  1.500000000000000]],
+    # tt out in torch TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000, 0.000000000000000,  1.500000000000000]],
     #         dtype=torch.bfloat16)
     golden_fn = ttnn.get_golden_function(ttnn.divide)
     z_torch = golden_fn(x_torch, y_torch)
@@ -146,8 +137,7 @@ def test_div_bf16(device):
     z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=None)  # bf16 runs FPU
     tt_out = ttnn.to_torch(z_tt_div)
 
-    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
-    assert status
+    assert_with_ulp(z_torch, tt_out, ulp_threshold=1, allow_nonfinite=True)
 
 
 def test_pow_fp32(device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+import math
+import pytest
+
+
+@pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
+@pytest.mark.parametrize("approx", [True, False])
+def test_div_zero(device, val_a, val_b, dtype, approx):
+    torch_dtype = getattr(torch, dtype)
+    tt_dtype = getattr(ttnn, dtype)
+
+    if val_a == 0.0 and val_b == 0.0 and dtype == "bfloat16":
+        pytest.skip("Skipping test for 0/0 on bfloat16")
+
+    x_torch = torch.tensor([[val_a]], dtype=torch_dtype)
+    y_torch = torch.tensor([[val_b]], dtype=torch_dtype)
+
+    golden_fn = ttnn.get_golden_function(ttnn.divide)
+    z_torch = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=tt_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=tt_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    z_tt_div = ttnn.divide(x_tt, y_tt, fast_and_approximate_mode=approx)
+    tt_out = ttnn.to_torch(z_tt_div)
+
+    # Note: torch.equal return false for if both tensors are nan
+    # This is why we use assert_with_ulp to test for equality
+
+    if approx and dtype == "bfloat16":
+        pytest.skip("Skipping test for fast approximate mode")
+
+    assert_with_ulp(z_torch, tt_out, 0, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
+@pytest.mark.parametrize("approx", [True, False])
+def test_divide_inplace_zero(device, val_a, val_b, dtype, approx):
+    torch_dtype = getattr(torch, dtype)
+    tt_dtype = getattr(ttnn, dtype)
+
+    if val_a == 0.0 and val_b == 0.0 and dtype == "bfloat16":
+        pytest.skip("Skipping test for 0/0 on bfloat16")
+
+    x_torch = torch.tensor([[val_a]], dtype=torch_dtype)
+    y_torch = torch.tensor([[val_b]], dtype=torch_dtype)
+
+    golden_fn = ttnn.get_golden_function(ttnn.divide)
+    z_torch = golden_fn(x_torch, y_torch)
+
+    x_tt_inplace = ttnn.from_torch(x_torch, dtype=tt_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt_inplace = ttnn.from_torch(y_torch, dtype=tt_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.divide_(x_tt_inplace, y_tt_inplace, fast_and_approximate_mode=approx)
+    tt_out_inplace = ttnn.to_torch(x_tt_inplace)
+
+    if approx and dtype == "bfloat16":
+        pytest.skip("Skipping test for fast approximate mode")
+
+    assert_with_ulp(z_torch, tt_out_inplace, 0, allow_nonfinite=True)

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -120,7 +120,8 @@ autograd::TensorPtr rmsnorm_composite(
         none,
         none,
         none,
-        false);  // [B,1,S,C] x [B,1,S,C] -> [B,1,S,C]
+        false,
+        /*fast_and_approximate*/ true);  // [B,1,S,C] x [B,1,S,C] -> [B,1,S,C]
 
     auto out = autograd::create_tensor(out_tensor);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -336,7 +336,8 @@ inline auto invoke_binary_ng(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<bool>& fast_and_approximate_mode) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
                          (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
@@ -390,6 +391,7 @@ inline auto invoke_binary_ng(
             out_dtype,
             mem_config,
             output,
+            fast_and_approximate_mode,
             lhs_activations,
             rhs_activations,
             post_activations);
@@ -415,6 +417,7 @@ inline auto invoke_binary_ng(
             input_a.dtype(),
             mem_config,
             output_tensor,
+            fast_and_approximate_mode,
             lhs_activations,
             rhs_activations,
             post_activations);
@@ -446,7 +449,8 @@ Tensor BinaryOperation<binary_op_type>::invoke(
         post_activations,
         lhs_activations,
         rhs_activations,
-        use_legacy);
+        use_legacy,
+        /*fast_and_approximate_mode*/ false);
 }
 
 template <BinaryOpType binary_op_type>
@@ -470,7 +474,60 @@ Tensor BinaryOperation<binary_op_type>::invoke(
         post_activations,
         lhs_activations,
         rhs_activations,
-        use_legacy);
+        use_legacy,
+        /*fast_and_approximate_mode*/ false);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& use_legacy,
+    const std::optional<bool>& fast_and_approximate_mode) {
+    return detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        fast_and_approximate_mode);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    float rhs,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& use_legacy,
+    const std::optional<bool>& fast_and_approximate_mode) {
+    return detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        fast_and_approximate_mode);
 }
 
 template <BinaryOpType binary_op_type>
@@ -494,7 +551,8 @@ Tensor RelationalBinary<binary_op_type>::invoke(
         post_activations,
         lhs_activations,
         rhs_activations,
-        use_legacy);
+        use_legacy,
+        /*fast_and_approximate_mode*/ false);
 }
 
 template <BinaryOpType binary_op_type>
@@ -526,7 +584,8 @@ Tensor RelationalBinary<binary_op_type>::invoke(
         post_activations,
         lhs_activations,
         rhs_activations,
-        use_legacy);
+        use_legacy,
+        /*fast_and_approximate_mode*/ false);
 }
 // scalar - tensor combination not available on Pytorch for this op
 template <BinaryOpType binary_op_type>
@@ -600,6 +659,50 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
 }
 
 template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> use_legacy,
+    std::optional<bool> fast_and_approximate_mode) {
+    return BinaryOperationWithFastApprox<binary_op_type>::invoke(
+        lhs,
+        rhs,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        fast_and_approximate_mode);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const float rhs,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    std::optional<bool> use_legacy,
+    std::optional<bool> fast_and_approximate_mode) {
+    return BinaryOperationWithFastApprox<binary_op_type>::invoke(
+        lhs,
+        rhs,
+        std::nullopt,
+        std::nullopt,
+        lhs,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        fast_and_approximate_mode);
+}
+
+template <BinaryOpType binary_op_type>
 Tensor BinaryOperationSfpu<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
@@ -620,7 +723,8 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
         post_activations,
         lhs_activations,
         rhs_activations,
-        use_legacy);
+        use_legacy,
+        /*fast_and_approximate_mode*/ false);
 }
 
 template <BinaryOpType binary_op_type>
@@ -663,7 +767,8 @@ Tensor BinaryOperationHypot<binary_op_type>::invoke(
         {},      // no post_activations
         {},      // no lhs_activations
         {},      // no rhs_activations
-        false);  // legacy_flag
+        false,   // legacy_flag
+        false);  // fast_and_approximate_mode
 }
 
 template struct BinaryOperation<BinaryOpType::ADD>;
@@ -730,5 +835,9 @@ template struct BinaryOperationSfpu<BinaryOpType::LCM>;
 template struct BinaryOperationAddalpha<BinaryOpType::ADDALPHA>;
 template struct BinaryOperationSubalpha<BinaryOpType::SUBALPHA>;
 template struct BinaryOperationHypot<BinaryOpType::HYPOT>;
+
+// Explicit template instantiations for BinaryOperationWithFastApprox
+template struct BinaryOperationWithFastApprox<BinaryOpType::DIV>;
+template struct InplaceBinaryOperationWithFastApprox<BinaryOpType::DIV>;
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -46,6 +46,33 @@ struct BinaryOperation {
 };
 
 template <BinaryOpType binary_op_type>
+struct BinaryOperationWithFastApprox {
+    static Tensor invoke(
+        const Tensor& lhs,
+        const Tensor& rhs,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt,
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
+
+    static Tensor invoke(
+        const ttnn::Tensor& lhs,
+        float rhs,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt,
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
+};
+
+template <BinaryOpType binary_op_type>
 struct RelationalBinary {
     static Tensor invoke(
         const Tensor& lhs,
@@ -125,6 +152,27 @@ struct InplaceBinaryOperation {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
+};
+
+template <BinaryOpType binary_op_type>
+struct InplaceBinaryOperationWithFastApprox {
+    static Tensor invoke(
+        const Tensor& lhs,
+        const Tensor& rhs,
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        std::optional<bool> use_legacy = std::nullopt,
+        std::optional<bool> fast_and_approximate_mode = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& lhs,
+        float rhs,
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        std::optional<bool> use_legacy = std::nullopt,
+        std::optional<bool> fast_and_approximate_mode = std::nullopt);
 };
 
 template <BinaryOpType binary_op_type>
@@ -231,11 +279,12 @@ constexpr auto squared_difference = ttnn::register_operation<
 constexpr auto squared_difference_ = ttnn::register_operation<
     "ttnn::squared_difference_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::SQUARED_DIFFERENCE>>();
-constexpr auto divide = ttnn::
-    register_operation<"ttnn::divide", operations::binary::BinaryOperation<operations::binary::BinaryOpType::DIV>>();
+constexpr auto divide = ttnn::register_operation<
+    "ttnn::divide",
+    operations::binary::BinaryOperationWithFastApprox<operations::binary::BinaryOpType::DIV>>();
 constexpr auto divide_ = ttnn::register_operation<
     "ttnn::divide_",
-    operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::DIV>>();
+    operations::binary::InplaceBinaryOperationWithFastApprox<operations::binary::BinaryOpType::DIV>>();
 constexpr auto gt_ = ttnn::register_operation<
     "ttnn::gt_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::GT>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1346,6 +1346,141 @@ void bind_div(
 }
 
 template <typename binary_operation_t>
+void bind_binary_operation_with_fast_approx(
+    py::module& module,
+    const binary_operation_t& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Number): the input tensor.
+
+        Keyword args:
+            fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {4}
+                 - TILE
+                 - 2, 3, 4
+
+            {5}
+
+        Example:
+            >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor1, tensor2, fast_and_approximate_mode=True)
+
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> scalar = 3
+            >>> output = {1}(tensor, scalar, fast_and_approximate_mode=False)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        math,
+        supported_dtype,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               bool fast_and_approximate_mode,
+               const std::optional<const DataType>& dtype,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+                return self(
+                    input_tensor_a,
+                    input_tensor_b,
+                    dtype,
+                    memory_config,
+                    output_tensor,
+                    activations,
+                    input_tensor_a_activations,
+                    input_tensor_b_activations,
+                    use_legacy,
+                    fast_and_approximate_mode);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("fast_and_approximate_mode") = false,
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("use_legacy") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               float value,
+               bool fast_and_approximate_mode,
+               const std::optional<const DataType>& dtype,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+                return self(
+                    input_tensor_a,
+                    value,
+                    dtype,
+                    memory_config,
+                    output_tensor,
+                    activations,
+                    input_tensor_a_activations,
+                    input_tensor_b_activations,
+                    use_legacy,
+                    fast_and_approximate_mode);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("fast_and_approximate_mode") = false,
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("use_legacy") = std::nullopt});
+}
+
+template <typename binary_operation_t>
 void bind_polyval(
     py::module& module,
     const binary_operation_t& operation,
@@ -1602,6 +1737,119 @@ void bind_inplace_operation(
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
         });
+}
+
+template <typename binary_operation_t>
+void bind_inplace_operation_with_fast_approx(
+    py::module& module,
+    const binary_operation_t& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {4}
+                 - TILE
+                 - 2, 3, 4
+
+            {5}
+
+        Example:
+            >>> tensor1 = ttnn.from_torch(torch.tensor([[2, 2], [2, 2]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 1], [1, 1]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> {1}(tensor1, tensor2, fast_and_approximate_mode=True)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        math,
+        supported_dtype,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        // tensor and tensor
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               bool fast_and_approximate_mode,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
+               const std::optional<bool>& use_legacy) {
+                return self(
+                    input_tensor_a,
+                    input_tensor_b,
+                    activations,
+                    input_tensor_a_activations,
+                    input_tensor_b_activations,
+                    use_legacy,
+                    fast_and_approximate_mode);
+            },
+            py::arg("input_a"),
+            py::arg("input_b"),
+            py::kw_only(),
+            py::arg("fast_and_approximate_mode") = false,
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("use_legacy") = std::nullopt},
+
+        // tensor and scalar
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               float value,
+               bool fast_and_approximate_mode,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
+               const std::optional<bool>& use_legacy) {
+                return self(
+                    input_tensor_a,
+                    value,
+                    activations,
+                    input_tensor_a_activations,
+                    input_tensor_b_activations,
+                    use_legacy,
+                    fast_and_approximate_mode);
+            },
+            py::arg("input_a"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("fast_and_approximate_mode") = false,
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("use_legacy") = std::nullopt});
 }
 
 template <typename binary_operation_t>
@@ -2068,11 +2316,16 @@ void py_module(py::module& module) {
         ". ",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
-    detail::bind_binary_operation(
+    detail::bind_binary_operation_with_fast_approx(
         module,
         ttnn::divide,
         R"doc(Divides :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
-        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i / \mathrm{{input\_tensor\_b}}_i))doc");
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i / \mathrm{{input\_tensor\_b}}_i))doc",
+        R"doc(BFLOAT16, FLOAT32, INT32, UINT16)doc",
+        R"doc(
+        When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero.
+        When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handle division by zero.
+        )doc");
 
     detail::bind_binary_operation(
         module,
@@ -2393,11 +2646,16 @@ void py_module(py::module& module) {
         R"doc(\verb|squared_difference|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
         R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
-    detail::bind_inplace_operation(
+    detail::bind_inplace_operation_with_fast_approx(
         module,
         ttnn::divide_,
         R"doc(Performs division in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
-        R"doc(\verb|divide|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc");
+        R"doc(\verb|divide|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        R"doc(BFLOAT16, FLOAT32, INT32, UINT16)doc",
+        R"doc(
+        When :attr:`fast_and_approximate_mode` is `True`, the operation uses FPU+SFPU implementation for better performance.
+        When :attr:`fast_and_approximate_mode` is `False` (default), the operation uses SFPU implementation for better accuracy.
+        )doc");
 
     detail::bind_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -10,7 +10,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::binary_ng {
 
 namespace utils {
-bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
+bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_approximate_mode = false) {
     using enum BinaryOpType;
     using enum DataType;
     switch (val) {
@@ -27,7 +27,6 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LOGICAL_XOR:
         case SQUARED_DIFFERENCE:
             return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));
-        case DIV:
         case LOGADDEXP:
         case LOGADDEXP2:
         case LDEXP:
@@ -54,6 +53,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case MINIMUM:
         case XLOGY:
         case POWER: return true;
+        case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32);
         default: return false;
     }
     return false;
@@ -416,6 +416,7 @@ BinaryNgDeviceOperation::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
+    const std::optional<bool>& fast_and_approximate_mode,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations) {
@@ -438,7 +439,8 @@ BinaryNgDeviceOperation::invoke(
 
     DataType dtype_a = input_tensor_a.dtype();
     DataType dtype_b = input_tensor_b.dtype();
-    bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b));
+    bool is_sfpu_op =
+        (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b, fast_and_approximate_mode.value_or(false)));
     bool is_quant_op = utils::is_quant_op(binary_op_type);
     return {
         operation_attributes_t{
@@ -470,11 +472,13 @@ BinaryNgDeviceOperation::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
+    const std::optional<bool>& fast_and_approximate_mode,
     tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations) {
     DataType dtype_a = input_tensor_a.dtype();
-    bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a));
+    bool is_sfpu_op =
+        (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
     bool is_quant_op = utils::is_quant_op(binary_op_type);
     return {
         operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -96,6 +96,7 @@ struct BinaryNgDeviceOperation {
         const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<Tensor>& optional_output_tensor,
+        const std::optional<bool>& fast_and_approximate_mode,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations);
@@ -108,6 +109,7 @@ struct BinaryNgDeviceOperation {
         const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<Tensor>& optional_output_tensor,
+        const std::optional<bool>& fast_and_approximate_mode,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations);

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -251,6 +251,7 @@ Tensor QuantOp::invoke(
                     c_dtype,
                     memory_config,
                     optional_output_tensor,
+                    /*fast_and_approximate_mode*/ false,
                     none,
                     none,
                     post_activation);
@@ -267,6 +268,7 @@ Tensor QuantOp::invoke(
                     c_dtype,
                     memory_config,
                     optional_output_tensor,
+                    /*fast_and_approximate_mode*/ false,
                     none,
                     none,
                     post_activation);
@@ -454,6 +456,7 @@ Tensor RequantOp::invoke(
                     c_dtype,
                     memory_config,
                     optional_output_tensor,
+                    /*fast_and_approximate_mode*/ false,
                     none,
                     none,
                     post_activation);
@@ -545,6 +548,7 @@ Tensor DequantOp::invoke(
                     c_dtype,
                     memory_config,
                     optional_output_tensor,
+                    /*fast_and_approximate_mode*/ false,
                     none,
                     none,
                     post_activation);
@@ -560,6 +564,7 @@ Tensor DequantOp::invoke(
                     c_dtype,
                     memory_config,
                     optional_output_tensor,
+                    /*fast_and_approximate_mode*/ false,
                     none,
                     none,
                     post_activation);


### PR DESCRIPTION
### Ticket
#25629

### Problem description
- float32 version of `ttnn.divide`/`ttnn.divide_` uses the divide LLK (SFPU) and handles division by zero cases 
- bfloat16 version uses the `recip + mul` LLKs (SFPU + FPU) but does not handle division by zero.

In the second case, there can be accuracy-related issues if one input is 0, because FPU will treat `1/0` output as regular number, which leads to a mistach. 

### What's changed

This PR adds a `fast_and_approximate_mode` flag to `ttnn.divide` to toggle between SFPU-only (handle div-by-zero) and SFPU+FPU version (does not handle div by zero). 

- If enabled, then, divide on bfloat16 will use SFPU + FPU version which is faster by a factor of 1.7-1.8. 
- Otherwise (default behavior), ttnn.divide will use SFPU-only version for bfloat16 (always the case for float32).

This allows `divide` to pass tests from #25629 . 

Tests have also been added to track this support (`./tests/ttnn/unit_tests/operations/eltwise/test_divide.py`)

To summarize:

| Data Type | fast_and_approximate_mode | Compute Units | Div-by-zero support |
| - | - | - | - |
| BFLOAT16 | false | SFPU | Y |  
| BFLOAT16 | true | SFPU+FPU | N |
| FLOAT32 | false | SFPU | Y |  
| FLOAT32 | true | SFPU | Y |  


### Implementation details 

Since no other binary ops used approx flags, I had to refactor some of the binary_ng code, which includes
- Adding a 'bool fast_and_approximate_mode' parameter to `is_binary_sfpu_op()`.
- Updating ttnn.divide and ttnn.divide_ pybinds
- Add 'generic' BinaryOperationWithFastApprox / InplaceBinaryOperationWithFastApprox binary operations. 

This adds a good amount of code, but this means that other ops are not inheriting an 'unused' `fast_and_approximate_mode` flag (c.f. for both python and C++ interfaces).  

### Testing

- Some tests were changed to use allclose rather than PCC. 
- Division-by-zero test has been moved in its own test case.

RMSNorm tests in tt-train checks its implementation against a composite version that uses ttnn.divide. Non-'approx' ttnn.divide is slightly more accurate that the SFPU+FPU version, which breaks the test. 
To address the issue, I've modified the composite RMSNorm to use the `fast_and_approximate=True` version (same results as before).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/18315620873
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/18315629385 ( [failed tests also on main](https://github.com/tenstorrent/tt-metal/actions/runs/18333382962))
- [x] tt-metal L2 Nightly tests: https://github.com/tenstorrent/tt-metal/actions/runs/18315642415 ([failed tests also in unrelated branch)](https://github.com/tenstorrent/tt-metal/actions/runs/18321405237)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml)  https://github.com/tenstorrent/tt-metal/actions/runs/18315650220
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml)  (https://github.com/tenstorrent/tt-metal/actions/runs/18061219820) : https://github.com/tenstorrent/tt-metal/actions/runs/18315658026 ([failed tests also on main](https://github.com/tenstorrent/tt-metal/actions/runs/18320342536))
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes