### PR TITLE
25387: add reduction methods to ttnn.scatter

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/scatter_common.hpp
@@ -11,6 +11,9 @@
 
 constexpr uint32_t ONE_PAGE = 1;
 
+// supported reduction methods for scatter to be applied for source values coming from recurring indices
+enum class ScatterReductionType : uint8_t { INVALID, ADD, MULTIPLY, AMIN, AMAX };
+
 // choose the right C++ POD type at compile-time
 template <DataFormat df>
 struct df_to_std {
@@ -73,6 +76,7 @@ struct ScatterCTAs {
     const uint32_t source_stick_size_bytes;
     const uint32_t output_stick_size_bytes;
     const uint32_t input_rank;
+    const ScatterReductionType scatter_reduction_type;
     const InputAccessorArgs input_args;
     const IndexAccessorArgs index_args;
     const SourceAccessorArgs source_args;
@@ -102,6 +106,7 @@ FORCE_INLINE constexpr auto get_ctas() {
         get_compile_time_arg_val(14),
         get_compile_time_arg_val(15),
         get_compile_time_arg_val(16),
+        static_cast<ScatterReductionType>(get_compile_time_arg_val(17)),
         input_args,
         index_args,
         source_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
@@ -86,7 +86,7 @@ ScatterDeviceOperation::invocation_result_t ScatterDeviceOperation::invoke(
     const MemoryConfig& output_memory_config,
     const std::optional<ScatterReductionType>& opt_reduction) {
     return {
-        operation_attributes_t{dim, output_memory_config, opt_reduction},
+        operation_attributes_t{dim, output_memory_config, opt_reduction.has_value() ? *opt_reduction : ScatterReductionType::INVALID},
         tensor_args_t{input_tensor, index_tensor, source_tensor}};
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation_types.hpp
@@ -15,7 +15,7 @@ struct operation_attributes_t {
     const int32_t dim;
     const tt::tt_metal::MemoryConfig output_memory_config;
     // reduction applied to source values coming from repeating indices
-    const std::optional<ScatterReductionType> opt_reduction;
+    const ScatterReductionType opt_reduction;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
@@ -11,6 +11,7 @@
 
 #include "slice/slice.hpp"
 #include "tt_stl/small_vector.hpp"
+#include "scatter/scatter_enums.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/copy/copy.hpp"
@@ -278,7 +279,7 @@ Tensor ScatterOperation::invoke(
         transformed_index_tensor,
         transformed_source_tensor,
         final_memory_config,
-        std::nullopt);
+        opt_reduction);
     output = CMAKE_UNIQUE_NAMESPACE::post_scatter_transform_tensor(
         output,
         after_transpose_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter_enums.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter_enums.hpp
@@ -15,6 +15,6 @@ namespace ttnn::operations::data_movement::scatter {
 using namespace tt;
 
 // supported reduction methods for scatter to be applied for source values coming from recurring indices
-enum class ScatterReductionType : uint8_t { ADD, MULTIPLY, AMIN, AMAX };
+enum class ScatterReductionType : uint8_t { INVALID, ADD, MULTIPLY, AMIN, AMAX };
 
 }  // namespace ttnn::operations::data_movement::scatter


### PR DESCRIPTION
### Ticket
#25387

### Problem description
add reduction methods to be applied on values supposed to be assigned to recurring indices, such as max, multiply, add, min

### What's changed
passed the `ScatterReductionType` to the scatter reader kernel, which, in turn, uses it in a switch to perform an appropriate action

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/18537767800)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes