### PR TITLE
Fixing compiler warnings in program factory

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -455,7 +455,8 @@ get_padded_slice_runtime_args_tile_sharded_output(
 
     const auto num_sticks_per_core = output_shard_spec.shape[0];
     const auto num_tiles_per_full_row = num_output_tiles_per_dim[1] * num_output_tiles_per_dim[0];
-    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input_tensor, output_tensor_start);
+    [[maybe_unused]] uint32_t start_offset =
+        ttnn::operations::data_movement::get_tiled_start_offset(input_tensor, output_tensor_start);
     log_debug(tt::LogOp, "Start Offset: {}", start_offset);
     uint32_t core_index = 0;
     for (const auto& core : cores) {
@@ -513,7 +514,7 @@ get_padded_slice_runtime_args_tile_sharded_output(
         std::ranges::reverse(start_index_per_dim);
         uint32_t input_start_id = ttnn::operations::data_movement::get_tiled_start_offset(
             input_tensor, ttnn::Shape(start_index_in_input_per_dim));
-        uint32_t input_end_id = ttnn::operations::data_movement::get_tiled_start_offset(
+        [[maybe_unused]] uint32_t input_end_id = ttnn::operations::data_movement::get_tiled_start_offset(
             input_tensor, ttnn::Shape(end_index_in_input_per_dim), true);
         ttnn::operations::data_movement::get_tiled_start_offset(actual_output_shape, ttnn::Shape(start_index_per_dim));
         ttnn::operations::data_movement::get_tiled_start_offset(
@@ -647,7 +648,8 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
         num_cores_channels);
     num_tiles_per_channel = num_tiles_per_channel / num_cores_channels;
 
-    uint32_t num_tiles_height_per_core = tt::div_up(output_shard_spec.shape[0], tt::constants::TILE_HEIGHT);
+    [[maybe_unused]] uint32_t num_tiles_height_per_core =
+        tt::div_up(output_shard_spec.shape[0], tt::constants::TILE_HEIGHT);
     uint32_t num_output_sticks_per_core = output_shard_spec.shape[0];
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23444

### Problem description
these variables are only used in log statements, so they're marked as unused in release builds.

### What's changed
the variables were flagged as maybe unused

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Build artifacts](https://github.com/tenstorrent/tt-metal/actions/workflows/build-artifact.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16946708203
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes