### PR TITLE
Remove legacy unit mesh tests and replace with fabric equivalents

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -121,7 +121,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, ReduceScatterAsync) {
     }
 }
 
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllReduce) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllReduceAsync) {
     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter.hpp"
 #include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.hpp"
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "test_fabric_edm_common.hpp"
@@ -59,27 +60,6 @@ protected:
     }
 };
 
-TEST_F(MultiCQMeshDevice2x4Fixture, AllGather) {
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-
-    std::vector<ttnn::Tensor> tensors;
-    TensorSpec tensor_spec(
-        ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-    for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
-        std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(devices[dev_idx].get()));
-    }
-    auto all_gathered =
-        ttnn::all_gather(tensors, 0, 1, std::nullopt, std::nullopt, std::nullopt, ttnn::ccl::Topology::Linear);
-    for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
-        auto data = all_gathered[dev_idx].to_vector<bfloat16>();
-        for (int i = 0; i < data.size(); i++) {
-            float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
-            EXPECT_EQ(data[i].to_float(), expected);
-        }
-    }
-}
-
 TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherAsync) {
     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
@@ -104,22 +84,37 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherAsync) {
     }
 }
 
-TEST_F(MultiCQMeshDevice2x4Fixture, ReduceScatter) {
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, ReduceScatterAsync) {
+    auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
+    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
 
     std::vector<ttnn::Tensor> tensors;
     TensorSpec tensor_spec(
         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-    for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(devices[dev_idx].get()));
+        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        log_info(tt::LogAlways, "Tensor ring index: {}, device id: {}", dev_idx, mesh_devices[dev_idx]->id());
     }
-    auto reduced = ttnn::reduce_scatter(
-        tensors, 3, ttnn::operations::reduction::ReduceType::Sum, 1, std::nullopt, ttnn::ccl::Topology::Linear);
-    for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
+    auto from_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+    auto to_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+
+    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
+    auto reduced = ttnn::experimental::reduce_scatter_async(
+        tensors,
+        3,
+        from_remote_multi_device_global_semaphore,
+        to_remote_multi_device_global_semaphore,
+        ttnn::operations::reduction::ReduceType::Sum,
+        std::nullopt,
+        ttnn::ccl::Topology::Linear,
+        1,
+        SubDeviceId(0));
+
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = reduced[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
-            float expected = static_cast<float>(devices.size());
+            float expected = static_cast<float>(mesh_devices.size());
             EXPECT_EQ(data[i].to_float(), expected);
         }
     }


### PR DESCRIPTION
### Ticket
#26833

### Problem description
Some level of unit mesh CCLs support is required. We need to support having tensors allocated on different submeshes and running all_gather/reduce_scatter on these.

### What's changed
Delete the legacy all gather test as that already has a tested fabric equivalent in the suite
Replace the Reduce Scatter test with a ReduceScatterAsync test.

### Checklist
- [ ] T3K unit test: https://github.com/tenstorrent/tt-metal/actions/runs/16949110503