### PR TITLE
Re-enable int test for specific permute case

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -109,9 +109,7 @@ def test_permute_on_less_than_4D(device, perm, dtype):
 @pytest.mark.parametrize("s", [8])
 @pytest.mark.parametrize("h", [1500])
 @pytest.mark.parametrize("w", [64])
-# @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-# #24347: Looks like we have a non-det issue on N150 + N300
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
 def test_permute_for_specific_case(device, b, s, h, w, dtype):
     torch.manual_seed(2005)
     shape = (b, s, h, w)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24347)

### Problem description
There was a non-det issue for permute, most likely related to this transpose LLK issue: #24713, but the issue has since been fixed, so we need to reenable the permute int test.

### What's changed
reenabled test, just need all CI to pass

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16974004743) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16974001875) CI with demo tests passes (if applicable)