### PR TITLE
#21875: Fix improper instruction in untilize uninit

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import comp_pcc, skip_for_blackhole
+from models.utility_functions import comp_pcc
 import ttnn
 
 
@@ -29,7 +29,6 @@ def generate_input_shapes():
     yield [q_len, q_heads, batch_size, K], [batch_size, kv_heads, K, seq_len]
 
 
-@skip_for_blackhole("Bad pcc on BH. Issue #21875")
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -64,7 +63,6 @@ def test_attn_matmul(num_loops, in0_dtype, in1_dtype, out_dtype, device):
             assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Bad pcc on BH P150. Issue #21875")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("num_loops", [20])
 def test_attn_matmul_fp32(num_loops, in_dtype, device):
@@ -103,7 +101,6 @@ def test_attn_matmul_fp32(num_loops, in_dtype, device):
             assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Bad pcc on BH. Issue #21875")
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -78,8 +78,9 @@ inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::u
 
     // Reset the values to default in unpack AB common.
     TT_SETADCXX(p_setadc::UNP_A, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
-    TTI_REG2FLOP(
-        1, 0, 0, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::FACE_DIM_16x16);
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+    TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
+    TTI_NOP;  // Wait for WRCFG to complete (takes 2 cycles)
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);
     cfg_reg_rmw_tensix<
         UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -87,9 +87,7 @@ void MAIN {
                 tilize_uninit_with_dt(cb_intermed2, cb_in1, out_cb_id);
 
                 pack_reconfig_data_format(out_cb_id, cb_intermed0);
-                // Workaround, needs to be reverted to the following when fix is found:
-                // mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);
-                mm_init(cb_in0, cb_in1, cb_intermed0, transpose_hw);
+                mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);
             }
         }
     }


### PR DESCRIPTION
### Ticket
 #21875, #19605, #20844
 
### Problem description
At some point in the past, tests from `tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py` started failing. 
While the investigation led to partial fixes, the real reason for tests failing was undiscovered.
However, when looking into `transformer_attn_matmul.cpp`, the issue was discovered in the function `untilize_uninit` - it calls `llk_unpack_untilize_uninit`, that uses instruction REG2FLOP, which is known to have a bug on BH.

### What's changed
Changed REG2FLOP to WRCFG, which is an alternative function to be used for BH. 
All the tests are passing for p150a.

Running the CI and testing locally on other machines at the moment.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16965259076)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16965271903)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes