### PR TITLE
collate test names

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -37,33 +37,33 @@ jobs:
         test-group:
           - name: All C++
             cmd: ./tests/scripts/run_cpp_unit_tests.sh # 15 minutes
-          - name: tools
-            cmd: |
-              ./tests/scripts/run_tools_tests.sh
-              ./build/test/tt_metal/unit_tests_debug_tools
-          - name: user kernel path
-            cmd: |
-              rm -rf /tmp/kernels
-              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
-          - name: dispatch
-            cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch" # 15 minutes
-          - name: eth and misc
-            cmd: |
-              ./build/test/tt_metal/unit_tests_eth
-              ./build/test/tt_metal/unit_tests_misc
-          - name: distributed
-            cmd: |
-              ./build/test/tt_metal/distributed/distributed_unit_tests
-              ./tests/tt_metal/multihost/run_multiprocess_socket_tests.sh
-          - name: dispatch multicmd queue
-            cmd: |
-              TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQ*Fixture.*
           - name: CCL
             cmd: |
               ./build/test/ttnn/unit_tests_ttnn_ccl
               ./build/test/ttnn/unit_tests_ttnn_ccl_ops
+          - name: dispatch
+            cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch" # 15 minutes
+          - name: dispatch multicmd queue
+            cmd: |
+              TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQ*Fixture.*
+          - name: distributed
+            cmd: |
+              ./build/test/tt_metal/distributed/distributed_unit_tests
+              ./tests/tt_metal/multihost/run_multiprocess_socket_tests.sh
+          - name: eth and misc
+            cmd: |
+              ./build/test/tt_metal/unit_tests_eth
+              ./build/test/tt_metal/unit_tests_misc
+          - name: tools
+            cmd: |
+              ./tests/scripts/run_tools_tests.sh
+              ./build/test/tt_metal/unit_tests_debug_tools
           - name: ttnn tensor accessor
             cmd: "./build/test/ttnn/unit_tests_ttnn_accessor"
+          - name: user kernel path
+            cmd: |
+              rm -rf /tmp/kernels
+              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image }}


### PR DESCRIPTION
### Ticket
NE

### Problem description
the c++ unit tests are not in order

### What's changed
Collate the test names

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes