### PR TITLE
#0: Some CI fixes, check description

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 35
+        default: 40
       docker-image:
         required: true
         type: string

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -15,7 +15,12 @@ jobs:
       version: 22.04
       build-wheel: true
   deploy:
-    runs-on: multi-host
+    runs-on:
+      # A physical, multi-host WH T3K that's in service
+      - multi-host
+      - arch-wormhole_b0
+      - bare-metal
+      - in-service
     needs: build-artifact
     steps:
       - name: ⬇️ Checkout

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -73,7 +73,8 @@ def test_falcon_causal_lm(
     else:
         shard_dim = 0
 
-    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True, ci_v2_timeout_in_s=900)
+    # This is way too long... but hopefully after github-ci-infra#1016 we can try lowering this again
+    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True, ci_v2_timeout_in_s=1200)
 
     configuration = transformers.FalconConfig.from_pretrained(model_location_or_version)
     configuration.num_hidden_layers = num_layers


### PR DESCRIPTION
### Ticket

N/A

### Problem description

- Multi-host runner tags were wayyyyy too permissive. Let's make it closer to how we handle other machines in CIv1
- N300 data movement tests are genuinely timing out at 35 minutes... Examples [1](https://github.com/tenstorrent/tt-metal/actions/runs/16941014420/job/48011733562) [2](https://github.com/tenstorrent/tt-metal/actions/runs/16940787576/job/48010597329). Will be pinging LLK team
- CIv2 job taking too long, but hopefully moving LFC to infra node https://github.com/tenstorrent/github-ci-infra/issues/1016 will help

### What's changed

- Up timeout of sd tests
- Up timeout of falcon7b download
- make tags for multi-host more idiomatic

### Checklist
- [ ] Multi host: https://github.com/tenstorrent/tt-metal/actions/runs/16945698715
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes