### PR TITLE
Fix compile time arguments generation for TensorAccessor

### DIFF
--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -89,7 +89,7 @@ TensorAccessorArgs::TensorAccessorArgs(const Buffer& buffer, tensor_accessor::Ar
     } else {
         args_config_ = tensor_accessor::ArgConfig::None;
     }
-    args_config_.set(tensor_accessor::ArgConfig::IsDram, buffer.is_dram());
+    args_config_.set(tensor_accessor::ArgConfig::IsDram, buffer.buffer_type() == BufferType::DRAM);
 
     if (args_config_.test(tensor_accessor::ArgConfig::RuntimeRank)) {
         TT_FATAL(


### PR DESCRIPTION
### Ticket

### Problem description
Compile time arguments generation in TensorAccessorArgs was incorrect, causing a failed test for stable diffusion model.
More specifically, TensorAccessorArgs used `buffer.is_dram()` to generate compile time arguments, however all program factories use `buffer.buffer_type() == BufferType::DRAM`, which surprisingly results in different values if tracing is enabled

### What's changed
Replaced `buffer.is_dram()` with `buffer.buffer_type() == BufferType::DRAM` in TensorAccessorArgs

### Checklist
- [ ] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16903427067)
- [x] [Stable diffusion CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16902980901/job/47886472805)
- [x] New/Existing tests provide coverage for changes