### PR TITLE
#25411: Fix and move user kernel path tests to existing test groups

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -35,12 +35,10 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          - name: All C++ and API tests
+          - name: All C++, API and user kernel path tests
             cmd: |
               ./tests/scripts/run_cpp_unit_tests.sh
               ./build/test/tt_metal/unit_tests_api
-          - name: user kernel path
-            cmd: |
               rm -rf /tmp/kernels
               mkdir -p /tmp/kernels
               TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -39,10 +39,11 @@ jobs:
             cmd: |
               ./tests/scripts/run_cpp_unit_tests.sh
               ./build/test/tt_metal/unit_tests_api
-          - name: user kernel path
-            cmd: |
-              rm -rf /tmp/kernels
-              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
+          # Disabled due to https://github.com/tenstorrent/tt-metal/issues/25411
+          # - name: user kernel path
+          #   cmd: |
+          #     rm -rf /tmp/kernels
+          #     TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
           - name: data_movement
             cmd: ./build/test/tt_metal/unit_tests_data_movement
           - name: debug_tools and device and dispatch

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -39,11 +39,11 @@ jobs:
             cmd: |
               ./tests/scripts/run_cpp_unit_tests.sh
               ./build/test/tt_metal/unit_tests_api
-          # Disabled due to https://github.com/tenstorrent/tt-metal/issues/25411
-          # - name: user kernel path
-          #   cmd: |
-          #     rm -rf /tmp/kernels
-          #     TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
+          - name: user kernel path
+            cmd: |
+              rm -rf /tmp/kernels
+              mkdir -p /tmp/kernels
+              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
           - name: data_movement
             cmd: ./build/test/tt_metal/unit_tests_data_movement
           - name: debug_tools and device and dispatch

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -60,10 +60,11 @@ jobs:
               ./build/test/tt_metal/unit_tests_debug_tools
           - name: ttnn tensor accessor
             cmd: "./build/test/ttnn/unit_tests_ttnn_accessor"
-          - name: user kernel path
-            cmd: |
-              rm -rf /tmp/kernels
-              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
+          # Disabled due to https://github.com/tenstorrent/tt-metal/issues/25411
+          # - name: user kernel path
+          #   cmd: |
+          #     rm -rf /tmp/kernels
+          #     TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -50,21 +50,19 @@ jobs:
             cmd: |
               ./build/test/tt_metal/distributed/distributed_unit_tests
               ./tests/tt_metal/multihost/run_multiprocess_socket_tests.sh
-          - name: eth and misc
+          - name: eth, misc, and user kernel path
             cmd: |
               ./build/test/tt_metal/unit_tests_eth
               ./build/test/tt_metal/unit_tests_misc
+              rm -rf /tmp/kernels
+              mkdir -p /tmp/kernels
+              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
           - name: tools
             cmd: |
               ./tests/scripts/run_tools_tests.sh
               ./build/test/tt_metal/unit_tests_debug_tools
           - name: ttnn tensor accessor
             cmd: "./build/test/ttnn/unit_tests_ttnn_accessor"
-          - name: user kernel path
-            cmd: |
-              rm -rf /tmp/kernels
-              mkdir -p /tmp/kernels
-              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -60,11 +60,11 @@ jobs:
               ./build/test/tt_metal/unit_tests_debug_tools
           - name: ttnn tensor accessor
             cmd: "./build/test/ttnn/unit_tests_ttnn_accessor"
-          # Disabled due to https://github.com/tenstorrent/tt-metal/issues/25411
-          # - name: user kernel path
-          #   cmd: |
-          #     rm -rf /tmp/kernels
-          #     TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
+          - name: user kernel path
+            cmd: |
+              rm -rf /tmp/kernels
+              mkdir -p /tmp/kernels
+              TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image }}


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/25411

### Problem description
After https://github.com/tenstorrent/tt-metal/commit/6f2f4e030d3266210da44e49c43cd8287236bf72 0 tests are run when the test group is re-enabled, which wastes CI resources.
Needs `/tmp/kernels` dir to be created before the test is run.

### What's changed
Create `/tmp/kernels` dir before test run.
Test takes <15s to run on n150/n300/p150, so I've moved it into existing sd/cpp test groups so that extra CI VM resources are not spun up/tore down.

### Checklist
- [x] APC sd/cpp: https://github.com/tenstorrent/tt-metal/actions/runs/16947999008
- [x] BHPC sd/cpp: https://github.com/tenstorrent/tt-metal/actions/runs/16948101094
- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/16948545470
- [x] BH PC: https://github.com/tenstorrent/tt-metal/actions/runs/16948548210

cc @riverwuTT