### PR TITLE
Composite RS

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -246,8 +246,8 @@ def run_reduce_scatter_impl(
         (8, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
         # Tests for training shapes
         (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 1, 32, 32], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        (8, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
+        (8, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -300,8 +300,8 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
     ids=["fabric_ring", "fabric_linear"],

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -234,16 +234,20 @@ def run_reduce_scatter_impl(
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
+    "num_devices, rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
     [
-        (8, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        (8, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fusedd
+        (8, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (8, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        # Tests for training shapes
+        (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        (8, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        (8, [1, 1, 32, 32], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -254,6 +258,9 @@ def run_reduce_scatter_impl(
         "batch_1_sd35_prompt",
         "batch_2",
         "batch_1",
+        "tt_training_test_one",
+        "tt_training_test_two",
+        "tt_training_test_three",
     ],
 )
 @pytest.mark.parametrize(
@@ -307,6 +314,7 @@ def test_reduce_scatter_async(
     dim,
     layout,
     rs_input_dtype,
+    is_training_shape,
     mem_config_input,
     mem_config_rs,
     enable_trace,
@@ -316,6 +324,9 @@ def test_reduce_scatter_async(
     use_persistent_buffers,
     rs_topology,
 ):
+    if is_training_shape and not use_barrier:
+        pytest.skip(f"Barrier semaphore required for training shapes that invoke composite RS")
+
     run_reduce_scatter_impl(
         t3k_mesh_device,
         num_devices,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -322,6 +322,9 @@ Tensor reduce_scatter_minimal_async_impl(
         std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr,
         "reduce_scatter_minimal_async op is only supported for Fast Dispatch");
 
+    int32_t rank = input_tensor.logical_shape().rank();
+    int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
+
     // For reduce_scatter_minimal_async_impl, we need to calculate the ring size based on cluster_axis
     // Since we don't have a specific coordinate here, we use the maximum possible devices
     uint32_t num_devices;
@@ -360,7 +363,7 @@ Tensor reduce_scatter_minimal_async_impl(
     return tt::tt_metal::operation::run(
                ttnn::ReduceScatterMinimalAsync(
                    devices,
-                   dim,
+                   scatter_dim,
                    num_links,
                    num_devices,
                    memory_config.value_or(input_tensor.memory_config()),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -80,6 +80,9 @@ ttnn::Tensor composite_reduce_scatter(
     bool convert_to_bfloat16_for_composite = input_dtype == DataType::BFLOAT8_B;
     bool is_tiled = input_tensor.layout() == Layout::TILE;
 
+    int32_t rank = input_tensor.logical_shape().rank();
+    int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
+
     // Convert to row major
     if (is_tiled) {
         // If input is tiled bfloat8_b, convert to bfloat16 to do the all_broadcast_async + concat
@@ -109,7 +112,7 @@ ttnn::Tensor composite_reduce_scatter(
 
     // Partition the reduced tensor (scatter)
     ttnn::Tensor reduce_scatter_output_tensor = ttnn::prim::mesh_partition(
-        all_reduced_tensor, 3, cluster_axis, memory_config.value_or(all_reduced_tensor.memory_config()));
+        all_reduced_tensor, scatter_dim, cluster_axis, memory_config.value_or(all_reduced_tensor.memory_config()));
 
     // Convert back to tiled
     if (is_tiled) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -104,6 +104,7 @@ ttnn::Tensor composite_reduce_scatter(
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];
     for (uint32_t i = 1; i < broadcasted_tensors.size(); ++i) {
         all_reduced_tensor = ttnn::add(all_reduced_tensor, broadcasted_tensors[i]);
+        broadcasted_tensors[i].deallocate();
     }
 
     // Partition the reduced tensor (scatter)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -4,11 +4,118 @@
 
 #include "reduce_scatter_minimal_async.hpp"
 #include <utility>
+#include "ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::experimental::ccl {
+
+bool use_composite_reduce_scatter(
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<GlobalSemaphore>& barrier_semaphore) {
+    // Composite only supported when barrier_semaphore is provided
+    if (!barrier_semaphore.has_value()) {
+        return false;
+    }
+
+    // Composite currently only valid for scattering on dim 3
+    int32_t rank = input_tensor.logical_shape().rank();
+    int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
+    if (scatter_dim != 3) {
+        return false;
+    }
+
+    // Use composite for row major tensors
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        return true;
+    }
+
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_height = tile_shape[0];
+    uint32_t tile_width = tile_shape[1];
+
+    uint32_t num_devices;
+    if (cluster_axis.has_value()) {
+        auto mesh_device = input_tensor.mesh_device();
+        const auto& mesh_view = mesh_device->get_view();
+        num_devices = (cluster_axis.value() == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    } else {
+        num_devices = ttnn::ccl::get_active_physical_devices(input_tensor).size();
+    }
+
+    // Use composite if tiled and scattering on padded dim 3
+    auto output_shape = input_tensor.logical_shape();
+    output_shape[scatter_dim] /= num_devices;
+    if (scatter_dim == 3 && output_shape[scatter_dim] % 32 != 0) {
+        return true;
+    }
+
+    return false;
+}
+
+// Composite always runs in row-major
+ttnn::Tensor composite_reduce_scatter(
+    ttnn::Tensor input_tensor,
+    const int32_t dim,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    const GlobalSemaphore& barrier_semaphore,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    std::optional<uint32_t> cluster_axis) {
+    DataType input_dtype = input_tensor.dtype();
+    bool convert_to_bfloat16_for_composite = input_dtype == DataType::BFLOAT8_B;
+    bool is_tiled = input_tensor.layout() == Layout::TILE;
+
+    // Convert to row major
+    if (is_tiled) {
+        // If input is tiled bfloat8_b, convert to bfloat16 to do the all_broadcast_async + concat
+        if (convert_to_bfloat16_for_composite) {
+            input_tensor = ttnn::typecast(input_tensor, DataType::BFLOAT16);
+        }
+        input_tensor = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);
+    }
+
+    // Broadcast each tensor to all other devices in the mesh
+    std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
+        input_tensor,
+        multi_device_global_semaphore[0],
+        num_links,
+        memory_config,
+        ttnn::ccl::Topology::Linear,
+        cluster_axis,
+        subdevice_id,
+        barrier_semaphore);
+
+    // Reduce broadcasted tensors into a single reduced tensor
+    ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];
+    for (uint32_t i = 1; i < broadcasted_tensors.size(); ++i) {
+        all_reduced_tensor = ttnn::add(all_reduced_tensor, broadcasted_tensors[i]);
+    }
+
+    // Partition the reduced tensor (scatter)
+    ttnn::Tensor reduce_scatter_output_tensor = ttnn::prim::mesh_partition(
+        all_reduced_tensor, 3, cluster_axis, memory_config.value_or(all_reduced_tensor.memory_config()));
+
+    // Convert back to tiled
+    if (is_tiled) {
+        reduce_scatter_output_tensor = ttnn::to_layout(reduce_scatter_output_tensor, Layout::TILE);
+        // If we had to convert the input dtype in order to execute the row-major composite op, convert back to the
+        // input dtype
+        if (convert_to_bfloat16_for_composite) {
+            reduce_scatter_output_tensor = ttnn::typecast(reduce_scatter_output_tensor, input_dtype);
+        }
+    }
+
+    return reduce_scatter_output_tensor;
+}
 
 ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     const ttnn::Tensor& input_tensor,
@@ -25,20 +132,32 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
-    return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(
-        input_tensor,
-        persistent_output_buffers,
-        dim,
-        multi_device_global_semaphore,
-        barrier_semaphore,
-        num_links,
-        memory_config,
-        intermediate_memory_config,
-        topology,
-        subdevice_id,
-        cluster_axis,
-        chunks_per_sync,
-        num_workers_per_link,
-        num_buffers_per_channel);
+    if (use_composite_reduce_scatter(input_tensor, dim, cluster_axis, barrier_semaphore)) {
+        return composite_reduce_scatter(
+            input_tensor,
+            dim,
+            multi_device_global_semaphore,
+            barrier_semaphore.value(),
+            num_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis);
+    } else {
+        return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(
+            input_tensor,
+            persistent_output_buffers,
+            dim,
+            multi_device_global_semaphore,
+            barrier_semaphore,
+            num_links,
+            memory_config,
+            intermediate_memory_config,
+            topology,
+            subdevice_id,
+            cluster_axis,
+            chunks_per_sync,
+            num_workers_per_link,
+            num_buffers_per_channel);
+    }
 }
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -96,12 +96,12 @@ ttnn::Tensor composite_reduce_scatter(
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
         input_tensor,
         multi_device_global_semaphore[0],
+        barrier_semaphore,
         num_links,
         memory_config,
         ttnn::ccl::Topology::Linear,
         cluster_axis,
-        subdevice_id,
-        barrier_semaphore);
+        subdevice_id);
 
     // Reduce broadcasted tensors into a single reduced tensor
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25574)

### Problem description
- The training team needs RS to work on subtile shapes

### What's changed
- Introduce a composite RS implementation to handle subtile shapes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16944931823
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16944934795
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16944936603
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/16944939659
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/16944942463
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes