### PR TITLE
concat-tilize issue leading to GPT-OSS P00

### DIFF
--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -13,7 +13,7 @@ from models.utility_functions import is_wormhole_b0
     (
         (True, 128, {"prefill_t/s": 1720, "decode_t/s": 549, "decode_t/s/u": 17.16}, False, None),
         (True, 1024, {"prefill_t/s": 2300, "decode_t/s": 487, "decode_t/s/u": 15.24}, False, None),
-        (True, 2048, {"prefill_t/s": 2277, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
+        (True, 2048, {"prefill_t/s": 2163, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -13,7 +13,7 @@ from models.utility_functions import is_wormhole_b0
     (
         (True, 128, {"prefill_t/s": 1720, "decode_t/s": 549, "decode_t/s/u": 17.16}, False, None),
         (True, 1024, {"prefill_t/s": 2300, "decode_t/s": 487, "decode_t/s/u": 15.24}, False, None),
-        (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
+        (True, 2048, {"prefill_t/s": 2277, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -123,20 +123,10 @@ MassagedConcat build_untilize_rm_retilize_concat(
             return std::make_tuple(itensors, dim, groups);
         },
         .post_transform = [&logical_output_shape, queue_id](const ttnn::Tensor& output) -> ttnn::Tensor {
-            // now we have a rm tensor, so we need ensure its's padded to tile size and re-tilize it
+            // now we have a rm tensor, so we need to re-tilize it
             if (output.layout() != ttnn::TILE_LAYOUT) {
                 return ttnn::tilize_with_val_padding(
                     output, compute_padded_shape(output.padded_shape()), 0.0f, output.memory_config());
-
-                //                 auto padded = pad_to_tile_vol(queue_id, output, 0.0f, true, output.memory_config());
-                //                 concat_db_print(true, "[DEBUG] padded to tile layout, now tilizing.");
-                //                 auto tilized =
-                //                     ttnn::tilize_with_val_padding(padded, padded.padded_shape(), 0.0f,
-                //                     output.memory_config());
-                //                 concat_db_print(true, "[DEBUG] tilized");
-                //                 // need to reshape tilized result to logical concat output shape
-                //                 auto reshaped = ttnn::reshape(tilized, logical_output_shape, tilized.padded_shape());
-                //                 return reshaped;
             }
             concat_db_print(true, "[DEBUG] already tilized");
             return output;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -125,14 +125,18 @@ MassagedConcat build_untilize_rm_retilize_concat(
         .post_transform = [&logical_output_shape, queue_id](const ttnn::Tensor& output) -> ttnn::Tensor {
             // now we have a rm tensor, so we need ensure its's padded to tile size and re-tilize it
             if (output.layout() != ttnn::TILE_LAYOUT) {
-                auto padded = pad_to_tile_vol(queue_id, output, 0.0f, true, output.memory_config());
-                concat_db_print(true, "[DEBUG] padded to tile layout, now tilizing.");
-                auto tilized =
-                    ttnn::tilize_with_val_padding(padded, padded.padded_shape(), 0.0f, output.memory_config());
-                concat_db_print(true, "[DEBUG] tilized");
-                // need to reshape tilized result to logical concat output shape
-                auto reshaped = ttnn::reshape(tilized, logical_output_shape, tilized.padded_shape());
-                return reshaped;
+                return ttnn::tilize_with_val_padding(
+                    output, compute_padded_shape(output.padded_shape()), 0.0f, output.memory_config());
+
+                //                 auto padded = pad_to_tile_vol(queue_id, output, 0.0f, true, output.memory_config());
+                //                 concat_db_print(true, "[DEBUG] padded to tile layout, now tilizing.");
+                //                 auto tilized =
+                //                     ttnn::tilize_with_val_padding(padded, padded.padded_shape(), 0.0f,
+                //                     output.memory_config());
+                //                 concat_db_print(true, "[DEBUG] tilized");
+                //                 // need to reshape tilized result to logical concat output shape
+                //                 auto reshaped = ttnn::reshape(tilized, logical_output_shape, tilized.padded_shape());
+                //                 return reshaped;
             }
             concat_db_print(true, "[DEBUG] already tilized");
             return output;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26656

### Problem description
GPT-OSS test was hanging at a reshape. Reshape creates a mapping tensor that gets persisted in program cache. This tensor was getting clobbered, leading to invalid kernel behavior. A messy series of ops for manual untilize+unpad that were composited in concat were doing the clobbering.

### What's changed
-  Replace the messy series of ops with `untilize_with_unpad`
- Did the same with `tilize_with_pad_value` while in there
- Small perf bump for falcon7B, makes sense since 3 ops are replaced with 1 in tiled `concat`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16975110016
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16992671436
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). https://github.com/tenstorrent/tt-metal/actions/runs/16975095951/job/48122970770
- [x] New/Existing tests provide coverage for changes