### PR TITLE
Qwen2.5-VL + vLLM integration for continuous batching of multiple users

### DIFF
--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -430,13 +430,14 @@ def test_demo(
         )
         # Get user-specific rotary position embeddings
         cos, sin = multimodal_rope_from_hf(inputs, input_embeds, reference_model, model_args, pad_token_id=pad_token_id)
-        model.rope_setup.set_cos_sin(cos, sin)
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
         logger.info("Starting prefill warmup...")
         profiler.start(f"compile_prefill", iteration=batch_idx)
+        # [INFO] prefill_forward_text is read-only of the cos/sin matrices
         logits = generator.prefill_forward_text(
             input_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
+            rot_mats=(cos, sin),
             page_table=page_table,
             kv_cache=tt_kv_cache,
             prompt_lens=decoding_pos,
@@ -448,10 +449,15 @@ def test_demo(
         profiler.start(f"inference_prefill", iteration=batch_idx)
         logits = generator.prefill_forward_text(
             input_prefill_pt,
+            rot_mats=(cos, sin),
             page_table=page_table,
             kv_cache=tt_kv_cache,
             prompt_lens=decoding_pos,
         )
+        # [INFO] update the cos/sin matrices in the rope_setup to get ready for decode
+        model.rope_setup.cos_matrix_pt.copy_(cos)
+        model.rope_setup.sin_matrix_pt.copy_(sin)
+        model.rope_setup.update_cos_sin()
         # torch.save(logits, f"ttnn_logits.pt")
         prefilled_token = torch.argmax(logits, dim=-1)
         profiler.end(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -455,7 +455,7 @@ def test_demo(
             prompt_lens=decoding_pos,
         )
         # [INFO] update the cos/sin matrices in the rope_setup to get ready for decode
-        model.rope_setup.update_cos_sin(cos_matrix_pt=cos, sin_matrix_pt=sin)
+        generator.update_cos_sin(cos_matrix_pt=cos, sin_matrix_pt=sin)
         # torch.save(logits, f"ttnn_logits.pt")
         prefilled_token = torch.argmax(logits, dim=-1)
         profiler.end(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -455,9 +455,7 @@ def test_demo(
             prompt_lens=decoding_pos,
         )
         # [INFO] update the cos/sin matrices in the rope_setup to get ready for decode
-        model.rope_setup.cos_matrix_pt.copy_(cos)
-        model.rope_setup.sin_matrix_pt.copy_(sin)
-        model.rope_setup.update_cos_sin()
+        model.rope_setup.update_cos_sin(cos_matrix_pt=cos, sin_matrix_pt=sin)
         # torch.save(logits, f"ttnn_logits.pt")
         prefilled_token = torch.argmax(logits, dim=-1)
         profiler.end(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/qwen25_vl/demo/sample_prompts/expected_text_32B.txt
+++ b/models/demos/qwen25_vl/demo/sample_prompts/expected_text_32B.txt
@@ -1,12 +1,15 @@
-The image appears to be a collage of several elements, including a mix of objects, text, and visual elements. Here is a detailed description:
+The image appears to be a collage of multiple elements, combining natural and artificial objects in a surreal and artistic manner. Here's a detailed description:
 
 ### **Foreground Elements:**
 1. **Wooden Poles:**
-   - Two wooden poles are prominently displayed in the center of the image. They are painted white and have a distinct design, with one pole having a red circular band around it. The poles are positioned upright and appear to be part of a larger structure or display.
+   - Two long, cylindrical wooden poles are prominently displayed in the center of the image.
+   - They are painted in alternating colors: one is primarily white with red bands, and the other is white with blue bands.
+   - The poles are positioned upright, resembling a pair of stilts or some form of structural support.
 
-2. **Text and Labels:**
-   - There is text in the image, which seems to be in a mix of languages, including English and possibly another language (e.g., Chinese or a similar script). The text includes phrases such as:
-     - "Billboard" or "Billboard Art" (translated from Chinese characters).
-     - "Bound" or "Bound Art" (translated from Chinese characters).
-     - "3D" or "3D Art" (translated from Chinese characters).
-     -
+2. **Human Figures:**
+   - There are several human figures in the image, depicted in a distorted and artistic style.
+   - The figures appear to be part of a surreal or abstract composition, with exaggerated features and poses.
+   - Some of the figures are wearing clothing, while others are more abstract or stylized.
+
+3. **Text and Labels:**
+   - There is text in the image, written in a mix of languages and styles,

--- a/models/demos/qwen25_vl/demo/sample_prompts/expected_text_72B.txt
+++ b/models/demos/qwen25_vl/demo/sample_prompts/expected_text_72B.txt
@@ -1,32 +1,8 @@
-The image is a collage of various elements. On the left side, there is a photograph of a person wearing a blue shirt, sitting in a garden-like setting. The person is holding a smartphone, and the background features greenery and a small fountain. On the right side, there is a collage of different objects and scenes, including a person holding a smartphone, a person holding a bouquet of flowers, a person holding a camera, and a person holding a book. The collage also includes various objects such as a bicycle, a car, a house, and a tree. The overall style of the image is a mix of photography and collage, with a focus on everyday objects and activities.
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
-📐
+The image is a collage of various elements, including:
+
+1. **Top Left Corner**: A person wearing a blue shirt and holding a camera, possibly taking a photo. The background appears to be an outdoor setting with trees and a building.
+2. **Top Right Corner**: A close-up of a hand holding a small object, possibly a piece of jewelry or a small tool. The background is blurred, focusing attention on the hand and the object.
+3. **Bottom Left Corner**: A person wearing a white shirt and holding a camera, similar to the person in the top left corner. The background is also an outdoor setting with trees and a building.
+4. **Bottom Right Corner**: A close-up of a hand holding a small object, similar to the hand in the top right corner. The background is blurred, focusing attention on the hand and the object.
+
+The image also includes text and icons, such as a heart symbol, a camera icon, and a location pin icon. The text includes phrases

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -77,6 +77,15 @@ class Generator:
 
         return output_logits
 
+    def update_cos_sin(self, cos_matrix_pt=None, sin_matrix_pt=None):
+        self.model.rope_setup.update_cos_sin(cos_matrix_pt=cos_matrix_pt, sin_matrix_pt=sin_matrix_pt)
+
+    def update_cos_sin_rows(self, rot_mats_seq_ids):
+        for i, (cos, sin) in enumerate(rot_mats_seq_ids):
+            self.model.rope_setup.cos_matrix_pt[i] = cos[0]
+            self.model.rope_setup.sin_matrix_pt[i] = sin[0]
+        self.update_cos_sin()
+
     def decode_forward_text(
         self,
         tokens,

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -237,13 +237,13 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         return logits, rot_mats
 
     def decode_forward(self, *args, **kwargs):
-        rot_mats_seq_ids = kwargs.pop("rot_mats_seq_ids", None)
+        rot_mats_seq_ids: list = kwargs.pop("rot_mats_seq_ids", None)
         assert rot_mats_seq_ids is not None, "rot_mats_seq_ids must be provided for Qwen2.5-VL"
 
         # [INFO] update the cos/sin matrices in the rope_setup to get ready for decode
-        for seq_id, (cos, sin) in rot_mats_seq_ids.items():
-            self.model.rope_setup.cos_matrix_pt[seq_id] = cos[0]
-            self.model.rope_setup.sin_matrix_pt[seq_id] = sin[0]
+        for i, (cos, sin) in enumerate(rot_mats_seq_ids):
+            self.model.rope_setup.cos_matrix_pt[i] = cos[0]
+            self.model.rope_setup.sin_matrix_pt[i] = sin[0]
         self.model.rope_setup.update_cos_sin()
 
         return super().decode_forward_text(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -237,13 +237,9 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         return logits, rot_mats
 
     def decode_forward(self, *args, **kwargs):
-        rot_mats_seq_ids: list = kwargs.pop("rot_mats_seq_ids", None)
-        assert rot_mats_seq_ids is not None, "rot_mats_seq_ids must be provided for Qwen2.5-VL"
-
-        # [INFO] update the cos/sin matrices in the rope_setup to get ready for decode
-        for i, (cos, sin) in enumerate(rot_mats_seq_ids):
-            self.model.rope_setup.cos_matrix_pt[i] = cos[0]
-            self.model.rope_setup.sin_matrix_pt[i] = sin[0]
-        self.model.rope_setup.update_cos_sin()
+        rot_mats_list: list = kwargs.pop("rot_mats_all_users", None)
+        assert rot_mats_list is not None, "rot_mats_all_users must be provided for Qwen2.5-VL"
+        # [INFO] update the cos/sin matrices for the current users in the batch
+        super().update_cos_sin_rows(rot_mats_list)
 
         return super().decode_forward_text(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/model.py
+++ b/models/demos/qwen25_vl/tt/model.py
@@ -4,7 +4,6 @@
 
 import torch
 from loguru import logger
-from typing_extensions import override
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
@@ -356,10 +355,29 @@ class Transformer(TTTransformer):
             rope_setup_class=RotarySetup,
         )
 
-    @override
-    def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None):
+    def _prepare_cos_sin(self, rot_mats):
+        cos_matrix = rot_mats[0]
+        sin_matrix = rot_mats[1]
+        assert cos_matrix.shape[0] == sin_matrix.shape[0], "cos_matrix and sin_matrix must have the same batch size"
+        outputs = []
+        for mat in (cos_matrix, sin_matrix):
+            outputs.append(
+                ttnn.from_torch(
+                    # [INFO] Qwen2.5 VL produces cos and sin matrices with shape [batch_size, 1, seq_len, head_dim]
+                    mat.expand(cos_matrix.shape[0], -1, -1, -1),
+                    device=self.mesh_device,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=self.rope_setup.datatype,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                ),
+            )
+        return outputs
+
+    def prepare_inputs_prefill(self, tokens, rot_mats, start_pos=0, page_table=None, chunk_page_table=None):
+        assert isinstance(rot_mats[0], torch.Tensor)
+        assert isinstance(rot_mats[1], torch.Tensor)
         # tokens is actually embeddings
-        assert tokens.dim() == 3, "tokens should be a 3D tensor"
+        assert tokens.dim() == 3, "tokens should be a 3D tensor"  # [batch_size = 1, seq_len, head_dim]
         S = tokens.shape[-2]
         tokens_embd = ttnn.from_torch(
             tokens.unsqueeze(1),
@@ -372,12 +390,13 @@ class Transformer(TTTransformer):
         )
 
         # Slice the rot mats to the prefill seqlen
+        cos_matrix, sin_matrix = self._prepare_cos_sin(rot_mats=rot_mats)
         assert (
-            self.rope_setup.cos_matrix.shape[2] >= start_pos + S
-        ), f"Padded prefill end idx {start_pos + S} exceeds max seq len {self.rope_setup.cos_matrix.shape[2]}"
+            cos_matrix.shape[2] >= start_pos + S
+        ), f"Padded prefill end idx {start_pos + S} exceeds max seq len {cos_matrix.shape[2]}"
         tt_rot_mats_prefill = [
-            self.rope_setup.cos_matrix[:, :, start_pos : start_pos + S, :],
-            self.rope_setup.sin_matrix[:, :, start_pos : start_pos + S, :],
+            cos_matrix[:, :, start_pos : start_pos + S, :],
+            sin_matrix[:, :, start_pos : start_pos + S, :],
         ]
 
         if page_table is not None:

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -179,9 +179,7 @@ class RotarySetup(LightweightModule):
         batch_size = position_idxs.shape[0]
         cos, sin = None, None
         for i in range(batch_size):
-            # [INFO] This is a work-around to avoid the slicing issue in position_idxs[i:i+1]
-            # todo)) this workaround can be removed after pulling changes from `main` --> the bug is fixed there
-            pos_i = ttnn.squeeze(ttnn.reshape(position_idxs, (batch_size, 1))[i : i + 1], dim=-1)
+            pos_i = position_idxs[i : i + 1]
             cos_i = ttnn.embedding(pos_i, self.cos_matrix[i : i + 1, ...])  # [1, head_dim]
             sin_i = ttnn.embedding(pos_i, self.sin_matrix[i : i + 1, ...])  # [1, head_dim]
 

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -43,7 +43,7 @@ class RotarySetup(LightweightModule):
         self.datatype = datatype
 
         # Generate the cos/sin matrices needed for ttnn.embedding op
-        cos_matrix, sin_matrix = compute_gather_cos_sin(
+        self.cos_matrix_pt, self.sin_matrix_pt = compute_gather_cos_sin(
             dhead=head_dim,
             end=max_seq_len * 2,
             theta=rope_theta,
@@ -51,8 +51,10 @@ class RotarySetup(LightweightModule):
             orig_context_len=rope_scaling.original_max_position_embeddings if rope_scaling is not None else None,
             position_ids=torch.arange(max_seq_len),
         )
-
-        self.set_cos_sin(cos_matrix, sin_matrix)
+        # [INFO] Qwen2.5 VL produces cos and sin matrices with shape [batch_size, 1, seq_len, head_dim]; clone to allocate memory for the expanded tensor
+        self.cos_matrix_pt = self.cos_matrix_pt.expand(self.batch_size, -1, -1, -1).clone()
+        self.sin_matrix_pt = self.sin_matrix_pt.expand(self.batch_size, -1, -1, -1).clone()
+        self.setup_cos_sin()
 
         self.batch_grid = (
             ttnn.CoreGrid(y=4, x=8)
@@ -102,41 +104,43 @@ class RotarySetup(LightweightModule):
             mesh_mapper=ReplicateTensorToMesh(device) if self.is_mesh_device else None,
         )
 
-    def set_cos_sin(self, cos_matrix, sin_matrix):
+    def update_cos_sin(self):
         # [INFO] we avoid re-allocating the cos_matrix and sin_matrix tensors to allow for correct processing of captured trace
-        if hasattr(self, "cos_matrix"):
-            assert (
-                cos_matrix.shape == self.cos_matrix.shape
-            ), "cos_matrix must be the same size as the existing cos_matrix"
-            assert (
-                sin_matrix.shape == self.sin_matrix.shape
-            ), "sin_matrix must be the same size as the existing sin_matrix"
-
-            for mat, mat_tt in zip((cos_matrix, sin_matrix), (self.cos_matrix, self.sin_matrix)):
-                mat = ttnn.from_torch(
-                    mat,
-                    device=None,
-                    layout=ttnn.TILE_LAYOUT,
-                    dtype=self.datatype,
-                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
-                )
-                mat = ttnn.unsqueeze_to_4D(mat)
-                ttnn.copy_host_to_device_tensor(mat, mat_tt)
-        else:
-            for mat, attr_name in zip((cos_matrix, sin_matrix), ("cos_matrix", "sin_matrix")):
-                setattr(
-                    self,
-                    attr_name,
+        assert hasattr(self, "cos_matrix")
+        assert hasattr(self, "sin_matrix")
+        assert (
+            self.cos_matrix_pt.shape == self.cos_matrix.shape
+        ), "cos_matrix must be the same size as the existing cos_matrix"
+        assert (
+            self.sin_matrix_pt.shape == self.sin_matrix.shape
+        ), "sin_matrix must be the same size as the existing sin_matrix"
+        for mat, mat_tt in zip((self.cos_matrix_pt, self.sin_matrix_pt), (self.cos_matrix, self.sin_matrix)):
+            ttnn.copy_host_to_device_tensor(
+                ttnn.unsqueeze_to_4D(
                     ttnn.from_torch(
-                        mat.expand(
-                            self.batch_size, -1, -1, -1
-                        ),  # [INFO] Qwen2.5 VL produces cos and sin matrices with shape [batch_size, 1, seq_len, head_dim]
-                        device=self.device,
+                        mat,
+                        device=None,
                         layout=ttnn.TILE_LAYOUT,
                         dtype=self.datatype,
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
-                    ),
-                )
+                    )
+                ),
+                mat_tt,
+            )
+
+    def setup_cos_sin(self):
+        for mat, attr_name in zip((self.cos_matrix_pt, self.sin_matrix_pt), ("cos_matrix", "sin_matrix")):
+            setattr(
+                self,
+                attr_name,
+                ttnn.from_torch(
+                    mat,
+                    device=self.device,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=self.datatype,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+                ),
+            )
 
     def get_rot_idxs(self, position_idxs, on_host=False):
         assert isinstance(position_idxs, torch.Tensor), "Position ids must be a torch tensor"

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -104,7 +104,12 @@ class RotarySetup(LightweightModule):
             mesh_mapper=ReplicateTensorToMesh(device) if self.is_mesh_device else None,
         )
 
-    def update_cos_sin(self):
+    def update_cos_sin(self, cos_matrix_pt=None, sin_matrix_pt=None):
+        if cos_matrix_pt is not None:
+            self.cos_matrix_pt.copy_(cos_matrix_pt)
+        if sin_matrix_pt is not None:
+            self.sin_matrix_pt.copy_(sin_matrix_pt)
+
         # [INFO] we avoid re-allocating the cos_matrix and sin_matrix tensors to allow for correct processing of captured trace
         assert hasattr(self, "cos_matrix")
         assert hasattr(self, "sin_matrix")
@@ -182,7 +187,6 @@ class RotarySetup(LightweightModule):
             pos_i = position_idxs[i : i + 1]
             cos_i = ttnn.embedding(pos_i, self.cos_matrix[i : i + 1, ...])  # [1, head_dim]
             sin_i = ttnn.embedding(pos_i, self.sin_matrix[i : i + 1, ...])  # [1, head_dim]
-
             cos = cos_i if cos is None else ttnn.concat([cos, cos_i], dim=0)  # towards [batch_size, head_dim]
             sin = sin_i if sin is None else ttnn.concat([sin, sin_i], dim=0)  # towards [batch_size, head_dim]
 

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -123,10 +123,6 @@ class RotarySetup(LightweightModule):
                 mat = ttnn.unsqueeze_to_4D(mat)
                 ttnn.copy_host_to_device_tensor(mat, mat_tt)
         else:
-            # [INFO] tt-transformers RotarySetup uses a single cos_matrix and sin_matrix for all batches
-            assert (
-                cos_matrix.shape[0] == 1 and sin_matrix.shape[0] == 1
-            ), "Init values of cos_matrix and sin_matrix must have batch size 1"
             for mat, attr_name in zip((cos_matrix, sin_matrix), ("cos_matrix", "sin_matrix")):
                 setattr(
                     self,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Current Qwen2.5-VL's `generator_vllm.py` does not correctly handle the continuous batching of more than one user. 

### What's changed
Decouple the prefill and decode stages of Qwen2.5-VL in terms of cos/sin matrices in the RoPE embedding module. This allows any number of users (as long as the number is smaller than `max_batch_size`) to go through prefill and decode without cross-contaminate the states of other active users that vLLM is managing. 

This PR is accompanied by this vLLM PR: https://github.com/tenstorrent/vllm/pull/158

### Checklist
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes 
  - https://github.com/tenstorrent/tt-metal/actions/runs/16922307043 
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
  - https://github.com/tenstorrent/tt-metal/actions/runs/16922318951 
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
  - https://github.com/tenstorrent/tt-metal/actions/runs/16922346377 