### PR TITLE
corrected indexing to update input in callback for program cache

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_non_zero_indices.py
+++ b/tests/ttnn/unit_tests/operations/test_non_zero_indices.py
@@ -38,3 +38,17 @@ def test_non_zero_indices_ttnn(input_shapes, device):
     tt_output_tensor = output_tensor2[:, :, :, :no_of_non_zero_indices]
 
     assert_equal(torch_output_tensor, tt_output_tensor)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_nonzero(
+    device,
+    reset_seeds,
+):
+    torch_input = torch.tensor([[[[0, 4, 0, 2, 4, 0, 3]]]])
+
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, device=device)
+    for i in range(6):
+        output_indices, output_tensor = ttnn.nonzero(ttnn_input)
+        ttnn.deallocate(output_indices)
+        ttnn.deallocate(output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -99,7 +99,7 @@ operation::ProgramWithCallbacks non_zero_indices_single_core(
                                               const std::vector<Tensor>& output_tensors) {
         const auto& output_0 = output_tensors.at(0);
         const auto& output_1 = output_tensors.at(1);
-        const auto& input = input_tensors.at(1);
+        const auto& input = input_tensors.at(0);
         uint32_t alignment_base = 32 / input.element_size();
         uint32_t aligned_elements = tt::div_up(input.padded_shape()[-1], alignment_base) * alignment_base;
         uint32_t actual_elements = input.padded_shape()[-1];


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25261)

### Problem description
Nonzero returns out of bounds indexing for multiple runs, the program cache was indexing incorrectly for the input tensor.

### What's changed
Only one input tensor in the vector, index from 1 to 0.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16918454285) CI passes
- [ ] [All BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16918459973) CI passes