### PR TITLE
Remove costly operations from kernels for fold tile layout tensors.

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -8,8 +8,9 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
-    constexpr uint32_t ntiles_per_row = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
+    constexpr uint32_t tiles_per_channel_dim = get_compile_time_arg_val(0);
+    constexpr uint32_t tiles_per_width_dim = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(2);
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t start_block_id = get_arg_val<uint32_t>(1);
@@ -25,20 +26,24 @@ void kernel_main() {
     uint32_t end_block_id = start_block_id + num_blocks;
     for (uint32_t i = start_block_id; i < end_block_id; ++i) {
         // Reserve space in the circular buffer for a row of tiles
-        cb_reserve_back(cb_id_in0, ntiles_per_row);
-        uint64_t l1_write_addr = get_write_ptr(cb_id_in0);
+        for (uint32_t j = 0; j < tiles_per_width_dim; ++j) {
+            cb_reserve_back(cb_id_in0, tiles_per_channel_dim);
+            uint64_t l1_write_addr = get_write_ptr(cb_id_in0);
 
-        // Read each tile in the current row
-        for (uint32_t j = 0; j < ntiles_per_row; ++j) {
-            // Calculate tile index and read from DRAM to L1
-            noc_async_read_tile(ntiles_per_row * i + j, s, l1_write_addr);
-            l1_write_addr += tile_bytes;
+            // Read each tile in the current row
+            for (uint32_t k = 0; k < tiles_per_channel_dim; ++k) {
+                // Calculate tile index and read from DRAM to L1
+                uint32_t tile_index = tiles_per_width_dim * tiles_per_channel_dim * i + tiles_per_channel_dim * j + k;
+                noc_async_read_tile(tile_index, s, l1_write_addr);
+
+                l1_write_addr += tile_bytes;
+            }
+
+            noc_async_read_barrier();
+
+            // Ensure all async reads are complete before proceeding
+            // Push the completed row of tiles to the circular buffer
+            cb_push_back(cb_id_in0, tiles_per_channel_dim);
         }
-
-        // Ensure all async reads are complete before proceeding
-        noc_async_read_barrier();
-
-        // Push the completed row of tiles to the circular buffer
-        cb_push_back(cb_id_in0, ntiles_per_row);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
     // Initialize interleaved address generator for DRAM access
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto src_args = TensorAccessorArgs<3>();
     const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     // Process each block of data

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -4,96 +4,90 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#include "tt-metalium/constants.hpp"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
-    // Compile-time arguments
-    constexpr uint32_t batch_size = get_compile_time_arg_val(0);      // Number of batches
-    constexpr uint32_t input_height = get_compile_time_arg_val(1);    // Height of input tensor
-    constexpr uint32_t input_width = get_compile_time_arg_val(2);     // Width of input tensor
-    constexpr uint32_t stride_height = get_compile_time_arg_val(3);   // Vertical stride
-    constexpr uint32_t stride_width = get_compile_time_arg_val(4);    // Horizontal stride
-    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(5);    // Size of each stick in bytes
-    constexpr uint32_t ntiles_per_row = get_compile_time_arg_val(6);  // Number of tiles per row
-    constexpr uint32_t element_size = get_compile_time_arg_val(7);    // Size of each element in bytes
-    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(8);       // Input compute buffer ID
-    constexpr auto dst_args = TensorAccessorArgs<9>();
+    constexpr uint32_t input_width = get_compile_time_arg_val(0);            // Width of input tensor
+    constexpr uint32_t stride_height = get_compile_time_arg_val(1);          // Vertical stride for fold
+    constexpr uint32_t stride_width = get_compile_time_arg_val(2);           // Horizontal stride for fold
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(3);           // Size of each stick in bytes
+    constexpr uint32_t aligned_stick_nbytes = get_compile_time_arg_val(4);   // Aligned size of each stick in bytes
+    constexpr uint32_t tiles_per_channel_dim = get_compile_time_arg_val(5);  // Number of tiles per channel dimension
+    constexpr uint32_t tiles_per_width_dim = get_compile_time_arg_val(6);    // Number of tiles per width dimension
+    constexpr uint32_t element_size = get_compile_time_arg_val(7);           // Size of each element in bytes
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(8);            // Input circular buffer ID
 
-    // Runtime arguments
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);          // Destination address in DRAM
-    uint32_t start_block_id = get_arg_val<uint32_t>(1);    // Starting block ID for processing
-    uint32_t num_blocks = get_arg_val<uint32_t>(2);        // Number of blocks to process
-    uint32_t nblocks_per_core = get_arg_val<uint32_t>(3);  // Number of blocks per core
+    // Runtime arguments - Processing parameters
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);        // Base destination address in DRAM
+    const uint32_t start_block_id = get_arg_val<uint32_t>(1);  // Starting block ID for processing
+    const uint32_t num_blocks = get_arg_val<uint32_t>(2);      // Number of blocks to process
+    uint32_t patch_height_offset = get_arg_val<uint32_t>(3);   // Current height offset within patch
+    uint32_t output_offset = get_arg_val<uint32_t>(4);         // Current output offset
 
-    // Constants for tile dimensions
-    constexpr uint32_t TILE_HEIGHT = 32;
-    constexpr uint32_t TILE_WIDTH = 32;
-    // dump(stick_nbytes);
+    // Calculated constants
+    constexpr uint32_t output_width = input_width / stride_width;  // Output tensor width
+    constexpr uint32_t patch_size = stride_height * stride_width;  // Total elements per patch
+    // Initialize DRAM address generator for interleaved memory access
+    const InterleavedAddrGen<true> dst = {.bank_base_address = dst_addr, .page_size = stick_nbytes};
 
-    // Initialize DRAM address generator
-    const auto d = TensorAccessor(dst_args, dst_addr, stick_nbytes);
-
-    // Pre-calculate output dimensions and patch size - moved outside loops
-    const uint32_t OH = input_height / stride_height;                   // Output height
-    const uint32_t OW = input_width / stride_width;                     // Output width
-    const uint32_t patch_size = stride_height * stride_width;           // Size of each patch
-    const uint32_t W_PAD = TILE_HEIGHT;                                 // Width padding
-    const uint32_t C_PAD = TILE_WIDTH * element_size * ntiles_per_row;  // Channel padding
-
-    // Calculate tile dimensions - moved outside loops
-    const uint32_t tile_cols = (input_width + W_PAD - 1) / W_PAD;  // Number of tile columns
-    const uint32_t tiles_per_batch = input_height * tile_cols;     // Tiles per batch
-
+    // Processing loop bounds and state variables
     const uint32_t end_block_id = start_block_id + num_blocks;
-    for (uint32_t i = start_block_id; i < end_block_id; ++i) {
-        // Wait for input data to be available
-        cb_wait_front(cb_id_in1, ntiles_per_row);
-        uint64_t l1_read_addr = get_read_ptr(cb_id_in1);
+    uint32_t curr_offset = output_offset;  // Current working offset
+    uint32_t orig_patch_height_offset = patch_height_offset;
 
-        // Pre-calculate batch and position indices - moved outside inner loop
-        const uint32_t batch_idx = i / tiles_per_batch;    // Batch index
-        const uint32_t bh_index = i % tiles_per_batch;     // Index within batch
-        const uint32_t height_idx = bh_index / tile_cols;  // Height index
-        const uint32_t tile_col = bh_index % tile_cols;    // Tile column index
+    // Main processing loop - iterate through each block
+    for (uint32_t block_id = start_block_id; block_id < end_block_id; block_id++) {
+        uint32_t stick_offset = 0;                // Current stick offset within patch
+        uint32_t stride_width_idx = 0;            // Current position within stride width
+        uint32_t output_stick_idx = curr_offset;  // Current destination stick index
+        uint32_t remaining_width = input_width;   // Remaining width to process
 
-        const uint32_t kernel_row_offset = (height_idx % stride_height) * stride_width;
-        const uint32_t output_row_idx = height_idx / stride_height;
-        const uint32_t base_dst_row = batch_idx * OH * OW + output_row_idx * OW;
+        // Process each tile in the width dimension
+        for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
+            cb_wait_front(input_cb_id, tiles_per_channel_dim);
+            uint64_t l1_read_addr = get_write_ptr(input_cb_id);
 
-        // Process each element in the tile
-        const uint32_t w_start = tile_col * W_PAD;
-        const uint32_t w_end = (w_start + W_PAD > input_width) ? input_width : w_start + W_PAD;
+            const uint32_t width_limit =
+                (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
 
-        // Pre-calculate as much as possible before entering the inner loop
-        uint32_t width_idx = w_start;
-        uint32_t out_width_idx = width_idx / stride_width;
-        uint32_t kernel_width_idx = width_idx % stride_width;
+            for (uint32_t stick_idx = 0; stick_idx < width_limit; stick_idx++) {
+                const uint64_t dst_noc_addr = get_noc_addr(output_stick_idx, dst);
+                noc_async_write(l1_read_addr, dst_noc_addr, stick_nbytes);
 
-        // Pre-compute values for the entire inner loop range
-        for (uint32_t w_local = 0; w_start + w_local < w_end; ++w_local) {
-            const uint64_t src = l1_read_addr + w_local * C_PAD;
+                // Update pointers and indices
+                l1_read_addr += aligned_stick_nbytes;
+                output_stick_idx++;
+                stride_width_idx++;
 
-            // Use pre-calculated values where possible
-            const uint32_t dst_row = base_dst_row + out_width_idx;
-            const uint32_t dst_col = kernel_row_offset + kernel_width_idx;
-            const uint64_t dst = dst_row * patch_size + dst_col;
-            const uint64_t dst_addr_ = get_noc_addr(dst, d);
-
-            // Write data to DRAM
-            noc_async_write(src, dst_addr_, stick_nbytes);
-
-            // Update indices for next iteration
-            width_idx++;
-            kernel_width_idx++;
-            if (kernel_width_idx == stride_width) {
-                kernel_width_idx = 0;
-                out_width_idx++;
+                // Check if we've completed a stride width - move to next patch row
+                if (stride_width_idx == stride_width) {
+                    stick_offset++;
+                    output_stick_idx = curr_offset + (stick_offset * patch_size);
+                    stride_width_idx = 0;
+                }
             }
-        }
-        // Ensure all writes are completed
-        noc_async_write_barrier();
 
-        // Pop processed data buffer
-        cb_pop_front(cb_id_in1, ntiles_per_row);
+            remaining_width -= tt::constants::TILE_HEIGHT;
+
+            // Ensure all writes complete before moving to next set of tiles_per_channel_dim tiles
+            noc_async_write_barrier();
+            cb_pop_front(input_cb_id, tiles_per_channel_dim);
+        }
+
+        // Update patch offset for next block
+        patch_height_offset++;
+
+        // Check if we've completed a full patch height - move to next patch
+        if (patch_height_offset == stride_height) {
+            // Calculate new output offset for next patch
+            curr_offset = output_offset + (patch_size * output_width) - (orig_patch_height_offset * stride_width);
+            output_offset = curr_offset;
+            patch_height_offset = 0;
+            orig_patch_height_offset = 0;
+        } else {
+            // Move to next row within the same patch
+            curr_offset += stride_width;
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -17,6 +17,7 @@ void kernel_main() {
     constexpr uint32_t tiles_per_width_dim = get_compile_time_arg_val(6);    // Number of tiles per width dimension
     constexpr uint32_t element_size = get_compile_time_arg_val(7);           // Size of each element in bytes
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(8);            // Input circular buffer ID
+    constexpr auto dst_args = TensorAccessorArgs<9>();
 
     // Runtime arguments - Processing parameters
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);        // Base destination address in DRAM
@@ -29,7 +30,7 @@ void kernel_main() {
     constexpr uint32_t output_width = input_width / stride_width;  // Output tensor width
     constexpr uint32_t patch_size = stride_height * stride_width;  // Total elements per patch
     // Initialize DRAM address generator for interleaved memory access
-    const InterleavedAddrGen<true> dst = {.bank_base_address = dst_addr, .page_size = stick_nbytes};
+    const auto dst = TensorAccessor(dst_args, dst_addr, stick_nbytes);
 
     // Processing loop bounds and state variables
     const uint32_t end_block_id = start_block_id + num_blocks;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
Currently, writer kernel for Tile Layout tensor fold is calculating output indexes inside kernel using several division and modulo operations.

### What's changed
Remove costly operations using prior offset calculations on host side. The perf improvement for various fold operation for higher strides and channels is around 1-3 %. Moreover, this Prepares codebase for reshape operation removal and further performance gains.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI Passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16960379092)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI Passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16960394062)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16935667323)