### PR TITLE
Set --min-connections 4 for deskbox system health check

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -30,16 +30,23 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        test-group: [
-          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*" },
-          {name: fabric 1D performance microbenchmarks, cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py },
-          {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
-          {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
-          {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },
-          {name: all gather nightly test, cmd: pytest tests/nightly/bh/ccl/all_gather_nightly.py -k "test_all_gather_nightly"},
-          {name: reduce scatter nightly test, cmd: pytest tests/nightly/bh/ccl/test_reduce_scatter_nightly.py -k "test_rs_nightly"},
-          # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
-        ]
+        test-group:
+          - name: fabric 1D unit tests
+            cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
+          - name: fabric 1D performance microbenchmarks
+            cmd: pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+          - name: fabric 2D fixture unit tests
+            cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+          - name: fabric system health tests
+            cmd: ./build/test/tt_metal/tt_fabric/test_system_health ${{ inputs.runner-label == 'BH-DeskBox' && '--min-connections 4' || '' }}
+          - name: cpp unit tests eth
+            cmd: ./build/test/tt_metal/unit_tests_eth
+          - name: all gather nightly test
+            cmd: pytest tests/nightly/bh/ccl/all_gather_nightly.py -k "test_all_gather_nightly"
+          - name: reduce scatter nightly test
+            cmd: pytest tests/nightly/bh/ccl/test_reduce_scatter_nightly.py -k "test_rs_nightly"
+          # - name: t3000 fast fabric tests
+          #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -80,7 +80,15 @@ test_suite_bh_single_pcie_llama_demo_tests() {
 test_suite_bh_multi_pcie_metal_unit_tests() {
     echo "[upstream-tests] Running BH LLMBox metal unit tests"
 
-    ./build/test/tt_metal/tt_fabric/test_system_health
+    # Sim HW deskbox has 8 connections so we need to pass in the min-connections arg
+    # This changes the connection count assert == 4 to assert >= 4
+    if [[ "$hw_topology" == "blackhole_deskbox" ]]; then
+        local min_connections_arg="--min-connections 4"
+    else
+        local min_connections_arg=""
+    fi
+
+    ./build/test/tt_metal/tt_fabric/test_system_health $min_connections_arg
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/unit_tests_eth


### PR DESCRIPTION
### Ticket
None

### Problem description
Simulated deskbox has 8 connections but mesh descriptor expects 4 after https://github.com/tenstorrent/tt-metal/pull/25838
If `--min-connections 4` is provided, the assert changes from a strict EQ check to GE (8 == 4 becomes 8 >= 4)

### What's changed
Pass arg `--min-connections 4` when running system health check on deskbox

### Checklist
- [x] BH multicard unit tests https://github.com/tenstorrent/tt-metal/actions/runs/16912612044
- [ ] Upstream tests https://github.com/tenstorrent/tt-metal/actions/runs/16913589825