### PR TITLE
Drop BH tests from PR/Merge Gates due to lack of capacity

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -163,7 +163,6 @@ jobs:
         platform: [
           "N300-viommu",
           "N300-llmbox",
-          "P150b-viommu",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -187,7 +186,6 @@ jobs:
         platform: [
           "N300-viommu",
           "N300-llmbox",
-          "P150b-viommu",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -226,7 +224,6 @@ jobs:
       matrix:
         platform: [
           "N150-viommu",
-          "P150b-viommu",
         ]
     uses: ./.github/workflows/basic.yaml
     with:
@@ -249,7 +246,6 @@ jobs:
       matrix:
         platform: [
           "N150-viommu",
-          "P150b-viommu",
         ]
     uses: ./.github/workflows/basic.yaml
     with:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -105,7 +105,6 @@ jobs:
       matrix:
         platform: [
           "N150-viommu",
-          "P150b-viommu",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -128,7 +127,6 @@ jobs:
       matrix:
         platform: [
           "N150-viommu",
-          "P150b-viommu",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Each day we're getting more and more backlogged on the BH machines in CIv2.  And GitHub gives us zero visibility to identify what jobs are causing all that load.  This severely impacts the Merge Queue and thus blocks development.

### What's changed
Drop BH from PR Gate / Merge Gate until we either find the cause of the load or get more capacity.