### PR TITLE
[skip ci] Switch to GNU mirror from UWaterloo

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -131,8 +131,8 @@ RUN mkdir -p /tmp/iwyu \
 RUN [ "$UBUNTU_VERSION" != "24.04" ] && apt-get remove -y gdb || true
 RUN [ "$UBUNTU_VERSION" != "24.04" ] \
     && mkdir -p /tmp/gdb-build && cd /tmp/gdb-build/ \
-    && wget -O /tmp/gdb-build/gdb.tar.gz https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz \
-    && tar -xvf /tmp/gdb-build/gdb.tar.gz -C /tmp/gdb-build --strip-components=1 \
+    && wget -O /tmp/gdb-build/gdb.tar.xz https://mirror.csclub.uwaterloo.ca/gnu/gdb/gdb-14.2.tar.xz \
+    && tar -xvf /tmp/gdb-build/gdb.tar.xz -C /tmp/gdb-build --strip-components=1 \
     && /tmp/gdb-build/configure --prefix=/usr/local \
     && make -j$(nproc) \
     && make install \


### PR DESCRIPTION
### Ticket
N/A

### Problem description
ftp.gnu.org dies.  

### What's changed
* Use a (hopefully more reliable) mirror.
* Bonus: switch to xz for smaller xfer size.