### PR TITLE
Add asserts that CBs reserved regions are contiguous

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -38,6 +38,9 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint32_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
+    // Assert that region is contiguous.
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <=
+           get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -40,7 +40,8 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <= get_local_cb_interface(output).fifo_limit);
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles * get_local_cb_interface(output).fifo_page_size <=
+           get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -40,8 +40,9 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles * get_local_cb_interface(output).fifo_page_size <=
-           get_local_cb_interface(output).fifo_limit);
+    ASSERT(
+        get_local_cb_interface(output).fifo_wr_ptr + num_tiles * get_local_cb_interface(output).fifo_page_size <=
+        get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -39,8 +39,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <=
-           get_local_cb_interface(output).fifo_limit);
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <= get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {
@@ -79,6 +78,7 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
     get_local_cb_interface(output).fifo_wr_ptr += num_words;
     get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
 
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr <= get_local_cb_interface(output).fifo_limit);
     if (get_local_cb_interface(output).fifo_wr_ptr >= get_local_cb_interface(output).fifo_limit) {
         get_local_cb_interface(output).fifo_wr_ptr -= get_local_cb_interface(output).fifo_size;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -11,6 +11,7 @@
 #include "stream_interface.h"
 #include "stream_io_map.h"
 #include "tools/profiler/kernel_profiler.hpp"
+#include "debug/assert.h"
 
 using namespace ckernel;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -38,6 +38,9 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint32_t free_tiles_wrap = get_local_cb_interface(output).fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
+    // Assert that region is contiguous.
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <=
+           get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -40,7 +40,8 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <= get_local_cb_interface(output).fifo_limit);
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles * get_local_cb_interface(output).fifo_page_size <=
+           get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -40,8 +40,9 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles * get_local_cb_interface(output).fifo_page_size <=
-           get_local_cb_interface(output).fifo_limit);
+    ASSERT(
+        get_local_cb_interface(output).fifo_wr_ptr + num_tiles * get_local_cb_interface(output).fifo_page_size <=
+        get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -11,6 +11,7 @@
 #include "stream_io_map.h"
 #include "llk_pack_common.h"
 #include "tools/profiler/kernel_profiler.hpp"
+#include "debug/assert.h"
 
 using namespace ckernel;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -39,8 +39,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         free_tiles = (std::int32_t)free_tiles_wrap;
     } while (free_tiles < num_tiles);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <=
-           get_local_cb_interface(output).fifo_limit);
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr + num_tiles <= get_local_cb_interface(output).fifo_limit);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {
@@ -79,6 +78,7 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
     get_local_cb_interface(output).fifo_wr_ptr += num_words;
     get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
 
+    ASSERT(get_local_cb_interface(output).fifo_wr_ptr <= get_local_cb_interface(output).fifo_limit);
     if (get_local_cb_interface(output).fifo_wr_ptr >= get_local_cb_interface(output).fifo_limit) {
         get_local_cb_interface(output).fifo_wr_ptr -= get_local_cb_interface(output).fifo_size;
     }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -159,7 +159,10 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
  * tiles visible to the consumer. Writing of the tiles and pushing is separated
  * to allow the producer to: 1) write the tile data to the CB via multiple
  * writes of sub-tiles 2) modify tiles (or sub-tiles) by random access of the
- * valid section of the CB
+ * valid section of the CB.
+ *
+ * Important note: CB total size must be an even multiple of the argument passed to this call, and each push to a CB
+ * should have the same number of pages.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -382,8 +382,9 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(operand).fifo_wr_ptr + num_pages * get_local_cb_interface(operand).fifo_page_size <=
-           get_local_cb_interface(operand).fifo_limit);
+    ASSERT(
+        get_local_cb_interface(operand).fifo_wr_ptr + num_pages * get_local_cb_interface(operand).fifo_page_size <=
+        get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CRBD");
 }
 
@@ -456,8 +457,9 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(operand).fifo_rd_ptr + num_pages * get_local_cb_interface(operand).fifo_page_size <=
-           get_local_cb_interface(operand).fifo_limit);
+    ASSERT(
+        get_local_cb_interface(operand).fifo_rd_ptr + num_pages * get_local_cb_interface(operand).fifo_page_size <=
+        get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CWFD");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -377,6 +377,9 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
             get_local_cb_interface(operand).fifo_num_pages - (pages_received - pages_acked);
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
+    // Assert that region is contiguous.
+    ASSERT(get_local_cb_interface(operand).fifo_wr_ptr + num_pages <=
+           get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CRBD");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -382,7 +382,8 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(operand).fifo_wr_ptr + num_pages <= get_local_cb_interface(operand).fifo_limit);
+    ASSERT(get_local_cb_interface(operand).fifo_wr_ptr + num_pages * get_local_cb_interface(operand).fifo_page_size <=
+           get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CRBD");
 }
 
@@ -455,7 +456,8 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(operand).fifo_rd_ptr + num_pages <= get_local_cb_interface(operand).fifo_limit);
+    ASSERT(get_local_cb_interface(operand).fifo_rd_ptr + num_pages * get_local_cb_interface(operand).fifo_page_size <=
+           get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CWFD");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -378,8 +378,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
     // Assert that region is contiguous.
-    ASSERT(get_local_cb_interface(operand).fifo_wr_ptr + num_pages <=
-           get_local_cb_interface(operand).fifo_limit);
+    ASSERT(get_local_cb_interface(operand).fifo_wr_ptr + num_pages <= get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CRBD");
 }
 
@@ -451,6 +450,8 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
     do {
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
+    // Assert that region is contiguous.
+    ASSERT(get_local_cb_interface(operand).fifo_rd_ptr + num_pages <= get_local_cb_interface(operand).fifo_limit);
     WAYPOINT("CWFD");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -24,6 +24,7 @@
 #include "dev_msgs.h"
 #include "accessor/tensor_accessor.h"
 #include "tools/profiler/kernel_profiler.hpp"
+#include "debug/assert.h"
 
 // clang-format off
 /**

--- a/tt_metal/include/compute_kernel_api/cb_api.h
+++ b/tt_metal/include/compute_kernel_api/cb_api.h
@@ -113,6 +113,9 @@ ALWI void cb_reserve_back(uint32_t cbid, uint32_t ntiles) {
  * cb pointers are not synchronized across threads. Per circular buffer index, only have one thread push tiles
  * to update the write pointer
  *
+ * Important note: CB total size must be an even multiple of the argument passed to this call, and each push to a CB should
+ * have the same number of pages.
+ *
  * Return value: None
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |

--- a/tt_metal/include/compute_kernel_api/cb_api.h
+++ b/tt_metal/include/compute_kernel_api/cb_api.h
@@ -34,7 +34,7 @@ namespace ckernel {
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of tiles to wait for      | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  * */
  // clang-format on
@@ -66,7 +66,7 @@ ALWI void cb_wait_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_wait_tiles
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of tiles to be popped     | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
  // clang-format on
@@ -83,7 +83,7 @@ ALWI void cb_pop_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_pop_tiles(c
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of free tiles to wait for | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
  // clang-format on
@@ -120,10 +120,10 @@ ALWI void cb_reserve_back(uint32_t cbid, uint32_t ntiles) {
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of tiles to be pushed     | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void cb_push_back(uint32_t cbid, uint32_t ntiles) { PACK((llk_push_tiles<false, false>(cbid, ntiles))); }
 
 // clang-format off
@@ -136,8 +136,8 @@ ALWI void cb_push_back(uint32_t cbid, uint32_t ntiles) { PACK((llk_push_tiles<fa
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
- * | index     | The tile index within the CB         | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
+ * | index     | The tile index within the CB         | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  * | p_tile    | The pointer that will be populated   | void*    | N/A                                                                                               | True     |
  */
  // clang-format on


### PR DESCRIPTION
### Problem description
If people choose the wrong sizes when reserving CB pages, that can cause the region that's reserved to wrap.
For example, if the CB is 4 pages and these calls are done:

- cb_reserve_back(0, 1)
- cb_push_back(0, 1)
- cb_pop_front(0, 1)
- cb_reserve_back(0, 4)

then the reserved region will start one page into the CB and go one page past the end of the CB

### What's changed
Add asserts that we always reserve contiguous regions that are contained with the CB memory region. Also add comments that we should always be doing push_back on the same number of pages, which will prevent these overflow errors.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
