### PR TITLE
Remove dependence on enum RISCV within kernel.cpp

### DIFF
--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -130,7 +130,7 @@ public:
     bool is_idle_eth() const;
 
 protected:
-    const HalProgrammableCoreType programmable_core_type_;
+    HalProgrammableCoreType programmable_core_type_;
 
     int watcher_kernel_id_;
     KernelSource kernel_src_;

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -121,7 +121,7 @@ public:
 
     int get_watcher_kernel_id() const { return watcher_kernel_id_; }
 
-    HalProgrammableCoreType get_kernel_programmable_core_type() const;
+    HalProgrammableCoreType get_kernel_programmable_core_type() const { return this->programmable_core_type_; }
     CoreType get_kernel_core_type() const;
     void set_full_name(const std::string& s) { kernel_full_name_ = s; }
     void add_defines(const std::map<std::string, std::string>& defines);
@@ -130,6 +130,8 @@ public:
     bool is_idle_eth() const;
 
 protected:
+    const HalProgrammableCoreType programmable_core_type_;
+
     int watcher_kernel_id_;
     KernelSource kernel_src_;
     std::string kernel_full_name_;  // Name + hash
@@ -153,6 +155,7 @@ private:
     void register_kernel_with_watcher();
 
     Kernel(
+        HalProgrammableCoreType programmable_core_type,
         const KernelSource& kernel_src,
         const CoreRangeSet& core_range_set,
         const std::vector<uint32_t>& compile_args,

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -158,9 +158,9 @@ CoreType Kernel::get_kernel_core_type() const {
         case HalProgrammableCoreType::TENSIX: return CoreType::WORKER;
         case HalProgrammableCoreType::ACTIVE_ETH:
         case HalProgrammableCoreType::IDLE_ETH: return CoreType::ETH;
-        default: TT_ASSERT(false, "Bad programmable core type!");
+        case HalProgrammableCoreType::COUNT: TT_THROW("Bad programmable core type!");
     }
-    return CoreType::WORKER;
+    TT_THROW("Unreachable");
 }
 
 const std::string& KernelImpl::get_full_kernel_name() const { return this->kernel_full_name_; }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -19,6 +19,7 @@
 
 #include "assert.hpp"
 #include "data_types.hpp"
+#include "hal_types.hpp"
 #include "jit_build/build.hpp"
 #include "jit_build/jit_build_options.hpp"
 #include "llrt.hpp"
@@ -28,6 +29,7 @@
 #include "tt_memory.h"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
+#include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
 #include "kernel_impl.hpp"
 
@@ -84,10 +86,12 @@ KernelSource::KernelSource(const std::string& source, const SourceType& source_t
 };
 
 Kernel::Kernel(
+    HalProgrammableCoreType programmable_core_type,
     const KernelSource& kernel_src,
     const CoreRangeSet& core_range_set,
     const std::vector<uint32_t>& compile_args,
     const std::map<std::string, std::string>& defines) :
+    programmable_core_type_(programmable_core_type),
     kernel_src_(kernel_src),
     core_range_set_(core_range_set),
     max_runtime_args_per_core_(0),
@@ -149,29 +153,12 @@ bool Kernel::is_on_logical_core(const CoreCoord& logical_core) const {
     return this->core_range_set_.contains(logical_core);
 }
 
-HalProgrammableCoreType Kernel::get_kernel_programmable_core_type() const {
-    RISCV riscv_processor = this->processor();
-    switch (riscv_processor) {
-        case RISCV::BRISC:
-        case RISCV::NCRISC:
-        case RISCV::COMPUTE: return HalProgrammableCoreType::TENSIX;
-        case RISCV::ERISC:
-        case RISCV::ERISC1:
-            return this->is_idle_eth() ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
-        default: TT_ASSERT(false, "Unsupported kernel processor!");
-    }
-    return HalProgrammableCoreType::TENSIX;
-}
-
 CoreType Kernel::get_kernel_core_type() const {
-    RISCV riscv_processor = this->processor();
-    switch (riscv_processor) {
-        case RISCV::BRISC:
-        case RISCV::NCRISC:
-        case RISCV::COMPUTE: return CoreType::WORKER;
-        case RISCV::ERISC:
-        case RISCV::ERISC1: return CoreType::ETH;
-        default: TT_ASSERT(false, "Unsupported kernel processor!");
+    switch (programmable_core_type_) {
+        case HalProgrammableCoreType::TENSIX: return CoreType::WORKER;
+        case HalProgrammableCoreType::ACTIVE_ETH:
+        case HalProgrammableCoreType::IDLE_ETH: return CoreType::ETH;
+        default: TT_ASSERT(false, "Bad programmable core type!");
     }
     return CoreType::WORKER;
 }
@@ -419,10 +406,7 @@ void Kernel::set_common_runtime_args_count(uint32_t count) {
     this->common_runtime_args_data_.rt_args_count = count;
 }
 
-bool Kernel::is_idle_eth() const {
-    return std::holds_alternative<EthernetConfig>(this->config()) &&
-           std::get<EthernetConfig>(this->config()).eth_mode == Eth::IDLE;
-}
+bool Kernel::is_idle_eth() const { return this->programmable_core_type_ == HalProgrammableCoreType::IDLE_ETH; }
 
 uint32_t KernelImpl::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <umd/device/tt_core_coordinates.h>
 #include <string>
 
 #include "api/tt-metalium/kernel.hpp"
+#include "core_coord.hpp"
+#include "hal_types.hpp"
 #include "jit_build/jit_build_settings.hpp"
 #include "jit_build/jit_build_options.hpp"
 #include <enchantum/enchantum.hpp>
@@ -45,11 +48,12 @@ public:
 
 protected:
     KernelImpl(
+        HalProgrammableCoreType programmable_core_type,
         const KernelSource& kernel_src,
         const CoreRangeSet& core_range_set,
         const std::vector<uint32_t>& compile_args,
         const std::map<std::string, std::string>& defines) :
-        Kernel(kernel_src, core_range_set, compile_args, defines) {}
+        Kernel(programmable_core_type, kernel_src, core_range_set, compile_args, defines) {}
     // DataMovement kernels have one binary each and Compute kernels have three binaries
     // Different set of binaries per device because kernel compilation is device dependent
     // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
@@ -63,7 +67,8 @@ protected:
 class DataMovementKernel : public KernelImpl {
 public:
     DataMovementKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const DataMovementConfig& config) :
-        KernelImpl(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
+        KernelImpl(HalProgrammableCoreType::TENSIX, kernel_src, cr_set, config.compile_args, config.defines),
+        config_(config) {
         this->dispatch_class_ =
             enchantum::to_underlying(HalProcessorClassType::DM) + enchantum::to_underlying(config.processor);
     }
@@ -100,7 +105,13 @@ private:
 class EthernetKernel : public KernelImpl {
 public:
     EthernetKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const EthernetConfig& config) :
-        KernelImpl(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
+        KernelImpl(
+            config.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH,
+            kernel_src,
+            cr_set,
+            config.compile_args,
+            config.defines),
+        config_(config) {
         this->dispatch_class_ =
             enchantum::to_underlying(HalProcessorClassType::DM) + enchantum::to_underlying(config.processor);
     }
@@ -136,7 +147,8 @@ private:
 class ComputeKernel : public KernelImpl {
 public:
     ComputeKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const ComputeConfig& config) :
-        KernelImpl(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
+        KernelImpl(HalProgrammableCoreType::TENSIX, kernel_src, cr_set, config.compile_args, config.defines),
+        config_(config) {
         this->dispatch_class_ = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
     }
 


### PR DESCRIPTION
### Ticket
#26820

### What's changed
HalProgrammableCoreType can be determined by subclass constructor, so store it in the class and do not rely on RISCV value for it.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16951315289) CI (ttnn group 5 tosa pcc is known flakyness)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16951317734) CI passed (eager unit tests 1 failing due to #21875)