### PR TITLE
#24728: Enable creation of distributed subcontexts

### DIFF
--- a/tests/tt_metal/distributed/config/1x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/1x2_multiprocess_rank_bindings.yaml
@@ -1,21 +1,25 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "0"
 
   - rank: 1
     mesh_id: 1
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "3"
 
   - rank: 2
     mesh_id: 2
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "1"
 
   - rank: 3
     mesh_id: 3
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "2"
 

--- a/tests/tt_metal/distributed/config/1x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/1x2_multiprocess_rank_bindings.yaml
@@ -1,25 +1,21 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
-    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "0"
 
   - rank: 1
     mesh_id: 1
-    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "3"
 
   - rank: 2
     mesh_id: 2
-    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "1"
 
   - rank: 3
     mesh_id: 3
-    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "2"
 

--- a/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
@@ -1,13 +1,11 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
-    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "0,1"
 
   - rank: 1
     mesh_id: 1
-    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "3,2"
 

--- a/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
@@ -1,11 +1,13 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "0,1"
 
   - rank: 1
     mesh_id: 1
+    mesh_host_rank: 1
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "3,2"
 

--- a/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
@@ -7,7 +7,7 @@ rank_bindings:
 
   - rank: 1
     mesh_id: 1
-    mesh_host_rank: 1
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "3,2"
 

--- a/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
@@ -1,8 +1,10 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
+    mesh_host_rank: 0
 
   - rank: 1
     mesh_id: 0
+    mesh_host_rank: 1
 
 mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
@@ -5,11 +5,13 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
+    mesh_host_rank: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "0,1"
 
   - rank: 1
     mesh_id: 0
+    mesh_host_rank: 1
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "2,3"
 

--- a/tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml
@@ -1,8 +1,10 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
+    mesh_host_rank: 0
 
   - rank: 1
     mesh_id: 1
+    mesh_host_rank: 0
 
 mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml
@@ -1,10 +1,8 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
-    mesh_host_rank: 0
 
   - rank: 1
     mesh_id: 1
-    mesh_host_rank: 0
 
 mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -30,11 +30,11 @@ TEST(BigMeshDualRankTest2x4, DistributedContext) {
 }
 
 TEST(BigMeshDualRankTest2x4, LocalRankBinding) {
-    auto& dctx = MetalContext::instance().global_distributed_context();
+    auto& global_context = MetalContext::instance().global_distributed_context();
     auto& control_plane = MetalContext::instance().get_control_plane();
 
     tt_fabric::MeshHostRankId local_rank_binding = control_plane.get_local_host_rank_id_binding();
-    if (dctx.rank() == multihost::Rank(0)) {
+    if (global_context.rank() == multihost::Rank(0)) {
         EXPECT_EQ(local_rank_binding, MeshHostRankId(0));
     } else {
         EXPECT_EQ(local_rank_binding, MeshHostRankId(1));
@@ -43,18 +43,25 @@ TEST(BigMeshDualRankTest2x4, LocalRankBinding) {
     const auto local_mesh_ids = control_plane.get_local_mesh_id_bindings();
     ASSERT_THAT(local_mesh_ids, ElementsAre(MeshId(0)));
 
-    if (*dctx.rank() == 0) {
+    if (*global_context.rank() == 0) {
         EXPECT_EQ(control_plane.get_local_mesh_offset(), MeshCoordinate(0, 0));
     } else {
         EXPECT_EQ(control_plane.get_local_mesh_offset(), MeshCoordinate(0, 2));
     }
 
-    const auto distributed_context = control_plane.get_distributed_context(MeshId(0));
-    ASSERT_NE(distributed_context, nullptr);
-    EXPECT_EQ(distributed_context->size(), multihost::Size(2));
-    EXPECT_EQ(distributed_context->rank(), dctx.rank());
+    const auto mesh_subcontext = control_plane.get_distributed_context(MeshId(0));
+    ASSERT_NE(mesh_subcontext, nullptr);
+    EXPECT_EQ(mesh_subcontext->size(), multihost::Size(2));
 
-    EXPECT_NE(MetalContext::instance().global_distributed_context().id(), distributed_context->id());
+    std::array original_ranks = {0, 1};
+    std::array translated_ranks = {-1, -1};
+    mesh_subcontext->translate_ranks_to_other_ctx(
+        original_ranks,
+        tt::tt_metal::distributed::multihost::DistributedContext::get_current_world(),
+        translated_ranks);
+
+    EXPECT_THAT(translated_ranks, ElementsAre(0, 1));
+    EXPECT_NE(MetalContext::instance().global_distributed_context().id(), mesh_subcontext->id());
 }
 
 TEST(BigMeshDualRankTest2x4, SystemMeshValidation) {

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -20,7 +20,7 @@
 namespace tt::tt_metal::distributed {
 
 using ::testing::ElementsAre;
-using ::tt::tt_fabric::HostRankId;
+using ::tt::tt_fabric::MeshHostRankId;
 using ::tt::tt_fabric::MeshId;
 using ::tt::tt_fabric::MeshScope;
 
@@ -33,11 +33,11 @@ TEST(BigMeshDualRankTest2x4, LocalRankBinding) {
     auto& dctx = MetalContext::instance().global_distributed_context();
     auto& control_plane = MetalContext::instance().get_control_plane();
 
-    tt_fabric::HostRankId local_rank_binding = control_plane.get_local_host_rank_id_binding();
+    tt_fabric::MeshHostRankId local_rank_binding = control_plane.get_local_host_rank_id_binding();
     if (dctx.rank() == multihost::Rank(0)) {
-        EXPECT_EQ(local_rank_binding, HostRankId(0));
+        EXPECT_EQ(local_rank_binding, MeshHostRankId(0));
     } else {
-        EXPECT_EQ(local_rank_binding, HostRankId(1));
+        EXPECT_EQ(local_rank_binding, MeshHostRankId(1));
     }
 
     const auto local_mesh_ids = control_plane.get_local_mesh_id_bindings();
@@ -54,8 +54,7 @@ TEST(BigMeshDualRankTest2x4, LocalRankBinding) {
     EXPECT_EQ(distributed_context->size(), multihost::Size(2));
     EXPECT_EQ(distributed_context->rank(), dctx.rank());
 
-    // TODO: #24728 - support multi-mesh environments, where these 2 contexts are different (sub-context vs global).
-    EXPECT_EQ(MetalContext::instance().global_distributed_context().id(), distributed_context->id());
+    EXPECT_NE(MetalContext::instance().global_distributed_context().id(), distributed_context->id());
 }
 
 TEST(BigMeshDualRankTest2x4, SystemMeshValidation) {
@@ -71,7 +70,7 @@ TEST(BigMeshDualRankTest2x4, SystemMeshValidation) {
     const MeshContainer<MaybeRemote<int>> physical_device_ids(MeshShape(2, 4), std::move(mapped_devices.device_ids));
     const MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids(
         MeshShape(2, 4), std::move(mapped_devices.fabric_node_ids));
-    if (rank == HostRankId{0}) {
+    if (rank == MeshHostRankId{0}) {
         EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 0)).is_local());
         EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(0, 1)).is_local());
         EXPECT_TRUE(physical_device_ids.at(MeshCoordinate(1, 0)).is_local());

--- a/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
+++ b/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
@@ -32,16 +32,15 @@ using ::tt::tt_metal::distributed::test::utils::TemporaryFile;
 // RAII guard for managing mesh binding environment variables
 class ScopedMeshBinding {
 public:
-    ScopedMeshBinding(const char* mesh_id, const char* host_rank)
-        : mesh_id_guard_("TT_MESH_ID", mesh_id),
-          host_rank_guard_("TT_HOST_RANK", host_rank) {}
+    ScopedMeshBinding(const char* mesh_id, const char* host_rank) :
+        mesh_id_guard_("TT_MESH_ID", mesh_id), host_rank_guard_("TT_MESH_HOST_RANK", host_rank) {}
 
     // Convenience constructor for numeric values
-    ScopedMeshBinding(uint32_t mesh_id, uint32_t host_rank)
-        : mesh_id_str_(std::to_string(mesh_id)),
-          host_rank_str_(std::to_string(host_rank)),
-          mesh_id_guard_("TT_MESH_ID", mesh_id_str_.c_str()),
-          host_rank_guard_("TT_HOST_RANK", host_rank_str_.c_str()) {}
+    ScopedMeshBinding(uint32_t mesh_id, uint32_t host_rank) :
+        mesh_id_str_(std::to_string(mesh_id)),
+        host_rank_str_(std::to_string(host_rank)),
+        mesh_id_guard_("TT_MESH_ID", mesh_id_str_.c_str()),
+        host_rank_guard_("TT_MESH_HOST_RANK", host_rank_str_.c_str()) {}
 
 private:
     std::string mesh_id_str_;
@@ -146,9 +145,9 @@ TEST_F(ControlPlaneLocalMeshBinding, PartialEnvironmentVariables) {
             std::runtime_error);
     }
 
-    // Test with only TT_HOST_RANK set
+    // Test with only TT_MESH_HOST_RANK set
     {
-        ScopedEnvVar host_only("TT_HOST_RANK", "0");
+        ScopedEnvVar host_only("TT_MESH_HOST_RANK", "0");
         EXPECT_THROW(
             {
                 auto chip_mapping = get_dual_host_chip_mapping();

--- a/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
+++ b/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
@@ -50,7 +50,7 @@ private:
 };
 
 struct MeshScopeTestParams {
-    HostRankId host_rank;
+    MeshHostRankId host_rank;
     MeshShape expected_local_shape;
     MeshCoordinate expected_start;
     MeshCoordinate expected_end;
@@ -109,7 +109,7 @@ TEST_F(ControlPlaneLocalMeshBinding, NoEnvironmentVariables) {
     auto chip_mapping = get_dual_host_chip_mapping();
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(kDualHostMeshDesc, chip_mapping);
     EXPECT_EQ(control_plane->get_local_mesh_id_bindings()[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), HostRankId{0});
+    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), MeshHostRankId{0});
 }
 
 TEST_F(ControlPlaneLocalMeshBinding, WithEnvironmentVariables) {
@@ -117,7 +117,7 @@ TEST_F(ControlPlaneLocalMeshBinding, WithEnvironmentVariables) {
     auto chip_mapping = get_dual_host_chip_mapping();
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(kDualHostMeshDesc, chip_mapping);
     EXPECT_EQ(control_plane->get_local_mesh_id_bindings()[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), HostRankId{0});
+    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), MeshHostRankId{0});
 }
 
 // Test case to verify exception when both env vars are set but invalid
@@ -164,7 +164,7 @@ TEST_F(ControlPlaneLocalMeshBinding, GetPhysicalMeshShapeWithScopeDualHost) {
     EXPECT_EQ(global_shape, MeshShape(2, 4));
 
     EXPECT_EQ(control_plane->get_local_mesh_id_bindings()[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), HostRankId{0});
+    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), MeshHostRankId{0});
 
     auto local_shape = control_plane->get_physical_mesh_shape(MeshId{0}, MeshScope::LOCAL);
     EXPECT_EQ(local_shape, MeshShape(2, 2));
@@ -183,7 +183,7 @@ TEST_F(ControlPlaneLocalMeshBinding, GetCoordRangeWithScopeDualHost) {
     EXPECT_EQ(global_range.shape(), MeshShape(2, 4));
 
     EXPECT_EQ(control_plane->get_local_mesh_id_bindings()[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), HostRankId{0});
+    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), MeshHostRankId{0});
 
     auto local_range = control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL);
     EXPECT_EQ(local_range.start_coord(), MeshCoordinate(0, 0));
@@ -198,7 +198,7 @@ TEST_F(ControlPlaneLocalMeshBinding, InvalidMeshId) {
     auto chip_mapping = get_dual_host_chip_mapping();
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(kDualHostMeshDesc, chip_mapping);
     EXPECT_EQ(control_plane->get_local_mesh_id_bindings()[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), HostRankId{0});
+    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), MeshHostRankId{0});
     EXPECT_THROW(control_plane->get_physical_mesh_shape(MeshId{99}, MeshScope::GLOBAL), std::runtime_error);
 }
 
@@ -206,7 +206,7 @@ TEST_F(ControlPlaneLocalMeshBinding, LocalMeshScopeQueryWithoutExplicitBinding) 
     auto chip_mapping = get_dual_host_chip_mapping();
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(kDualHostMeshDesc, chip_mapping);
     EXPECT_EQ(control_plane->get_local_mesh_id_bindings()[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), HostRankId{0});
+    EXPECT_EQ(control_plane->get_local_host_rank_id_binding(), MeshHostRankId{0});
     EXPECT_NO_THROW(control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL));
 }
 
@@ -269,13 +269,13 @@ INSTANTIATE_TEST_SUITE_P(
     MeshScopeParameterizedTest,
     ::testing::Values(
         MeshScopeTestParams{
-            HostRankId{0},
+            MeshHostRankId{0},
             MeshShape(2, 2),       // Host 0 owns 2x2 (left half)
             MeshCoordinate(0, 0),  // Start at (0,0)
             MeshCoordinate(1, 1),  // End at (1,1)
             "HostRank0"},
         MeshScopeTestParams{
-            HostRankId{1},
+            MeshHostRankId{1},
             MeshShape(2, 2),       // Host 1 owns 2x2 (right half)
             MeshCoordinate(0, 2),  // Start at (0,2)
             MeshCoordinate(1, 3),  // End at (1,3)

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -18,13 +18,13 @@ namespace fabric_router_tests {
 template <typename Fixture>
 void validate_and_setup_control_plane_config(Fixture* fixture) {
     const char* mesh_id_str = std::getenv("TT_MESH_ID");
-    const char* host_rank_str = std::getenv("TT_HOST_RANK");
+    const char* host_rank_str = std::getenv("TT_MESH_HOST_RANK");
     auto local_mesh_id = std::string(mesh_id_str);
     auto local_host_rank = std::string(host_rank_str);
 
     TT_FATAL(
         local_mesh_id.size() and local_host_rank.size(),
-        "TT_MESH_ID and TT_HOST_RANK environment variables must be set for Multi-Host Fabric Tests.");
+        "TT_MESH_ID and TT_MESH_HOST_RANK environment variables must be set for Multi-Host Fabric Tests.");
 
     auto chip_to_eth_coord_mapping = multihost_utils::get_physical_chip_mapping_from_eth_coords_mapping(
         fixture->get_eth_coord_mapping(), std::stoi(local_mesh_id));

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -18,16 +18,10 @@ namespace fabric_router_tests {
 template <typename Fixture>
 void validate_and_setup_control_plane_config(Fixture* fixture) {
     const char* mesh_id_str = std::getenv("TT_MESH_ID");
-    const char* host_rank_str = std::getenv("TT_MESH_HOST_RANK");
-    auto local_mesh_id = std::string(mesh_id_str);
-    auto local_host_rank = std::string(host_rank_str);
-
-    TT_FATAL(
-        local_mesh_id.size() and local_host_rank.size(),
-        "TT_MESH_ID and TT_MESH_HOST_RANK environment variables must be set for Multi-Host Fabric Tests.");
+    TT_FATAL(mesh_id_str != nullptr, "TT_MESH_ID environment variable must be set for Multi-Host Fabric Tests.");
 
     auto chip_to_eth_coord_mapping = multihost_utils::get_physical_chip_mapping_from_eth_coords_mapping(
-        fixture->get_eth_coord_mapping(), std::stoi(local_mesh_id));
+        fixture->get_eth_coord_mapping(), std::stoi(mesh_id_str));
     tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
         fixture->get_path_to_mesh_graph_desc(), chip_to_eth_coord_mapping);
     TT_FATAL(

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_mesh_graph_descriptor.yaml
@@ -20,13 +20,13 @@ Mesh: [
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_1x8_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_1x8_mesh_graph_descriptor.yaml
@@ -20,32 +20,32 @@ Mesh: [
   board: 1x8,
   device_topology: [1, 8],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 1x8,
   device_topology: [1, 8],
   host_topology: [1, 1],
 
-  host_ranks: [[0]]},
+},
 {
   id: 2,
   board: 1x8,
   device_topology: [1, 8],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 3,
   board: 1x8,
   device_topology: [1, 8],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 4,
   board: 1x8,
   device_topology: [1, 8],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_mesh_graph_descriptor.yaml
@@ -20,32 +20,32 @@ Mesh: [
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
 
-  host_ranks: [[0]]},
+},
 {
   id: 2,
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 3,
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 4,
   board: 2x4,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml
@@ -21,49 +21,49 @@ Mesh: [
   board:  1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 2,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 3,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 4,
   board:  1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 5,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 6,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 7,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
@@ -21,25 +21,25 @@ Mesh: [
   board:  1x2,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 1x2,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 2,
   board: 1x2,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 3,
   board: 1x2,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: T3K,
   device_topology: [1, 8],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
@@ -27,25 +27,25 @@ Mesh: [
   board:  2x2,
   device_topology: [2, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 1x2,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 2,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 3,
   board: 1x1,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml
@@ -21,13 +21,13 @@ Mesh: [
   board: 2x2,
   device_topology: [2, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 2x2,
   device_topology: [2, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
@@ -21,13 +21,13 @@ Mesh: [
   board: 2x2,
   device_topology: [2, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: 2x2,
   device_topology: [2, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: T3K,
   device_topology: [2, 4],
   host_topology: [1, 2],
-  host_ranks: [[0, 1]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: T3K,
   device_topology: [3, 5],  # Invalid: 3 is not divisible by 2, 5 is not divisible by 2
   host_topology: [1, 1],
-  host_ranks: [[0, 1]]}
+}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -55,19 +55,19 @@ TEST(MeshGraphValidation, TestTGMeshGraphInit) {
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(tg_mesh_graph_desc_path.string());
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{1}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{1}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{2}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{2}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{3}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{3}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{4}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{4}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 7)));
 }
 
@@ -109,7 +109,7 @@ TEST(MeshGraphValidation, TestT3kMeshGraphInit) {
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(t3k_mesh_graph_desc_path.string());
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 3)));
 }
 
@@ -244,18 +244,18 @@ TEST(MeshGraphValidation, TestT3kDualHostMeshGraph) {
 
     // Check host ranks by accessing the values vector
     const auto& host_ranks = mesh_graph->get_host_ranks(MeshId{0});
-    EXPECT_EQ(host_ranks, MeshContainer<HostRankId>(MeshShape(1, 2), {HostRankId(0), HostRankId(1)}));
+    EXPECT_EQ(host_ranks, MeshContainer<MeshHostRankId>(MeshShape(1, 2), {MeshHostRankId(0), MeshHostRankId(1)}));
 
     EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}), MeshShape(2, 4));
-    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, HostRankId(0)), MeshShape(2, 2));
-    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, HostRankId(1)), MeshShape(2, 2));
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, MeshHostRankId(0)), MeshShape(2, 2));
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, MeshHostRankId(1)), MeshShape(2, 2));
 
     EXPECT_EQ(mesh_graph->get_coord_range(MeshId{0}), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 3)));
     EXPECT_EQ(
-        mesh_graph->get_coord_range(MeshId{0}, HostRankId(0)),
+        mesh_graph->get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
     EXPECT_EQ(
-        mesh_graph->get_coord_range(MeshId{0}, HostRankId(1)),
+        mesh_graph->get_coord_range(MeshId{0}, MeshHostRankId(1)),
         MeshCoordinateRange(MeshCoordinate(0, 2), MeshCoordinate(1, 3)));
 
     EXPECT_THAT(mesh_graph->get_mesh_ids(), ElementsAre(MeshId{0}));
@@ -264,10 +264,10 @@ TEST(MeshGraphValidation, TestT3kDualHostMeshGraph) {
         mesh_graph->get_chip_ids(MeshId{0}),
         MeshContainer<chip_id_t>(MeshShape(2, 4), std::vector<chip_id_t>{0, 1, 2, 3, 4, 5, 6, 7}));
     EXPECT_EQ(
-        mesh_graph->get_chip_ids(MeshId{0}, HostRankId(0)),
+        mesh_graph->get_chip_ids(MeshId{0}, MeshHostRankId(0)),
         MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 4, 5}));
     EXPECT_EQ(
-        mesh_graph->get_chip_ids(MeshId{0}, HostRankId(1)),
+        mesh_graph->get_chip_ids(MeshId{0}, MeshHostRankId(1)),
         MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{2, 3, 6, 7}));
 }
 
@@ -282,19 +282,19 @@ TEST(MeshGraphValidation, TestT3k2x2MeshGraph) {
 
     // Check host ranks for mesh 0 - single host rank 0
     const auto& host_ranks_mesh0 = mesh_graph->get_host_ranks(MeshId{0});
-    EXPECT_EQ(host_ranks_mesh0, MeshContainer<HostRankId>(MeshShape(1, 1), {HostRankId(0)}));
+    EXPECT_EQ(host_ranks_mesh0, MeshContainer<MeshHostRankId>(MeshShape(1, 1), {MeshHostRankId(0)}));
 
     // Check host ranks for mesh 1 - single host rank 0
     const auto& host_ranks_mesh1 = mesh_graph->get_host_ranks(MeshId{1});
-    EXPECT_EQ(host_ranks_mesh1, MeshContainer<HostRankId>(MeshShape(1, 1), {HostRankId(0)}));
+    EXPECT_EQ(host_ranks_mesh1, MeshContainer<MeshHostRankId>(MeshShape(1, 1), {MeshHostRankId(0)}));
 
     // Each mesh has a 2x2 board topology
     EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}), MeshShape(2, 2));
     EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{1}), MeshShape(2, 2));
 
     // Since there's only one host rank per mesh, mesh shape should be same
-    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, HostRankId(0)), MeshShape(2, 2));
-    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{1}, HostRankId(0)), MeshShape(2, 2));
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, MeshHostRankId(0)), MeshShape(2, 2));
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{1}, MeshHostRankId(0)), MeshShape(2, 2));
 
     // Check coordinate ranges
     EXPECT_EQ(mesh_graph->get_coord_range(MeshId{0}), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
@@ -302,10 +302,10 @@ TEST(MeshGraphValidation, TestT3k2x2MeshGraph) {
 
     // Since each mesh has only one host rank, the coord range should be the same
     EXPECT_EQ(
-        mesh_graph->get_coord_range(MeshId{0}, HostRankId(0)),
+        mesh_graph->get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
     EXPECT_EQ(
-        mesh_graph->get_coord_range(MeshId{1}, HostRankId(0)),
+        mesh_graph->get_coord_range(MeshId{1}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
 
     // Check chip IDs - each mesh has 4 chips (2x2)
@@ -318,10 +318,10 @@ TEST(MeshGraphValidation, TestT3k2x2MeshGraph) {
 
     // Check chip IDs per host rank
     EXPECT_EQ(
-        mesh_graph->get_chip_ids(MeshId{0}, HostRankId(0)),
+        mesh_graph->get_chip_ids(MeshId{0}, MeshHostRankId(0)),
         MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 2, 3}));
     EXPECT_EQ(
-        mesh_graph->get_chip_ids(MeshId{1}, HostRankId(0)),
+        mesh_graph->get_chip_ids(MeshId{1}, MeshHostRankId(0)),
         MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 2, 3}));
 }
 
@@ -336,15 +336,15 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
     // Based on the dual host configuration:
     // Host rank 0 controls chips 0, 1, 4, 5 (left board)
     // Host rank 1 controls chips 2, 3, 6, 7 (right board)
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 0), HostRankId(0));
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 1), HostRankId(0));
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 4), HostRankId(0));
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 5), HostRankId(0));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 0), MeshHostRankId(0));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 1), MeshHostRankId(0));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 4), MeshHostRankId(0));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 5), MeshHostRankId(0));
 
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 2), HostRankId(1));
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 3), HostRankId(1));
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 6), HostRankId(1));
-    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 7), HostRankId(1));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 2), MeshHostRankId(1));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 3), MeshHostRankId(1));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 6), MeshHostRankId(1));
+    EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 7), MeshHostRankId(1));
 
     // Test invalid chip IDs (out of range)
     EXPECT_EQ(mesh_graph->get_host_rank_for_chip(MeshId{0}, 8), std::nullopt);
@@ -361,7 +361,7 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
 
     // In single host configuration, all chips should belong to host rank 0
     for (chip_id_t chip_id = 0; chip_id < 8; chip_id++) {
-        EXPECT_EQ(mesh_graph_single_host->get_host_rank_for_chip(MeshId{0}, chip_id), HostRankId(0));
+        EXPECT_EQ(mesh_graph_single_host->get_host_rank_for_chip(MeshId{0}, chip_id), MeshHostRankId(0));
     }
 
     // Test with 2x2 configuration (two separate meshes)
@@ -372,8 +372,8 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
 
     // Each mesh has only one host rank (0)
     for (chip_id_t chip_id = 0; chip_id < 4; chip_id++) {
-        EXPECT_EQ(mesh_graph_2x2->get_host_rank_for_chip(MeshId{0}, chip_id), HostRankId(0));
-        EXPECT_EQ(mesh_graph_2x2->get_host_rank_for_chip(MeshId{1}, chip_id), HostRankId(0));
+        EXPECT_EQ(mesh_graph_2x2->get_host_rank_for_chip(MeshId{0}, chip_id), MeshHostRankId(0));
+        EXPECT_EQ(mesh_graph_2x2->get_host_rank_for_chip(MeshId{1}, chip_id), MeshHostRankId(0));
     }
 
     // Test invalid chip IDs for 2x2 configuration
@@ -750,10 +750,10 @@ TEST(MeshGraphValidation, TestDualGalaxyMeshGraph) {
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(mesh_graph_desc_path.string());
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(0)),
+        mesh_graph_desc->get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(7, 3)));
     EXPECT_EQ(
-        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(1)),
+        mesh_graph_desc->get_coord_range(MeshId{0}, MeshHostRankId(1)),
         MeshCoordinateRange(MeshCoordinate(0, 4), MeshCoordinate(7, 7)));
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -1370,7 +1370,7 @@ private:
 
     void initialize_and_validate_custom_physical_config(const PhysicalMeshConfig& physical_mesh_config) {
         const auto mesh_id_str = std::string(std::getenv("TT_MESH_ID"));
-        const auto host_rank_str = std::string(std::getenv("TT_HOST_RANK"));
+        const auto host_rank_str = std::string(std::getenv("TT_MESH_HOST_RANK"));
 
         const auto local_mesh_id = MeshId{std::stoi(mesh_id_str)};
         local_host_rank_ = HostRankId{std::stoi(host_rank_str)};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -40,7 +40,7 @@ using ReplicatedBufferConfig = tt::tt_metal::distributed::ReplicatedBufferConfig
 using MeshBuffer = tt::tt_metal::distributed::MeshBuffer;
 using BufferDistributionSpec = tt::tt_metal::BufferDistributionSpec;
 using Shape = tt::tt_metal::Shape;
-using HostRankId = tt::tt_fabric::HostRankId;
+using MeshHostRankId = tt::tt_fabric::MeshHostRankId;
 using SystemMesh = tt::tt_metal::distributed::SystemMesh;
 using MeshDeviceConfig = tt::tt_metal::distributed::MeshDeviceConfig;
 
@@ -1363,7 +1363,7 @@ private:
     std::shared_ptr<MeshDevice> mesh_device_;
     std::shared_ptr<MeshWorkload> mesh_workload_;
     MeshId local_mesh_id_;
-    std::optional<HostRankId> local_host_rank_;
+    std::optional<MeshHostRankId> local_host_rank_;
 
     bool are_devices_open_ = false;
     bool wrap_around_mesh_ = false;
@@ -1373,7 +1373,7 @@ private:
         const auto host_rank_str = std::string(std::getenv("TT_MESH_HOST_RANK"));
 
         const auto local_mesh_id = MeshId{std::stoi(mesh_id_str)};
-        local_host_rank_ = HostRankId{std::stoi(host_rank_str)};
+        local_host_rank_ = MeshHostRankId{std::stoi(host_rank_str)};
 
         const auto& eth_coord_mapping = physical_mesh_config.eth_coord_mapping;
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -1369,12 +1369,7 @@ private:
     bool wrap_around_mesh_ = false;
 
     void initialize_and_validate_custom_physical_config(const PhysicalMeshConfig& physical_mesh_config) {
-        const auto mesh_id_str = std::string(std::getenv("TT_MESH_ID"));
-        const auto host_rank_str = std::string(std::getenv("TT_MESH_HOST_RANK"));
-
-        const auto local_mesh_id = MeshId{std::stoi(mesh_id_str)};
-        local_host_rank_ = MeshHostRankId{std::stoi(host_rank_str)};
-
+        const auto local_mesh_id = MeshId{std::stoi(std::getenv("TT_MESH_ID"))};
         const auto& eth_coord_mapping = physical_mesh_config.eth_coord_mapping;
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
@@ -1393,14 +1388,16 @@ private:
         tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
             physical_mesh_config.mesh_descriptor_path, chip_to_eth_coord_mapping);
 
+        // ensure user specified matches what control plane sees
         const auto user_mesh_id =
             tt::tt_metal::MetalContext::instance().get_control_plane().get_user_physical_mesh_ids()[0];
-        // ensure user specified matches what control plane sees
         TT_FATAL(
             *user_mesh_id == *local_mesh_id,
             "Local mesh id {} does not not match user mesh id {}",
             *user_mesh_id,
             *local_mesh_id);
+
+        local_host_rank_ = tt::tt_metal::MetalContext::instance().get_control_plane().get_local_host_rank_id_binding();
     }
 
     void open_devices_internal(tt::tt_fabric::FabricConfig fabric_config) {

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
@@ -25,7 +25,7 @@ using ::testing::ElementsAre;
 using ::testing::FloatEq;
 using ::testing::Pointwise;
 using ::testing::SizeIs;
-using ::tt::tt_fabric::HostRankId;
+using ::tt::tt_fabric::MeshHostRankId;
 using ::tt::tt_metal::DataType;
 using ::tt::tt_metal::Layout;
 using ::tt::tt_metal::MemoryConfig;

--- a/tt-train/sources/examples/nano_gpt/3tier/run_3tier_demo.sh
+++ b/tt-train/sources/examples/nano_gpt/3tier/run_3tier_demo.sh
@@ -111,9 +111,9 @@ echo "✔ Remote copy complete."
 # launch MPI job
 echo "Launching MPI 3-tier demo..."
 mpirun --hostfile "${HOSTFILE}" \
-  -np "${WORKER_COUNT}" bash -lc "export TT_METAL_HOME='${METAL_HOME}' && export TT_LOGGER_LEVEL=FATAL && export TT_MESH_ID=0 && export TT_HOST_RANK=0 && \"${BIN_DIR}/nano_gpt\" -c \"${CFG_DIR}/${CONFIG}\" $RUN_FLAG" \
-  : -np "${AGG_COUNT}"    bash -lc "export TT_METAL_HOME='${METAL_HOME}' && export TT_LOGGER_LEVEL=FATAL && export TT_MESH_ID=0 && export TT_HOST_RANK=0 && \"${BIN_DIR}/nano_gpt_aggregator\" -c \"${CFG_DIR}/${CONFIG}\" $RUN_FLAG" \
-  : -np "${OPT_COUNT}"    bash -lc "export TT_METAL_HOME='${METAL_HOME}' && export TT_LOGGER_LEVEL=FATAL && export TT_MESH_ID=0 && export TT_HOST_RANK=0 && \"${BIN_DIR}/nano_gpt_optimizer\" -c \"${CFG_DIR}/${CONFIG}\" $RUN_FLAG"
+  -np "${WORKER_COUNT}" bash -lc "export TT_METAL_HOME='${METAL_HOME}' && export TT_LOGGER_LEVEL=FATAL && export TT_MESH_ID=0 && export TT_MESH_HOST_RANK=0 && \"${BIN_DIR}/nano_gpt\" -c \"${CFG_DIR}/${CONFIG}\" $RUN_FLAG" \
+  : -np "${AGG_COUNT}"    bash -lc "export TT_METAL_HOME='${METAL_HOME}' && export TT_LOGGER_LEVEL=FATAL && export TT_MESH_ID=0 && export TT_MESH_HOST_RANK=0 && \"${BIN_DIR}/nano_gpt_aggregator\" -c \"${CFG_DIR}/${CONFIG}\" $RUN_FLAG" \
+  : -np "${OPT_COUNT}"    bash -lc "export TT_METAL_HOME='${METAL_HOME}' && export TT_LOGGER_LEVEL=FATAL && export TT_MESH_ID=0 && export TT_MESH_HOST_RANK=0 && \"${BIN_DIR}/nano_gpt_optimizer\" -c \"${CFG_DIR}/${CONFIG}\" $RUN_FLAG"
 
 # cleanup
 rm -f "${HOSTFILE}"

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -38,6 +38,6 @@ enum class FabricReliabilityMode : uint32_t {
 namespace tt::tt_fabric {
 
 using MeshId = tt::stl::StrongType<uint32_t, struct MeshIdTag>;
-using HostRankId = tt::stl::StrongType<uint32_t, struct HostRankTag>;
+using MeshHostRankId = tt::stl::StrongType<uint32_t, struct HostRankTag>;
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -92,23 +92,23 @@ public:
 
     // Get the host ranks for a given mesh_id
     // Returned MeshContainer has a shape denoting the shape of how the "board" are arranged
-    const MeshContainer<HostRankId>& get_host_ranks(MeshId mesh_id) const;
+    const MeshContainer<MeshHostRankId>& get_host_ranks(MeshId mesh_id) const;
 
     // Get the shape of the mesh, or the shape of the submesh for a given host rank if provided
-    MeshShape get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;
+    MeshShape get_mesh_shape(MeshId mesh_id, std::optional<MeshHostRankId> host_rank = std::nullopt) const;
 
     // Get the coordinate range of the mesh, or the coordinate range of the submesh for a given host rank if provided
-    MeshCoordinateRange get_coord_range(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;
+    MeshCoordinateRange get_coord_range(MeshId mesh_id, std::optional<MeshHostRankId> host_rank = std::nullopt) const;
 
     std::vector<MeshId> get_mesh_ids() const;
 
     // Get the chip ids for a given mesh_id
     // If host_rank is provided, return the chip ids for the submesh for that host rank
     // Otherwise, return the chip ids for the entire mesh
-    MeshContainer<chip_id_t> get_chip_ids(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;
+    MeshContainer<chip_id_t> get_chip_ids(MeshId mesh_id, std::optional<MeshHostRankId> host_rank = std::nullopt) const;
 
     // Get the host rank that owns a given chip in a mesh
-    std::optional<HostRankId> get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const;
+    std::optional<MeshHostRankId> get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const;
 
     // Translation functions for chip_id and coordinate using RM-convention
     MeshCoordinate chip_to_coordinate(MeshId mesh_id, chip_id_t chip_id) const;
@@ -137,8 +137,8 @@ private:
     InterMeshConnectivity inter_mesh_connectivity_;
 
     // For distributed context, bookkeeping of host ranks and their shapes
-    std::vector<MeshContainer<HostRankId>> mesh_host_ranks_;
-    std::unordered_map<std::pair<MeshId, HostRankId>, MeshCoordinateRange, hash_pair> mesh_host_rank_coord_ranges_;
+    std::vector<MeshContainer<MeshHostRankId>> mesh_host_ranks_;
+    std::unordered_map<std::pair<MeshId, MeshHostRankId>, MeshCoordinateRange, hash_pair> mesh_host_rank_coord_ranges_;
 
     static const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>&
         cluster_type_to_mesh_graph_descriptor;

--- a/tt_metal/api/tt-metalium/multi_mesh_types.hpp
+++ b/tt_metal/api/tt-metalium/multi_mesh_types.hpp
@@ -33,7 +33,7 @@ struct EthChanDescriptor {
 struct IntermeshLinkTable {
     // Local mesh ID
     MeshId local_mesh_id = MeshId{0};
-    HostRankId local_host_rank_id = HostRankId{0};
+    MeshHostRankId local_host_rank_id = MeshHostRankId{0};
     // Maps local eth channel to remote eth channel
     std::map<EthChanDescriptor, EthChanDescriptor> intermesh_links;
 };

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -435,6 +435,7 @@ void ControlPlane::initialize_distributed_contexts() {
                 mesh_host_ranks->second.end(),
                 std::back_inserter(mpi_neighbors),
                 [](const auto& p) { return p.second.get(); });
+            std::sort(mpi_neighbors.begin(), mpi_neighbors.end());
             distributed_contexts_.emplace(local_mesh_id, global_context->create_sub_context(mpi_neighbors));
         }
     }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -158,6 +158,16 @@ std::vector<chip_id_t> get_adjacent_chips_from_ethernet_connections(
     return adjacent_chips;
 }
 
+std::uint64_t encode_mesh_id_and_rank(MeshId mesh_id, MeshHostRankId host_rank) {
+    return (static_cast<uint64_t>(mesh_id.get()) << 32) | static_cast<uint64_t>(host_rank.get());
+}
+
+std::pair<MeshId, MeshHostRankId> decode_mesh_id_and_rank(std::uint64_t encoded_value) {
+    return {
+        MeshId{static_cast<std::uint32_t>(encoded_value >> 32)},
+        MeshHostRankId{static_cast<std::uint32_t>(encoded_value & 0xFFFFFFFF)}};
+}
+
 }  // namespace
 
 void ControlPlane::initialize_dynamic_routing_plane_counts(
@@ -352,12 +362,12 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
             local_mesh_ids.push_back(mesh_id);
         }
         TT_FATAL(local_mesh_ids.size() > 0, "No local meshes found.");
-        return LocalMeshBinding{.mesh_ids = std::move(local_mesh_ids), .host_rank = HostRankId{0}};
+        return LocalMeshBinding{.mesh_ids = std::move(local_mesh_ids), .host_rank = MeshHostRankId{0}};
     }
 
     // If both TT_MESH_ID and TT_MESH_HOST_RANK are set, we'll use the values from the environment variables.
     auto local_mesh_binding = LocalMeshBinding{
-        .mesh_ids = {MeshId{std::stoi(mesh_id_str)}}, .host_rank = HostRankId{std::stoi(host_rank_str)}};
+        .mesh_ids = {MeshId{std::stoi(mesh_id_str)}}, .host_rank = MeshHostRankId{std::stoi(host_rank_str)}};
 
     log_debug(
         tt::LogDistributed,
@@ -367,11 +377,10 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
 
     // Validate the local mesh binding exists in the mesh graph descriptor
     const auto mesh_ids = this->routing_table_generator_->mesh_graph->get_mesh_ids();
-    if (std::find(mesh_ids.begin(), mesh_ids.end(), local_mesh_binding.mesh_ids[0]) == mesh_ids.end()) {
-        TT_THROW(
-            "Invalid TT_MESH_ID: Local mesh binding mesh_id {} not found in mesh graph descriptor",
-            local_mesh_binding.mesh_ids[0]);
-    }
+    TT_FATAL(
+        std::find(mesh_ids.begin(), mesh_ids.end(), local_mesh_binding.mesh_ids[0]) != mesh_ids.end(),
+        "Invalid TT_MESH_ID: Local mesh binding mesh_id {} not found in mesh graph descriptor",
+        local_mesh_binding.mesh_ids[0]);
 
     // Validate host rank (only if mesh_id is valid)
     const auto& host_ranks =
@@ -384,6 +393,55 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
     return local_mesh_binding;
 }
 
+void ControlPlane::initialize_distributed_contexts() {
+    const auto& global_context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    if (*global_context->size() == 1) {
+        host_local_context_ = global_context;
+        std::transform(
+            local_mesh_binding_.mesh_ids.begin(),
+            local_mesh_binding_.mesh_ids.end(),
+            std::inserter(distributed_contexts_, distributed_contexts_.end()),
+            [&](const MeshId& mesh_id) { return std::make_pair(mesh_id, global_context); });
+        return;
+    }
+
+    std::array this_host = {*global_context->rank()};
+    host_local_context_ = global_context->create_sub_context(this_host);
+
+    // Find out which MPI ranks manage the same meshes as this host.
+    uint64_t this_host_encoded_ids =
+        encode_mesh_id_and_rank(local_mesh_binding_.mesh_ids[0], local_mesh_binding_.host_rank);
+    std::vector<std::uint64_t> encoded_mesh_ids(*global_context->size());
+    global_context->all_gather(
+        ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(&this_host_encoded_ids), sizeof(std::uint64_t)),
+        ttsl::as_writable_bytes(ttsl::make_span(encoded_mesh_ids)));
+
+    int mpi_rank = 0;
+    for (std::uint64_t encoded_value : encoded_mesh_ids) {
+        const auto [mesh_id, mesh_host_rank] = decode_mesh_id_and_rank(encoded_value);
+        mpi_ranks_[mesh_id][mesh_host_rank] = tt::tt_metal::distributed::multihost::Rank{mpi_rank++};
+    }
+
+    // Create a sub-context for each mesh-host-rank pair.
+    for (const auto local_mesh_id : local_mesh_binding_.mesh_ids) {
+        auto mesh_host_ranks = mpi_ranks_.find(local_mesh_id);
+        TT_FATAL(mesh_host_ranks != mpi_ranks_.end(), "Mesh {} not found in mpi_ranks.", local_mesh_id);
+        if (mesh_host_ranks->second.size() == 1) {
+            distributed_contexts_.emplace(local_mesh_id, host_local_context_);
+        } else {
+            std::vector<int> mpi_neighbors;
+            std::transform(
+                mesh_host_ranks->second.begin(),
+                mesh_host_ranks->second.end(),
+                std::back_inserter(mpi_neighbors),
+                [](const auto& p) { return p.second.get(); });
+            distributed_contexts_.emplace(local_mesh_id, global_context->create_sub_context(mpi_neighbors));
+        }
+    }
+
+    global_context->barrier();
+}
+
 void ControlPlane::init_control_plane(
     const std::string& mesh_graph_desc_file,
     std::optional<std::reference_wrapper<const std::map<FabricNodeId, chip_id_t>>>
@@ -391,20 +449,7 @@ void ControlPlane::init_control_plane(
     this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
 
-    const auto& global_context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
-    std::transform(
-        this->local_mesh_binding_.mesh_ids.begin(),
-        this->local_mesh_binding_.mesh_ids.end(),
-        std::inserter(this->distributed_contexts_, this->distributed_contexts_.end()),
-        [&](const MeshId& mesh_id) { return std::make_pair(mesh_id, global_context); });
-    if (*global_context->size() > 1) {
-        std::array this_host = {*global_context->rank()};
-        this->host_local_context_ =
-            tt::tt_metal::distributed::multihost::DistributedContext::get_current_world()->create_sub_context(
-                this_host);
-    } else {
-        this->host_local_context_ = global_context;
-    }
+    this->initialize_distributed_contexts();
 
     // Printing, only enabled with log_debug
     this->routing_table_generator_->mesh_graph->print_connectivity();
@@ -1617,7 +1662,7 @@ std::vector<MeshId> ControlPlane::get_user_physical_mesh_ids() const {
 }
 
 MeshShape ControlPlane::get_physical_mesh_shape(MeshId mesh_id, MeshScope scope) const {
-    std::optional<HostRankId> local_host_rank_id =
+    std::optional<MeshHostRankId> local_host_rank_id =
         MeshScope::LOCAL == scope ? std::make_optional(this->get_local_host_rank_id_binding()) : std::nullopt;
     return this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id, local_host_rank_id);
 }
@@ -1831,7 +1876,7 @@ bool ControlPlane::is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord et
 }
 
 const std::vector<std::pair<CoreCoord, chan_id_t>>& ControlPlane::get_intermesh_eth_links(chip_id_t chip_id) const {
-    return this->intermesh_eth_links_.at(chip_id);
+    return intermesh_eth_links_.at(chip_id);
 }
 
 const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, chan_id_t>>>&
@@ -2171,7 +2216,7 @@ std::vector<MeshId> ControlPlane::get_local_mesh_id_bindings() const {
     return local_mesh_ids;
 }
 
-HostRankId ControlPlane::get_local_host_rank_id_binding() const { return this->local_mesh_binding_.host_rank; }
+MeshHostRankId ControlPlane::get_local_host_rank_id_binding() const { return this->local_mesh_binding_.host_rank; }
 
 MeshCoordinate ControlPlane::get_local_mesh_offset() const {
     auto coord_range = this->get_coord_range(this->get_local_mesh_id_bindings()[0], MeshScope::LOCAL);
@@ -2179,7 +2224,7 @@ MeshCoordinate ControlPlane::get_local_mesh_offset() const {
 }
 
 MeshCoordinateRange ControlPlane::get_coord_range(MeshId mesh_id, MeshScope scope) const {
-    std::optional<HostRankId> local_host_rank_id =
+    std::optional<MeshHostRankId> local_host_rank_id =
         MeshScope::LOCAL == scope ? std::make_optional(this->get_local_host_rank_id_binding()) : std::nullopt;
     return this->routing_table_generator_->mesh_graph->get_coord_range(mesh_id, local_host_rank_id);
 }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -343,7 +343,7 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
         TT_THROW("Both TT_MESH_ID and TT_MESH_HOST_RANK environment variables must be set together or both unset");
     }
 
-    // If both TT_MESH_ID and TT_MESH_HOST_RANK are unset, we don't initialzie the local mesh binding.
+    // If both TT_MESH_ID and TT_MESH_HOST_RANK are unset, we don't initialize the local mesh binding.
     // A nullopt here indicates that the host this ControlPlane is runnning on owns all Meshes in
     // the MeshGraphDescriptor. Single Host Multi-Mesh is only used for testing purposes.
     if (mesh_id_str == nullptr && host_rank_str == nullptr) {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -328,31 +328,34 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
 
 LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
     const char* mesh_id_str = std::getenv("TT_MESH_ID");
-    const char* host_rank_str = std::getenv("TT_HOST_RANK");
+    const char* host_rank_str = std::getenv("TT_MESH_HOST_RANK");
     if (mesh_id_str == nullptr ^ host_rank_str == nullptr) {
-        TT_THROW("Both TT_MESH_ID and TT_HOST_RANK environment variables must be set together or both unset");
+        TT_THROW("Both TT_MESH_ID and TT_MESH_HOST_RANK environment variables must be set together or both unset");
     }
 
-    // If both TT_MESH_ID and TT_HOST_RANK are unset, we don't initialzie the local mesh binding.
+    // If both TT_MESH_ID and TT_MESH_HOST_RANK are unset, we don't initialzie the local mesh binding.
     // A nullopt here indicates that the host this ControlPlane is runnning on owns all Meshes in
     // the MeshGraphDescriptor. Single Host Multi-Mesh is only used for testing purposes.
     if (mesh_id_str == nullptr && host_rank_str == nullptr) {
         auto& ctx = tt::tt_metal::MetalContext::instance().global_distributed_context();
-        auto mpi_rank = *ctx.rank();
+        TT_FATAL(
+            *ctx.size() == 1 && *ctx.rank() == 0,
+            "Not specifying TT_MESH_ID and TT_MESH_HOST_RANK is only supported for single host systems.");
         std::vector<MeshId> local_mesh_ids;
         for (const auto& mesh_id : this->routing_table_generator_->mesh_graph->get_mesh_ids()) {
             const auto& host_ranks = this->routing_table_generator_->mesh_graph->get_host_ranks(mesh_id);
-            for (const auto& [coord, rank] : host_ranks) {
-                if (mpi_rank == *rank) {
-                    local_mesh_ids.push_back(mesh_id);
-                }
-            }
+            TT_FATAL(
+                host_ranks.size() == 1 && *host_ranks.values().front() == 0,
+                "Mesh {} has {} host ranks, expected 1",
+                mesh_id,
+                host_ranks.size());
+            local_mesh_ids.push_back(mesh_id);
         }
-        TT_FATAL(local_mesh_ids.size() > 0, "No local meshes found for host rank {}", mpi_rank);
-        return LocalMeshBinding{.mesh_ids = std::move(local_mesh_ids), .host_rank = HostRankId{mpi_rank}};
+        TT_FATAL(local_mesh_ids.size() > 0, "No local meshes found.");
+        return LocalMeshBinding{.mesh_ids = std::move(local_mesh_ids), .host_rank = HostRankId{0}};
     }
 
-    // If both TT_MESH_ID and TT_HOST_RANK are set, we'll use the values from the environment variables.
+    // If both TT_MESH_ID and TT_MESH_HOST_RANK are set, we'll use the values from the environment variables.
     auto local_mesh_binding = LocalMeshBinding{
         .mesh_ids = {MeshId{std::stoi(mesh_id_str)}}, .host_rank = HostRankId{std::stoi(host_rank_str)}};
 
@@ -363,7 +366,7 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
         local_mesh_binding.host_rank);
 
     // Validate the local mesh binding exists in the mesh graph descriptor
-    auto mesh_ids = this->routing_table_generator_->mesh_graph->get_mesh_ids();
+    const auto mesh_ids = this->routing_table_generator_->mesh_graph->get_mesh_ids();
     if (std::find(mesh_ids.begin(), mesh_ids.end(), local_mesh_binding.mesh_ids[0]) == mesh_ids.end()) {
         TT_THROW(
             "Invalid TT_MESH_ID: Local mesh binding mesh_id {} not found in mesh graph descriptor",
@@ -371,14 +374,11 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
     }
 
     // Validate host rank (only if mesh_id is valid)
-    const auto& host_ranks = this->routing_table_generator_->mesh_graph->get_host_ranks(local_mesh_binding.mesh_ids[0]);
-    bool is_valid_host_rank = std::find_if(host_ranks.begin(), host_ranks.end(), [&](const auto& coord_rank_pair) {
-                                  return coord_rank_pair.value() == local_mesh_binding.host_rank;
-                              }) != host_ranks.end();
-
+    const auto& host_ranks =
+        this->routing_table_generator_->mesh_graph->get_host_ranks(local_mesh_binding.mesh_ids[0]).values();
     TT_FATAL(
-        is_valid_host_rank,
-        "Invalid TT_HOST_RANK: Local mesh binding host_rank {} not found in mesh graph descriptor",
+        std::find(host_ranks.begin(), host_ranks.end(), local_mesh_binding.host_rank) != host_ranks.end(),
+        "Invalid TT_MESH_HOST_RANK: Local mesh binding host_rank {} not found in mesh graph descriptor",
         local_mesh_binding.host_rank);
 
     return local_mesh_binding;

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -219,7 +219,7 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             this->inter_mesh_connectivity_.resize(*mesh_id + 1);
             // Resize mesh_host_ranks_ by adding empty containers
             while (this->mesh_host_ranks_.size() <= *mesh_id) {
-                this->mesh_host_ranks_.emplace_back(MeshShape{1, 1}, HostRankId{0});
+                this->mesh_host_ranks_.emplace_back(MeshShape{1, 1}, MeshHostRankId{0});
             }
             mesh_edge_ports_to_chip_id.resize(*mesh_id + 1);
         }
@@ -268,10 +268,10 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         this->mesh_to_chip_ids_.emplace(*mesh_id, MeshContainer<chip_id_t>(mesh_shape, chip_ids));
 
         // Assign ranks in row-major order based on host topology.
-        std::vector<HostRankId> mesh_host_ranks_values;
+        std::vector<MeshHostRankId> mesh_host_ranks_values;
         uint32_t next_rank = 0;
         for (const auto& host_coord : MeshCoordinateRange(MeshShape(mesh_board_ns_size, mesh_board_ew_size))) {
-            mesh_host_ranks_values.push_back(HostRankId{next_rank++});
+            mesh_host_ranks_values.push_back(MeshHostRankId{next_rank++});
             mesh_host_rank_coord_ranges_.emplace(
                 std::make_pair(*mesh_id, mesh_host_ranks_values.back()),
                 MeshCoordinateRange(
@@ -280,7 +280,7 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         }
 
         this->mesh_host_ranks_[*mesh_id] =
-            MeshContainer<HostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
+            MeshContainer<MeshHostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
 
         // Fill in connectivity for Mesh
         MeshCoordinateRange mesh_coord_range(mesh_shape);
@@ -412,7 +412,7 @@ void MeshGraph::validate_mesh_id(MeshId mesh_id) const {
         mesh_id);
 }
 
-MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<MeshHostRankId> host_rank) const {
     this->validate_mesh_id(mesh_id);
 
     if (host_rank.has_value()) {
@@ -422,7 +422,7 @@ MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> ho
     return this->mesh_to_chip_ids_.at(mesh_id).shape();
 }
 
-MeshCoordinateRange MeshGraph::get_coord_range(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+MeshCoordinateRange MeshGraph::get_coord_range(MeshId mesh_id, std::optional<MeshHostRankId> host_rank) const {
     this->validate_mesh_id(mesh_id);
 
     if (host_rank.has_value()) {
@@ -450,7 +450,7 @@ std::vector<MeshId> MeshGraph::get_mesh_ids() const {
     return mesh_ids;
 }
 
-MeshContainer<chip_id_t> MeshGraph::get_chip_ids(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+MeshContainer<chip_id_t> MeshGraph::get_chip_ids(MeshId mesh_id, std::optional<MeshHostRankId> host_rank) const {
     auto it = mesh_to_chip_ids_.find(mesh_id);
     TT_FATAL(it != mesh_to_chip_ids_.end(), "MeshGraph: mesh_id {} not found", mesh_id);
 
@@ -485,7 +485,7 @@ chip_id_t MeshGraph::coordinate_to_chip(MeshId mesh_id, MeshCoordinate coordinat
     return coordinate[0] * mesh_shape[1] + coordinate[1];
 }
 
-std::optional<HostRankId> MeshGraph::get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const {
+std::optional<MeshHostRankId> MeshGraph::get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const {
     auto it = mesh_to_chip_ids_.find(mesh_id);
     if (it == mesh_to_chip_ids_.end()) {
         return std::nullopt;
@@ -506,7 +506,9 @@ std::optional<HostRankId> MeshGraph::get_host_rank_for_chip(MeshId mesh_id, chip
     return std::nullopt;
 }
 
-const MeshContainer<HostRankId>& MeshGraph::get_host_ranks(MeshId mesh_id) const { return mesh_host_ranks_[*mesh_id]; }
+const MeshContainer<MeshHostRankId>& MeshGraph::get_host_ranks(MeshId mesh_id) const {
+    return mesh_host_ranks_[*mesh_id];
+}
 
 std::filesystem::path MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type(
     tt::tt_metal::ClusterType cluster_type, const std::string& root_dir) {

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -4,6 +4,7 @@
 
 #include "mesh_graph.hpp"
 
+#include <algorithm>
 #include <enchantum/enchantum.hpp>
 #include <yaml-cpp/yaml.h>
 #include <array>
@@ -266,42 +267,18 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         std::iota(chip_ids.begin(), chip_ids.end(), 0);
         this->mesh_to_chip_ids_.emplace(*mesh_id, MeshContainer<chip_id_t>(mesh_shape, chip_ids));
 
-        // Fill in host ranks for Mesh
-        TT_FATAL(
-            mesh["host_ranks"].IsSequence() and mesh["host_ranks"].size() == mesh_board_ns_size,
-            "MeshGraph: Expecting host_ranks to define a 2D array that matches host topology NS size {}",
-            mesh_board_ns_size);
-
+        // Assign ranks in row-major order based on host topology.
         std::vector<HostRankId> mesh_host_ranks_values;
-        mesh_host_ranks_values.reserve(mesh_board_ns_size * mesh_board_ew_size);
-
-        // Track the start and end coordinates of each host rank
-        std::unordered_map<HostRankId, std::pair<MeshCoordinate, MeshCoordinate>> host_rank_submesh_start_end_coords;
-        for (std::uint32_t i = 0; i < mesh_board_ns_size; i++) {
-            TT_FATAL(
-                mesh["host_ranks"][i].IsSequence() and mesh["host_ranks"][i].size() == mesh_board_ew_size,
-                "MeshGraph: Expecting host_ranks to define a 2D array that matches host topology EW size {}",
-                mesh_board_ew_size);
-            for (std::uint32_t j = 0; j < mesh_board_ew_size; j++) {
-                HostRankId host_rank{mesh["host_ranks"][i][j].as<std::uint32_t>()};
-                if (host_rank_submesh_start_end_coords.find(host_rank) == host_rank_submesh_start_end_coords.end()) {
-                    host_rank_submesh_start_end_coords.insert(
-                        {host_rank, std::make_pair(MeshCoordinate(i, j), MeshCoordinate(i, j))});
-                } else {
-                    host_rank_submesh_start_end_coords.at(host_rank).second = MeshCoordinate(i, j);
-                }
-                mesh_host_ranks_values.push_back(host_rank);
-            }
-        }
-        // Fill in all host rank coordinate ranges
-        for (const auto& [host_rank, coords] : host_rank_submesh_start_end_coords) {
-            this->mesh_host_rank_coord_ranges_.emplace(
-                std::make_pair(*mesh_id, host_rank),
+        uint32_t next_rank = 0;
+        for (const auto& host_coord : MeshCoordinateRange(MeshShape(mesh_board_ns_size, mesh_board_ew_size))) {
+            mesh_host_ranks_values.push_back(HostRankId{next_rank++});
+            mesh_host_rank_coord_ranges_.emplace(
+                std::make_pair(*mesh_id, mesh_host_ranks_values.back()),
                 MeshCoordinateRange(
-                    MeshCoordinate(coords.first[0] * board_ns_size, coords.first[1] * board_ew_size),
-                    MeshCoordinate(
-                        (coords.second[0] + 1) * board_ns_size - 1, (coords.second[1] + 1) * board_ew_size - 1)));
+                    MeshCoordinate(host_coord[0] * board_ns_size, host_coord[1] * board_ew_size),
+                    MeshCoordinate((host_coord[0] + 1) * board_ns_size - 1, (host_coord[1] + 1) * board_ew_size - 1)));
         }
+
         this->mesh_host_ranks_[*mesh_id] =
             MeshContainer<HostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
 
@@ -429,9 +406,10 @@ void MeshGraph::print_connectivity() const {
 }
 
 void MeshGraph::validate_mesh_id(MeshId mesh_id) const {
-    if (this->mesh_to_chip_ids_.find(mesh_id) == this->mesh_to_chip_ids_.end()) {
-        TT_THROW("Invalid mesh_id {} in get_mesh_shape", mesh_id);
-    }
+    TT_FATAL(
+        this->mesh_to_chip_ids_.find(mesh_id) != this->mesh_to_chip_ids_.end(),
+        "MeshGraph: mesh_id {} not found",
+        mesh_id);
 }
 
 MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
@@ -448,7 +426,13 @@ MeshCoordinateRange MeshGraph::get_coord_range(MeshId mesh_id, std::optional<Hos
     this->validate_mesh_id(mesh_id);
 
     if (host_rank.has_value()) {
-        return this->mesh_host_rank_coord_ranges_.at(std::make_pair(mesh_id, *host_rank));
+        auto it = this->mesh_host_rank_coord_ranges_.find(std::make_pair(mesh_id, *host_rank));
+        TT_FATAL(
+            it != this->mesh_host_rank_coord_ranges_.end(),
+            "MeshGraph: host_rank {} not found for mesh {}",
+            *host_rank,
+            *mesh_id);
+        return it->second;
     }
     auto mesh_shape = this->mesh_to_chip_ids_.at(mesh_id).shape();
     return MeshCoordinateRange(mesh_shape);

--- a/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: Galaxy,
   device_topology: [8, 8],
   host_topology: [1, 2],
-  host_ranks: [[0, 1]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: N150,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: N300_2x2,
   host_topology: [1, 1],
   device_topology: [2, 2],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: N300,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: P100,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: P150,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: P150,
   device_topology: [1, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: P150,
   device_topology: [2, 2],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   board: P150,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: Galaxy,
   device_topology: [8, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: Galaxy,
   device_topology: [8, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: Galaxy,
   device_topology: [8, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: Galaxy,
   device_topology: [8, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
@@ -21,7 +21,7 @@ Mesh: [
   board: T3K,
   device_topology: [2, 4],
   host_topology: [1, 1],
-  host_ranks: [[0]]}
+}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
@@ -24,31 +24,31 @@ Mesh: [
   board: N150Gateway,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 1,
   board: N150Gateway,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 2,
   board: N150Gateway,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 3,
   board: N150Gateway,
   device_topology: [1, 1],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 {
   id: 4,
   board: Galaxy,
   device_topology: [4, 8],
   host_topology: [1, 1],
-  host_ranks: [[0]]},
+},
 ]
 
 Graph: [

--- a/tt_metal/fabric/serialization/intermesh_link_table.cpp
+++ b/tt_metal/fabric/serialization/intermesh_link_table.cpp
@@ -13,7 +13,7 @@ std::vector<uint8_t> serialize_to_bytes(const IntermeshLinkTable& intermesh_link
 
     auto mesh_id = tt::tt_fabric::flatbuffer::CreateMeshId(builder, *(intermesh_link_table.local_mesh_id));
     auto host_rank_id =
-        tt::tt_fabric::flatbuffer::CreateHostRankId(builder, *(intermesh_link_table.local_host_rank_id));
+        tt::tt_fabric::flatbuffer::CreateMeshHostRankId(builder, *(intermesh_link_table.local_host_rank_id));
 
     // Create vector of EthernetLink objects (flatbuffers dont support std::unordered_map directly)
     std::vector<flatbuffers::Offset<tt::tt_fabric::flatbuffer::EthernetLink>> ethernet_links;
@@ -60,7 +60,7 @@ IntermeshLinkTable deserialize_from_bytes(const std::vector<uint8_t>& data) {
     }
 
     if (intermesh_link_table->local_host_rank_id()) {
-        result.local_host_rank_id = HostRankId{intermesh_link_table->local_host_rank_id()->value()};
+        result.local_host_rank_id = MeshHostRankId{intermesh_link_table->local_host_rank_id()->value()};
     }
 
     // Extract intermesh links into unordered_map

--- a/tt_metal/fabric/serialization/intermesh_link_table.fbs
+++ b/tt_metal/fabric/serialization/intermesh_link_table.fbs
@@ -4,7 +4,7 @@ table MeshId {
   value: uint32;
 }
 
-table HostRankId {
+table MeshHostRankId {
   value: uint32;
 }
 
@@ -20,7 +20,7 @@ table EthernetLink {
 
 table IntermeshLinkTable {
   local_mesh_id: MeshId;
-  local_host_rank_id: HostRankId;
+  local_host_rank_id: MeshHostRankId;
   intermesh_links: [EthernetLink];
 }
 

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -30,6 +30,7 @@ class RankBinding(BaseModel):
 
     rank: int = Field(..., ge=0, description="MPI rank (must be >= 0)")
     mesh_id: int = Field(..., ge=0, description="`MeshId` defines the mesh to which the rank belongs")
+    mesh_host_rank: int = Field(..., ge=0, description="Host rank within the mesh")
     env_overrides: Dict[str, str] = Field(default_factory=dict, description="Environment variable overrides")
 
 
@@ -77,9 +78,7 @@ def parse_binding_config(yaml_path: Path) -> TTRunConfig:
         raise ValueError(f"Invalid configuration: {e}")
 
 
-def get_rank_environment(
-    binding: RankBinding, config: TTRunConfig, mesh_to_host_rank_id: Dict[int, int]
-) -> Dict[str, str]:
+def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str, str]:
     """Get all environment variables for a specific rank.
 
     Args:
@@ -95,14 +94,13 @@ def get_rank_environment(
             DEFAULT_CACHE_DIR_PATTERN.format(home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank),
         ),  # Need to explicitly configure this because kernel cache is not multi-process safe (#21089)
         "TT_MESH_ID": str(binding.mesh_id),
-        "TT_HOST_RANK": str(mesh_to_host_rank_id[binding.mesh_id]),
+        "TT_MESH_HOST_RANK": str(binding.mesh_host_rank),
         "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,
         "TT_METAL_HOME": os.environ.get("TT_METAL_HOME", str(Path.home())),
         "PYTHONPATH": os.environ.get("PYTHONPATH", str(Path.home())),
         # 26640: TODO - Investigate why this needs to be set for multi-host CI environments
         "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", DEFAULT_LD_LIBRARY_PATH.format(home=str(Path.home()))),
     }
-    mesh_to_host_rank_id[binding.mesh_id] += 1
 
     # Apply environment variables with expansion and proper precedence
     # Global environment variables first
@@ -113,9 +111,7 @@ def get_rank_environment(
     return env
 
 
-def build_rank_environment_args(
-    binding: RankBinding, config: TTRunConfig, mesh_to_host_rank_id: Dict[int, int]
-) -> List[str]:
+def build_rank_environment_args(binding: RankBinding, config: TTRunConfig) -> List[str]:
     """Build environment variable arguments for mpirun.
 
     Args:
@@ -126,7 +122,7 @@ def build_rank_environment_args(
         List of ["-x", "KEY=value"] arguments for mpirun
     """
     env_args = []
-    env = get_rank_environment(binding, config, mesh_to_host_rank_id)
+    env = get_rank_environment(binding, config)
 
     for key, value in env.items():
         env_args.extend(["-x", f"{key}={value}"])
@@ -148,13 +144,12 @@ def build_mpi_command(config: TTRunConfig, program: List[str], mpi_args: Optiona
         cmd.extend(mpi_args)
 
     # Build per-rank application contexts
-    mesh_to_host_rank_id = defaultdict(int)
     for i, binding in sorted(enumerate(config.rank_bindings), key=lambda x: x[1].rank):
         if i > 0:
             cmd.append(":")
 
         cmd.extend(["-np", "1"])
-        cmd.extend(build_rank_environment_args(binding, config, mesh_to_host_rank_id))
+        cmd.extend(build_rank_environment_args(binding, config))
         cmd.extend(program)
 
     return cmd
@@ -222,10 +217,12 @@ def main(ctx: click.Context, rank_binding: Path, dry_run: bool, verbose: bool, m
         rank_bindings:
           - rank: 0                  # MPI rank
             mesh_id: 0               # Mesh ID
+            mesh_host_rank: 0        # Host rank within the mesh
             env_overrides:
               RANK_0_ENV_VAR: "value"
           - rank: 1
             mesh_id: 0
+            mesh_host_rank: 1        # Host rank within the mesh
             env_overrides:
               RANK_1_ENV_VAR: "value"
         global_env:                  # Environment variables for all ranks
@@ -251,7 +248,7 @@ def main(ctx: click.Context, rank_binding: Path, dry_run: bool, verbose: bool, m
     Environment Variables:
         The following variables are automatically set for each rank:
         - TT_MESH_ID: Mesh identifier
-        - TT_HOST_RANK: Host rank within the mesh
+        - TT_MESH_HOST_RANK: Host rank within the mesh
         - TT_METAL_CACHE: Per-rank cache directory
         - TT_METAL_HOME: TT-Metal installation directory
         - PYTHONPATH: Python module search path

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -26,7 +26,7 @@ PRETTY_PRINT_THRESHOLD = 10  # Minimum args to trigger multi-line formatting
 
 
 class RankBinding(BaseModel):
-    """Binding between MPI rank to target MeshId and HostRankId as defined in the mesh graph descriptor."""
+    """Binding between MPI rank to target MeshId and MeshHostRankId as defined in the mesh graph descriptor."""
 
     rank: int = Field(..., ge=0, description="MPI rank (must be >= 0)")
     mesh_id: int = Field(..., ge=0, description="`MeshId` defines the mesh to which the rank belongs")
@@ -202,7 +202,7 @@ def main(ctx: click.Context, rank_binding: Path, dry_run: bool, verbose: bool, m
 
     tt-run is a lightweight wrapper around `mpirun` that simplifies launching
     TT-Metal and TT-NN distributed applications by automatically mapping
-    MPI ranks to target MeshId and HostRankId as defined in the mesh graph descriptor.
+    MPI ranks to target MeshId and MeshHostRankId as defined in the mesh graph descriptor.
 
     \b
     Quick Start:


### PR DESCRIPTION
### Ticket
#24728

### Problem description
Need to enable proper host-to-host communication, confined to host ranks managing a specific mesh.

### What's changed
* Rename "host rank" to "mesh host rank" to emphasize the host rank is the rank within the mesh.
  * Similarly renamed `TT_HOST_RANK` and `HostRankId`.
* Added `mesh_host_rank` to rank binding file, instead of deriving this data implicitly.
* Removed `host_ranks` from yaml MGD. This is not necesasry.
* Added logic to exchange (mesh ID, mesh host rank ID) -> MPI rank mappings, then create subcontexts based on this information.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16949566216)
- [X] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16946447226)
- [X] New/Existing tests provide coverage for changes