### PR TITLE
Add information about the GO message to tt-triage

### DIFF
--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -193,7 +193,7 @@ class DispatcherData:
             kernel = self.inspector_data.kernels.get(watcher_kernel_id)
             go_message_index = mem_access(fw_elf, f"mailboxes->go_message_index", loc_mem_reader)[0][0]
             go_data = mem_access(fw_elf, f"mailboxes->go_messages[{go_message_index}]", loc_mem_reader)[0][0]
-            preload = mem_access(fw_elf, f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.preload", loc_mem_reader)[0][0]
+            preload = mem_access(fw_elf, f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.preload", loc_mem_reader)[0][0] != 0
         except:
             kernel_config_base = -1
             kernel_text_offset = -1
@@ -225,7 +225,8 @@ class DispatcherData:
         else:
             kernel_path = None
             kernel_offset = None
-        go_data_state = self._go_message_states.get(go_data & 0xff, str(go_data & 0xff))
+        go_state = (go_data >> 24) & 0xff
+        go_data_state = self._go_message_states.get(go_state, str(go_state))
 
         return DispatcherCoreData(
             firmware_path=firmware_path,

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -206,6 +206,7 @@ class DispatcherData:
             kernel = None
             go_message_index = -1
             go_data = -1
+            preload = False
 
         if proc_name.lower() == "erisc" or proc_name.lower() == "erisc0":
             firmware_path = self._a_kernel_path + "../../../firmware/idle_erisc/idle_erisc.elf"

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -155,7 +155,7 @@ class DispatcherData:
         def get_const_value(name):
             return mem_access(fw_elf, name, loc_mem_reader)[3]
 
-        # Initialize go message states if not already initialized
+        # Go message states are constant values in the firmware elf, so we cache them
         if not hasattr(self, "_go_message_states"):
             self._go_message_states = {
                 get_const_value("RUN_MSG_INIT"): "INIT",

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -40,8 +40,8 @@ class DispatcherCoreData:
     firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"))
     kernel_path: str | None = combined_field()
     kernel_name: str | None = combined_field()
-    go_message_index: int = triage_field("Go Message Index")
-    go_data: int = triage_field("Go Data", hex_serializer)
+    subdevice: int = triage_field("Subdevice")
+    go_message: str = triage_field("Go Message")
 
 
 class DispatcherData:
@@ -75,6 +75,13 @@ class DispatcherData:
         # Access the value of enumerator for supported blocks
         self._ProgrammableCoreTypes_TENSIX = self._brisc_elf.enumerators["ProgrammableCoreType::TENSIX"].value
         self._ProgrammableCoreTypes_IDLE_ETH = self._brisc_elf.enumerators["ProgrammableCoreType::IDLE_ETH"].value
+        self._go_message_states = {
+            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_INIT"].value: "INIT",
+            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_GO"].value: "GO",
+            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_DONE"].value: "DONE",
+            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_RESET_READ_PTR"].value: "RESET_READ_PTR",
+            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_RESET_READ_PTR_FROM_HOST"].value: "RESET_READ_PTR_FROM_HOST",
+        }
 
         # Enumerators for tensix block
         self._enum_values_tenisx = {
@@ -210,6 +217,7 @@ class DispatcherData:
         else:
             kernel_path = None
             kernel_offset = None
+        go_data_state = self._go_message_states.get(go_data & 0xff, str(go_data & 0xff))
 
         return DispatcherCoreData(
             firmware_path=firmware_path,
@@ -220,8 +228,8 @@ class DispatcherData:
             kernel_config_base=kernel_config_base,
             kernel_text_offset=kernel_text_offset,
             watcher_kernel_id=watcher_kernel_id,
-            go_message_index=go_message_index,
-            go_data=go_data,
+            subdevice=go_message_index,
+            go_message=go_data_state,
         )
 
     @staticmethod

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -193,7 +193,12 @@ class DispatcherData:
             kernel = self.inspector_data.kernels.get(watcher_kernel_id)
             go_message_index = mem_access(fw_elf, f"mailboxes->go_message_index", loc_mem_reader)[0][0]
             go_data = mem_access(fw_elf, f"mailboxes->go_messages[{go_message_index}]", loc_mem_reader)[0][0]
-            preload = mem_access(fw_elf, f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.preload", loc_mem_reader)[0][0] != 0
+            preload = (
+                mem_access(fw_elf, f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.preload", loc_mem_reader)[0][
+                    0
+                ]
+                != 0
+            )
         except:
             kernel_config_base = -1
             kernel_text_offset = -1
@@ -225,7 +230,7 @@ class DispatcherData:
         else:
             kernel_path = None
             kernel_offset = None
-        go_state = (go_data >> 24) & 0xff
+        go_state = (go_data >> 24) & 0xFF
         go_data_state = self._go_message_states.get(go_state, str(go_state))
 
         return DispatcherCoreData(

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -75,13 +75,6 @@ class DispatcherData:
         # Access the value of enumerator for supported blocks
         self._ProgrammableCoreTypes_TENSIX = self._brisc_elf.enumerators["ProgrammableCoreType::TENSIX"].value
         self._ProgrammableCoreTypes_IDLE_ETH = self._brisc_elf.enumerators["ProgrammableCoreType::IDLE_ETH"].value
-        self._go_message_states = {
-            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_INIT"].value: "INIT",
-            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_GO"].value: "GO",
-            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_DONE"].value: "DONE",
-            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_RESET_READ_PTR"].value: "RESET_READ_PTR",
-            self._brisc_elf.enumerators["go_message_state_t::RUN_MSG_RESET_READ_PTR_FROM_HOST"].value: "RESET_READ_PTR_FROM_HOST",
-        }
 
         # Enumerators for tensix block
         self._enum_values_tenisx = {
@@ -158,6 +151,16 @@ class DispatcherData:
         # Refer to tt_metal/api/tt-metalium/dev_msgs.h for struct kernel_config_msg_t
         launch_msg_rd_ptr = mem_access(fw_elf, "mailboxes->launch_msg_rd_ptr", loc_mem_reader)[0][0]
 
+        def get_const_value(name):
+            return mem_access(fw_elf, name, loc_mem_reader)[3]
+        go_message_states = {
+            get_const_value("RUN_MSG_INIT"): "INIT",
+            get_const_value("RUN_MSG_GO"): "GO",
+            get_const_value("RUN_MSG_DONE"): "DONE",
+            get_const_value("RUN_MSG_RESET_READ_PTR"): "RESET_READ_PTR",
+            get_const_value("RUN_MSG_RESET_READ_PTR_FROM_HOST"): "RESET_READ_PTR_FROM_HOST",
+        }
+
         try:
             # Indexed with enum ProgrammableCoreType - tt_metal/hw/inc/*/core_config.h
             kernel_config_base = mem_access(
@@ -217,7 +220,7 @@ class DispatcherData:
         else:
             kernel_path = None
             kernel_offset = None
-        go_data_state = self._go_message_states.get(go_data & 0xff, str(go_data & 0xff))
+        go_data_state = go_message_states.get(go_data & 0xff, str(go_data & 0xff))
 
         return DispatcherCoreData(
             firmware_path=firmware_path,

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -40,6 +40,8 @@ class DispatcherCoreData:
     firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"))
     kernel_path: str | None = combined_field()
     kernel_name: str | None = combined_field()
+    go_message_index: int = triage_field("Go Message Index")
+    go_data: int = triage_field("Go Data", hex_serializer)
 
 
 class DispatcherData:
@@ -175,11 +177,15 @@ class DispatcherData:
             )
 
             kernel = self.inspector_data.kernels.get(watcher_kernel_id)
+            go_message_index = mem_access(fw_elf, f"mailboxes->go_message_index", loc_mem_reader)[0][0]
+            go_data = mem_access(fw_elf, f"mailboxes->go_messages[{go_message_index}]", loc_mem_reader)[0][0]
         except:
             kernel_config_base = -1
             kernel_text_offset = -1
             watcher_kernel_id = -1
             kernel = None
+            go_message_index = -1
+            go_data = -1
 
         if proc_name.lower() == "erisc" or proc_name.lower() == "erisc0":
             firmware_path = self._a_kernel_path + "../../../firmware/idle_erisc/idle_erisc.elf"
@@ -214,6 +220,8 @@ class DispatcherData:
             kernel_config_base=kernel_config_base,
             kernel_text_offset=kernel_text_offset,
             watcher_kernel_id=watcher_kernel_id,
+            go_message_index=go_message_index,
+            go_data=go_data,
         )
 
     @staticmethod

--- a/scripts/debugging_scripts/dump_callstacks.py
+++ b/scripts/debugging_scripts/dump_callstacks.py
@@ -305,7 +305,9 @@ def run(args, context: Context):
     check_per_device = get_check_per_device(args, context)
     dispatcher_data = get_dispatcher_data(args, context)
     return check_per_device.run_check(
-        lambda device: dump_callstacks(device, dispatcher_data, context, full_callstack, gdb_callstack, active_cores, port)
+        lambda device: dump_callstacks(
+            device, dispatcher_data, context, full_callstack, gdb_callstack, active_cores, port
+        )
     )
 
 

--- a/scripts/debugging_scripts/dump_callstacks.py
+++ b/scripts/debugging_scripts/dump_callstacks.py
@@ -5,11 +5,12 @@
 
 """
 Usage:
-    dump_callstacks [--full_callstack] [--gdb_callstack --port=<port>]
+    dump_callstacks [--full_callstack] [--gdb_callstack --port=<port>] [--active_cores]
 
 Options:
     --full_callstack   Dump full callstack with all frames. Defaults to dumping only the top frame.
     --gdb_callstack    Dump callstack using GDB client instead of built-in methods.
+    --active_cores     Only dump callstacks for cores running kernels.
     --port=<port>      Port to use for GDB client.
 
 Description:
@@ -229,6 +230,7 @@ def dump_callstacks(
     context: Context,
     full_callstack: bool,
     gdb_callstack: bool,
+    active_cores: bool,
     port: int | None,
 ) -> list[DumpCallstacksData]:
     blocks_to_test = ["functional_workers", "eth"]
@@ -260,6 +262,8 @@ def dump_callstacks(
 
                 for risc_name in noc_block.risc_names:
                     dispatcher_core_data = dispatcher_data.get_core_data(location, risc_name)
+                    if active_cores and dispatcher_core_data.go_message != "GO":
+                        continue
                     if gdb_callstack:
                         if risc_name == "ncrisc":
                             # Cannot attach to NCRISC process due to lack of debug hardware so we return empty struct
@@ -296,11 +300,12 @@ def dump_callstacks(
 def run(args, context: Context):
     full_callstack = args["--full_callstack"]
     gdb_callstack = args["--gdb_callstack"]
+    active_cores = args["--active_cores"]
     port = int(args["--port"]) if gdb_callstack else None
     check_per_device = get_check_per_device(args, context)
     dispatcher_data = get_dispatcher_data(args, context)
     return check_per_device.run_check(
-        lambda device: dump_callstacks(device, dispatcher_data, context, full_callstack, gdb_callstack, port)
+        lambda device: dump_callstacks(device, dispatcher_data, context, full_callstack, gdb_callstack, active_cores, port)
     )
 
 

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -61,13 +61,11 @@ using profiler_msg_t = profiler_msg_template_t<MAX_RISCV_PER_CORE>;
 #endif
 
 // Messages for host to tell brisc to go
-enum go_message_state_t : uint32_t {
-    RUN_MSG_INIT = 0x40,
-    RUN_MSG_GO = 0x80,
-    RUN_MSG_RESET_READ_PTR = 0xc0,
-    RUN_MSG_RESET_READ_PTR_FROM_HOST = 0xe0,
-    RUN_MSG_DONE = 0,
-};
+constexpr uint32_t RUN_MSG_INIT = 0x40;
+constexpr uint32_t RUN_MSG_GO = 0x80;
+constexpr uint32_t RUN_MSG_RESET_READ_PTR = 0xc0;
+constexpr uint32_t RUN_MSG_RESET_READ_PTR_FROM_HOST = 0xe0;
+constexpr uint32_t RUN_MSG_DONE = 0;
 
 // 0x80808000 is a micro-optimization, calculated with 1 riscv insn
 constexpr uint32_t RUN_SYNC_MSG_INIT = 0x40;

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -61,11 +61,13 @@ using profiler_msg_t = profiler_msg_template_t<MAX_RISCV_PER_CORE>;
 #endif
 
 // Messages for host to tell brisc to go
-constexpr uint32_t RUN_MSG_INIT = 0x40;
-constexpr uint32_t RUN_MSG_GO = 0x80;
-constexpr uint32_t RUN_MSG_RESET_READ_PTR = 0xc0;
-constexpr uint32_t RUN_MSG_RESET_READ_PTR_FROM_HOST = 0xe0;
-constexpr uint32_t RUN_MSG_DONE = 0;
+enum go_message_state_t : uint32_t {
+    RUN_MSG_INIT = 0x40,
+    RUN_MSG_GO = 0x80,
+    RUN_MSG_RESET_READ_PTR = 0xc0,
+    RUN_MSG_RESET_READ_PTR_FROM_HOST = 0xe0,
+    RUN_MSG_DONE = 0,
+};
 
 // 0x80808000 is a micro-optimization, calculated with 1 riscv insn
 constexpr uint32_t RUN_SYNC_MSG_INIT = 0x40;


### PR DESCRIPTION
### Problem description
Currently triage doesn't provide much information about the dispatch state for each core, which makes it difficult to connect up behavior on different cores.

### What's changed
Add information to each core about

- Which subdevice it's on
- What the GO message status for it currently is
- Whether it's been told by the dispatcher to preload a kernel or not.

Also use the GO message data to implement an --active_cores command-line flag for dump_callstacks, which causes the command only to dump data for cores that currently have RUN_MSG_GO.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes