### PR TITLE
#26763: Correctly upload tensor to device

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -165,6 +165,7 @@ public:
     template <typename T>
     [[nodiscard]] T item(ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
 
+    // TODO: #26832 - Use `mem_config` argument as an optional argument.
     [[nodiscard]] Tensor to_device(
         distributed::MeshDevice* mesh_device,
         const MemoryConfig& mem_config = MemoryConfig{},

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -461,7 +461,7 @@ Tensor load_tensor_flatbuffer(const std::string& file_name, MeshDevice* device) 
     Tensor tensor =
         ttnn::from_flatbuffer(fb_tensor, tt::stl::Span<std::byte>(file_data + data_offset, data_size), memory_pin);
     if (device != nullptr) {
-        tensor = tensor.to_device(device);
+        tensor = tensor.to_device(device, tensor.tensor_spec().memory_config());
     }
     return tensor;
 }


### PR DESCRIPTION
### Ticket
#26763

### Problem description
`to_device()` is not called with correct memory config.

### What's changed
Provide the correct argument and add tests.

Root problem is this subtle behavior:
```cpp
    [[nodiscard]] Tensor to_device(
        distributed::MeshDevice* mesh_device,
        const MemoryConfig& mem_config = MemoryConfig{},
        ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
```

The default of `mem_config` is default constructed `MemoryConfig` and not `MemoryConfig` that is present in `Tensor` already. Not clear why.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16954358388)
- [X] New/Existing tests provide coverage for changes