### PR TITLE
Composite AG For Padded on Gather Dim

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -192,23 +192,29 @@ def run_all_gather_impl(
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout, ag_input_dtype",
     [
-        (8, [1, 1, 1024, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [8, 1, 512, 512], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 1024, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [8, 1, 512, 512], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 1, 64], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 16, 256], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 8, 1], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 64, 1], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (8, [1, 1, 256, 16], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
-    ids=[
-        "sd35_spatial",
-        "sd35_prompt",
-        "gather_dim_0",
-        "gather_dim_1",
-        "gather_dim_2",
-        "gather_dim_2_padded_dim_3",
-        "gather_dim_3_padded_dim_2",
-    ],
+    # ids=[
+    #     "sd35_spatial",
+    #     "sd35_prompt",
+    #     "gather_dim_0",
+    #     "gather_dim_1",
+    #     "gather_dim_2",
+    #     "gather_dim_2_padded_dim_3",
+    #     "gather_dim_3_padded_dim_2",
+    # ],
 )
 @pytest.mark.parametrize(
     "mem_config_input, mem_config_ag",
@@ -222,10 +228,10 @@ def run_all_gather_impl(
 @pytest.mark.parametrize(
     "enable_trace,num_iters",
     [
-        (True, 10),
+        # (True, 10),
         (False, 1),
     ],
-    ids=["perf", "check"],
+    # ids=["perf", "check"],
 )
 @pytest.mark.parametrize(
     "use_barrier, use_persistent_buffers",
@@ -240,10 +246,10 @@ def run_all_gather_impl(
     "device_params, all_gather_topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        # ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
-    ids=["fabric_ring", "fabric_linear"],
+    # ids=["fabric_ring", "fabric_linear"],
 )
 def test_all_gather_async(
     t3k_mesh_device,

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -46,9 +46,9 @@ def run_all_gather_impl(
     tile = (32, 32)
 
     ag_input_shape = ag_output_shape[:]
-    ag_input_shape[dim] *= num_devices
-    is_unpadded_on_gather_dim = (dim == 2 or dim == 3) and (
-        ag_input_shape[2] % tile[0] != 0 or ag_input_shape[3] % tile[1] != 0
+    ag_input_shape[dim] /= num_devices
+    is_unpadded_on_gather_dim = (dim == 2 and ag_input_shape[2] % tile[0] != 0) or (
+        dim == 3 and ag_input_shape[3] % tile[1] != 0
     )
     invoking_composite = layout == ttnn.ROW_MAJOR_LAYOUT or is_unpadded_on_gather_dim
 
@@ -241,10 +241,10 @@ def run_all_gather_impl(
 @pytest.mark.parametrize(
     "enable_trace,num_iters",
     [
-        # (True, 10),
+        (True, 10),
         (False, 1),
     ],
-    # ids=["perf", "check"],
+    ids=["perf", "check"],
 )
 @pytest.mark.parametrize(
     "use_barrier, use_persistent_buffers",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -6,16 +6,15 @@
 #include <utility>
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.hpp"
-// #include "ttnn/operations/core/to_layout/to_layout_op.cpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::experimental::ccl {
 
-bool use_native_all_gather(
-    const ttnn::Tensor& input_tensor, const std::optional<ttnn::MemoryConfig>& memory_config, const uint32_t dim) {
+bool use_native_all_gather(const ttnn::Tensor& input_tensor, const uint32_t dim) {
     // Row major
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
         return false;
@@ -24,7 +23,10 @@ bool use_native_all_gather(
     // Tiled and padded on the gather dim
     if (dim == 2 || dim == 3) {
         auto input_shape = input_tensor.logical_shape();
-        if (input_shape[dim] % 32 != 0) {
+        auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+        uint32_t tile_height = tile_shape[0];
+        uint32_t tile_width = tile_shape[1];
+        if (input_shape[2] % tile_height != 0 || input_shape[3] % tile_width != 0) {
             return false;
         }
     }
@@ -32,8 +34,9 @@ bool use_native_all_gather(
     return true;
 }
 
+// Composite always runs in row-major
 ttnn::Tensor all_broadcast_composite_all_gather(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor input_tensor,
     const int32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     const uint32_t num_links,
@@ -44,32 +47,65 @@ ttnn::Tensor all_broadcast_composite_all_gather(
     TT_FATAL(
         barrier_semaphore.has_value(),
         "all_gather_async composite using all_broadcast_async requires a barrier semaphore");
-
-    ttnn::MemoryConfig output_memory_config = memory_config.value_or(input_tensor.memory_config());
+    DataType input_dtype = input_tensor.dtype();
+    bool convert_to_bfloat16_for_composite = input_dtype == DataType::BFLOAT8_B;
     bool is_tiled = input_tensor.layout() == Layout::TILE;
 
     // Convert to row major
-    ttnn::Tensor all_broadcast_input_tensor =
-        is_tiled ? ttnn::to_layout(input_tensor, Layout::ROW_MAJOR) : input_tensor;
+    if (is_tiled) {
+        // If input is tiled bfloat8_b, convert to bfloat16 to do the all_broadcast_async + concat
+        if (convert_to_bfloat16_for_composite) {
+            input_tensor = ttnn::typecast(input_tensor, DataType::BFLOAT16);
+        }
+        input_tensor = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);
+    }
 
-    ttnn::MemoryConfig all_broadcast_memory_config = input_tensor.memory_config();
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
         input_tensor,
         multi_device_global_semaphore[0],
         num_links,
-        all_broadcast_memory_config,
+        input_tensor.memory_config(),
         ttnn::ccl::Topology::Linear,
         subdevice_id,
         barrier_semaphore);
 
     ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, dim);
 
-    // Convert to tiled
+    // Convert back to tiled
     if (is_tiled) {
         all_gather_output_tensor = ttnn::to_layout(all_gather_output_tensor, Layout::TILE);
+        // If we had to convert the input dtype in order to execute the row-major composite op, convert back to the
+        // input dtype
+        if (convert_to_bfloat16_for_composite) {
+            all_gather_output_tensor = ttnn::typecast(all_gather_output_tensor, input_dtype);
+        }
     }
 
     return all_gather_output_tensor;
+}
+
+// Composite always runs in row-major
+std::vector<ttnn::Tensor> all_broadcast_composite_all_gather(
+    const std::vector<ttnn::Tensor>& input_tensors,
+    const int32_t dim,
+    const std::vector<global_semaphore::MultiDeviceGlobalSemaphore>& multi_device_global_semaphore,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    std::vector<GlobalSemaphore> semaphore;
+    semaphore.reserve(multi_device_global_semaphore.size());
+    for (size_t i = 0; i < multi_device_global_semaphore.size(); i++) {
+        semaphore.push_back(multi_device_global_semaphore.at(i).global_semaphores.at(i));
+    }
+    std::vector<Tensor> output_tensors;
+    output_tensors.reserve(input_tensors.size());
+    for (size_t i = 0; i < input_tensors.size(); i++) {
+        output_tensors.push_back(all_broadcast_composite_all_gather(
+            input_tensors[i], dim, semaphore, num_links, memory_config, subdevice_id, cluster_axis, barrier_semaphore));
+    }
+    return output_tensors;
 }
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
@@ -82,17 +118,28 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    std::cout << "A" << std::endl;
-    return ttnn::operations::experimental::ccl::all_gather_async(
-        input_tensor,
-        dim,
-        multi_device_global_semaphore,
-        num_links,
-        memory_config,
-        topology,
-        subdevice_id,
-        use_optimal_ccl_for_llama,
-        barrier_semaphore);
+    if (use_native_all_gather(input_tensor, dim)) {
+        return ttnn::operations::experimental::ccl::all_gather_async(
+            input_tensor,
+            dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            topology,
+            subdevice_id,
+            use_optimal_ccl_for_llama,
+            barrier_semaphore);
+    } else {
+        return all_broadcast_composite_all_gather(
+            input_tensor,
+            dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            subdevice_id,
+            /*cluster_axis*/ std::nullopt,
+            barrier_semaphore);
+    }
 }
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
@@ -110,32 +157,33 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
-    return all_broadcast_composite_all_gather(
-        input_tensor,
-        dim,
-        multi_device_global_semaphore,
-        num_links,
-        memory_config,
-        subdevice_id,
-        cluster_axis,
-        barrier_semaphore);
-
-    std::cout << "B" << std::endl;
-    return ttnn::operations::experimental::ccl::all_gather_async(
-        input_tensor,
-        persistent_output_buffer,
-        dim,
-        multi_device_global_semaphore,
-        num_links,
-        memory_config,
-        topology,
-        subdevice_id,
-        cluster_axis,
-        use_optimal_ccl_for_llama,
-        barrier_semaphore,
-        chunks_per_sync,
-        num_workers_per_link,
-        num_buffers_per_channel);
+    if (use_native_all_gather(input_tensor, dim)) {
+        return ttnn::operations::experimental::ccl::all_gather_async(
+            input_tensor,
+            persistent_output_buffer,
+            dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            topology,
+            subdevice_id,
+            cluster_axis,
+            use_optimal_ccl_for_llama,
+            barrier_semaphore,
+            chunks_per_sync,
+            num_workers_per_link,
+            num_buffers_per_channel);
+    } else {
+        return all_broadcast_composite_all_gather(
+            input_tensor,
+            dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            barrier_semaphore);
+    }
 }
 
 std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
@@ -148,17 +196,28 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    std::cout << "C" << std::endl;
-    return ttnn::operations::experimental::ccl::all_gather_async(
-        input_tensors,
-        dim,
-        multi_device_global_semaphore,
-        num_links,
-        memory_config,
-        topology,
-        subdevice_id,
-        use_optimal_ccl_for_llama,
-        barrier_semaphore);
+    if (use_native_all_gather(input_tensors[0], dim)) {
+        return ttnn::operations::experimental::ccl::all_gather_async(
+            input_tensors,
+            dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            topology,
+            subdevice_id,
+            use_optimal_ccl_for_llama,
+            barrier_semaphore);
+    } else {
+        return all_broadcast_composite_all_gather(
+            input_tensors,
+            dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            subdevice_id,
+            /*cluster_axis*/ std::nullopt,
+            barrier_semaphore);
+    }
 }
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
@@ -174,20 +233,31 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    std::cout << "D" << std::endl;
-    return ttnn::operations::experimental::ccl::all_gather_async(
-        input_tensor,
-        dim,
-        cluster_axis,
-        mesh_device,
-        topology,
-        multi_device_global_semaphore,
-        persistent_output_tensor,
-        memory_config,
-        num_preferred_links,
-        subdevice_id,
-        use_optimal_ccl_for_llama,
-        barrier_semaphore);
+    if (use_native_all_gather(input_tensor, dim)) {
+        return ttnn::operations::experimental::ccl::all_gather_async(
+            input_tensor,
+            dim,
+            cluster_axis,
+            mesh_device,
+            topology,
+            multi_device_global_semaphore,
+            persistent_output_tensor,
+            memory_config,
+            num_preferred_links,
+            subdevice_id,
+            use_optimal_ccl_for_llama,
+            barrier_semaphore);
+    } else {
+        return all_broadcast_composite_all_gather(
+            input_tensor,
+            dim,
+            multi_device_global_semaphore,
+            num_preferred_links.value_or(1),
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            barrier_semaphore);
+    }
 }
 
 std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
@@ -203,20 +273,31 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    std::cout << "E" << std::endl;
-    return ttnn::operations::experimental::ccl::all_gather_async(
-        input_tensors,
-        dim,
-        cluster_axis,
-        mesh_device,
-        topology,
-        multi_device_global_semaphore,
-        persistent_output_tensor,
-        memory_config,
-        num_preferred_links,
-        subdevice_id,
-        use_optimal_ccl_for_llama,
-        barrier_semaphore);
+    if (use_native_all_gather(input_tensors[0], dim)) {
+        return ttnn::operations::experimental::ccl::all_gather_async(
+            input_tensors,
+            dim,
+            cluster_axis,
+            mesh_device,
+            topology,
+            multi_device_global_semaphore,
+            persistent_output_tensor,
+            memory_config,
+            num_preferred_links,
+            subdevice_id,
+            use_optimal_ccl_for_llama,
+            barrier_semaphore);
+    } else {
+        return all_broadcast_composite_all_gather(
+            input_tensors,
+            dim,
+            multi_device_global_semaphore,
+            num_preferred_links.value_or(1),
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            barrier_semaphore);
+    }
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -63,7 +63,7 @@ ttnn::Tensor all_broadcast_composite_all_gather(
         input_tensor,
         multi_device_global_semaphore[0],
         num_links,
-        input_tensor.memory_config(),
+        memory_config,
         ttnn::ccl::Topology::Linear,
         cluster_axis,
         subdevice_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -66,6 +66,7 @@ ttnn::Tensor all_broadcast_composite_all_gather(
         num_links,
         input_tensor.memory_config(),
         ttnn::ccl::Topology::Linear,
+        cluster_axis,
         subdevice_id,
         barrier_semaphore);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -15,20 +15,19 @@
 namespace ttnn::operations::experimental::ccl {
 
 bool use_native_all_gather(const ttnn::Tensor& input_tensor, const uint32_t dim) {
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_height = tile_shape[0];
+    uint32_t tile_width = tile_shape[1];
+
     // Row major
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
         return false;
     }
 
     // Tiled and padded on the gather dim
-    if (dim == 2 || dim == 3) {
-        auto input_shape = input_tensor.logical_shape();
-        auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-        uint32_t tile_height = tile_shape[0];
-        uint32_t tile_width = tile_shape[1];
-        if (input_shape[2] % tile_height != 0 || input_shape[3] % tile_width != 0) {
-            return false;
-        }
+    auto input_shape = input_tensor.logical_shape();
+    if ((dim == 2 && input_shape[2] % tile_height != 0) || (dim == 3 && input_shape[3] % tile_width != 0)) {
+        return false;
     }
 
     return true;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -5,10 +5,72 @@
 #include "all_gather_async.hpp"
 #include <utility>
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+#include "ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.hpp"
+// #include "ttnn/operations/core/to_layout/to_layout_op.cpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::experimental::ccl {
+
+bool use_native_all_gather(
+    const ttnn::Tensor& input_tensor, const std::optional<ttnn::MemoryConfig>& memory_config, const uint32_t dim) {
+    // Row major
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        return false;
+    }
+
+    // Tiled and padded on the gather dim
+    if (dim == 2 || dim == 3) {
+        auto input_shape = input_tensor.logical_shape();
+        if (input_shape[dim] % 32 != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+ttnn::Tensor all_broadcast_composite_all_gather(
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    TT_FATAL(
+        barrier_semaphore.has_value(),
+        "all_gather_async composite using all_broadcast_async requires a barrier semaphore");
+
+    ttnn::MemoryConfig output_memory_config = memory_config.value_or(input_tensor.memory_config());
+    bool is_tiled = input_tensor.layout() == Layout::TILE;
+
+    // Convert to row major
+    ttnn::Tensor all_broadcast_input_tensor =
+        is_tiled ? ttnn::to_layout(input_tensor, Layout::ROW_MAJOR) : input_tensor;
+
+    ttnn::MemoryConfig all_broadcast_memory_config = input_tensor.memory_config();
+    std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
+        input_tensor,
+        multi_device_global_semaphore[0],
+        num_links,
+        all_broadcast_memory_config,
+        ttnn::ccl::Topology::Linear,
+        subdevice_id,
+        barrier_semaphore);
+
+    ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, dim);
+
+    // Convert to tiled
+    if (is_tiled) {
+        all_gather_output_tensor = ttnn::to_layout(all_gather_output_tensor, Layout::TILE);
+    }
+
+    return all_gather_output_tensor;
+}
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
     const ttnn::Tensor& input_tensor,
@@ -20,6 +82,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    std::cout << "A" << std::endl;
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensor,
         dim,
@@ -47,6 +110,17 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
+    return all_broadcast_composite_all_gather(
+        input_tensor,
+        dim,
+        multi_device_global_semaphore,
+        num_links,
+        memory_config,
+        subdevice_id,
+        cluster_axis,
+        barrier_semaphore);
+
+    std::cout << "B" << std::endl;
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensor,
         persistent_output_buffer,
@@ -74,6 +148,7 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    std::cout << "C" << std::endl;
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensors,
         dim,
@@ -99,6 +174,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    std::cout << "D" << std::endl;
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensor,
         dim,
@@ -127,6 +203,7 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    std::cout << "E" << std::endl;
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensors,
         dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -72,12 +72,12 @@ ttnn::Tensor composite_all_gather(
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
         input_tensor,
         multi_device_global_semaphore[0],
+        barrier_semaphore,
         num_links,
         memory_config,
         ttnn::ccl::Topology::Linear,
         cluster_axis,
-        subdevice_id,
-        barrier_semaphore);
+        subdevice_id);
 
     ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, gather_dim);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25575)

### Problem description
- The training team needs AG to work when the gather dim has padding

### What's changed
- Composite AG: untilize -> all_broadcast -> concat -> tilize
  - With conditional dtype conversion if input is tiled bfloat8_b

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16896972893
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16896974582
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/16896977578
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/16896978889
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/16896981224
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
- [ ] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/16896990945
- [ ] T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/16896992046
