### PR TITLE
[Fabric] fix connectin info size to align 4 bytes

### DIFF
--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -122,19 +122,25 @@ struct tensix_routing_l1_info_t {
 } __attribute__((packed));
 
 struct fabric_connection_info_t {
-    uint8_t edm_direction;
-    uint8_t edm_noc_x;
-    uint8_t edm_noc_y;
     uint32_t edm_buffer_base_addr;
-    uint8_t num_buffers_per_channel;
     uint32_t edm_l1_sem_addr;
     uint32_t edm_connection_handshake_addr;
     uint32_t edm_worker_location_info_addr;
-    uint16_t buffer_size_bytes;
     uint32_t buffer_index_semaphore_id;
+    uint16_t buffer_size_bytes;
+    uint8_t edm_direction;
+    uint8_t edm_noc_x;
+    uint8_t edm_noc_y;
+    uint8_t num_buffers_per_channel;
+    // NOTE: This padding can be removed once "non device-init fabric"
+    //       is completely removed
+    uint8_t padding[2];
 } __attribute__((packed));
 
-static_assert(sizeof(fabric_connection_info_t) == 26, "Struct size mismatch!");
+static_assert(sizeof(fabric_connection_info_t) == 28, "Struct size mismatch!");
+// NOTE: This assertion can be removed once "non device-init fabric"
+//       is completely removed
+static_assert(sizeof(fabric_connection_info_t) % 4 == 0, "Struct size must be 4-byte aligned");
 
 struct fabric_aligned_connection_info_t {
     // 16-byte aligned semaphore address for flow control

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -110,8 +110,8 @@
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
-#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 688        // sizeof(tensix_fabric_connections_l1_info_t)
-#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO 432  // offsetof(tensix_fabric_connections_l1_info_t, read_write)
+#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 720        // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO 464  // offsetof(tensix_fabric_connections_l1_info_t, read_write)
 
 // Packet header pool sizing constants
 #define PACKET_HEADER_MAX_SIZE 64

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -104,8 +104,8 @@
 
 // Tensix fabric connection metadata for workers
 #define MEM_TENSIX_FABRIC_CONNECTIONS_BASE (MEM_TENSIX_ROUTING_TABLE_BASE + MEM_TENSIX_ROUTING_TABLE_SIZE)
-#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 688        // sizeof(tensix_fabric_connections_l1_info_t)
-#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO 432  // offsetof(tensix_fabric_connections_l1_info_t, read_write)
+#define MEM_TENSIX_FABRIC_CONNECTIONS_SIZE 720        // sizeof(tensix_fabric_connections_l1_info_t)
+#define MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO 464  // offsetof(tensix_fabric_connections_l1_info_t, read_write)
 
 // Packet header pool sizing constants
 #define PACKET_HEADER_MAX_SIZE 64


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26406

### Problem description
Mux bench has been hanged from PR https://github.com/tenstorrent/tt-metal/pull/25572

### What's changed
The mux bench has been writing custom connection information to (2-bytes aligned) L1 address, which cause the data to be corrupted.
Make the connection information to 28 bytes (4-bytes aligned).

Additionally reorder the contents for efficiently copy.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes