### PR TITLE
Resubmit Changes for "End-to-End Multi-Host "Big-Mesh" TT-NN/TT-Metal Support"

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -25,8 +25,8 @@ jobs:
         test-group: [
           { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 35, owner_id: ULMEPM2MA}, #Sean Nijjar
           { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
-          { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 10, owner_id: U03NG0A5ND7}, #Aditya Saigal
-          { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 5, owner_id: U013121KDH9}, #Austin Ho
+          { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 25, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 15, owner_id: U013121KDH9}, #Austin Ho
           { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz

--- a/conftest.py
+++ b/conftest.py
@@ -405,13 +405,13 @@ def mesh_device(request, silicon_arch_name, device_params):
         num_devices_requested = min(param, len(device_ids))
         mesh_shape = ttnn.MeshShape(1, num_devices_requested)
 
-    request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
-
     updated_device_params = get_updated_device_params(device_params)
     fabric_config = updated_device_params.pop("fabric_config", None)
     reliability_mode = updated_device_params.pop("reliability_mode", None)
     set_fabric(fabric_config)
     mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **updated_device_params)
+    num_local_devices = len(mesh_device.get_device_ids())
+    request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids[:num_local_devices]]
 
     logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
     yield mesh_device

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -113,15 +113,28 @@ run_t3000_ttnn_tests() {
 }
 
 run_t3000_tt_metal_multiprocess_tests() {
-  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
-  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests
-  tt-run --mpi-args "--allow-run-as-root --tag-output" --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter="*BigMeshDualRankTest2x4*"
-  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+  local mpi_args="--allow-run-as-root --tag-output"
+
+  tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
+  tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests
+  tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+
+  # Big-Mesh 2x4 Regression tests
+  local mesh2x4_rank_binding="tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml"
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter="*BigMeshDualRankTest2x4*"
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*MeshWorkloadTest*"
 }
 
 run_t3000_ttnn_multiprocess_tests() {
-  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/multiprocess/unit_tests_dual_rank_2x2
-  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml ./build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4
+  local mpi_args="--allow-run-as-root --tag-output"
+
+  tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/multiprocess/unit_tests_dual_rank_2x2
+
+  # Big-Mesh 2x4 Regression tests
+  local mesh2x4_rank_binding="tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml"
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/unit_tests_ttnn --gtest_filter="*LaunchOperation*"
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/distributed/test_data_parallel_example.py
 }
 
 run_t3000_falcon7b_tests() {

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -14,8 +14,13 @@
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/distributed.hpp>
 
 #include <tt-metalium/tt_metal.hpp>
+
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -24,12 +29,38 @@ using ::tt::tt_fabric::MeshHostRankId;
 using ::tt::tt_fabric::MeshId;
 using ::tt::tt_fabric::MeshScope;
 
-TEST(BigMeshDualRankTest2x4, DistributedContext) {
+// Parameterized test fixture for mesh device validation
+class BigMeshDualRankMeshShapeSweepFixture : public MeshDeviceFixtureBase,
+                                             public testing::WithParamInterface<MeshShape> {
+public:
+    BigMeshDualRankMeshShapeSweepFixture() :
+        MeshDeviceFixtureBase(Config{
+            .mesh_shape = GetParam(),
+        }) {}
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    BigMeshDualRankMeshShapeSweep,
+    BigMeshDualRankMeshShapeSweepFixture,
+    ::testing::Values(
+        MeshShape(2, 4),
+        /* Issue #25355: Cannot create a MeshDevice with only one rank active.
+        MeshShape(1, 1),
+        MeshShape(1, 2),
+        MeshShape(2, 1),
+        MeshShape(2, 2),
+        */
+        MeshShape(1, 8),
+        MeshShape(8, 1)));
+
+using BigMeshDualRankTest2x4 = MeshDevice2x4Fixture;
+
+TEST(BigMeshDualRankTest, DistributedContext) {
     auto& dctx = MetalContext::instance().global_distributed_context();
     EXPECT_EQ(dctx.size(), multihost::Size(2));
 }
 
-TEST(BigMeshDualRankTest2x4, LocalRankBinding) {
+TEST(BigMeshDualRankTest, LocalRankBinding) {
     auto& global_context = MetalContext::instance().global_distributed_context();
     auto& control_plane = MetalContext::instance().get_control_plane();
 
@@ -64,7 +95,9 @@ TEST(BigMeshDualRankTest2x4, LocalRankBinding) {
     EXPECT_NE(MetalContext::instance().global_distributed_context().id(), mesh_subcontext->id());
 }
 
-TEST(BigMeshDualRankTest2x4, SystemMeshValidation) {
+TEST_P(BigMeshDualRankMeshShapeSweepFixture, MeshDeviceValidation) { EXPECT_EQ(mesh_device_->shape(), GetParam()); }
+
+TEST_F(BigMeshDualRankTest2x4, SystemMeshValidation) {
     ASSERT_NO_THROW({ SystemMesh::instance(); });
 
     const auto& system_mesh = SystemMesh::instance();
@@ -108,15 +141,74 @@ TEST(BigMeshDualRankTest2x4, SystemMeshValidation) {
     EXPECT_EQ(fabric_node_ids.at(MeshCoordinate(1, 3)).chip_id, 7);
 }
 
-TEST(BigMeshDualRankTest2x4, MeshDevice2x4Validation) {
-    auto mesh_device = MeshDevice::create(
-        MeshDeviceConfig(MeshShape(2, 4)),
-        DEFAULT_L1_SMALL_SIZE,
-        DEFAULT_TRACE_REGION_SIZE,
-        1,
-        tt::tt_metal::DispatchCoreType::WORKER);
-    EXPECT_EQ(mesh_device->shape(), MeshShape(2, 4));
-    EXPECT_EQ(mesh_device->get_view().mesh_id(), MeshId(0));
+TEST_F(BigMeshDualRankTest2x4, DistributedHostBuffer) {
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    DistributedHostBuffer host_buffer = DistributedHostBuffer::create(mesh_device_->get_view());
+    auto rank = control_plane.get_local_host_rank_id_binding();
+
+    host_buffer.emplace_shard(MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{0, 0, 0}); });
+    host_buffer.emplace_shard(MeshCoordinate(0, 1), []() { return HostBuffer(std::vector<int>{0, 0, 0}); });
+    host_buffer.emplace_shard(MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{0, 0, 0}); });
+    host_buffer.emplace_shard(MeshCoordinate(1, 1), []() { return HostBuffer(std::vector<int>{0, 0, 0}); });
+
+    host_buffer.emplace_shard(MeshCoordinate(0, 2), []() { return HostBuffer(std::vector<int>{1, 1, 1}); });
+    host_buffer.emplace_shard(MeshCoordinate(0, 3), []() { return HostBuffer(std::vector<int>{1, 1, 1}); });
+    host_buffer.emplace_shard(MeshCoordinate(1, 2), []() { return HostBuffer(std::vector<int>{1, 1, 1}); });
+    host_buffer.emplace_shard(MeshCoordinate(1, 3), []() { return HostBuffer(std::vector<int>{1, 1, 1}); });
+
+    auto validate_local_shards = [rank](const HostBuffer& buffer) {
+        fmt::print(
+            "Rank {}: {}\n", *rank, std::vector<int>(buffer.view_as<int>().begin(), buffer.view_as<int>().end()));
+        auto span = buffer.view_as<int>();
+        for (const auto& value : span) {
+            EXPECT_EQ(value, *rank);
+        }
+    };
+
+    host_buffer.apply(validate_local_shards);
+}
+
+TEST_F(BigMeshDualRankTest2x4, SimpleShardedBufferTest) {
+    // Simple test with a 2x4 mesh, 64x128 buffer, 32x32 shards
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+    Shape2D global_buffer_shape = {64, 128};
+    Shape2D shard_shape = {32, 32};
+
+    uint32_t global_buffer_size = global_buffer_shape.height() * global_buffer_shape.width() * sizeof(uint32_t);
+
+    ShardedBufferConfig sharded_config{
+        .global_size = global_buffer_size,
+        .global_buffer_shape = global_buffer_shape,
+        .shard_shape = shard_shape,
+        .shard_orientation = ShardOrientation::ROW_MAJOR,
+    };
+
+    auto mesh_buffer = MeshBuffer::create(sharded_config, per_device_buffer_config, mesh_device_.get());
+
+    // Create input data
+    std::vector<uint32_t> src_vec(global_buffer_shape.height() * global_buffer_shape.width(), 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    // Write and read back
+    EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec);
+    std::vector<uint32_t> dst_vec;
+    EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer);
+
+    // The expectation is that EnqueueWriteMeshBuffer/EnqueueReadMeshBuffer
+    // should handle sharding/unsharding transparently, so dst should equal src
+    for (int i = 0; i < dst_vec.size(); i++) {
+        auto shard_row = i / global_buffer_shape.width();
+        auto shard_col = i % global_buffer_shape.width();
+        auto device_row = shard_row / shard_shape.height();
+        auto device_col = shard_col / shard_shape.width();
+        if (mesh_device_->is_local(MeshCoordinate(device_row, device_col))) {
+            EXPECT_EQ(dst_vec[i], src_vec[i]) << "Mismatch at index: " << i;
+        }
+    }
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -355,6 +355,9 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
 
             for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
                 for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+                    if (!mesh_device_->is_local(MeshCoordinate(logical_y, logical_x))) {
+                        continue;
+                    }
                     std::vector<uint32_t> dst_vec = {};
                     ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, MeshCoordinate(logical_y, logical_x));
                     EXPECT_EQ(dst_vec, src_vec);

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -126,6 +126,9 @@ void verify_cb_config(
 
     for (const auto& [device_range, _] : workload.get_programs()) {
         for (const auto& coord : device_range) {
+            if (!mesh_device->is_local(coord)) {
+                continue;
+            }
             auto device = mesh_device->get_device(coord);
             uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
             for (const auto& core_range : crs.ranges()) {
@@ -190,11 +193,13 @@ TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
     for (int i = 0; i < num_workloads; i++) {
         std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
         for (const auto& device_coord : MeshCoordinateRange(mesh_device_->shape())) {
-            IDevice* device = mesh_device_->get_device(device_coord);
-            auto programs = utils::create_random_programs(
-                1, mesh_device_->compute_with_storage_grid_size(), seed, device->get_active_ethernet_cores(true));
-            AddProgramToMeshWorkload(
-                *workload, std::move(*programs[0]), MeshCoordinateRange(device_coord, device_coord));
+            if (mesh_device_->is_local(device_coord)) {
+                IDevice* device = mesh_device_->get_device(device_coord);
+                auto programs = utils::create_random_programs(
+                    1, mesh_device_->compute_with_storage_grid_size(), seed, device->get_active_ethernet_cores(true));
+                AddProgramToMeshWorkload(
+                    *workload, std::move(*programs[0]), MeshCoordinateRange(device_coord, device_coord));
+            }
         }
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
         workloads.push_back(workload);
@@ -702,11 +707,17 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreDifferentPrograms) {
     Finish(mesh_device_->mesh_command_queue());
 
     for (const auto& device_coord : devices_0) {
+        if (!mesh_device_->is_local(device_coord)) {
+            continue;
+        }
         auto device = mesh_device_->get_device(device_coord);
         validate_sems(mesh_device_, device, full_grid, mesh_workload, expected_semaphore_values_0);
     }
 
     for (const auto& device_coord : devices_1) {
+        if (!mesh_device_->is_local(device_coord)) {
+            continue;
+        }
         auto device = mesh_device_->get_device(device_coord);
         validate_sems(mesh_device_, device, full_grid, mesh_workload, expected_semaphore_values_1);
     }

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
@@ -52,7 +52,7 @@ TEST_F(BigMeshDualRankTest2x4, HostAllGather) {
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
-    ASSERT_EQ(device_tensors.size(), 4);
+    ASSERT_EQ(device_tensors.size(), 8);
 
     // Perform all-gather on host and validate the data at each host.
     auto all_gather_tensor = host_ccl::all_gather(sharded_tensor);

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
@@ -757,3 +756,22 @@ def test_heterogenous_operation_dispatch():
 def test_fabric_with_submeshes(t3k_mesh_device):
     logger.info("Spawning 2 1x4 submeshes on a 2x4 mesh device with fabric enabled")
     submeshes = t3k_mesh_device.create_submeshes(ttnn.MeshShape(1, 4))
+
+
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+def test_multihost_sanity(mesh_device):
+    torch.manual_seed(0)
+
+    shard_size = 32
+    torch_tensor = torch.rand((1, 1, 32, shard_size * mesh_device.get_num_devices()), dtype=torch.bfloat16)
+    torch_gelu = torch.nn.functional.gelu(torch_tensor)
+
+    ttnn_tensor = ttnn.from_torch(
+        torch_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(mesh_device, dim=3)
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_tensor = ttnn.gelu(ttnn_tensor)
+    ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
+
+    assert_with_pcc(torch_gelu, torch_loop_back_tensor, pcc=0.9999)

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -64,6 +64,13 @@ void ReadShard(
     const std::shared_ptr<MeshBuffer>& mesh_buffer,
     const MeshCoordinate& coord,
     bool blocking = true) {
+    // TODO: #26591 - `is_local` Handling should be done under `MeshCommandQueue`.
+    // Tracking removal of free function APIs in this file in this issue.
+    auto mesh_device = mesh_cq.device();
+    if (!mesh_device->is_local(coord)) {
+        return;
+    }
+
     auto shard = mesh_buffer->get_device_buffer(coord);
     dst.resize(shard->page_size() * shard->num_pages() / sizeof(DType));
     std::vector<MeshCommandQueue::ShardDataTransfer> shard_data_transfers = {{
@@ -135,6 +142,9 @@ void Synchronize(
     MeshDevice* device, std::optional<uint8_t> cq_id, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 void Finish(MeshCommandQueue& mesh_cq, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
+// Returns true if the distributed environment is initialized and world_size > 1.
+bool UsingDistributedEnvironment();
 
 }  // namespace distributed
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -130,7 +130,7 @@ private:
         DeviceAddr device_local_size,
         MeshDevice* mesh_device,
         std::shared_ptr<Buffer> backing_buffer) :
-        buffers_(MeshShape(mesh_device->shape()), nullptr),
+        buffers_(MeshShape(mesh_device->shape())),
         config_(config),
         device_local_config_(device_local_config),
         mesh_device_(mesh_device->shared_from_this()),
@@ -145,7 +145,7 @@ private:
         DeviceAddr address,
         DeviceAddr device_local_size,
         MeshDevice* mesh_device) :
-        buffers_(MeshShape(mesh_device->shape()), /*fill_value=*/nullptr),
+        buffers_(MeshShape(mesh_device->shape())),
         config_(config),
         device_local_config_(device_local_config),
         mesh_device_(mesh_device->shared_from_this()),
@@ -160,7 +160,7 @@ private:
     DeviceAddr address_ = 0;
     DeviceAddr device_local_size_ = 0;
 
-    MeshContainer<std::shared_ptr<Buffer>> buffers_;
+    DistributedMeshContainer<std::shared_ptr<Buffer>> buffers_;
 
     // `MeshBufferState` specifies the state of the MeshBuffer. It can either be:
     // 1. Owned - a single device buffer is responsible for providing the address for the entire mesh buffer.

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -96,4 +96,9 @@ void Finish(MeshCommandQueue& mesh_cq, tt::stl::Span<const SubDeviceId> sub_devi
     mesh_cq.finish(sub_device_ids);
 }
 
+bool UsingDistributedEnvironment() {
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+    return distributed_context.is_initialized() && *(distributed_context.size()) > 1;
+}
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -55,6 +55,29 @@ struct ProgramCommandSequence;
 
 namespace tt::tt_metal::distributed {
 
+namespace {
+
+template <typename Container, typename Func>
+void for_each_local(MeshDevice* mesh_device, const Container& container, Func&& func) {
+    for (auto it = container.begin(); it != container.end(); ++it) {
+        const auto& coord = *it;
+        if (mesh_device->is_local(coord)) {
+            func(coord);
+        }
+    }
+}
+
+MeshCoordinate get_local_start_coord(MeshDevice* mesh_device, const MeshCoordinateRange& range) {
+    for (const auto& coord : range) {
+        if (mesh_device->is_local(coord)) {
+            return coord;
+        }
+    }
+    TT_THROW("No local device found for range");
+}
+
+}  // namespace
+
 struct MeshReadEventDescriptor {
     ReadEventDescriptor single_device_descriptor;
     MeshCoordinateRange device_range;
@@ -137,7 +160,7 @@ void FDMeshCommandQueue::populate_read_descriptor_queue() {
 
 void FDMeshCommandQueue::populate_virtual_program_dispatch_core() {
     int device_idx = 0;
-    for (auto device : this->mesh_device_->get_devices()) {
+    for (auto device : mesh_device_->get_devices()) {
         if (device_idx) {
             TT_FATAL(
                 this->dispatch_core_ == device->virtual_program_dispatch_core(this->id_),
@@ -192,7 +215,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.impl().determine_sub_device_ids(mesh_device_);
     TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
     SubDeviceId sub_device_id = *(sub_device_ids.begin());
-    auto mesh_device_id = this->mesh_device_->id();
+    auto mesh_device_id = mesh_device_->id();
     auto& sysmem_manager = this->reference_sysmem_manager();
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
@@ -386,6 +409,10 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
     auto lock = lock_api_function_();
+    if (!mesh_device_->is_local(address.device_coord)) {
+        return;
+    }
+
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
 
@@ -417,6 +444,10 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
     auto lock = lock_api_function_();
+    if (!mesh_device_->is_local(address.device_coord)) {
+        return;
+    }
+
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
@@ -469,6 +500,10 @@ void FDMeshCommandQueue::write_shard_to_device(
     const std::optional<BufferRegion>& region,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
+    if (!mesh_device_->is_local(device_coord)) {
+        return;
+    }
+
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture. trace id: {}", trace_id_.value());
 
@@ -492,6 +527,10 @@ void FDMeshCommandQueue::read_shard_from_device(
     std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
+    if (!mesh_device_->is_local(device_coord)) {
+        return;
+    }
+
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
@@ -605,10 +644,10 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
             notify_host);
     };
 
-    for (const auto& coord : event.device_range()) {
+    for_each_local(mesh_device_, event.device_range(), [&](const auto& coord) {
         dispatch_thread_pool_->enqueue(
             [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
-    }
+    });
     dispatch_thread_pool_->wait();
     return event;
 }
@@ -650,10 +689,10 @@ void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
     auto lock = lock_api_function_();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
-    for (const auto& coord : sync_event.device_range()) {
+    for_each_local(mesh_device_, sync_event.device_range(), [&](const auto& coord) {
         event_dispatch::issue_wait_for_event_commands(
             id_, sync_event.mesh_cq_id(), mesh_device_->get_device(coord)->sysmem_manager(), sync_event.id());
-    }
+    });
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
     for (auto& sub_device_entry : sub_device_cq_owner) {
         sub_device_entry.waited_for_event(sync_event.id(), sync_event.mesh_cq_id(), this->id_);
@@ -741,7 +780,7 @@ void FDMeshCommandQueue::copy_buffer_data_to_user_space(MeshBufferReadDescriptor
 
 void FDMeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& read_event_descriptor) {
     auto& device_range = read_event_descriptor.device_range;
-    for (const auto& coord : device_range) {
+    for_each_local(mesh_device_, device_range, [&](const auto& coord) {
         auto device = mesh_device_->get_device(coord);
         chip_id_t mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
@@ -751,10 +790,13 @@ void FDMeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& re
 
         event_dispatch::read_events_from_completion_queue(
             read_event_descriptor.single_device_descriptor, mmio_device_id, channel, id_, device->sysmem_manager());
-    }
+    });
 }
 
 void FDMeshCommandQueue::read_l1_data_from_completion_queue(MeshCoreDataReadDescriptor& read_l1_data_descriptor) {
+    if (!mesh_device_->is_local(read_l1_data_descriptor.device_coord)) {
+        return;
+    }
     IDevice* device = mesh_device_->get_device(read_l1_data_descriptor.device_coord);
     const chip_id_t mmio_device_id =
         tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
@@ -818,13 +860,13 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     uint32_t program_runtime_id) {
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    for (const auto& coord : sub_grid) {
-        auto device = this->mesh_device_->get_device(coord);
+    for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
+        auto device = mesh_device_->get_device(coord);
         this->update_launch_messages_for_device_profiler(program_cmd_seq, program_runtime_id, device);
         program_dispatch::write_program_command_sequence(
             program_cmd_seq, device->sysmem_manager(), id_, dispatch_core_type, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
-    }
+    });
 }
 
 void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
@@ -834,7 +876,7 @@ void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
     bool mcast_go_signals,
     bool unicast_go_signals,
     const program_dispatch::ProgramDispatchMetadata& dispatch_md) {
-    for (auto& device : this->mesh_device_->get_devices()) {
+    for (auto& device : mesh_device_->get_devices()) {
         if (chip_ids_in_workload.find(device->id()) == chip_ids_in_workload.end()) {
             write_go_signal(
                 id_,
@@ -863,11 +905,11 @@ void FDMeshCommandQueue::capture_program_trace_on_subgrid(
     // Host Memory Intensive Path (when profiler is enabled): The launch messages across devices are unique, since
     // the host_assigned_field in the launch_msg contains the physical device id (required by the performance profiler).
     // Hence the trace per device must be uniquely captured.
-    for (const auto& coord : sub_grid) {
+    for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto& sysmem_manager_for_trace = mesh_device_->get_device(coord)->sysmem_manager();
         uint32_t sysmem_manager_offset = sysmem_manager_for_trace.get_issue_queue_write_ptr(id_);
 
-        auto device = this->mesh_device_->get_device(coord);
+        auto device = mesh_device_->get_device(coord);
         this->update_launch_messages_for_device_profiler(program_cmd_seq, program_runtime_id, device);
         program_dispatch::write_program_command_sequence(
             program_cmd_seq, sysmem_manager_for_trace, id_, dispatch_core_type, stall_first, stall_before_program);
@@ -877,11 +919,12 @@ void FDMeshCommandQueue::capture_program_trace_on_subgrid(
             sysmem_manager_offset,
             sysmem_manager_for_trace.get_issue_queue_write_ptr(id_) - sysmem_manager_offset};
         ordered_mesh_trace_md_.push_back(mesh_trace_md);
-    }
+    });
 #else
     // Optimized Path (generic use-cases): Program dispatch commands across the entire sub-grid are identical.
     // Capture once.
-    auto& sysmem_manager_for_trace = mesh_device_->get_device(sub_grid.start_coord())->sysmem_manager();
+    auto local_start_coord = get_local_start_coord(mesh_device_, sub_grid);
+    auto& sysmem_manager_for_trace = mesh_device_->get_device(local_start_coord)->sysmem_manager();
     uint32_t sysmem_manager_offset = sysmem_manager_for_trace.get_issue_queue_write_ptr(id_);
 
     program_dispatch::write_program_command_sequence(
@@ -905,6 +948,9 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
     MeshCoordinateRange full_grid(mesh_device_->shape());
     MeshCoordinateRangeSet unused_grids = subtract(full_grid, active_grid);
     for (const auto& unused_grid : unused_grids.ranges()) {
+        if (!mesh_device_->is_local(unused_grid.start_coord())) {
+            continue;
+        }
         auto& sysmem_manager_for_trace = mesh_device_->get_device(unused_grid.start_coord())->sysmem_manager();
         uint32_t sysmem_manager_offset = sysmem_manager_for_trace.get_issue_queue_write_ptr(id_);
         write_go_signal(
@@ -1015,7 +1061,8 @@ void FDMeshCommandQueue::record_end() {
 }
 
 SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
-    return mesh_device_->get_device(0, 0)->sysmem_manager();
+    auto local_devices = mesh_device_->get_devices();
+    return local_devices.at(0)->sysmem_manager();
 }
 
 void FDMeshCommandQueue::update_launch_messages_for_device_profiler(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -176,8 +176,10 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
             this->write_shard_to_device(buffer, coord, host_data, region);
         };
         for (const auto& coord : device_range) {
-            dispatch_thread_pool_->enqueue(
-                [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
+            if (mesh_device_->is_local(coord)) {
+                dispatch_thread_pool_->enqueue(
+                    [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
+            }
         }
         dispatch_thread_pool_->wait();
     } else {
@@ -218,9 +220,12 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
     };
 
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
-        dispatch_thread_pool_->enqueue(
-            [&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); },
-            mesh_device_->get_device(shard_data_transfers[shard_idx].shard_coord)->id());
+        auto shard_coord = shard_data_transfers[shard_idx].shard_coord;
+        if (mesh_device_->is_local(shard_coord)) {
+            dispatch_thread_pool_->enqueue(
+                [&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); },
+                mesh_device_->get_device(shard_coord)->id());
+        }
     }
     dispatch_thread_pool_->wait();
 
@@ -263,12 +268,14 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
     for (const auto& shard_data_transfer : shard_data_transfers) {
-        this->read_shard_from_device(
-            *buffer,
-            shard_data_transfer.shard_coord,
-            shard_data_transfer.host_data,
-            shard_data_transfer.region,
-            num_txns_per_device);
+        if (mesh_device_->is_local(shard_data_transfer.shard_coord)) {
+            this->read_shard_from_device(
+                *buffer,
+                shard_data_transfer.shard_coord,
+                shard_data_transfer.host_data,
+                shard_data_transfer.region,
+                num_txns_per_device);
+        }
     }
     this->submit_memcpy_request(num_txns_per_device, blocking);
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -500,6 +500,7 @@ void MetalContext::construct_control_plane(const std::filesystem::path& mesh_gra
 
 void MetalContext::initialize_control_plane() {
     if (custom_mesh_graph_desc_path_.has_value()) {
+        log_debug(tt::LogDistributed, "Using custom mesh graph descriptor: {}", custom_mesh_graph_desc_path_.value());
         std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc_path_.value());
         TT_FATAL(
             std::filesystem::exists(mesh_graph_desc_path),
@@ -510,6 +511,7 @@ void MetalContext::initialize_control_plane() {
         this->construct_control_plane(mesh_graph_desc_path);
         return;
     }
+    log_debug(tt::LogDistributed, "Using default mesh graph descriptor.");
 
     auto cluster_type = cluster_->get_cluster_type();
     auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_type);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -420,9 +420,6 @@ void MetalContext::set_fabric_config(
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
-    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED && fabric_config != this->fabric_config_) {
-        control_plane_.reset();
-    }
 
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED ||
         fabric_config == tt_fabric::FabricConfig::DISABLED) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -420,6 +420,9 @@ void MetalContext::set_fabric_config(
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED && fabric_config != this->fabric_config_) {
+        control_plane_.reset();
+    }
 
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED ||
         fabric_config == tt_fabric::FabricConfig::DISABLED) {

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -15,6 +15,7 @@
 #include <ttnn/tensor/host_buffer/functions.hpp>
 #include <ttnn/tensor/tensor_utils.hpp>
 #include <ttnn/distributed/distributed_tensor_config.hpp>
+#include <ttnn/distributed/host_ccl.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include <ttnn/distributed/types.hpp>
@@ -66,7 +67,8 @@ void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_de
 std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
     if (std::holds_alternative<tt::tt_metal::HostStorage>(tensor.storage())) {
         std::vector<ttnn::Tensor> tensors;
-        const auto& distributed_buffer = tensor.host_storage().buffer();
+        auto gathered_tensor = host_ccl::all_gather(tensor);
+        const auto& distributed_buffer = gathered_tensor.host_storage().buffer();
         distributed_buffer.apply(
             [&](const HostBuffer& buffer) { tensors.push_back(Tensor{buffer, tensor.tensor_spec()}); });
         return tensors;

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -15,6 +15,7 @@
 #include <pybind11/pytypes.h>
 
 #include <tt-metalium/command_queue.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
@@ -715,6 +716,7 @@ void py_module(py::module& module) {
             Returns:
                 Tensor: The combined tensor.
             )doc");
+    module.def("using_distributed_env", &tt::tt_metal::distributed::UsingDistributedEnvironment);
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -27,6 +27,7 @@
 #include "ttnn/tensor/xtensor/conversion_utils.hpp"
 #include "ttnn/tensor/xtensor/partition.hpp"
 #include "ttnn/distributed/tensor_topology.hpp"
+#include "ttnn/distributed/host_ccl.hpp"
 
 namespace ttnn::distributed {
 namespace {
@@ -370,7 +371,8 @@ public:
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const {
         const auto cpu_tensor = tensor.cpu();
-        const auto& src_buffer = cpu_tensor.host_storage().buffer();
+        auto all_gather_tensor = host_ccl::all_gather(cpu_tensor);
+        const auto& src_buffer = all_gather_tensor.host_storage().buffer();
 
         auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
         auto dst_buffer = tt::tt_metal::DistributedHostBuffer::create(distribution_shape_);

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -111,6 +111,7 @@ from ttnn._ttnn.multi_device import (
     create_mesh_composer,
     aggregate_tensor,
     distribute_tensor,
+    using_distributed_env,
 )
 
 from ttnn._ttnn.events import (

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -249,8 +249,7 @@ def create_system_mesh_table():
 
 
 def get_num_devices() -> List[int]:
-    system_mesh_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()
-    return system_mesh_desc.shape().mesh_size()
+    return ttnn._ttnn.device.GetNumAvailableDevices()
 
 
 def get_num_pcie_devices() -> int:

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -249,7 +249,8 @@ def create_system_mesh_table():
 
 
 def get_num_devices() -> List[int]:
-    return ttnn._ttnn.device.GetNumAvailableDevices()
+    system_mesh_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()
+    return system_mesh_desc.shape().mesh_size()
 
 
 def get_num_pcie_devices() -> int:

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -708,10 +708,11 @@ def as_tensor(
             storage_type = f"_multi_device_{device.get_num_devices()}"
         else:
             storage_type = ""
-        if enable_multihost_format:
-            cache_file_name = f"{cache_file_name}{storage_type}_dtype_{dtype_name}_layout_{layout_name}_{os.getenv('TT_HOST_RANK')}.bin"
-        else:
-            cache_file_name = f"{cache_file_name}{storage_type}_dtype_{dtype_name}_layout_{layout_name}.bin"
+
+        base_file_name = f"{cache_file_name}{storage_type}_dtype_{dtype_name}_layout_{layout_name}"
+        if ttnn.using_distributed_env():
+            base_file_name = f"{base_file_name}_{os.getenv('TT_HOST_RANK')}"
+        cache_file_name = f"{base_file_name}.bin"
 
         cache_path = pathlib.Path(cache_file_name)
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -711,7 +711,7 @@ def as_tensor(
 
         base_file_name = f"{cache_file_name}{storage_type}_dtype_{dtype_name}_layout_{layout_name}"
         if ttnn.using_distributed_env():
-            base_file_name = f"{base_file_name}_{os.getenv('TT_HOST_RANK')}"
+            base_file_name = f"{base_file_name}_{os.getenv('TT_MESH_HOST_RANK')}"
         cache_file_name = f"{base_file_name}.bin"
 
         cache_path = pathlib.Path(cache_file_name)


### PR DESCRIPTION
### Ticket
None

### Problem description
Previous "End-to-End Multi-Host Big-Mesh TT-NN/TT-Metal Support" was reverted because of failing 6U ring CCL tests. 

The failure was root-caused to be: **Changes exposed fabric re-initialization bug causing wrong mesh graph descriptor selection for 6U TORUS_XY configurations**

### Root Cause

There's a timing issue in the ControlPlane initialization sequence that affects 6U regression tests using Torus-XY links:

1. **Default State**: Fabric starts as FabricConfig::DISABLED by default
2. **Initialization Sequence**: When `ControlPlane::get_control_plane()` is called before `set_fabric()`, it triggers `initialize_control_plane()`. This initialization is configured based on the MeshGraph Descriptor.
3. **Wrong Descriptor Selection**: The mesh graph descriptor selection logic ends up using the default `FabricConfig::DISABLED`, which always returns `FabricType::MESH` (not `TORUS_XY`)
```
auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_type);

// get_fabric_type() only returns TORUS_XY when:
// cluster_type == GALAXY && fabric_config == FABRIC_1D_RING
// When fabric_config is DISABLED, it always returns MESH
if (cluster_type == tt::tt_metal::ClusterType::GALAXY && fabric_type == tt::tt_fabric::FabricType::TORUS_XY) {
    mesh_graph_desc_path = /* correct torus_xy_graph_descriptor.yaml */;
}
```
4. Incomplete Re-initialization: When set_fabric() is later called with the correct config, the old ControlPlane instance isn't properly invalidated


### What's changed
- Avoid changing initialization order of `MetalContext` and `ControlPlane` because it is fragile
- Resubmit all the changes in the previously submitted PR: https://github.com/tenstorrent/tt-metal/pull/25431


### Checklist
- [x] All post-commit tests (in_progress)https://github.com/tenstorrent/tt-metal/actions/runs/16983005218
- [x] (T3K) T3000 unit tests (in_progress)https://github.com/tenstorrent/tt-metal/actions/runs/16983005762
- [x] Galaxy Quick (in_progress)https://github.com/tenstorrent/tt-metal/actions/runs/16983010384
- [x] Galaxy unit tests (queued)https://github.com/tenstorrent/tt-metal/actions/runs/16983023297