### PR TITLE
#25522: Add fp32 support for tanhshrink

### DIFF
--- a/models/tt_transformers/tt/multimodal/llama_cross_block.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_block.py
@@ -144,7 +144,7 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
         )
         # FIXME: DRAM workaround for No circular buffer with id error
         attn_out = ttnn.to_memory_config(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        attn_out = ttnn.mul(attn_out, ttnn.tanh(self.gate_attn))
+        attn_out = ttnn.mul(attn_out, ttnn.tanh(self.gate_attn, fast_and_approximate_mode=True))
 
         res = ttnn.add(x_11SH, attn_out)
         mlp_out = self.feed_forward(self.ffn_norm(res, mode=mode), mode=mode)
@@ -152,6 +152,6 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
         mlp_out = ttnn.to_memory_config(mlp_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
         mlp_out = ttnn.mul(mlp_out, full_text_row_masked_out_mask_11SD)
-        mlp_out = ttnn.mul(mlp_out, ttnn.tanh(self.gate_ffwd))
+        mlp_out = ttnn.mul(mlp_out, ttnn.tanh(self.gate_ffwd, fast_and_approximate_mode=True))
         out = ttnn.add(res, mlp_out)
         return out

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -61,15 +61,16 @@ def test_tanh_range(device, torch_dtype, ttnn_dtype):
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn.tanh(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG, accuracy=True)
+    output_tensor = ttnn.tanh(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_allclose(output_tensor, torch_output_tensor, rtol=1e-05, atol=0.012)
     pcc, pcc_msg = assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
-    # pcc_msg 0.9999663646890817, accuracy=False pcc 0.9978378297942829
+    # pcc_msg 0.9999663646890817, fast_and_approximate_mode=True pcc 0.9978378297942829
     # pcc_msg 0.9999583453515977 - fpu arithmetic, pcc_msg 0.9999669593009368 sfpu arithmetic
-    # fp32 pcc_msg 0.9999829606828651 (accuracy=True) , 0.9977552960423647 (accuracy=False)
+    # fp32 pcc_msg 0.9999829606828651 (fast_and_approximate_mode=False) , 0.9977552960423647 (fast_and_approximate_mode=True)
+    # Single-tile tanh: accurate = 5325ns, approx = 1789ns (~66% faster)
     assert pcc
 
 
@@ -94,7 +95,7 @@ def test_tanh_inplace(device, high, low, torch_dtype, ttnn_dtype):
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    ttnn.tanh(input_tensor_a, accuracy=True, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_tensor=input_tensor_a)
+    ttnn.tanh(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_tensor=input_tensor_a)
     output_tensor = ttnn.to_torch(input_tensor_a)
 
     assert_allclose(output_tensor, torch_output_tensor, rtol=1e-05, atol=0.016)
@@ -129,7 +130,7 @@ def test_tanh_accuracy(device, input_shapes, high, low, torch_dtype, ttnn_dtype)
     torch_output_tensor = golden_function(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    output = ttnn.tanh(input_tensor, accuracy=True)
+    output = ttnn.tanh(input_tensor)
     output_tensor = ttnn.to_torch(output)
 
     assert_allclose(output_tensor, torch_output_tensor, rtol=1e-05, atol=0.016)
@@ -177,7 +178,7 @@ def test_tanh_height_sharded(device, input_shapes, high, low, torch_dtype, ttnn_
         device=device,
         memory_config=input_mem_config,
     )
-    output_tensor = ttnn.tanh(input_tensor1, accuracy=True)
+    output_tensor = ttnn.tanh(input_tensor1)
     output_tensor = ttnn.to_torch(output_tensor)
     golden_function = ttnn.get_golden_function(ttnn.tanh)
     golden_tensor = golden_function(in_data)
@@ -273,7 +274,7 @@ def test_tanh_sharded(device, high, low, input_mem_config, torch_dtype, ttnn_dty
         device=device,
         memory_config=return_mem_config(input_mem_config),
     )
-    output_tensor = ttnn.tanh(input_tensor1, accuracy=True)
+    output_tensor = ttnn.tanh(input_tensor1)
     output_tensor = ttnn.to_torch(output_tensor)
     golden_function = ttnn.get_golden_function(ttnn.tanh)
     golden_tensor = golden_function(in_data)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -214,12 +214,6 @@ def test_exp(device, h, w):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tanh(device, h, w):
-    run_unary_test(device, h, w, ttnn.tanh, pcc=0.993)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
 def test_gelu(device, h, w):
     run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
 
@@ -799,7 +793,6 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
     [
         (torch.float32, ttnn.float32, 0.016),
         (torch.bfloat16, ttnn.bfloat16, 0.012),
-        (torch.bfloat16, ttnn.bfloat8_b, 0.24),
     ],
 )
 def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
@@ -813,6 +806,38 @@ def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, devi
     golden_tensor = golden_function(in_data1)
 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([32, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        in_data1 = ttnn.to_torch(input_tensor1, dtype=torch_dtype)
+
+    output_tensor = ttnn.tanhshrink(input_tensor1, fast_and_approximate_mode=True)
+    golden_function = ttnn.get_golden_function(ttnn.tanhshrink)
+    golden_tensor = golden_function(in_data1)
+
+    assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=0.25)
     assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
@@ -1531,3 +1556,66 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
         golden_tensor = golden_function(in_data1, min, max)
         assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
         assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([32, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype, atol",
+    [
+        (torch.float32, ttnn.float32, 0.016),
+        (torch.bfloat16, ttnn.bfloat16, 0.016),
+    ],
+)
+def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        in_data1 = ttnn.to_torch(input_tensor1, dtype=torch_dtype)
+
+    output_tensor = ttnn.tanh(input_tensor1)
+    golden_function = ttnn.get_golden_function(ttnn.tanh)
+    golden_tensor = golden_function(in_data1)
+
+    assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([32, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        in_data1 = ttnn.to_torch(input_tensor1, dtype=torch_dtype)
+
+    output_tensor = ttnn.tanh(input_tensor1, fast_and_approximate_mode=True)
+    golden_function = ttnn.get_golden_function(ttnn.tanh)
+    golden_tensor = golden_function(in_data1)
+
+    assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=0.15)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -787,22 +787,33 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
 @pytest.mark.parametrize(
     "input_shapes",
     (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([100])),
+        (torch.Size([32, 32])),
+        (torch.Size([3, 128, 32])),
         (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
     ),
 )
-def test_unary_tanhshrink_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-    cq_id = 0
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype, atol",
+    [
+        (torch.float32, ttnn.float32, 0.016),
+        (torch.bfloat16, ttnn.bfloat16, 0.012),
+        (torch.bfloat16, ttnn.bfloat8_b, 0.24),
+    ],
+)
+def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        in_data1 = ttnn.to_torch(input_tensor1, dtype=torch_dtype)
 
-    ttnn.tanhshrink(input_tensor1, queue_id=cq_id, output_tensor=output_tensor)
+    output_tensor = ttnn.tanhshrink(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn.tanhshrink)
     golden_tensor = golden_function(in_data1)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -809,7 +809,12 @@ std::string get_compute_kernel_path(
     UnaryOpType op_type, const std::string& compute_root, std::optional<DataType> input_dtype) {
     switch (op_type) {
         case UnaryOpType::MISH: return fmt::format("{}/{}", compute_root, "mish_kernel.cpp");
-        case UnaryOpType::TANHSHRINK: return fmt::format("{}/{}", compute_root, "tanhshrink_kernel.cpp");
+        case UnaryOpType::TANHSHRINK:
+            if (input_dtype.has_value() && input_dtype.value() == DataType::FLOAT32) {
+                return fmt::format("{}/{}", compute_root, "tanhshrink_sfpu_kernel.cpp");
+            } else {
+                return fmt::format("{}/{}", compute_root, "tanhshrink_kernel.cpp");
+            }
         case UnaryOpType::IDENTITY: return fmt::format("{}/{}", compute_root, "eltwise_identity_kernel.cpp");
         case UnaryOpType::WHERE_TSS: return fmt::format("{}/{}", compute_root, "where_tss_kernel.cpp");
         case UnaryOpType::HARDSHRINK:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/tanhshrink_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/tanhshrink_sfpu_kernel.cpp
@@ -5,10 +5,12 @@
 #include <cstdint>
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api.h"
+#include "compute_kernel_api/copy_dest_values.h"
 
 namespace NAMESPACE {
 void MAIN {
@@ -27,17 +29,18 @@ void MAIN {
 
             // Pop tile after tile, copy to DST and pack
             copy_tile_init(cb_input);
-            copy_tile(cb_input, 0, 0);
+            copy_tile(cb_input, 0, 1);
 
             tanh_tile_init();
-            tanh_tile(0);
+            tanh_tile(1);
 
-            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_input);
-            binary_dest_reuse_tiles<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                cb_input, 0, 0);
+            // output = cb_input - tanh(x)
+            copy_tile_init(cb_input);
+            copy_tile(cb_input, 0, 0);
+            sub_binary_tile_init();
+            sub_binary_tile(0, 1, 0);
 
             tile_regs_commit();
-
             tile_regs_wait();
 
             pack_tile(0, cb_output);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
@@ -44,7 +44,7 @@ void MAIN {
             cb_wait_front(cb_input, 1);
             tile_regs_acquire();
 
-            copy_tile_to_dst_init_short(cb_input);
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
             tanh_tile_init();
             tanh_tile(0);
@@ -58,7 +58,7 @@ void MAIN {
             // exp(2x)
             cb_reserve_back(cb_exp_2x, 1);
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_input);
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
 
             mul_unary_tile(0, two);
@@ -77,7 +77,7 @@ void MAIN {
             cb_reserve_back(cb_sub, 1);
             cb_wait_front(cb_exp_2x, 1);
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile_init(cb_exp_2x);
             copy_tile(cb_exp_2x, 0, 0);
 
             sub_unary_tile(0, one);
@@ -94,7 +94,7 @@ void MAIN {
 
             cb_reserve_back(cb_add, 1);
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile_init(cb_exp_2x);
             copy_tile(cb_exp_2x, 0, 0);
 
             add_unary_tile(0, one);
@@ -123,9 +123,9 @@ void MAIN {
 #endif
 
 #ifdef TANH_FP32
-            copy_tile_to_dst_init_short(cb_sub);
+            copy_tile_init(cb_sub);
             copy_tile(cb_sub, 0, 0);
-            copy_tile_to_dst_init_short(cb_add);
+            copy_tile_init(cb_add);
             copy_tile(cb_add, 0, 1);
             mul_binary_tile_init();
             mul_binary_tile(0, 1, 0);
@@ -147,15 +147,15 @@ void MAIN {
             cb_wait_front(cb_input, 1);
 
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_input);
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
             abs_tile_init();
             abs_tile(0);
             unary_gt_tile_init();
             unary_gt_tile(0, limit);
-            copy_tile_to_dst_init_short(cb_tanh_lut);
+            copy_tile_init(cb_tanh_lut);
             copy_tile(cb_tanh_lut, 0, 1);
-            copy_tile_to_dst_init_short(cb_tanh_exp);
+            copy_tile_init(cb_tanh_exp);
             copy_tile(cb_tanh_exp, 0, 2);
             where_tile_init();
 #ifdef TANH_FP32

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp
@@ -45,7 +45,7 @@ void MAIN {
             cb_wait_front(cb_input, 1);
             tile_regs_acquire();
 
-            copy_tile_to_dst_init_short(cb_input);
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
             tanh_tile_init();
             tanh_tile(0);
@@ -59,7 +59,7 @@ void MAIN {
             // exp(2x)
             cb_reserve_back(cb_exp_2x, 1);
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_input);
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
 
             mul_unary_tile(0, two);
@@ -78,7 +78,7 @@ void MAIN {
             cb_reserve_back(cb_sub, 1);
             cb_wait_front(cb_exp_2x, 1);
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile_init(cb_exp_2x);
             copy_tile(cb_exp_2x, 0, 0);
 
             sub_unary_tile(0, one);
@@ -95,7 +95,7 @@ void MAIN {
 
             cb_reserve_back(cb_add, 1);
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile_init(cb_exp_2x);
             copy_tile(cb_exp_2x, 0, 0);
 
             add_unary_tile(0, one);
@@ -124,12 +124,12 @@ void MAIN {
 #endif
 
 #ifdef TANH_FP32
-            copy_tile_to_dst_init_short(cb_sub);
+            copy_tile_init(cb_sub);
             copy_tile(cb_sub, 0, 0);
-            copy_tile_to_dst_init_short(cb_add);
+            copy_tile_init(cb_add);
             copy_tile(cb_add, 0, 1);
             mul_binary_tile_init();
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
 #endif
 
             tile_regs_commit();
@@ -149,34 +149,30 @@ void MAIN {
             cb_wait_front(cb_input, 1);
 
             tile_regs_acquire();
-            copy_tile_to_dst_init_short(cb_input);
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
             abs_tile_init();
             abs_tile(0);
             unary_gt_tile_init();
             unary_gt_tile(0, limit);
-            copy_tile_to_dst_init_short(cb_tanh_lut);
+            copy_tile_init(cb_tanh_lut);
             copy_tile(cb_tanh_lut, 0, 1);
-            copy_tile_to_dst_init_short(cb_tanh_exp);
+            copy_tile_init(cb_tanh_exp);
             copy_tile(cb_tanh_exp, 0, 2);
             where_tile_init();
 #ifdef TANH_FP32
-            where_fp32_tile(0, 1, 2);
+            where_fp32_tile(0, 1, 2, 0);
+            copy_dest_values(1, 0);
+            copy_tile_init(cb_input);
+            copy_tile(cb_input, 0, 0);
+            sub_binary_tile_init();
+            sub_binary_tile(0, 1, 0);
 #endif
 #ifdef TANH_BF16
-            where_tile(0, 1, 2);
-#endif
-#ifdef TANH_BF16
+            where_tile(0, 1, 2, 0);
             binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_input);
             binary_dest_reuse_tiles<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
                 cb_input, 0, 0);
-#endif
-#ifdef TANH_FP32
-            copy_dest_values(1, 0);
-            copy_tile_to_dst_init_short(cb_input);
-            copy_tile(cb_input, 0, 0);
-            sub_binary_tile_init();
-            sub_binary_tile(0, 1);
 #endif
             tile_regs_commit();
             tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
@@ -126,6 +126,7 @@ bool TanhAccurateDeviceOperation::skip_launch(
 std::tuple<TanhAccurateDeviceOperation::operation_attributes_t, TanhAccurateDeviceOperation::tensor_args_t>
 TanhAccurateDeviceOperation::invoke(
     const Tensor& input,
+    const std::vector<UnaryWithParam>& op_chain,
     DataType output_dtype,
     const MemoryConfig& output_memory_config,
     bool fp32_dest_acc_en,
@@ -134,6 +135,7 @@ TanhAccurateDeviceOperation::invoke(
     const std::optional<Tensor>& preallocated_output) {
     return {
         operation_attributes_t{
+            .op_chain = op_chain,
             .output_dtype = output_dtype,
             .output_memory_config = output_memory_config,
             .fp32_dest_acc_en = fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.hpp
@@ -14,6 +14,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 namespace ttnn::operations::unary {
 
@@ -41,6 +42,7 @@ struct TanhAccurateDeviceOperation {
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,
+        const std::vector<UnaryWithParam>& op_chain,
         DataType output_dtype,
         const MemoryConfig& output_memory_config,
         bool fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
@@ -22,6 +22,7 @@ TanhAccurateProgramFactory::cached_program_t TanhAccurateProgramFactory::create(
     using namespace tt::tt_metal;
 
     const auto& input = tensor_args.input;
+    const auto& ops_chain = args.op_chain;
 
     tt::tt_metal::Program program{};
 
@@ -135,7 +136,11 @@ TanhAccurateProgramFactory::cached_program_t TanhAccurateProgramFactory::create(
     } else {
         unary_defines["TANH_BF16"] = "1";
     }
+
     auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
+    if (ops_chain[0].op_type == UnaryOpType::TANHSHRINK) {
+        path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp";
+    }
 
     tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
@@ -20,6 +20,7 @@ TanhAccurateShardedProgramFactory::cached_program_t TanhAccurateShardedProgramFa
     using namespace tt::tt_metal;
 
     const auto& input = tensor_args.input;
+    const auto& ops_chain = args.op_chain;
 
     tt::tt_metal::Program program = CreateProgram();
 
@@ -163,6 +164,9 @@ TanhAccurateShardedProgramFactory::cached_program_t TanhAccurateShardedProgramFa
         unary_defines["TANH_BF16"] = "1";
     }
     auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
+    if (ops_chain[0].op_type == UnaryOpType::TANHSHRINK) {
+        path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp";
+    }
 
     tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
@@ -20,10 +20,21 @@ struct Tanh_accurate {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Tanhshrink_accurate {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 }  // namespace unary
 }  // namespace operations
 
 constexpr auto tanh_accurate =
     ttnn::register_operation<"ttnn::tanh_accurate", ttnn::operations::unary::Tanh_accurate>();
+
+constexpr auto tanhshrink_accurate =
+    ttnn::register_operation<"ttnn::tanhshrink_accurate", ttnn::operations::unary::Tanhshrink_accurate>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -110,7 +110,6 @@ template struct ExecuteUnary<UnaryOpType::SIN>;
 template struct ExecuteUnary<UnaryOpType::SQRT>;
 template struct ExecuteUnary<UnaryOpType::SQUARE>;
 template struct ExecuteUnary<UnaryOpType::TAN>;
-template struct ExecuteUnary<UnaryOpType::TANH>;
 template struct ExecuteUnary<UnaryOpType::TILED_PROD>;
 template struct ExecuteUnary<UnaryOpType::BITWISE_NOT>;
 template struct ExecuteUnary<UnaryOpType::ALT_COMPLEX_ROTATE90>;
@@ -330,9 +329,9 @@ Tensor Tanh::invoke(
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    bool accuracy) {
+    bool approx) {
     UnaryOpType op_type = UnaryOpType::TANH;
-    if (!accuracy) {
+    if (approx || input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B) {
         return detail::unary_impl(
             queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
     } else {
@@ -396,9 +395,10 @@ Tensor Tanhshrink::invoke(
     QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    bool approx) {
     UnaryOpType op_type = UnaryOpType::TANHSHRINK;
-    if (input_tensor.dtype() == DataType::BFLOAT8_B) {
+    if (approx || input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B) {
         return detail::unary_impl(
             queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
     } else {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -398,7 +398,12 @@ Tensor Tanhshrink::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::TANHSHRINK;
-    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    if (input_tensor.dtype() == DataType::BFLOAT8_B) {
+        return detail::unary_impl(
+            queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    } else {
+        return ttnn::tanhshrink_accurate(queue_id, input_tensor, memory_config, optional_output_tensor);
+    }
 }
 
 Tensor Hardshrink::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -267,14 +267,6 @@ struct Mish {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
-struct Tanhshrink {
-    static Tensor invoke(
-        QueueId queue_id,
-        const Tensor& input_tensor,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
 struct Hardshrink {
     static Tensor invoke(
         QueueId queue_id,
@@ -325,7 +317,16 @@ struct Tanh {
         const Tensor& input,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        bool accuracy = false);
+        bool approx = false);
+};
+
+struct Tanhshrink {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        bool approx = false);
 };
 
 struct Clamp {
@@ -482,7 +483,6 @@ constexpr auto identity = ttnn::register_operation<"ttnn::identity", ttnn::opera
 constexpr auto abs = ttnn::register_operation<"ttnn::abs", ttnn::operations::unary::Abs>();
 constexpr auto eqz = ttnn::register_operation<"ttnn::eqz", ttnn::operations::unary::Eqz>();
 constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::unary::Mish>();
-constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto hardshrink = ttnn::register_operation<"ttnn::hardshrink", ttnn::operations::unary::Hardshrink>();
 constexpr auto hardtanh = ttnn::register_operation<"ttnn::hardtanh", ttnn::operations::unary::Hardtanh>();
 constexpr auto softshrink = ttnn::register_operation<"ttnn::softshrink", ttnn::operations::unary::Softshrink>();
@@ -491,6 +491,7 @@ constexpr auto rad2deg = ttnn::register_operation<"ttnn::rad2deg", ttnn::operati
 constexpr auto clamp_tss = ttnn::register_operation<"ttnn::clamp_tss", ttnn::operations::unary::Clamp>();
 constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();
 constexpr auto tanh = ttnn::register_operation<"ttnn::tanh", ttnn::operations::unary::Tanh>();
+constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
 
 constexpr auto sigmoid_accurate =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -833,7 +833,7 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
                * - Dtypes
                  - Layouts
                  - Ranks
-               * - BFLOAT16
+               * - BFLOAT16, BFLOAT8_B
                  - TILE
                  - 2, 3, 4
 
@@ -866,7 +866,7 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
 }
 
 template <typename unary_operation_t>
-void bind_tanh(py::module& module, const unary_operation_t& operation) {
+void bind_tanh_like(py::module& module, const unary_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
@@ -880,7 +880,7 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            accuracy (Boolean, optional): provides better accuracy for input range -3 to 3, for dtype BFLOAT16, FLOAT32. Defaults to `False`.
+            fast_and_approximate_mode (Boolean, optional): Enables a performance-optimized approximation method. When True, the operation runs faster but may produce results with minor precision differences. Defaults to `False`.
             queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
@@ -899,29 +899,31 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
                  - TILE
                  - 2, 3, 4
 
+            BFLOAT8_B/BFLOAT4_B is supported only for approx=True mode.
+
         Example:
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-            >>> output = {1}(tensor, accuracy=False)
+            >>> output = {1}(tensor, fast_and_approximate_mode=False)
         )doc",
-        ttnn::tanh.base_name(),
-        ttnn::tanh.python_fully_qualified_name());
+        operation.base_name(),
+        operation.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
-        ttnn::tanh,
+        operation,
         doc,
         ttnn::pybind_overload_t{
             [](const unary_operation_t& self,
                const Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<Tensor>& output_tensor,
-               bool accuracy,
-               const QueueId queue_id) { return self(queue_id, input, memory_config, output_tensor, accuracy); },
+               bool approx,
+               const QueueId queue_id) { return self(queue_id, input, memory_config, output_tensor, approx); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("accuracy") = false,
+            py::arg("fast_and_approximate_mode") = false,
             py::arg("queue_id") = DefaultQueueId});
 }
 
@@ -1923,12 +1925,6 @@ void py_module(py::module& module) {
         R"doc(The last dimension of the input tensor must be even.)doc");
     bind_unary_operation(
         module,
-        ttnn::tanhshrink,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|tanhshrink|(\mathrm{{input\_tensor}}_i))doc",
-        "",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
-    bind_unary_operation(
-        module,
         ttnn::deg2rad,
         R"doc(\mathrm{{output\_tensor}}_i = \verb|deg2rad|(\mathrm{{input\_tensor}}_i))doc",
         "",
@@ -2088,7 +2084,8 @@ void py_module(py::module& module) {
 
     // Other unaries (unary chain operations)
     bind_softplus(module, ttnn::softplus);
-    bind_tanh(module, ttnn::tanh);
+    bind_tanh_like(module, ttnn::tanh);
+    bind_tanh_like(module, ttnn::tanhshrink);
     bind_sigmoid_accurate(module, ttnn::sigmoid_accurate);
     bind_sigmoid_mode_appx(module, ttnn::sigmoid);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -880,7 +880,7 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            accuracy (Boolean, optional): provides better accuracy for input range -3 to 3, for dtype BFLOAT16. Defaults to `False`.
+            accuracy (Boolean, optional): provides better accuracy for input range -3 to 3, for dtype BFLOAT16, FLOAT32. Defaults to `False`.
             queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
@@ -1926,7 +1926,7 @@ void py_module(py::module& module) {
         ttnn::tanhshrink,
         R"doc(\mathrm{{output\_tensor}}_i = \verb|tanhshrink|(\mathrm{{input\_tensor}}_i))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation(
         module,
         ttnn::deg2rad,


### PR DESCRIPTION
### Ticket
Link to Github Issue #25522 

### What's changed
- Added fp32 support for tanhshrink.
- Modified ttnn.tanh flags: accurate version is now the default version, the faster LUT version is available by setting `approx=True`
- Removed accuracy flag for `ttnn.tanh` and added `approx` flag

### Perf results:

Accurate mode (Default version):

tanh -  5325 ns 
tanhshrink - 5454 ns 

Approx Mode:

tanh - 1789ns ( ~66% faster)
tanhshrink -  1874ns (~65% faster)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16945288849)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16945299269)