### PR TITLE
AGMM PCC Fix for Small Shapes

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_matmul_async.py
@@ -335,7 +335,6 @@ def run_all_gather_impl(
     [
         (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
         (8, 1, [1, 1, 32, 512], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
-        (8, 1, [1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_matmul_async.py
@@ -333,7 +333,7 @@ def run_all_gather_impl(
 @pytest.mark.parametrize(
     "num_devices, num_links, ag_output_shape, dim, layout, matmul_output_dim, max_in0_block_w, matmul_weights_dtype, ag_input_dtype, use_bias",
     [
-        # (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
+        (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
         (8, 1, [1, 1, 32, 512], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
         (8, 1, [1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
     ],

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_matmul_async.py
@@ -333,7 +333,9 @@ def run_all_gather_impl(
 @pytest.mark.parametrize(
     "num_devices, num_links, ag_output_shape, dim, layout, matmul_output_dim, max_in0_block_w, matmul_weights_dtype, ag_input_dtype, use_bias",
     [
-        (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
+        # (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
+        (8, 1, [1, 1, 32, 512], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
+        (8, 1, [1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT, 960, 2, ttnn.bfloat16, ttnn.bfloat16, True),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -365,6 +365,11 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                 uint32_t chunks_per_sync_val = chunks_per_sync.value_or(
                     std::max((input_tile_id_end - input_tile_id_start) / num_tiles_to_write_per_packet, (uint32_t)1));
 
+                uint32_t self_write_done_semaphore;
+                if (fuse_op) {
+                    self_write_done_semaphore = CreateSemaphore(program, {core}, 0);
+                }
+
                 // Reader
                 std::vector<uint32_t> sender_reader_compile_args = {
                     ring_index,                                        // my_chip_id
@@ -417,6 +422,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                     shard_builder::extend_sharding_run_time_args(output_tensor, reader_rt_args);
                 }
                 if (fuse_op) {
+                    reader_rt_args.push_back(self_write_done_semaphore);
                     if (dir) {
                         fused_op_signaler_forward->push_all_gather_fused_op_rt_args(
                             reader_rt_args,
@@ -513,6 +519,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                     shard_builder::extend_sharding_run_time_args(output_tensor, writer_rt_args);
                 }
                 if (fuse_op) {
+                    writer_rt_args.push_back(self_write_done_semaphore);
                     fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(
                         writer_rt_args,
                         num_workers_per_direction * num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -109,7 +109,9 @@ void kernel_main() {
 #endif
 
     OpSignaler op_signaler;
+    uint32_t self_write_done_semaphore_addr;
     if constexpr (fuse_op) {
+        self_write_done_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
         op_signaler = OpSignaler(arg_idx);
     }
 
@@ -182,10 +184,6 @@ void kernel_main() {
         } else {
             sender_chip_id = my_chip_id - (slices_received + 1);
             actual_sender_chip_id = (sender_chip_id < 0) ? ring_size + sender_chip_id : sender_chip_id;
-        }
-        if (fuse_op) {
-            // Signal matmul to go
-            op_signaler.synchronize_workers_and_signal_op(actual_sender_chip_id);
         }
 
         // Direction == backward: Should I forward what I got from the left to my right?
@@ -271,6 +269,15 @@ void kernel_main() {
         }
 
         slices_received++;
+        if (fuse_op) {
+            // Signal matmul to go
+            if (direction == 1 && slices_received == 1) {
+                noc_semaphore_wait_min(
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(self_write_done_semaphore_addr), 1);
+                noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(self_write_done_semaphore_addr), 0);
+            }
+            op_signaler.synchronize_workers_and_signal_op(actual_sender_chip_id);
+        }
     }
 
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -146,7 +146,9 @@ void kernel_main() {
 
     /* Args for overlapped all gather */
     OpSignaler op_signaler_sender;
+    uint32_t self_write_done_semaphore_addr;
     if constexpr (fuse_op) {
+        self_write_done_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
         op_signaler_sender = OpSignaler(arg_idx);
     }
 
@@ -336,6 +338,9 @@ void kernel_main() {
     if (fuse_op && direction == 1) {
         // Synchronize and signal that the local tensor slice is available
         op_signaler_sender.synchronize_workers_and_signal_op(my_chip_id);
+        uint64_t self_write_done_semaphore_noc_addr =
+            safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, self_write_done_semaphore_addr, 0);
+        noc_semaphore_inc(self_write_done_semaphore_noc_addr, 1);
     }
 
     uint32_t writes_expected = 0;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26349)

### Problem description
- Fused AGMM had a pcc bug on small shapes
- Reader kernel would signal for matmul to start before the local slice was written out to it's output tensor

### What's changed
- Add an additional semaphore to ensure the local slice is written out before signalling for the matmul to start

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16967939198
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16967943441
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes