### PR TITLE
Extend TensorAccessorArgs API to allow for easy placeholder support

### DIFF
--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -16,11 +16,11 @@ class TensorAccessorArgs {
 public:
     explicit TensorAccessorArgs(
         const Buffer& buffer, tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
+    explicit TensorAccessorArgs(
+        const Buffer* buffer, tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
 
     void append_to(std::vector<uint32_t>& compile_time_args) const;
     void append_to(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
-
-    static void append_placeholder_to(std::vector<uint32_t>& compile_time_args);
 
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;
@@ -28,6 +28,8 @@ public:
     static constexpr size_t MAX_NUM_DIMENSIONS = 8;
 
 private:
+    void update_args_config();
+
     const Buffer* buffer_ = nullptr;
     tensor_accessor::ArgsConfig args_config_ = tensor_accessor::ArgConfig::None;
 };

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -20,6 +20,8 @@ public:
     void append_to(std::vector<uint32_t>& compile_time_args) const;
     void append_to(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
 
+    static void append_placeholder_to(std::vector<uint32_t>& compile_time_args);
+
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;
 

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -14,6 +14,7 @@ namespace tt::tt_metal {
 
 class TensorAccessorArgs {
 public:
+    TensorAccessorArgs() = default;
     explicit TensorAccessorArgs(
         const Buffer& buffer, tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
     explicit TensorAccessorArgs(

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -126,6 +126,10 @@ void TensorAccessorArgs::append_to(std::vector<uint32_t>& compile_time_args) con
     }
 }
 
+void TensorAccessorArgs::append_placeholder_to(std::vector<uint32_t>& compile_time_args) {
+    compile_time_args.push_back(0);
+}
+
 std::vector<uint32_t> TensorAccessorArgs::get_compile_time_args() const {
     std::vector<uint32_t> compile_time_args;
     if (args_config_.test(tensor_accessor::ArgConfig::Sharded)) {

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -84,12 +84,26 @@ void append_sharded_args(
 
 TensorAccessorArgs::TensorAccessorArgs(const Buffer& buffer, tensor_accessor::ArgsConfig args_config) :
     buffer_(&buffer), args_config_(args_config) {
-    if (is_sharded(buffer.buffer_layout())) {
+    update_args_config();
+}
+
+TensorAccessorArgs::TensorAccessorArgs(const Buffer* buffer, tensor_accessor::ArgsConfig args_config) :
+    buffer_(buffer), args_config_(args_config) {
+    update_args_config();
+}
+
+void TensorAccessorArgs::update_args_config() {
+    if (!buffer_) {
+        args_config_ = tensor_accessor::ArgConfig::None;
+        return;
+    }
+
+    if (is_sharded(buffer_->buffer_layout())) {
         args_config_.set(tensor_accessor::ArgConfig::Sharded);
     } else {
         args_config_ = tensor_accessor::ArgConfig::None;
     }
-    args_config_.set(tensor_accessor::ArgConfig::IsDram, buffer.is_dram());
+    args_config_.set(tensor_accessor::ArgConfig::IsDram, buffer_->is_dram());
 
     if (args_config_.test(tensor_accessor::ArgConfig::RuntimeRank)) {
         TT_FATAL(
@@ -124,10 +138,6 @@ void TensorAccessorArgs::append_to(std::vector<uint32_t>& compile_time_args) con
     } else {
         compile_time_args.push_back(args_config_.raw());
     }
-}
-
-void TensorAccessorArgs::append_placeholder_to(std::vector<uint32_t>& compile_time_args) {
-    compile_time_args.push_back(0);
 }
 
 std::vector<uint32_t> TensorAccessorArgs::get_compile_time_args() const {


### PR DESCRIPTION
### Ticket

### Problem description
Currently it's complicated to handle/port kernels when a Tensor is being passed to a kernel optionally.
This forces the user to use `#ifdef` to not create the missing TensorAccessorArgs, which causes even more complication with calculating offsets for the next Tensors.
This PR adds `TensorAccessorArgs` constructor from `Buffer*`, handling nullptr Buffer as a placeholder, so the kernel can still create TensorAccessorArgs for all (even placeholder) tensors with the unified code.

Future usage / motivating examples:
Porting Moreh layer norm OP: https://github.com/tenstorrent/tt-metal/commit/69b39d14c8485a32926f5815c34004e1476e7476
Porting Moreh get item OP: https://github.com/tenstorrent/tt-metal/commit/6355d0586f56068cac33ecf9c3fc3bb9e7dba9de

### What's changed
Added TensorAccessorArgs constructor from `Buffer*`, which has support for the passed buffer to be nullptr
Added default constructor

The usages of this feature are coming in next pull requests

### Checklist
- [ ] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16931313631)