### PR TITLE
[Fabric] Fix the number of route_id

### DIFF
--- a/tt_metal/fabric/hw/inc/packet_header_pool.h
+++ b/tt_metal/fabric/hw/inc/packet_header_pool.h
@@ -31,8 +31,7 @@ private:
     static const uint32_t risc_pool_start = proc_type * POOL_SIZE_PER_RISC;
     static const uint32_t risc_pool_end = risc_pool_start + POOL_SIZE_PER_RISC;
     static uint8_t route_id_;
-    // !!!! really tight size limitation !!!!
-    static const uint32_t HEADER_GROUP_SIZE_PER_RISC = POOL_SIZE_PER_RISC / 4;
+    static const uint32_t HEADER_GROUP_SIZE_PER_RISC = NUM_PACKET_HEADERS / MaxDMProcessorsPerCoreType;
 
 public:
     // {route_id: [header_ptr, num_headers]}

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -115,13 +115,13 @@
 
 // Packet header pool sizing constants
 #define PACKET_HEADER_MAX_SIZE 64
-#define PACKET_HEADER_MAX_DIRECTIONS \
-    6 * 2 * MaxDMProcessorsPerCoreType  // (EAST, WEST, NORTH, SOUTH, UP, DOWN) * convention * (DM0, DM1)
+#define NUM_PACKET_HEADERS \
+    (6 * 2 * MaxDMProcessorsPerCoreType)  // (EAST, WEST, NORTH, SOUTH, UP, DOWN) * convention * (DM0, DM1)
 
 // Packet header pool for fabric networking
 // Size: 64 * 6 * 2 * 2 = 1536
 #define MEM_PACKET_HEADER_POOL_BASE (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_CONNECTIONS_SIZE)
-#define MEM_PACKET_HEADER_POOL_SIZE (PACKET_HEADER_MAX_SIZE * PACKET_HEADER_MAX_DIRECTIONS)
+#define MEM_PACKET_HEADER_POOL_SIZE (PACKET_HEADER_MAX_SIZE * NUM_PACKET_HEADERS)
 #if (MEM_PACKET_HEADER_POOL_BASE % 16 != 0) || (MEM_PACKET_HEADER_POOL_SIZE % 16 != 0)
 #error "Packet header pool base and size must be 16-byte aligned"
 #endif

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -109,13 +109,12 @@
 
 // Packet header pool sizing constants
 #define PACKET_HEADER_MAX_SIZE 64
-#define PACKET_HEADER_MAX_DIRECTIONS \
-    4 * 2 * MaxDMProcessorsPerCoreType  // (EAST, WEST, NORTH, SOUTH) * convention * (DM0, DM1)
+#define NUM_PACKET_HEADERS (4 * 2 * MaxDMProcessorsPerCoreType)  // (EAST, WEST, NORTH, SOUTH) * convention * (DM0, DM1)
 
 // Packet header pool for fabric networking
 // Size: 64 * 4 * 2 * 2 = 1024
 #define MEM_PACKET_HEADER_POOL_BASE (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_CONNECTIONS_SIZE)
-#define MEM_PACKET_HEADER_POOL_SIZE (PACKET_HEADER_MAX_SIZE * PACKET_HEADER_MAX_DIRECTIONS)
+#define MEM_PACKET_HEADER_POOL_SIZE (PACKET_HEADER_MAX_SIZE * NUM_PACKET_HEADERS)
 #if (MEM_PACKET_HEADER_POOL_BASE % 16 != 0) || (MEM_PACKET_HEADER_POOL_SIZE % 16 != 0)
 #error "Packet header pool base and size must be 16-byte aligned"
 #endif


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24881

### Problem description
HEADER_GROUP_SIZE_PER_RISC is intended to represent the number of maximum route_id, but it uses allocated header size bytes

### What's changed
Use the number of statically allocated headers. not bytes

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes