### PR TITLE
[DM] Skip Core Location and Noc Swap Tests for Interleaved Page (in APC)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -234,6 +234,8 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageNumbers) {
 
 /* ========== Test case for varying core location; Test id = 62 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocations) {
+    GTEST_SKIP() << "Skipping test";
+
     // Parameters
     uint32_t num_pages = 16;
     uint32_t page_size_bytes = 32 * 32 * 2;  // = tile
@@ -353,6 +355,8 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
 
 /* ========== Directed Ideal Test Case; Test id = 65 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
+    GTEST_SKIP() << "Skipping test";
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
@@ -382,6 +386,8 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
 
 /* ========== Test noc_async_read_page kernel only with swapped noc; Test id = 72 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
+    GTEST_SKIP() << "Skipping test";
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
@@ -427,6 +433,8 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageReadNocSwap) {
 
 /* ========== Test noc_async_write_page kernel only with swapped noc; Test id = 73 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNocSwap) {
+    GTEST_SKIP() << "Skipping test";
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
@@ -516,6 +524,8 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageNumbers) {
 
 /* ========== Test case for varying core location; Test id = 67 ========== */
 TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageCoreLocations) {
+    GTEST_SKIP() << "Skipping test";
+
     // Parameters
     uint32_t num_pages = 16;
     uint32_t page_size_bytes = 32 * 32 * 2;  // = tile
@@ -635,6 +645,8 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
 
 /* ========== Directed Ideal Test Case; Test id = 71 ========== */
 TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
+    GTEST_SKIP() << "Skipping test";
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
@@ -665,6 +677,8 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
 
 /* ========== Test noc_async_read_page only with swapped noc; Test id = 74 ========== */
 TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
+    GTEST_SKIP() << "Skipping test";
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
@@ -709,6 +723,8 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageReadNocSwap) {
 }
 /* ========== Test noc_async_write_page only; Test id = 75 ========== */
 TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNocSwap) {
+    GTEST_SKIP() << "Skipping test";
+
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -355,8 +355,6 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageWriteNumbers) {
 
 /* ========== Directed Ideal Test Case; Test id = 65 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPageDirectedIdeal) {
-    GTEST_SKIP() << "Skipping test";
-
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
@@ -645,8 +643,6 @@ TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageWriteNumbers) {
 
 /* ========== Directed Ideal Test Case; Test id = 71 ========== */
 TEST_F(DeviceFixture, TensixDataMovementL1InterleavedPageDirectedIdeal) {
-    GTEST_SKIP() << "Skipping test";
-
     // Physical Constraints
     auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/pull/26790)

### Problem description
N300 Data Movement tests on the APC pipeline are timing out. Unnecessary tests need to be skipped to reduce the time taken.

### What's changed
Skipping the core location and noc swap cases for the interleaved page tests. This should help reduce time taken in post-commit tests to avoid unnecessarily slowing down development.