### PR TITLE
Added operation ttnn::from_buffer emulating the behavior of pytorch

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -446,7 +446,7 @@ def test_tensor_creation_with_tensor_spec(tensor_spec, device):
     ],
 )
 def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
-    tt_tensor = ttnn.from_buffer(buffer, shape, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_tensor = ttnn.from_buffer(buffer, shape, dtype=dtype, device=device)
     assert tt_tensor.shape == shape
     assert tt_tensor.dtype == dtype
     assert tt_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
@@ -478,7 +478,7 @@ def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
 )
 def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device):
     try:
-        tt_tensor = ttnn.from_buffer(buffer, [2, 3], dtype, ttnn.TILE_LAYOUT, device)
+        tt_tensor = ttnn.from_buffer(buffer, [2, 3], dtype, device, ttnn.TILE_LAYOUT)
     except Exception as e:
         assert "Unsupported DataType!" in str(e)
     else:

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -480,6 +480,6 @@ def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, devic
     try:
         tt_tensor = ttnn.from_buffer(buffer, [2, 3], dtype, device, ttnn.TILE_LAYOUT)
     except Exception as e:
-        assert "Unsupported DataType!" in str(e)
+        assert "Unreachable" in str(e)
     else:
         pytest.fail("Expected an exception, but got none")

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -356,3 +356,26 @@ def test_tensor_creation_with_tensor_spec(tensor_spec, device):
     assert tt_tensor.spec == tensor_spec
     py_tensor_after_round_trip = ttnn.to_torch(tt_tensor)
     assert torch.allclose(py_tensor, py_tensor_after_round_trip)
+
+
+@pytest.mark.parametrize(
+    "dtype,buffer",
+    [
+        (ttnn.uint8, [[1, 2, 3], [4, 5, 6]]),
+        (ttnn.uint16, [[1000, 2000, 3000], [4000, 5000, 6000]]),
+        (ttnn.int32, [[-100, -200, -300], [400, 500, 600]]),
+        (ttnn.uint32, [[1000000, 2000000, 3000000], [4000000, 5000000, 6000000]]),
+        (ttnn.float32, [[1.5, 2.7, 3.14], [4.2, 5.8, 6.9]]),
+        (ttnn.bfloat16, [[1.25, 2.75, 3.125], [4.375, 5.625, 6.875]]),
+    ],
+)
+def test_tensor_creation_from_buffer(dtype, buffer, device):
+    tt_tensor = ttnn.from_buffer(buffer, dtype, ttnn.ROW_MAJOR_LAYOUT, device)
+    assert tt_tensor.shape == [2, 3]
+    assert tt_tensor.dtype == dtype
+    assert tt_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+    if dtype == ttnn.float32:
+        rounded = [[round(v, 5) for v in row] for row in tt_tensor.to_list()]
+        assert rounded == buffer
+    else:
+        assert tt_tensor.to_list() == buffer

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -359,26 +359,113 @@ def test_tensor_creation_with_tensor_spec(tensor_spec, device):
 
 
 @pytest.mark.parametrize(
-    "dtype,buffer",
+    "dtype,shape,buffer",
     [
-        (ttnn.uint8, [[1, 2, 3], [4, 5, 6]]),
-        (ttnn.uint16, [[1000, 2000, 3000], [4000, 5000, 6000]]),
-        (ttnn.int32, [[-100, -200, -300], [400, 500, 600]]),
-        (ttnn.uint32, [[1000000, 2000000, 3000000], [4000000, 5000000, 6000000]]),
-        (ttnn.float32, [[1.5, 2.7, 3.14], [4.2, 5.8, 6.9]]),
-        (ttnn.bfloat16, [[1.25, 2.75, 3.125], [4.375, 5.625, 6.875]]),
+        # 1D tensors
+        (ttnn.uint8, [1, 3], [1, 2, 3]),
+        (ttnn.uint16, [1, 3], [1000, 2000, 3000]),
+        (ttnn.int32, [1, 3], [-100, -200, -300]),
+        (ttnn.uint32, [1, 3], [1000000, 2000000, 3000000]),
+        (ttnn.float32, [1, 3], [1.5, 2.7, 3.14]),
+        (ttnn.bfloat16, [1, 3], [1.25, 2.75, 3.125]),
+        # 2D tensors
+        (ttnn.uint8, [2, 3], [1, 2, 3, 4, 5, 6]),
+        (ttnn.uint16, [2, 3], [1000, 2000, 3000, 4000, 5000, 6000]),
+        (ttnn.int32, [2, 3], [-100, -200, -300, 400, 500, 600]),
+        (ttnn.uint32, [2, 3], [1000000, 2000000, 3000000, 4000000, 5000000, 6000000]),
+        (ttnn.float32, [2, 3], [1.5, 2.7, 3.14, 4.2, 5.8, 6.9]),
+        (ttnn.bfloat16, [2, 3], [1.25, 2.75, 3.125, 4.375, 5.625, 6.875]),
+        # 3D tensors
+        (ttnn.uint8, [2, 2, 2], [1, 2, 3, 4, 5, 6, 7, 8]),
+        (ttnn.uint16, [2, 2, 2], [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]),
+        (ttnn.int32, [2, 2, 2], [-100, -200, -300, -400, -500, -600, -700, -800]),
+        (ttnn.uint32, [2, 2, 2], [1000000, 2000000, 3000000, 4000000, 5000000, 6000000, 7000000, 8000000]),
+        (ttnn.float32, [2, 2, 2], [1.5, 2.7, 3.14, 4.2, 5.8, 6.9, 7.1, 8.2]),
+        (ttnn.bfloat16, [2, 2, 2], [1.25, 2.75, 3.125, 4.375, 5.625, 6.875, 7.125, 8.25]),
+        # 4D tensors
+        (ttnn.uint8, [2, 2, 2, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        (
+            ttnn.uint16,
+            [2, 2, 2, 2],
+            [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000, 13000, 14000, 15000, 16000],
+        ),
+        (
+            ttnn.int32,
+            [2, 2, 2, 2],
+            [-100, -200, -300, -400, -500, -600, -700, -800, -900, -1000, -1100, -1200, -1300, -1400, -1500, -1600],
+        ),
+        (
+            ttnn.uint32,
+            [2, 2, 2, 2],
+            [
+                1000000,
+                2000000,
+                3000000,
+                4000000,
+                5000000,
+                6000000,
+                7000000,
+                8000000,
+                9000000,
+                10000000,
+                11000000,
+                12000000,
+                13000000,
+                14000000,
+                15000000,
+                16000000,
+            ],
+        ),
+        (
+            ttnn.float32,
+            [2, 2, 2, 2],
+            [1.5, 2.7, 3.14, 4.2, 5.8, 6.9, 7.1, 8.2, 9.3, 10.4, 11.5, 12.6, 13.7, 14.8, 15.9, 16.1],
+        ),
+        (
+            ttnn.bfloat16,
+            [2, 2, 2, 2],
+            [
+                1.25,
+                2.75,
+                3.125,
+                4.375,
+                5.625,
+                6.875,
+                7.125,
+                8.25,
+                9.375,
+                10.625,
+                11.875,
+                12.125,
+                13.375,
+                14.625,
+                15.875,
+                16.125,
+            ],
+        ),
     ],
 )
-def test_tensor_creation_from_buffer(dtype, buffer, device):
-    tt_tensor = ttnn.from_buffer(buffer, dtype, ttnn.ROW_MAJOR_LAYOUT, device)
-    assert tt_tensor.shape == [2, 3]
+def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
+    tt_tensor = ttnn.from_buffer(buffer, shape, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    assert tt_tensor.shape == shape
     assert tt_tensor.dtype == dtype
     assert tt_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
-    if dtype == ttnn.float32:
-        rounded = [[round(v, 5) for v in row] for row in tt_tensor.to_list()]
+
+    def flatten_list(data):
+        if isinstance(data, list):
+            return [
+                item for sublist in data for item in (flatten_list(sublist) if isinstance(sublist, list) else [sublist])
+            ]
+        return [data]
+
+    tensor_list = tt_tensor.to_list()
+    flattened = flatten_list(tensor_list)
+
+    if dtype in [ttnn.float32, ttnn.bfloat16]:
+        rounded = [round(v, 5) for v in flattened]
         assert rounded == buffer
     else:
-        assert tt_tensor.to_list() == buffer
+        assert flattened == buffer
 
 
 @pytest.mark.parametrize(
@@ -391,7 +478,7 @@ def test_tensor_creation_from_buffer(dtype, buffer, device):
 )
 def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device):
     try:
-        tt_tensor = ttnn.from_buffer(buffer, dtype, ttnn.ROW_MAJOR_LAYOUT, device)
+        tt_tensor = ttnn.from_buffer(buffer, [2, 3], dtype, ttnn.TILE_LAYOUT, device)
     except Exception as e:
         assert "Unsupported DataType!" in str(e)
     else:

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -379,3 +379,20 @@ def test_tensor_creation_from_buffer(dtype, buffer, device):
         assert rounded == buffer
     else:
         assert tt_tensor.to_list() == buffer
+
+
+@pytest.mark.parametrize(
+    "dtype,buffer",
+    [
+        (ttnn.bfloat8_b, [[1, 2, 3], [4, 5, 6]]),
+        (ttnn.bfloat4_b, [[1, 2, 3], [4, 5, 6]]),
+        (ttnn.DataType.INVALID, [[1, 2, 3], [4, 5, 6]]),
+    ],
+)
+def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device):
+    try:
+        tt_tensor = ttnn.from_buffer(buffer, dtype, ttnn.ROW_MAJOR_LAYOUT, device)
+    except Exception as e:
+        assert "Unsupported DataType!" in str(e)
+    else:
+        pytest.fail("Expected an exception, but got none")

--- a/ttnn/cpp/ttnn-pybind/bfloat16_type_caster.hpp
+++ b/ttnn/cpp/ttnn-pybind/bfloat16_type_caster.hpp
@@ -20,9 +20,8 @@ struct type_caster<bfloat16> {
             value = bfloat16(src.cast<float>());
             return true;
         } else if (isinstance<pybind11::int_>(src)) {
-            // Handle Python int (can be int32, uint32, int16, etc.)
-            int64_t int_value = src.cast<int64_t>();
-            value = bfloat16(static_cast<float>(int_value));
+            int32_t int_value = src.cast<int32_t>();
+            value = bfloat16(int_value);
             return true;
         }
 

--- a/ttnn/cpp/ttnn-pybind/bfloat16_type_caster.hpp
+++ b/ttnn/cpp/ttnn-pybind/bfloat16_type_caster.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pytypes.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <tt-metalium/bfloat16.hpp>
+
+namespace PYBIND11_NAMESPACE {
+namespace detail {
+template <>
+struct type_caster<bfloat16> {
+    PYBIND11_TYPE_CASTER(bfloat16, _("bfloat16"));
+
+    bool load(handle src, bool) {
+        if (isinstance<pybind11::float_>(src)) {
+            value = bfloat16(src.cast<float>());
+            return true;
+        } else if (isinstance<pybind11::int_>(src)) {
+            // Handle Python int (can be int32, uint32, int16, etc.)
+            int64_t int_value = src.cast<int64_t>();
+            value = bfloat16(static_cast<float>(int_value));
+            return true;
+        }
+
+        return false;
+    }
+
+    static handle cast(const bfloat16& src, return_value_policy, handle) {
+        return pybind11::float_(src.to_float()).release();
+    }
+};
+}  // namespace detail
+}  // namespace PYBIND11_NAMESPACE

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -119,6 +119,8 @@ auto create_pybind_from_buffer_overload() {
                     TT_THROW("Unreachable");
                 }
             }
