### PR TITLE
Add uint32/int32 support for concat

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_pytorch2.py
@@ -4218,7 +4218,6 @@ def test_concat_pytorch2(concat_spec, dtype, layout, device):
     if dtype == ttnn.bfloat16 and any([shape[-1] % 2 != 0 for shape in shapes]) and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Skipping test for RM bfloat16 with odd last dimension")
 
-    # torch_input_tensors = [torch_random(shape, -0.1, 0.1, dtype=torch.bfloat16) for shape in shapes]
     torch_input_tensors = [random_torch_tensor(dtype, shape) for shape in shapes]
     torch_output_tensor = torch.cat(torch_input_tensors, dim=dim)
 

--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_pytorch2.py
@@ -4180,8 +4180,10 @@ torch.manual_seed(0)
 def random_torch_tensor(dtype, shape):
     if dtype == ttnn.uint16:
         return torch.randint(0, 100, shape).to(torch.int16)
-    if dtype == ttnn.int32 or dtype == ttnn.uint32:
+    if dtype == ttnn.int32:
         return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
     return torch.rand(shape).bfloat16().float()
 
 
@@ -4216,7 +4218,8 @@ def test_concat_pytorch2(concat_spec, dtype, layout, device):
     if dtype == ttnn.bfloat16 and any([shape[-1] % 2 != 0 for shape in shapes]) and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Skipping test for RM bfloat16 with odd last dimension")
 
-    torch_input_tensors = [torch_random(shape, -0.1, 0.1, dtype=torch.bfloat16) for shape in shapes]
+    # torch_input_tensors = [torch_random(shape, -0.1, 0.1, dtype=torch.bfloat16) for shape in shapes]
+    torch_input_tensors = [random_torch_tensor(dtype, shape) for shape in shapes]
     torch_output_tensor = torch.cat(torch_input_tensors, dim=dim)
 
     ttnn_input_tensors = [

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -47,9 +47,7 @@ def test_tiled_concat(device, concat_spec, dtype):
 @pytest.mark.parametrize("dim", [0, 1])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint32])
 def test_concat(device, height, width, dim, dtype):
-    # torch_input_tensor_a = torch.rand((height, width), dtype=torch.bfloat16)
     torch_input_tensor_a = random_torch_tensor(dtype, (height, width))
-    # torch_input_tensor_b = torch.rand((height, width), dtype=torch.bfloat16)
     torch_input_tensor_b = random_torch_tensor(dtype, (height, width))
     torch_output_tensor = torch.concat([torch_input_tensor_a, torch_input_tensor_b], dim=dim)
 
@@ -184,7 +182,6 @@ def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy
                 strategy=strategy,
                 use_height_and_width_as_shard_shape=True,
             )
-            # torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
             torch_input_tensor = random_torch_tensor(dtype, shape)
             input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device, dtype=dtype)
             input_tensor = ttnn.to_memory_config(input_tensor, input_sharded_memory_config)
@@ -219,8 +216,7 @@ def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy
 
 @pytest.mark.parametrize("dim", [3])
 @pytest.mark.parametrize("groups", [1, 2, 4])
-# @pytest.mark.parametrize("dtype", [ttnn.int32])
-@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.uint32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
 @pytest.mark.parametrize(
     "input_shapes, output_shape, core_grid, layout",
     (
@@ -270,7 +266,6 @@ def test_sharded_concat_with_groups(device, input_shapes, output_shape, dim, gro
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint32])
 def test_concat_5d(device, dim, dtype):
-    # torch_input_tensor = torch.rand(1, 1, 1, 1, 2, dtype=torch.bfloat16)
     torch_input_tensor = random_torch_tensor(dtype, (1, 1, 1, 1, 2))
     torch_result = torch.cat([torch_input_tensor, torch_input_tensor], dim=dim)
 
@@ -306,7 +301,6 @@ def test_concat_sharded_pad(device, core_grid, hw, channels1, channels2, shard_h
     shape1_memory_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shape1_shard_spec
     )
-    # torch_input_tensor1 = torch.randn(shape1, dtype=torch.bfloat16)
     torch_input_tensor1 = random_torch_tensor(dtype, shape1)
     ttnn_input_tensor1 = ttnn.from_torch(torch_input_tensor1, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     ttnn_input_tensor1 = ttnn.to_device(ttnn_input_tensor1, device, memory_config=shape1_memory_config)
@@ -316,7 +310,6 @@ def test_concat_sharded_pad(device, core_grid, hw, channels1, channels2, shard_h
     shape2_memory_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shape2_shard_spec
     )
-    # torch_input_tensor2 = torch.randn(shape2, dtype=torch.bfloat16)
     torch_input_tensor2 = random_torch_tensor(dtype, shape2)
     ttnn_input_tensor2 = ttnn.from_torch(torch_input_tensor2, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     ttnn_input_tensor2 = ttnn.to_device(ttnn_input_tensor2, device, memory_config=shape2_memory_config)

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -16,8 +16,10 @@ torch.manual_seed(0)
 def random_torch_tensor(dtype, shape):
     if dtype == ttnn.uint16:
         return torch.randint(0, 100, shape).to(torch.int16)
-    if dtype == ttnn.int32 or dtype == ttnn.uint32:
+    if dtype == ttnn.int32:
         return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
     return torch.rand(shape).bfloat16().float()
 
 

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -218,7 +218,7 @@ def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy
 
 @pytest.mark.parametrize("dim", [3])
 @pytest.mark.parametrize("groups", [1, 2, 4])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.bfloat8_b])
 @pytest.mark.parametrize(
     "input_shapes, output_shape, core_grid, layout",
     (
@@ -262,7 +262,10 @@ def test_sharded_concat_with_groups(device, input_shapes, output_shape, dim, gro
     )
 
     actual = ttnn.to_torch(z)
-    assert torch.equal(expected, actual)
+    if dtype == ttnn.bfloat8_b:
+        assert_with_pcc(expected, actual, 0.99)
+    else:
+        assert torch.equal(expected, actual)
 
 
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -41,7 +41,7 @@ def test_tiled_concat(device, concat_spec, dtype):
     output = ttnn.concat(input_tensors, dim=dim)
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, 0.9999)
+    assert torch.equal(torch_output_tensor, output)
 
 
 @pytest.mark.parametrize("height", [20, 32])
@@ -59,7 +59,7 @@ def test_concat(device, height, width, dim, dtype):
     output = ttnn.concat([input_tensor_a, input_tensor_b], dim=dim)
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, 0.9999)
+    assert torch.equal(torch_output_tensor, output)
 
 
 @pytest.mark.parametrize(
@@ -201,7 +201,7 @@ def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy
     torch_output_tensor = torch.concat([torch_tensor for torch_tensor, _ in input_tensors], dim=dim)
     output = ttnn.concat([tensor for _, tensor in input_tensors], dim=dim, memory_config=output_sharded_memory_config)
     output = ttnn.to_torch(output)
-    assert_with_pcc(torch_output_tensor, output)
+    assert torch.equal(torch_output_tensor, output)
 
     # If cache mode is enabled, run the second set of input tensors to verify buffers are updated when cache hits.
     if not cache_mode:
@@ -213,7 +213,7 @@ def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy
         [tensor for _, tensor in input_tensors_2], dim=dim, memory_config=output_sharded_memory_config
     )
     output_2 = ttnn.to_torch(output_2)
-    assert_with_pcc(torch_output_tensor_2, output_2)
+    assert torch.equal(torch_output_tensor_2, output_2)
 
 
 @pytest.mark.parametrize("dim", [3])
@@ -262,7 +262,7 @@ def test_sharded_concat_with_groups(device, input_shapes, output_shape, dim, gro
     )
 
     actual = ttnn.to_torch(z)
-    assert_with_pcc(expected, actual, 1.0 if dtype == ttnn.bfloat16 else 0.99995)
+    assert torch.equal(expected, actual)
 
 
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
@@ -274,7 +274,7 @@ def test_concat_5d(device, dim, dtype):
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
     ttnn_result = ttnn.concat([ttnn_input_tensor, ttnn_input_tensor], dim=dim)
     ttnn_result = ttnn.to_torch(ttnn_result)
-    assert_with_pcc(torch_result, ttnn_result, 0.9999)
+    assert torch.equal(torch_result, ttnn_result)
 
 
 @pytest.mark.parametrize(
@@ -328,4 +328,4 @@ def test_concat_sharded_pad(device, core_grid, hw, channels1, channels2, shard_h
         memory_config=output_memory_config,
     )
     expected = torch.concat([torch_input_tensor1, torch_input_tensor2], dim=-1)
-    assert_with_pcc(expected, ttnn.to_torch(actual), 0.9999)
+    assert torch.equal(expected, ttnn.to_torch(actual))

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -24,7 +24,7 @@
 #include <utility>
 
 // toggle this to enable debug prints
-constexpr bool debug_concat = true;
+constexpr bool debug_concat = false;
 inline void concat_db_print(bool condition, const std::string& msg) {
     if constexpr (debug_concat) {
         if (condition) {
@@ -118,32 +118,14 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     TT_FATAL(
                         input_tensor.layout() == ttnn::TILE_LAYOUT,
                         "ttnn.concat: expected all input tensors to be in tile layout");
-                    // if(is_all_zeros(input_tensor)) std::cout << "input_tensor is all zeros!" << std::endl;
-                    // else std::cout << "input_tensor is not all zeros!" << std::endl;
                     auto untilized_tensor = ttnn::untilize(input_tensor);
                     // untilized, so now we have a padded rm tensor. we slice to
                     // remove the padding.
                     const auto& input_shape = input_tensor.logical_shape();
-                    std::cout << "input_shape: " << input_shape << std::endl;
                     std::vector<uint32_t> begins_vec(input_shape.rank(), 0);
                     tt::stl::Span<const uint32_t> begins = begins_vec;
-                    std::cout << "begins: ";
-                    for (const auto& v : begins) {
-                        std::cout << v << " ";
-                    }
-                    std::cout << std::endl;
                     tt::stl::Span<const uint32_t> ends = input_shape.view();
-                    std::cout << "ends: ";
-                    for (const auto& v : ends) {
-                        std::cout << v << " ";
-                    }
-                    std::cout << std::endl;
                     std::vector<uint32_t> steps_vec(input_shape.rank(), 1);
-                    std::cout << "steps: ";
-                    for (const auto& v : steps_vec) {
-                        std::cout << v << " ";
-                    }
-                    std::cout << std::endl;
                     tt::stl::Span<const uint32_t> steps = steps_vec;
 
                     // we now perform a padding-oblivious slice to remove the
@@ -151,8 +133,6 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     // FIXME: change this to a legit slice call once
                     // padding-oblivious entry point is uplifted to the slice
                     // op.
-                    // if(is_all_zeros(untilized_tensor)) std::cout << "untilized_tensor is all zeros!" << std::endl;
-                    // else std::cout << "untilized_tensor is not all zeros!" << std::endl;
                     untilized_tensor = tt::tt_metal::operation::run(
                         SliceDeviceOperation{
                             ttnn::Shape(begins), ttnn::Shape(ends), ttnn::Shape(steps), output_memory_config},
@@ -161,7 +141,6 @@ MassagedConcat build_untilize_rm_retilize_concat(
                         {std::nullopt},
                         queue_id)[0];
 
-                    std::cout << "untilized_tensor shape: " << untilized_tensor.logical_shape() << std::endl;
                     untilized_tensor = ttnn::reshape(untilized_tensor, input_tensor.logical_shape());
                     return untilized_tensor;
                 });

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -24,7 +24,7 @@
 #include <utility>
 
 // toggle this to enable debug prints
-constexpr bool debug_concat = false;
+constexpr bool debug_concat = true;
 inline void concat_db_print(bool condition, const std::string& msg) {
     if constexpr (debug_concat) {
         if (condition) {
@@ -36,6 +36,11 @@ inline void concat_db_print(bool condition, const std::string& msg) {
 namespace ttnn {
 namespace operations {
 namespace data_movement {
+
+bool is_all_zeros(const tt::tt_metal::Tensor& tensor) {
+    auto vec = tensor.to_vector<int32_t>();
+    return std::all_of(vec.begin(), vec.end(), [](int32_t val) { return val == 0; });
+}
 
 using OwnedConcatArgs = std::tuple<std::vector<ttnn::Tensor>, int, unsigned int>;
 
@@ -113,14 +118,32 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     TT_FATAL(
                         input_tensor.layout() == ttnn::TILE_LAYOUT,
                         "ttnn.concat: expected all input tensors to be in tile layout");
+                    // if(is_all_zeros(input_tensor)) std::cout << "input_tensor is all zeros!" << std::endl;
+                    // else std::cout << "input_tensor is not all zeros!" << std::endl;
                     auto untilized_tensor = ttnn::untilize(input_tensor);
                     // untilized, so now we have a padded rm tensor. we slice to
                     // remove the padding.
                     const auto& input_shape = input_tensor.logical_shape();
+                    std::cout << "input_shape: " << input_shape << std::endl;
                     std::vector<uint32_t> begins_vec(input_shape.rank(), 0);
                     tt::stl::Span<const uint32_t> begins = begins_vec;
+                    std::cout << "begins: ";
+                    for (const auto& v : begins) {
+                        std::cout << v << " ";
+                    }
+                    std::cout << std::endl;
                     tt::stl::Span<const uint32_t> ends = input_shape.view();
+                    std::cout << "ends: ";
+                    for (const auto& v : ends) {
+                        std::cout << v << " ";
+                    }
+                    std::cout << std::endl;
                     std::vector<uint32_t> steps_vec(input_shape.rank(), 1);
+                    std::cout << "steps: ";
+                    for (const auto& v : steps_vec) {
+                        std::cout << v << " ";
+                    }
+                    std::cout << std::endl;
                     tt::stl::Span<const uint32_t> steps = steps_vec;
 
                     // we now perform a padding-oblivious slice to remove the
@@ -128,6 +151,8 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     // FIXME: change this to a legit slice call once
                     // padding-oblivious entry point is uplifted to the slice
                     // op.
+                    // if(is_all_zeros(untilized_tensor)) std::cout << "untilized_tensor is all zeros!" << std::endl;
+                    // else std::cout << "untilized_tensor is not all zeros!" << std::endl;
                     untilized_tensor = tt::tt_metal::operation::run(
                         SliceDeviceOperation{
                             ttnn::Shape(begins), ttnn::Shape(ends), ttnn::Shape(steps), output_memory_config},
@@ -136,6 +161,7 @@ MassagedConcat build_untilize_rm_retilize_concat(
                         {std::nullopt},
                         queue_id)[0];
 
+                    std::cout << "untilized_tensor shape: " << untilized_tensor.logical_shape() << std::endl;
                     untilized_tensor = ttnn::reshape(untilized_tensor, input_tensor.logical_shape());
                     return untilized_tensor;
                 });

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -37,11 +37,6 @@ namespace ttnn {
 namespace operations {
 namespace data_movement {
 
-bool is_all_zeros(const tt::tt_metal::Tensor& tensor) {
-    auto vec = tensor.to_vector<int32_t>();
-    return std::all_of(vec.begin(), vec.end(), [](int32_t val) { return val == 0; });
-}
-
 using OwnedConcatArgs = std::tuple<std::vector<ttnn::Tensor>, int, unsigned int>;
 
 using MassagedConcat = MassagedOperation<ttnn::Tensor, const std::vector<ttnn::Tensor>&, int, unsigned int>;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -37,7 +37,6 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
     const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
     // If we end up here for concat with more than 2 tensors on any other dim we should have
     // taken another path
-    std::cout << "reached s2s_tiled_concat_two_tensors_height_multi_core" << std::endl;
     TT_FATAL(dim == 3, "Sharded concat with tiled inputs only supports dim=3 (was {})", dim);
     TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors (was {})", input_tensors.size());
 
@@ -123,8 +122,6 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
         }
         return tt::tt_metal::CreateCircularBuffer(program, cores, config);
     };
-
-    std::cout << "Creating circular buffers for input tensors" << std::endl;
 
     const auto create_cb_from_tensor =
         [&create_circular_buffer](
@@ -224,7 +221,6 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
         UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors[0].buffer());
     };
 
-    std::cout << "Created program for s2s_tiled_concat_two_tensors_height_multi_core" << std::endl;
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -154,20 +154,18 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
         cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16);
         cb_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
     }
-    const auto bf16_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16);
-    const auto bf16_tile_size = tt::tt_metal::detail::TileSize(bf16_data_format);
 
     const auto in0_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[0]);
     const uint32_t cb_input0_transpose_id = cb_inputs.size() + 1;
-    create_circular_buffer(cb_input0_transpose_id, in0_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+    create_circular_buffer(cb_input0_transpose_id, in0_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
 
     const auto in1_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[1]);
     const uint32_t cb_input1_transpose_id = cb_inputs.size() + 2;
-    create_circular_buffer(cb_input1_transpose_id, in1_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+    create_circular_buffer(cb_input1_transpose_id, in1_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
 
     const auto out_total_tiles_width = in0_total_tiles_width + in1_total_tiles_width;
     const uint32_t cb_concat_id = cb_inputs.size() + 3;
-    create_circular_buffer(cb_concat_id, out_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+    create_circular_buffer(cb_concat_id, out_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
 
     const uint32_t cb_output_transpose_id = cb_inputs.size() + 4;
     create_circular_buffer(cb_output_transpose_id, out_total_tiles_width, tile_size, data_format, nullptr);
@@ -188,7 +186,9 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
         groups,
     };
     std::map<std::string, std::string> reader_defines;
-    reader_defines["BF8"] = bf8 ? "1" : "0";
+    if (bf8) {
+        reader_defines["BF8"] = "1";
+    }
     tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -147,22 +147,17 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
     const auto total_num_output_tiles = get_total_num_tiles_per_shard(num_tiles_for_output_shard);
     const CBHandle cb_output = create_cb_from_tensor(cb_output_id, output, total_num_output_tiles);
 
-    // const auto bf16_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16);
-    // const auto bf16_tile_size = tt::tt_metal::detail::TileSize(bf16_data_format);
-    const auto bf16_data_format = data_format;
-    const auto bf16_tile_size = tile_size;
-
     const auto in0_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[0]);
     const uint32_t cb_input0_transpose_id = cb_inputs.size() + 1;
-    create_circular_buffer(cb_input0_transpose_id, in0_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+    create_circular_buffer(cb_input0_transpose_id, in0_total_tiles_width, tile_size, data_format, nullptr);
 
     const auto in1_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[1]);
     const uint32_t cb_input1_transpose_id = cb_inputs.size() + 2;
-    create_circular_buffer(cb_input1_transpose_id, in1_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+    create_circular_buffer(cb_input1_transpose_id, in1_total_tiles_width, tile_size, data_format, nullptr);
 
     const auto out_total_tiles_width = in0_total_tiles_width + in1_total_tiles_width;
     const uint32_t cb_concat_id = cb_inputs.size() + 3;
-    create_circular_buffer(cb_concat_id, out_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+    create_circular_buffer(cb_concat_id, out_total_tiles_width, tile_size, data_format, nullptr);
 
     const uint32_t cb_output_transpose_id = cb_inputs.size() + 4;
     create_circular_buffer(cb_output_transpose_id, out_total_tiles_width, tile_size, data_format, nullptr);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -193,6 +193,9 @@ tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_mu
     // TODO: Skip the tile transpose in compute kernel if the following condition is true:
     // >> (input_tensors[0].padded_shape()[-1] / groups % TILE_WIDTH == 0
     // >> && input_tensors[1].padded_shape()[-1] / groups % TILE_WIDTH == 0)
+    constexpr uint32_t MAX_1_BYTE_TILES_PER_BATCH = 16;
+    uint32_t BatchSize = MAX_1_BYTE_TILES_PER_BATCH / input_tensors[0].element_size();
+    compile_time_args_0.push_back(BatchSize);
     tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/"

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
@@ -6,7 +6,7 @@
 
 #include "compute_kernel_api/transpose_wh.h"
 
-constexpr uint32_t MAX_BATCH_SIZE = 8;
+constexpr uint32_t MAX_BATCH_SIZE = 4;
 
 template <uint32_t BatchSize = 1>
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
@@ -6,8 +6,6 @@
 
 #include "compute_kernel_api/transpose_wh.h"
 
-constexpr uint32_t MAX_BATCH_SIZE = 4;
-
 template <uint32_t BatchSize = 1>
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
     cb_wait_front(cb_in, BatchSize);
@@ -48,6 +46,9 @@ void MAIN {
     constexpr uint32_t tile_size = get_compile_time_arg_val(11);
     constexpr uint32_t groups = get_compile_time_arg_val(12);
 
+    uint32_t input_elem_size_bytes = tile_size / 32 / 32;
+    uint32_t MAX_BATCH_SIZE = 16 / input_elem_size_bytes;
+
     transpose_wh_init(input0_cb, input0_transpose_cb);
 
     constexpr uint32_t output_num_tiles_width = input0_num_tiles_width + input1_num_tiles_width;
@@ -55,14 +56,14 @@ void MAIN {
     for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
         reconfig_data_format_srca(input0_cb);
         pack_reconfig_data_format(input0_transpose_cb);
-        if constexpr (input0_num_tiles_width <= MAX_BATCH_SIZE) {
+        if (input0_num_tiles_width <= MAX_BATCH_SIZE) {
             transpose<input0_num_tiles_width>(input0_cb, input0_transpose_cb);
         } else {
             for (uint32_t j = 0; j < input0_num_tiles_width; j++) {
                 transpose(input0_cb, input0_transpose_cb);
             }
         }
-        if constexpr (input1_num_tiles_width <= MAX_BATCH_SIZE) {
+        if (input1_num_tiles_width <= MAX_BATCH_SIZE) {
             transpose<input1_num_tiles_width>(input1_cb, input1_transpose_cb);
         } else {
             for (uint32_t j = 0; j < input1_num_tiles_width; j++) {
@@ -72,7 +73,7 @@ void MAIN {
 
         reconfig_data_format_srca(concat_cb);
         pack_reconfig_data_format(output_transpose_cb);
-        if constexpr (output_num_tiles_width <= MAX_BATCH_SIZE) {
+        if (output_num_tiles_width <= MAX_BATCH_SIZE) {
             transpose<output_num_tiles_width>(concat_cb, output_transpose_cb);
         } else {
             for (uint32_t j = 0; j < output_num_tiles_width; j++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
@@ -71,7 +71,7 @@ void MAIN {
 
         reconfig_data_format_srca(concat_cb);
         pack_reconfig_data_format(output_transpose_cb);
-        if (output_num_tiles_width <= MAX_BATCH_SIZE) {
+        if constexpr (output_num_tiles_width <= MAX_BATCH_SIZE) {
             transpose<output_num_tiles_width>(concat_cb, output_transpose_cb);
         } else {
             for (uint32_t j = 0; j < output_num_tiles_width; j++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
@@ -45,9 +45,7 @@ void MAIN {
 
     constexpr uint32_t tile_size = get_compile_time_arg_val(11);
     constexpr uint32_t groups = get_compile_time_arg_val(12);
-
-    uint32_t input_elem_size_bytes = tile_size / 32 / 32;
-    uint32_t MAX_BATCH_SIZE = 16 / input_elem_size_bytes;
+    constexpr uint32_t MAX_BATCH_SIZE = get_compile_time_arg_val(13);
 
     transpose_wh_init(input0_cb, input0_transpose_cb);
 
@@ -56,14 +54,14 @@ void MAIN {
     for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
         reconfig_data_format_srca(input0_cb);
         pack_reconfig_data_format(input0_transpose_cb);
-        if (input0_num_tiles_width <= MAX_BATCH_SIZE) {
+        if constexpr (input0_num_tiles_width <= MAX_BATCH_SIZE) {
             transpose<input0_num_tiles_width>(input0_cb, input0_transpose_cb);
         } else {
             for (uint32_t j = 0; j < input0_num_tiles_width; j++) {
                 transpose(input0_cb, input0_transpose_cb);
             }
         }
-        if (input1_num_tiles_width <= MAX_BATCH_SIZE) {
+        if constexpr (input1_num_tiles_width <= MAX_BATCH_SIZE) {
             transpose<input1_num_tiles_width>(input1_cb, input1_transpose_cb);
         } else {
             for (uint32_t j = 0; j < input1_num_tiles_width; j++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -24,10 +24,8 @@ void kernel_main() {
     constexpr uint32_t tile_size = get_compile_time_arg_val(11);
     constexpr uint32_t groups = get_compile_time_arg_val(12);
 
-    // constexpr uint32_t bf16_tile_size = 32 * 32 * 2;
-    constexpr uint32_t bf16_tile_size = tile_size;
-    constexpr uint32_t input0_stride = bf16_tile_size * input0_num_tiles_width / groups;
-    constexpr uint32_t input1_stride = bf16_tile_size * input1_num_tiles_width / groups;
+    constexpr uint32_t input0_stride = tile_size * input0_num_tiles_width / groups;
+    constexpr uint32_t input1_stride = tile_size * input1_num_tiles_width / groups;
     constexpr uint32_t group_stride = input0_stride + input1_stride;
 
     const uint32_t base_l1_read_addr_0 = get_read_ptr(input0_transpose_cb);
@@ -38,11 +36,9 @@ void kernel_main() {
 
     cb_push_back(input0_cb, input0_num_tiles_height * input0_num_tiles_width);
     cb_push_back(input1_cb, input1_num_tiles_height * input1_num_tiles_width);
-    // DPRINT << "we here?" << ENDL();
 
     for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
         cb_reserve_back(concat_cb, output_num_tiles_width);
-        // DPRINT << "tile " << i << " of " << input0_num_tiles_height << ENDL();
 
         cb_wait_front(input0_transpose_cb, input0_num_tiles_width);
 
@@ -76,5 +72,4 @@ void kernel_main() {
 
         cb_push_back(concat_cb, output_num_tiles_width);
     }
-    // DPRINT << "done concat" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <debug/dprint.h>
 
 void kernel_main() {
     constexpr uint32_t input0_cb = get_compile_time_arg_val(0);
@@ -23,7 +24,8 @@ void kernel_main() {
     constexpr uint32_t tile_size = get_compile_time_arg_val(11);
     constexpr uint32_t groups = get_compile_time_arg_val(12);
 
-    constexpr uint32_t bf16_tile_size = 32 * 32 * 2;
+    // constexpr uint32_t bf16_tile_size = 32 * 32 * 2;
+    constexpr uint32_t bf16_tile_size = tile_size;
     constexpr uint32_t input0_stride = bf16_tile_size * input0_num_tiles_width / groups;
     constexpr uint32_t input1_stride = bf16_tile_size * input1_num_tiles_width / groups;
     constexpr uint32_t group_stride = input0_stride + input1_stride;
@@ -36,9 +38,11 @@ void kernel_main() {
 
     cb_push_back(input0_cb, input0_num_tiles_height * input0_num_tiles_width);
     cb_push_back(input1_cb, input1_num_tiles_height * input1_num_tiles_width);
+    // DPRINT << "we here?" << ENDL();
 
     for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
         cb_reserve_back(concat_cb, output_num_tiles_width);
+        // DPRINT << "tile " << i << " of " << input0_num_tiles_height << ENDL();
 
         cb_wait_front(input0_transpose_cb, input0_num_tiles_width);
 
@@ -72,4 +76,5 @@ void kernel_main() {
 
         cb_push_back(concat_cb, output_num_tiles_width);
     }
+    // DPRINT << "done concat" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -23,10 +23,15 @@ void kernel_main() {
     constexpr uint32_t tile_size = get_compile_time_arg_val(11);
     constexpr uint32_t groups = get_compile_time_arg_val(12);
 
+    constexpr uint32_t bf16_tile_size = 32 * 32 * 2;
+#ifdef BF8
+    constexpr uint32_t input0_stride = bf16_tile_size * input0_num_tiles_width / groups;
+    constexpr uint32_t input1_stride = bf16_tile_size * input1_num_tiles_width / groups;
+#else
     constexpr uint32_t input0_stride = tile_size * input0_num_tiles_width / groups;
     constexpr uint32_t input1_stride = tile_size * input1_num_tiles_width / groups;
+#endif
     constexpr uint32_t group_stride = input0_stride + input1_stride;
-
     const uint32_t base_l1_read_addr_0 = get_read_ptr(input0_transpose_cb);
     const uint64_t noc_addr_0 = get_noc_addr(base_l1_read_addr_0);
     const uint32_t base_l1_read_addr_1 = get_read_ptr(input1_transpose_cb);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include <debug/dprint.h>
 
 void kernel_main() {
     constexpr uint32_t input0_cb = get_compile_time_arg_val(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -30,8 +30,10 @@ void kernel_main() {
     const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     uint32_t l1_write_addr = base_l1_write_addr;
     for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
+        DPRINT << "tile " << i << " of " << input0_num_tiles_height << ENDL();
         cb_reserve_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);
         cb_wait_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
+        DPRINT << "cb_wait_front done" << ENDL();
 
         const uint32_t base_l1_read_addr_0 = get_read_ptr(output_transpose_cb);
         const uint64_t noc_addr_0 = get_noc_addr(base_l1_read_addr_0);
@@ -39,9 +41,15 @@ void kernel_main() {
         noc_async_read_one_packet_with_state<true>(base_l1_read_addr_0, l1_write_addr);
         l1_write_addr += width_len_bytes;
 
-        noc_async_read_barrier();
+        DPRINT << "NOC read done" << ENDL();
+
+        // noc_async_read_barrier();
+
+        DPRINT << "read barrier done" << ENDL();
 
         cb_pop_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
         cb_push_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);
+        DPRINT << "cb_pop_front and cb_push_back done" << ENDL();
     }
+    DPRINT << "done concat" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -30,26 +30,17 @@ void kernel_main() {
     const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     uint32_t l1_write_addr = base_l1_write_addr;
     for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
-        DPRINT << "tile " << i << " of " << input0_num_tiles_height << ENDL();
         cb_reserve_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);
         cb_wait_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
-        DPRINT << "cb_wait_front done" << ENDL();
 
         const uint32_t base_l1_read_addr_0 = get_read_ptr(output_transpose_cb);
         const uint64_t noc_addr_0 = get_noc_addr(base_l1_read_addr_0);
-        noc_async_read_one_packet_set_state(noc_addr_0, width_len_bytes);
-        noc_async_read_one_packet_with_state<true>(base_l1_read_addr_0, l1_write_addr);
+        noc_async_read(noc_addr_0, l1_write_addr, width_len_bytes);
         l1_write_addr += width_len_bytes;
 
-        DPRINT << "NOC read done" << ENDL();
-
-        // noc_async_read_barrier();
-
-        DPRINT << "read barrier done" << ENDL();
+        noc_async_read_barrier();
 
         cb_pop_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
         cb_push_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);
-        DPRINT << "cb_pop_front and cb_push_back done" << ENDL();
     }
-    DPRINT << "done concat" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -33,7 +33,7 @@ uint32_t get_packed_value(const Tensor tensor, const ttnn::PadValue pad_value) {
                     TT_FATAL(
                         tensor.dtype() == DataType::FLOAT32 or tensor.dtype() == DataType::UINT32 or
                             tensor.dtype() == DataType::INT32,
-                        "only supporting bfloat16, float32, and int32/uint32");
+                        "only supporting bfloat16, float32, and uint32/int32");
                     return (uint32_t)((pad_value));
                 }
             } else if constexpr (std::is_same_v<T, uint32_t>) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25788)

### Problem description
Concat did not enable uint32/int32 support, originally had pcc issues, but with the pad now supporting int these have gone away, so just needed to enable support.
There were some hangs/problems with height sharded concat, mainly it was using noc_async_read_one_packet_with_state, where one packet is too small for 32 bit test cases, and it was setting the state before every usage.

THIS IS AN UPDATE ON A REVERTED BRANCH:::
The reverted branch had issues in unet with bf8 sharded concat, the last commit addresses this!

### What's changed
Simply enabled int32 and generalized some kernel/pf code that was hardcoded for bf16, (NEW PR hardcodes bf16 CB formats if dtype is bf8).
For the sharded case, from what I understand there was no benefit to setting the state, and since our use cases are now larger than 1 packet, I switched simply to noc_async_read. Do correct me if I'm wrong with any of these assumptions.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16919483821) CI passes
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16919485730) CI passes (if applicable)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16919488346) CI with demo tests passes (if applicable)