### PR TITLE
Add real weights tests for MLA

### DIFF
--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -13,9 +13,10 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention
 from models.demos.deepseek_v3.tt.mla_1d import MLA1D
 from models.demos.deepseek_v3.tt.rope import RotarySetup
+from models.demos.deepseek_v3.utils.config_helpers import dequantize_state_dict
 from models.demos.deepseek_v3.utils.reference_forwards import reference_forward_mla as reference_forward
 from models.demos.deepseek_v3.utils.run_config import create_run_config
-from models.demos.deepseek_v3.utils.test_utils import MAX_START_POS
+from models.demos.deepseek_v3.utils.test_utils import MAX_START_POS, load_state_dict
 from models.utility_functions import comp_pcc
 
 
@@ -71,6 +72,10 @@ def get_cache_on_host(tt_cache: ttnn.Tensor, row_idx: int, mesh_device: ttnn.Mes
     [True],
 )
 @pytest.mark.parametrize(
+    "weights_type",
+    ["random", "real"],
+)
+@pytest.mark.parametrize(
     "device_params",
     [
         {
@@ -78,6 +83,10 @@ def get_cache_on_host(tt_cache: ttnn.Tensor, row_idx: int, mesh_device: ttnn.Mes
         }
     ],
     indirect=True,
+)
+@pytest.mark.parametrize(
+    "module_path",
+    ["model.layers.0.self_attn"],
 )
 def test_forward_pass(
     mode,
@@ -89,6 +98,9 @@ def test_forward_pass(
     tmp_path,
     mesh_device,
     ccl,
+    weights_type,
+    model_path,
+    module_path,
 ):
     # Hang workaround for large shapes
     if seq_len > 1024:
@@ -101,6 +113,10 @@ def test_forward_pass(
     paged_config = MLA1D.get_valid_paged_config(hf_config.max_seq_len, MLA1D.MAX_BATCH_SIZE, dp_factor)
 
     reference_model = reference
+    if weights_type == "real":
+        state_dict = load_state_dict(model_path, module_path)
+        dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
+        reference_model.load_state_dict(dequantized_state_dict)
 
     if mode == "prefill":
         assert batch_size == 1, "Prefill mode only supports batch size of 1"

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -73,7 +73,7 @@ def get_cache_on_host(tt_cache: ttnn.Tensor, row_idx: int, mesh_device: ttnn.Mes
 )
 @pytest.mark.parametrize(
     "weights_type",
-    ["random", "real"],
+    [None, "real"],
 )
 @pytest.mark.parametrize(
     "device_params",

--- a/models/demos/deepseek_v3/tests/test_mla_1d.py
+++ b/models/demos/deepseek_v3/tests/test_mla_1d.py
@@ -73,7 +73,7 @@ def get_cache_on_host(tt_cache: ttnn.Tensor, row_idx: int, mesh_device: ttnn.Mes
 )
 @pytest.mark.parametrize(
     "weights_type",
-    [None, "real"],
+    ["random", "real"],
 )
 @pytest.mark.parametrize(
     "device_params",


### PR DESCRIPTION
### Ticket
None

### Problem description
Rather than using random weights use real weights from pretrained HF model for more realistic cases.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes