### PR TITLE
Fix CI: Use Rustup to install newer Rust version fixing the build

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -13,6 +13,8 @@ COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_depende
 COPY /tt_metal/sfpi-version.sh /opt/tt_metal_infra/scripts/docker/sfpi-version.sh
 RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docker
 
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 #############################################################
 
 FROM base AS ci-build

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -8,12 +8,14 @@ FROM public.ecr.aws/ubuntu/ubuntu:${UBUNTU_VERSION} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH="$CARGO_HOME/bin:$PATH"
+
 # Install runtime deps
 COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
 COPY /tt_metal/sfpi-version.sh /opt/tt_metal_infra/scripts/docker/sfpi-version.sh
 RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docker
-
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 #############################################################
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -189,7 +189,6 @@ init_packages() {
                 "cmake"
                 "ninja-build"
                 "pkg-config"
-                "cargo"
                 "$gpp_package"
                 "pandoc"
                 "xz-utils"
@@ -221,7 +220,6 @@ init_packages() {
                 "cmake"
                 "ninja-build"
                 "pkgconf-pkg-config"
-                "cargo"
                 "xz"
                 "python3-devel"
                 "python3-pip"
@@ -421,6 +419,10 @@ install_mpi_ulfm() {
     apt-get install -f -y "$TMP_DIR/$DEB_FILE"
 }
 
+install_rust() {
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.89.0 -y
+}
+
 # We don't really want to have hugepages dependency
 # This could be removed in the future
 
@@ -461,6 +463,7 @@ install() {
     install_sfpi
     install_llvm
     install_mpi_ulfm
+    install_rust
 
     # Configure system (hugepages, etc.) - only for baremetal if requested (not docker)
     if [ "$docker" -ne 1 ] && [ "$hugepages" -eq 1 ]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -205,6 +205,7 @@ init_packages() {
                 "libc++-17-dev"
                 "libc++abi-17-dev"
                 "wget"
+                "curl"
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi-bin" "libopenmpi-dev")
@@ -231,6 +232,7 @@ init_packages() {
                 "tbb-devel"
                 "capstone-devel"
                 "wget"
+                "curl"
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi" "openmpi-devel")

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -116,7 +116,7 @@ CPMAddPackage(
 CPMAddPackage(
     NAME tokenizers-cpp
     GITHUB_REPOSITORY mlc-ai/tokenizers-cpp
-    GIT_TAG 5de6f656c06da557d4f0fb1ca611b16d6e9ff11d
+    GIT_TAG 55d53aa38dc8df7d9c8bd9ed50907e82ae83ce66
     PATCH_COMMAND
         patch --dry-run -p1 -R < ${CMAKE_CURRENT_LIST_DIR}/tokenizers-cpp.patch || patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/tokenizers-cpp.patch
     OPTIONS


### PR DESCRIPTION
### Ticket

### Problem description
The build on CI is currently broken with the following error:
```
error: package `rayon-core v1.13.0` cannot be built because it requires rustc 1.80 or newer, while the currently active rustc version is 1.75.0
Either upgrade to rustc 1.80 or newer, or use
cargo update rayon-core@1.13.0 --precise ver
where `ver` is the latest version of `rayon-core` supporting rustc 1.75.0
```

### What's changed
Install the newer version of Rust in CI docker containers using Rustup (the recommended method)
Updated tokenizers-cpp dependency to fix build issues

Future work is required to prevent this issue from happening in the future and will be done in a separate (non urgent) PR

### Checklist
- [x] [All post commit CI build passes](https://github.com/tenstorrent/tt-metal/actions/runs/16934398888)
- [x] New/Existing tests provide coverage for changes