### PR TITLE
[skip ci] Reduce timeout of custom dispatch pipeline to 2 hours

### DIFF
--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -75,7 +75,7 @@ jobs:
   test-dispatch:
     # needs: setup
     needs: build-artifact
-    timeout-minutes: 1440
+    timeout-minutes: 120
     runs-on: ${{ fromJSON(inputs.runner-label) }}
     steps:
       - name: ⬇️ Checkout


### PR DESCRIPTION
We do not want our CI runners to be running a single job on custom dispatch for a full day.
https://github.com/tenstorrent/tt-metal/actions/runs/16832697669

Reduce the timeout to 2 hours.