### PR TITLE
Append logical tensor shape columns

### DIFF
--- a/tests/ttnn/tracy/test_perf_op_report.py
+++ b/tests/ttnn/tracy/test_perf_op_report.py
@@ -44,6 +44,11 @@ def verify_columns(received_columns, expected_columns, verify_func):
     assert len(failures) == 0, "\n" + "\n".join(failures)
 
 
+def get_first_op_columns(columns):
+    firstOpIndex = 0
+    return {column: columns[column][firstOpIndex] for column in columns}
+
+
 matmul_test = {
     "name": "Matmul",
     "command": "pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py::test_run_matmul_test[BFLOAT16-input_shapes0]",
@@ -53,24 +58,49 @@ matmul_test = {
 @skip_for_blackhole()
 @pytest.mark.parametrize("run_test", [pytest.param(matmul_test, id=matmul_test["name"])], indirect=True)
 class TestSingleOp:
-    def get_first_op_columns(cls, columns):
-        firstOpIndex = 0
-        return {column: columns[column][firstOpIndex] for column in columns}
-
     def test_core_count(self, run_test_do_post_proc):
         res, request = run_test_do_post_proc
-        received_columns = self.get_first_op_columns(res)
+        received_columns = get_first_op_columns(res)
         expected_columns = {"CORE COUNT": 1}
         verify_columns(received_columns, expected_columns, verify_equal)
 
     def test_performance_models(self, run_test_do_post_proc):
         res, request = run_test_do_post_proc
-        received_columns = self.get_first_op_columns(res)
+        received_columns = get_first_op_columns(res)
         expected_columns = {
             "PM IDEAL [ns]": 7,
             "PM COMPUTE [ns]": 1,
             "PM BANDWIDTH [ns]": 7,
             "PM REQ I BW": "[292.5714416503906; 292.5714416503906]",
             "PM REQ O BW": "[292.5714416503906]",
+        }
+        verify_columns(received_columns, expected_columns, verify_equal)
+
+
+matmul_test_tensor_io = {
+    "name": "Matmul_tensor_io",
+    "command": 'pytest "\\"tests/ttnn/unit_tests/operations/matmul/test_matmul.py::test_matmul_padding[program_config=MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(in0_block_w=1,per_core_M=1,per_core_N=1,fused_activation=std::nullopt)-input_a_memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::WIDTH_SHARDED,buffer_type=BufferType::L1,shard_spec=ShardSpec(grid={[(x=0,y=0) - (x=2,y=0)]},shape={32, 32},orientation=ShardOrientation::ROW_MAJOR,mode=ShardMode::PHYSICAL,physical_shard_shape=std::nullopt),nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)-input_b_memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::WIDTH_SHARDED,buffer_type=BufferType::DRAM,shard_spec=ShardSpec(grid={[(x=0,y=0) - (x=2,y=0)]},shape={96, 32},orientation=ShardOrientation::ROW_MAJOR,mode=ShardMode::PHYSICAL,physical_shard_shape=std::nullopt),nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)-output_memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::WIDTH_SHARDED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)-input_a_shape=(32, 96)-input_b_shape=(96, 32)-input_a_reshape=(1, 65)-input_b_reshape=(65, 16)-input_a_value=4.0-input_b_value=2.0]\\""',
+}
+
+
+@skip_for_blackhole()
+@pytest.mark.parametrize("run_test", [pytest.param(matmul_test_tensor_io, id=matmul_test["name"])], indirect=True)
+class TestTensorIO:
+    def test_tensor_io(self, run_test_do_post_proc):
+        res, request = run_test_do_post_proc
+        received_columns = get_first_op_columns(res)
+        expected_columns = {
+            "INPUT_0_W_PAD[LOGICAL]": "1[1]",
+            "INPUT_0_Z_PAD[LOGICAL]": "1[1]",
+            "INPUT_0_Y_PAD[LOGICAL]": "32[1]",
+            "INPUT_0_X_PAD[LOGICAL]": "96[65]",
+            "INPUT_1_W_PAD[LOGICAL]": "1[1]",
+            "INPUT_1_Z_PAD[LOGICAL]": "1[1]",
+            "INPUT_1_Y_PAD[LOGICAL]": "96[65]",
+            "INPUT_1_X_PAD[LOGICAL]": "32[16]",
+            "OUTPUT_0_W_PAD[LOGICAL]": "1[1]",
+            "OUTPUT_0_Z_PAD[LOGICAL]": "1[1]",
+            "OUTPUT_0_Y_PAD[LOGICAL]": "32[1]",
+            "OUTPUT_0_X_PAD[LOGICAL]": "32[16]",
         }
         verify_columns(received_columns, expected_columns, verify_equal)

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -691,9 +691,10 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
             data = {}
             if ioField == "shape":
                 for field in ["W", "Z", "Y", "X"]:
-                    headers.append(field)
+                    padded_logical_field = field + "_PAD[LOGICAL]"
+                    headers.append(padded_logical_field)
                     assert field in ioData, "Wrong io tensor shape data format"
-                    data[field] = ioData[field]
+                    data[padded_logical_field] = ioData[field]
             elif ioField == "dtype":
                 headers = ["DATATYPE"]
                 data["DATATYPE"] = ioData

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -281,11 +281,21 @@ static inline json get_tensor_json(const Tensor& tensor) {
         ret["storage_type"] = fmt::format("{}", enchantum::to_string(tensor.storage_type()));
     }
 
-    auto tensor_shape = tensor.padded_shape();
-    ret["shape"]["W"] = tensor_shape.rank() >= 4 ? tensor_shape[-4] : 1;
-    ret["shape"]["Z"] = tensor_shape.rank() >= 3 ? tensor_shape[-3] : 1;
-    ret["shape"]["Y"] = tensor_shape.rank() >= 2 ? tensor_shape[-2] : 1;
-    ret["shape"]["X"] = tensor_shape[-1];
+    auto tensor_shape_padded = tensor.padded_shape();
+    auto tensor_shape_logical = tensor.logical_shape();
+    ret["shape"]["W"] = fmt::format(
+        "{}[{}]",
+        tensor_shape_padded.rank() >= 4 ? tensor_shape_padded[-4] : 1,
+        tensor_shape_logical.rank() >= 4 ? tensor_shape_logical[-4] : 1);
+    ret["shape"]["Z"] = fmt::format(
+        "{}[{}]",
+        tensor_shape_padded.rank() >= 3 ? tensor_shape_padded[-3] : 1,
+        tensor_shape_logical.rank() >= 3 ? tensor_shape_logical[-3] : 1);
+    ret["shape"]["Y"] = fmt::format(
+        "{}[{}]",
+        tensor_shape_padded.rank() >= 2 ? tensor_shape_padded[-2] : 1,
+        tensor_shape_logical.rank() >= 2 ? tensor_shape_logical[-2] : 1);
+    ret["shape"]["X"] = fmt::format("{}[{}]", tensor_shape_padded[-1], tensor_shape_logical[-1]);
     ret["layout"] = fmt::format("{}", enchantum::to_string(tensor.layout()));
     ret["dtype"] = fmt::format("{}", enchantum::to_string(tensor.dtype()));
 


### PR DESCRIPTION
### Ticket
[#26585](https://github.com/tenstorrent/tt-metal/issues/26585)

### Problem description
Logical tensor shape is not presented in ops perf report

### What's changed
Show logical shape alongside padded 
<img width="495" height="232" alt="Screenshot 2025-08-12 at 11 03 39 AM" src="https://github.com/user-attachments/assets/26b7d3b0-ddd7-4cbc-810f-5b0a21763933" />


### Checklist
- [x] [All post commit - profiler only](https://github.com/tenstorrent/tt-metal/actions/runs/16966275913)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/16912942725)