### PR TITLE
NoC tracing fixes:

### DIFF
--- a/tt_metal/hw/inc/accessor/tensor_accessor.h
+++ b/tt_metal/hw/inc/accessor/tensor_accessor.h
@@ -49,6 +49,7 @@ uint64_t get_dram_bank_base_offset(uint32_t bank_id, uint8_t noc) {
 template <typename _DSpec>
 struct TensorAccessor {
     using DSpec = _DSpec;
+    static constexpr bool is_dram = DSpec::is_dram;
 
 private:
     // DSpec can be static or dynamic, so we use a conditional instance

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -266,6 +266,7 @@ std::uint64_t get_noc_addr(std::uint32_t addr, uint8_t noc = noc_index) {
 
 template <bool DRAM>
 struct InterleavedAddrGen {
+    static constexpr bool is_dram = DRAM;
     uint32_t bank_base_address;  // Base address for the whole tensor.
     const uint32_t page_size;    // Num bytes in page.
     const uint32_t aligned_page_size =
@@ -295,6 +296,7 @@ struct InterleavedAddrGen {
 
 template <bool DRAM>
 struct InterleavedPow2AddrGen {
+    static constexpr bool is_dram = DRAM;
     const uint32_t bank_base_address;
     const uint32_t log_base_2_of_page_size;  // WARNING: This struct is used for optimized get_noc_addr in which case
                                              // you know that bank_unit_size is a power of 2
@@ -328,6 +330,7 @@ struct InterleavedPow2AddrGen {
 
 template <bool DRAM, uint32_t tile_hw = 1024>
 struct InterleavedAddrGenFast {
+    static constexpr bool is_dram = DRAM;
     uint32_t bank_base_address;  // Base address for the whole tensor.
     // TODO: Remove page_size from argument list. This can be derived from data_format
     uint32_t page_size;      // Num bytes in bank unit.
@@ -358,6 +361,7 @@ struct InterleavedAddrGenFast {
 // TODO: need static assert + host assert that page size <= 8192, hard constraint
 template <bool DRAM>
 struct InterleavedPow2AddrGenFast {
+    static constexpr bool is_dram = DRAM;
     uint32_t bank_base_address;              // Base address for the whole tensor.
     const uint32_t log_base_2_of_page_size;  // Num bytes in bank unit.
     static constexpr uint32_t log_base_2_of_allocator_alignment =

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -657,7 +657,7 @@ __attribute__((noinline)) void trace_init() {
 
 // null macros when noc tracing is disabled
 #define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)
-#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, num_bytes, vc)
 #define RECORD_NOC_EVENT(type)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 


### PR DESCRIPTION
- Fix decode_noc_coord_reg_to_coord for dram cores on wormhole. Dram cores on
  wormhole are not virtualized so their coordinates should be treated
  appropriately as either NOC0 or NOC1 coordinates
- prevent duplicate NOC tracing calls in dataflow_api.h with an
  enable_noc_tracing flag

### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/26422

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16980199637
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16980203553
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes