### PR TITLE
Add NoC tracing support for 2d routing fabric configs (low-latency mode)

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -8,8 +8,8 @@ import re
 import inspect
 import pytest
 import subprocess
-import glob
 from loguru import logger
+from conftest import is_6u
 
 import pandas as pd
 import numpy as np
@@ -515,13 +515,13 @@ def test_noc_event_profiler():
 
 
 @skip_for_blackhole()
-def test_fabric_event_profiler_unicast():
+def test_fabric_event_profiler_1d():
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in ["wormhole_b0", "blackhole"]
 
     # test that current device has a valid fabric API connection
     sanity_check_test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
-    sanity_check_test_name = "Fabric1DFixture.TestUnicastConnAPI"
+    sanity_check_test_name = "Fabric1DFixture.TestChipMCast1DWithTracing2"
     sanity_check_succeeded = run_gtest_profiler_test(
         sanity_check_test_bin, sanity_check_test_name, skip_get_device_data=True
     )
@@ -531,71 +531,18 @@ def test_fabric_event_profiler_unicast():
 
     # if device supports fabric API, test fabric event profiler
     test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
-    test_name = "Fabric1DFixture.TestUnicastRawWithTracing"
-    nocEventProfilerEnv = "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1"
-    try:
-        not_skipped = run_gtest_profiler_test(test_bin, test_name, False, True)
-        assert not_skipped, f"gtest command '{test_bin}' was skipped unexpectedly"
-    except subprocess.CalledProcessError as e:
-        ret_code = e.returncode
-        assert ret_code == 0, f"test command '{test_bin}' returned unsuccessfully"
-
-    expected_cluster_coords_file = f"{PROFILER_LOGS_DIR}/cluster_coordinates.json"
-    assert os.path.isfile(
-        expected_cluster_coords_file
-    ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
-
-    expected_trace_file = f"{PROFILER_LOGS_DIR}/noc_trace_dev0_ID0.json"
-    assert os.path.isfile(expected_trace_file), f"expected noc trace file '{expected_trace_file}' does not exist"
-
-    fabric_event_count = 0
-    with open(expected_trace_file, "r") as nocTraceJson:
-        try:
-            noc_trace_data = json.load(nocTraceJson)
-        except json.JSONDecodeError:
-            raise ValueError(f"noc trace file '{expected_trace_file}' is not a valid JSON file")
-
-        assert isinstance(noc_trace_data, list), f"noc trace file '{expected_trace_file}' format is incorrect"
-        assert len(noc_trace_data) > 0, f"noc trace file '{expected_trace_file}' is empty"
-        for event in noc_trace_data:
-            assert isinstance(event, dict), f"noc trace file format error; found event that is not a dict"
-            if event.get("type", "") == "FABRIC_UNICAST_WRITE":
-                fabric_event_count += 1
-                fabric_send_metadata = event.get("fabric_send", None)
-                if fabric_send_metadata is not None:
-                    assert fabric_send_metadata.get("eth_chan", None) is not None
-                    assert fabric_send_metadata.get("start_distance", None) is not None
-
-    EXPECTED_FABRIC_EVENT_COUNT = 10
-    assert (
-        fabric_event_count == EXPECTED_FABRIC_EVENT_COUNT
-    ), f"Incorrect number of fabric events found in noc trace: {fabric_event_count}, expected {EXPECTED_FABRIC_EVENT_COUNT}"
-
-
-@skip_for_blackhole()
-def test_fabric_event_profiler_1d_multicast():
-    ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
-    assert ENV_VAR_ARCH_NAME in ["wormhole_b0", "blackhole"]
-
-    # test that current device has a valid fabric API connection
-    sanity_check_test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
-    sanity_check_test_name = "Fabric1DFixture.TestMCastConnAPI"
-    sanity_check_succeeded = run_gtest_profiler_test(
-        sanity_check_test_bin, sanity_check_test_name, skip_get_device_data=True
-    )
-    if not sanity_check_succeeded:
-        logger.info("Device does not have testable fabric connections, skipping ...")
-        return
-
-    # if device supports fabric API, test fabric event profiler
-    test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
-    tests = ["Fabric1DFixture.TestChipMCast1DWithTracing", "Fabric1DFixture.TestChipMCast1DWithTracing2"]
-    expected_outputs = [
-        {"START_DISTANCE": 1, "RANGE": 3, "FABRIC_EVENT_COUNT": 100},
-        {"START_DISTANCE": 2, "RANGE": 2, "FABRIC_EVENT_COUNT": 100},
+    tests = [
+        "Fabric1DFixture.TestUnicastRaw",
+        "Fabric1DFixture.TestChipMCast1DWithTracing",
+        "Fabric1DFixture.TestChipMCast1DWithTracing2",
+    ]
+    all_tests_expected_event_counts = [
+        {frozenset({"start_distance": 1, "range": 1}.items()): 10},
+        {frozenset({"start_distance": 1, "range": 3}.items()): 100},
+        {frozenset({"start_distance": 2, "range": 2}.items()): 100},
     ]
 
-    for test_name, expected_output in zip(tests, expected_outputs):
+    for test_name, expected_event_counts in zip(tests, all_tests_expected_event_counts):
         nocEventProfilerEnv = "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1"
         try:
             not_skipped = run_gtest_profiler_test(test_bin, test_name, False, True)
@@ -609,11 +556,14 @@ def test_fabric_event_profiler_1d_multicast():
             expected_cluster_coords_file
         ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
 
-        noc_trace_files = glob.glob(f"{PROFILER_LOGS_DIR}/noc_trace_dev[0-9]_ID[0-9].json")
+        noc_trace_files = []
+        for f in os.listdir(f"{PROFILER_LOGS_DIR}"):
+            if re.match(r"^noc_trace_dev[0-9]+_ID[0-9]+.json$", f):
+                noc_trace_files.append(f)
 
-        fabric_event_count = 0
+        actual_event_counts = {}
         for trace_file in noc_trace_files:
-            with open(trace_file, "r") as nocTraceJson:
+            with open(f"{PROFILER_LOGS_DIR}/{trace_file}", "r") as nocTraceJson:
                 try:
                     noc_trace_data = json.load(nocTraceJson)
                 except json.JSONDecodeError:
@@ -623,27 +573,28 @@ def test_fabric_event_profiler_1d_multicast():
                 assert len(noc_trace_data) > 0, f"noc trace file '{trace_file}' is empty"
                 for event in noc_trace_data:
                     assert isinstance(event, dict), f"noc trace file format error; found event that is not a dict"
-                    if event.get("type", "") == "FABRIC_UNICAST_WRITE":
-                        fabric_event_count += 1
+                    if event.get("type", "").startswith("FABRIC_"):
+                        assert event.get("fabric_send", None) is not None
                         fabric_send_metadata = event.get("fabric_send", None)
-                        if fabric_send_metadata is not None:
-                            assert fabric_send_metadata.get("eth_chan", None) is not None
-                            assert (
-                                fabric_send_metadata.get("start_distance", None) == expected_output["START_DISTANCE"]
-                            ), f"Incorrect start distance for fabric event in noc trace: {fabric_send_metadata.get('start_distance', None)}, "
-                            f"expected {expected_output['START_DISTANCE']}"
-                            assert (
-                                fabric_send_metadata.get("range", None) == expected_output["RANGE"]
-                            ), f"Incorrect range for fabric event in noc trace: {fabric_send_metadata.get('range', None)}, "
-                            f"expected {expected_output['RANGE']}"
+                        assert fabric_send_metadata.get("eth_chan", None) is not None
+                        del fabric_send_metadata["eth_chan"]
+                        key = frozenset(fabric_send_metadata.items())
+                        if key not in actual_event_counts:
+                            actual_event_counts[key] = 0
+                        actual_event_counts[key] += 1
 
-        assert (
-            fabric_event_count == expected_output["FABRIC_EVENT_COUNT"]
-        ), f"Incorrect number of fabric events found in noc trace: {fabric_event_count}, expected {expected_output['FABRIC_EVENT_COUNT']}"
+        # compare expected event counts to actual event_counts
+        for event in expected_event_counts.keys() | actual_event_counts.keys():
+            assert expected_event_counts.get(event, 0) == actual_event_counts.get(
+                event, 0
+            ), f"There are {actual_event_counts.get(event, 0)} fabric events with fields {event}, expected {expected_event_counts.get(event, 0)}"
 
 
 @skip_for_blackhole()
 def test_fabric_event_profiler_fabric_mux():
+    ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
+    assert ENV_VAR_ARCH_NAME in ["wormhole_b0", "blackhole"]
+
     # test that current device has a valid fabric API connection
     sanity_check_test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
     sanity_check_test_name = "Fabric1DFixture.TestUnicastConnAPI"
@@ -675,11 +626,14 @@ def test_fabric_event_profiler_fabric_mux():
             expected_cluster_coords_file
         ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
 
-        noc_trace_files = glob.glob(f"{PROFILER_LOGS_DIR}/noc_trace_dev[0-9]_ID[0-9].json")
+        noc_trace_files = []
+        for f in os.listdir(f"{PROFILER_LOGS_DIR}"):
+            if re.match(r"^noc_trace_dev[0-9]+_ID[0-9]+.json$", f):
+                noc_trace_files.append(f)
 
         fabric_event_count = 0
         for trace_file in noc_trace_files:
-            with open(trace_file, "r") as nocTraceJson:
+            with open(f"{PROFILER_LOGS_DIR}/{trace_file}", "r") as nocTraceJson:
                 try:
                     noc_trace_data = json.load(nocTraceJson)
                 except json.JSONDecodeError:
@@ -707,6 +661,122 @@ def test_fabric_event_profiler_fabric_mux():
         assert (
             fabric_event_count == expected_output["FABRIC_EVENT_COUNT"]
         ), f"Incorrect number of fabric events found in noc trace: {fabric_event_count}, expected {expected_output['FABRIC_EVENT_COUNT']}"
+
+
+@skip_for_blackhole()
+def test_fabric_event_profiler_2d():
+    ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
+    assert ENV_VAR_ARCH_NAME in ["wormhole_b0", "blackhole"]
+
+    # test that current device has a valid fabric API connection
+    sanity_check_test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
+    sanity_check_test_name = "Fabric2DFixture.Test2DMCastConnAPI_1N1E1W"
+    sanity_check_succeeded = run_gtest_profiler_test(
+        sanity_check_test_bin, sanity_check_test_name, skip_get_device_data=True
+    )
+    if not sanity_check_succeeded:
+        logger.info("Device does not have testable fabric connections, skipping ...")
+        return
+
+    # if device supports fabric API, test fabric event profiler
+    test_bin = "build/test/tt_metal/tt_fabric/fabric_unit_tests"
+    tests = [
+        "Fabric2DFixture.TestUnicastRaw_3E",
+        "Fabric2DFixture.TestMCastConnAPI_1W2E",
+        "Fabric2DFixture.Test2DMCastConnAPI_1N1E1W",
+    ]
+
+    if is_6u():
+        tests.extend(
+            [
+                "Fabric2DFixture.TestUnicastRaw_3N",
+                "Fabric2DFixture.TestUnicastRaw_3N3E",
+                "Fabric2DFixture.TestMCastConnAPI_2N1S",
+                "Fabric2DFixture.Test2DMCastConnAPI_7N3E",
+            ]
+        )
+
+    all_tests_expected_event_counts = [
+        {
+            frozenset({"ns_hops": 0, "e_hops": 3, "w_hops": 0, "is_mcast": False}.items()): 10,
+        },
+        {
+            frozenset({"ns_hops": 0, "e_hops": 0, "w_hops": 1, "is_mcast": False}.items()): 100,
+            frozenset({"ns_hops": 0, "e_hops": 2, "w_hops": 0, "is_mcast": True}.items()): 100,
+        },
+        {
+            frozenset({"ns_hops": 1, "e_hops": 1, "w_hops": 1, "is_mcast": True}.items()): 100,
+            frozenset({"ns_hops": 0, "e_hops": 1, "w_hops": 0, "is_mcast": False}.items()): 100,
+            frozenset({"ns_hops": 0, "e_hops": 0, "w_hops": 1, "is_mcast": False}.items()): 100,
+        },
+    ]
+
+    if is_6u():
+        all_tests_expected_event_counts.extend(
+            [
+                {
+                    frozenset({"ns_hops": 3, "e_hops": 0, "w_hops": 0, "is_mcast": False}.items()): 10,
+                },
+                {
+                    frozenset({"ns_hops": 2, "e_hops": 4, "w_hops": 0, "is_mcast": False}.items()): 10,
+                },
+                {
+                    frozenset({"ns_hops": 2, "e_hops": 0, "w_hops": 0, "is_mcast": True}.items()): 100,
+                    frozenset({"ns_hops": 1, "e_hops": 0, "w_hops": 0, "is_mcast": False}.items()): 100,
+                },
+                {
+                    frozenset({"ns_hops": 7, "e_hops": 3, "w_hops": 0, "is_mcast": True}.items()): 100,
+                    frozenset({"ns_hops": 0, "e_hops": 3, "w_hops": 0, "is_mcast": True}.items()): 100,
+                },
+            ]
+        )
+
+    for test_name, expected_event_counts in zip(tests, all_tests_expected_event_counts):
+        nocEventProfilerEnv = "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1"
+        try:
+            not_skipped = run_gtest_profiler_test(test_bin, test_name, False, True)
+            assert not_skipped, f"gtest command '{test_bin}' was skipped unexpectedly"
+        except subprocess.CalledProcessError as e:
+            ret_code = e.returncode
+            assert ret_code == 0, f"test command '{test_bin}' returned unsuccessfully"
+
+        expected_cluster_coords_file = f"{PROFILER_LOGS_DIR}/cluster_coordinates.json"
+        assert os.path.isfile(
+            expected_cluster_coords_file
+        ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
+
+        noc_trace_files = []
+        for f in os.listdir(f"{PROFILER_LOGS_DIR}"):
+            if re.match(r"^noc_trace_dev[0-9]+_ID[0-9]+.json$", f):
+                noc_trace_files.append(f)
+
+        actual_event_counts = {}
+        for trace_file in noc_trace_files:
+            with open(f"{PROFILER_LOGS_DIR}/{trace_file}", "r") as nocTraceJson:
+                try:
+                    noc_trace_data = json.load(nocTraceJson)
+                except json.JSONDecodeError:
+                    raise ValueError(f"noc trace file '{trace_file}' is not a valid JSON file")
+
+                assert isinstance(noc_trace_data, list), f"noc trace file '{trace_file}' format is incorrect"
+                assert len(noc_trace_data) > 0, f"noc trace file '{trace_file}' is empty"
+                for event in noc_trace_data:
+                    assert isinstance(event, dict), f"noc trace file format error; found event that is not a dict"
+                    if event.get("type", "").startswith("FABRIC_"):
+                        assert event.get("fabric_send", None) is not None
+                        fabric_send_metadata = event.get("fabric_send", None)
+                        assert fabric_send_metadata.get("eth_chan", None) is not None
+                        del fabric_send_metadata["eth_chan"]
+                        key = frozenset(fabric_send_metadata.items())
+                        if key not in actual_event_counts:
+                            actual_event_counts[key] = 0
+                        actual_event_counts[key] += 1
+
+        # compare expected event counts to actual event_counts
+        for event in expected_event_counts.keys() | actual_event_counts.keys():
+            assert expected_event_counts.get(event, 0) == actual_event_counts.get(
+                event, 0
+            ), f"There are {actual_event_counts.get(event, 0)} fabric events with fields {event}, expected {expected_event_counts.get(event, 0)}"
 
 
 def test_sub_device_profiler():

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -241,15 +241,15 @@ struct McastRoutingInfo {
 };
 
 void RunTestUnicastRaw(
-    BaseFabricFixture* fixture,
-    uint32_t num_hops = 1,
-    RoutingDirection direction = RoutingDirection::E,
-    bool enable_fabric_tracing = false);
+    BaseFabricFixture* fixture, uint32_t num_hops = 1, RoutingDirection direction = RoutingDirection::E);
 
 void RunTestUnicastConnAPI(
     BaseFabricFixture* fixture, uint32_t num_hops = 1, RoutingDirection direction = RoutingDirection::E, bool use_dram_dst = false);
 
 void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture);
+
+void RunTestUnicastRaw2D(
+    BaseFabricFixture* fixture, uint32_t ns_hops, RoutingDirection ns_dir, uint32_t ew_hops, RoutingDirection ew_dir);
 
 void RunTestMCastConnAPI(
     BaseFabricFixture* fixture,
@@ -261,12 +261,7 @@ void RunTestMCastConnAPI(
 void RunTest2DMCastConnAPI(
     BaseFabricFixture* fixture, uint32_t north_hops, uint32_t south_hops, uint32_t east_hops, uint32_t west_hops);
 
-void RunTestChipMCast1D(
-    BaseFabricFixture* fixture,
-    RoutingDirection dir,
-    uint32_t start_distance,
-    uint32_t range,
-    bool enable_fabric_tracing = false);
+void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32_t start_distance, uint32_t range);
 
 void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRoutingInfo>& mcast_routing_info);
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -33,7 +33,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/fabric.hpp>
-#include <tt-metalium/tt_metal_profiler.hpp>
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
@@ -355,8 +354,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     }
 }
 
-void RunTestUnicastRaw(
-    BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction, bool enable_fabric_tracing) {
+void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
@@ -468,10 +466,6 @@ void RunTestUnicastRaw(
         defines["FABRIC_2D"] = "";
     }
 
-    if (enable_fabric_tracing) {
-        defines["TEST_ENABLE_FABRIC_TRACING"] = "1";
-    }
-
     // Create the sender program
     auto sender_program = tt_metal::CreateProgram();
     auto sender_kernel = tt_metal::CreateKernel(
@@ -525,10 +519,6 @@ void RunTestUnicastRaw(
     fixture->RunProgramNonblocking(sender_device, sender_program);
     fixture->WaitForSingleProgramDone(sender_device, sender_program);
     fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
-
-    if (enable_fabric_tracing) {
-        tt_metal::detail::ReadDeviceProfilerResults(sender_device->get_devices()[0]);
-    }
 
     // Validate the status and packets processed by sender and receiver
     std::vector<uint32_t> sender_status;
@@ -766,6 +756,84 @@ void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture) {
 
     const auto src_physical_device_id = devices[random_dev_list[0]]->get_devices()[0]->id();
     const auto dst_physical_device_id = devices[random_dev_list[1]]->get_devices()[0]->id();
+
+    log_info(tt::LogTest, "Src Phys ChipId {}", src_physical_device_id);
+    log_info(tt::LogTest, "Dst Phys ChipId {}", dst_physical_device_id);
+
+    run_unicast_test_bw_chips(
+        fixture, src_physical_device_id, dst_physical_device_id, 0 /* num_hops, not needed for 2d */);
+}
+
+void RunTestUnicastRaw2D(
+    BaseFabricFixture* fixture, uint32_t ns_hops, RoutingDirection ns_dir, uint32_t ew_hops, RoutingDirection ew_dir) {
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    // use control plane to find a mesh with (ns_hops + 1) * (ew_hops + 1) devices
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
+    std::optional<MeshId> mesh_id;
+    for (const auto& mesh : user_meshes) {
+        auto mesh_shape = control_plane.get_physical_mesh_shape(mesh);
+        if (mesh_shape.mesh_size() >= (ns_hops + 1) * (ew_hops + 1)) {
+            mesh_id = mesh;
+            break;
+        }
+    }
+    if (!mesh_id.has_value()) {
+        GTEST_SKIP() << "No appropriate mesh found for 2d unicast test";
+    }
+
+    // Find a device num_hops away in specified direction.
+    FabricNodeId src_fabric_node_id(MeshId{0}, 0);
+    std::unordered_map<RoutingDirection, uint32_t> fabric_hops;
+    std::unordered_map<RoutingDirection, uint32_t> branch_hops;
+
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>> end_fabric_node_ids_by_dir;
+    chip_id_t src_phys_chip_id;
+    std::unordered_map<RoutingDirection, std::vector<chip_id_t>> physical_end_device_ids_by_dir;
+
+    if (ns_hops != 0) {
+        fabric_hops[ns_dir] = ns_hops;
+    }
+    if (ew_hops != 0) {
+        fabric_hops[ew_dir] = ew_hops;
+    }
+
+    tt::tt_metal::distributed::MeshShape mesh_shape;
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+    uint32_t is_2d_fabric = topology == Topology::Mesh;
+
+    if (!is_2d_fabric) {
+        GTEST_SKIP() << "Need 2D Fabric for this test.";
+    }
+
+    // Get the mcast sender device and mcast receiver devices that satisfy the input number of trunk hops
+    if (!find_device_with_neighbor_in_multi_direction(
+            fixture,
+            src_fabric_node_id,
+            end_fabric_node_ids_by_dir,
+            src_phys_chip_id,
+            physical_end_device_ids_by_dir,
+            fabric_hops)) {
+        log_info(
+            tt::LogTest,
+            "No destinations found for {} hops in direction {} and {} hops in direction {}.",
+            ns_hops,
+            ns_dir,
+            ew_hops,
+            ew_dir);
+        GTEST_SKIP() << "Skipping Test";
+    }
+
+    mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+    uint32_t ew_dim = mesh_shape[1];
+    auto device_offset = ns_dir == RoutingDirection::N ? -1 : 1;
+    auto dst_fabric_node_id = src_fabric_node_id;
+    if (ew_hops != 0) {
+        dst_fabric_node_id = end_fabric_node_ids_by_dir[ew_dir][ew_hops - 1];
+    }
+    dst_fabric_node_id.chip_id += device_offset * ew_dim * ns_hops;
+    auto dst_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
+    auto src_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
 
     log_info(tt::LogTest, "Src Phys ChipId {}", src_physical_device_id);
     log_info(tt::LogTest, "Dst Phys ChipId {}", dst_physical_device_id);
@@ -1606,12 +1674,7 @@ void RunTest2DMCastConnAPI(
     }
 }
 
-void RunTestChipMCast1D(
-    BaseFabricFixture* fixture,
-    RoutingDirection dir,
-    uint32_t start_distance,
-    uint32_t range,
-    bool enable_fabric_tracing) {
+void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32_t start_distance, uint32_t range) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
     std::vector<tt_metal::Program> receiver_programs;
@@ -1699,10 +1762,6 @@ void RunTestChipMCast1D(
         0 /* additional_dir */};
 
     std::map<std::string, std::string> defines = {};
-
-    if (enable_fabric_tracing) {
-        defines["TEST_ENABLE_FABRIC_TRACING"] = "1";
-    }
 
     // Create the sender program
     auto sender_program = tt_metal::CreateProgram();
@@ -1798,10 +1857,6 @@ void RunTestChipMCast1D(
     }
     log_info(tt::LogTest, "All Receivers Finished");
 
-    if (enable_fabric_tracing) {
-        tt_metal::detail::ReadDeviceProfilerResults(sender_device->get_devices()[0]);
-    }
-
     // Validate the status and packets processed by sender and receiver
     std::vector<uint32_t> sender_status;
     std::vector<uint32_t> left_recv_status;
@@ -1850,17 +1905,15 @@ void RunTestChipMCast1D(
     }
 }
 
-TEST_F(Fabric1DFixture, TestUnicastRaw) { RunTestUnicastRaw(this, 1, RoutingDirection::E, false); }
+TEST_F(Fabric1DFixture, TestUnicastRaw) { RunTestUnicastRaw(this, 1, RoutingDirection::E); }
 TEST_F(Fabric1DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
 TEST_F(Fabric1DFixture, TestUnicastConnAPIDRAM) { RunTestUnicastConnAPI(this, 1, RoutingDirection::E, true); }
 TEST_F(Fabric1DFixture, TestUnicastTGGateways) { RunTestUnicastTGGateways(this); }
 TEST_F(Fabric1DFixture, TestMCastConnAPI) { RunTestMCastConnAPI(this); }
 
 // only chip multicast (test start and range)
-TEST_F(Fabric1DFixture, TestChipMCast1DWithTracing) { RunTestChipMCast1D(this, RoutingDirection::E, 1, 3, true); }
-TEST_F(Fabric1DFixture, TestChipMCast1DWithTracing2) { RunTestChipMCast1D(this, RoutingDirection::E, 2, 2, true); }
-
-TEST_F(Fabric1DFixture, TestUnicastRawWithTracing) { RunTestUnicastRaw(this, 1, RoutingDirection::E, true); }
+TEST_F(Fabric1DFixture, TestChipMCast1DWithTracing) { RunTestChipMCast1D(this, RoutingDirection::E, 1, 3); }
+TEST_F(Fabric1DFixture, TestChipMCast1DWithTracing2) { RunTestChipMCast1D(this, RoutingDirection::E, 2, 2); }
 
 void RunEDMConnectionStressTest(
     BaseFabricFixture* fixture,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -215,6 +215,18 @@ TEST_F(Fabric2DFixture, TestUnicastRaw) {
     }
 }
 
+TEST_F(Fabric2DFixture, TestUnicastRaw_3N) {
+    RunTestUnicastRaw2D(this, 3, RoutingDirection::N, 0, RoutingDirection::E);
+}
+
+TEST_F(Fabric2DFixture, TestUnicastRaw_3E) {
+    RunTestUnicastRaw2D(this, 0, RoutingDirection::N, 3, RoutingDirection::E);
+}
+
+TEST_F(Fabric2DFixture, TestUnicastRaw_3N3E) {
+    RunTestUnicastRaw2D(this, 3, RoutingDirection::N, 3, RoutingDirection::E);
+}
+
 TEST_F(Fabric2DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
 
 TEST_F(Fabric2DFixture, TestUnicastConnAPIDRAM) { RunTestUnicastConnAPI(this, 1, RoutingDirection::E, true); }
@@ -260,6 +272,10 @@ TEST_F(Fabric2DFixture, TestMCastConnAPI_1N2S) {
 TEST_F(Fabric2DFixture, TestMCastConnAPI_2N1S) {
     RunTestMCastConnAPI(this, RoutingDirection::N, 2, RoutingDirection::S, 1);
 }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1N1E1W) { RunTest2DMCastConnAPI(this, 1, 0, 1, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_7N3E) { RunTest2DMCastConnAPI(this, 7, 0, 3, 0); }
 
 TEST_F(NightlyFabric2DFixture, Test2DMCast) {
     auto valid_combinations = GenerateAllValidCombinations(this);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -24,7 +24,6 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
-#include <tt-metalium/tt_metal_profiler.hpp>
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {
@@ -65,7 +64,6 @@ struct TestConfig {
     uint32_t num_full_size_channel_iters = 0;
     bool is_2d_fabric = false;
     bool terminate_from_kernel = false;
-    bool enable_fabric_tracing = false;
 };
 
 struct WorkerMemoryMap {
@@ -644,9 +642,6 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     log_info(LogTest, "Waiting for programs");
     for (auto i = 0; i < devices.size(); i++) {
         fixture->WaitForSingleProgramDone(devices[i], program_handles[i]);
-        if (test_config.enable_fabric_tracing) {
-            tt::tt_metal::detail::ReadDeviceProfilerResults(devices[i]->get_devices()[0]);
-        }
     }
 
     auto validate_worker_results = [&](tt::tt_metal::IDevice* device, const CoreCoord& core) {
@@ -722,6 +717,7 @@ TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariant3) {
     run_mux_test_variant(this, test_config);
 }
 
+// Use fewer packets to prevent profiler buffer from becoming full
 TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariantWithNocTracing) {
     TestConfig test_config = {
         .num_devices = 2,
@@ -736,7 +732,6 @@ TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariantWithNocTracing) {
         .uniform_sender_receiver_split = true,
         .num_open_close_iters = 1,
         .num_full_size_channel_iters = 1,
-        .enable_fabric_tracing = true,
     };
     run_mux_test_variant(this, test_config);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp
@@ -12,10 +12,7 @@
 #include "fabric/fabric_edm_packet_header.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
-
-#ifdef TEST_ENABLE_FABRIC_TRACING
 #include "tt_metal/tools/profiler/fabric_event_profiler.hpp"
-#endif
 
 // clang-format on
 
@@ -130,9 +127,7 @@ inline void send_notification(
     volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header, tt::tt_fabric::WorkerToFabricEdmSender& connection) {
     // Notify mailbox that the packets have been sent
     connection.wait_for_empty_write_slot();
-#ifdef TEST_ENABLE_FABRIC_TRACING
     RECORD_FABRIC_HEADER(packet_header);
-#endif
     connection.send_payload_flush_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
 }
 
@@ -150,9 +145,7 @@ inline void send_packet(
         reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address + packet_payload_size_bytes - 4);
 #endif
     connection.wait_for_empty_write_slot();
-#ifdef TEST_ENABLE_FABRIC_TRACING
     RECORD_FABRIC_HEADER(packet_header);
-#endif
     connection.send_payload_without_header_non_blocking_from_address(
         source_l1_buffer_address, packet_payload_size_bytes);
     connection.send_payload_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_2d_mcast_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_2d_mcast_tx.cpp
@@ -12,10 +12,7 @@
 #include "fabric/fabric_edm_packet_header.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
-
-#ifdef TEST_ENABLE_FABRIC_TRACING
 #include "tt_metal/tools/profiler/fabric_event_profiler.hpp"
-#endif
 
 // clang-format on
 
@@ -54,9 +51,7 @@ inline void send_packet(
         reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address + packet_payload_size_bytes - 4);
 #endif
     connection.wait_for_empty_write_slot();
-#ifdef TEST_ENABLE_FABRIC_TRACING
     RECORD_FABRIC_HEADER(packet_header);
-#endif
     connection.send_payload_without_header_non_blocking_from_address(
         source_l1_buffer_address, packet_payload_size_bytes);
     connection.send_payload_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));

--- a/tt_metal/tools/profiler/fabric_event_profiler.hpp
+++ b/tt_metal/tools/profiler/fabric_event_profiler.hpp
@@ -12,6 +12,54 @@
 
 namespace kernel_profiler {
 
+// how slow is this? alternative is sotring entire route buffer which isn't ideal either...
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordRoutingFields2D(
+    const volatile tt::tt_fabric::LowLatencyMeshRoutingFields& routing_fields, const volatile uint8_t* route_buffer) {
+    KernelProfilerNocEventMetadata ev_md;
+    auto& routing_fields_2d = ev_md.data.fabric_routing_fields_2d;
+    routing_fields_2d.noc_xfer_type = KernelProfilerNocEventMetadata::NocEventType::FABRIC_ROUTING_FIELDS_2D;
+
+    // dimension order routing: first we have N/S forwarding with possible branching/local writes for mcast
+    uint8_t total_hops = 0;
+    while (route_buffer[total_hops] & tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS) {
+        total_hops++;
+    }
+
+    routing_fields_2d.ns_hops = total_hops;
+
+    // compute e/w hops and check for e/w line mcast
+    while (route_buffer[total_hops] != tt::tt_fabric::LowLatencyMeshRoutingFields::NOOP) {
+        total_hops++;
+    }
+
+    // Look at last entry in buffer to check if west branch exists
+    // If west branch exists, compute west hops and east hops as remaining
+    // Otherwise, we only have east hops (which is trivially to 0 if we have no e/w hops at all)
+    if (route_buffer[total_hops - 1] == tt::tt_fabric::LowLatencyMeshRoutingFields::FORWARD_EAST) {
+        routing_fields_2d.w_hops = total_hops - routing_fields.branch_west_offset;
+        routing_fields_2d.e_hops = routing_fields.branch_west_offset - routing_fields_2d.ns_hops;
+    } else {
+        routing_fields_2d.e_hops = total_hops - routing_fields_2d.ns_hops;
+    }
+
+    // look at first entries of trunk/branches in buffer to check for N/S line mcast, E/W line mcast, or 2d mcast
+    // the last check is for the 1N1E1W edge case (which is a 2d mcast)
+    if (routing_fields_2d.ns_hops > 0 &&
+            (route_buffer[0] & tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS) ==
+                tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS ||
+        routing_fields_2d.e_hops > 0 && route_buffer[routing_fields.branch_east_offset] ==
+                                            tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_EW ||
+        routing_fields_2d.w_hops > 0 && route_buffer[routing_fields.branch_west_offset] ==
+                                            tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_EW ||
+        routing_fields_2d.e_hops > 0 && routing_fields_2d.w_hops > 0) {
+        routing_fields_2d.is_mcast = true;
+    }
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+}
+
 void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) {
     // determine routing fields type at compile time
     KernelProfilerNocEventMetadata::FabricPacketType routing_fields_type;
@@ -23,6 +71,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         routing_fields_type = KernelProfilerNocEventMetadata::FabricPacketType::REGULAR;
     }
 
+    // first profiler packet stores XY address data as well as packet type tag (used to decode routing fields)
     auto noc_send_type = fabric_header_ptr->get_noc_send_type();
     switch (noc_send_type) {
         case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
@@ -30,8 +79,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
             noc_event_profiler::recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_WRITE,
                 routing_fields_type,
-                unicast_write_cmd.noc_address,
-                fabric_header_ptr->routing_fields.value);
+                unicast_write_cmd.noc_address);
             break;
         }
         case tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC: {
@@ -39,8 +87,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
             noc_event_profiler::recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_ATOMIC_INC,
                 routing_fields_type,
-                unicast_write_cmd.noc_address,
-                fabric_header_ptr->routing_fields.value);
+                unicast_write_cmd.noc_address);
             break;
         }
         case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: {
@@ -48,8 +95,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
             noc_event_profiler::recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_FUSED_UNICAST_ATOMIC_INC,
                 routing_fields_type,
-                unicast_write_cmd.noc_address,
-                fabric_header_ptr->routing_fields.value);
+                unicast_write_cmd.noc_address);
             break;
         }
         case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE: {
@@ -57,8 +103,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
             noc_event_profiler::recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_INLINE_WRITE,
                 routing_fields_type,
-                unicast_write_cmd.noc_address,
-                fabric_header_ptr->routing_fields.value);
+                unicast_write_cmd.noc_address);
             break;
         }
         case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE: {
@@ -68,8 +113,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
                 routing_fields_type,
                 unicast_write_cmd.noc_address,
                 unicast_write_cmd.chunk_size,
-                NOC_SCATTER_WRITE_MAX_CHUNKS,
-                fabric_header_ptr->routing_fields.value);
+                NOC_SCATTER_WRITE_MAX_CHUNKS);
             break;
         }
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE: {
@@ -80,8 +124,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
                 mcast_write_cmd.noc_x_start,
                 mcast_write_cmd.noc_y_start,
                 mcast_write_cmd.mcast_rect_size_x,
-                mcast_write_cmd.mcast_rect_size_y,
-                fabric_header_ptr->routing_fields.value);
+                mcast_write_cmd.mcast_rect_size_y);
             break;
         }
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_ATOMIC_INC: {
@@ -92,10 +135,20 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
                 mcast_write_cmd.noc_x_start,
                 mcast_write_cmd.noc_y_start,
                 mcast_write_cmd.size_x,
-                mcast_write_cmd.size_y,
-                fabric_header_ptr->routing_fields.value);
+                mcast_write_cmd.size_y);
             break;
         }
+    }
+
+    // following profiler event just stores the routing fields
+    if constexpr (std::is_base_of_v<tt::tt_fabric::LowLatencyMeshRoutingFields, ROUTING_FIELDS_TYPE>) {
+#if defined(FABRIC_2D) && !defined(DYNAMIC_ROUTING_ENABLED)
+        recordRoutingFields2D(fabric_header_ptr->routing_fields, fabric_header_ptr->route_buffer);
+#endif
+    } else if constexpr (std::is_base_of_v<tt::tt_fabric::LowLatencyRoutingFields, ROUTING_FIELDS_TYPE>) {
+        noc_event_profiler::recordRoutingFields1D(fabric_header_ptr->routing_fields.value);
+    } else if constexpr (std::is_base_of_v<tt::tt_fabric::RoutingFields, ROUTING_FIELDS_TYPE>) {
+        noc_event_profiler::recordRoutingFields1D(fabric_header_ptr->routing_fields.value);
     }
 }
 }  // namespace kernel_profiler


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-npe/issues/72

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes: test_fabric_event_profiler_2d in test_device_profiler.py