### PR TITLE
Lower Falcon7B TG perf targets to account for higher recent variability

### DIFF
--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -71,9 +71,9 @@ def test_demo_multichip(
         assert max_seq_len in [128, 1024, 2048], f"Unexpected max_seq_len: {max_seq_len} for perf mode"
         expected_perf_dict = {
             "4U": {
-                128: {"prefill_t/s": 24800, "decode_t/s/u": 7.12},
-                1024: {"prefill_t/s": 21200, "decode_t/s/u": 6.50},
-                2048: {"prefill_t/s": 20400, "decode_t/s/u": 6.90},
+                128: {"prefill_t/s": 24100, "decode_t/s/u": 6.90},
+                1024: {"prefill_t/s": 21200, "decode_t/s/u": 6.30},
+                2048: {"prefill_t/s": 20400, "decode_t/s/u": 6.60},
             },
             "6U": {
                 128: {"prefill_t/s": 32900, "decode_t/s/u": 12.19},


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7b TG perf has recently become more varied on CI causing some perf checks to fail due to slightly underperforming the targets. (Avg perf looks about the same as before)
<img width="1852" height="697" alt="image" src="https://github.com/user-attachments/assets/2e9ceb53-e17f-428c-b9e7-6355220fb90f" />


### What's changed
- Slightly lowered Falcon7b-TG perf targets

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes