### PR TITLE
Add native bfp8 support for tiled reshape 

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -639,3 +639,30 @@ def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape):
     for tensor_shard in ttnn.get_device_tensors(tt_output_tensor):
         tt_output_tensor = ttnn.to_torch(tensor_shard)
         assert tt_output_tensor.shape == torch.Size(output_shape)
+
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape",
+    [
+        ((1, 1018, 1018, 32), (1, 1, 1036324, 32)),
+        ((1, 990, 990, 64), (1, 1, 980100, 64)),
+        ((1, 1006, 254, 64), (1, 1, 255524, 64)),
+        ((1, 1020, 1020, 32), (1, 1, 1040400, 32)),
+    ],
+)
+def test_dram_tile_bfp8(input_shape, output_shape, device):
+    torch_input_tensor = torch.randn(input_shape)
+    torch_result = torch_input_tensor.reshape(output_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_output = ttnn.reshape(input_tensor, output_shape)
+
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_result, output, 0.9999)

--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -648,6 +648,10 @@ def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape):
         ((1, 990, 990, 64), (1, 1, 980100, 64)),
         ((1, 1006, 254, 64), (1, 1, 255524, 64)),
         ((1, 1020, 1020, 32), (1, 1, 1040400, 32)),
+        ((2, 2, 2), (1, 4, 2)),
+        ((2, 2, 16), (1, 4, 16)),
+        ((10, 17, 18), (1, 170, 18)),
+        ((984, 21, 129), (1, 20664, 129)),
     ],
 )
 def test_dram_tile_bfp8(input_shape, output_shape, device):

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -91,10 +91,11 @@ void kernel_main() {
                 uint32_t exp_idx = faceline_row * output_subtile_id + output_row_id;
                 exp_buffer[exp_idx] = input_ptr[faceline_row * subtile_id + row_id];
 
-                if (map_ptr[seg_idx].num_elements == faceline_row * 2) {  // if reading 2 facelines at a time
-
-                    exp_buffer[exp_idx + 1] = input_ptr[faceline_row * subtile_id + row_id + 1];
-                    faceline_ctr = two_facelines ? faceline_ctr + 1 : faceline_ctr + 2;
+                if (map_ptr[seg_idx].num_elements > faceline_row) {  // if reading more than one faceline at a time
+                    for (uint32_t f = 1; f < map_ptr[seg_idx].num_elements / faceline_row; f++) {
+                        exp_buffer[exp_idx + f] = input_ptr[faceline_row * subtile_id + row_id + f];
+                        faceline_ctr = two_facelines ? faceline_ctr + 1 : faceline_ctr + 2;
+                    }
                 }
                 faceline_ctr = two_facelines ? faceline_ctr + 1 : faceline_ctr + 2;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -78,6 +78,9 @@ void kernel_main() {
             const uint32_t input_addr = input_base_addr + input_page_offset;
             const uint32_t szbytes = map_ptr[seg_idx].num_elements * element_sz_bytes;
 
+            // for bfp8, the exponents are stored in the first 64 bytes of the tile in faceline order
+            // this kernel stores the exponents corresponsing to the output shape in a separate buffer
+            // then copies them to the appropriate address at the end
             if constexpr (is_bfp8) {
                 volatile tt_l1_ptr uint8_t* input_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(input_base_addr);
                 volatile tt_l1_ptr uint8_t* exp_buffer = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(exp_ptr_addr);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -23,19 +23,25 @@ void kernel_main() {
     constexpr uint32_t cb_id_mapping = get_compile_time_arg_val(3);
     constexpr uint32_t cb_id_input = get_compile_time_arg_val(4);
     constexpr uint32_t cb_id_working = get_compile_time_arg_val(5);  // scratch
-    constexpr auto output_args = TensorAccessorArgs<6>();
+    constexpr bool is_bfp8 = get_compile_time_arg_val(6);
+    constexpr auto output_args = TensorAccessorArgs<7>();
 
     const auto output_addrgen = TensorAccessor(output_args, output_base_addr, Tile_size_bytes);
 
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;
+    constexpr uint32_t faceline_size = 256;
+    constexpr uint32_t faceline_row = 16;
+    constexpr uint32_t exponents_size = 64;
     cb_reserve_back(cb_id_working, 1);
     const uint32_t working_write_addr = get_write_ptr(cb_id_working);
     for (uint32_t output_page_idx = start_output_page; output_page_idx < end_output_page; ++output_page_idx) {
+        uint8_t exp_buffer[exponents_size] = {0};  // for bfloat8_b exponents
         cb_wait_front(cb_id_mapping, 1);
         const uint32_t map_addr = get_read_ptr(cb_id_mapping);
         auto map_ptr = reinterpret_cast<volatile tt_l1_ptr SegmentMapData*>(map_addr);
         uint32_t input_base_addr, previous_input_page_idx = std::numeric_limits<uint32_t>::max();
+        uint32_t faceline_ctr = 0;
         for (uint32_t seg_idx = 0; seg_idx < Max_Map_Entries; ++seg_idx) {
             if (map_ptr[seg_idx].num_elements == 0) {
                 if (output_page_idx == end_output_page - 1 && seg_idx == Max_Map_Entries - 1) {
@@ -59,12 +65,38 @@ void kernel_main() {
                 previous_input_page_idx = map_ptr[seg_idx].input_page_index;
             }
             // TODO (maybe) pre calculate size and offsets in bytes on host
-            const uint32_t output_addr = working_write_addr + map_ptr[seg_idx].output_page_offset * element_sz_bytes;
-            const uint32_t input_addr = input_base_addr + map_ptr[seg_idx].input_page_offset * element_sz_bytes;
+            uint32_t input_page_offset = map_ptr[seg_idx].input_page_offset * element_sz_bytes;
+            uint32_t output_page_offset = map_ptr[seg_idx].output_page_offset * element_sz_bytes;
+
+            const uint32_t output_addr = working_write_addr + output_page_offset;
+            const uint32_t input_addr = input_base_addr + input_page_offset;
             const uint32_t szbytes = map_ptr[seg_idx].num_elements * element_sz_bytes;
-            tt_memmove<false, true, false, Tile_size_bytes>(output_addr, input_addr, szbytes);
+
+            if (is_bfp8) {
+                volatile tt_l1_ptr uint8_t* input_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(input_base_addr);
+                uint32_t subtile_id = input_page_offset / faceline_size;
+                uint32_t row_id = (input_page_offset % faceline_size) / faceline_row;
+                uint32_t output_row_id = (faceline_ctr / 2) % faceline_row;
+                uint32_t output_subtile_id = output_page_offset / faceline_size;
+                exp_buffer[faceline_row * output_subtile_id + output_row_id] =
+                    input_ptr[faceline_row * subtile_id + row_id];  // store first byte for debugging
+                if (seg_idx == 31 &&
+                    map_ptr[seg_idx].num_elements == faceline_row * 2) {  // if reading 2 facelines at a time
+                    exp_buffer[32] = input_ptr[faceline_row * subtile_id + row_id + 1];
+                    faceline_ctr++;
+                }
+                faceline_ctr++;
+            }
+            // skip exponents for bfloat8_b when moving data
+            tt_memmove<false, true, false, Tile_size_bytes>(
+                output_addr + exponents_size * is_bfp8, input_addr + exponents_size * is_bfp8, szbytes);
         }
         noc_async_write_barrier();
+
+        if (is_bfp8) {
+            // copy exponents for bfloat8_b
+            memmove((void*)working_write_addr, (const void*)&exp_buffer[0], exponents_size);
+        }
 
         const uint64_t output_noc_addr = get_noc_addr(output_page_idx, output_addrgen);
         enhanced_noc_async_write<Tile_size_bytes, true>(working_write_addr, output_noc_addr, Tile_size_bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -78,7 +78,7 @@ void kernel_main() {
             const uint32_t input_addr = input_base_addr + input_page_offset;
             const uint32_t szbytes = map_ptr[seg_idx].num_elements * element_sz_bytes;
 
-            if (is_bfp8) {
+            if constexpr (is_bfp8) {
                 volatile tt_l1_ptr uint8_t* input_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(input_base_addr);
                 volatile tt_l1_ptr uint8_t* exp_buffer = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(exp_ptr_addr);
                 uint32_t subtile_id = input_page_offset / faceline_size;
@@ -101,7 +101,7 @@ void kernel_main() {
         }
         noc_async_write_barrier();
 
-        if (is_bfp8) {
+        if constexpr (is_bfp8) {
             // copy exponents for bfloat8_b
             memmove((void*)working_write_addr, (const void*)exp_ptr_addr, exponents_size);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
@@ -376,15 +376,16 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
         "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp",
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-
+    bool is_bfloat8_b = input_tensor.dtype() == DataType::BFLOAT8_B;
     const uint32_t max_map_entries = mapping_page_size / detail::SegmentMapData::size;
     std::vector<uint32_t> writer_compile_time_args = {
         input_tile_size_bytes,
         max_map_entries,
-        tt::datum_size(output_cb_data_format),
+        is_bfloat8_b ? 1 : tt::datum_size(output_cb_data_format),
         mapping_cb_idx,
         input_cb_idx,
-        output_cb_idx};
+        output_cb_idx,
+        is_bfloat8_b};
     tt::tt_metal::TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
@@ -365,6 +365,16 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
         [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
             tt::tt_metal::split_work_to_cores(grid, num_output_pages);
 
+    bool is_bfloat8_b = input_tensor.dtype() == DataType::BFLOAT8_B;
+    constexpr auto exp_cb_idx = tt::CBIndex::c_3;
+    uint32_t exponents_size = 64;
+    tt::tt_metal::CircularBufferConfig cb_exponents =
+        tt::tt_metal::CircularBufferConfig(exponents_size, {{exp_cb_idx, output_cb_data_format}})
+            .set_page_size(exp_cb_idx, exponents_size);
+    if (is_bfloat8_b) {
+        tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_exponents);
+    }
+
     TT_ASSERT(num_cores <= num_output_pages);
 
     std::vector<uint32_t> reader_compile_time_args = {
@@ -376,12 +386,13 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
         "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp",
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    bool is_bfloat8_b = input_tensor.dtype() == DataType::BFLOAT8_B;
+
     const uint32_t max_map_entries = mapping_page_size / detail::SegmentMapData::size;
     uint32_t faceline_row = 16;
     uint32_t tile_width = output_tensor.tensor_spec().tile().get_width();
     uint32_t tiles_per_row = std::ceil((float)output_shape[-1] / (float)tile_width);
     bool last_is_two_facelines = (output_shape[-1] - (tiles_per_row - 1) * tile_width) > faceline_row;
+    uint32_t faceline_size = 256;
     std::vector<uint32_t> writer_compile_time_args = {
         input_tile_size_bytes,
         max_map_entries,
@@ -391,7 +402,11 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
         output_cb_idx,
         is_bfloat8_b,
         tiles_per_row,
-        last_is_two_facelines};
+        last_is_two_facelines,
+        faceline_row,
+        faceline_size,
+        exp_cb_idx,
+        exponents_size};
     tt::tt_metal::TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -23,6 +23,10 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
             input_tensor_a.dtype() == DataType::INT32,
         "Can only work with bfloat16/float32 or int32/uint32 tensors");
     TT_FATAL(
+        !(input_tensor_a.layout() == TILE_LAYOUT && input_tensor_a.dtype() == DataType::BFLOAT8_B &&
+          input_tensor_a.logical_shape()[-1] != logical_output_shape[-1]),
+        "Reshape only supports bfp8 inputs and outputs with the same last dimension size");
+    TT_FATAL(
         this->output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),
         "Output tensor must have the same memory layout as input tensor");
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -18,8 +18,9 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(
-        input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::UINT32 or
-            input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::INT32,
+        input_tensor_a.dtype() == DataType::BFLOAT8_B or input_tensor_a.dtype() == DataType::BFLOAT16 or
+            input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::FLOAT32 or
+            input_tensor_a.dtype() == DataType::INT32,
         "Can only work with bfloat16/float32 or int32/uint32 tensors");
     TT_FATAL(
         this->output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -228,7 +228,7 @@ ttnn::Tensor reshape_tiled(
         tensor3d = ttnn::sharded_to_interleaved(queue_id, tensor, working_input_memory_config, std::nullopt);
     }
 
-    if (tensor.dtype() == DataType::BFLOAT8_B && tensor3d.logical_shape()[-1] != tensor.logical_shape()[1]) {
+    if (tensor.dtype() == DataType::BFLOAT8_B && tensor.logical_shape()[-1] != requested_shape_3d[-1]) {
         tensor3d = ttnn::typecast(tensor3d, DataType::BFLOAT16);
     }
 
@@ -251,7 +251,7 @@ ttnn::Tensor reshape_tiled(
         output_tensor_3d = ttnn::interleaved_to_sharded(queue_id, output_tensor_3d, memory_config, std::nullopt);
     }
 
-    if (tensor.dtype() == DataType::BFLOAT8_B && output_tensor_3d.logical_shape()[-1] != tensor.logical_shape()[1]) {
+    if (tensor.dtype() == DataType::BFLOAT8_B && tensor.logical_shape()[-1] != requested_shape_3d[-1]) {
         output_tensor_3d = ttnn::typecast(output_tensor_3d, tensor.dtype());
     }
     return PerformView(output_tensor_3d, logical_shape, compute_padded_shape(logical_shape));

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -228,6 +228,10 @@ ttnn::Tensor reshape_tiled(
         tensor3d = ttnn::sharded_to_interleaved(queue_id, tensor, working_input_memory_config, std::nullopt);
     }
 
+    if (tensor.dtype() == DataType::BFLOAT8_B && tensor3d.logical_shape()[-1] != tensor.logical_shape()[1]) {
+        tensor3d = ttnn::typecast(tensor3d, DataType::BFLOAT16);
+    }
+
     MemoryConfig working_output_memory_config = memory_config;
     if (memory_config.is_sharded()) {
         working_output_memory_config =
@@ -245,6 +249,10 @@ ttnn::Tensor reshape_tiled(
 
     if (memory_config.is_sharded()) {
         output_tensor_3d = ttnn::interleaved_to_sharded(queue_id, output_tensor_3d, memory_config, std::nullopt);
+    }
+
+    if (tensor.dtype() == DataType::BFLOAT8_B && output_tensor_3d.logical_shape()[-1] != tensor.logical_shape()[1]) {
+        output_tensor_3d = ttnn::typecast(output_tensor_3d, tensor.dtype());
     }
     return PerformView(output_tensor_3d, logical_shape, compute_padded_shape(logical_shape));
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -228,10 +228,6 @@ ttnn::Tensor reshape_tiled(
         tensor3d = ttnn::sharded_to_interleaved(queue_id, tensor, working_input_memory_config, std::nullopt);
     }
 
-    if (tensor.dtype() == DataType::BFLOAT8_B) {
-        tensor3d = ttnn::typecast(tensor3d, DataType::BFLOAT16);
-    }
-
     MemoryConfig working_output_memory_config = memory_config;
     if (memory_config.is_sharded()) {
         working_output_memory_config =
@@ -250,11 +246,6 @@ ttnn::Tensor reshape_tiled(
     if (memory_config.is_sharded()) {
         output_tensor_3d = ttnn::interleaved_to_sharded(queue_id, output_tensor_3d, memory_config, std::nullopt);
     }
-
-    if (tensor.dtype() == DataType::BFLOAT8_B) {
-        output_tensor_3d = ttnn::typecast(output_tensor_3d, tensor.dtype());
-    }
-
     return PerformView(output_tensor_3d, logical_shape, compute_padded_shape(logical_shape));
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/26020

### Problem description
For Tiled bfloat8_b tensors, reshape op uses typecast before and after the op to convert it to bfloat16

### What's changed
Add native support for bfloat8 for tiled reshape. This requires changing the kernels to rewrite the exponents to the tile based on the new shape
Add tests for reshaping DRAM bfp8 tiled tensors from 4D to folded 2D

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16886282563
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16894128129
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes