### PR TITLE
Fix alignment bug in untilize with unpadding

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -197,45 +197,6 @@ def run_identity_test(device, h, w, data_type):
         assert_equal(torch_output_tensor, output_tensor)
 
 
-def run_unary_with_aprox_mode_fruit_test(
-    device, h, w, memory_type, shard_shape, ttnn_function, vector_mode, approx_mode, pcc=0.9999
-):
-    torch.manual_seed(0)
-
-    torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn_function)
-    torch_output_tensor = golden_function(torch_input_tensor, device=device)
-    if memory_type == "L1":
-        core_grid = device.compute_with_storage_grid_size()
-        num_cores = core_grid.x * core_grid.y
-        assert num_cores == 64
-
-        shard_spec = ttnn.ShardSpec(
-            grid=ttnn.num_cores_to_corerangeset(num_cores, device.compute_with_storage_grid_size()),
-            shard_shape=shard_shape,
-            shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        memory_config = ttnn.MemoryConfig(
-            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=shard_spec
-        )
-    else:  # memory_type == "DRAM":
-        memory_config = ttnn.MemoryConfig(
-            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED, buffer_type=ttnn.BufferType.DRAM
-        )
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config
-    )
-    print(
-        f"shape: {input_tensor.shape}, dtype: {input_tensor.dtype}, layout: {input_tensor.layout}, memory_config: {input_tensor.memory_config()}"
-    )
-    output_tensor = ttnn_function(input_tensor, vector_mode=vector_mode, fast_and_approximate_mode=approx_mode)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
-
-
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
@@ -1420,23 +1381,3 @@ def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
     golden_tensor = golden_function(in_data)
 
     assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
-
-
-@pytest.mark.parametrize("h", [1024 * 128])
-@pytest.mark.parametrize("w", [1])
-@pytest.mark.parametrize("memory_type", ["L1", "DRAM"])
-@pytest.mark.parametrize("shard_shape", [(2048, 32)])
-@pytest.mark.parametrize("approx_mode", [True, False])
-@pytest.mark.parametrize("vector_mode", [4])
-def test_sigmoid_fruit(device, h, w, memory_type, shard_shape, vector_mode, approx_mode):
-    run_unary_with_aprox_mode_fruit_test(
-        device,
-        h,
-        w,
-        memory_type,
-        shard_shape,
-        ttnn.sigmoid,
-        vector_mode=vector_mode,
-        approx_mode=approx_mode,
-        pcc=0.999,
-    )

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -197,6 +197,45 @@ def run_identity_test(device, h, w, data_type):
         assert_equal(torch_output_tensor, output_tensor)
 
 
+def run_unary_with_aprox_mode_fruit_test(
+    device, h, w, memory_type, shard_shape, ttnn_function, vector_mode, approx_mode, pcc=0.9999
+):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+    if memory_type == "L1":
+        core_grid = device.compute_with_storage_grid_size()
+        num_cores = core_grid.x * core_grid.y
+        assert num_cores == 64
+
+        shard_spec = ttnn.ShardSpec(
+            grid=ttnn.num_cores_to_corerangeset(num_cores, device.compute_with_storage_grid_size()),
+            shard_shape=shard_shape,
+            shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=shard_spec
+        )
+    else:  # memory_type == "DRAM":
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED, buffer_type=ttnn.BufferType.DRAM
+        )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config
+    )
+    print(
+        f"shape: {input_tensor.shape}, dtype: {input_tensor.dtype}, layout: {input_tensor.layout}, memory_config: {input_tensor.memory_config()}"
+    )
+    output_tensor = ttnn_function(input_tensor, vector_mode=vector_mode, fast_and_approximate_mode=approx_mode)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
@@ -1381,3 +1420,23 @@ def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
     golden_tensor = golden_function(in_data)
 
     assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
+
+
+@pytest.mark.parametrize("h", [1024 * 128])
+@pytest.mark.parametrize("w", [1])
+@pytest.mark.parametrize("memory_type", ["L1", "DRAM"])
+@pytest.mark.parametrize("shard_shape", [(2048, 32)])
+@pytest.mark.parametrize("approx_mode", [True, False])
+@pytest.mark.parametrize("vector_mode", [4])
+def test_sigmoid_fruit(device, h, w, memory_type, shard_shape, vector_mode, approx_mode):
+    run_unary_with_aprox_mode_fruit_test(
+        device,
+        h,
+        w,
+        memory_type,
+        shard_shape,
+        ttnn.sigmoid,
+        vector_mode=vector_mode,
+        approx_mode=approx_mode,
+        pcc=0.999,
+    )

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -468,8 +468,7 @@ def run_unary_with_aprox_mode_fruit_test(
     torch_output_tensor = golden_function(torch_input_tensor, device=device)
     if memory_type == "L1":
         core_grid = device.compute_with_storage_grid_size()
-        num_cores = core_grid.x * core_grid.y
-        assert num_cores == 64
+        num_cores = 64
 
         shard_spec = ttnn.ShardSpec(
             grid=ttnn.num_cores_to_corerangeset(num_cores, device.compute_with_storage_grid_size()),

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -456,3 +456,62 @@ def test_untilize_int32_t(shape, dtype, device):
     output_tensor = ttnn.untilize(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)
+
+
+def run_unary_with_aprox_mode_fruit_test(
+    device, h, w, memory_type, shard_shape, ttnn_function, vector_mode, approx_mode, pcc=0.9999
+):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+    if memory_type == "L1":
+        core_grid = device.compute_with_storage_grid_size()
+        num_cores = core_grid.x * core_grid.y
+        assert num_cores == 64
+
+        shard_spec = ttnn.ShardSpec(
+            grid=ttnn.num_cores_to_corerangeset(num_cores, device.compute_with_storage_grid_size()),
+            shard_shape=shard_shape,
+            shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=shard_spec
+        )
+    else:  # memory_type == "DRAM":
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED, buffer_type=ttnn.BufferType.DRAM
+        )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config
+    )
+    print(
+        f"shape: {input_tensor.shape}, dtype: {input_tensor.dtype}, layout: {input_tensor.layout}, memory_config: {input_tensor.memory_config()}"
+    )
+    output_tensor = ttnn_function(input_tensor, vector_mode=vector_mode, fast_and_approximate_mode=approx_mode)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [1024 * 128])
+@pytest.mark.parametrize("w", [1])
+@pytest.mark.parametrize("memory_type", ["L1", "DRAM"])
+@pytest.mark.parametrize("shard_shape", [(2048, 32)])
+@pytest.mark.parametrize("approx_mode", [True, False])
+@pytest.mark.parametrize("vector_mode", [4])
+def test_sigmoid_fruit(device, h, w, memory_type, shard_shape, vector_mode, approx_mode):
+    run_unary_with_aprox_mode_fruit_test(
+        device,
+        h,
+        w,
+        memory_type,
+        shard_shape,
+        ttnn.sigmoid,
+        vector_mode=vector_mode,
+        approx_mode=approx_mode,
+        pcc=0.999,
+    )

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
@@ -15,6 +15,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_untilize_out = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
+    constexpr uint32_t aligned_page_size = get_compile_time_arg_val(2);
 
     cb_reserve_back(cb_id_out, num_unpadded_output_rows);
     uint32_t l1_write_addr = get_write_ptr(cb_id_out);
@@ -26,7 +27,7 @@ void kernel_main() {
         for (uint32_t row = 0; row < num_unpadded_rows_per_batch; ++row) {
             noc_async_read(noc_l1_read_addr, l1_write_addr, unpadded_block_row_size_bytes);
             noc_l1_read_addr += padded_block_row_size_bytes;
-            l1_write_addr += unpadded_block_row_size_bytes;
+            l1_write_addr += aligned_page_size;
         }
 
         noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -942,6 +942,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
         src_sharded ? a.buffer() : nullptr);
 
     uint32_t num_output_tiles = out_sharded ? (unpad_tensor_w_16 ? 16 : ntiles_per_batch * 2) : ntiles_per_block * 2;
+    auto aligned_page_size = output.buffer()->aligned_page_size();
     auto [output_cb_index, cb_output] = create_cb(
         tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_output_tiles, output_cb_data_format);
 
@@ -973,7 +974,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
      */
     KernelHandle unary_writer_kernel_id;
     if (out_sharded) {
-        std::vector<uint32_t> writer_ct_args = {(uint32_t)output_cb_index, (uint32_t)sharded_output_cb_index};
+        std::vector<uint32_t> writer_ct_args = {
+            (uint32_t)output_cb_index, (uint32_t)sharded_output_cb_index, aligned_page_size};
         unary_writer_kernel_id = CreateKernel(
             program,
             unpad_tensor_w_16


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/22606

### Problem description
to_layout_op is causing PCC failures in sigmoid operation

### What's changed
The PCC failures is due to an alignment issue in the sharded kernels of untilize with unpadding. This PR fixes the bug

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16997797897
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16990700039
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes