### PR TITLE
#0: Properly align serialized flatbuffer for multi-host aware tensor serialization

### DIFF
--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/tensor/serialization.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <string>
@@ -417,6 +418,10 @@ void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) 
 
     std::vector<HostBuffer> buffers;
     flatbuffers::FlatBufferBuilder builder;
+    // To be able to read flatbuffer data with `mmap` safely, make sure the serialized flatbuffer is aligned to at least
+    // 8 bytes, just like `header_size`. Individual `buffers` are aligned according to their element size, which is
+    // already what we need for `mmap` to work.
+    builder.Align(alignof(uint64_t));
     auto tensor_offset = ttnn::to_flatbuffer(cpu_tensor, builder, buffers);
     builder.Finish(tensor_offset);
 

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -284,6 +284,8 @@ DistributedStorage load_storage(
     return DistributedStorage{load_host_storage(input_file, data_type), ReplicateTensor{}};
 }
 
+constexpr std::uint32_t kFlatbufferAlignment = alignof(std::uint64_t);
+
 }  // namespace
 
 Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
@@ -418,11 +420,11 @@ void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) 
 
     std::vector<HostBuffer> buffers;
     flatbuffers::FlatBufferBuilder builder;
+    auto tensor_offset = ttnn::to_flatbuffer(cpu_tensor, builder, buffers);
     // To be able to read flatbuffer data with `mmap` safely, make sure the serialized flatbuffer is aligned to at least
     // 8 bytes, just like `header_size`. Individual `buffers` are aligned according to their element size, which is
     // already what we need for `mmap` to work.
-    builder.Align(alignof(uint64_t));
-    auto tensor_offset = ttnn::to_flatbuffer(cpu_tensor, builder, buffers);
+    builder.Align(kFlatbufferAlignment);
     builder.Finish(tensor_offset);
 
     uint64_t header_size = builder.GetSize();
@@ -463,8 +465,12 @@ Tensor load_tensor_flatbuffer(const std::string& file_name, MeshDevice* device) 
     const uint64_t data_offset = sizeof(header_size) + header_size;
     const uint64_t data_size = file_size - data_offset;
 
-    Tensor tensor =
-        ttnn::from_flatbuffer(fb_tensor, tt::stl::Span<std::byte>(file_data + data_offset, data_size), memory_pin);
+    std::byte* data_region = file_data + data_offset;
+    TT_FATAL(
+        (reinterpret_cast<uintptr_t>(data_region) & (kFlatbufferAlignment - 1)) == 0,
+        "Tensor data pointer must be 8-byte aligned!");
+
+    Tensor tensor = ttnn::from_flatbuffer(fb_tensor, tt::stl::Span<std::byte>(data_region, data_size), memory_pin);
     if (device != nullptr) {
         tensor = tensor.to_device(device);
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Flatbuffer needs to be aligned, so that the data region is similarly aligned to at least 8 bytes. This is enough for existing tensor dtypes.

### What's changed
Add `builder.Align(alignof(uint64_t));` statement.

### Checklist
- [X] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16950473237)
- [X] New/Existing tests provide coverage for changes