### PR TITLE
[skip ci] Trim a few GB of bloat from the CI Docker image

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -94,12 +94,11 @@ COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
 COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/.
 COPY /tt_metal/python_env/requirements-dev.txt ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 
+# TODO: Why do we need the chmod?
 RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
-    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
-
-# Adjust permissions to allow any user to use and modify the venv
-RUN chmod -R 777 $VIRTUAL_ENV
+    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt && \
+    chmod -R 777 $VIRTUAL_ENV
 
 #############################################################
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Baking a layer with 3GB of data and then making a new layer to chmod those 3GB makes for 3GB of bloat.  Save 3GB by rolling them into one layer.

### What's changed
Roll two layers into one.