### PR TITLE
#26263: Implement sdxl encoding on device, also batch host encoding.

### DIFF
--- a/models/experimental/stable_diffusion_35_large/tt/linear.py
+++ b/models/experimental/stable_diffusion_35_large/tt/linear.py
@@ -34,7 +34,7 @@ class TtLinearParameters:
         else:
             bias = None
         weight = state["weight"]
-        if os.environ["MESH_DEVICE"] == "T3K":
+        if os.environ.get("MESH_DEVICE", "") == "T3K":
             hidden_dim = 2432
             hidden_dim_pad = 128
             hidden_dim_new = 2560
@@ -123,7 +123,7 @@ class TtLinearParameters:
         weight = state["weight"]
         torch_weight = weight.transpose(0, 1)
 
-        if os.environ["MESH_DEVICE"] == "T3K":
+        if os.environ.get("MESH_DEVICE", "") == "T3K":
             head_size = torch_weight.shape[1] // 3 // unpadded_num_heads
             head_padding = device.get_num_devices() - (unpadded_num_heads % device.get_num_devices())
             weight_h, weight_w = torch_weight.shape
@@ -185,7 +185,7 @@ class TtLinearParameters:
         weight = state["weight"]
         torch_weight = weight.transpose(0, 1)
 
-        if os.environ["MESH_DEVICE"] == "T3K":
+        if os.environ.get("MESH_DEVICE", "") == "T3K":
             weight_h, weight_w = torch_weight.shape
             torch_weight = torch_weight.reshape(weight_h, num_chunks, -1)
             torch_weight = torch.nn.functional.pad(

--- a/models/experimental/stable_diffusion_35_large/tt/patch_embedding.py
+++ b/models/experimental/stable_diffusion_35_large/tt/patch_embedding.py
@@ -31,7 +31,7 @@ class TtPatchEmbedParameters:
         out_channels: int,
     ) -> TtPatchEmbedParameters:
         pos_embed_param = state["pos_embed"]
-        if os.environ["MESH_DEVICE"] == "T3K":
+        if os.environ.get("MESH_DEVICE", "") == "T3K":
             pos_embed_param = torch.nn.functional.pad(
                 pos_embed_param, pad=(0, hidden_dim_padding), mode="constant", value=0
             )

--- a/models/experimental/stable_diffusion_35_large/tt/patch_embedding_conv2d.py
+++ b/models/experimental/stable_diffusion_35_large/tt/patch_embedding_conv2d.py
@@ -40,7 +40,7 @@ class TtPatchEmbeddingConv2dParameters:
         else:
             bias = None
 
-        if os.environ["MESH_DEVICE"] == "T3K":
+        if os.environ.get("MESH_DEVICE", "") == "T3K":
             weight = torch.nn.functional.pad(weight, pad=(0, hidden_dim_padding), mode="constant", value=0)
             if not bias == None:
                 bias = torch.nn.functional.pad(bias, pad=(0, hidden_dim_padding), mode="constant", value=0)

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -43,6 +43,14 @@ OUT_ROOT, RESULTS_FILE_NAME = "test_reports", "sdxl_test_results.json"
     ],
     ids=("with_trace", "no_trace"),
 )
+@pytest.mark.parametrize(
+    "encoders_on_device",
+    [
+        (True),
+        (False),
+    ],
+    ids=("device_encoders", "host_encoders"),
+)
 @pytest.mark.parametrize("captions_path", ["models/experimental/stable_diffusion_xl_base/coco_data/captions.tsv"])
 @pytest.mark.parametrize("coco_statistics_path", ["models/experimental/stable_diffusion_xl_base/coco_data/val2014.npz"])
 def test_accuracy_sdxl(
@@ -51,6 +59,7 @@ def test_accuracy_sdxl(
     num_inference_steps,
     vae_on_device,
     capture_trace,
+    encoders_on_device,
     captions_path,
     coco_statistics_path,
     evaluation_range,
@@ -71,6 +80,7 @@ def test_accuracy_sdxl(
         prompts,
         num_inference_steps,
         vae_on_device,
+        encoders_on_device,
         capture_trace,
         evaluation_range,
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy_with_reset.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy_with_reset.py
@@ -42,11 +42,20 @@ IMAGES_PATH, IMAGE_NAME_BASE = "output", "output"
     ],
     ids=("with_trace", "no_trace"),
 )
+@pytest.mark.parametrize(
+    "encoders_on_device",
+    [
+        (True),
+        (False),
+    ],
+    ids=("device_encoders", "host_encoders"),
+)
 @pytest.mark.parametrize("captions_path", ["models/experimental/stable_diffusion_xl_base/coco_data/captions.tsv"])
 @pytest.mark.parametrize("coco_statistics_path", ["models/experimental/stable_diffusion_xl_base/coco_data/val2014.npz"])
 @pytest.mark.skipif(is_6u() or IS_RING_6U_LOCAL, reason="skip when 6u, as it does not support reset")
 def test_accuracy_with_reset(
     vae_on_device,
+    encoders_on_device,
     capture_trace,
     captions_path,
     coco_statistics_path,
@@ -64,6 +73,7 @@ def test_accuracy_with_reset(
 
     vae_str = "device_vae" if vae_on_device else "host_vae"
     trace_str = "with_trace" if capture_trace else "no_trace"
+    encoders_str = "device_encoders" if encoders_on_device else "host_encoders"
 
     logger.info(
         f"Running test_accuracy_with_reset with vae_on_device={vae_on_device}, capture_trace={capture_trace}, reset_bool={reset_bool}, reset_period={reset_period}"
@@ -91,7 +101,7 @@ def test_accuracy_with_reset(
                 "--num-prompts",
                 str(current_num_prompts),
                 "-k",
-                f"{vae_str} and {trace_str}",
+                f"{vae_str} and {trace_str} and {encoders_str}",
             ]
         )
         subprocess.run(command, check=True)

--- a/tests/nightly/single_card/stable_diffusion_xl_base/test_sdxl_clip_encoders.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/test_sdxl_clip_encoders.py
@@ -1,0 +1,1 @@
+../../../../models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py


### PR DESCRIPTION
### Ticket
#26263

### Problem description
SDXL encoding has hude overhead on galaxy (~5 sec).
This PR enables device encoders by reusing SD 3.5 ones.
Encoding dime down to ~0.25 seconds in this our (DP=32) case.
Also made the host encoders work in a batched fashion, bringing the cost down to ~2.5s there as well.

SD3.5 encoders had to be modified a little:
- SD3.5 has 2 clip encoders (ClipTextModelWithProjection), and ttnn impl assumes that the projection is present always
- SDXL has one ClipTextModel (no projection), and one ClipTextModelWithProjection, so changed the implementation a little to skip projection if needed
- SD3.5 has parallelized encoders over devices, we need a DP solution, so added a few ifs to skipp all gathers and other ccls so the code can be reused

I haven't tested with negative prompt, so put an assert there for now.
Images are a little bit different then with host encoding, so left out options to run either host or device encoding
Also missing trace implementation of encoders, but not that critical atm

### Checklist
- [x] [T3K model perf](https://github.com/tenstorrent/tt-metal/actions/runs/16989841888) CI passes
- [x] [T3K frequent](https://github.com/tenstorrent/tt-metal/actions/runs/16989837056) Unreleated fails in llama vision
- [x] [T3K demo] (https://github.com/tenstorrent/tt-metal/actions/runs/16989795691) Unreleated fails in qwen, llama and mixtral
- [x] [Model frequent tests] (https://github.com/tenstorrent/tt-metal/actions/runs/17051484904) Unrelated failures
