### PR TITLE
Updated SD35 VAE optimization

### DIFF
--- a/models/experimental/stable_diffusion_35_large/tt/fun_vae_decoder/fun_resnet_block.py
+++ b/models/experimental/stable_diffusion_35_large/tt/fun_vae_decoder/fun_resnet_block.py
@@ -74,8 +74,9 @@ class TtResnetBlock2DParameters:
         )
 
 
+# NOTE: CCL Calls with persistent buffer affect the programming expectations
 def resnet_block(x_in: ttnn.Tensor, parameters: TtResnetBlock2DParameters) -> ttnn.Tensor:
-    residual = x_in
+    residual = ttnn.clone(x_in)
     x = vae_group_norm(x_in, parameters.norm1)
     x = ttnn.silu(x)
     x = vae_conv2d(x, parameters.conv1)

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -100,7 +100,7 @@ run_t3000_stable_diffusion_35_large_tests() {
 
   echo "LOG_METAL: Running run_t3000_stable_diffusion_35_large_tests"
 
-  pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "t3k_cfg2_sp2_tp2" ; fail+=$?
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "t3k_cfg2_sp2_tp2" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -100,7 +100,7 @@ run_t3000_stable_diffusion_35_large_tests() {
 
   echo "LOG_METAL: Running run_t3000_stable_diffusion_35_large_tests"
 
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "t3k_cfg2_sp2_tp2" ; fail+=$?
+  pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "t3k_cfg2_sp2_tp2" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Ticket
N/A
### Problem description
Further optimization SD 3.5 VAE.
T3K Performance
```
================================================================================
STABLE DIFFUSION 3.5 PERFORMANCE RESULTS
================================================================================
Model: large
Image Size: 1024x1024
Guidance Scale: 3.5
Inference Steps: 20
Configuration: cfg=2, sp=2, tp=2
--------------------------------------------------------------------------------
CLIP Encoding             | Mean:   0.0897s | Std:   0.0043s | Min:   0.0848s | Max:   0.0923s
T5 Encoding               | Mean:   0.0000s | Std:   0.0000s | Min:   0.0000s | Max:   0.0000s
Total Encoding            | Mean:   0.1842s | Std:   0.0021s | Min:   0.1821s | Max:   0.1862s
Denoising (per step)      | Mean:   0.4870s | Std:   0.0012s | Min:   0.4846s | Max:   0.4903s
VAE Decoding              | Mean:   1.7379s | Std:   0.0169s | Min:   1.7184s | Max:   1.7481s
Total Pipeline            | Mean:  11.6840s | Std:   0.0387s | Min:  11.6402s | Max:  11.7136s
--------------------------------------------------------------------------------
Average total denoising time: 9.7402s
Denoising throughput: 2.05 steps/second
Overall throughput: 0.0856 images/second

Time breakdown:
  Encoding: 1.6%
  Denoising: 83.4%
  VAE: 14.9%
================================================================================
```

Galaxy Performance:
```
================================================================================
STABLE DIFFUSION 3.5 PERFORMANCE RESULTS
================================================================================
Model: large
Image Size: 1024x1024
Guidance Scale: 3.5
Inference Steps: 20
Configuration: cfg=2, sp=4, tp=4
--------------------------------------------------------------------------------
CLIP Encoding             | Mean:   0.1122s | Std:   0.0063s | Min:   0.1053s | Max:   0.1179s
T5 Encoding               | Mean:   0.1213s | Std:   0.0036s | Min:   0.1172s | Max:   0.1240s
Total Encoding            | Mean:   0.4645s | Std:   0.0117s | Min:   0.4510s | Max:   0.4724s
Denoising (per step)      | Mean:   0.1712s | Std:   0.0013s | Min:   0.1695s | Max:   0.1751s
VAE Decoding              | Mean:   1.3754s | Std:   0.0041s | Min:   1.3709s | Max:   1.3790s
Total Pipeline            | Mean:   5.2868s | Std:   0.0115s | Min:   5.2798s | Max:   5.3000s
--------------------------------------------------------------------------------
Average total denoising time: 3.4249s
Denoising throughput: 5.84 steps/second
Overall throughput: 0.1892 images/second

Time breakdown:
  Encoding: 8.8%
  Denoising: 64.8%
  VAE: 26.0%
================================================================================
2025-08-13 23:21:14.344 | INFO     | models.experimental.stable_diffusion_35_large.tests.test_performance:test_sd35_performance:306 - Perf check passed!
PASSED
```
### What's changed
1. Reduced host workload after the denoising step
2. Performed parameter sweep for all gather ccl
3. Enabled multi device group norm computation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes