### PR TITLE
TT_CACHE_PATH caching per model

### DIFF
--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -140,7 +140,7 @@ Description of these environment variables:
 
 On the first execution of each model, TTNN will create weight cache files for that model, to speed up future runs. These cache files only need to be created once for each model and device. These files are stored in one of three places:
 
-1. `TT_CACHE_PATH` if you have set it.
+1. `TT_CACHE_PATH/HF_MODEL/device_name` if you have set `TT_CACHE_PATH`.
 2. `HF_MODEL/device_name` if a path to downloaded weights was specified using `HF_MODEL`.
 3. `LLAMA_DIR/device_name` if a path to downloaded Meta-provided weights was specified using `LLAMA_DIR`.
 4. `model_cache/HF_MODEL/device_name` if a HuggingFace model name was specified using `HF_MODEL`.

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -477,7 +477,7 @@ class ModelArgs:
             self.TOKENIZER_PATH = HF_MODEL
             if not self.CACHE_PATH:
                 self.CACHE_PATH = os.path.join("model_cache", HF_MODEL, self.device_name)
-            else:  # For HF models, always append the model and device name device name (e.g. N150/N300/T3K/TG) to the cache path
+            else:  # For HF models, always append the model and device name (e.g. N150/N300/T3K/TG) to the cache path
                 self.CACHE_PATH = os.path.join(self.CACHE_PATH, HF_MODEL, self.device_name)
             self.model_name = HF_MODEL.strip("/").split("/")[
                 -1

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -477,8 +477,8 @@ class ModelArgs:
             self.TOKENIZER_PATH = HF_MODEL
             if not self.CACHE_PATH:
                 self.CACHE_PATH = os.path.join("model_cache", HF_MODEL, self.device_name)
-            else:  # For HF models, always append the device name (e.g. N150/N300/T3K/TG) to the cache path
-                self.CACHE_PATH = os.path.join(self.CACHE_PATH, self.device_name)
+            else:  # For HF models, always append the model and device name device name (e.g. N150/N300/T3K/TG) to the cache path
+                self.CACHE_PATH = os.path.join(self.CACHE_PATH, HF_MODEL, self.device_name)
             self.model_name = HF_MODEL.strip("/").split("/")[
                 -1
             ]  # HF model names use / even on windows. May be overridden by config.


### PR DESCRIPTION
### Ticket
#26777 

### Problem description
If TT_CACHE_PATH is set, weight cache for model A is interpreted as weight cache for model B on the same device.

### What's changed
Changed the weight caching subfolder from TT_CACHE_PATH/[device_name] to TT_CACHE_PATH/[model_name]/[device_name], matching the subpath in default caching dir. Updated docs to match.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes