### PR TITLE
[skip ci] Move BH slow dispatch and cpp unit tests back to CIv1 p150b

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}
@@ -197,7 +197,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Follow-on to https://github.com/tenstorrent/tt-metal/pull/26856
Move some CIv2 p150b jobs back to CIv1 to alleviate runner backlog

### What's changed
- [ ] New/Existing tests provide coverage for changes