+            // This is a fallback to make the compiler happy.
+            TT_THROW("Unreachable");
         },
         py::arg("buffer"),
         py::arg("shape"),

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -454,7 +454,7 @@ void bind_from_buffer_operation(py::module& module, const creation_operation_t& 
         Example:
             >>> tensor = ttnn.{0}(buffer=[1, 2, 3, 4, 5, 6], shape=[2, 3], dtype=ttnn.int32, device=device)
             >>> print(tensor)
-            ttnn.Tensor([[1, 2, 3, 4, 5, 6]], shape=Shape([2, 3]), dtype=DataType::INT32, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[1, 2, 3], [4, 5, 6]], shape=Shape([2, 3]), dtype=DataType::INT32, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -78,9 +78,9 @@ auto create_pybind_from_buffer_overload() {
            const py::object& buffer,
            const Shape& shape,
            const DataType dtype,
-           const Layout layout,
            MeshDevice* device,
-           const MemoryConfig& memory_config) -> ttnn::Tensor {
+           const std::optional<Layout>& layout,
+           const std::optional<MemoryConfig>& memory_config) -> ttnn::Tensor {
             // Overloading this with templates is not working quite as expected,
             // the problem is that the buffer is a py::object, so we can't deduce the type of the data.
             // and sometimes the wrong type is handling the data.
@@ -89,27 +89,27 @@ auto create_pybind_from_buffer_overload() {
             switch (dtype) {
                 case DataType::UINT8: {
                     auto cpp_buffer = buffer.cast<std::vector<uint8_t>>();
-                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
+                    return self(cpp_buffer, shape, dtype, device, layout, memory_config);
                 }
                 case DataType::UINT16: {
                     auto cpp_buffer = buffer.cast<std::vector<uint16_t>>();
-                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
+                    return self(cpp_buffer, shape, dtype, device, layout, memory_config);
                 }
                 case DataType::INT32: {
                     auto cpp_buffer = buffer.cast<std::vector<int32_t>>();
-                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
+                    return self(cpp_buffer, shape, dtype, device, layout, memory_config);
                 }
                 case DataType::UINT32: {
                     auto cpp_buffer = buffer.cast<std::vector<uint32_t>>();
-                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
+                    return self(cpp_buffer, shape, dtype, device, layout, memory_config);
                 }
                 case DataType::FLOAT32: {
                     auto cpp_buffer = buffer.cast<std::vector<float>>();
-                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
+                    return self(cpp_buffer, shape, dtype, device, layout, memory_config);
                 }
                 case DataType::BFLOAT16: {
                     auto cpp_buffer = buffer.cast<std::vector<::bfloat16>>();
-                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
+                    return self(cpp_buffer, shape, dtype, device, layout, memory_config);
                 }
                 case DataType::BFLOAT8_B:
                 case DataType::BFLOAT4_B:
@@ -123,9 +123,9 @@ auto create_pybind_from_buffer_overload() {
         py::arg("buffer"),
         py::arg("shape"),
         py::arg("dtype"),
-        py::arg("layout"),
         py::arg("device"),
-        py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG};
+        py::arg("layout") = std::nullopt,
+        py::arg("memory_config") = std::nullopt};
 }
 
 template <typename creation_operation_t>
@@ -444,17 +444,17 @@ void bind_from_buffer_operation(py::module& module, const creation_operation_t& 
             buffer (List[Any]): The buffer to be used to create the tensor.
             shape (ttnn.Shape): The shape of the tensor to be created.
             dtype (ttnn.DataType): The tensor data type.
-            layout (ttnn.Layout): The tensor layout.
             device (ttnn.Device | ttnn.MeshDevice): The device where the tensor will be allocated.
+            layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR` unless `dtype` is `ttnn.bfloat4` or `ttnn.bfloat8`, in which case it defaults to `ttnn.TILE`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
 
         Returns:
             ttnn.Tensor: A tensor with the values from the buffer.
 
         Example:
-            >>> tensor = ttnn.{0}(buffer=[1, 2, 3, 4, 5, 6], shape=[2, 3], dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR, device=device)
+            >>> tensor = ttnn.{0}(buffer=[1, 2, 3, 4, 5, 6], shape=[2, 3], dtype=ttnn.int32, device=device)
             >>> print(tensor)
-            ttnn.Tensor([[1, 2, 3, 4, 5, 6]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[1, 2, 3, 4, 5, 6]], shape=Shape([2, 3]), dtype=DataType::INT32, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -116,7 +116,7 @@ auto create_pybind_from_buffer_overload() {
                 case DataType::INVALID: {
                     // convert_to_data_type() in types.hpp has not an implementation for bfloat8_b and bfloat4_b
                     // Both are empty structs, so let's not allow users to use them for this particular operation
-                    TT_THROW("Unsupported DataType!");
+                    TT_THROW("Unreachable");
                 }
             }
         },

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -76,6 +76,7 @@ auto create_pybind_from_buffer_overload() {
     return ttnn::pybind_overload_t{
         [](const creation_operation_t& self,
            const py::object& buffer,
+           const Shape& shape,
            const DataType dtype,
            const Layout layout,
            MeshDevice* device,
@@ -87,28 +88,28 @@ auto create_pybind_from_buffer_overload() {
             // in further validations.
             switch (dtype) {
                 case DataType::UINT8: {
-                    auto cpp_buffer = buffer.cast<std::vector<std::vector<uint8_t>>>();
-                    return self(cpp_buffer, dtype, layout, device, memory_config);
+                    auto cpp_buffer = buffer.cast<std::vector<uint8_t>>();
+                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
                 }
                 case DataType::UINT16: {
-                    auto cpp_buffer = buffer.cast<std::vector<std::vector<uint16_t>>>();
-                    return self(cpp_buffer, dtype, layout, device, memory_config);
+                    auto cpp_buffer = buffer.cast<std::vector<uint16_t>>();
+                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
                 }
                 case DataType::INT32: {
-                    auto cpp_buffer = buffer.cast<std::vector<std::vector<int32_t>>>();
-                    return self(cpp_buffer, dtype, layout, device, memory_config);
+                    auto cpp_buffer = buffer.cast<std::vector<int32_t>>();
+                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
                 }
                 case DataType::UINT32: {
-                    auto cpp_buffer = buffer.cast<std::vector<std::vector<uint32_t>>>();
-                    return self(cpp_buffer, dtype, layout, device, memory_config);
+                    auto cpp_buffer = buffer.cast<std::vector<uint32_t>>();
+                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
                 }
                 case DataType::FLOAT32: {
-                    auto cpp_buffer = buffer.cast<std::vector<std::vector<float>>>();
-                    return self(cpp_buffer, dtype, layout, device, memory_config);
+                    auto cpp_buffer = buffer.cast<std::vector<float>>();
+                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
                 }
                 case DataType::BFLOAT16: {
-                    auto cpp_buffer = buffer.cast<std::vector<std::vector<::bfloat16>>>();
-                    return self(cpp_buffer, dtype, layout, device, memory_config);
+                    auto cpp_buffer = buffer.cast<std::vector<::bfloat16>>();
+                    return self(cpp_buffer, shape, dtype, layout, device, memory_config);
                 }
                 case DataType::BFLOAT8_B:
                 case DataType::BFLOAT4_B:
@@ -120,6 +121,7 @@ auto create_pybind_from_buffer_overload() {
             }
         },
         py::arg("buffer"),
+        py::arg("shape"),
         py::arg("dtype"),
         py::arg("layout"),
         py::arg("device"),
@@ -439,7 +441,8 @@ void bind_from_buffer_operation(py::module& module, const creation_operation_t& 
         Creates a device tensor with values from a buffer of the specified, data type, layout, and memory configuration.
 
         Args:
-            buffer (List[List[Any]]): The buffer to be used to create the tensor.
+            buffer (List[Any]): The buffer to be used to create the tensor.
+            shape (ttnn.Shape): The shape of the tensor to be created.
             dtype (ttnn.DataType): The tensor data type.
             layout (ttnn.Layout): The tensor layout.
             device (ttnn.Device | ttnn.MeshDevice): The device where the tensor will be allocated.
@@ -449,9 +452,9 @@ void bind_from_buffer_operation(py::module& module, const creation_operation_t& 
             ttnn.Tensor: A tensor with the values from the buffer.
 
         Example:
-            >>> tensor = ttnn.{0}(buffer=[[1, 2, 3], [4, 5, 6]], shape=[2, 3], dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR, device=device)
+            >>> tensor = ttnn.{0}(buffer=[1, 2, 3, 4, 5, 6], shape=[2, 3], dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR, device=device)
             >>> print(tensor)
-            ttnn.Tensor([[[[1, 2, 3], [4, 5, 6]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[1, 2, 3, 4, 5, 6]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -430,7 +430,7 @@ template <typename creation_operation_t>
 void bind_from_buffer_operation(py::module& module, const creation_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
-        Creates a device tensor with values from a buffer of the specified shape, data type, layout, and memory configuration.
+        Creates a device tensor with values from a buffer of the specified, data type, layout, and memory configuration.
 
         Args:
             buffer (List[List[Any]]): The buffer to be used to create the tensor.

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -293,8 +293,8 @@ struct FromBuffer {
     template <typename BufferType>
     static Tensor invoke(
         const std::vector<std::vector<BufferType>>& buffer,
-        const DataType& dtype,
-        const Layout& layout,
+        const DataType dtype,
+        const Layout layout,
         MeshDevice* device,
         const MemoryConfig& memory_config) {
         size_t height = buffer.size();

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -284,10 +284,10 @@ struct FromBuffer {
         const std::optional<MemoryConfig>& memory_config = std::nullopt) {
         // This is validated from the invoker, but we need to handle it just in case that the user wants to use it
         TT_ASSERT(dtype != DataType::BFLOAT4_B && dtype != DataType::BFLOAT8_B, "Unsupported DataType!");
-        Layout selected_layout = layout.has_value() ? layout.value() : ttnn::ROW_MAJOR_LAYOUT;
-        MemoryConfig mem_cfg =
-            memory_config.has_value() ? memory_config.value() : memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
-        TensorSpec spec(shape, TensorLayout(dtype, PageConfig(selected_layout), mem_cfg));
+        TensorSpec spec(
+            shape,
+            TensorLayout(
+                dtype, PageConfig(layout.value_or(ttnn::ROW_MAJOR_LAYOUT)), memory_config.value_or(MemoryConfig{})));
         return Tensor::from_vector<BufferType>(buffer, spec, device);
     }
 };

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -275,34 +275,15 @@ struct Empty {
 
 struct FromBuffer {
     template <typename BufferType>
-    static std::vector<BufferType> flatten_buffer(const std::vector<std::vector<BufferType>>& buffer) {
-        std::vector<BufferType> flattened;
-        size_t total_size = 0;
-        for (const auto& row : buffer) {
-            total_size += row.size();
-        }
-        flattened.reserve(total_size);
-
-        for (const auto& row : buffer) {
-            flattened.insert(flattened.end(), row.begin(), row.end());
-        }
-
-        return flattened;
-    }
-
-    template <typename BufferType>
     static Tensor invoke(
-        const std::vector<std::vector<BufferType>>& buffer,
+        const std::vector<BufferType>& buffer,
+        const Shape& shape,
         const DataType dtype,
         const Layout layout,
         MeshDevice* device,
         const MemoryConfig& memory_config) {
-        size_t height = buffer.size();
-        size_t width = buffer.empty() ? 0 : buffer[0].size();
-        ttnn::Shape shape({height, width});
         TensorSpec spec(shape, TensorLayout(dtype, PageConfig(layout), memory_config));
-        std::vector<BufferType> flattened_buffer = flatten_buffer(buffer);
-        return Tensor::from_vector<BufferType>(flattened_buffer, spec, device);
+        return Tensor::from_vector<BufferType>(buffer, spec, device);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -279,10 +279,15 @@ struct FromBuffer {
         const std::vector<BufferType>& buffer,
         const Shape& shape,
         const DataType dtype,
-        const Layout layout,
         MeshDevice* device,
-        const MemoryConfig& memory_config) {
-        TensorSpec spec(shape, TensorLayout(dtype, PageConfig(layout), memory_config));
+        const std::optional<Layout>& layout = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        // This is validated from the invoker, but we need to handle it just in case that the user wants to use it
+        TT_ASSERT(dtype != DataType::BFLOAT4_B && dtype != DataType::BFLOAT8_B, "Unsupported DataType!");
+        Layout selected_layout = layout.has_value() ? layout.value() : ttnn::ROW_MAJOR_LAYOUT;
+        MemoryConfig mem_cfg =
+            memory_config.has_value() ? memory_config.value() : memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
+        TensorSpec spec(shape, TensorLayout(dtype, PageConfig(selected_layout), mem_cfg));
         return Tensor::from_vector<BufferType>(buffer, spec, device);
     }
 };


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/26627)

### Problem description
We need to provide an operation to TT-train that allows then to create a tensor from a memory array (like pytorch does with from_buffer)

### What's changed
Created a new operation that based on the data type we are trying to fill, it will generate a tensor with the data provided, similarly to pytorch. The only difference is that our tensors are immutable, so changing the data in the tensor won't affect the data in the array.
Also given that python is less strict with types, I had to handle bfloat in python and create an array of data based on the type requested in the operation instead of deducing it from the vector. This is also a limitation in pytorch

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
