### PR TITLE
Remove read/write hex vec. Use write_reg for writes where wc splits are not allowed

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -148,7 +148,8 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
         EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, true);
 
         for (auto device : mesh_device_->get_devices()) {
-            llrt::write_hex_vec_to_core(device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
+            MetalContext::instance().get_cluster().write_core(
+                device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
         }
         mesh_device_->reset_sub_device_stall_group();
         for (std::size_t logical_x = 0; logical_x < output_buf->device()->num_cols(); logical_x++) {

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -461,7 +461,8 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), add_mesh_workload, false);
 
     for (auto device : mesh_device_->get_devices()) {
-        tt::llrt::write_hex_vec_to_core(device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
     }
 
     // Capture Trace
@@ -483,7 +484,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
         EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, true);
 
         for (auto device : mesh_device_->get_devices()) {
-            tt::llrt::write_hex_vec_to_core(
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                 device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
         }
         mesh_device_->reset_sub_device_stall_group();

--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -32,7 +32,7 @@ TEST_F(MeshDispatchFixture, InitializeGlobalSemaphores) {
             auto address = global_semaphore.address();
             Synchronize(device);
             for (const auto& core : cores_vec) {
-                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                auto sem_vals = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
 
                 EXPECT_EQ(sem_vals[0], initial_value);
@@ -44,7 +44,7 @@ TEST_F(MeshDispatchFixture, InitializeGlobalSemaphores) {
             auto address = global_semaphore.address();
             Synchronize(device);
             for (const auto& core : cores_vec) {
-                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                auto sem_vals = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
                 EXPECT_EQ(sem_vals[0], initial_value);
             }
@@ -77,7 +77,7 @@ TEST_F(MeshDispatchFixture, CreateMultipleGlobalSemaphoresOnSameCore) {
                 const auto& initial_value = initial_values[i];
                 const auto& cores_vec = cores_vecs[i];
                 for (const auto& core : cores_vec) {
-                    auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                    auto sem_vals = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                         device->id(),
                         device->worker_core_from_logical_core(core),
                         address,
@@ -103,15 +103,15 @@ TEST_F(MeshDispatchFixture, ResetGlobalSemaphores) {
             auto address = global_semaphore.address();
             Synchronize(device);
             for (const auto& core : cores_vec) {
-                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                auto sem_vals = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
-                tt::llrt::write_hex_vec_to_core(
+                tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                     device->id(), device->worker_core_from_logical_core(core), overwrite_value, address);
                 EXPECT_EQ(sem_vals[0], initial_value);
             }
             tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
             for (const auto& core : cores_vec) {
-                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                auto sem_vals = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
 
                 EXPECT_EQ(sem_vals[0], overwrite_value[0]);
@@ -119,9 +119,9 @@ TEST_F(MeshDispatchFixture, ResetGlobalSemaphores) {
             global_semaphore.reset_semaphore_value(reset_value);
             Synchronize(device);
             for (const auto& core : cores_vec) {
-                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                auto sem_vals = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
-                tt::llrt::write_hex_vec_to_core(
+                tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                     device->id(), device->worker_core_from_logical_core(core), overwrite_value, address);
                 EXPECT_EQ(sem_vals[0], reset_value);
             }

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -230,7 +230,8 @@ TEST_F(DeviceFixture, TestUnorderedHeightShardReadWrite) {
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
         auto input_it = input.begin();
         for (const auto& physical_core : physical_cores) {
-            auto readback = tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer->address(), page_size);
+            auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                device->id(), physical_core, buffer->address(), page_size);
             EXPECT_TRUE(std::equal(input_it, input_it + tt::constants::TILE_HW, readback.begin()));
             input_it += tt::constants::TILE_HW;
         }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -52,7 +52,8 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
         // Only force a retrain on odd-numbered eth cores
         if (eth_core.y % 2) {
             CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
-            tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, reset_val, retrain_force_addr);
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+                device->id(), virtual_core, reset_val, retrain_force_addr);
         }
     }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -407,7 +407,8 @@ void CheckHostSanitization(IDevice* device) {
     uint64_t addr = 0;
     uint32_t sz_bytes = 4;
     try {
-        llrt::read_hex_vec_from_core(device->id(), core, addr, sz_bytes);
+        [[maybe_unused]] auto data =
+            tt::tt_metal::MetalContext::instance().get_cluster().read_core(device->id(), core, addr, sz_bytes);
     } catch (std::runtime_error& e) {
         const std::string expected = fmt::format("Host watcher: bad {} NOC coord {}\n", "read", core.str());
         const std::string error = std::string(e.what());

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -158,7 +158,7 @@ void RunDelayTestOnCore(WatcherDelayFixture* fixture, IDevice* device, CoreCoord
         std::vector<uint32_t> read_vec;
 
         CoreCoord virtual_core = device->virtual_core_from_logical_core({0, 0}, CoreType::WORKER);
-        read_vec = tt::llrt::read_hex_vec_from_core(
+        read_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             device->id(),
             virtual_core,
             device->get_dev_addr(virtual_core, HalL1MemAddrType::WATCHER) +

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -112,7 +112,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     EXPECT_EQ(input_1, output_1);
     auto input_1_it = input_1.begin();
     for (const auto& physical_core : physical_cores_1) {
-        auto readback = tt::llrt::read_hex_vec_from_core(
+        auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             mesh_device->get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
         EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
         input_1_it += page_size_1 / sizeof(uint32_t);
@@ -137,7 +137,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     EXPECT_EQ(input_2, output_2);
     auto input_2_it = input_2.begin();
     for (const auto& physical_core : physical_cores_2) {
-        auto readback = tt::llrt::read_hex_vec_from_core(
+        auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             mesh_device->get_devices()[0]->id(), physical_core, buffer_3->address(), page_size_2);
         EXPECT_TRUE(std::equal(input_2_it, input_2_it + page_size_2 / sizeof(uint32_t), readback.begin()));
         input_2_it += page_size_2 / sizeof(uint32_t);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -44,7 +44,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestBasicReadL1) {
 
     for (IDevice* device : this->devices_) {
         const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-        tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, src_data, address);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(device->id(), virtual_core, src_data, address);
 
         std::vector<uint32_t> dst_data(num_elements, 0);
         dynamic_cast<HWCommandQueue&>(device->command_queue())
@@ -71,8 +71,8 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestBasicWriteL1) {
 
         Finish(device->command_queue());
 
-        const std::vector<uint32_t> dst_data =
-            tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, address, num_elements * sizeof(uint32_t));
+        const std::vector<uint32_t> dst_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            device->id(), virtual_core, address, num_elements * sizeof(uint32_t));
 
         EXPECT_EQ(src_data, dst_data);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -260,7 +260,7 @@ void test_dummy_EnqueueProgram_with_runtime_args(
     distributed::EnqueueMeshWorkload(cq, workload, false);
     Finish(cq);
 
-    vector<uint32_t> dummy_kernel0_args_readback = tt::llrt::read_hex_vec_from_core(
+    vector<uint32_t> dummy_kernel0_args_readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         device->id(),
         eth_noc_xy,
         MetalContext::instance().hal().get_dev_addr(
@@ -831,7 +831,8 @@ bool verify_rt_args(
     auto noc_xy = (core_type == HalProgrammableCoreType::ACTIVE_ETH || core_type == HalProgrammableCoreType::IDLE_ETH)
                       ? device->ethernet_core_from_logical_core(logical_core)
                       : device->worker_core_from_logical_core(logical_core);
-    std::vector<uint32_t> args_readback = tt::llrt::read_hex_vec_from_core(device->id(), noc_xy, addr, expected_rt_args.size() * sizeof(uint32_t));
+    std::vector<uint32_t> args_readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        device->id(), noc_xy, addr, expected_rt_args.size() * sizeof(uint32_t));
     log_debug(tt::LogTest, "Verifying {} {} RT args for {} (Logical: {}) at addr: 0x{:x} w/ incr_val: {}", expected_rt_args.size(), label, noc_xy, logical_core.str(), addr, incr_val);
 
     for(int i=0; i<expected_rt_args.size(); i++){

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -167,14 +167,14 @@ void test_sub_device_synchronization(distributed::MeshDevice* device) {
     EXPECT_EQ(input_1, output_1);
     auto input_1_it = input_1.begin();
     for (const auto& physical_core : physical_cores_1) {
-        auto readback = tt::llrt::read_hex_vec_from_core(
+        auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             device->get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
         EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
         input_1_it += page_size_1 / sizeof(uint32_t);
     }
     auto sem_addr = global_semaphore.address();
     auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
-    tt::llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         device->get_devices()[0]->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
 
     // Full synchronization

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -140,7 +140,7 @@ inline void verify_kernel_coordinates(
             const auto& virtual_coord = mesh_device->virtual_core_from_logical_core(logical_coord, core_type);
             CoreCoord relative_coord{logical_coord.x - sub_device_origin.x, logical_coord.y - sub_device_origin.y};
             for (const auto& device : mesh_device->get_devices()) {
-                auto read_coords_raw = tt::llrt::read_hex_vec_from_core(
+                auto read_coords_raw = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                     device->id(), virtual_coord, cb_addr, sizeof(tt::tt_metal::CoreCoordsL1));
                 auto read_coords = reinterpret_cast<volatile tt::tt_metal::CoreCoordsL1*>(read_coords_raw.data());
 

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -93,7 +93,7 @@ bool eth_direct_sender_receiver_kernels(
         dst_eth_l1_byte_address);
     // Generate inputs
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         sender_device->id(),
         sender_device->ethernet_core_from_logical_core(eth_sender_core),
         inputs,
@@ -101,7 +101,7 @@ bool eth_direct_sender_receiver_kernels(
 
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
-    llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         receiver_device->id(),
         receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
         all_zeros,
@@ -170,7 +170,7 @@ bool eth_direct_sender_receiver_kernels(
         t2.join();
     }
 
-    auto readback_vec = llrt::read_hex_vec_from_core(
+    auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         receiver_device->id(),
         receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
         dst_eth_l1_byte_address,
@@ -231,25 +231,33 @@ bool send_over_eth(
     uint32_t app_sync_info_base_addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::APP_SYNC_INFO);
     for (const auto& eth_core : eth_cores) {
-        llrt::write_hex_vec_to_core(sender_device->id(), eth_core, run_test_app_flag, fw_launch_addr);
-        llrt::write_hex_vec_to_core(receiver_device->id(), eth_core, run_test_app_flag, fw_launch_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            sender_device->id(), eth_core, run_test_app_flag, fw_launch_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            receiver_device->id(), eth_core, run_test_app_flag, fw_launch_addr);
         std::vector<uint32_t> zero = {0, 0, 0, 0, 0, 0, 0, 0};
-        llrt::write_hex_vec_to_core(sender_device->id(), eth_core, zero, app_sync_info_base_addr);
-        llrt::write_hex_vec_to_core(receiver_device->id(), eth_core, zero, app_sync_info_base_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            sender_device->id(), eth_core, zero, app_sync_info_base_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            receiver_device->id(), eth_core, zero, app_sync_info_base_addr);
     }
 
     // TODO: is it possible that receiver core app is stil running when we push inputs here???
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    llrt::write_hex_vec_to_core(sender_device->id(), sender_core, inputs, erisc_unreserved_base_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        sender_device->id(), sender_core, inputs, erisc_unreserved_base_addr);
 
     // Zero out receiving address to ensure no stale data is causing tests to pass
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
-    llrt::write_hex_vec_to_core(receiver_device->id(), receiver_core, all_zeros, erisc_unreserved_base_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        receiver_device->id(), receiver_core, all_zeros, erisc_unreserved_base_addr);
 
     std::vector<uint32_t> args_0 = {uint32_t(byte_size), 0};
-    llrt::write_hex_vec_to_core(sender_device->id(), sender_core, args_0, app_sync_info_base_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        sender_device->id(), sender_core, args_0, app_sync_info_base_addr);
     std::vector<uint32_t> args_1 = {uint32_t(byte_size), 1};
-    llrt::write_hex_vec_to_core(receiver_device->id(), receiver_core, args_1, app_sync_info_base_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        receiver_device->id(), receiver_core, args_1, app_sync_info_base_addr);
 
     // TODO: this should be updated to use kernel api
     uint32_t active_eth_index = tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
@@ -264,27 +272,33 @@ bool send_over_eth(
     const ll_api::memory& binary_mem_receive = llrt::get_risc_binary(receiver_firmware_path);
 
     for (const auto& eth_core : eth_cores) {
-        llrt::write_hex_vec_to_core(sender_device->id(), eth_core, binary_mem_send.data(), fw_base_addr);
-        llrt::write_hex_vec_to_core(receiver_device->id(), eth_core, binary_mem_receive.data(), fw_base_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            sender_device->id(), eth_core, binary_mem_send.data(), fw_base_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            receiver_device->id(), eth_core, binary_mem_receive.data(), fw_base_addr);
     }
 
     // Activate sender core runtime app
     run_test_app_flag = {0x1};
     // send remote first, otherwise eth core may be blocked, very ugly for now...
     if (receiver_device->id() == 1) {
-        llrt::write_hex_vec_to_core(1, receiver_core, run_test_app_flag, fw_launch_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            1, receiver_core, run_test_app_flag, fw_launch_addr);
     } else {
-        llrt::write_hex_vec_to_core(1, sender_core, run_test_app_flag, fw_launch_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            1, sender_core, run_test_app_flag, fw_launch_addr);
     }
     if (sender_device->id() == 0) {
-        llrt::write_hex_vec_to_core(0, sender_core, run_test_app_flag, fw_launch_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            0, sender_core, run_test_app_flag, fw_launch_addr);
     } else {
-        llrt::write_hex_vec_to_core(0, receiver_core, run_test_app_flag, fw_launch_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            0, receiver_core, run_test_app_flag, fw_launch_addr);
     }
 
     bool pass = true;
-    auto readback_vec =
-        llrt::read_hex_vec_from_core(receiver_device->id(), receiver_core, erisc_unreserved_base_addr, byte_size);
+    auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        receiver_device->id(), receiver_core, erisc_unreserved_base_addr, byte_size);
     pass &= (readback_vec == inputs);
 
     return pass;

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -257,12 +257,12 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
              (uint32_t)i,
              (uint32_t)sem_l1_byte_address});
 
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             sender_device->id(),
             sender_device->ethernet_core_from_logical_core(eth_sender_core),
             inputs[i],
             src_eth_l1_byte_address + i * byte_size_per_device);
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             sender_device->id(),
             sender_device->ethernet_core_from_logical_core(eth_sender_core),
             std::vector{INVALID},
@@ -280,12 +280,12 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
             }
         }
 
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             receiver_device->id(),
             receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
             all_zeros,
             dst_eth_l1_byte_address);
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             receiver_device->id(),
             receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
             std::vector{INVALID},
@@ -323,7 +323,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
     for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
         const auto& device = std::get<0>(sender_receivers[i]);
         const auto& core = std::get<2>(sender_receivers[i]);
-        auto readback_vec = llrt::read_hex_vec_from_core(
+        auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             device->id(),
             device->ethernet_core_from_logical_core(core),
             src_eth_l1_byte_address,
@@ -415,13 +415,13 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
              (uint32_t)cfg.num_pages,
              (uint32_t)cfg.page_size_bytes,
              (uint32_t)sem_l1_byte_address});
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device->id(),
             device->ethernet_core_from_logical_core(eth_sender_core),
             std::vector{INVALID},
             sem_l1_byte_address);
 
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device->id(),
             device->ethernet_core_from_logical_core(eth_receiver_core),
             std::vector{INVALID},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -40,7 +40,8 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
         for (const auto& buffer_addr : print_buffer_addrs) {
             std::vector<std::uint32_t> profile_buffer;
             uint32_t end_index;
-            profile_buffer = tt::llrt::read_hex_vec_from_core(device_id, worker_core, buffer_addr, DPRINT_BUFFER_SIZE);
+            profile_buffer = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                device_id, worker_core, buffer_addr, DPRINT_BUFFER_SIZE);
 
             end_index = profile_buffer[BUFFER_END_INDEX];
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -12,6 +12,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/allocator.hpp>
 
+#include "tt_metal.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 
 #include "llrt.hpp"
@@ -394,7 +395,8 @@ inline bool DeviceData::validate_one_core(
         tt::tt_metal::detail::ReadFromDeviceDRAMChannel(device, bank_id, result_addr, size_bytes, results);
     } else {
         result_addr += bank_offset;
-        results = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, result_addr, size_bytes);
+        results = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            device->id(), phys_core, result_addr, size_bytes);
     }
 
     log_info(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -541,7 +541,8 @@ int main(int argc, char** argv) {
         // Generate commands once and write them to prefetcher core.
         vector<uint32_t> cmds;
         gen_cmds(device, cmds, all_workers_g, device_data, dispatch_buffer_page_size_g);
-        llrt::write_hex_vec_to_core(device->id(), phys_spoof_prefetch_core, cmds, l1_buf_base);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            device->id(), phys_spoof_prefetch_core, cmds, l1_buf_base);
 
         const uint32_t spoof_prefetch_core_sem_0_id =
             tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, dispatch_buffer_pages);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -808,7 +808,8 @@ void gen_host_test(
         data.push_back(i);
     }
     CoreCoord phys_worker_core = device->worker_core_from_logical_core(first_worker_g);
-    llrt::write_hex_vec_to_core(device->id(), phys_worker_core, data, l1_buf_base_g);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        device->id(), phys_worker_core, data, l1_buf_base_g);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     for (int count = 1; count < 100; count++) {
@@ -1737,9 +1738,10 @@ void write_prefetcher_cmds(
 
         prefetch_q_rd_ptr_addr_data.push_back(
             prefetch_q_base + prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type));
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device->id(), phys_prefetch_core, prefetch_q_rd_ptr_addr_data, prefetch_q_rd_ptr_addr);
-        llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q, prefetch_q_base);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            device->id(), phys_prefetch_core, prefetch_q, prefetch_q_base);
 
         host_mem_ptr = (uint32_t*)host_hugepage_base;
         prefetch_q_dev_ptr = prefetch_q_base;
@@ -1876,7 +1878,8 @@ void configure_for_single_chip(
     uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
     dispatch_wait_addr_g = l1_unreserved_base_aligned + MetalContext::instance().hal().get_alignment(HalMemType::L1);
     vector<uint32_t> zero_data(0);
-    llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 
     uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type);
     uint32_t noc_read_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
@@ -1910,8 +1913,10 @@ void configure_for_single_chip(
     uint32_t completion_q_rd_ptr = MetalContext::instance()
                                        .dispatch_mem_map(DISPATCH_CORE_TYPE)
                                        .get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-    tt::llrt::write_hex_vec_to_core(device->id(), phys_dispatch_host_core, tmp, completion_q_wr_ptr);
-    tt::llrt::write_hex_vec_to_core(device->id(), phys_dispatch_host_core, tmp, completion_q_rd_ptr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        device->id(), phys_dispatch_host_core, tmp, completion_q_wr_ptr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        device->id(), phys_dispatch_host_core, tmp, completion_q_rd_ptr);
     dirty_host_completion_buffer(host_hugepage_completion_buffer);
 
     const uint32_t prefetch_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_core}, 0);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
@@ -104,12 +104,12 @@ bool RunWriteBWTest(
 
     // Initialize L1s:
     std::vector<uint32_t> zeros = std::vector<uint32_t>(32, 0);
-    llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         sender_device->id(),
         sender_device->ethernet_core_from_logical_core(eth_sender_core),
         zeros,
         src_eth_l1_byte_address);
-    llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         receiver_device->id(),
         receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
         zeros,
@@ -117,7 +117,7 @@ bool RunWriteBWTest(
 
     // Generate inputs
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, size_in_bytes / sizeof(uint32_t));
-    llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         sender_device->id(),
         sender_device->ethernet_core_from_logical_core(eth_sender_core),
         inputs,
@@ -125,7 +125,7 @@ bool RunWriteBWTest(
 
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
-    llrt::write_hex_vec_to_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         receiver_device->id(),
         receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
         all_zeros,
@@ -198,7 +198,7 @@ bool RunWriteBWTest(
     th1.join();
     std::cout << "sender done" << std::endl;
 
-    auto readback_vec = llrt::read_hex_vec_from_core(
+    auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         receiver_device->id(),
         receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
         dst_eth_l1_byte_address,

--- a/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
@@ -68,8 +68,8 @@ bool runTest(
         }
         expected |= 0x4000;
     }
-    std::vector<uint32_t> args =
-        tt::llrt::read_hex_vec_from_core(mesh_device->get_devices()[0]->id(), noc_xy, args_addr, sizeof(uint32_t));
+    std::vector<uint32_t> args = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        mesh_device->get_devices()[0]->id(), noc_xy, args_addr, sizeof(uint32_t));
     unsigned result = args[0];
     bool pass = result == expected;
     if (pass) {

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -395,7 +395,7 @@ struct mailboxes_t {
     profiler_msg_t profiler;
 };
 
-// Watcher struct needs to be 32b-divisible, since we need to write it from host using write_hex_vec_to_core().
+// Watcher struct needs to be 32b-divisible, since we need to write it from host using write_core().
 static_assert(sizeof(watcher_msg_t) % sizeof(uint32_t) == 0);
 static_assert(sizeof(kernel_config_msg_t) % sizeof(uint32_t) == 0);
 static_assert(sizeof(core_info_msg_t) % sizeof(uint32_t) == 0);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -633,7 +633,11 @@ void MetalContext::reset_cores(chip_id_t device_id) {
             // Active
             std::vector<uint32_t> clear_flag_data = {0};
             tt::llrt::write_hex_vec_to_core(
-                device_id, virtual_core, clear_flag_data, get_active_erisc_launch_flag_addr(), true);
+                device_id,
+                virtual_core,
+                clear_flag_data,
+                get_active_erisc_launch_flag_addr(),
+                llrt::HostWriteType::IMMEDIATE);
         }
     };
 
@@ -983,6 +987,8 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
     launch_msg_t launch_msg{};
     go_msg_t go_msg{};
     std::memset(&launch_msg, 0, sizeof(launch_msg_t));
+    go_msg_t go_msg;
+    go_msg.all = 0;
     go_msg.signal = RUN_MSG_INIT;
 
     // Populate core info, which will be written to device
@@ -1145,7 +1151,7 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
                     worker_core,
                     core_info_vec,
                     hal_->get_dev_addr(get_programmable_core_type(worker_core, device_id), HalL1MemAddrType::CORE_INFO),
-                    true);
+                    llrt::HostWriteType::IMMEDIATE);
                 initialize_firmware(device_id, HalProgrammableCoreType::TENSIX, worker_core, &launch_msg, &go_msg);
                 not_done_cores.insert(worker_core);
             }
@@ -1166,7 +1172,7 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             virtual_core,
             zero_vec_erisc_init,
             hal_->get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO),
-            true);
+            llrt::HostWriteType::IMMEDIATE);
     }
 
     // Load erisc app base FW to eth cores on WH and active_erisc FW on second risc of BH active eth cores
@@ -1181,7 +1187,7 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             virtual_core,
             core_info_vec,
             hal_->get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::CORE_INFO),
-            true);
+            llrt::HostWriteType::IMMEDIATE);
         initialize_firmware(device_id, HalProgrammableCoreType::ACTIVE_ETH, virtual_core, &launch_msg, &go_msg);
         if (!hal_->get_eth_fw_is_cooperative()) {
             active_eth_cores.insert(virtual_core);
@@ -1199,7 +1205,7 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             virtual_core,
             core_info_vec,
             hal_->get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::CORE_INFO),
-            true);
+            llrt::HostWriteType::IMMEDIATE);
         initialize_firmware(device_id, HalProgrammableCoreType::IDLE_ETH, virtual_core, &launch_msg, &go_msg);
         not_done_cores.insert(virtual_core);
     }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -633,7 +633,7 @@ void MetalContext::reset_cores(chip_id_t device_id) {
             // Active
             std::vector<uint32_t> clear_flag_data = {0};
             tt::llrt::write_hex_vec_to_core(
-                device_id, virtual_core, clear_flag_data, get_active_erisc_launch_flag_addr());
+                device_id, virtual_core, clear_flag_data, get_active_erisc_launch_flag_addr(), true);
         }
     };
 
@@ -1144,8 +1144,8 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
                     device_id,
                     worker_core,
                     core_info_vec,
-                    hal_->get_dev_addr(
-                        get_programmable_core_type(worker_core, device_id), HalL1MemAddrType::CORE_INFO));
+                    hal_->get_dev_addr(get_programmable_core_type(worker_core, device_id), HalL1MemAddrType::CORE_INFO),
+                    true);
                 initialize_firmware(device_id, HalProgrammableCoreType::TENSIX, worker_core, &launch_msg, &go_msg);
                 not_done_cores.insert(worker_core);
             }
@@ -1165,7 +1165,8 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             device_id,
             virtual_core,
             zero_vec_erisc_init,
-            hal_->get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO));
+            hal_->get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO),
+            true);
     }
 
     // Load erisc app base FW to eth cores on WH and active_erisc FW on second risc of BH active eth cores
@@ -1179,7 +1180,8 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             device_id,
             virtual_core,
             core_info_vec,
-            hal_->get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::CORE_INFO));
+            hal_->get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::CORE_INFO),
+            true);
         initialize_firmware(device_id, HalProgrammableCoreType::ACTIVE_ETH, virtual_core, &launch_msg, &go_msg);
         if (!hal_->get_eth_fw_is_cooperative()) {
             active_eth_cores.insert(virtual_core);
@@ -1196,7 +1198,8 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
             device_id,
             virtual_core,
             core_info_vec,
-            hal_->get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::CORE_INFO));
+            hal_->get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::CORE_INFO),
+            true);
         initialize_firmware(device_id, HalProgrammableCoreType::IDLE_ETH, virtual_core, &launch_msg, &go_msg);
         not_done_cores.insert(virtual_core);
     }

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -363,7 +363,7 @@ void WriteInitMagic(chip_id_t device_id, const CoreCoord& virtual_core, int risc
     // Force wait for first kernel launch by first writing a non-zero and waiting for a zero.
     std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
     initbuf[0] = uint32_t(enabled ? DEBUG_PRINT_SERVER_STARTING_MAGIC : DEBUG_PRINT_SERVER_DISABLED_MAGIC);
-    tt::llrt::write_hex_vec_to_core(device_id, virtual_core, initbuf, base_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(device_id, virtual_core, initbuf, base_addr);
 
     // Prevent race conditions during runtime by waiting until the init value is actually written
     // DPrint is only used for debug purposes so this delay should not be a big issue.
@@ -373,7 +373,8 @@ void WriteInitMagic(chip_id_t device_id, const CoreCoord& virtual_core, int risc
     // 4. now we will access wpos at the starting magic which is incorrect
     uint32_t num_tries = 100000;
     while (num_tries-- > 0) {
-        auto result = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, base_addr, 4);
+        auto result =
+            tt::tt_metal::MetalContext::instance().get_cluster().read_core(device_id, virtual_core, base_addr, 4);
         if (result[0] == DEBUG_PRINT_SERVER_STARTING_MAGIC && enabled) {
             return;
         } else if (result[0] == DEBUG_PRINT_SERVER_DISABLED_MAGIC && !enabled) {
@@ -391,7 +392,7 @@ bool CheckInitMagicCleared(chip_id_t device_id, const CoreCoord& virtual_core, i
     // compute the buffer address for the requested risc
     uint32_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
 
-    auto result = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, base_addr, 4);
+    auto result = tt::tt_metal::MetalContext::instance().get_cluster().read_core(device_id, virtual_core, base_addr, 4);
     return (result[0] != DEBUG_PRINT_SERVER_STARTING_MAGIC && result[0] != DEBUG_PRINT_SERVER_DISABLED_MAGIC);
 }  // CheckInitMagicCleared
 
@@ -796,7 +797,8 @@ void DPrintServer::Impl::detach_device(chip_id_t device_id) {
                     // Check if rpos < wpos, indicating unprocessed prints.
                     constexpr int eightbytes = 8;
                     uint32_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
-                    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, virtual_core, base_addr, eightbytes);
+                    auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                        chip_id, virtual_core, base_addr, eightbytes);
                     uint32_t wpos = from_dev[0], rpos = from_dev[1];
                     if (rpos < wpos) {
                         outstanding_prints = true;
@@ -944,7 +946,8 @@ bool DPrintServer::Impl::peek_one_risc_non_blocking(
     // Device is incrementing wpos
     // Host is reading wpos and incrementing local rpos up to wpos
     // Device is filling the buffer and in the end waits on host to write rpos
-    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, virtual_core, base_addr, DPRINT_BUFFER_SIZE);
+    auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        chip_id, virtual_core, base_addr, DPRINT_BUFFER_SIZE);
     DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
     uint32_t rpos = l->aux.rpos;
     uint32_t wpos = l->aux.wpos;
@@ -1173,7 +1176,8 @@ bool DPrintServer::Impl::peek_one_risc_non_blocking(
         std::vector<uint32_t> rposbuf;
         rposbuf.push_back(rpos);
         uint32_t offs = DebugPrintMemLayout().rpos_offs();
-        tt::llrt::write_hex_vec_to_core(chip_id, virtual_core, rposbuf, base_addr + offs);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            chip_id, virtual_core, rposbuf, base_addr + offs);
 
         // Return true to signal that some print data was read
         return true;

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -51,7 +51,8 @@ void DumpCoreNocData(chip_id_t device_id, const CoreDescriptor& logical_core, no
     for (int risc_id = 0; risc_id < GetNumRiscs(device_id, logical_core); risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
         uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
-        auto from_dev = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
+        auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
         DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
         uint32_t* data = reinterpret_cast<uint32_t*>(l->data);
 
@@ -113,7 +114,7 @@ void ClearNocData(chip_id_t device_id) {
         for (int risc_id = 0; risc_id < GetNumRiscs(device_id, logical_core); risc_id++) {
             uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
-            tt::llrt::write_hex_vec_to_core(device_id, virtual_core, initbuf, addr);
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(device_id, virtual_core, initbuf, addr);
         }
     }
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -187,7 +187,7 @@ WatcherDeviceReader::WatcherDeviceReader(FILE* f, chip_id_t device_id, const std
             CoreCoord virtual_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                     device_id, eth_core, CoreType::ETH);
-            read_data = tt::llrt::read_hex_vec_from_core(
+            read_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                 device_id,
                 virtual_core,
                 MetalContext::instance().hal().get_dev_addr(
@@ -208,7 +208,7 @@ WatcherDeviceReader::~WatcherDeviceReader() {
             CoreCoord virtual_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                     device_id, eth_core, CoreType::ETH);
-            read_data = tt::llrt::read_hex_vec_from_core(
+            read_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                 device_id,
                 virtual_core,
                 MetalContext::instance().hal().get_dev_addr(
@@ -360,11 +360,11 @@ void WatcherDeviceReader::Dump(FILE* file) {
                             offsetof(watcher_msg_t, pause_status);
 
             // Clear only the one flag that we saved, in case another one was raised on device
-            auto pause_data =
-                tt::llrt::read_hex_vec_from_core(device_id, virtual_core, addr, sizeof(debug_pause_msg_t));
+            auto pause_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                device_id, virtual_core, addr, sizeof(debug_pause_msg_t));
             auto pause_msg = reinterpret_cast<debug_pause_msg_t*>(&(pause_data[0]));
             pause_msg->flags[risc_id] = 0;
-            tt::llrt::write_hex_vec_to_core(device_id, virtual_core, pause_data, addr);
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(device_id, virtual_core, pause_data, addr);
         }
     }
     fflush(f);
@@ -412,7 +412,8 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
 
     constexpr uint32_t mailbox_read_size = offsetof(mailboxes_t, watcher) + sizeof(watcher_msg_t);
     std::vector<uint32_t> data;
-    data = tt::llrt::read_hex_vec_from_core(device_id, virtual_core.coord, mailbox_addr, mailbox_read_size);
+    data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        device_id, virtual_core.coord, mailbox_addr, mailbox_read_size);
     mailboxes_t* mbox_data = (mailboxes_t*)(&data[0]);
     // Get the launch message buffer read pointer.
     // For more accurate reporting of launch messages and running kernel ids, dump data from the previous valid
@@ -527,7 +528,8 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
 void WatcherDeviceReader::DumpL1Status(CoreDescriptor& core, const launch_msg_t* launch_msg) {
     // Read L1 address 0, looking for memory corruption
     std::vector<uint32_t> data;
-    data = tt::llrt::read_hex_vec_from_core(device_id, core.coord, HAL_MEM_L1_BASE, sizeof(uint32_t));
+    data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        device_id, core.coord, HAL_MEM_L1_BASE, sizeof(uint32_t));
     TT_ASSERT(core.type == CoreType::WORKER);
     uint32_t core_type_idx =
         MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
@@ -962,11 +964,13 @@ void WatcherDeviceReader::DumpSyncRegs(CoreDescriptor& core) {
         uint32_t base = NOC_OVERLAY_START_ADDR + (OPERAND_START_STREAM + operand) * NOC_STREAM_REG_SPACE_SIZE;
 
         uint32_t rcvd_addr = base + STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX * sizeof(uint32_t);
-        data = tt::llrt::read_hex_vec_from_core(device_id, core.coord, rcvd_addr, sizeof(uint32_t));
+        data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            device_id, core.coord, rcvd_addr, sizeof(uint32_t));
         uint32_t rcvd = data[0];
 
         uint32_t ackd_addr = base + STREAM_REMOTE_DEST_BUF_START_REG_INDEX * sizeof(uint32_t);
-        data = tt::llrt::read_hex_vec_from_core(device_id, core.coord, ackd_addr, sizeof(uint32_t));
+        data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            device_id, core.coord, ackd_addr, sizeof(uint32_t));
         uint32_t ackd = data[0];
 
         if (rcvd != ackd) {

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -492,7 +492,7 @@ void WatcherServer::Impl::init_device(chip_id_t device_id) {
             } else {
                 data->debug_insert_delays = debug_delays_val_zero;
             }
-            tt::llrt::write_hex_vec_to_core(
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                 device_id,
                 worker_core,
                 tt::stl::Span<const uint32_t>(watcher_init_val.data(), watcher_init_val.size()),
@@ -510,7 +510,7 @@ void WatcherServer::Impl::init_device(chip_id_t device_id) {
         } else {
             data->debug_insert_delays = debug_delays_val_zero;
         }
-        tt::llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device_id,
             virtual_core,
             watcher_init_val,

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -898,7 +898,7 @@ void writeToCoreControlBuffer(IDevice* device, const CoreCoord& virtual_core, co
                     true);
         }
     } else {
-        tt::llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device->id(), virtual_core, data, reinterpret_cast<uint64_t>(profiler_msg->control_vector));
     }
 }
@@ -992,7 +992,7 @@ void DeviceProfiler::issueSlowDispatchReadFromL1DataBuffer(
     const Hal& hal = MetalContext::instance().hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
     profiler_msg_t* profiler_msg = hal.get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    core_l1_data_buffer = tt::llrt::read_hex_vec_from_core(
+    core_l1_data_buffer = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         device_id,
         worker_core,
         reinterpret_cast<uint64_t>(profiler_msg->buffer),
@@ -1047,7 +1047,7 @@ void DeviceProfiler::readControlBufferForCore(IDevice* device, const CoreCoord& 
                     true);
         }
     } else {
-        core_control_buffers[virtual_core] = tt::llrt::read_hex_vec_from_core(
+        core_control_buffers[virtual_core] = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             device_id,
             virtual_core,
             reinterpret_cast<uint64_t>(profiler_msg->control_vector),

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -166,8 +166,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     constexpr uint32_t briscIndex = 0;
     uint64_t addr = reinterpret_cast<uint64_t>(&profiler_msg->buffer[briscIndex][kernel_profiler::CUSTOM_MARKERS]);
 
-    std::vector<std::uint32_t> sync_times =
-        tt::llrt::read_hex_vec_from_core(device_id, core, addr, (sampleCount + 1) * 2 * sizeof(uint32_t));
+    std::vector<std::uint32_t> sync_times = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        device_id, core, addr, (sampleCount + 1) * 2 * sizeof(uint32_t));
 
     uint32_t preDeviceTime = 0;
     uint32_t preHostTime = 0;
@@ -727,11 +727,12 @@ void ReadDeviceProfilerResults(
 
                 profiler_msg_t* profiler_msg = hal.get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
                 for (int i = 0; i < maxLoopCount; i++) {
-                    const std::vector<std::uint32_t> control_buffer = tt::llrt::read_hex_vec_from_core(
-                        device->id(),
-                        core,
-                        reinterpret_cast<uint64_t>(profiler_msg->control_vector),
-                        kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
+                    const std::vector<std::uint32_t> control_buffer =
+                        tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                            device->id(),
+                            core,
+                            reinterpret_cast<uint64_t>(profiler_msg->control_vector),
+                            kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
                     if (control_buffer[kernel_profiler::PROFILER_DONE] == 1) {
                         is_core_done = true;
                         break;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -983,7 +983,7 @@ void detail::ProgramImpl::init_semaphores(
     CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
     auto semaphores_on_core = this->semaphores_on_core(logical_core, core_type);
     for (auto semaphore : semaphores_on_core) {
-        llrt::write_hex_vec_to_core(
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             device.id(),
             device.virtual_core_from_logical_core(logical_core, core_type),
             std::vector{semaphore.get().initial_value()},

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -83,18 +83,6 @@ const ll_api::memory& get_risc_binary(
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
 
-void write_hex_vec_to_core(
-    chip_id_t chip,
-    const CoreCoord& core,
-    tt::stl::Span<const uint8_t> hex_vec,
-    uint64_t addr,
-    bool bypass_wc = false) {
-    // the API is named "write_core", and its overloaded variant is taking (chip, core) pair, ie. it can write to
-    // core's L1
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        hex_vec.data(), hex_vec.size(), tt_cxy_pair(chip, core), addr, bypass_wc);
-}
-
 std::vector<uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t sz_bytes) {
     std::vector<uint32_t> read_hex_vec;
     tt::tt_metal::MetalContext::instance().get_cluster().read_core(
@@ -237,7 +225,7 @@ static bool check_if_riscs_on_specified_core_done(chip_id_t chip_id, const CoreC
     auto get_mailbox_is_done = [&](uint64_t go_msg_addr) {
         constexpr int RUN_MAILBOX_BOGUS = 3;
         std::vector<uint32_t> run_mailbox_read_val = {RUN_MAILBOX_BOGUS};
-        run_mailbox_read_val = read_hex_vec_from_core(chip_id, core, go_msg_addr & ~0x3, sizeof(uint32_t));
+        run_mailbox_read_val = read_hex_vec_from_core(chip_id, core, go_msg_addr & ~0x3, sizeof(go_msg_t));
         go_msg_t* core_status = (go_msg_t*)(run_mailbox_read_val.data());
         uint8_t run = core_status->signal;
         if (run != run_state && run != RUN_MSG_DONE) {
@@ -363,19 +351,12 @@ void send_msg_to_eth_mailbox(
     wait_for_mailbox([=](uint32_t mailbox_val) { return (mailbox_val & status_mask) != call; });
 
     // Must write args first.
-    auto write_arg = [&](int index, uint32_t val) {
-        uint32_t arg_addr = hal.get_eth_fw_mailbox_arg_addr(index);
-        write_hex_vec_to_core(device_id, virtual_core, std::vector<uint32_t>{val}, arg_addr, true);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
-    };
-
     const auto max_args = hal.get_eth_fw_mailbox_arg_count();
     TT_ASSERT(args.size() <= max_args, "Too many args provided {} max args {}", args.size(), max_args);
-    // Pad remaining args to zero
     args.resize(max_args, 0);
-    for (int i = 0; i < max_args; ++i) {
-        write_arg(i, args[i]);
-    }
+    uint32_t first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(0);
+    write_hex_vec_to_core(device_id, virtual_core, args, first_arg_addr, HostWriteType::IMMEDIATE);
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
 
     const auto msg_val = hal.get_eth_fw_mailbox_val(msg_type);
     const uint32_t msg = call | msg_val;
@@ -386,7 +367,7 @@ void send_msg_to_eth_mailbox(
         virtual_core.str(),
         mailbox_addr,
         msg);
-    write_hex_vec_to_core(device_id, virtual_core, std::vector<uint32_t>{msg}, mailbox_addr, true);
+    write_hex_vec_to_core(device_id, virtual_core, std::vector<uint32_t>{msg}, mailbox_addr, HostWriteType::IMMEDIATE);
 
     // Wait for ack
     if (wait_for_ack) {

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -126,14 +126,14 @@ void send_reset_go_signal(chip_id_t chip, const CoreCoord& virtual_core) {
 
     go_msg_t reset_msg{};
     reset_msg.signal = RUN_MSG_RESET_READ_PTR_FROM_HOST;
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        &reset_msg, sizeof(go_msg_t), tt_cxy_pair(chip, virtual_core), go_signal_adrr, true);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+        &reset_msg, sizeof(go_msg_t), tt_cxy_pair(chip, virtual_core), go_signal_adrr);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(chip);
     uint32_t go_message_index_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
         dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG_INDEX);
     uint32_t zero = 0;
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        &zero, sizeof(uint32_t), tt_cxy_pair(chip, virtual_core), go_message_index_addr, true);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+        &zero, sizeof(uint32_t), tt_cxy_pair(chip, virtual_core), go_message_index_addr);
 }
 
 void write_launch_msg_to_core(chip_id_t chip, const CoreCoord core, launch_msg_t *msg, go_msg_t *go_msg,  uint64_t base_addr, bool send_go) {
@@ -144,12 +144,12 @@ void write_launch_msg_to_core(chip_id_t chip, const CoreCoord core, launch_msg_t
     // TODO: Get this from the hal. Need to modify the write_launch_msg_to_core API to get the LM and Go signal addr from the hal.
     uint64_t go_addr = base_addr + sizeof(launch_msg_t) * launch_msg_buffer_num_entries;
 
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        (void*)&msg->kernel_config, sizeof(kernel_config_msg_t), tt_cxy_pair(chip, core), launch_addr, true);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+        (void*)&msg->kernel_config, sizeof(kernel_config_msg_t), tt_cxy_pair(chip, core), launch_addr);
     tt_driver_atomics::sfence();
     if (send_go) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            go_msg, sizeof(go_msg_t), tt_cxy_pair(chip, core), go_addr, true);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+            go_msg, sizeof(go_msg_t), tt_cxy_pair(chip, core), go_addr);
     }
 }
 
@@ -185,7 +185,7 @@ bool test_load_write_read_risc_binary(
         uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
 
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), relo_addr, true);
+            &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), relo_addr);
     });
 
     log_debug(tt::LogLLRuntime, "wrote hex to core {}", core.str().c_str());

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -82,14 +82,6 @@ const ll_api::memory& get_risc_binary(
 // CoreCoord core --> NOC coordinates ("functional workers" from the SOC descriptor)
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
-
-std::vector<uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t sz_bytes) {
-    std::vector<uint32_t> read_hex_vec;
-    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        read_hex_vec, sz_bytes, tt_cxy_pair(chip, core), addr);
-    return read_hex_vec;
-}
-
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, const CoreCoord &ethernet_core) {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
         chip_id, ethernet_core);
@@ -225,7 +217,8 @@ static bool check_if_riscs_on_specified_core_done(chip_id_t chip_id, const CoreC
     auto get_mailbox_is_done = [&](uint64_t go_msg_addr) {
         constexpr int RUN_MAILBOX_BOGUS = 3;
         std::vector<uint32_t> run_mailbox_read_val = {RUN_MAILBOX_BOGUS};
-        run_mailbox_read_val = read_hex_vec_from_core(chip_id, core, go_msg_addr & ~0x3, sizeof(go_msg_t));
+        run_mailbox_read_val = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            chip_id, core, go_msg_addr & ~0x3, sizeof(go_msg_t));
         go_msg_t* core_status = (go_msg_t*)(run_mailbox_read_val.data());
         uint8_t run = core_status->signal;
         if (run != run_state && run != RUN_MSG_DONE) {
@@ -328,7 +321,8 @@ void send_msg_to_eth_mailbox(
 
         while (true) {
             tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
-            uint32_t mailbox_val = read_hex_vec_from_core(device_id, virtual_core, mailbox_addr, sizeof(uint32_t))[0];
+            uint32_t mailbox_val = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                device_id, virtual_core, mailbox_addr, sizeof(uint32_t))[0];
             log_debug(tt::LogLLRuntime, "Device {}: Eth {} Mailbox {:#x}", device_id, virtual_core.str(), mailbox_val);
 
             const auto timenow = std::chrono::high_resolution_clock::now();
@@ -355,7 +349,8 @@ void send_msg_to_eth_mailbox(
     TT_ASSERT(args.size() <= max_args, "Too many args provided {} max args {}", args.size(), max_args);
     args.resize(max_args, 0);
     uint32_t first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(0);
-    write_hex_vec_to_core(device_id, virtual_core, args, first_arg_addr, HostWriteType::IMMEDIATE);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+        device_id, virtual_core, args, first_arg_addr);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
 
     const auto msg_val = hal.get_eth_fw_mailbox_val(msg_type);
@@ -367,7 +362,8 @@ void send_msg_to_eth_mailbox(
         virtual_core.str(),
         mailbox_addr,
         msg);
-    write_hex_vec_to_core(device_id, virtual_core, std::vector<uint32_t>{msg}, mailbox_addr, HostWriteType::IMMEDIATE);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+        device_id, virtual_core, std::vector<uint32_t>{msg}, mailbox_addr);
 
     // Wait for ack
     if (wait_for_ack) {

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -70,12 +70,14 @@ const ll_api::memory& get_risc_binary(
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
 template <typename DType>
-void write_hex_vec_to_core(chip_id_t chip, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) {
+void write_hex_vec_to_core(
+    chip_id_t chip, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr, bool bypass_wc = false) {
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, bypass_wc);
 }
 template <typename DType>
-void write_hex_vec_to_core(chip_id_t chip, const CoreCoord& core, tt::stl::Span<const DType> hex_vec, uint64_t addr) {
+void write_hex_vec_to_core(
+    chip_id_t chip, const CoreCoord& core, tt::stl::Span<const DType> hex_vec, uint64_t addr, bool bypass_wc = false) {
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
 }

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -57,59 +57,12 @@ using NUM_REPETITIONS = std::uint32_t;
 using WorkerCore = tt_cxy_pair;
 using WorkerCores = std::vector<WorkerCore>;
 
-enum class HostWriteType : uint8_t {
-    // Write combining is possible. But not guaranteed.
-    COMBINED = 0,
-    // Immediate write.
-    IMMEDIATE = 1,
-};
-
 // Return a reference to a potentially shared binary image.
 // The images are cached by path name only.
 const ll_api::memory& get_risc_binary(
     std::string_view path,
     ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE,
     std::function<void(ll_api::memory&)> update_callback = nullptr);
-
-// TODO: try using "stop" method from device instead, it's the proper way of asserting reset
-
-// CoreCoord core --> NOC coordinates ("functional workers" from the SOC descriptor)
-// NOC coord is also synonymous to routing / physical coord
-// dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
-template <typename DType>
-void write_hex_vec_to_core(
-    chip_id_t chip,
-    const CoreCoord& core,
-    const std::vector<DType>& hex_vec,
-    uint64_t addr,
-    HostWriteType type = HostWriteType::COMBINED) {
-    bool bypass_wc = type == HostWriteType::IMMEDIATE;
-    if (bypass_wc) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
-            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
-    } else {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
-    }
-}
-template <typename DType>
-void write_hex_vec_to_core(
-    chip_id_t chip,
-    const CoreCoord& core,
-    tt::stl::Span<const DType> hex_vec,
-    uint64_t addr,
-    HostWriteType type = HostWriteType::COMBINED) {
-    bool bypass_wc = type == HostWriteType::IMMEDIATE;
-    if (bypass_wc) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
-            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
-    } else {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
-    }
-}
-
-std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
 
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord& ethernet_core);
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -84,8 +84,13 @@ void write_hex_vec_to_core(
     uint64_t addr,
     HostWriteType type = HostWriteType::COMBINED) {
     bool bypass_wc = type == HostWriteType::IMMEDIATE;
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, bypass_wc);
+    if (bypass_wc) {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+    } else {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+    }
 }
 template <typename DType>
 void write_hex_vec_to_core(
@@ -95,8 +100,13 @@ void write_hex_vec_to_core(
     uint64_t addr,
     HostWriteType type = HostWriteType::COMBINED) {
     bool bypass_wc = type == HostWriteType::IMMEDIATE;
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, bypass_wc);
+    if (bypass_wc) {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
+            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+    } else {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+    }
 }
 
 std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -661,8 +661,7 @@ bool Cluster::supports_dma_operations(chip_id_t chip_id, uint32_t sz_in_bytes) c
            sz_in_bytes >= min_dma_size_bytes;
 }
 
-void Cluster::write_core(
-    const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool bypass_wc) const {
+void Cluster::write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const {
     const chip_id_t chip_id = core.chip;
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
     if (rtoptions_.get_watcher_enabled()) {
@@ -678,12 +677,7 @@ void Cluster::write_core(
     }
     tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
 
-    if (bypass_wc) {
-        // Risk of duplicate or split writes from the host when WC Hugepage is used.
-        // write_to_device_reg does not use WC
-        this->driver_->write_to_device_reg(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
-    } else if (this->supports_dma_operations(chip_id, sz_in_bytes)) {
-        // log_info(tt::LogMetal, "Writing to device {} using DMA", core.chip);
+    if (this->supports_dma_operations(chip_id, sz_in_bytes)) {
         this->driver_->dma_write_to_device(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
     } else {
         this->driver_->write_to_device(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
@@ -712,10 +706,33 @@ void Cluster::read_core(void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core,
     tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
 
     if (this->supports_dma_operations(chip_id, size_in_bytes)) {
-        // log_info(tt::LogMetal, "Reading from device {} using DMA", core.chip);
         this->driver_->dma_read_from_device(mem_ptr, size_in_bytes, core.chip, core_coord, addr);
     } else {
         this->driver_->read_from_device(mem_ptr, core.chip, core_coord, addr, size_in_bytes);
+    }
+}
+
+void Cluster::write_core_immediate(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+    const chip_id_t chip_id = core.chip;
+    const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
+
+    if (rtoptions_.get_watcher_enabled()) {
+        tt::watcher_sanitize_host_noc_write(
+            soc_desc,
+            this->virtual_worker_cores_.at(chip_id),
+            this->virtual_eth_cores_.at(chip_id),
+            this->virtual_pcie_cores_.at(chip_id),
+            this->virtual_dram_cores_.at(chip_id),
+            {core.x, core.y},
+            addr,
+            sz_in_bytes);
+    }
+
+    tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
+    this->driver_->write_to_device_reg(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
+
+    if (this->cluster_desc_->is_chip_remote(chip_id)) {
+        this->driver_->wait_for_non_mmio_flush(chip_id);
     }
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -661,7 +661,8 @@ bool Cluster::supports_dma_operations(chip_id_t chip_id, uint32_t sz_in_bytes) c
            sz_in_bytes >= min_dma_size_bytes;
 }
 
-void Cluster::write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+void Cluster::write_core(
+    const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool bypass_wc) const {
     const chip_id_t chip_id = core.chip;
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
     if (rtoptions_.get_watcher_enabled()) {
@@ -677,7 +678,11 @@ void Cluster::write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair 
     }
     tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
 
-    if (this->supports_dma_operations(chip_id, sz_in_bytes)) {
+    if (bypass_wc) {
+        // Risk of duplicate or split writes from the host when WC Hugepage is used.
+        // write_to_device_reg does not use WC
+        this->driver_->write_to_device_reg(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
+    } else if (this->supports_dma_operations(chip_id, sz_in_bytes)) {
         // log_info(tt::LogMetal, "Writing to device {} using DMA", core.chip);
         this->driver_->dma_write_to_device(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
     } else {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -153,7 +153,8 @@ public:
     void read_dram_vec(void* mem_ptr, uint32_t size_in_bytes, chip_id_t device_id, int dram_view, uint64_t addr) const;
 
     // Accepts physical noc coordinates
-    void write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+    void write_core(
+        const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool bypass_wc = false) const;
     void read_core(void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
     void read_core(std::vector<uint32_t>& data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -153,8 +153,9 @@ public:
     void read_dram_vec(void* mem_ptr, uint32_t size_in_bytes, chip_id_t device_id, int dram_view, uint64_t addr) const;
 
     // Accepts physical noc coordinates
-    void write_core(
-        const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool bypass_wc = false) const;
+    void write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+    // Access physical noc coordinates without write combining effects
+    void write_core_immediate(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
     void read_core(void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
     void read_core(std::vector<uint32_t>& data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -152,12 +152,50 @@ public:
         const void* mem_ptr, uint32_t sz_in_bytes, chip_id_t device_id, int dram_view, uint64_t addr) const;
     void read_dram_vec(void* mem_ptr, uint32_t size_in_bytes, chip_id_t device_id, int dram_view, uint64_t addr) const;
 
-    // Accepts physical noc coordinates
+    // Write to core. Accepts physical noc coordinates
     void write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
-    // Access physical noc coordinates without write combining effects
+
+    // Access physical noc coordinates. Does write without effects of write combining
     void write_core_immediate(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+
+    // Write to core without effects of write combining
+    template <typename DType>
+    void write_core_immediate(
+        chip_id_t device_id, const CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
+        write_core_immediate(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
+    }
+
+    // Write to core without effects of write combining
+    template <typename DType>
+    void write_core_immediate(
+        chip_id_t device_id, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
+        write_core_immediate(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
+    }
+
+    // Write span to core
+    template <typename DType>
+    void write_core(chip_id_t device_id, const CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
+        write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
+    }
+
+    // Write vector to core
+    template <typename DType>
+    void write_core(
+        chip_id_t device_id, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
+        write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
+    }
+
     void read_core(void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+
     void read_core(std::vector<uint32_t>& data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+
+    template <typename DType = uint32_t>
+    [[nodiscard]] std::vector<DType> read_core(
+        chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size) const {
+        std::vector<DType> read_hex_vec;
+        read_core(read_hex_vec, size, tt_cxy_pair(chip, core), addr);
+        return read_hex_vec;
+    }
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair& target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -21,7 +21,7 @@ void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.
     const metal_SocDescriptor& sdesc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(chip_id);
     for (auto& worker_core : sdesc.get_cores(CoreType::TENSIX, CoordSystem::NOC0)) {
-        tt::llrt::write_hex_vec_to_core(chip_id, worker_core, mem_vec, start_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(chip_id, worker_core, mem_vec, start_addr);
     }
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25427

### Problem description
- Writes using UMD write_to_device go through a hugepage with WC enabled. Such writes may be split into multiple parts resulting in the PCIe core on the device to issue 2 NoC transactions leading to undefined behaviour is some rare cases
- Critical writes where ordering / atomics matter should use the write_reg function rather than write_to_device to bypass this write combining behaviour

### What's changed
- Removed the old read/write_hex_vec functions and replaced their usages to use tt_Cluster.
- Make init functions, Slow dispatch launch, go, mailbox functions use write_core_immediate

### Checklist
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/17028393737
BH
https://github.com/tenstorrent/tt-metal/actions/runs/17028389943
TG
https://github.com/tenstorrent/tt-metal/actions/runs/17028390865
T3K Unit
https://github.com/tenstorrent/tt-metal/actions/runs/17053161631
APC
https://github.com/tenstorrent/tt-metal/actions/runs/17104523867
