### PR TITLE
Add initial impl for fabric mux integration into fabric router

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -57,7 +57,9 @@ public:
     }
 
     static void DoSetUpTestSuite(
-        tt_fabric::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt) {
+        tt_fabric::FabricConfig fabric_config,
+        std::optional<uint8_t> num_routing_planes = std::nullopt,
+        tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED) {
         slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch_) {
             log_info(tt::LogTest, "Running fabric api tests with slow dispatch");
@@ -73,7 +75,10 @@ public:
             ids.push_back(id);
         }
         tt::tt_fabric::SetFabricConfig(
-            fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, num_routing_planes);
+            fabric_config,
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+            num_routing_planes,
+            fabric_tensix_config);
         devices_map_ = tt::tt_metal::detail::CreateDevices(ids);
         for (auto& [id, device] : devices_map_) {
             devices_.push_back(device);
@@ -113,6 +118,15 @@ public:
 class Fabric1DFixture : public BaseFabricFixture {
 protected:
     static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D); }
+    static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
+};
+
+class Fabric1DTensixFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        BaseFabricFixture::DoSetUpTestSuite(
+            tt::tt_fabric::FabricConfig::FABRIC_1D, std::nullopt, tt::tt_fabric::FabricTensixConfig::MUX);
+    }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2135,6 +2135,7 @@ void FabricUnicastCommon(BaseFabricFixture* fixture, NocSendType noc_send_type, 
         fixture->RunProgramNonblocking(receiver_device, receiver_program);
     }
     fixture->RunProgramNonblocking(sender_device, sender_program);
+
     fixture->WaitForSingleProgramDone(sender_device, sender_program);
     for (auto& receiver_device : receiver_devices) {
         fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
@@ -2488,6 +2489,23 @@ TEST_F(NightlyFabric1DFixture, TestLinearFabricMulticastNocFusedAtomicInc1D) {
 }
 TEST_F(NightlyFabric1DFixture, TestLinearFabricMulticastNocFusedAtomicInc1DMultiDir) {
     FabricMulticastCommon(this, NOC_FUSED_UNICAST_ATOMIC_INC, 2);
+}
+
+// Test cases using the new Fabric1DTensixFixture to test tensix config with mux
+TEST_F(Fabric1DTensixFixture, TestLinearFabricUnicastNocUnicastWrite1DMux) {
+    FabricUnicastCommon(this, NOC_UNICAST_WRITE);
+}
+
+TEST_F(Fabric1DTensixFixture, TestLinearFabricUnicastNocAtomicInc1DMux) {
+    FabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC);
+}
+
+TEST_F(Fabric1DTensixFixture, TestLinearFabricMulticastNocUnicastWrite1DMux) {
+    FabricMulticastCommon(this, NOC_UNICAST_WRITE);
+}
+
+TEST_F(Fabric1DTensixFixture, TestLinearFabricMulticastNocAtomicInc1DMux) {
+    FabricMulticastCommon(this, NOC_UNICAST_ATOMIC_INC);
 }
 
 }  // namespace fabric_router_tests

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -150,6 +150,9 @@ public:
 
     void clear_fabric_context();
 
+    // Initialize fabric tensix config (call after routing tables are configured)
+    void initialize_fabric_tensix_config();
+
     // Check if ANY managed chip supports intermesh links
     bool system_has_intermesh_links() const;
 
@@ -274,6 +277,14 @@ private:
     void write_routing_tables_to_eth_cores(MeshId mesh_id, chip_id_t chip_id) const;
     void write_routing_tables_to_tensix_cores(MeshId mesh_id, chip_id_t chip_id) const;
     void write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip_id_t chip_id) const;
+
+    // Helper to populate fabric connection info for both router and mux configurations
+    void populate_fabric_connection_info(
+        tt::tt_fabric::fabric_connection_info_t& connection_info,
+        tt::tt_fabric::fabric_connection_info_t& tensix_connection_info,
+        chip_id_t physical_chip_id,
+        chan_id_t eth_channel_id,
+        eth_chan_directions router_direction) const;
 
     // TODO: remove once UMD can provide all intermesh links
     // Populate the local intermesh link to remote intermesh link table

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -151,7 +151,7 @@ public:
     void clear_fabric_context();
 
     // Initialize fabric tensix config (call after routing tables are configured)
-    void initialize_fabric_tensix_config();
+    void initialize_fabric_tensix_datamover_config();
 
     // Check if ANY managed chip supports intermesh links
     bool system_has_intermesh_links() const;

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -25,9 +25,12 @@ struct core_descriptor_t {
     std::vector<RelativeCoreCoord> relative_storage_cores;
     std::optional<uint32_t> storage_core_bank_size = std::nullopt;
     std::vector<RelativeCoreCoord> relative_dispatch_cores;
+    std::vector<RelativeCoreCoord> relative_fabric_mux_cores;
+
     std::vector<CoreCoord> logical_compute_cores;
     std::vector<CoreCoord> logical_storage_cores;
     std::vector<CoreCoord> logical_dispatch_cores;
+    std::vector<CoreCoord> logical_fabric_mux_cores;
 };
 
 inline const std::string& get_product_name(tt::ARCH arch, uint32_t num_harvested_on_axis) {
@@ -70,6 +73,12 @@ inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.logical_dispatch_cores;
+}
+
+inline const std::vector<CoreCoord>& get_logical_fabric_mux_cores(
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
+    return core_desc.logical_fabric_mux_cores;
 }
 
 }  // namespace tt

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -116,6 +116,12 @@ struct FabricEriscDatamoverConfig {
     static constexpr std::size_t dateline_upstream_receiver_channel_skip_idx = 1;
     static constexpr std::size_t dateline_upstream_adjcent_sender_channel_skip_idx = 2;
 
+    // num sender channels based on more accurate topology
+    static constexpr std::size_t num_sender_channels_1d_linear = 2;
+    static constexpr std::size_t num_sender_channels_2d_mesh = 4;
+    static constexpr std::size_t num_sender_channels_1d_ring = 3;
+    static constexpr std::size_t num_sender_channels_2d_torus = 5;
+
     static constexpr std::size_t num_sender_channels_1d = 3;
     static constexpr std::size_t num_sender_channels_2d = 5;
     static constexpr std::size_t num_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -97,7 +97,8 @@ tt::tt_fabric::Topology get_fabric_topology();
 void SetFabricConfig(
     FabricConfig fabric_config,
     FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-    std::optional<uint8_t> num_routing_planes = std::nullopt);
+    std::optional<uint8_t> num_routing_planes = std::nullopt,
+    FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED);
 
 FabricConfig GetFabricConfig();
 

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -23,6 +23,11 @@ enum class FabricConfig : uint32_t {
     CUSTOM = 11
 };
 
+enum class FabricTensixConfig : uint32_t {
+    DISABLED = 0,
+    MUX = 1,
+};
+
 enum class FabricReliabilityMode : uint32_t {
 
     // When fabric is initialized, user expects live links/devices to exactly match the mesh graph descriptor.

--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -1,0 +1,123 @@
+# Core descriptor for fabric mux enabled configurations for Blackhole
+# First half of dispatch cores allocated to fabric mux, second half to dispatch
+# Based on blackhole_140_arch.yaml structure
+# Anything using [[#, #]] is logical coordinates (Can be relative)
+# relative index: 0 means first row, -1 means last row of functional grid...
+
+# product name:
+#   num of HW command queues:
+#     core descriptor config
+
+unharvested:
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [12, 9]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
+      fabric_mux_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+
+      dispatch_cores:
+        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [12, 9]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # Same allocation for 2 CQ configuration
+      fabric_mux_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+
+      dispatch_cores:
+        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+
+      dispatch_core_type:
+        "tensix"
+
+1xharvested:
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [11, 9]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
+      fabric_mux_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+
+      dispatch_cores:
+        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [11, 9]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # Same allocation for 2 CQ configuration
+      fabric_mux_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+
+      dispatch_cores:
+        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+
+      dispatch_core_type:
+        "tensix"
+
+2xharvested:
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [10, 9]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
+      fabric_mux_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+
+      dispatch_cores:
+        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [10, 9]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # Same allocation for 2 CQ configuration
+      fabric_mux_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+
+      dispatch_cores:
+        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
@@ -1,0 +1,271 @@
+# Core descriptor for fabric mux enabled configurations
+# First half of dispatch cores allocated to fabric mux, second half to dispatch
+# Anything using [[#, #]] is logical coordinates (Can be relative)
+# relative index: 0 means first row, -1 means last row of functional grid...
+
+# product name:
+#   num of HW command queues:
+#     core descriptor config
+
+galaxy:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 6]
+
+      storage_cores:
+        []
+
+      # First half for fabric mux, second half for dispatch
+      fabric_mux_cores:
+        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+
+      dispatch_cores:
+        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 6]
+
+      storage_cores:
+        []
+
+      # Same allocation for 2 CQ configuration
+      fabric_mux_cores:
+        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+
+      dispatch_cores:
+        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [5, 9]
+
+      storage_cores:
+        []
+
+      fabric_mux_cores:
+        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+
+      dispatch_cores:
+        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [5, 9]
+
+      storage_cores:
+        []
+
+      fabric_mux_cores:
+        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+
+      dispatch_cores:
+        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"
+
+nebula_x1:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 6]
+
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
+
+      storage_cores:
+        []
+
+      fabric_mux_cores:
+        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+
+      dispatch_cores:
+        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 6]
+
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
+
+      storage_cores:
+        []
+
+      fabric_mux_cores:
+        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+
+      dispatch_cores:
+        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+
+      dispatch_core_type:
+        "tensix"
+
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [5, 8]
+
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
+
+      storage_cores:
+        []
+
+      fabric_mux_cores:
+        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+
+      dispatch_cores:
+        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [5, 8]
+
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
+
+      storage_cores:
+        []
+
+      fabric_mux_cores:
+        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+
+      dispatch_cores:
+        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+
+      dispatch_core_type:
+        "tensix"
+
+nebula_x2:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 5]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      fabric_mux_cores:
+        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+
+      dispatch_cores:
+        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 5]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      fabric_mux_cores:
+        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+
+      dispatch_cores:
+        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [5, 7]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      fabric_mux_cores:
+        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+
+      dispatch_cores:
+        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [5, 7]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      fabric_mux_cores:
+        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+
+      dispatch_cores:
+        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
@@ -12,7 +12,7 @@ galaxy:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 6]
+        end: [7, 7]
 
       storage_cores:
         []
@@ -30,7 +30,7 @@ galaxy:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 6]
+        end: [7, 7]
 
       storage_cores:
         []

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(
         fabric_host_utils.cpp
         fabric_context.cpp
         fabric_mux_config.cpp
+        fabric_tensix_builder.cpp
         compressed_routing_table.cpp
         serialization/intermesh_link_table.cpp
         erisc_datamover_builder_helper.cpp

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1445,6 +1445,61 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction
     return {};
 }
 
+static void write_to_worker_or_fabric_tensix_cores(
+    const void* fabric_data,
+    const void* tensix_data,
+    size_t size,
+    tt::tt_metal::HalL1MemAddrType addr_type,
+    chip_id_t physical_chip_id) {
+    TT_FATAL(
+        size ==
+            tt_metal::MetalContext::instance().hal().get_dev_size(tt_metal::HalProgrammableCoreType::TENSIX, addr_type),
+        "ControlPlane: Tensix core data size mismatch expected {} but got {}",
+        size,
+        tt_metal::MetalContext::instance().hal().get_dev_size(tt_metal::HalProgrammableCoreType::TENSIX, addr_type));
+
+    const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(physical_chip_id);
+    const std::vector<tt::umd::CoreCoord>& all_tensix_cores =
+        soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+
+    // Check if tensix config is enabled
+    bool tensix_config_enabled = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
+                                 tt::tt_fabric::FabricTensixConfig::DISABLED;
+
+    // Get pre-computed translated fabric mux cores from tensix config
+    std::unordered_set<CoreCoord> mux_cores_translated;
+    if (tensix_config_enabled) {
+        const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+        const auto& tensix_config = fabric_context.get_tensix_config();
+        mux_cores_translated = tensix_config.get_translated_fabric_or_dispatch_mux_cores();
+    }
+
+    size_t mux_cores_written = 0;
+    size_t worker_cores_written = 0;
+    for (const auto& tensix_core : all_tensix_cores) {
+        CoreCoord core_coord(tensix_core.x, tensix_core.y);
+        bool is_mux_core = mux_cores_translated.find(core_coord) != mux_cores_translated.end();
+        bool write_fabric_data;
+        if (tensix_config_enabled) {
+            if (is_mux_core) {
+                write_fabric_data = true;
+            } else {
+                write_fabric_data = false;
+            }
+        } else {
+            write_fabric_data = true;
+        }
+
+        const void* data_to_write = write_fabric_data ? fabric_data : tensix_data;
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            data_to_write,
+            size,
+            tt_cxy_pair(physical_chip_id, core_coord),
+            tt_metal::MetalContext::instance().hal().get_dev_addr(
+                tt_metal::HalProgrammableCoreType::TENSIX, addr_type));
+    }
+}
+
 static void write_to_all_tensix_cores(
     const void* data, size_t size, tt::tt_metal::HalL1MemAddrType addr_type, chip_id_t physical_chip_id) {
     TT_FATAL(
@@ -1548,11 +1603,8 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip
     FabricNodeId src_fabric_node_id{mesh_id, chip_id};
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
 
-    const auto& fabric_context = this->get_fabric_context();
-    const auto& edm_config = fabric_context.get_fabric_router_config();
-    const bool is_2d_fabric = fabric_context.is_2D_routing_enabled();
-
     tt::tt_fabric::tensix_fabric_connections_l1_info_t fabric_connections = {};
+    tt::tt_fabric::tensix_fabric_connections_l1_info_t fabric_tensix_connections = {};
 
     // Get all physically connected ethernet channels directly from the cluster
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -1574,35 +1626,30 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip
                 break;
             }
 
-            CoreCoord fabric_router_virtual_core =
-                cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_channel_id);
-
-            // Populate connection info for fabric-routed channels
-            const auto sender_channel = is_2d_fabric ? router_direction : 0;
+            // Populate connection info for regular fabric connections (for tensix mux cores)
             auto& connection_info = fabric_connections.read_only[eth_channel_id];
             connection_info.edm_direction = router_direction;
-            connection_info.edm_noc_x = static_cast<uint8_t>(fabric_router_virtual_core.x);
-            connection_info.edm_noc_y = static_cast<uint8_t>(fabric_router_virtual_core.y);
-            connection_info.edm_buffer_base_addr = edm_config.sender_channels_base_address[sender_channel];
-            connection_info.num_buffers_per_channel = edm_config.sender_channels_num_buffers[sender_channel];
-            connection_info.edm_l1_sem_addr =
-                edm_config.sender_channels_local_flow_control_semaphore_address[sender_channel];
-            connection_info.edm_connection_handshake_addr =
-                edm_config.sender_channels_connection_semaphore_address[sender_channel];
-            connection_info.edm_worker_location_info_addr =
-                edm_config.sender_channels_worker_conn_info_base_address[sender_channel];
-            connection_info.buffer_size_bytes = edm_config.channel_buffer_size_bytes;
-            connection_info.buffer_index_semaphore_id =
-                edm_config.sender_channels_buffer_index_semaphore_address[sender_channel];
+
+            // Populate connection info for tensix mux connections (for normal worker cores)
+            auto& tensix_connection_info = fabric_tensix_connections.read_only[eth_channel_id];
+            tensix_connection_info.edm_direction = router_direction;
+
+            // Use helper function to populate both connection types
+            this->populate_fabric_connection_info(
+                connection_info, tensix_connection_info, physical_chip_id, eth_channel_id, router_direction);
 
             // Mark this connection as valid for fabric communication
             fabric_connections.valid_connections_mask |= (1u << eth_channel_id);
+            fabric_tensix_connections.valid_connections_mask |= (1u << eth_channel_id);
             num_eth_endpoint++;
         }
     }
 
-    write_to_all_tensix_cores(
-        &fabric_connections,
+    // Write fabric connections (fabric router config) to mux cores and tensix connections (tensix config) to worker
+    // cores
+    write_to_worker_or_fabric_tensix_cores(
+        &fabric_connections,         // fabric_data - goes to mux cores
+        &fabric_tensix_connections,  // tensix_data - goes to worker cores
         sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t),
         tt::tt_metal::HalL1MemAddrType::TENSIX_FABRIC_CONNECTIONS,
         physical_chip_id);
@@ -1746,6 +1793,11 @@ FabricContext& ControlPlane::get_fabric_context() const {
 }
 
 void ControlPlane::clear_fabric_context() { this->fabric_context_.reset(nullptr); }
+
+void ControlPlane::initialize_fabric_tensix_config() {
+    TT_FATAL(this->fabric_context_ != nullptr, "Fabric context must be initialized first");
+    this->fabric_context_->initialize_tensix_config();
+}
 
 void ControlPlane::initialize_intermesh_eth_links() {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -2250,6 +2302,64 @@ const std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>&
 const std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>& ControlPlane::get_host_local_context()
     const {
     return host_local_context_;
+}
+
+void ControlPlane::populate_fabric_connection_info(
+    tt::tt_fabric::fabric_connection_info_t& connection_info,
+    tt::tt_fabric::fabric_connection_info_t& tensix_connection_info,
+    chip_id_t physical_chip_id,
+    chan_id_t eth_channel_id,
+    eth_chan_directions router_direction) const {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& fabric_context = this->get_fabric_context();
+    const auto topology = fabric_context.get_fabric_topology();
+    const bool is_2d_fabric = topology == Topology::Mesh;
+    const auto sender_channel = is_2d_fabric ? router_direction : 0;
+
+    // Always populate fabric router config for normal workers
+    const auto& edm_config = fabric_context.get_fabric_router_config();
+    CoreCoord fabric_router_virtual_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_channel_id);
+    connection_info.edm_noc_x = static_cast<uint8_t>(fabric_router_virtual_core.x);
+    connection_info.edm_noc_y = static_cast<uint8_t>(fabric_router_virtual_core.y);
+    connection_info.edm_buffer_base_addr = edm_config.sender_channels_base_address[sender_channel];
+    connection_info.num_buffers_per_channel = edm_config.sender_channels_num_buffers[sender_channel];
+    connection_info.edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[sender_channel];
+    connection_info.edm_connection_handshake_addr =
+        edm_config.sender_channels_connection_semaphore_address[sender_channel];
+    connection_info.edm_worker_location_info_addr =
+        edm_config.sender_channels_worker_conn_info_base_address[sender_channel];
+    connection_info.buffer_size_bytes = edm_config.channel_buffer_size_bytes;
+    connection_info.buffer_index_semaphore_id =
+        edm_config.sender_channels_buffer_index_semaphore_address[sender_channel];
+    // TODO: remove hardcoding, and have a common file between host and device for constants
+    connection_info.worker_free_slots_stream_id = 17;
+
+    // Check if fabric tensix config is enabled, if so populate tensix mux config as well
+    if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
+        tt::tt_fabric::FabricTensixConfig::DISABLED) {
+        const auto& tensix_config = fabric_context.get_tensix_config();
+        CoreCoord mux_core_logical = tensix_config.get_core_for_channel(physical_chip_id, eth_channel_id);
+        CoreCoord mux_core_virtual = cluster.get_virtual_coordinate_from_logical_coordinates(
+            physical_chip_id, mux_core_logical, CoreType::WORKER);
+        // Get the RISC ID that handles this ethernet channel
+        auto risc_id = tensix_config.get_risc_id_for_channel(physical_chip_id, eth_channel_id);
+        // Use tensix config methods for mux configuration
+        tensix_connection_info.edm_noc_x = static_cast<uint8_t>(mux_core_virtual.x);
+        tensix_connection_info.edm_noc_y = static_cast<uint8_t>(mux_core_virtual.y);
+        tensix_connection_info.edm_buffer_base_addr = tensix_config.get_channels_base_address(risc_id, sender_channel);
+        tensix_connection_info.num_buffers_per_channel = tensix_config.get_num_buffers_per_channel();
+        tensix_connection_info.buffer_size_bytes = tensix_config.get_buffer_size_bytes_full_size_channel();
+        tensix_connection_info.edm_l1_sem_addr =
+            tensix_config.get_local_flow_control_semaphore_address(physical_chip_id, eth_channel_id, sender_channel);
+        tensix_connection_info.edm_connection_handshake_addr =
+            tensix_config.get_connection_semaphore_address(physical_chip_id, eth_channel_id, sender_channel);
+        tensix_connection_info.edm_worker_location_info_addr =
+            tensix_config.get_worker_conn_info_base_address(physical_chip_id, eth_channel_id, sender_channel);
+        tensix_connection_info.buffer_index_semaphore_id =
+            tensix_config.get_buffer_index_semaphore_address(physical_chip_id, eth_channel_id, sender_channel);
+        tensix_connection_info.worker_free_slots_stream_id =
+            tensix_config.get_channel_credits_stream_id(physical_chip_id, eth_channel_id, sender_channel);
+    }
 }
 
 ControlPlane::~ControlPlane() = default;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1794,7 +1794,7 @@ FabricContext& ControlPlane::get_fabric_context() const {
 
 void ControlPlane::clear_fabric_context() { this->fabric_context_.reset(nullptr); }
 
-void ControlPlane::initialize_fabric_tensix_config() {
+void ControlPlane::initialize_fabric_tensix_datamover_config() {
     TT_FATAL(this->fabric_context_ != nullptr, "Fabric context must be initialized first");
     this->fabric_context_->initialize_tensix_config();
 }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1445,7 +1445,7 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction
     return {};
 }
 
-static void write_to_worker_or_fabric_tensix_cores(
+void write_to_worker_or_fabric_tensix_cores(
     const void* fabric_data,
     const void* tensix_data,
     size_t size,
@@ -1500,7 +1500,7 @@ static void write_to_worker_or_fabric_tensix_cores(
     }
 }
 
-static void write_to_all_tensix_cores(
+void write_to_all_tensix_cores(
     const void* data, size_t size, tt::tt_metal::HalL1MemAddrType addr_type, chip_id_t physical_chip_id) {
     TT_FATAL(
         size ==

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2310,6 +2310,7 @@ void ControlPlane::populate_fabric_connection_info(
     chip_id_t physical_chip_id,
     chan_id_t eth_channel_id,
     eth_chan_directions router_direction) const {
+    constexpr uint16_t WORKER_FREE_SLOTS_STREAM_ID = 17;
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& fabric_context = this->get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
@@ -2331,8 +2332,8 @@ void ControlPlane::populate_fabric_connection_info(
     connection_info.buffer_size_bytes = edm_config.channel_buffer_size_bytes;
     connection_info.buffer_index_semaphore_id =
         edm_config.sender_channels_buffer_index_semaphore_address[sender_channel];
-    // TODO: remove hardcoding, and have a common file between host and device for constants
-    connection_info.worker_free_slots_stream_id = 17;
+    // TODO: issue #26853, remove hardcoding, and have a common file between host and device for constants
+    connection_info.worker_free_slots_stream_id = WORKER_FREE_SLOTS_STREAM_ID;
 
     // Check if fabric tensix config is enabled, if so populate tensix mux config as well
     if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -237,8 +237,12 @@ tt::tt_fabric::Topology get_fabric_topology() {
 FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
 
 void SetFabricConfig(
-    FabricConfig fabric_config, FabricReliabilityMode reliability_mode, std::optional<uint8_t> num_routing_planes) {
-    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
+    FabricConfig fabric_config,
+    FabricReliabilityMode reliability_mode,
+    std::optional<uint8_t> num_routing_planes,
+    FabricTensixConfig fabric_tensix_config) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        fabric_config, reliability_mode, num_routing_planes, fabric_tensix_config);
 }
 
 std::optional<eth_chan_directions> get_eth_forwarding_direction(

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <limits>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
+#include "tt_metal/fabric/fabric_tensix_builder.hpp"
 
 namespace tt::tt_fabric {
 
@@ -43,6 +44,12 @@ public:
     tt::tt_fabric::FabricEriscDatamoverConfig& get_fabric_router_config(
         tt::tt_fabric::FabricEriscDatamoverType fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::Default,
         tt::tt_fabric::FabricEriscDatamoverAxis fabric_edm_axis = tt::tt_fabric::FabricEriscDatamoverAxis::Short) const;
+
+    // Get fabric tensix config for mux configuration
+    tt::tt_fabric::FabricTensixDatamoverConfig& get_tensix_config() const;
+
+    // Initialize fabric tensix config (call after routing tables are configured)
+    void initialize_tensix_config();
 
     void set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers);
     uint32_t get_num_fabric_initialized_routers(chip_id_t chip_id) const;
@@ -86,6 +93,9 @@ private:
         {};
     std::array<std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig>, 2>
         dateline_upstream_adjcent_upstream_router_config_ = {};
+
+    // Tensix config for fabric mux configuration (same for all devices)
+    std::unique_ptr<tt::tt_fabric::FabricTensixDatamoverConfig> tensix_config_;
 
     // Using vectors. Use Device IDs as indices
     size_t num_devices = 0;

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -1,0 +1,420 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fabric_tensix_builder.hpp"
+
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include "impl/context/metal_context.hpp"
+#include <tt-metalium/core_descriptor.hpp>
+#include <tt-metalium/device_pool.hpp>
+#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_host_utils.hpp"
+#include "tt_align.hpp"
+#include <bit>
+#include <algorithm>
+
+namespace tt::tt_fabric {
+
+// FabricTensixDatamoverConfig implementation
+
+FabricTensixDatamoverConfig::FabricTensixDatamoverConfig() {
+    // Initialize channel mappings and configurations
+    initialize_channel_mappings();
+    calculate_buffer_allocations();
+    create_mux_configs();
+}
+
+void FabricTensixDatamoverConfig::initialize_channel_mappings() {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto num_devices = cluster.number_of_devices();
+
+    // Get logical fabric mux cores from the first available device (same for all devices), except for TG
+    const bool is_TG =
+        (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG);
+
+    const auto& all_active_devices = tt::DevicePool::instance().get_all_active_devices();
+    TT_FATAL(!all_active_devices.empty(), "No active devices found in DevicePool");
+
+    auto device_id = all_active_devices.front()->id();
+    if (is_TG) {
+        // For TG systems, use a non-MMIO device for fabric mux cores
+        for (const auto& device : all_active_devices) {
+            if (device && !device->is_mmio_capable()) {
+                device_id = device->id();
+                break;
+            }
+        }
+    }
+
+    uint8_t num_hw_cqs = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
+    tt::tt_metal::DispatchCoreConfig dispatch_core_config =
+        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    logical_fabric_mux_cores_ = tt::get_logical_fabric_mux_cores(device_id, num_hw_cqs, dispatch_core_config);
+    // TODO: once we merge the mux cores from dispatch to fabric, we can remove this.
+    logical_dispatch_mux_cores_ = tt::get_logical_dispatch_cores(device_id, num_hw_cqs, dispatch_core_config);
+
+    TT_FATAL(!logical_fabric_mux_cores_.empty(), "No logical fabric mux cores found for device {}", device_id);
+
+    // Initialize translated mux cores (coordinates should be same across devices)
+    auto device = tt::DevicePool::instance().get_active_device(device_id);
+    TT_FATAL(device != nullptr, "Device {} not found in DevicePool", device_id);
+    if (device != nullptr) {
+        for (const auto& logical_core : logical_fabric_mux_cores_) {
+            CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+            translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
+        }
+        for (const auto& logical_core : logical_dispatch_mux_cores_) {
+            CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+            translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
+        }
+        log_info(
+            tt::LogTest,
+            "DEBUG: Initialized {} translated fabric mux cores",
+            translated_fabric_or_dispatch_mux_cores_.size());
+    }
+
+    // Get maximum number of active ethernet channels from control plane across all devices
+    size_t max_eth_channels = 0;
+
+    // First pass: find max_eth_channels
+    for (const auto& device : all_active_devices) {
+        if (!(is_TG && device->is_mmio_capable())) {
+            auto dev_id = device->id();
+            auto dev_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
+
+            // Get all active ethernet channels for this device
+            auto active_channels = control_plane.get_active_fabric_eth_channels(dev_fabric_node_id);
+            max_eth_channels = std::max(max_eth_channels, active_channels.size());
+        }
+    }
+
+    TT_FATAL(max_eth_channels > 0, "No active ethernet channels found in the system");
+    TT_FATAL(!logical_fabric_mux_cores_.empty(), "logical_fabric_mux_cores_ is empty before division");
+
+    // Calculate number of configs per core and riscs needed BEFORE using them
+    num_configs_per_core_ =
+        (max_eth_channels + logical_fabric_mux_cores_.size() - 1) / logical_fabric_mux_cores_.size();
+    num_used_riscs_per_tensix_ = num_configs_per_core_;
+
+    // Second pass: create per-device channel mappings using real ethernet channel IDs
+    for (const auto& device : all_active_devices) {
+        if (!(is_TG && device->is_mmio_capable())) {
+            auto dev_id = device->id();
+            auto dev_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
+
+            // Get all active ethernet channels for this device
+            auto active_channels = control_plane.get_active_fabric_eth_channels(dev_fabric_node_id);
+
+            // Initialize per-device mappings
+            eth_chan_to_core_index_[dev_id] = std::unordered_map<size_t, size_t>();
+            eth_chan_to_risc_id_[dev_id] = std::unordered_map<size_t, size_t>();
+
+            // Create round-robin mapping using the actual ethernet channel IDs from active_channels
+            size_t channel_index = 0;
+            for (auto [eth_chan_id, eth_chan_dir] : active_channels) {
+                size_t core_index = channel_index % logical_fabric_mux_cores_.size();
+                eth_chan_to_core_index_[dev_id][eth_chan_id] = core_index;
+
+                // Determine RISC ID: round-robin assignment (0 = BRISC, 1 = NCRISC, etc.)
+                size_t channels_on_core = (channel_index / logical_fabric_mux_cores_.size());
+                size_t risc_id = channels_on_core % num_used_riscs_per_tensix_;
+                eth_chan_to_risc_id_[dev_id][eth_chan_id] = risc_id;
+
+                channel_index++;
+            }
+        }
+    }
+}
+
+void FabricTensixDatamoverConfig::calculate_buffer_allocations() {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+
+    // Get buffer size from fabric context
+    buffer_size_bytes_full_size_channel_ =
+        fabric_context.get_fabric_packet_header_size_bytes() + tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+
+    // Calculate available L1 space for tensix cores
+    uint32_t l1_base = hal.get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
+    uint32_t l1_size = hal.get_dev_size(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+    // Get L1 alignment requirement
+    size_t l1_alignment = hal.get_alignment(tt::tt_metal::HalMemType::L1);
+
+    // Reserve space for both RISC types with proper alignment
+    size_t space_per_risc = l1_size / num_used_riscs_per_tensix_;     // Split between BRISC and NCRISC
+    space_per_risc = (space_per_risc / l1_alignment) * l1_alignment;  // Align down to L1 alignment
+
+    // Get the maximum number of channels per RISC based on fabric topology from fabric context
+    auto topology = fabric_context.get_fabric_topology();
+
+    switch (topology) {
+        case tt::tt_fabric::Topology::Linear:
+            num_channels_ = tt::tt_fabric::FabricEriscDatamoverConfig::num_sender_channels_1d_linear;
+            break;
+        case tt::tt_fabric::Topology::Mesh:
+            num_channels_ = tt::tt_fabric::FabricEriscDatamoverConfig::num_sender_channels_2d_mesh;
+            break;
+        case tt::tt_fabric::Topology::Ring:
+            num_channels_ = tt::tt_fabric::FabricEriscDatamoverConfig::num_sender_channels_1d_ring;
+            break;
+        case tt::tt_fabric::Topology::Torus:
+            num_channels_ = tt::tt_fabric::FabricEriscDatamoverConfig::num_sender_channels_2d_torus;
+            break;
+        default: TT_THROW("unknow fabric topology: {}", topology); break;
+    }
+
+    // Calculate buffers per channel based on available space and max channels
+    size_t space_needed_for_max_channels = num_channels_ * buffer_size_bytes_full_size_channel_;
+    num_buffers_per_channel_ = std::bit_floor(space_per_risc / space_needed_for_max_channels);
+
+    // Set base addresses for each RISC ID with proper L1 alignment
+    for (size_t risc_id = 0; risc_id < num_used_riscs_per_tensix_; ++risc_id) {
+        base_l1_addresses_[risc_id] = l1_base + (risc_id * space_per_risc);
+    }
+}
+
+void FabricTensixDatamoverConfig::create_mux_configs() {
+    // Create mux configs for the number of RISCs we actually need - much cleaner!
+    for (size_t risc_id = 0; risc_id < num_used_riscs_per_tensix_; ++risc_id) {
+        mux_configs_[risc_id] = std::make_shared<tt::tt_fabric::FabricMuxConfig>(
+            static_cast<uint8_t>(num_channels_),             // num_full_size_channels
+            0,                                               // num_header_only_channels (set to 0 for now)
+            static_cast<uint8_t>(num_buffers_per_channel_),  // num_buffers_full_size_channel
+            0,                                               // num_buffers_header_only_channel
+            buffer_size_bytes_full_size_channel_,            // buffer_size_bytes_full_size_channel
+            base_l1_addresses_[risc_id],                     // base_l1_address
+            CoreType::WORKER                                 // core_type (always tensix)
+        );
+    }
+}
+
+// Getter implementations
+size_t FabricTensixDatamoverConfig::get_base_l1_address(size_t risc_id) const {
+    auto it = base_l1_addresses_.find(risc_id);
+    TT_FATAL(it != base_l1_addresses_.end(), "Base L1 address not found for RISC ID {}", risc_id);
+    return it->second;
+}
+
+std::pair<uint32_t, uint32_t> FabricTensixDatamoverConfig::get_noc_xy(
+    tt::tt_metal::IDevice* device, uint32_t eth_chan_id) const {
+    CoreCoord core = get_core_for_channel(device->id(), eth_chan_id);
+    CoreCoord physical_core = device->worker_core_from_logical_core(core);
+    return {physical_core.x, physical_core.y};
+}
+
+size_t FabricTensixDatamoverConfig::get_channels_base_address(size_t risc_id, uint8_t tensix_channel_id) const {
+    auto mux_config = get_mux_config(risc_id);
+    return mux_config->get_channel_base_address(
+        tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, tensix_channel_id);
+}
+
+size_t FabricTensixDatamoverConfig::get_risc_id_for_channel(chip_id_t device_id, uint32_t eth_chan_id) const {
+    auto device_it = eth_chan_to_risc_id_.find(device_id);
+    TT_FATAL(device_it != eth_chan_to_risc_id_.end(), "Device {} not found in risc mapping", device_id);
+
+    auto it = device_it->second.find(eth_chan_id);
+    TT_FATAL(
+        it != device_it->second.end(),
+        "RISC ID not found for ethernet channel {} on device {}",
+        eth_chan_id,
+        device_id);
+    return it->second;
+}
+
+CoreCoord FabricTensixDatamoverConfig::get_core_for_channel(chip_id_t device_id, uint32_t eth_chan_id) const {
+    auto device_it = eth_chan_to_core_index_.find(device_id);
+    TT_FATAL(device_it != eth_chan_to_core_index_.end(), "Device {} not found in core mapping", device_id);
+
+    auto it = device_it->second.find(eth_chan_id);
+    TT_FATAL(
+        it != device_it->second.end(),
+        "Core index not found for ethernet channel {} on device {}",
+        eth_chan_id,
+        device_id);
+
+    size_t core_index = it->second;
+    TT_FATAL(core_index < logical_fabric_mux_cores_.size(), "Invalid core index {}", core_index);
+    return logical_fabric_mux_cores_[core_index];
+}
+
+std::shared_ptr<tt::tt_fabric::FabricMuxConfig> FabricTensixDatamoverConfig::get_mux_config(size_t risc_id) const {
+    auto it = mux_configs_.find(risc_id);
+    TT_FATAL(it != mux_configs_.end(), "Mux config not found for RISC ID {}", risc_id);
+    return it->second;
+}
+
+bool FabricTensixDatamoverConfig::is_risc_id_active(size_t risc_id) const {
+    return mux_configs_.find(risc_id) != mux_configs_.end();
+}
+
+size_t FabricTensixDatamoverConfig::get_local_flow_control_semaphore_address(
+    chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const {
+    auto risc_id = get_risc_id_for_channel(device_id, eth_chan_id);
+    auto mux_config = get_mux_config(risc_id);
+    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    return mux_config->get_flow_control_address(channel_type, channel_id);
+}
+
+size_t FabricTensixDatamoverConfig::get_connection_semaphore_address(
+    chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const {
+    auto risc_id = get_risc_id_for_channel(device_id, eth_chan_id);
+    auto mux_config = get_mux_config(risc_id);
+    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    return mux_config->get_connection_handshake_address(channel_type, channel_id);
+}
+
+size_t FabricTensixDatamoverConfig::get_worker_conn_info_base_address(
+    chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const {
+    auto risc_id = get_risc_id_for_channel(device_id, eth_chan_id);
+    auto mux_config = get_mux_config(risc_id);
+    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    return mux_config->get_connection_info_address(channel_type, channel_id);
+}
+
+size_t FabricTensixDatamoverConfig::get_buffer_index_semaphore_address(
+    chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const {
+    auto risc_id = get_risc_id_for_channel(device_id, eth_chan_id);
+    auto mux_config = get_mux_config(risc_id);
+    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    return mux_config->get_buffer_index_address(channel_type, channel_id);
+}
+
+size_t FabricTensixDatamoverConfig::get_channel_credits_stream_id(
+    chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const {
+    auto risc_id = get_risc_id_for_channel(device_id, eth_chan_id);
+    auto mux_config = get_mux_config(risc_id);
+    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    return mux_config->get_channel_credits_stream_id(channel_type, channel_id);
+}
+
+std::pair<uint32_t, uint32_t> FabricTensixDatamoverConfig::get_termination_address_and_signal(
+    chip_id_t device_id, uint32_t eth_chan_id) const {
+    auto risc_id = get_risc_id_for_channel(device_id, eth_chan_id);
+    TT_FATAL(is_risc_id_active(risc_id), "RISC ID {} is not active in fabric tensix config", risc_id);
+
+    auto mux_config = get_mux_config(risc_id);
+    return std::make_pair(
+        mux_config->get_termination_signal_address(), tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+}
+
+// FabricTensixDatamoverBuilder implementation
+
+FabricTensixDatamoverBuilder::FabricTensixDatamoverBuilder(
+    const CoreCoord& my_core_logical,
+    tt::tt_fabric::FabricNodeId local_fabric_node_id,
+    tt::tt_fabric::FabricNodeId remote_fabric_node_id,
+    uint32_t ethernet_channel_id,
+    uint32_t link_idx,
+    size_t risc_id,
+    uint32_t noc_x,
+    uint32_t noc_y,
+    std::shared_ptr<tt::tt_fabric::FabricMuxConfig> fabric_mux_config) :
+    my_core_logical_(my_core_logical),
+    local_fabric_node_id_(local_fabric_node_id),
+    remote_fabric_node_id_(remote_fabric_node_id),
+    ethernet_channel_id_(ethernet_channel_id),
+    link_idx_(link_idx),
+    risc_id_(risc_id),
+    noc_x_(noc_x),
+    noc_y_(noc_y),
+    fabric_mux_config_(fabric_mux_config) {
+    TT_FATAL(fabric_mux_config_ != nullptr, "FabricMuxConfig cannot be null");
+}
+
+FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build(
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::Program& program,
+    tt::tt_fabric::FabricNodeId local_fabric_node_id,
+    tt::tt_fabric::FabricNodeId remote_fabric_node_id,
+    uint32_t ethernet_channel_id) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+
+    const auto& tensix_config = fabric_context.get_tensix_config();
+
+    // Get RISC ID for this ethernet channel
+    size_t risc_id = tensix_config.get_risc_id_for_channel(device->id(), ethernet_channel_id);
+
+    // Get core for this ethernet channel
+    CoreCoord my_core_logical = tensix_config.get_core_for_channel(device->id(), ethernet_channel_id);
+
+    // Get NOC coordinates
+    auto [noc_x, noc_y] = tensix_config.get_noc_xy(device, ethernet_channel_id);
+
+    // Get link index (routing plane ID) from control plane using channel ID
+    uint32_t link_idx = control_plane.get_routing_plane_id(local_fabric_node_id, ethernet_channel_id);
+
+    // Get mux config for this RISC ID
+    auto fabric_mux_config = tensix_config.get_mux_config(risc_id);
+
+    return FabricTensixDatamoverBuilder(
+        my_core_logical,
+        local_fabric_node_id,
+        remote_fabric_node_id,
+        ethernet_channel_id,
+        link_idx,
+        risc_id,
+        noc_x,
+        noc_y,
+        fabric_mux_config);
+}
+
+void FabricTensixDatamoverBuilder::create_and_compile(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program) {
+    // Select processor and NOC based on RISC ID
+    tt::tt_metal::DataMovementProcessor processor =
+        (risc_id_ == 0) ? tt::tt_metal::DataMovementProcessor::RISCV_0 : tt::tt_metal::DataMovementProcessor::RISCV_1;
+
+    tt::tt_metal::NOC noc = (risc_id_ == 0) ? tt::tt_metal::NOC::RISCV_0_default : tt::tt_metal::NOC::RISCV_1_default;
+
+    // Create the mux kernel using the fabric mux kernel file
+    auto mux_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
+        my_core_logical_,
+        tt::tt_metal::DataMovementConfig{
+            .processor = processor, .noc = noc, .compile_args = get_compile_time_args(), .defines = {}});
+
+    // Set runtime arguments
+    tt::tt_metal::SetRuntimeArgs(program, mux_kernel, my_core_logical_, get_runtime_args(program));
+}
+
+tt::tt_fabric::SenderWorkerAdapterSpec FabricTensixDatamoverBuilder::build_connection_to_fabric_channel(
+    uint32_t channel_id) const {
+    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+
+    return tt::tt_fabric::SenderWorkerAdapterSpec{
+        noc_x_,                                                                  // edm_noc_x
+        noc_y_,                                                                  // edm_noc_y
+        fabric_mux_config_->get_channel_base_address(channel_type, channel_id),  // edm_buffer_base_addr
+        fabric_mux_config_->get_num_buffers(channel_type),                       // num_buffers_per_channel
+        fabric_mux_config_->get_flow_control_address(channel_type, channel_id),  // edm_l1_sem_addr
+        fabric_mux_config_->get_connection_handshake_address(
+            channel_type, channel_id),                                              // edm_connection_handshake_addr
+        fabric_mux_config_->get_connection_info_address(channel_type, channel_id),  // edm_worker_location_info_addr
+        fabric_mux_config_->get_buffer_size_bytes(channel_type),                    // buffer_size_bytes
+        fabric_mux_config_->get_buffer_index_address(channel_type, channel_id),     // buffer_index_semaphore_id
+        tt::tt_fabric::eth_chan_directions::EAST                                    // edm_direction
+    };
+}
+
+std::vector<uint32_t> FabricTensixDatamoverBuilder::get_compile_time_args() const {
+    // Get compile time args from the underlying mux config
+    return fabric_mux_config_->get_fabric_mux_compile_time_args();
+}
+
+std::vector<uint32_t> FabricTensixDatamoverBuilder::get_runtime_args(tt::tt_metal::Program& program) const {
+    // Get runtime args from the underlying mux config
+    return fabric_mux_config_->get_fabric_mux_run_time_args(
+        local_fabric_node_id_, remote_fabric_node_id_, link_idx_, program, {my_core_logical_});
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -101,30 +101,28 @@ void FabricTensixDatamoverConfig::initialize_channel_mappings() {
 
     // Second pass: create per-device channel mappings using real ethernet channel IDs
     for (const auto& device : all_active_devices) {
-        if (!(is_TG && device->is_mmio_capable())) {
-            auto dev_id = device->id();
-            auto dev_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
+        auto dev_id = device->id();
+        auto dev_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
 
-            // Get all active ethernet channels for this device
-            auto active_channels = control_plane.get_active_fabric_eth_channels(dev_fabric_node_id);
+        // Get all active ethernet channels for this device
+        auto active_channels = control_plane.get_active_fabric_eth_channels(dev_fabric_node_id);
 
-            // Initialize per-device mappings
-            eth_chan_to_core_index_[dev_id] = std::unordered_map<size_t, size_t>();
-            eth_chan_to_risc_id_[dev_id] = std::unordered_map<size_t, size_t>();
+        // Initialize per-device mappings
+        eth_chan_to_core_index_[dev_id] = std::unordered_map<size_t, size_t>();
+        eth_chan_to_risc_id_[dev_id] = std::unordered_map<size_t, size_t>();
 
-            // Create round-robin mapping using the actual ethernet channel IDs from active_channels
-            size_t channel_index = 0;
-            for (auto [eth_chan_id, eth_chan_dir] : active_channels) {
-                size_t core_index = channel_index % logical_fabric_mux_cores_.size();
-                eth_chan_to_core_index_[dev_id][eth_chan_id] = core_index;
+        // Create round-robin mapping using the actual ethernet channel IDs from active_channels
+        size_t channel_index = 0;
+        for (auto [eth_chan_id, eth_chan_dir] : active_channels) {
+            size_t core_index = channel_index % logical_fabric_mux_cores_.size();
+            eth_chan_to_core_index_[dev_id][eth_chan_id] = core_index;
 
-                // Determine RISC ID: round-robin assignment (0 = BRISC, 1 = NCRISC, etc.)
-                size_t channels_on_core = (channel_index / logical_fabric_mux_cores_.size());
-                size_t risc_id = channels_on_core % num_used_riscs_per_tensix_;
-                eth_chan_to_risc_id_[dev_id][eth_chan_id] = risc_id;
+            // Determine RISC ID: round-robin assignment (0 = BRISC, 1 = NCRISC, etc.)
+            size_t channels_on_core = (channel_index / logical_fabric_mux_cores_.size());
+            size_t risc_id = channels_on_core % num_used_riscs_per_tensix_;
+            eth_chan_to_risc_id_[dev_id][eth_chan_id] = risc_id;
 
-                channel_index++;
-            }
+            channel_index++;
         }
     }
 }

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -49,7 +49,6 @@ FabricTensixDatamoverConfig::FabricTensixDatamoverConfig() {
 void FabricTensixDatamoverConfig::initialize_channel_mappings() {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    auto num_devices = cluster.number_of_devices();
 
     // Get logical fabric mux cores from the first available device (same for all devices), except for TG
     const bool is_TG =
@@ -73,19 +72,13 @@ void FabricTensixDatamoverConfig::initialize_channel_mappings() {
     // Initialize translated mux cores (coordinates should be same across devices)
     auto device = tt::DevicePool::instance().get_active_device(device_id);
     TT_FATAL(device != nullptr, "Device {} not found in DevicePool", device_id);
-    if (device != nullptr) {
-        for (const auto& logical_core : logical_fabric_mux_cores_) {
-            CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
-            translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
-        }
-        for (const auto& logical_core : logical_dispatch_mux_cores_) {
-            CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
-            translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
-        }
-        log_info(
-            tt::LogTest,
-            "DEBUG: Initialized {} translated fabric mux cores",
-            translated_fabric_or_dispatch_mux_cores_.size());
+    for (const auto& logical_core : logical_fabric_mux_cores_) {
+        CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+        translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
+    }
+    for (const auto& logical_core : logical_dispatch_mux_cores_) {
+        CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+        translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
     }
 
     // Get maximum number of active ethernet channels from control plane across all devices

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+#include <optional>
+#include <vector>
+#include <memory>
+#include <unordered_map>
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/fabric.hpp>
+#include <tt-metalium/core_descriptor.hpp>
+#include <tt-metalium/erisc_datamover_builder.hpp>
+#include "core_coord.hpp"
+
+namespace tt::tt_fabric {
+
+class FabricTensixDatamoverConfig {
+public:
+    FabricTensixDatamoverConfig();
+
+    // Getters for core and channel configuration
+    size_t get_num_configs_per_core() const { return num_configs_per_core_; }
+    size_t get_num_riscs_per_core() const { return num_used_riscs_per_tensix_; }
+    uint8_t get_num_buffers_per_channel() const { return num_buffers_per_channel_; }
+    size_t get_buffer_size_bytes_full_size_channel() const { return buffer_size_bytes_full_size_channel_; }
+
+    // Get base L1 address for a RISC ID
+    size_t get_base_l1_address(size_t risc_id) const;
+
+    // Get NOC coordinates for ethernet channel (requires device)
+    std::pair<uint32_t, uint32_t> get_noc_xy(tt::tt_metal::IDevice* device, uint32_t eth_chan_id) const;
+
+    // Get channel base address for mux channel ID
+    size_t get_channels_base_address(size_t risc_id, uint8_t tensix_channel_id) const;
+
+    // Get the RISC ID for a given ethernet channel on a specific device
+    size_t get_risc_id_for_channel(chip_id_t device_id, uint32_t eth_chan_id) const;
+
+    // Get the core for a given ethernet channel on a specific device
+    CoreCoord get_core_for_channel(chip_id_t device_id, uint32_t eth_chan_id) const;
+
+    // Get the mux config for a specific RISC ID
+    std::shared_ptr<tt::tt_fabric::FabricMuxConfig> get_mux_config(size_t risc_id) const;
+
+    // Check if a RISC ID is active (has channels)
+    bool is_risc_id_active(size_t risc_id) const;
+
+    // Get translated fabric mux cores
+    const std::unordered_set<CoreCoord>& get_translated_fabric_or_dispatch_mux_cores() const {
+        return translated_fabric_or_dispatch_mux_cores_;
+    }
+
+    // Wrapper APIs for mux config access - these takes device_id, eth_chan_id and channel_id (channels inside a mux)
+    size_t get_local_flow_control_semaphore_address(
+        chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const;
+    size_t get_connection_semaphore_address(chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const;
+    size_t get_worker_conn_info_base_address(chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const;
+    size_t get_buffer_index_semaphore_address(chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const;
+    size_t get_channel_credits_stream_id(chip_id_t device_id, uint32_t eth_chan_id, uint32_t channel_id) const;
+    std::pair<uint32_t, uint32_t> get_termination_address_and_signal(chip_id_t device_id, uint32_t eth_chan_id) const;
+
+private:
+    std::vector<CoreCoord> logical_fabric_mux_cores_;
+    std::vector<CoreCoord> logical_dispatch_mux_cores_;
+    std::unordered_set<CoreCoord> translated_fabric_or_dispatch_mux_cores_;
+
+    // based on the number of channels used, get the number of risc needed per tensix
+    size_t num_used_riscs_per_tensix_;
+
+    // Configuration parameters
+    size_t num_configs_per_core_;
+    size_t num_channels_;
+    size_t num_buffers_per_channel_;
+    size_t buffer_size_bytes_full_size_channel_;
+
+    // Base L1 addresses for each RISC ID, [risc id] -> [base addr] mapping
+    std::unordered_map<size_t, size_t> base_l1_addresses_;
+
+    // [device_id][eth chan] -> [core index] mapping for round-robin assignment
+    std::unordered_map<chip_id_t, std::unordered_map<size_t, size_t>> eth_chan_to_core_index_;
+
+    // [device_id][eth chan] -> [risc id] mapping
+    std::unordered_map<chip_id_t, std::unordered_map<size_t, size_t>> eth_chan_to_risc_id_;
+
+    // Mux configs per RISC ID, [risc id] -> [mux config] mapping
+    std::unordered_map<size_t, std::shared_ptr<tt::tt_fabric::FabricMuxConfig>> mux_configs_;
+
+    // Helper methods for initialization
+    void initialize_channel_mappings();
+    void calculate_buffer_allocations();
+    void create_mux_configs();
+};
+
+/**
+ * FabricTensixDatamoverBuilder
+ * - Builds mux kernels on fabric tensix cores for worker → mux → fabric router routing.
+ * - Build the connections between Fabric routers, fabric router -> mux -> downstream fabric router.
+ */
+class FabricTensixDatamoverBuilder {
+public:
+    // Constructor for fabric tensix datamover builder
+    FabricTensixDatamoverBuilder(
+        const CoreCoord& my_core_logical,
+        tt::tt_fabric::FabricNodeId local_fabric_node_id,
+        tt::tt_fabric::FabricNodeId remote_fabric_node_id,
+        uint32_t ethernet_channel_id,
+        uint32_t link_idx,
+        size_t risc_id,
+        uint32_t noc_x,
+        uint32_t noc_y,
+        std::shared_ptr<tt::tt_fabric::FabricMuxConfig> fabric_mux_config);
+
+    // Static builder method called from topology to construct a tensix builder
+    static FabricTensixDatamoverBuilder build(
+        tt::tt_metal::IDevice* device,
+        tt::tt_metal::Program& program,
+        tt::tt_fabric::FabricNodeId local_fabric_node_id,
+        tt::tt_fabric::FabricNodeId remote_fabric_node_id,
+        uint32_t ethernet_channel_id);
+
+    // Create and compile the mux kernel
+    void create_and_compile(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program);
+
+    // Build connection to fabric channel - returns connection specs for EDMs to connect to this mux
+    tt::tt_fabric::SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t channel_id) const;
+
+    // Getters
+    const CoreCoord& get_logical_core() const { return my_core_logical_; }
+    tt::tt_fabric::FabricNodeId get_local_fabric_node_id() const { return local_fabric_node_id_; }
+    tt::tt_fabric::FabricNodeId get_remote_fabric_node_id() const { return remote_fabric_node_id_; }
+    uint32_t get_ethernet_channel_id() const { return ethernet_channel_id_; }
+    size_t get_risc_id() const { return risc_id_; }
+    uint32_t get_noc_x() const { return noc_x_; }
+    uint32_t get_noc_y() const { return noc_y_; }
+
+private:
+    // Core and fabric configuration
+    CoreCoord my_core_logical_;
+    tt::tt_fabric::FabricNodeId local_fabric_node_id_;
+    tt::tt_fabric::FabricNodeId remote_fabric_node_id_;
+    uint32_t ethernet_channel_id_;
+    uint32_t link_idx_;
+
+    // RISC and NOC configuration
+    size_t risc_id_;
+    uint32_t noc_x_;
+    uint32_t noc_y_;
+
+    // Mux configuration
+    std::shared_ptr<tt::tt_fabric::FabricMuxConfig> fabric_mux_config_;
+
+    // Helper methods for kernel compilation
+    std::vector<uint32_t> get_compile_time_args() const;
+    std::vector<uint32_t> get_runtime_args(tt::tt_metal::Program& program) const;
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -80,7 +80,8 @@ struct WorkerToFabricEdmSenderImpl {
         uint16_t buffer_size_bytes;
         uint32_t edm_copy_of_wr_counter_addr;
         volatile uint32_t* writer_send_sem_addr;
-        uint32_t worker_free_slots_stream_id;
+        uint32_t worker_free_slots_stream_id;  // used to update the available buffer slot on the receiving router
+                                               // (decrement by 1 from the sending side for each packet)
 
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24959
         // remove redundant nested constructor to avoid copy

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -80,6 +80,7 @@ struct WorkerToFabricEdmSenderImpl {
         uint16_t buffer_size_bytes;
         uint32_t edm_copy_of_wr_counter_addr;
         volatile uint32_t* writer_send_sem_addr;
+        uint32_t worker_free_slots_stream_id;
 
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24959
         // remove redundant nested constructor to avoid copy
@@ -101,6 +102,7 @@ struct WorkerToFabricEdmSenderImpl {
             edm_copy_of_wr_counter_addr = conn->buffer_index_semaphore_id;
             writer_send_sem_addr = reinterpret_cast<volatile uint32_t*>(
                 reinterpret_cast<uintptr_t>(&aligned_conn->worker_flow_control_semaphore));
+            worker_free_slots_stream_id = static_cast<uint32_t>(conn->worker_free_slots_stream_id);
         } else {
             // TODO: will be deprecated. currently for ethernet dispatch case
             //       ethernet core need to have same memory mapping as worker
@@ -118,6 +120,7 @@ struct WorkerToFabricEdmSenderImpl {
             auto writer_send_sem_id = get_arg_val<uint32_t>(arg_idx++);
             writer_send_sem_addr =
                 reinterpret_cast<volatile uint32_t*>(get_semaphore<my_core_type>(writer_send_sem_id));
+            worker_free_slots_stream_id = sender_channel_0_free_slots_stream_id;
         }
 
         // DEAD CODE
@@ -143,7 +146,7 @@ struct WorkerToFabricEdmSenderImpl {
             writer_send_sem_addr,
             worker_teardown_sem_addr,
             worker_buffer_index_semaphore_addr,
-            sender_channel_0_free_slots_stream_id,
+            worker_free_slots_stream_id,
             my_fc_stream_channel_id,
             write_reg_cmd_buf,
             write_at_cmd_buf);

--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -132,9 +132,7 @@ struct fabric_connection_info_t {
     uint8_t edm_noc_x;
     uint8_t edm_noc_y;
     uint8_t num_buffers_per_channel;
-    // NOTE: This padding can be removed once "non device-init fabric"
-    //       is completely removed
-    uint8_t padding[2];
+    uint16_t worker_free_slots_stream_id;
 } __attribute__((packed));
 
 static_assert(sizeof(fabric_connection_info_t) == 28, "Struct size mismatch!");

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -22,6 +22,10 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_20(uint32_t n) {
     return (((uint64_t)n * 0xCCCCCCCD) >> 32) >> 4;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_48(uint32_t n) {
+    return (((uint64_t)n * 0xAAAAAAAB) >> 32) >> 5;
+}
+
 inline __attribute__((always_inline)) uint32_t fast_udiv_56(uint32_t n) {
     return (((uint64_t)n * 0x24924925) >> 32) >> 3;
 }
@@ -72,9 +76,14 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
     } else if constexpr (d == 12) {
         // fast divide for 12 divisor
         return fast_udiv_12(n);
+<<<<<<< HEAD
     } else if constexpr (d == 20) {
         // fast divide for 20 divisor
         return fast_udiv_20(n);
+=======
+    } else if constexpr (d == 48) {
+        return fast_udiv_48(n);
+>>>>>>> address comment
     } else if constexpr (d == 56) {
         // fast divide for 56 divisor. Handles Banked L1 address generation for N300
         return fast_udiv_56(n);

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -76,14 +76,11 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
     } else if constexpr (d == 12) {
         // fast divide for 12 divisor
         return fast_udiv_12(n);
-<<<<<<< HEAD
     } else if constexpr (d == 20) {
         // fast divide for 20 divisor
         return fast_udiv_20(n);
-=======
     } else if constexpr (d == 48) {
         return fast_udiv_48(n);
->>>>>>> address comment
     } else if constexpr (d == 56) {
         // fast divide for 56 divisor. Handles Banked L1 address generation for N300
         return fast_udiv_56(n);

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -34,15 +34,15 @@ void validate_num_banks(uint32_t num_banks, const BufferType& buffer_type, bool 
     // address gen For non pow2 num banks, special cases need to be added to avoid falling back to generic
     // implementation. See https://github.com/tenstorrent/tt-metal/issues/3321
     std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {
-        7, 12, 20, 56, 63, 70, 80, 94, 110, 120, 124, 130, 140};
+        7, 12, 20, 48, 56, 63, 70, 80, 94, 110, 120, 124, 130, 140};
     bool custom_mod_bank_id_calculation_exists = acceptable_num_non_pow2_mem_banks.count(num_banks) > 0;
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {
         TT_THROW(
-            "Invalid number of memory banks for {}. Num banks must be power of 2 or have a dedicated modulo "
+            "Invalid number of memory banks {} for {}. Num banks must be power of 2 or have a dedicated modulo "
             "implementation",
-            enchantum::to_string(buffer_type),
-            num_banks);
+            num_banks,
+            enchantum::to_string(buffer_type));
     }
 }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -420,7 +420,8 @@ void MetalContext::teardown_fabric_config() {
 void MetalContext::set_fabric_config(
     const tt_fabric::FabricConfig fabric_config,
     tt_fabric::FabricReliabilityMode reliability_mode,
-    std::optional<uint8_t> num_routing_planes) {
+    std::optional<uint8_t> num_routing_planes,
+    tt_fabric::FabricTensixConfig fabric_tensix_config) {
     if (is_2d_fabric_config(fabric_config) && cluster_->get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
         const auto fabric_type = get_fabric_type(fabric_config);
         if (fabric_type == tt::tt_fabric::FabricType::TORUS_X || fabric_type == tt::tt_fabric::FabricType::TORUS_Y ||
@@ -480,6 +481,9 @@ void MetalContext::set_fabric_config(
             new_val);
     }
     this->num_fabric_active_routing_planes_ = new_val;
+
+    // Set the fabric tensix config
+    this->set_fabric_tensix_config(fabric_tensix_config);
 }
 
 void MetalContext::initialize_fabric_config() {
@@ -495,9 +499,20 @@ void MetalContext::initialize_fabric_config() {
     }
     control_plane.configure_routing_tables_for_fabric_ethernet_channels(
         this->fabric_config_, this->fabric_reliability_mode_);
+
+    // Initialize fabric tensix config after routing tables are configured
+    if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
+        control_plane.initialize_fabric_tensix_config();
+    }
 }
 
 tt_fabric::FabricConfig MetalContext::get_fabric_config() const { return fabric_config_; }
+
+void MetalContext::set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config) {
+    fabric_tensix_config_ = fabric_tensix_config;
+}
+
+tt_fabric::FabricTensixConfig MetalContext::get_fabric_tensix_config() const { return fabric_tensix_config_; }
 
 void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {
     if (logical_mesh_chip_id_to_physical_chip_id_mapping_.size()) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -499,9 +499,16 @@ void MetalContext::initialize_fabric_config() {
     }
     control_plane.configure_routing_tables_for_fabric_ethernet_channels(
         this->fabric_config_, this->fabric_reliability_mode_);
+}
 
-    // Initialize fabric tensix config after routing tables are configured
+void MetalContext::initialize_fabric_tensix_config() {
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
+        return;
+    }
+
+    // Initialize fabric tensix config after routing tables are configured and devices are available
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
+        auto& control_plane = this->get_control_plane();
         control_plane.initialize_fabric_tensix_config();
     }
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -501,7 +501,7 @@ void MetalContext::initialize_fabric_config() {
         this->fabric_config_, this->fabric_reliability_mode_);
 }
 
-void MetalContext::initialize_fabric_tensix_config() {
+void MetalContext::initialize_fabric_tensix_datamover_config() {
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
         return;
     }
@@ -509,7 +509,7 @@ void MetalContext::initialize_fabric_tensix_config() {
     // Initialize fabric tensix config after routing tables are configured and devices are available
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         auto& control_plane = this->get_control_plane();
-        control_plane.initialize_fabric_tensix_config();
+        control_plane.initialize_fabric_tensix_datamover_config();
     }
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -82,11 +82,16 @@ public:
         tt_fabric::FabricConfig fabric_config,
         tt_fabric::FabricReliabilityMode reliability_mode =
             tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-        std::optional<uint8_t> num_routing_planes = std::nullopt);
+        std::optional<uint8_t> num_routing_planes = std::nullopt,
+        tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED);
     void initialize_fabric_config();
     tt_fabric::FabricConfig get_fabric_config() const;
 
     distributed::multihost::DistributedContext& global_distributed_context();
+
+    // Fabric tensix configuration
+    void set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config);
+    tt_fabric::FabricTensixConfig get_fabric_tensix_config() const;
 
 private:
     friend class tt::stl::Indestructible<MetalContext>;
@@ -146,6 +151,7 @@ private:
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
+    tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
 
     // Strict system health mode requires (expects) all links/devices to be live. When enabled, it

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -85,6 +85,7 @@ public:
         std::optional<uint8_t> num_routing_planes = std::nullopt,
         tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED);
     void initialize_fabric_config();
+    void initialize_fabric_tensix_config();
     tt_fabric::FabricConfig get_fabric_config() const;
 
     distributed::multihost::DistributedContext& global_distributed_context();

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -85,7 +85,7 @@ public:
         std::optional<uint8_t> num_routing_planes = std::nullopt,
         tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED);
     void initialize_fabric_config();
-    void initialize_fabric_tensix_config();
+    void initialize_fabric_tensix_datamover_config();
     tt_fabric::FabricConfig get_fabric_config() const;
 
     distributed::multihost::DistributedContext& global_distributed_context();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -253,7 +253,6 @@ void DevicePool::initialize(
     _inst->using_fast_dispatch = tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
 
     std::vector<chip_id_t> device_ids_to_open = device_ids;
-    _inst->add_devices_to_pool(device_ids_to_open);
     // Never skip for TG Cluster
     bool is_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
     bool skip = !is_galaxy;
@@ -331,6 +330,11 @@ void DevicePool::initialize(
 
     _inst->skip_remote_devices = skip;
     _inst->use_max_eth_core_count_on_all_devices_ = use_max_eth_core_count_on_all_devices;
+    _inst->add_devices_to_pool(device_ids_to_open);
+
+    // Initialize fabric tensix config after devices are added to the pool
+    tt::tt_metal::MetalContext::instance().initialize_fabric_tensix_config();
+
     _inst->init_firmware_on_active_devices();
 }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -859,7 +859,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
         std::vector<uint32_t> termination_signal(1, signal);
 
         // Terminate fabric tensix configs (mux cores) if enabled
-        // TODO: move the termination process to device
+        // TODO: issue #26855, move the termination process to device
         bool tensix_config_enabled = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
                                      tt::tt_fabric::FabricTensixConfig::DISABLED;
         if (tensix_config_enabled) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -332,8 +332,8 @@ void DevicePool::initialize(
     _inst->use_max_eth_core_count_on_all_devices_ = use_max_eth_core_count_on_all_devices;
     _inst->add_devices_to_pool(device_ids_to_open);
 
-    // Initialize fabric tensix config after devices are added to the pool
-    tt::tt_metal::MetalContext::instance().initialize_fabric_tensix_config();
+    // Initialize fabric tensix datamover config after devices are added to the pool
+    tt::tt_metal::MetalContext::instance().initialize_fabric_tensix_datamover_config();
 
     _inst->init_firmware_on_active_devices();
 }

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
@@ -100,6 +100,12 @@ public:
     // and workers that only need the header only channel are specified in the downstream kernels.
     // Throws if not found
     int GetWorkerChannelIndex(int worker_id, tt::tt_fabric::FabricMuxChannelType channel_type) const;
+
+    // Get the link index used by dispatch for coordination with fabric tensix
+    static uint32_t get_dispatch_link_index(
+        tt::tt_fabric::FabricNodeId src_fabric_node_id,
+        tt::tt_fabric::FabricNodeId dst_fabric_node_id,
+        IDevice* device);
 };
 
 // Helper function to assemble the dispatch_fabric_mux_client_config args

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -8,6 +8,7 @@
 #include <host_api.hpp>
 #include <enchantum/enchantum.hpp>
 #include <tt-metalium/erisc_datamover_builder.hpp>
+#include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt_metal.hpp>
 #include <algorithm>
@@ -31,6 +32,7 @@
 #include "dispatch_core_common.hpp"
 #include "hostdevcommon/fabric_common.h"
 #include "kernel_config/fd_kernel.hpp"
+#include "dispatch/kernel_config/relay_mux.hpp"
 #include "kernel_types.hpp"
 #include "metal_soc_descriptor.h"
 #include "persistent_kernel_cache.hpp"
@@ -957,7 +959,8 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
 void build_tt_fabric_program(
     IDevice* device,
     Program* fabric_program_ptr,
-    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder>& edm_builders) {
+    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder>& edm_builders,
+    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricTensixDatamoverBuilder>& tensix_builders) {
     using namespace tt_fabric;
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
@@ -1080,6 +1083,11 @@ void build_tt_fabric_program(
                            fabric_edm_type == tt::tt_fabric::FabricEriscDatamoverType::Dateline;
 
         const auto& curr_edm_config = fabric_context.get_fabric_router_config(fabric_edm_type, fabric_edm_axis);
+
+        // Create fabric tensix builder for this ethernet channel
+        // Skip the link used by dispatch using relay mux API
+        uint32_t dispatch_link_idx = RelayMux::get_dispatch_link_index(fabric_node_id, remote_fabric_node_id, device);
+
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
             auto edm_builder = tt::tt_fabric::FabricEriscDatamoverBuilder::build(
@@ -1093,6 +1101,17 @@ void build_tt_fabric_program(
                 is_dateline,
                 control_plane.routing_direction_to_eth_direction(direction));
             edm_builders.insert({eth_chan, edm_builder});
+
+            auto link_idx = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);
+            if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
+                tt::tt_fabric::FabricTensixConfig::DISABLED) {
+                // Only create tensix builder if this channel is not used by dispatch
+                if (!(device_has_dispatch_tunnel && link_idx == dispatch_link_idx)) {
+                    auto tensix_builder = tt::tt_fabric::FabricTensixDatamoverBuilder::build(
+                        device, *fabric_program_ptr, fabric_node_id, remote_fabric_node_id, eth_chan);
+                    tensix_builders.insert({eth_chan, tensix_builder});
+                }
+            }
         }
 
         // Last link may be used by dispatch if there is tunneling
@@ -1131,6 +1150,11 @@ void build_tt_fabric_program(
 
                 auto& edm_builder1 = edm_builders.at(eth_chan_dir1);
                 auto& edm_builder2 = edm_builders.at(eth_chan_dir2);
+
+                // TODO: if have fabric_tensix_builders, need to get the tensix builder 1/2,
+                // then edm_builder1 connect_to_downstream_edm (tensix builder 2)
+                // edm_builder2 connect_to_downstream_edm (tensix builder 1)
+
                 edm_builder1.connect_to_downstream_edm(edm_builder2);
                 edm_builder2.connect_to_downstream_edm(edm_builder1);
 
@@ -1173,14 +1197,23 @@ void build_tt_fabric_program(
 std::unique_ptr<Program> create_and_compile_tt_fabric_program(IDevice* device) {
     std::unique_ptr<Program> fabric_program_ptr = std::make_unique<Program>();
     std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
+    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricTensixDatamoverBuilder> tensix_builders;
 
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
-    build_tt_fabric_program(device, fabric_program_ptr.get(), edm_builders);
+    build_tt_fabric_program(device, fabric_program_ptr.get(), edm_builders, tensix_builders);
     fabric_context.set_num_fabric_initialized_routers(device->id(), edm_builders.size());
     if (edm_builders.empty()) {
         return nullptr;
+    }
+
+    // Compile all fabric tensix builders
+    if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
+        tt::tt_fabric::FabricTensixConfig::DISABLED) {
+        for (auto& [eth_chan, tensix_builder] : tensix_builders) {
+            tensix_builder.create_and_compile(device, *fabric_program_ptr);
+        }
     }
 
     // for now it doesnt matter which channel is the master, so just pick the 1st in the map

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1087,6 +1087,8 @@ void build_tt_fabric_program(
         // Create fabric tensix builder for this ethernet channel
         // Skip the link used by dispatch using relay mux API
         uint32_t dispatch_link_idx = RelayMux::get_dispatch_link_index(fabric_node_id, remote_fabric_node_id, device);
+        bool fabric_tensix_enabled = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
+                                     tt::tt_fabric::FabricTensixConfig::DISABLED;
 
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
@@ -1103,8 +1105,7 @@ void build_tt_fabric_program(
             edm_builders.insert({eth_chan, edm_builder});
 
             auto link_idx = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);
-            if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
-                tt::tt_fabric::FabricTensixConfig::DISABLED) {
+            if (fabric_tensix_enabled) {
                 // Only create tensix builder if this channel is not used by dispatch
                 if (!(device_has_dispatch_tunnel && link_idx == dispatch_link_idx)) {
                     auto tensix_builder = tt::tt_fabric::FabricTensixDatamoverBuilder::build(
@@ -1151,7 +1152,7 @@ void build_tt_fabric_program(
                 auto& edm_builder1 = edm_builders.at(eth_chan_dir1);
                 auto& edm_builder2 = edm_builders.at(eth_chan_dir2);
 
-                // TODO: if have fabric_tensix_builders, need to get the tensix builder 1/2,
+                // TODO: issue #26792, if have fabric_tensix_builders, need to get the tensix builder 1/2,
                 // then edm_builder1 connect_to_downstream_edm (tensix builder 2)
                 // edm_builder2 connect_to_downstream_edm (tensix builder 1)
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -68,18 +68,31 @@ inline std::string get_core_descriptor_file(
             case tt::ARCH::QUASAR: TT_THROW("No core descriptor for Quasar"); break;
         };
     } else {
+        // Check if fabric tensix is enabled based on fabric tensix config
+        tt_fabric::FabricTensixConfig fabric_tensix_config =
+            tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+        bool use_fabric_tensix = (fabric_tensix_config == tt_fabric::FabricTensixConfig::MUX);
+
         switch (arch) {
             default:
                 throw std::runtime_error(
                     "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
             case tt::ARCH::WORMHOLE_B0:
-                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH
-                                            ? "wormhole_b0_80_arch_eth_dispatch.yaml"
-                                            : "wormhole_b0_80_arch.yaml");
+                if (dispatch_core_config.get_core_type() == CoreType::ETH) {
+                    return core_desc_dir + "wormhole_b0_80_arch_eth_dispatch.yaml";
+                } else if (use_fabric_tensix) {
+                    return core_desc_dir + "wormhole_b0_80_arch_fabric_mux.yaml";
+                } else {
+                    return core_desc_dir + "wormhole_b0_80_arch.yaml";
+                }
             case tt::ARCH::BLACKHOLE:
-                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH
-                                            ? "blackhole_140_arch_eth_dispatch.yaml"
-                                            : "blackhole_140_arch.yaml");
+                if (dispatch_core_config.get_core_type() == CoreType::ETH) {
+                    return core_desc_dir + "blackhole_140_arch_eth_dispatch.yaml";
+                } else if (use_fabric_tensix) {
+                    return core_desc_dir + "blackhole_140_arch_fabric_mux.yaml";
+                } else {
+                    return core_desc_dir + "blackhole_140_arch.yaml";
+                }
             case tt::ARCH::QUASAR: TT_THROW("No core descriptor for Quasar"); break;
         };
     }
@@ -88,12 +101,14 @@ inline std::string get_core_descriptor_file(
 
 const core_descriptor_t& get_core_descriptor_config(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    // {arch : {product : {dispatch core axis: {num hardware command queues : config}}}}
+    // {arch : {product : {dispatch core axis: {fabric tensix config: {num hardware command queues : config}}}}}
     static std::unordered_map<
         ARCH,
         std::unordered_map<
             std::string,
-            std::unordered_map<tt_metal::DispatchCoreConfig, std::unordered_map<uint8_t, core_descriptor_t>>>>
+            std::unordered_map<
+                tt_metal::DispatchCoreConfig,
+                std::unordered_map<tt_fabric::FabricTensixConfig, std::unordered_map<uint8_t, core_descriptor_t>>>>>
         config_by_arch;
 
     ARCH arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
@@ -119,8 +134,10 @@ const core_descriptor_t& get_core_descriptor_config(
         }
     }
 
+    tt_fabric::FabricTensixConfig fabric_tensix_config =
+        tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
     std::unordered_map<uint8_t, core_descriptor_t>& config_by_num_cqs =
-        config_by_arch[arch][product_name][dispatch_core_config];
+        config_by_arch[arch][product_name][dispatch_core_config][fabric_tensix_config];
     if (config_by_num_cqs.count(num_hw_cqs)) {
         return config_by_num_cqs.at(num_hw_cqs);
     }
@@ -242,6 +259,20 @@ const core_descriptor_t& get_core_descriptor_config(
         dispatch_cores.size() || tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled(),
         "Dispatch cores size must be positive");
 
+    // Parse fabric_mux_cores
+    std::vector<RelativeCoreCoord> fabric_mux_cores;
+    if (desc_yaml["fabric_mux_cores"]) {
+        for (const auto& core_node : desc_yaml["fabric_mux_cores"]) {
+            RelativeCoreCoord coord = {};
+            if (core_node.IsSequence()) {
+                coord = RelativeCoreCoord({.x = core_node[0].as<int>(), .y = core_node[1].as<int>()});
+            } else {
+                TT_THROW("Only logical relative coords supported for fabric_mux_cores");
+            }
+            fabric_mux_cores.push_back(coord);
+        }
+    }
+
     std::vector<CoreCoord> logical_compute_cores;
     logical_compute_cores.reserve(compute_cores.size());
     std::transform(
@@ -266,6 +297,15 @@ const core_descriptor_t& get_core_descriptor_config(
         std::back_inserter(logical_dispatch_cores),
         [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
 
+    // Convert fabric mux cores to logical coordinates
+    std::vector<CoreCoord> logical_fabric_mux_cores;
+    logical_fabric_mux_cores.reserve(fabric_mux_cores.size());
+    std::transform(
+        fabric_mux_cores.cbegin(),
+        fabric_mux_cores.cend(),
+        std::back_inserter(logical_fabric_mux_cores),
+        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
+
     auto [it, _] = config_by_num_cqs.emplace(std::make_pair(
         num_hw_cqs,
         core_descriptor_t{
@@ -274,9 +314,11 @@ const core_descriptor_t& get_core_descriptor_config(
             .relative_storage_cores = std::move(storage_cores),
             .storage_core_bank_size = std::move(storage_core_bank_size),
             .relative_dispatch_cores = std::move(dispatch_cores),
+            .relative_fabric_mux_cores = std::move(fabric_mux_cores),
             .logical_compute_cores = std::move(logical_compute_cores),
             .logical_storage_cores = std::move(logical_storage_cores),
             .logical_dispatch_cores = std::move(logical_dispatch_cores),
+            .logical_fabric_mux_cores = std::move(logical_fabric_mux_cores),
         }));
     return it->second;
 }

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -32,7 +32,7 @@ void py_bind_fabric_api(py::module& module) {
         .value("DYNAMIC_RECONFIG", tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE);
 
     py::enum_<tt::tt_fabric::FabricTensixConfig>(module, "FabricTensixConfig", R"(
-        Specifies the fabric tensix configuration mode for mux functionality.
+        Specifies the fabric tensix configuration mode for mux functionality. Enabling a FabricTensixConfig will result in fabric permanently reserving additional worker cores for the duration of the workload. This means fewer worker cores will be available for compute.
         Values:
             DISABLED: Fabric tensix mux functionality is disabled (default).
             MUX: Enable fabric tensix mux mode for worker → mux → fabric router routing.

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -31,12 +31,22 @@ void py_bind_fabric_api(py::module& module) {
         .value("RELAXED_INIT", tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE)
         .value("DYNAMIC_RECONFIG", tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE);
 
+    py::enum_<tt::tt_fabric::FabricTensixConfig>(module, "FabricTensixConfig", R"(
+        Specifies the fabric tensix configuration mode for mux functionality.
+        Values:
+            DISABLED: Fabric tensix mux functionality is disabled (default).
+            MUX: Enable fabric tensix mux mode for worker → mux → fabric router routing.
+        )")
+        .value("DISABLED", tt::tt_fabric::FabricTensixConfig::DISABLED)
+        .value("MUX", tt::tt_fabric::FabricTensixConfig::MUX);
+
     module.def(
         "set_fabric_config",
         &tt::tt_fabric::SetFabricConfig,
         py::arg("config"),
         py::arg("reliability_mode") = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-        py::arg("num_planes") = std::nullopt);
+        py::arg("num_planes") = std::nullopt,
+        py::arg("fabric_tensix_config") = tt::tt_fabric::FabricTensixConfig::DISABLED);
 }
 
 }  // namespace ttnn::fabric

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -32,7 +32,7 @@ void py_bind_fabric_api(py::module& module) {
         .value("DYNAMIC_RECONFIG", tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE);
 
     py::enum_<tt::tt_fabric::FabricTensixConfig>(module, "FabricTensixConfig", R"(
-        Specifies the fabric tensix configuration mode for mux functionality. Enabling a FabricTensixConfig will result in fabric permanently reserving additional worker cores for the duration of the workload. This means fewer worker cores will be available for compute.
+        Specifies the fabric tensix configuration mode for mux functionality. Enabling a FabricTensixConfig will result in fabric permanently reserving additional worker cores for the duration of the workload.
         Values:
             DISABLED: Fabric tensix mux functionality is disabled (default).
             MUX: Enable fabric tensix mux mode for worker → mux → fabric router routing.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26792)

### Problem description
we need to insert mux (or other types of fabric kernels that lives on tensix, for now we only have mux) into the fabric build flow, so that kernel can connect to mux instead of to router directly, and move channels from router into mux.

### What's changed

1. add a fabric tensix config, that stores info about the eth channels to cores mapping, address allocations, and act as a wrapper around mux config.
2. add a fabric tensix builder, similar to edm builder, that build and compile and get rt/ct args from mux config.
insert the mux into the fabric build flow, build the mux using the tensix builder for all eth channels except for the ones used by dispatch, as it has its own mux kernel.
3. writing meta info into reserved l1, currently reserved l1 stores connection info to fabric router, we need to modify it to store mux kernel info instead.
4. during device close, we need to teardown the mux. currently done in host side

TODO in later PR:
build the connection between upstream and downstream fabric router with mux, ie, we move sender channels from fabric router into mux, and upstream populate the adaptor with correct info for the mux core, and send packet to mux, then mux send packet to downstream router.

during device close, we need to teardown the mux. currently done in host side, should move to kernel side to speed up close.


### Checklist
- [ ] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/16948737945
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes