### PR TITLE
Refactor fabric router builder 

### DIFF
--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -265,6 +265,35 @@ struct FabricEriscDatamoverConfig {
     // emd vcs
     std::size_t edm_noc_vc = 0;
 
+    // Stream IDs
+    // Packet send/ack/complete stream IDs
+    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
+    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
+    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;
+    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
+    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
+    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
+    static constexpr uint32_t to_sender_4_pkts_acked_id = 6;
+    static constexpr uint32_t to_sender_0_pkts_completed_id = 7;
+    static constexpr uint32_t to_sender_1_pkts_completed_id = 8;
+    static constexpr uint32_t to_sender_2_pkts_completed_id = 9;
+    static constexpr uint32_t to_sender_3_pkts_completed_id = 10;
+    static constexpr uint32_t to_sender_4_pkts_completed_id = 11;
+    // Receiver channel free slots stream IDs
+    static constexpr uint32_t receiver_channel_0_free_slots_from_east_stream_id = 12;
+    static constexpr uint32_t receiver_channel_0_free_slots_from_west_stream_id = 13;
+    static constexpr uint32_t receiver_channel_0_free_slots_from_north_stream_id = 14;
+    static constexpr uint32_t receiver_channel_0_free_slots_from_south_stream_id = 15;
+    static constexpr uint32_t receiver_channel_1_free_slots_from_downstream_stream_id = 16;
+    // Sender channel free slots stream IDs
+    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;
+    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;
+    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;
+    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;
+    static constexpr uint32_t vc1_sender_channel_free_slots_stream_id = 22;
+    // Multi-RISC teardown synchronization stream ID
+    static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
+
 private:
     void configure_buffer_slots_helper(
         Topology topology,

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -77,6 +77,123 @@ enum class FabricEriscDatamoverContextSwitchType : uint8_t {
     INTERVAL = 1,
 };
 
+/*
+Receiver channel side registers are defined here to receive free-slot credits from downstream sender channels.
+
+                                North Router
+                        ┌───────────────────────────────────┐
+                        │                                   │
+                        │  ┌────┐ ┌────┐ ┌────┐ ┌────┐      │
+                        │  │    │ │    │ │    │ │    │      │
+                        │  │    │ │    │ │    │ │    │      │
+                        │  └────┘ └────┘ └────┘ └────┘      │
+                        │  ┌────┐ ┌────┐ ┌────┐ ┌────┐      │
+                        │  │    │ │    │ │    │ │    │      │
+                        │  │    │ │    │ │    │ │    │      │
+                        │  │    │ │    │ │    │ │    │      │
+                        │  │    │ │    │ │    │ │    │      │
+                        │  └────┘ └─┬──┘ └────┘ └────┘      │
+    West Router         └───────────┼───────────────────────┘        East Router
+ ┌─────────────────────┐            │                             ┌────────────────────────────┐
+ │                     │            │                             │                            │
+ │                     │            │                             │                            │
+ │               ┌────┐│ (increment)│    Acks From East           │┌──────────────┐ ┌────┐     │
+ │   Free Slots  │    ◄┼────────────┼───────────────────┐         ││              │ │    │ E   │
+ │     East      │    ││            │                   │         ││              │ │    │     │
+ │               └────┘│            │                   │         │└──────────────┘ └────┘     │
+ │                 12  │            │                   │         │                            │
+ │               ┌────┐│            │                   │         │┌──────────────┐ ┌────┐     │
+ │   Free Slots  │    ││            │                   │         ││              │ │    │ W   │
+ │     West      │    ││            │                   └─────────┼┼              │ │    │     │
+ │               └────┘│            │                             │└──────────────┘ └────┘     │
+ │                 13  │            │                             │                            │
+ │               ┌────┐│ (increment)│                             │┌──────────────┐ ┌────┐     │
+ │   Free Slots  │    │◄────────────┘                             ││              │ │    │ N   │
+ │     North     │    ││  Acks From North                         ││              │ │    │     │
+ │               └────┘│                                          │└──────────────┘ └────┘     │
+ │                 14  │                                          │                            │
+ │               ┌────┐│  Acks From South                         │┌──────────────┐ ┌────┐     │
+ │   Free Slots  │    │◄────────────────┐                         ││              │ │    │ S   │
+ │     South     │    ││ (increment)    │                         ││              │ │    │     │
+ │               └────┘│                │                         │└──────────────┘ └────┘     │
+ │                 15  │                │                         │                            │
+ │                     │                │                         │                            │
+ │                     │                │                         │                            │
+ └─────────────────────┘  ┌─────────────┼───────────────────┐     └────────────────────────────┘
+                          │   ┌────┐ ┌──┼─┐ ┌────┐ ┌────┐   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   └────┘ └────┘ └────┘ └────┘   │
+                          │   ┌────┐ ┌────┐ ┌────┐ ┌────┐   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   │    │ │    │ │    │ │    │   │
+                          │   └────┘ └────┘ └────┘ └────┘   │
+                          │                                 │
+                          └─────────────────────────────────┘
+                                   South Router
+*/
+struct stream_reg_assignments {
+    // Packet send/ack/complete stream IDs
+    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
+    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
+    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;
+    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
+    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
+    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
+    static constexpr uint32_t to_sender_4_pkts_acked_id = 6;
+    static constexpr uint32_t to_sender_0_pkts_completed_id = 7;
+    static constexpr uint32_t to_sender_1_pkts_completed_id = 8;
+    static constexpr uint32_t to_sender_2_pkts_completed_id = 9;
+    static constexpr uint32_t to_sender_3_pkts_completed_id = 10;
+    static constexpr uint32_t to_sender_4_pkts_completed_id = 11;
+    // Receiver channel free slots stream IDs
+    static constexpr uint32_t receiver_channel_0_free_slots_from_east_stream_id = 12;
+    static constexpr uint32_t receiver_channel_0_free_slots_from_west_stream_id = 13;
+    static constexpr uint32_t receiver_channel_0_free_slots_from_north_stream_id = 14;
+    static constexpr uint32_t receiver_channel_0_free_slots_from_south_stream_id = 15;
+    static constexpr uint32_t receiver_channel_1_free_slots_from_downstream_stream_id = 16;
+    // Sender channel free slots stream IDs
+    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;
+    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;
+    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;
+    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;
+    static constexpr uint32_t vc1_sender_channel_free_slots_stream_id = 22;
+    // Multi-RISC teardown synchronization stream ID
+    static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
+
+    // Helper method to get all stream IDs as a vector
+    static std::vector<uint32_t> get_all_stream_ids() {
+        return {
+            to_receiver_0_pkts_sent_id,
+            to_receiver_1_pkts_sent_id,
+            to_sender_0_pkts_acked_id,
+            to_sender_1_pkts_acked_id,
+            to_sender_2_pkts_acked_id,
+            to_sender_3_pkts_acked_id,
+            to_sender_4_pkts_acked_id,
+            to_sender_0_pkts_completed_id,
+            to_sender_1_pkts_completed_id,
+            to_sender_2_pkts_completed_id,
+            to_sender_3_pkts_completed_id,
+            to_sender_4_pkts_completed_id,
+            receiver_channel_0_free_slots_from_east_stream_id,
+            receiver_channel_0_free_slots_from_west_stream_id,
+            receiver_channel_0_free_slots_from_north_stream_id,
+            receiver_channel_0_free_slots_from_south_stream_id,
+            receiver_channel_1_free_slots_from_downstream_stream_id,
+            sender_channel_1_free_slots_stream_id,
+            sender_channel_2_free_slots_stream_id,
+            sender_channel_3_free_slots_stream_id,
+            sender_channel_4_free_slots_stream_id,
+            vc1_sender_channel_free_slots_stream_id,
+            multi_risc_teardown_sync_stream_id};
+    }
+};
+
 struct FabricRouterBufferConfig {
     bool enable_dateline_sender_extra_buffer_slots = false;
     bool enable_dateline_receiver_extra_buffer_slots = false;
@@ -263,35 +380,6 @@ struct FabricEriscDatamoverConfig {
 
     // emd vcs
     std::size_t edm_noc_vc = 0;
-
-    // Stream IDs
-    // Packet send/ack/complete stream IDs
-    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
-    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
-    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;
-    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
-    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
-    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
-    static constexpr uint32_t to_sender_4_pkts_acked_id = 6;
-    static constexpr uint32_t to_sender_0_pkts_completed_id = 7;
-    static constexpr uint32_t to_sender_1_pkts_completed_id = 8;
-    static constexpr uint32_t to_sender_2_pkts_completed_id = 9;
-    static constexpr uint32_t to_sender_3_pkts_completed_id = 10;
-    static constexpr uint32_t to_sender_4_pkts_completed_id = 11;
-    // Receiver channel free slots stream IDs
-    static constexpr uint32_t receiver_channel_0_free_slots_from_east_stream_id = 12;
-    static constexpr uint32_t receiver_channel_0_free_slots_from_west_stream_id = 13;
-    static constexpr uint32_t receiver_channel_0_free_slots_from_north_stream_id = 14;
-    static constexpr uint32_t receiver_channel_0_free_slots_from_south_stream_id = 15;
-    static constexpr uint32_t receiver_channel_1_free_slots_from_downstream_stream_id = 16;
-    // Sender channel free slots stream IDs
-    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;
-    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;
-    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;
-    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;
-    static constexpr uint32_t vc1_sender_channel_free_slots_stream_id = 22;
-    // Multi-RISC teardown synchronization stream ID
-    static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
 
 private:
     void configure_buffer_slots_helper(

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -136,7 +136,7 @@ Receiver channel side registers are defined here to receive free-slot credits fr
                           └─────────────────────────────────┘
                                    South Router
 */
-struct stream_reg_assignments {
+struct StreamRegAssignments {
     // Packet send/ack/complete stream IDs
     static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
     static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
@@ -165,9 +165,8 @@ struct stream_reg_assignments {
     // Multi-RISC teardown synchronization stream ID
     static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
 
-    // Helper method to get all stream IDs as a vector
-    static std::vector<uint32_t> get_all_stream_ids() {
-        return {
+    static const std::array<uint32_t, 23>& get_all_stream_ids() {
+        static constexpr std::array<uint32_t, 23> stream_ids = {
             to_receiver_0_pkts_sent_id,
             to_receiver_1_pkts_sent_id,
             to_sender_0_pkts_acked_id,
@@ -191,6 +190,7 @@ struct stream_reg_assignments {
             sender_channel_4_free_slots_stream_id,
             vc1_sender_channel_free_slots_stream_id,
             multi_risc_teardown_sync_stream_id};
+        return stream_ids;
     }
 };
 

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -165,8 +165,8 @@ struct StreamRegAssignments {
     // Multi-RISC teardown synchronization stream ID
     static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
 
-    static const std::array<uint32_t, 23>& get_all_stream_ids() {
-        static constexpr std::array<uint32_t, 23> stream_ids = {
+    static const auto& get_all_stream_ids() {
+        static constexpr std::array stream_ids = {
             to_receiver_0_pkts_sent_id,
             to_receiver_1_pkts_sent_id,
             to_sender_0_pkts_acked_id,

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -403,7 +403,7 @@ public:
         const FabricEriscDatamoverConfig& config,
         eth_chan_directions direction,
         bool build_in_worker_connection_mode = false,
-        bool dateline_connection = false);
+        FabricEriscDatamoverType fabric_edm_type = FabricEriscDatamoverType::Default);
 
     static FabricEriscDatamoverBuilder build(
         tt::tt_metal::IDevice* device,
@@ -413,7 +413,7 @@ public:
         const FabricNodeId& peer_fabric_node_id,
         const FabricEriscDatamoverConfig& config,
         bool build_in_worker_connection_mode = false,
-        bool dateline_connection = false,
+        FabricEriscDatamoverType fabric_edm_type = FabricEriscDatamoverType::Default,
         eth_chan_directions direction = eth_chan_directions::EAST);
 
     static FabricEriscDatamoverBuilder build(
@@ -424,7 +424,7 @@ public:
         chip_id_t peer_physical_chip_id,
         const FabricEriscDatamoverConfig& config,
         bool build_in_worker_connection_mode = false,
-        bool dateline_connection = false,
+        FabricEriscDatamoverType fabric_edm_type = FabricEriscDatamoverType::Default,
         eth_chan_directions direction = eth_chan_directions::EAST);
 
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_worker_channel() const;
@@ -523,6 +523,7 @@ public:
     FabricEriscDatamoverContextSwitchType firmware_context_switch_type = default_firmware_context_switch_type;
     bool enable_first_level_ack = false;
     bool fuse_receiver_flush_and_completion_ptr = true;
+    FabricEriscDatamoverType fabric_edm_type = FabricEriscDatamoverType::Default;
     bool dateline_connection = false;
     bool wait_for_host_signal = false;
 };

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -61,8 +61,7 @@ enum class FabricEriscDatamoverType {
     Dateline = 1,
     DatelineUpstream = 2,
     DatelineUpstreamAdjacentDevice = 3,
-    DatelineUpstreamAdjacentDeviceUpstream = 4,
-    Invalid = 5,
+    Invalid = 4,
 };
 
 enum class FabricEriscDatamoverAxis : std::size_t {
@@ -301,8 +300,7 @@ private:
         std::array<size_t, num_sender_channels>& num_sender_buffer_slots,
         std::array<size_t, num_sender_channels>& num_remote_sender_buffer_slots,
         std::array<size_t, num_receiver_channels>& num_receiver_buffer_slots,
-        std::array<size_t, num_receiver_channels>& num_remote_receiver_buffer_slots,
-        std::array<size_t, num_downstream_sender_channels>& num_downstream_sender_buffer_slots);
+        std::array<size_t, num_receiver_channels>& num_remote_receiver_buffer_slots);
 
     FabricEriscDatamoverConfig(Topology topology = Topology::Linear);
 };

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1090,7 +1090,11 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
 
     const auto& fabric_context = control_plane.get_fabric_context();
 
-    auto ct_args = std::vector<uint32_t>{
+    const auto& stream_ids = StreamRegAssignments::get_all_stream_ids();
+    auto ct_args = std::vector<uint32_t>(stream_ids.begin(), stream_ids.end());
+    ct_args.push_back(0xFFEE0001);
+
+    const std::vector<uint32_t> main_args = {
         num_sender_channels,
         num_receiver_channels,
         config.num_fwd_paths,
@@ -1195,12 +1199,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         // Special marker to help with identifying misalignment bugs
         0x00c0ffee};
 
-    // Insert stream IDs at the beginning of ct_args
-    auto stream_ids = stream_reg_assignments::get_all_stream_ids();
-    ct_args.insert(ct_args.begin(), stream_ids.begin(), stream_ids.end());
-
-    // Insert special marker after stream IDs
-    ct_args.insert(ct_args.begin() + stream_ids.size(), 0xFFEE0001);
+    // Add main arguments to ct_args
+    ct_args.insert(ct_args.end(), main_args.begin(), main_args.end());
 
     // insert the sender channel num buffers
     // Index updated to account for 23 stream ID arguments + 1 marker at the beginning

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1091,31 +1091,6 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     const auto& fabric_context = control_plane.get_fabric_context();
 
     auto ct_args = std::vector<uint32_t>{
-        // Stream IDs
-        FabricEriscDatamoverConfig::to_receiver_0_pkts_sent_id,
-        FabricEriscDatamoverConfig::to_receiver_1_pkts_sent_id,
-        FabricEriscDatamoverConfig::to_sender_0_pkts_acked_id,
-        FabricEriscDatamoverConfig::to_sender_1_pkts_acked_id,
-        FabricEriscDatamoverConfig::to_sender_2_pkts_acked_id,
-        FabricEriscDatamoverConfig::to_sender_3_pkts_acked_id,
-        FabricEriscDatamoverConfig::to_sender_4_pkts_acked_id,
-        FabricEriscDatamoverConfig::to_sender_0_pkts_completed_id,
-        FabricEriscDatamoverConfig::to_sender_1_pkts_completed_id,
-        FabricEriscDatamoverConfig::to_sender_2_pkts_completed_id,
-        FabricEriscDatamoverConfig::to_sender_3_pkts_completed_id,
-        FabricEriscDatamoverConfig::to_sender_4_pkts_completed_id,
-        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_east_stream_id,
-        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_west_stream_id,
-        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_north_stream_id,
-        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_south_stream_id,
-        FabricEriscDatamoverConfig::receiver_channel_1_free_slots_from_downstream_stream_id,
-        FabricEriscDatamoverConfig::sender_channel_1_free_slots_stream_id,
-        FabricEriscDatamoverConfig::sender_channel_2_free_slots_stream_id,
-        FabricEriscDatamoverConfig::sender_channel_3_free_slots_stream_id,
-        FabricEriscDatamoverConfig::sender_channel_4_free_slots_stream_id,
-        FabricEriscDatamoverConfig::vc1_sender_channel_free_slots_stream_id,
-        FabricEriscDatamoverConfig::multi_risc_teardown_sync_stream_id,
-
         num_sender_channels,
         num_receiver_channels,
         config.num_fwd_paths,
@@ -1220,9 +1195,16 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         // Special marker to help with identifying misalignment bugs
         0x00c0ffee};
 
+    // Insert stream IDs at the beginning of ct_args
+    auto stream_ids = stream_reg_assignments::get_all_stream_ids();
+    ct_args.insert(ct_args.begin(), stream_ids.begin(), stream_ids.end());
+
+    // Insert special marker after stream IDs
+    ct_args.insert(ct_args.begin() + stream_ids.size(), 0xFFEE0001);
+
     // insert the sender channel num buffers
-    // Index updated to account for 23 stream ID arguments at the beginning
-    const size_t sender_channel_num_buffers_idx = 36;  // 13 + 23
+    // Index updated to account for 23 stream ID arguments + 1 marker at the beginning
+    const size_t sender_channel_num_buffers_idx = 37;  // 13 + 23 + 1
     ct_args.insert(
         ct_args.begin() + sender_channel_num_buffers_idx,
         this->sender_channels_num_buffers.begin(),

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1002,7 +1002,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     const FabricEriscDatamoverConfig& config,
     eth_chan_directions direction,
     bool build_in_worker_connection_mode,
-    bool dateline_connection) :
+    FabricEriscDatamoverType fabric_edm_type) :
     my_eth_core_logical(my_eth_core_logical),
     my_eth_channel(my_eth_core_logical.y),
     my_noc_x(my_noc_x),
@@ -1038,7 +1038,8 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     edm_local_sync_ptr(config.edm_local_sync_address),
     edm_status_ptr(config.edm_status_address),
     build_in_worker_connection_mode(build_in_worker_connection_mode),
-    dateline_connection(dateline_connection) {
+    fabric_edm_type(fabric_edm_type),
+    dateline_connection(fabric_edm_type == tt::tt_fabric::FabricEriscDatamoverType::Dateline) {
     std::fill(
         sender_channel_connection_liveness_check_disable_array.begin(),
         sender_channel_connection_liveness_check_disable_array.end(),
@@ -1396,7 +1397,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     chip_id_t peer_physical_chip_id,
     const FabricEriscDatamoverConfig& config,
     bool build_in_worker_connection_mode,
-    bool dateline_connection,
+    FabricEriscDatamoverType fabric_edm_type,
     eth_chan_directions direction) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     return FabricEriscDatamoverBuilder::build(
@@ -1407,8 +1408,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         control_plane.get_fabric_node_id_from_physical_chip_id(peer_physical_chip_id),
         config,
         build_in_worker_connection_mode,
-        dateline_connection,
-        direction);
+        fabric_edm_type);
 }
 
 FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
@@ -1419,7 +1419,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     const FabricNodeId& peer_fabric_node_id,
     const FabricEriscDatamoverConfig& config,
     bool build_in_worker_connection_mode,
-    bool dateline_connection,
+    FabricEriscDatamoverType fabric_edm_type,
     eth_chan_directions direction) {
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_buffer_index_semaphore_id;
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_flow_control_semaphore_id;
@@ -1486,7 +1486,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         config,
         direction,
         build_in_worker_connection_mode,
-        dateline_connection);
+        fabric_edm_type);
 }
 
 SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_worker_channel() const {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1564,6 +1564,8 @@ void FabricEriscDatamoverBuilder::connect_to_downstream_edm(FabricEriscDatamover
     this->downstream_edm_vcs_semaphore_address[1] = adapter_spec.edm_l1_sem_addr;
     this->downstream_edm_vcs_worker_registration_address[1] = adapter_spec.edm_connection_handshake_addr;
     this->downstream_edm_vcs_worker_location_info_address[1] = adapter_spec.edm_worker_location_info_addr;
+    // all downstream buffer slots are equal currently
+    this->downstream_sender_channels_num_buffers.fill(adapter_spec.num_buffers_per_channel);
 
     // VC 1
     if (!fabric_context.need_deadlock_avoidance_support(this->direction)) {
@@ -1606,9 +1608,6 @@ void FabricEriscDatamoverBuilder::connect_to_downstream_edm(FabricEriscDatamover
     if (!is_2D_routing) {
         this->downstream_vcs_sender_channel_buffer_index_semaphore_id[2] = adapter_spec.buffer_index_semaphore_id;
     }
-
-    // all downstream buffer slots are equal currently
-    this->downstream_sender_channels_num_buffers.fill(adapter_spec.num_buffers_per_channel);
 }
 
 eth_chan_directions FabricEriscDatamoverBuilder::get_direction() const { return this->direction; }

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -690,8 +690,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
     log_trace(
         tt::LogOp,
-        "is_dateline {} is_dateline_upstream {} is_dateline_upstream_adj_dev {} "
-        "{}",
+        "is_dateline {} is_dateline_upstream {} is_dateline_upstream_adj_dev {}",
         is_dateline,
         is_dateline_upstream,
         is_dateline_upstream_adj_dev);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -547,7 +547,6 @@ void FabricEriscDatamoverConfig::configure_buffer_slots_helper(
         num_remote_sender_buffer_slots.fill(default_num_sender_buffer_slots);
         num_receiver_buffer_slots.fill(default_num_receiver_buffer_slots);
         num_remote_receiver_buffer_slots.fill(default_num_receiver_buffer_slots);
-        num_downstream_sender_buffer_slots.fill(default_num_sender_buffer_slots);
 
         auto buffer_config = options.edm_buffer_config;
         if (options.edm_type == FabricEriscDatamoverType::Dateline) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1117,6 +1117,31 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     const auto& fabric_context = control_plane.get_fabric_context();
 
     auto ct_args = std::vector<uint32_t>{
+        // Stream IDs
+        FabricEriscDatamoverConfig::to_receiver_0_pkts_sent_id,
+        FabricEriscDatamoverConfig::to_receiver_1_pkts_sent_id,
+        FabricEriscDatamoverConfig::to_sender_0_pkts_acked_id,
+        FabricEriscDatamoverConfig::to_sender_1_pkts_acked_id,
+        FabricEriscDatamoverConfig::to_sender_2_pkts_acked_id,
+        FabricEriscDatamoverConfig::to_sender_3_pkts_acked_id,
+        FabricEriscDatamoverConfig::to_sender_4_pkts_acked_id,
+        FabricEriscDatamoverConfig::to_sender_0_pkts_completed_id,
+        FabricEriscDatamoverConfig::to_sender_1_pkts_completed_id,
+        FabricEriscDatamoverConfig::to_sender_2_pkts_completed_id,
+        FabricEriscDatamoverConfig::to_sender_3_pkts_completed_id,
+        FabricEriscDatamoverConfig::to_sender_4_pkts_completed_id,
+        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_east_stream_id,
+        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_west_stream_id,
+        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_north_stream_id,
+        FabricEriscDatamoverConfig::receiver_channel_0_free_slots_from_south_stream_id,
+        FabricEriscDatamoverConfig::receiver_channel_1_free_slots_from_downstream_stream_id,
+        FabricEriscDatamoverConfig::sender_channel_1_free_slots_stream_id,
+        FabricEriscDatamoverConfig::sender_channel_2_free_slots_stream_id,
+        FabricEriscDatamoverConfig::sender_channel_3_free_slots_stream_id,
+        FabricEriscDatamoverConfig::sender_channel_4_free_slots_stream_id,
+        FabricEriscDatamoverConfig::vc1_sender_channel_free_slots_stream_id,
+        FabricEriscDatamoverConfig::multi_risc_teardown_sync_stream_id,
+
         num_sender_channels,
         num_receiver_channels,
         config.num_fwd_paths,
@@ -1222,7 +1247,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         0x00c0ffee};
 
     // insert the sender channel num buffers
-    const size_t sender_channel_num_buffers_idx = 13;
+    // Index updated to account for 23 stream ID arguments at the beginning
+    const size_t sender_channel_num_buffers_idx = 36;  // 13 + 23
     ct_args.insert(
         ct_args.begin() + sender_channel_num_buffers_idx,
         this->sender_channels_num_buffers.begin(),

--- a/tt_metal/fabric/erisc_datamover_builder_helper.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder_helper.cpp
@@ -197,7 +197,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                         dest_device->id(),
                         src_curr_edm_config,
                         build_in_worker_connection_mode,
-                        dateline));
+                        src_device_edm_type));
 
                 log_trace(
                     tt::LogOp,
@@ -213,7 +213,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                         src_device->id(),
                         dest_curr_edm_config,
                         build_in_worker_connection_mode,
-                        dateline));
+                        dest_device_edm_type));
             }
         };
 

--- a/tt_metal/fabric/erisc_datamover_builder_helper.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder_helper.cpp
@@ -135,20 +135,6 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                     dest_device->id() == device_sequence.back()->id()) {
                     src_device_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDevice;
                     dest_device_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstream;
-                } else if (
-                    src_device->id() == device_sequence.at(1)->id() &&
-                    dest_device->id() != device_sequence.front()->id()) {
-                    src_device_edm_type =
-                        tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream;
-                    if (dest_device->id() == device_sequence.at(device_sequence.size() - 2)->id()) {
-                        dest_device_edm_type =
-                            tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream;
-                    }
-                } else if (
-                    src_device->id() == device_sequence.at(device_sequence.size() - 3)->id() &&
-                    dest_device->id() == device_sequence.at(device_sequence.size() - 2)->id()) {
-                    dest_device_edm_type =
-                        tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream;
                 }
             }
 

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -155,14 +155,6 @@ FabricContext::FabricContext(tt::tt_fabric::FabricConfig fabric_config) {
         tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDevice,
         tt::tt_fabric::FabricEriscDatamoverAxis::Long);
 
-    // dateline upstream adjacent upstream edm router
-    this->dateline_upstream_adjcent_upstream_router_config_[short_axis] = get_edm_config_options(
-        tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream,
-        tt::tt_fabric::FabricEriscDatamoverAxis::Short);
-    this->dateline_upstream_adjcent_upstream_router_config_[long_axis] = get_edm_config_options(
-        tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream,
-        tt::tt_fabric::FabricEriscDatamoverAxis::Long);
-
     // Tensix config will be initialized later after routing tables are configured
     tensix_config_ = nullptr;
 
@@ -245,12 +237,6 @@ tt::tt_fabric::FabricEriscDatamoverConfig& FabricContext::get_fabric_router_conf
                 this->dateline_upstream_adjcent_router_config_[axis_index] != nullptr,
                 "Error, fabric dateline upstream adjacent device router config is uninitialized");
             return *this->dateline_upstream_adjcent_router_config_[axis_index].get();
-            break;
-        case tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream:
-            TT_FATAL(
-                this->dateline_upstream_adjcent_upstream_router_config_[axis_index] != nullptr,
-                "Error, fabric dateline upstream adjacent device upstream router config is uninitialized");
-            return *this->dateline_upstream_adjcent_upstream_router_config_[axis_index].get();
             break;
         default: TT_FATAL(false, "Error, invalid fabric edm type");
     }

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -91,8 +91,6 @@ private:
     std::array<std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig>, 2> dateline_upstream_router_config_ = {};
     std::array<std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig>, 2> dateline_upstream_adjcent_router_config_ =
         {};
-    std::array<std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig>, 2>
-        dateline_upstream_adjcent_upstream_router_config_ = {};
 
     // Tensix config for fabric mux configuration (same for all devices)
     std::unique_ptr<tt::tt_fabric::FabricTensixDatamoverConfig> tensix_config_;

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -18,32 +18,6 @@
 
 constexpr uint32_t DEFAULT_ETH_TXQ = 0;
 
-// STREAM REGISTER ASSIGNMENT
-// senders update this stream
-constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
-// senders update this stream
-constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_0_pkts_acked_id = 2;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_1_pkts_acked_id = 3;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_2_pkts_acked_id = 4;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_3_pkts_acked_id = 5;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_4_pkts_acked_id = 6;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_0_pkts_completed_id = 7;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_1_pkts_completed_id = 8;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_2_pkts_completed_id = 9;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_3_pkts_completed_id = 10;
-// receivers updates the reg on this stream
-constexpr uint32_t to_sender_4_pkts_completed_id = 11;
-
 /*
 Receiver channel side registers are defined here to receive free-slot credits from downstream sender channels.
 
@@ -104,34 +78,6 @@ Receiver channel side registers are defined here to receive free-slot credits fr
                                    South Router
 */
 constexpr size_t NUM_ROUTER_CARDINAL_DIRECTIONS = 4;
-constexpr uint32_t receiver_channel_0_free_slots_from_east_stream_id = 12;
-constexpr uint32_t receiver_channel_0_free_slots_from_west_stream_id = 13;
-constexpr uint32_t receiver_channel_0_free_slots_from_north_stream_id = 14;
-constexpr uint32_t receiver_channel_0_free_slots_from_south_stream_id = 15;
-
-// For post-dateline connection. We only have one counter here because if we are
-// post-dateline, there is only one other possible post-dateline consumer that we
-// can forward to (the consumer in the same direction). Switching directions/turning
-// requires directing back to pre-dateline consumer channels (in those cases, we'd
-// use the receiver_channel_0_free_slots_* location). For the time being, this is
-// placeholder until 2D torus is implemented
-constexpr uint32_t receiver_channel_1_free_slots_from_downstream_stream_id = 16;
-
-// These are the
-// Slot 17 is defined in the edm_fabric_worker_adapter
-constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;
-constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;
-constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;
-constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;
-constexpr uint32_t vc1_sender_channel_free_slots_stream_id = 22;
-
-// For multi-RISC router implementations, the two risc cores must coordinate
-// on the teardown process.
-// The teardown process is as follows:
-// Every RISC core must increment this counter when it is ready to teardown.
-// each waits for the counter to reach the active RISC core count before proceeding
-// One of the RISC cores is designated as the master to complete the teardown (RISC0)
-constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = 31;
 
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;
 constexpr size_t MAX_NUM_SENDER_CHANNELS = 5;
@@ -139,7 +85,40 @@ constexpr size_t MAX_NUM_SENDER_CHANNELS = 5;
 // Compile Time args
 
 constexpr bool SPECIAL_MARKER_CHECK_ENABLED = true;
-constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = 0;
+
+// Stream IDs from compile time arguments (first 23 arguments)
+constexpr size_t STREAM_ID_ARGS_START_IDX = 0;
+constexpr uint32_t to_receiver_0_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 0);
+constexpr uint32_t to_receiver_1_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 1);
+constexpr uint32_t to_sender_0_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 2);
+constexpr uint32_t to_sender_1_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 3);
+constexpr uint32_t to_sender_2_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 4);
+constexpr uint32_t to_sender_3_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 5);
+constexpr uint32_t to_sender_4_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 6);
+constexpr uint32_t to_sender_0_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 7);
+constexpr uint32_t to_sender_1_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 8);
+constexpr uint32_t to_sender_2_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 9);
+constexpr uint32_t to_sender_3_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);
+constexpr uint32_t to_sender_4_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);
+constexpr uint32_t receiver_channel_0_free_slots_from_east_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);
+constexpr uint32_t receiver_channel_0_free_slots_from_west_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
+constexpr uint32_t receiver_channel_0_free_slots_from_north_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 14);
+constexpr uint32_t receiver_channel_0_free_slots_from_south_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 15);
+constexpr uint32_t receiver_channel_1_free_slots_from_downstream_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);
+constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);
+constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 18);
+constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
+constexpr uint32_t sender_channel_4_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
+constexpr uint32_t vc1_sender_channel_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
+constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 22);
+
+// Main configuration arguments (after stream IDs)
+constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = STREAM_ID_ARGS_START_IDX + 23;
 constexpr size_t NUM_SENDER_CHANNELS = get_compile_time_arg_val(SENDER_CHANNEL_NOC_CONFIG_START_IDX);
 constexpr size_t NUM_RECEIVER_CHANNELS_CT_ARG_IDX = SENDER_CHANNEL_NOC_CONFIG_START_IDX + 1;
 constexpr size_t NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(NUM_RECEIVER_CHANNELS_CT_ARG_IDX);
@@ -158,11 +137,11 @@ static_assert(
 static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
-static_assert(wait_for_host_signal_IDX == 3, "wait_for_host_signal_IDX must be 3");
+static_assert(wait_for_host_signal_IDX == 26, "wait_for_host_signal_IDX must be 26 (23 stream IDs + 3 config args)");
 static_assert(
     get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
     "wait_for_host_signal must be 0 or 1");
-static_assert(MAIN_CT_ARGS_START_IDX == 4, "MAIN_CT_ARGS_START_IDX must be 4");
+static_assert(MAIN_CT_ARGS_START_IDX == 27, "MAIN_CT_ARGS_START_IDX must be 27 (23 stream IDs + 4 config args)");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -863,8 +863,6 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
             fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstream;
         } else if ((chip1 == 0 || chip1 == mesh_num_columns) && chip0 == chip1 + 1) {
             fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDevice;
-        } else if ((chip0 == 1 || chip0 == mesh_num_columns + 1) && (chip1 == chip0 + 1)) {
-            fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream;
         }
         // check if edm is on the longer axis
         if ((mesh_num_rows * mesh_num_columns) >=
@@ -922,14 +920,6 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
         // Row dateline upstream adjacent
         else if (is_dateline_upstream_adjacent_edm_along_row) {
             fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDevice;
-        }
-        // Column dateline upstream adjacent device upstream
-        else if (is_dateline_upstream_adjacent_upstream_edm_along_column) {
-            fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream;
-        }
-        // Row dateline upstream adjacent device upstream
-        else if (is_dateline_upstream_adjacent_upstream_edm_along_row) {
-            fabric_edm_type = tt::tt_fabric::FabricEriscDatamoverType::DatelineUpstreamAdjacentDeviceUpstream;
         }
 
         // check if edm is on the longer axis

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -828,7 +828,8 @@ void configure_dispatch_cores(IDevice* device) {
 std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDatamoverAxis> get_fabric_edm_type(
     const tt::tt_fabric::ControlPlane& control_plane,
     const tt::tt_fabric::RoutingDirection direction,
-    tt::tt_fabric::MeshId mesh_id,
+    tt::tt_fabric::MeshId mesh_id0,
+    tt::tt_fabric::MeshId mesh_id1,
     chip_id_t chip0,
     chip_id_t chip1,
     bool wrap_around_mesh) {
@@ -838,11 +839,11 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
     const auto& fabric_context = control_plane.get_fabric_context();
 
     const auto eth_chan_direction = control_plane.routing_direction_to_eth_direction(direction);
-    if (!fabric_context.need_deadlock_avoidance_support(eth_chan_direction)) {
+    if (mesh_id0 != mesh_id1 || !fabric_context.need_deadlock_avoidance_support(eth_chan_direction)) {
         return {fabric_edm_type, fabric_edm_axis};
     }
 
-    auto physical_mesh_shape = control_plane.get_physical_mesh_shape(mesh_id);
+    auto physical_mesh_shape = control_plane.get_physical_mesh_shape(mesh_id0);
     TT_FATAL(physical_mesh_shape.dims() == 2, "Dateline routing only supported for 2D mesh");
 
     auto mesh_num_rows = physical_mesh_shape[0];
@@ -851,7 +852,7 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
     auto smaller_chip_id = std::min(chip0, chip1);
     auto larger_chip_id = std::max(chip0, chip1);
 
-    // Refactor this once mesh_id has row/col control
+    // Refactor this once mesh_id0 has row/col control
     // wrap_around_mesh is used to fold the edm connections on the corner chips of a 2D mesh to form an outer ring of
     // devices on the mesh.
     if (wrap_around_mesh) {
@@ -991,8 +992,8 @@ void build_tt_fabric_program(
                 fabric_node_id,
                 FabricNodeId{fabric_node_id.mesh_id, fabric_node_id.chip_id + 1},
                 edm_config,
-                false, /* build_in_worker_connection_mode */
-                false, /* is_dateline */
+                false,                                            /* build_in_worker_connection_mode */
+                tt::tt_fabric::FabricEriscDatamoverType::Default, /* fabric_edm_type */
                 eth_direction);
             // Both links used by dispatch on TG Gateway (mmio device)
             // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
@@ -1074,12 +1075,10 @@ void build_tt_fabric_program(
             control_plane,
             direction,
             fabric_node_id.mesh_id,
+            remote_fabric_node_id.mesh_id,
             fabric_node_id.chip_id,
             remote_fabric_node_id.chip_id,
             wrap_around_mesh);
-
-        bool is_dateline = remote_fabric_node_id.mesh_id == fabric_node_id.mesh_id &&
-                           fabric_edm_type == tt::tt_fabric::FabricEriscDatamoverType::Dateline;
 
         const auto& curr_edm_config = fabric_context.get_fabric_router_config(fabric_edm_type, fabric_edm_axis);
 
@@ -1099,7 +1098,7 @@ void build_tt_fabric_program(
                 remote_fabric_node_id,
                 curr_edm_config,
                 false, /* build_in_worker_connection_mode */
-                is_dateline,
+                fabric_edm_type,
                 control_plane.routing_direction_to_eth_direction(direction));
             edm_builders.insert({eth_chan, edm_builder});
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26792

### Problem description
As part of the prerequisites for enabling mux integration into fabric build flow, we need to move the stream id constant outside of device code, and make it visible to fabric builder and fabric tensix builder.
We also need to setup the downstream buffer slots properly from the downstream edm builder, not from the fabric config, also part of prerequisite for mux integration 
 
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes