### PR TITLE
Fix Rust installation in install_dependencies.sh

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -422,7 +422,12 @@ install_mpi_ulfm() {
 }
 
 install_rust() {
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.89.0 -y
+    INSTALL_CMD="curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.89.0 --profile minimal -y"
+    if [ -n "$SUDO_USER" ]; then
+        sudo -u "$SUDO_USER" /bin/bash -c "$INSTALL_CMD"
+    else
+        /bin/bash -c "$INSTALL_CMD"
+    fi
 }
 
 # We don't really want to have hugepages dependency


### PR DESCRIPTION
### Ticket

### Problem description
In the regular installation process install_dependencies.sh script is being run with sudo, which results in Rust being installed for root instead of the current user

### What's changed
Changed Rust installation command line to make sure it's being executed as the current user, not the root
Added `--profile minimal` flag trying to minimize docker image size for CI

### Checklist
- [x] Manually verified the installation on the clean VM
- [x] [CI build passes](https://github.com/tenstorrent/tt-metal/actions/runs/16954830647)
- [x] New/Existing tests provide coverage for changes