### PR TITLE
SD3.5 CI - create empty benchmark result if test is skipped

### DIFF
--- a/models/experimental/stable_diffusion_35_large/tests/test_performance.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_performance.py
@@ -53,6 +53,18 @@ def test_sd35_performance(
     """Performance test for SD35 pipeline with detailed timing analysis."""
 
     if galaxy_type == "4U":
+        # NOTE: Pipelines fail if a performance test is skipped without providing a benchmark output.
+        if is_ci_env:
+            profiler = BenchmarkProfiler()
+            with profiler("run", iteration=0):
+                pass
+
+            benchmark_data = BenchmarkData()
+            benchmark_data.save_partial_run_json(
+                profiler,
+                run_type="empty_run",
+                ml_model_name="empty_run",
+            )
         pytest.skip("4U is not supported for this test")
 
     # Setup parallel manager


### PR DESCRIPTION
### Problem description
TG model perf pipeline is failing since SD3.5 model perf test is (purposefully) skipped on 4U https://github.com/tenstorrent/tt-metal/actions/runs/16966146973/job/48091639762

Higher level, the problem is that the TG and Galaxy pipelines are coupled. This test was meant to run on 6U only but has to be part of a 4U pipeline, just to get skipped.

### What's changed
On 4U, the test dumps an empty profile. 

CC @subinleeTT 


### Checklist
- [x] TG model perf https://github.com/tenstorrent/tt-metal/actions/runs/16966146973/job/48091639762