### PR TITLE
[DM] Skipping Multicast Schemes and Virtual Channels Sweep Tests (For APC)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -524,12 +524,14 @@ TEST_F(DeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal) {
 /* ======== VIRTUAL CHANNELS ======== */
 
 TEST_F(DeviceFixture, TensixDataMovementAllFromAllVirtualChannels) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 317;
 
     unit_tests::dm::all_from_all::virtual_channels_test(arch_, devices_, num_devices_, test_case_id);
 }
 
 TEST_F(DeviceFixture, TensixDataMovementAllFromAllCustom) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 318;
 
     // Parameters

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -533,12 +533,16 @@ TEST_F(DeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal) {
 /* ======== VIRTUAL CHANNELS ======== */
 
 TEST_F(DeviceFixture, TensixDataMovementAllToAllVirtualChannels) {
+    GTEST_SKIP() << "Skipping test";
+
     uint32_t test_case_id = 307;
 
     unit_tests::dm::all_to_all::virtual_channels_test(arch_, devices_, num_devices_, test_case_id);
 }
 
 TEST_F(DeviceFixture, TensixDataMovementAllToAllCustom) {
+    GTEST_SKIP() << "Skipping test";
+
     uint32_t test_case_id = 308;
 
     // Custom Parameters

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -361,6 +361,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
+    GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 153;
     CoreCoord master_core_coord = {0, 0};
@@ -373,6 +374,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllCustom) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -318,6 +318,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
+    GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 151;
 
@@ -332,6 +333,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneFromOneCustom) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
 
     // Parameters

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -167,6 +167,8 @@ void run_all_tests(
 /* ============================================================= */
 
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesLoopback) {
+    GTEST_SKIP() << "Skipping test";
+
     uint32_t test_case_id = 100;
 
     bool loopback = true;
@@ -176,6 +178,8 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesLoopback) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
+    GTEST_SKIP() << "Skipping test";
+
     uint32_t test_case_id = 101;
 
     bool loopback = false;
@@ -206,6 +210,8 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoopback) {
 */
 
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
+    GTEST_SKIP() << "Skipping test";
+
     uint32_t test_case_id = 110;
 
     bool loopback = false;

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -780,6 +780,8 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirectedIdeal) {
 /* ========== VIRTUAL CHANNELS ========== */
 
 TEST_F(DeviceFixture, TensixDataMovementOneToAllUnicastVirtualChannels) {  // Expose loopback here?
+    GTEST_SKIP() << "Skipping test";
+
     // Parameters
     uint32_t test_case_id = 152;
 
@@ -810,6 +812,8 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllUnicastVirtualChannels) {  // Ex
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneToAllUnicastCustom) {
+    GTEST_SKIP() << "Skipping test";
+
     // Parameters
     uint32_t test_case_id = 160;
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -342,6 +342,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToOneDirectedIdeal) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
+    GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
     uint32_t test_id = 150;
 
@@ -356,6 +357,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
 }
 
 TEST_F(DeviceFixture, TensixDataMovementOneToOneCustom) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_id = 160;
 
     // Parameters


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/pull/26790)

### Problem description
N300 Data Movement tests on the APC pipeline are timing out. Unnecessary tests need to be skipped to reduce the time taken. 

### What's changed
All multicast schemes and VC sweep tests are now being skipped by default. This should reduce the time taken by a considerable amount.