### PR TITLE
#0: Make create_mesh_workload optional if create_program_at/create_at is defined

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -10,11 +10,13 @@
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/indestructible.hpp>
 #include "ttnn/tensor/tensor.hpp"
+#include <unordered_map>
 
 #include <tt-metalium/program_cache.hpp>
 #include <tracy/Tracy.hpp>
 #include "tools/profiler/op_profiler.hpp"
 #include <tt_stl/reflection.hpp>
+#include <tt_stl/concepts.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/api.hpp"
@@ -65,6 +67,53 @@ auto compute_program_hash(
         ZoneScopedN("Compute default program hash");
         return tt::stl::hash::hash_objects_with_default_seed(
             tt::stl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
+    }
+}
+
+
+// Helper to create a mesh workload from a WorkloadFactory that may or may not
+// provide create_mesh_workload. If missing, synthesize it from create_at.
+template <typename WorkloadFactory, typename device_operation_t>
+static auto create_mesh_workload_from_workload_factory(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    typename device_operation_t::tensor_return_value_t& tensor_return_value) {
+    using cached_mesh_workload_t = typename WorkloadFactory::cached_mesh_workload_t;
+    if constexpr (requires(
+                      const typename device_operation_t::operation_attributes_t& operation_attributes,
+                      const ttnn::MeshCoordinateRangeSet& tensor_coords,
+                      const typename device_operation_t::tensor_args_t& tensor_args,
+                      typename device_operation_t::tensor_return_value_t& tensor_return_value) {
+                      WorkloadFactory::create_mesh_workload(
+                          operation_attributes, tensor_coords, tensor_args, tensor_return_value);
+                  }) {
+        return WorkloadFactory::create_mesh_workload(
+            operation_attributes, tensor_coords, tensor_args, tensor_return_value);
+    } else if constexpr (requires(
+                             const typename device_operation_t::operation_attributes_t& operation_attributes,
+                             const ttnn::MeshCoordinate& mesh_coordinate,
+                             const typename device_operation_t::tensor_args_t& tensor_args,
+                             typename device_operation_t::tensor_return_value_t& tensor_return_value) {
+                             WorkloadFactory::create_at(
+                                 operation_attributes, mesh_coordinate, tensor_args, tensor_return_value);
+                         }) {
+        using shared_variables_t = typename WorkloadFactory::shared_variables_t;
+        tt::tt_metal::distributed::MeshWorkload mesh_workload;
+        std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+        for (const auto& coord : tensor_coords.coords()) {
+            auto cached_program =
+                WorkloadFactory::create_at(operation_attributes, coord, tensor_args, tensor_return_value);
+            mesh_workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
+            shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+        }
+        return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+    } else {
+        static_assert(
+            tt::stl::concepts::always_false_v<WorkloadFactory>,
+            "WorkloadFactory must implement create_mesh_workload(operation_attributes, tensor_coords, tensor_args, "
+            "tensor_return_value) or create_at(operation_attributes, mesh_coordinate, tensor_args, "
+            "tensor_return_value, tensor_coords)");
     }
 }
 
@@ -246,7 +295,7 @@ void create_and_cache_mesh_workload(
                     tensor_coords.merge(ttnn::MeshCoordinateRange(coord, coord));
                 }
             }
-            auto cached_workload = WorkloadFactory::create_mesh_workload(
+            auto cached_workload = create_mesh_workload_from_workload_factory<WorkloadFactory, mesh_device_operation_t>(
                 operation_attributes, tensor_coords, tensor_args, tensor_return_value);
 
             if (program_cache.is_enabled()) {

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -338,6 +338,9 @@ using has_create_program_t = decltype(std::declval<T>().create_program(std::decl
 template <class T, class... Args>
 using has_create_mesh_workload_t = decltype(std::declval<T>().create_mesh_workload(std::declval<Args>()...));
 
+template <class T, class... Args>
+using has_create_program_at_t = decltype(std::declval<T>().create_program_at(std::declval<Args>()...));
+
 template <class T>
 constexpr bool implements_create_program() {
     return std::experimental::is_detected_v<has_create_program_t, T, const Tensors&, Tensors&> or
@@ -394,6 +397,32 @@ constexpr bool implements_create_mesh_workload_with_optional_input_tensors() {
                OptionalTensors&>;
 }
 
+template <class T>
+constexpr bool implements_create_program_at() {
+    return std::experimental::
+               is_detected_v<has_create_program_at_t, T, const ttnn::MeshCoordinate&, const Tensors&, Tensors&> or
+           std::experimental::
+               is_detected_v<has_create_program_at_t, T, const ttnn::MeshCoordinate&, const Tensors&, OptionalTensors&>;
+}
+
+template <class T>
+constexpr bool implements_create_program_at_with_optional_input_tensors() {
+    return std::experimental::is_detected_v<
+               has_create_program_at_t,
+               T,
+               const ttnn::MeshCoordinate&,
+               const Tensors&,
+               const std::vector<std::optional<const Tensor>>&,
+               Tensors&> or
+           std::experimental::is_detected_v<
+               has_create_program_at_t,
+               T,
+               const ttnn::MeshCoordinate&,
+               const Tensors&,
+               const std::vector<std::optional<const Tensor>>&,
+               OptionalTensors&>;
+}
+
 template <class T, class... Args>
 using has_create_op_performance_model_t =
     decltype(std::declval<T>().create_op_performance_model(std::declval<Args>()...));
@@ -429,11 +458,22 @@ constexpr bool implements_compute_program_hash_with_optional_input_tensors() {
         const std::vector<std::optional<const Tensor>>&>;
 }
 
+// Helper functions to check if the operation implements a program or a program with optional input tensors
+template <class T>
+constexpr bool implements_program() {
+    return implements_create_program<T>() || implements_create_mesh_workload<T>() || implements_create_program_at<T>();
+}
+
+template <class T>
+constexpr bool implements_program_with_optional_input_tensors() {
+    return implements_create_program_with_optional_input_tensors<T>() ||
+           implements_create_mesh_workload_with_optional_input_tensors<T>() ||
+           implements_create_program_at_with_optional_input_tensors<T>();
+}
+
 template <class T>
 constexpr bool is_device_operation() {
-    return implements_create_program<T>() || implements_create_mesh_workload<T>() ||
-           implements_create_program_with_optional_input_tensors<T>() ||
-           implements_create_mesh_workload_with_optional_input_tensors<T>();
+    return implements_program<T>() || implements_program_with_optional_input_tensors<T>();
 }
 
 template <class T, class... Args>
@@ -447,6 +487,7 @@ constexpr bool implements_get_parallelization_strategy() {
 
 }  // namespace detail
 
+// Helper function to create output tensors from compute_output_specs
 template <typename ConcreteOperation>
 auto default_create_output_tensors(
     const ConcreteOperation& operation, const Tensors& input_tensors, const OptionalTensors& optional_output_tensors)
@@ -471,6 +512,54 @@ auto default_create_output_tensors(
         output_tensors.emplace_back(create_device_tensor(output_spec, device));
     }
     return output_tensors;
+}
+
+// Helper function to create a mesh workload from single-device programs
+template <typename ConcreteOperation>
+auto default_create_mesh_workload(
+    const ConcreteOperation& operation,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    ProgramOutputTensors<ConcreteOperation>& output_tensors)
+    -> CacheableMeshWorkload<ProgramOutputTensors<ConcreteOperation>> {
+    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
+
+    if constexpr (detail::implements_create_program_at<ConcreteOperation>()) {
+        TT_FATAL(
+            optional_input_tensors.empty(),
+            "Optional input tensors not supported by {}",
+            tt::stl::get_type_name<ConcreteOperation>());
+    } else if constexpr (detail::implements_create_program_at_with_optional_input_tensors<ConcreteOperation>()) {
+        TT_FATAL(
+            not optional_input_tensors.empty(),
+            "Non-optional input tensors not supported by {}",
+            tt::stl::get_type_name<ConcreteOperation>());
+    }
+
+    auto create_program = [&](const ttnn::MeshCoordinate& coord) {
+        if constexpr (detail::implements_create_program_at<ConcreteOperation>()) {
+            return operation.create_program_at(coord, input_tensors, output_tensors);
+        } else if constexpr (detail::implements_create_program_at_with_optional_input_tensors<ConcreteOperation>()) {
+            return operation.create_program_at(coord, input_tensors, optional_input_tensors, output_tensors);
+        } else {
+            static_assert(tt::stl::concepts::always_false_v<ConcreteOperation>);
+        }
+    };
+
+    CacheableMeshWorkload<OutputTensors> workload_with_callbacks;
+    for (const auto& range : tensor_coords.ranges()) {
+        for (const auto& coord : range) {
+            const ttnn::MeshCoordinateRange program_range(coord, coord);
+            auto program_with_callbacks = create_program(coord);
+            workload_with_callbacks.workload.add_program(program_range, std::move(program_with_callbacks.program));
+            if (program_with_callbacks.override_runtime_arguments_callback.has_value()) {
+                workload_with_callbacks.per_program_callbacks.emplace(
+                    program_range, std::move(*program_with_callbacks.override_runtime_arguments_callback));
+            }
+        }
+    }
+    return workload_with_callbacks;
 }
 
 template <class OutputTensorsT = Tensors>
@@ -618,17 +707,14 @@ public:
                     static_assert(
                         tt::stl::concepts::always_false_v<T>,
                         "You cannot implement both validate and validate_with_output_tensors");
-                } else if constexpr (
-                    detail::implements_validate<T>() and
-                    not(detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>())) {
+                } else if constexpr (detail::implements_validate<T>() and not(detail::implements_program<T>())) {
                     static_assert(
                         tt::stl::concepts::always_false_v<T>,
                         "Operation doesn't implement both the validate and the correct create_program or "
                         "create_mesh_workload methods");
                 } else if constexpr (
                     detail::implements_validate_with_optional_input_tensors<T>() and
-                    not(detail::implements_create_program_with_optional_input_tensors<T>() ||
-                        detail::implements_create_mesh_workload_with_optional_input_tensors<T>())) {
+                    not(detail::implements_program_with_optional_input_tensors<T>())) {
                     static_assert(
                         tt::stl::concepts::always_false_v<T>,
                         "Operation doesn't implement both the validate and the correct create_program or "
@@ -736,6 +822,11 @@ public:
                         tt::stl::get_type_name<T>());
                     return operation.create_mesh_workload(
                         tensor_coords, input_tensors, optional_input_tensors, output_tensors);
+                } else if constexpr (
+                    detail::implements_create_program_at<T>() ||
+                    detail::implements_create_program_at_with_optional_input_tensors<T>()) {
+                    return default_create_mesh_workload(
+                        operation, tensor_coords, input_tensors, optional_input_tensors, output_tensors);
                 } else {
                     TT_THROW("Operation doesn't implement create_mesh_workload");
                 }
@@ -781,7 +872,8 @@ public:
 
                 if constexpr (detail::implements_compute_program_hash<T>()) {
                     static_assert(
-                        detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>());
+                        detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>() ||
+                        detail::implements_create_program_at<T>());
                     TT_FATAL(
                         optional_input_tensors.empty(),
                         "Optional input tensors not supported by {}",
@@ -790,14 +882,16 @@ public:
                 } else if constexpr (detail::implements_compute_program_hash_with_optional_input_tensors<T>()) {
                     static_assert(
                         detail::implements_create_program_with_optional_input_tensors<T>() ||
-                        detail::implements_create_mesh_workload_with_optional_input_tensors<T>());
+                        detail::implements_create_mesh_workload_with_optional_input_tensors<T>() ||
+                        detail::implements_create_program_at_with_optional_input_tensors<T>());
                     TT_FATAL(
                         not optional_input_tensors.empty(),
                         "Non-optional input tensors not supported by {}",
                         tt::stl::get_type_name<T>());
                     return operation.compute_program_hash(input_tensors, optional_input_tensors);
                 } else if constexpr (
-                    detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>()) {
+                    detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>() ||
+                    detail::implements_create_program_at<T>()) {
                     TT_FATAL(
                         optional_input_tensors.empty(),
                         "Optional input tensors not supported by {}",
@@ -805,7 +899,8 @@ public:
                     return hash_operation<T>(operation, input_tensors);
                 } else if constexpr (
                     detail::implements_create_program_with_optional_input_tensors<T>() ||
-                    detail::implements_create_mesh_workload_with_optional_input_tensors<T>()) {
+                    detail::implements_create_mesh_workload_with_optional_input_tensors<T>() ||
+                    detail::implements_create_program_at_with_optional_input_tensors<T>()) {
                     TT_FATAL(
                         not optional_input_tensors.empty(),
                         "Non-optional input tensors not supported by {}",
@@ -814,7 +909,7 @@ public:
                 } else {
                     static_assert(
                         tt::stl::concepts::always_false_v<T>,
-                        "Operation doesn't implement create_program or create_mesh_workload");
+                        "Operation doesn't implement create_program, create_program_at, or create_mesh_workload");
                 }
             }},
         uses_custom_program_hash_impl_{[]() -> bool {
@@ -827,14 +922,19 @@ public:
             }
         }},
         has_create_workload_method_impl_{[]() -> bool {
-            // Operation must implement exactly one of the `create_program` or `create_mesh_workload` methods.
-            static_assert(
-                (detail::implements_create_mesh_workload<T>() ||
-                 detail::implements_create_mesh_workload_with_optional_input_tensors<T>()) !=
-                (detail::implements_create_program<T>() ||  //
-                 detail::implements_create_program_with_optional_input_tensors<T>()));
-            return detail::implements_create_mesh_workload<T>() ||
-                   detail::implements_create_mesh_workload_with_optional_input_tensors<T>();
+            // Operation must implement exactly one of the following creator methods:
+            // - Mesh workload creators: create_mesh_workload(_with_optional_input_tensors) OR
+            // create_program_at(_with_optional_input_tensors)
+            // - Program creators: create_program(_with_optional_input_tensors)
+            constexpr bool has_mesh_creator =
+                detail::implements_create_mesh_workload<T>() ||
+                detail::implements_create_mesh_workload_with_optional_input_tensors<T>() ||
+                detail::implements_create_program_at<T>() ||
+                detail::implements_create_program_at_with_optional_input_tensors<T>();
+            constexpr bool has_program_creator = detail::implements_create_program<T>() ||
+                                                 detail::implements_create_program_with_optional_input_tensors<T>();
+            static_assert(has_mesh_creator != has_program_creator);
+            return has_mesh_creator;
         }},
         create_profiler_info_impl_{[](const storage_t& storage, const Tensors& input_tensors) -> ProfilerInfo {
             const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
@@ -28,16 +28,6 @@ std::vector<Tensor> Barrier::create_output_tensors(const std::vector<Tensor>& in
     return input_tensors;
 }
 
-tt::tt_metal::operation::MeshWorkloadWithCallbacks Barrier::create_mesh_workload(
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const std::vector<Tensor>& input_tensors,
-    std::vector<Tensor>& output_tensors) const {
-    return ccl::create_mesh_workload_from_programs(
-        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
-            return create_program_at(coord, input_tensors, output_tensors);
-        });
-}
-
 tt::tt_metal::operation::ProgramWithCallbacks Barrier::create_program_at(
     const ttnn::MeshCoordinate& mesh_coord,
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
@@ -21,10 +21,6 @@ struct Barrier {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const std::vector<Tensor>& input_tensors,
-        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& mesh_coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
@@ -50,12 +50,6 @@ struct MeshPartitionDeviceOperation {
         };
         using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
 
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
         static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
             const operation_attributes_t& operation_attributes,
             const ttnn::MeshCoordinate& mesh_coordinate,

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -32,22 +32,6 @@ uint32_t get_cluster_axis_index(
 }
 }  // namespace detail
 
-MeshPartitionDeviceOperation::MeshPartition::cached_mesh_workload_t
-MeshPartitionDeviceOperation::MeshPartition::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
-
 ttnn::device_operation::CachedProgram<MeshPartitionDeviceOperation::MeshPartition::shared_variables_t>
 MeshPartitionDeviceOperation::MeshPartition::create_at(
     const operation_attributes_t& operation_attributes,


### PR DESCRIPTION
### Ticket
None

### Problem description
Looks like most multi-chip OPs (including all CCLs?) implement `create_mesh_workload` in exactly the same way by looping through single-device program creation and inserting to a mesh workload. This PR adds this pattern to be natively supported in OP infra so it better reflects intention of this pattern.

### What's changed
- Make changes to both OP infras to support this
- Remove create_mesh_workload from OP as examples:
  * all gather (uses old type-erased OP infra)
  * all to all dispatch (uses new compile-time interfaces OP infra)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17218183763
   - T3K: https://github.com/tenstorrent/tt-metal/actions/runs/17218205182
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes