### PR TITLE
#22835: Uplift Additional Tests to TT-Mesh APIs

### DIFF
--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -277,7 +277,7 @@ TEST_F(UnitMeshCQProgramFixture, TensixTestPipelineAcrossRows) {
         GTEST_SKIP();
     }
 
-    unit_tests::create_pipeline::PipelineRowConfig test_config;
+    unit_tests::create_pipeline::PipelineRowConfig test_config{};
     auto mesh_device = this->devices_[0];
     // // saturate DRAM
     test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -40,6 +40,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "umd/device/types/arch.h"
 #include <tt-metalium/utils.hpp>
+#include <tt-metalium/distributed.hpp>
 
 namespace tt {
 namespace tt_metal {
@@ -65,10 +66,12 @@ struct PipelineRowConfig {
     size_t num_repetitions;
 };
 
-void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowConfig& test_config) {
-    CommandQueue& cq = device->command_queue();
+void create_and_run_row_pipeline(
+    std::shared_ptr<distributed::MeshDevice> mesh_device, const PipelineRowConfig& test_config) {
+    auto& cq = mesh_device->mesh_command_queue();
 
     tt_metal::Program program = tt_metal::CreateProgram();
+    distributed::MeshWorkload mesh_workload;
 
     uint32_t num_cores = (uint32_t)test_config.num_cores;
     uint32_t num_tiles = (uint32_t)test_config.num_tiles;
@@ -119,11 +122,18 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
 
     tt_metal::BufferType buff_type =
         test_config.IO_data_in_dram ? tt_metal::BufferType::DRAM : tt_metal::BufferType::L1;
-    tt_metal::InterleavedBufferConfig buff_config{
-        .device = device, .size = buffer_size, .page_size = buffer_size, .buffer_type = buff_type};
 
-    auto src_buffer = CreateBuffer(buff_config);
-    auto dst_buffer = CreateBuffer(buff_config);
+    const distributed::DeviceLocalBufferConfig device_local_config{
+        .page_size = buffer_size,
+        .buffer_type = buff_type,
+    };
+
+    const distributed::ReplicatedBufferConfig replicated_buffer_config{
+        .size = buffer_size,
+    };
+
+    auto src_buffer = distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, mesh_device.get());
+    auto dst_buffer = distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, mesh_device.get());
 
     src_address = src_buffer->address();
     dst_address = dst_buffer->address();
@@ -205,8 +215,8 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
                 program,
                 receiver_kernels.at(core_id),
                 core,
-                {(uint32_t)device->worker_core_from_logical_core(cores[core_id - 1]).x,
-                 (uint32_t)device->worker_core_from_logical_core(cores[core_id - 1]).y,
+                {(uint32_t)mesh_device->worker_core_from_logical_core(cores[core_id - 1]).x,
+                 (uint32_t)mesh_device->worker_core_from_logical_core(cores[core_id - 1]).y,
                  (uint32_t)num_tiles,
                  (uint32_t)sender_semaphore_id,
                  (uint32_t)receiver_semaphore_id,
@@ -224,8 +234,8 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
                 program,
                 sender_kernels.at(core_id),
                 core,
-                {(uint32_t)device->worker_core_from_logical_core(cores[core_id + 1]).x,
-                 (uint32_t)device->worker_core_from_logical_core(cores[core_id + 1]).y,
+                {(uint32_t)mesh_device->worker_core_from_logical_core(cores[core_id + 1]).x,
+                 (uint32_t)mesh_device->worker_core_from_logical_core(cores[core_id + 1]).y,
                  (uint32_t)num_tiles,
                  (uint32_t)sender_semaphore_id,
                  (uint32_t)receiver_semaphore_id,
@@ -233,7 +243,8 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
                  (uint32_t)num_repetitions});
         }
     }
-
+    distributed::AddProgramToMeshWorkload(
+        mesh_workload, std::move(program), distributed::MeshCoordinateRange(mesh_device->shape()));
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////
@@ -242,17 +253,16 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
     log_info(LogTest, "Writing to device buffer->..");
-    tt_metal::detail::WriteToBuffer(src_buffer, src_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec);
     log_info(LogTest, "Writing to device buffer Done.");
-
-    EnqueueProgram(cq, program, false);
-    Finish(cq);
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    distributed::Finish(cq);
 
     log_info(LogTest, "Kernels done.");
 
     log_info(LogTest, "Reading results from device...");
     std::vector<uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::ReadShard(cq, result_vec, dst_buffer, distributed::MeshCoordinate(0, 0));
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Validation & Teardown
@@ -262,93 +272,93 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
 
 }  // namespace unit_tests::create_pipeline
 
-TEST_F(CommandQueueProgramFixture, TensixTestPipelineAcrossRows) {
+TEST_F(UnitMeshCQProgramFixture, TensixTestPipelineAcrossRows) {
     if (this->arch_ != tt::ARCH::GRAYSKULL) {
         GTEST_SKIP();
     }
 
-    unit_tests::create_pipeline::PipelineRowConfig test_config{};
-
+    unit_tests::create_pipeline::PipelineRowConfig test_config;
+    auto mesh_device = this->devices_[0];
     // // saturate DRAM
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64 * 1024;
     test_config.block_size_tiles = 16;
     test_config.num_blocks_in_CB = 2;
     test_config.IO_data_in_dram = true;
     test_config.num_repetitions = 1;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // saturate L1
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 16;
     test_config.num_blocks_in_CB = 2;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 64;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #1
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 1;
     test_config.num_blocks_in_CB = 16;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #2
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 2;
     test_config.num_blocks_in_CB = 16;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #3
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 4;
     test_config.num_blocks_in_CB = 16;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #4
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 8;
     test_config.num_blocks_in_CB = 8;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #5
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 16;
     test_config.num_blocks_in_CB = 4;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #6
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 32;
     test_config.num_blocks_in_CB = 4;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 
     // test #7
-    test_config.num_cores = this->device_->compute_with_storage_grid_size().x - 1;
+    test_config.num_cores = mesh_device->compute_with_storage_grid_size().x - 1;
     test_config.num_tiles = 64;
     test_config.block_size_tiles = 64;
     test_config.num_blocks_in_CB = 4;
     test_config.IO_data_in_dram = false;
     test_config.num_repetitions = 128;
-    unit_tests::create_pipeline::create_and_run_row_pipeline(this->device_, test_config);
+    unit_tests::create_pipeline::create_and_run_row_pipeline(mesh_device, test_config);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -17,7 +17,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
-#include "device_fixture.hpp"
+#include "command_queue_fixture.hpp"
 #include "env_lib.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -25,6 +25,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/df/float32.hpp"
+#include <tt-metalium/distributed.hpp>
 
 namespace tt::tt_metal {
 
@@ -34,7 +35,7 @@ using namespace tt::test_utils;
 using namespace tt::test_utils::df;
 
 void build_and_run_program(
-    tt::tt_metal::IDevice* device,
+    std::shared_ptr<distributed::MeshDevice> device,
     bool slow_dispatch,
     uint32_t NUM_PROGRAMS,
     uint32_t MAX_LOOP,
@@ -46,7 +47,6 @@ void build_and_run_program(
     log_info(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
-    // CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
     CoreCoord worker_grid_size = {1,1};
     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     CoreRangeSet cr_set(cr);
@@ -132,59 +132,49 @@ void build_and_run_program(
             tt::tt_metal::SetRuntimeArgs(program2, ncrisc_kernel2, core, rt_args);
         }
     }
-
-    tt::tt_metal::detail::CompileProgram(device, program1);
-    tt::tt_metal::detail::CompileProgram(device, program2);
+    distributed::MeshWorkload workload1;
+    distributed::MeshWorkload workload2;
+    distributed::AddProgramToMeshWorkload(
+        workload1, std::move(program1), distributed::MeshCoordinateRange(device->shape()));
+    distributed::AddProgramToMeshWorkload(
+        workload2, std::move(program2), distributed::MeshCoordinateRange(device->shape()));
 
     // This loop caches program1 and runs
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         log_info(tt::LogTest, "Running program1 {} of {}", i + 1, NUM_PROGRAMS);
         if (i % 2 == 0) {
-            if (slow_dispatch) {
-                tt::tt_metal::detail::LaunchProgram(device, program1);
-            } else {
-                EnqueueProgram(device->command_queue(), program1, false);
-            }
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload1, false);
         } else {
-            if (slow_dispatch) {
-                tt::tt_metal::detail::LaunchProgram(device, program2);
-            } else {
-                EnqueueProgram(device->command_queue(), program2, false);
-            }
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload2, false);
         }
     }
-    if (!slow_dispatch) {
-        Finish(device->command_queue());
-        log_info(tt::LogTest, "Finish FD runs");
-    } else {
-        log_info(tt::LogTest, "Finish SD runs");
-    }
+    distributed::Finish(device->mesh_command_queue());
 }
 
-TEST_F(DeviceSingleCardFastSlowDispatchFixture, TestDynamicNoCOneProgram) {
+TEST_F(UnitMeshCQFixture, TestDynamicNoCOneProgram) {
     uint32_t NUM_PROGRAMS = 1;
     uint32_t MAX_LOOP = 65536;
     uint32_t page_size = 1024;
     bool mix_noc_mode = false;
 
-    build_and_run_program(this->device_, this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
+    build_and_run_program(this->devices_[0], this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
 }
 
-TEST_F(DeviceSingleCardFastSlowDispatchFixture, TestDynamicNoCMutlipleProgram) {
+TEST_F(UnitMeshCQFixture, TestDynamicNoCMutlipleProgram) {
     uint32_t NUM_PROGRAMS = 3;
     uint32_t MAX_LOOP = 65536;
     uint32_t page_size = 1024;
     bool mix_noc_mode = false;
 
-    build_and_run_program(this->device_, this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
+    build_and_run_program(this->devices_[0], this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
 }
 
-TEST_F(DeviceSingleCardFastSlowDispatchFixture, TestDynamicNoCMutlipleProgramMixedMode) {
+TEST_F(UnitMeshCQFixture, TestDynamicNoCMutlipleProgramMixedMode) {
     uint32_t NUM_PROGRAMS = 5;
     uint32_t MAX_LOOP = 65536;
     uint32_t page_size = 1024;
     bool mix_noc_mode = true;
 
-    build_and_run_program(this->device_, this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
+    build_and_run_program(this->devices_[0], this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
 }
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -15,12 +15,13 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/tt_metal_profiler.hpp>
 #include <tt-metalium/utils.hpp>
+#include <tt-metalium/distributed.hpp>
 
 namespace tt_metal = tt::tt_metal;
 
 int main(int argc, char** argv) {
     int device_id = 0;
-    auto device = tt_metal::CreateDevice(device_id);
+    auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
     CoreCoord compute_with_storage_size = device->compute_with_storage_grid_size();
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
@@ -39,7 +40,10 @@ int main(int argc, char** argv) {
             .defines = kernel_defines,
         });
 
-    tt_metal::EnqueueProgram(device->command_queue(), program, true);
-    tt_metal::detail::ReadDeviceProfilerResults(device);
-    tt_metal::CloseDevice(device);
+    tt_metal::distributed::MeshWorkload workload;
+    tt_metal::distributed::AddProgramToMeshWorkload(
+        workload, std::move(program), tt_metal::distributed::MeshCoordinateRange(device->shape()));
+    tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, true);
+    tt_metal::ReadMeshDeviceProfilerResults(*device);
+    device->close();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_last_stage.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_last_stage.cpp
@@ -7,12 +7,6 @@
 
 void kernel_main() {
     std::uint32_t buffer_dst_addr = get_arg_val<uint32_t>(0);
-    std::uint32_t dst_noc_x = get_arg_val<uint32_t>(1);
-    std::uint32_t dst_noc_y = get_arg_val<uint32_t>(2);
-    std::uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    std::uint32_t num_repetitions = get_arg_val<uint32_t>(4);
-
-    std::uint32_t buffer_dst_addr = get_arg_val<uint32_t>(0);
     std::uint32_t dst_bank_id = get_arg_val<uint32_t>(1);
     std::uint32_t num_tiles = get_arg_val<uint32_t>(2);
     std::uint32_t num_repetitions = get_arg_val<uint32_t>(3);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22835)

### Problem description
Several tests are using legacy `CommandQueue` APIs.

### What's changed
Migrate more tests as part of the TT-Mesh uplift effort.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes