### PR TITLE
#21906: Added float32 support ttnn.softmax for dim != rank-1

### DIFF
--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp
@@ -83,6 +83,7 @@ FORCE_INLINE void noc_async_write_tile_helper(tt::CBIndex cb, uint32_t num_tiles
     cb_pop_front(cb, num_tiles);
 }
 
+template <typename T = uint16_t>
 FORCE_INLINE void generate_bcast_scaler(uint32_t cb_scaler, uint32_t scaler) {
     union {
         float f;
@@ -90,17 +91,22 @@ FORCE_INLINE void generate_bcast_scaler(uint32_t cb_scaler, uint32_t scaler) {
     } u;
     u.u = scaler;
     cb_reserve_back(cb_scaler, 1);
-    auto ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_scaler));
+    auto ptr = reinterpret_cast<T*>(get_write_ptr(cb_scaler));
 
     for (int j = 0; j < 1024; j++) {
-        ptr[j] = uint16_t(0);
+        ptr[j] = T(0);
     }
 
     for (int k = 0; k < 4; k++) {
         for (int j = 0; j < 16; j++) {
-            ptr[k * 256 + j] = uint16_t(u.u >> 16);
+            if constexpr (std::is_same_v<T, uint16_t>) {
+                ptr[k * 256 + j] = T(u.u >> 16);
+            } else {
+                ptr[k * 256 + j] = T(u.u);
+            }
         }
     }
+
     cb_push_back(cb_scaler, 1);
 }
 
@@ -167,139 +173,108 @@ FORCE_INLINE uint32_t get_tilized_gamma_beta_idx_in_tile(
     return tilized_idx_in_tile;
 }
 
+template <typename T>
+FORCE_INLINE T get_mask_value(const Scalar& scalar, bool is_one) {
+    if constexpr (std::is_same_v<T, uint16_t>) {
+        return T(scalar.u >> 16);
+    } else {
+        return T(scalar.u);
+    }
+}
+
+template <typename T>
+FORCE_INLINE void fill_subtile_mask_h(
+    T* ptr, uint32_t w, uint32_t subtile_offset, uint32_t active_height, const Scalar& one, const Scalar& zero) {
+    uint32_t h = 0;
+    // Fill active elements with one
+    for (; h < active_height; h++) {
+        ptr[h * 16 + w + subtile_offset] = get_mask_value<T>(one, true);
+    }
+    // Fill remaining elements with zero
+    for (; h < 16; h++) {
+        ptr[h * 16 + w + subtile_offset] = get_mask_value<T>(zero, false);
+    }
+}
+
+template <typename T>
+FORCE_INLINE void fill_subtile_mask_w(
+    T* ptr, uint32_t h, uint32_t subtile_offset, uint32_t active_width, const Scalar& one, const Scalar& zero) {
+    uint32_t w = 0;
+    // Fill active elements with one
+    for (; w < active_width; w++) {
+        ptr[h * 16 + w + subtile_offset] = get_mask_value<T>(one, true);
+    }
+    // Fill remaining elements with zero
+    for (; w < 16; w++) {
+        ptr[h * 16 + w + subtile_offset] = get_mask_value<T>(zero, false);
+    }
+}
+
+template <typename T = uint16_t>
 FORCE_INLINE void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
-    Scalar one;
-    Scalar zero;
+    Scalar one = {};
+    Scalar zero = {};
 
     one.f = 1.0f;
     zero.f = 0.0f;
 
     cb_reserve_back(cb_mask, 1);
-    auto ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask));
+    auto ptr = reinterpret_cast<T*>(get_write_ptr(cb_mask));
+
+    // Calculate mask heights for top and bottom subtiles
+    const uint32_t mask_h_top = (mask_h >= 16) ? 16 : mask_h;        // subtiles 0, 1
+    const uint32_t mask_h_bottom = (mask_h < 16) ? 0 : mask_h - 16;  // subtiles 2, 3
+
+    // Define subtile offsets: [0, 256, 512, 768] for subtiles [0, 1, 2, 3]
+    constexpr uint32_t subtile_offsets[4] = {0, 256, 512, 768};
 
     for (uint32_t w = 0; w < 16; w++) {
-        // sub tile 0
-        {
-            uint32_t mask_h_0 = mask_h;
-            if (mask_h_0 >= 16) {
-                mask_h_0 = 16;
-            }
-            uint32_t h = 0;
-            for (; h < mask_h_0; h++) {
-                ptr[h * 16 + w] = uint16_t(one.u >> 16);
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 0 (top-left)
+        fill_subtile_mask_h<T>(ptr, w, subtile_offsets[0], mask_h_top, one, zero);
 
-        // sub tile 1
-        {
-            uint32_t mask_h_0 = mask_h;
-            if (mask_h_0 >= 16) {
-                mask_h_0 = 16;
-            }
-            uint32_t h = 0;
-            for (; h < mask_h_0; h++) {
-                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 1 (top-right)
+        fill_subtile_mask_h<T>(ptr, w, subtile_offsets[1], mask_h_top, one, zero);
 
-        // sub tile 2
-        {
-            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
-            uint32_t h = 0;
-            for (; h < mask_h_1; h++) {
-                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 2 (bottom-left)
+        fill_subtile_mask_h<T>(ptr, w, subtile_offsets[2], mask_h_bottom, one, zero);
 
-        // sub tile 3
-        {
-            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
-            uint32_t h = 0;
-            for (; h < mask_h_1; h++) {
-                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 3 (bottom-right)
+        fill_subtile_mask_h<T>(ptr, w, subtile_offsets[3], mask_h_bottom, one, zero);
     }
 
     cb_push_back(cb_mask, 1);
 }
 
+template <typename T = uint16_t>
 FORCE_INLINE void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
-    Scalar one;
-    Scalar zero;
+    Scalar one = {};
+    Scalar zero = {};
 
     one.f = 1.0f;
     zero.f = 0.0f;
 
     cb_reserve_back(cb_mask, 1);
-    auto ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_mask));
+    auto ptr = reinterpret_cast<T*>(get_write_ptr(cb_mask));
+
+    // Calculate mask widths for left and right subtiles
+    const uint32_t mask_w_left = (mask_w >= 16) ? 16 : mask_w;      // subtiles 0, 2
+    const uint32_t mask_w_right = (mask_w < 16) ? 0 : mask_w - 16;  // subtiles 1, 3
+
+    // Define subtile offsets: [0, 256, 512, 768] for subtiles [0, 1, 2, 3]
+    constexpr uint32_t subtile_offsets[4] = {0, 256, 512, 768};
 
     for (uint32_t h = 0; h < 16; h++) {
-        // sub tile 0
-        {
-            uint32_t mask_w_0 = mask_w;
-            if (mask_w_0 >= 16) {
-                mask_w_0 = 16;
-            }
-            uint32_t w = 0;
-            for (; w < mask_w_0; w++) {
-                ptr[h * 16 + w] = uint16_t(one.u >> 16);
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 0 (top-left)
+        fill_subtile_mask_w<T>(ptr, h, subtile_offsets[0], mask_w_left, one, zero);
 
-        // sub tile 1
-        {
-            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
-            uint32_t w = 0;
-            for (; w < mask_w_1; w++) {
-                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 1 (top-right)
+        fill_subtile_mask_w<T>(ptr, h, subtile_offsets[1], mask_w_right, one, zero);
 
-        // sub tile 2
-        {
-            uint32_t mask_w_0 = mask_w;
-            if (mask_w_0 >= 16) {
-                mask_w_0 = 16;
-            }
-            uint32_t w = 0;
-            for (; w < mask_w_0; w++) {
-                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 2 (bottom-left)
+        fill_subtile_mask_w<T>(ptr, h, subtile_offsets[2], mask_w_left, one, zero);
 
-        // sub tile 3
-        {
-            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
-            uint32_t w = 0;
-            for (; w < mask_w_1; w++) {
-                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
-            }
-        }
+        // sub tile 3 (bottom-right)
+        fill_subtile_mask_w<T>(ptr, h, subtile_offsets[3], mask_w_right, one, zero);
     }
 
     cb_push_back(cb_mask, 1);
@@ -316,60 +291,25 @@ FORCE_INLINE void generate_int_mask_h(uint32_t cb_mask, uint32_t mask_h) {
     cb_reserve_back(cb_mask, 1);
     auto ptr = reinterpret_cast<int32_t*>(get_write_ptr(cb_mask));
 
+    // Calculate mask heights for top and bottom subtiles
+    const uint32_t mask_h_top = (mask_h >= 16) ? 16 : mask_h;        // subtiles 0, 1
+    const uint32_t mask_h_bottom = (mask_h < 16) ? 0 : mask_h - 16;  // subtiles 2, 3
+
+    // Define subtile offsets: [0, 256, 512, 768] for subtiles [0, 1, 2, 3]
+    constexpr uint32_t subtile_offsets[4] = {0, 256, 512, 768};
+
     for (uint32_t w = 0; w < 16; w++) {
-        // sub tile 0
-        {
-            uint32_t mask_h_0 = mask_h;
-            if (mask_h_0 >= 16) {
-                mask_h_0 = 16;
-            }
-            uint32_t h = 0;
-            for (; h < mask_h_0; h++) {
-                ptr[h * 16 + w] = one.u;
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w] = zero.u;
-            }
-        }
+        // sub tile 0 (top-left)
+        fill_subtile_mask_h<int32_t>(ptr, w, subtile_offsets[0], mask_h_top, one, zero);
 
-        // sub tile 1
-        {
-            uint32_t mask_h_0 = mask_h;
-            if (mask_h_0 >= 16) {
-                mask_h_0 = 16;
-            }
-            uint32_t h = 0;
-            for (; h < mask_h_0; h++) {
-                ptr[h * 16 + w + 256] = one.u;
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w + 256] = zero.u;
-            }
-        }
+        // sub tile 1 (top-right)
+        fill_subtile_mask_h<int32_t>(ptr, w, subtile_offsets[1], mask_h_top, one, zero);
 
-        // sub tile 2
-        {
-            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
-            uint32_t h = 0;
-            for (; h < mask_h_1; h++) {
-                ptr[h * 16 + w + 512] = one.u;
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w + 512] = zero.u;
-            }
-        }
+        // sub tile 2 (bottom-left)
+        fill_subtile_mask_h<int32_t>(ptr, w, subtile_offsets[2], mask_h_bottom, one, zero);
 
-        // sub tile 3
-        {
-            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
-            uint32_t h = 0;
-            for (; h < mask_h_1; h++) {
-                ptr[h * 16 + w + 768] = one.u;
-            }
-            for (; h < 16; h++) {
-                ptr[h * 16 + w + 768] = zero.u;
-            }
-        }
+        // sub tile 3 (bottom-right)
+        fill_subtile_mask_h<int32_t>(ptr, w, subtile_offsets[3], mask_h_bottom, one, zero);
     }
 
     cb_push_back(cb_mask, 1);
@@ -385,60 +325,25 @@ FORCE_INLINE void generate_int_mask_w(uint32_t cb_mask, uint32_t mask_w) {
     cb_reserve_back(cb_mask, 1);
     auto ptr = reinterpret_cast<int32_t*>(get_write_ptr(cb_mask));
 
+    // Calculate mask widths for left and right subtiles
+    const uint32_t mask_w_left = (mask_w >= 16) ? 16 : mask_w;      // subtiles 0, 2
+    const uint32_t mask_w_right = (mask_w < 16) ? 0 : mask_w - 16;  // subtiles 1, 3
+
+    // Define subtile offsets: [0, 256, 512, 768] for subtiles [0, 1, 2, 3]
+    constexpr uint32_t subtile_offsets[4] = {0, 256, 512, 768};
+
     for (uint32_t h = 0; h < 16; h++) {
-        // sub tile 0
-        {
-            uint32_t mask_w_0 = mask_w;
-            if (mask_w_0 >= 16) {
-                mask_w_0 = 16;
-            }
-            uint32_t w = 0;
-            for (; w < mask_w_0; w++) {
-                ptr[h * 16 + w] = one.u;
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w] = zero.u;
-            }
-        }
+        // sub tile 0 (top-left)
+        fill_subtile_mask_w<int32_t>(ptr, h, subtile_offsets[0], mask_w_left, one, zero);
 
-        // sub tile 1
-        {
-            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
-            uint32_t w = 0;
-            for (; w < mask_w_1; w++) {
-                ptr[h * 16 + w + 256] = one.u;
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w + 256] = zero.u;
-            }
-        }
+        // sub tile 1 (top-right)
+        fill_subtile_mask_w<int32_t>(ptr, h, subtile_offsets[1], mask_w_right, one, zero);
 
-        // sub tile 2
-        {
-            uint32_t mask_w_0 = mask_w;
-            if (mask_w_0 >= 16) {
-                mask_w_0 = 16;
-            }
-            uint32_t w = 0;
-            for (; w < mask_w_0; w++) {
-                ptr[h * 16 + w + 512] = one.u;
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w + 512] = zero.u;
-            }
-        }
+        // sub tile 2 (bottom-left)
+        fill_subtile_mask_w<int32_t>(ptr, h, subtile_offsets[2], mask_w_left, one, zero);
 
-        // sub tile 3
-        {
-            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
-            uint32_t w = 0;
-            for (; w < mask_w_1; w++) {
-                ptr[h * 16 + w + 768] = one.u;
-            }
-            for (; w < 16; w++) {
-                ptr[h * 16 + w + 768] = zero.u;
-            }
-        }
+        // sub tile 3 (bottom-right)
+        fill_subtile_mask_w<int32_t>(ptr, h, subtile_offsets[3], mask_w_right, one, zero);
     }
 
     cb_push_back(cb_mask, 1);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
@@ -1,36 +1,44 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t N = get_arg_val<uint32_t>(1);
-    uint32_t tile_offset = get_arg_val<uint32_t>(2);
-    uint32_t Ht = get_arg_val<uint32_t>(3);
-    uint32_t Wt = get_arg_val<uint32_t>(4);
-    uint32_t scaler = get_arg_val<uint32_t>(5);
-    uint32_t mask_h = get_arg_val<uint32_t>(6);
+    // Runtime arguments
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t N = get_arg_val<uint32_t>(1);
+    const uint32_t tile_offset = get_arg_val<uint32_t>(2);
+    const uint32_t Ht = get_arg_val<uint32_t>(3);
+    const uint32_t Wt = get_arg_val<uint32_t>(4);
+    const uint32_t scaler = get_arg_val<uint32_t>(5);
+    const uint32_t mask_h = get_arg_val<uint32_t>(6);
 
+    // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_mask = tt::CBIndex::c_1;
     constexpr auto cb_scaler = tt::CBIndex::c_2;
 
-    uint32_t l1_write_addr_in;
-
-    // ublocks size defined in tiles
+    // Ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
 
-    constexpr auto in_args = TensorAccessorArgs<0>();
+    // Input tensor
+    constexpr bool is_fp32 = get_compile_time_arg_val(0) == 1;
+    constexpr auto in_args = TensorAccessorArgs<1>();
     const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
-    // TODO(AP): cleanup, probably with named args/param pack/reflection.
-    generate_bcast_scaler(cb_scaler, scaler);
-    generate_mask_h(cb_mask, mask_h);
+    // Generate scaler and mask tiles
+    if (is_fp32) {
+        generate_bcast_scaler<uint32_t>(cb_scaler, scaler);
+        generate_mask_h<uint32_t>(cb_mask, mask_h);
+    } else {
+        generate_bcast_scaler<uint16_t>(cb_scaler, scaler);
+        generate_mask_h<uint16_t>(cb_mask, mask_h);
+    }
 
-    // read ublocks from src0 to CB0, then push ublocks to compute (unpacker)
+    // Read ublocks from src0 to CB0, then push ublocks to compute kernel
+    uint32_t l1_write_addr_in = 0;
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         uint32_t w_idx = curr_tile % Wt;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
@@ -1,36 +1,44 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t N = get_arg_val<uint32_t>(1);
-    uint32_t tile_offset = get_arg_val<uint32_t>(2);
-    uint32_t Ht = get_arg_val<uint32_t>(3);
-    uint32_t Wt = get_arg_val<uint32_t>(4);
-    uint32_t scaler = get_arg_val<uint32_t>(5);
-    uint32_t mask_h = get_arg_val<uint32_t>(6);
+    // Runtime args
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t N = get_arg_val<uint32_t>(1);
+    const uint32_t tile_offset = get_arg_val<uint32_t>(2);
+    const uint32_t Ht = get_arg_val<uint32_t>(3);
+    const uint32_t Wt = get_arg_val<uint32_t>(4);
+    const uint32_t scaler = get_arg_val<uint32_t>(5);
+    const uint32_t mask_h = get_arg_val<uint32_t>(6);
 
+    // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_mask = tt::CBIndex::c_1;
     constexpr auto cb_scaler = tt::CBIndex::c_2;
 
-    uint32_t l1_write_addr_in;
-
-    // ublocks size defined in tiles
+    // Ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
 
-    constexpr auto in_args = TensorAccessorArgs<0>();
+    // Input tensor
+    constexpr bool is_fp32 = get_compile_time_arg_val(0) == 1;
+    constexpr auto in_args = TensorAccessorArgs<1>();
     const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
-    // TODO(AP): cleanup, probably with named args/param pack/reflection.
-    generate_bcast_scaler(cb_scaler, scaler);
-    generate_mask_h(cb_mask, mask_h);
+    // Generate scaler and mask tiles
+    if (is_fp32) {
+        generate_bcast_scaler<uint32_t>(cb_scaler, scaler);
+        generate_mask_h<uint32_t>(cb_mask, mask_h);
+    } else {
+        generate_bcast_scaler<uint16_t>(cb_scaler, scaler);
+        generate_mask_h<uint16_t>(cb_mask, mask_h);
+    }
 
-    // read ublocks from src0 to CB0, then push ublocks to compute (unpacker)
+    // read ublocks from src0 to CB0, then push ublocks to compute kernel
+    uint32_t l1_write_addr_in = 0;
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         uint32_t w_idx = curr_tile % Wt;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
@@ -1,35 +1,45 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
-void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t N = get_arg_val<uint32_t>(1);
-    uint32_t tile_offset = get_arg_val<uint32_t>(2);
-    uint32_t Wt = get_arg_val<uint32_t>(3);
-    uint32_t scaler = get_arg_val<uint32_t>(4);
-    uint32_t mask_w = get_arg_val<uint32_t>(5);
+#include <cstdint>
 
+void kernel_main() {
+    // Runtime args
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t N = get_arg_val<uint32_t>(1);
+    const uint32_t tile_offset = get_arg_val<uint32_t>(2);
+    const uint32_t Wt = get_arg_val<uint32_t>(3);
+    const uint32_t scaler = get_arg_val<uint32_t>(4);
+    const uint32_t mask_w = get_arg_val<uint32_t>(5);
+
+    // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_mask = tt::CBIndex::c_1;
     constexpr auto cb_scaler = tt::CBIndex::c_2;
 
-    uint32_t l1_write_addr_in;
-
-    // ublocks size defined in tiles
+    // Ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
 
-    constexpr auto in_args = TensorAccessorArgs<0>();
+    // Input tensor
+    constexpr bool is_fp32 = get_compile_time_arg_val(0) == 1;
+    constexpr auto in_args = TensorAccessorArgs<1>();
     const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
-    // TODO(AP): cleanup, probably with named args/param pack/reflection.
-    generate_bcast_scaler(cb_scaler, scaler);
-    generate_mask_w(cb_mask, mask_w);
+    // Generate scaler and mask tiles
+    if (is_fp32) {
+        generate_bcast_scaler<uint32_t>(cb_scaler, scaler);
+        generate_mask_w<uint32_t>(cb_mask, mask_w);
+    } else {
+        generate_bcast_scaler<uint16_t>(cb_scaler, scaler);
+        generate_mask_w<uint16_t>(cb_mask, mask_w);
+    }
 
-    // read ublocks from src0 to CB0, then push ublocks to compute (unpacker)
+    // Read ublocks from src0 to CB0, then push ublocks to compute kernel
+    uint32_t l1_write_addr_in = 0;
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         cb_reserve_back(cb_in, Wt);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
@@ -1,35 +1,45 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
-void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t N = get_arg_val<uint32_t>(1);
-    uint32_t tile_offset = get_arg_val<uint32_t>(2);
-    uint32_t Wt = get_arg_val<uint32_t>(3);
-    uint32_t scaler = get_arg_val<uint32_t>(4);
-    uint32_t mask_w = get_arg_val<uint32_t>(5);
+#include <cstdint>
 
+void kernel_main() {
+    // Runtime args
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t N = get_arg_val<uint32_t>(1);
+    const uint32_t tile_offset = get_arg_val<uint32_t>(2);
+    const uint32_t Wt = get_arg_val<uint32_t>(3);
+    const uint32_t scaler = get_arg_val<uint32_t>(4);
+    const uint32_t mask_w = get_arg_val<uint32_t>(5);
+
+    // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_mask = tt::CBIndex::c_1;
     constexpr auto cb_scaler = tt::CBIndex::c_2;
 
-    uint32_t l1_write_addr_in;
-
-    // ublocks size defined in tiles
+    // Ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t src_in_tile_bytes = get_tile_size(cb_in);
 
-    constexpr auto in_args = TensorAccessorArgs<0>();
+    // Input tensor
+    constexpr bool is_fp32 = get_compile_time_arg_val(0) == 1;
+    constexpr auto in_args = TensorAccessorArgs<1>();
     const auto src_in = TensorAccessor(in_args, src_addr, src_in_tile_bytes);
 
-    // TODO(AP): cleanup, probably with named args/param pack/reflection.
-    generate_bcast_scaler(cb_scaler, scaler);
-    generate_mask_w(cb_mask, mask_w);
+    // Generate scaler and mask tiles
+    if (is_fp32) {
+        generate_bcast_scaler<uint32_t>(cb_scaler, scaler);
+        generate_mask_w<uint32_t>(cb_mask, mask_w);
+    } else {
+        generate_bcast_scaler<uint16_t>(cb_scaler, scaler);
+        generate_mask_w<uint16_t>(cb_mask, mask_w);
+    }
 
-    // read ublocks from src0 to CB0, then push ublocks to compute (unpacker)
+    // Read ublocks from src0 to CB0, then push ublocks to compute kernel
+    uint32_t l1_write_addr_in = 0;
     uint32_t curr_tile = tile_offset;
     for (uint32_t i = 0; i < N; i += onetile) {
         uint32_t curr_offset_i = curr_tile;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp
@@ -5,16 +5,19 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
+    // Runtime args
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t N = get_arg_val<uint32_t>(1);
     uint32_t tile_offset = get_arg_val<uint32_t>(2);
     uint32_t Ht = get_arg_val<uint32_t>(3);
     uint32_t Wt = get_arg_val<uint32_t>(4);
 
+    // Constants
     constexpr uint32_t cb_id_out = tt::CBIndex::c_16;
     constexpr uint32_t onetile = 1;
-    uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
 
+    // Output tensor
     constexpr auto out_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(out_args, dst_addr, tile_bytes);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_softmax_device_operation.hpp"
-
+#include <enchantum/enchantum.hpp>  // to_string
+#include <enchantum/iostream.hpp>   // iostream support
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::moreh::moreh_softmax {
@@ -73,7 +74,8 @@ bool is_moreh_softmax_h_small_available(const Tensor& tensor, const DeviceComput
 MorehSoftmaxOperation::program_factory_t MorehSoftmaxOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto strategy = get_parallelization_strategy(operation_attributes, tensor_args);
-
+    std::cout << "moreh_softmax_device_operation.cpp:select_program_factory - strategy: "
+              << enchantum::to_string(strategy) << std::endl;
     switch (strategy) {
         case MorehSoftmaxOpParallelizationStrategy::SMALL_W: return MorehSoftmaxWSmallFactory{};
         case MorehSoftmaxOpParallelizationStrategy::SMALL_H: return MorehSoftmaxHSmallFactory{};
@@ -89,9 +91,6 @@ void MorehSoftmaxOperation::validate_inputs(
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
     TT_FATAL(input.buffer() != nullptr, "Operands to softmax need to be allocated in buffers on device!");
     TT_FATAL((input.layout() == Layout::TILE), "Inputs to softmax must be tilized");
-    TT_FATAL(
-        input.dtype() == DataType::BFLOAT16 || input.dtype() == DataType::BFLOAT8_B,
-        "Inputs must be of bfloat16 or bfloat8_b type");
 
     const auto rank = input.logical_shape().rank();
     const auto dim = operation_attributes.dim;
@@ -155,7 +154,8 @@ MorehSoftmaxOpParallelizationStrategy MorehSoftmaxOperation::get_parallelization
     const auto strategy = operation_attributes.strategy;
     const auto dim = operation_attributes.dim;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
-
+    std::cout << "moreh_softmax_device_operation.cpp:get_parallelization_strategy - strategy: "
+              << enchantum::to_string(strategy) << std::endl;
     auto rank = input.logical_shape().rank();
     if (strategy == MorehSoftmaxOpParallelizationStrategy::NONE) {
         if (rank - 1 == dim) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
@@ -140,13 +140,15 @@ MorehSoftmaxOperation::invoke(
     const MorehSoftmaxOpParallelizationStrategy strategy,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    const bool is_fp32 = input.dtype() == DataType::FLOAT32;
     return {
         operation_attributes_t{
             dim,
             op,
             strategy,
             memory_config.value_or(input.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
+            init_device_compute_kernel_config(
+                input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32)},
         tensor_args_t{input, output}};
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -42,8 +42,10 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    if (input.dtype() == DataType::FLOAT32) {
-        fp32_dest_acc_en = true;
+    if (input.dtype() == DataType::FLOAT32 && fp32_dest_acc_en != true) {
+        TT_THROW(
+            "FP32 destination accumulation must be enabled when input tensor has FLOAT32 data type. Please update the "
+            "compute kernel configuration.");
     }
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -42,6 +42,10 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
+    if (input.dtype() == DataType::FLOAT32) {
+        fp32_dest_acc_en = true;
+    }
+
     Program program = Program();
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -41,6 +41,10 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
+    if (input.dtype() == DataType::FLOAT32) {
+        fp32_dest_acc_en = true;
+    }
+
     Program program = Program();
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -41,8 +41,10 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    if (input.dtype() == DataType::FLOAT32) {
-        fp32_dest_acc_en = true;
+    if (input.dtype() == DataType::FLOAT32 && fp32_dest_acc_en != true) {
+        TT_THROW(
+            "FP32 destination accumulation must be enabled when input tensor has FLOAT32 data type. Please update the "
+            "compute kernel configuration.");
     }
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -68,11 +68,11 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    std::vector<uint32_t> reader_ct_args = {};
+    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels//reader_moreh_softmax_h_large.cpp",
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp",
         all_cores,
         reader_ct_args,
         reader_defines);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -43,8 +43,10 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    if (input.dtype() == DataType::FLOAT32) {
-        fp32_dest_acc_en = true;
+    if (input.dtype() == DataType::FLOAT32 && fp32_dest_acc_en != true) {
+        TT_THROW(
+            "FP32 destination accumulation must be enabled when input tensor has FLOAT32 data type. Please update the "
+            "compute kernel configuration.");
     }
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -1,12 +1,13 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
-#include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+
+#include <string>
+#include <cstdint>
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
@@ -69,7 +70,7 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    std::vector<uint32_t> reader_ct_args = {};
+    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -43,6 +43,10 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
+    if (input.dtype() == DataType::FLOAT32) {
+        fp32_dest_acc_en = true;
+    }
+
     Program program = Program();
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -1,12 +1,13 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
-#include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+
+#include <cstdint>
+#include <string>
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
@@ -69,7 +70,7 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    std::vector<uint32_t> reader_ct_args = {};
+    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -43,6 +43,10 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
+    if (input.dtype() == DataType::FLOAT32) {
+        fp32_dest_acc_en = true;
+    }
+
     Program program = Program();
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -43,8 +43,10 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    if (input.dtype() == DataType::FLOAT32) {
-        fp32_dest_acc_en = true;
+    if (input.dtype() == DataType::FLOAT32 && fp32_dest_acc_en != true) {
+        TT_THROW(
+            "FP32 destination accumulation must be enabled when input tensor has FLOAT32 data type. Please update the "
+            "compute kernel configuration.");
     }
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -68,8 +68,7 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {};
+    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
     auto reader_kernel_id = CreateReadKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#include "tt-metalium/assert.hpp"
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
@@ -42,8 +43,10 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    if (input.dtype() == DataType::FLOAT32) {
-        fp32_dest_acc_en = true;
+    if (input.dtype() == DataType::FLOAT32 && fp32_dest_acc_en != true) {
+        TT_THROW(
+            "FP32 destination accumulation must be enabled when input tensor has FLOAT32 data type. Please update the "
+            "compute kernel configuration.");
     }
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -42,6 +42,10 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
+    if (input.dtype() == DataType::FLOAT32) {
+        fp32_dest_acc_en = true;
+    }
+
     Program program = Program();
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
 
 #ifdef DO_MASK_H
     constexpr uint32_t cb_id_mask_h = 1;
-    generate_int_mask_h(cb_id_mask_h, mask_h);
+    generate_mask_h<int32_t>(cb_id_mask_h, mask_h);
 #endif
 
     const auto s = TensorAccessor(src_args, src_addr, tile_bytes);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_mask_w = 1;
 #ifdef DO_MASK_W
-    generate_int_mask_w(cb_id_mask_w, mask_w);
+    generate_mask_w<int32_t>(cb_id_mask_w, mask_w);
 #endif
 
     // ublocks size defined in tiles


### PR DESCRIPTION
### Ticket
#21906

### Problem description
When using `ttnn.softmax` with `float32` dtype and `dim != rank -1` it produced wrong results. 

### What's changed
- Added `float32` support, 
- Added test for different types. 

### Next steps
As part of the next steps, the softmax will be cleaned up. The Moreh implementation will be merged with the one in the normalization directory, and the tests will be unified. [#26841](https://github.com/tenstorrent/tt-metal/issues/26841)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16961652510
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16933458487
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes