### PR TITLE
#26890: [skip ci] Tidy up release container trigger workflow to enable iterating on release image

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -236,6 +236,7 @@ jobs:
     with:
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   release-docs:
     needs: [
       build-artifact,

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -234,7 +234,6 @@ jobs:
     secrets: inherit
     if: github.ref != 'refs/heads/main'
     with:
-      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' }}
   release-docs:

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -27,6 +27,5 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}
       is_major_version: false

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -29,3 +29,4 @@ jobs:
     with:
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}
       is_major_version: false
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -3,10 +3,6 @@ name: "[internal] Create and Publish Release Docker Image"
 on:
   workflow_call:
     inputs:
-      base-image:
-        description: "Base image to build on top of"
-        required: true
-        type: string
       version:
         required: true
         type: string
@@ -57,7 +53,6 @@ jobs:
           push: true
           build-args: |
             WHEEL_FILENAME=${{ env.WHEEL_FILENAME }}
-            BASE_IMAGE=${{ inputs.base-image }}
           tags: ${{ env.TAG_NAME }}
           context: .
           file: dockerfile/Dockerfile

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -14,6 +14,9 @@ on:
         required: false
         type: number
         default: 10
+      wheel-artifact-name:
+        required: true
+        type: string
 jobs:
   create-docker-release-image:
     strategy:
@@ -37,7 +40,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
-          name: eager-dist-${{ matrix.os }}-any
+          name: ${{ inputs.wheel-artifact-name }}
       - name: Get the name of the wheel and set up env variables
         id: generate-tag-name
         run: |


### PR DESCRIPTION
…g on release image

### Ticket

#26890

### Problem description

@knauth should start using this trigger workflow to start iterating on a new container meant for external release

### What's changed

Some tidy ups

- don't use `base-image` because it's not a real input

### Checklist
- [ ] release docker workflow https://github.com/tenstorrent/tt-metal/actions/runs/16991694960
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes