### PR TITLE
generalize element size for strided slice

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -13,6 +13,16 @@ from .test_utils import round_up
 import math
 
 
+def random_torch_tensor(dtype, shape):
+    if dtype == ttnn.uint16:
+        return torch.randint(0, 100, shape).to(torch.int16)
+    if dtype == ttnn.int32:
+        return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
+    return torch.rand(shape).bfloat16().float()
+
+
 def run_slice_rm_sharded(device, n, c, h, w):
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     n_unpadded = n
@@ -559,12 +569,13 @@ def test_run_slice_test(
 
 # slice alternate elements in a given tensor
 @pytest.mark.parametrize("dim", [4, 12, 20, 68])
-def test_stride_slice_single_dim_skip_2(dim, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_stride_slice_single_dim_skip_2(dim, dtype, device):
     torch.manual_seed(2005)
-    torch_input = torch.rand(dim)
+    torch_input = random_torch_tensor(dtype, (dim,))
     torch_output = torch_input[::2]
 
-    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=dtype)
     ttnn_output = ttnn_input[::2]
     ttnn_output = ttnn.to_torch(ttnn_output)
 
@@ -577,12 +588,13 @@ def test_stride_slice_single_dim_skip_2(dim, device):
 @pytest.mark.parametrize("begins_w", [2])
 @pytest.mark.parametrize("stride_h", [2])
 @pytest.mark.parametrize("stride_w", [2])
-def test_stride_slice_two_dim(h, w, begins_h, begins_w, stride_h, stride_w, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_stride_slice_two_dim(h, w, begins_h, begins_w, stride_h, stride_w, dtype, device):
     torch.manual_seed(2005)
-    torch_input = torch.rand(h, w)
+    torch_input = random_torch_tensor(dtype, (h, w))
     torch_output = torch_input[begins_h:h:stride_h, begins_w:w:stride_w]
 
-    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=dtype)
     ttnn_output = ttnn_input[begins_h::stride_h, begins_w::stride_w]
     ttnn_output = ttnn.to_torch(ttnn_output)
 
@@ -598,12 +610,13 @@ def test_stride_slice_two_dim(h, w, begins_h, begins_w, stride_h, stride_w, devi
 @pytest.mark.parametrize("stride_c", [2])
 @pytest.mark.parametrize("stride_h", [1])
 @pytest.mark.parametrize("stride_w", [1])
-def test_stride_slice_three_dim(c, h, w, begins_c, begins_h, begins_w, stride_c, stride_h, stride_w, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_stride_slice_three_dim(c, h, w, begins_c, begins_h, begins_w, stride_c, stride_h, stride_w, dtype, device):
     torch.manual_seed(2005)
-    torch_input = torch.rand(c, h, w)
+    torch_input = random_torch_tensor(dtype, (c, h, w))
     torch_output = torch_input[begins_c:c:stride_c, begins_h:h:stride_h, begins_w:w:stride_w]
 
-    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=dtype)
     ttnn_output = ttnn_input[begins_c:c:stride_c, begins_h:h:stride_h, begins_w:w:stride_w]
     ttnn_output = ttnn.to_torch(ttnn_output)
 
@@ -615,16 +628,17 @@ def test_stride_slice_three_dim(c, h, w, begins_c, begins_h, begins_w, stride_c,
 @pytest.mark.parametrize("ends", [[18, 16, 16, 18]])
 @pytest.mark.parametrize("strides", [[2, 2, 2, 2]])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-def test_stride_slice_four_dim(dims, begins, ends, strides, layout, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_stride_slice_four_dim(dims, begins, ends, strides, layout, dtype, device):
     torch.manual_seed(2005)
-    torch_input = torch.rand(dims)
+    torch_input = random_torch_tensor(dtype, dims)
     slices = []
     for i in range(len(dims)):
         slices.append(slice(begins[i], ends[i], strides[i]))
 
     torch_output = torch_input[slices[0], slices[1], slices[2], slices[3]]
 
-    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=dtype)
     ttnn_output = ttnn_input[slices[0], slices[1], slices[2], slices[3]]
     ttnn_output = ttnn.to_torch(ttnn_output)
 
@@ -636,16 +650,17 @@ def test_stride_slice_four_dim(dims, begins, ends, strides, layout, device):
 @pytest.mark.parametrize("ends", [[1, -1, 56, 96], [1, 56, 56, 95], [-1, 1, -1, -1]])
 @pytest.mark.parametrize("strides", [[1, 2, 1, 1]])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_stride_slice_four_dim_tiled(dims, begins, ends, strides, layout, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_stride_slice_four_dim_tiled(dims, begins, ends, strides, layout, dtype, device):
     torch.manual_seed(2005)
-    torch_input = torch.rand(dims)
+    torch_input = random_torch_tensor(dtype, dims)
     slices = []
     for i in range(len(dims)):
         slices.append(slice(begins[i], ends[i], strides[i]))
 
     torch_output = torch_input[slices[0], slices[1], slices[2], slices[3]]
 
-    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=dtype)
     ttnn_output = ttnn_input[slices[0], slices[1], slices[2], slices[3]]
     ttnn_output = ttnn.to_torch(ttnn_output)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -114,7 +114,6 @@ void SliceDeviceOperation::validate_with_output_tensors(
     if (has_step) {  // if all ones modify before passing in to function
         TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Strided slice is only supported for row major layout");
         TT_FATAL(!input_tensor_a.is_sharded(), "Strided slice is not supported for sharded tensor");
-        TT_FATAL(input_tensor_a.dtype() == DataType::BFLOAT16, "Strided slice is only supported for BFLOAT16");
         TT_FATAL(
             step.size() == this->slice_end.rank(),
             "Number of steps {} must match number of ends/starts {}",

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -353,7 +353,7 @@ operation::ProgramWithCallbacks slice_rm_strided_single_core_n_dims(
     tt::tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
     tt::tt_metal::CreateCircularBuffer(program, core, cb_dst0_config);
 
-    std::vector<uint32_t> reader_compile_time_args = {page_size_input, input_shape.rank()};
+    std::vector<uint32_t> reader_compile_time_args = {page_size_input, input_shape.rank(), a.element_size()};
     TensorAccessorArgs(*a.buffer()).append_to(reader_compile_time_args);
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,


### PR DESCRIPTION
### Ticket
Link to Github Issue:
#25787 #26691 

### Problem description
Strided slice only supported 2 byte element sizes.

### What's changed
Generalized the strided reader kernel such that it rights byte by byte instead of element by element. noc write wasn't being used in the first place, but I will make sure to run device perf before merging.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17051575166) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16977097365) CI with demo tests passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17051581048) CI passes (if applicable)