### PR TITLE
Benchmark for TTNN read/write throughput

### DIFF
--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -28,23 +28,24 @@ def test_benchmark_from_torch_with_format_conversion(benchmark, to_layout, dtype
     benchmark(run)
 
 
-# @pytest.mark.parametrize(
-#     "layout", [(ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT), (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT)]
-# )
-# @pytest.mark.parametrize("dtype", [(ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)])
-# @pytest.mark.parametrize("tensor_size", [(8096, 8096)])
-# def test_benchmark_to_torch(benchmark, layout, dtype, tensor_size):
-#     from_layout, to_layout = layout
-#     from_dtype, to_dtype = dtype
+@pytest.mark.parametrize(
+    # No translation, tileize
+    "from_layout",
+    [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+)
+@pytest.mark.parametrize("dtype", [(ttnn.bfloat16, torch.float32), (ttnn.float32, torch.bfloat16)])
+@pytest.mark.parametrize("tensor_size", [(8096, 8096)])
+def test_benchmark_to_torch(benchmark, from_layout, dtype, tensor_size):
+    from_dtype, to_dtype = dtype
 
-#     device = ttnn.open_device(device_id=0)
-#     ttnn_tensor = ttnn.rand(tensor_size, dtype=from_dtype, layout=from_layout, device=device)
+    device = ttnn.open_device(device_id=0)
+    ttnn_tensor = ttnn.rand(tensor_size, dtype=from_dtype, layout=from_layout, device=device)
 
-#     def run():
-#         _ = ttnn.to_torch(ttnn_tensor, dtype=to_dtype, layout=to_layout, device=device)
-#         ttnn.synchronize_device(device)
+    def run():
+        _ = ttnn.to_torch(ttnn_tensor, dtype=to_dtype, device=device)
+        ttnn.synchronize_device(device)
 
-#     benchmark(run)
+    benchmark(run)
 
 
 @pytest.mark.parametrize("tensor_size", [(8096, 8096)])

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -7,42 +7,42 @@ import ttnn
 import pytest
 
 
-@pytest.mark.parametrize(
-    "layout", [(ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT), (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT)]
-)
-@pytest.mark.parametrize("dtype", [(ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)])
-@pytest.mark.parametrize("tensor_size", [(8096, 8096)])
-def test_benchmark_from_torch_with_format_conversion(benchmark, layout, dtype, tensor_size):
-    from_layout, to_layout = layout
-    from_dtype, to_dtype = dtype
+# @pytest.mark.parametrize(
+#     "layout", [(ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT), (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT)]
+# )
+# @pytest.mark.parametrize("dtype", [(ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)])
+# @pytest.mark.parametrize("tensor_size", [(8096, 8096)])
+# def test_benchmark_from_torch_with_format_conversion(benchmark, layout, dtype, tensor_size):
+#     from_layout, to_layout = layout
+#     from_dtype, to_dtype = dtype
 
-    device = ttnn.open_device(device_id=0)
-    torch_tensor = torch.rand(tensor_size, dtype=from_dtype, layout=from_layout)
+#     device = ttnn.open_device(device_id=0)
+#     torch_tensor = torch.rand(tensor_size, dtype=from_dtype, layout=from_layout)
 
-    def run():
-        ttnn.from_torch(torch_tensor, dtype=to_dtype, layout=to_layout, device=device)
-        ttnn.synchronize_device(device)
+#     def run():
+#         ttnn.from_torch(torch_tensor, dtype=to_dtype, layout=to_layout, device=device)
+#         ttnn.synchronize_device(device)
 
-    benchmark(run)
+#     benchmark(run)
 
 
-@pytest.mark.parametrize(
-    "layout", [(ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT), (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT)]
-)
-@pytest.mark.parametrize("dtype", [(ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)])
-@pytest.mark.parametrize("tensor_size", [(8096, 8096)])
-def test_benchmark_to_torch(benchmark, layout, dtype, tensor_size):
-    from_layout, to_layout = layout
-    from_dtype, to_dtype = dtype
+# @pytest.mark.parametrize(
+#     "layout", [(ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT), (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT)]
+# )
+# @pytest.mark.parametrize("dtype", [(ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)])
+# @pytest.mark.parametrize("tensor_size", [(8096, 8096)])
+# def test_benchmark_to_torch(benchmark, layout, dtype, tensor_size):
+#     from_layout, to_layout = layout
+#     from_dtype, to_dtype = dtype
 
-    device = ttnn.open_device(device_id=0)
-    ttnn_tensor = ttnn.rand(tensor_size, dtype=from_dtype, layout=from_layout, device=device)
+#     device = ttnn.open_device(device_id=0)
+#     ttnn_tensor = ttnn.rand(tensor_size, dtype=from_dtype, layout=from_layout, device=device)
 
-    def run():
-        _ = ttnn.to_torch(ttnn_tensor, dtype=to_dtype, layout=to_layout, device=device)
-        ttnn.synchronize_device(device)
+#     def run():
+#         _ = ttnn.to_torch(ttnn_tensor, dtype=to_dtype, layout=to_layout, device=device)
+#         ttnn.synchronize_device(device)
 
-    benchmark(run)
+#     benchmark(run)
 
 
 @pytest.mark.parametrize("tensor_size", [(8096, 8096)])
@@ -61,7 +61,7 @@ def test_benchmark_from_device(benchmark, tensor_size):
 def test_benchmark_copy_host_to_device_tensor(benchmark, tensor_size):
     device = ttnn.open_device(device_id=0)
     ttnn_tensor = ttnn.rand(tensor_size, device=device)
-    host_tensor = ttnn.allocate_tensor_on_host(ttnn_tensor.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device)
+    host_tensor = ttnn.allocate_tensor_on_host(ttnn_tensor.spec, device)
 
     def run():
         ttnn.copy_host_to_device_tensor(host_tensor, ttnn_tensor)
@@ -74,7 +74,7 @@ def test_benchmark_copy_host_to_device_tensor(benchmark, tensor_size):
 def test_benchmark_copy_device_to_host_tensor(benchmark, tensor_size):
     device = ttnn.open_device(device_id=0)
     device_tensor = ttnn.rand(tensor_size, device=device)
-    host_tensor = ttnn.allocate_tensor_on_host(device_tensor.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device)
+    host_tensor = ttnn.allocate_tensor_on_host(device_tensor.spec, device)
 
     def run():
         ttnn.copy_device_to_host_tensor(device_tensor, host_tensor)

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -7,23 +7,25 @@ import ttnn
 import pytest
 
 
-# @pytest.mark.parametrize(
-#     "layout", [(ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT), (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT)]
-# )
-# @pytest.mark.parametrize("dtype", [(ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)])
-# @pytest.mark.parametrize("tensor_size", [(8096, 8096)])
-# def test_benchmark_from_torch_with_format_conversion(benchmark, layout, dtype, tensor_size):
-#     from_layout, to_layout = layout
-#     from_dtype, to_dtype = dtype
+@pytest.mark.parametrize(
+    # torch tensor is row major by default, so this maps to:
+    # No translation, tileize
+    "to_layout",
+    [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+)
+@pytest.mark.parametrize("dtype", [(torch.bfloat16, ttnn.float32), (torch.float32, ttnn.bfloat16)])
+@pytest.mark.parametrize("tensor_size", [(8096, 8096)])
+def test_benchmark_from_torch_with_format_conversion(benchmark, to_layout, dtype, tensor_size):
+    from_dtype, to_dtype = dtype
 
-#     device = ttnn.open_device(device_id=0)
-#     torch_tensor = torch.rand(tensor_size, dtype=from_dtype, layout=from_layout)
+    device = ttnn.open_device(device_id=0)
+    torch_tensor = torch.rand(tensor_size, dtype=from_dtype)
 
-#     def run():
-#         ttnn.from_torch(torch_tensor, dtype=to_dtype, layout=to_layout, device=device)
-#         ttnn.synchronize_device(device)
+    def run():
+        ttnn.from_torch(torch_tensor, dtype=to_dtype, layout=to_layout, device=device)
+        ttnn.synchronize_device(device)
 
-#     benchmark(run)
+    benchmark(run)
 
 
 # @pytest.mark.parametrize(

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+
+def _make_host_tensor(shape):
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    return ttnn.from_torch(torch_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+def _make_device_tensor_like(host_tensor, device):
+    return ttnn.allocate_tensor_on_device(host_tensor.shape, host_tensor.dtype, host_tensor.layout, device)
+
+
+"""
+from_torch with device specified(both with format conversion and without)
+"""
+
+
+def test_benchmark_from_torch_to_device_row_major_no_format_conversion(benchmark):
+    # Host -> device, row-major layout (no conversion), same dtype
+    device = ttnn.open_device(device_id=0)
+    torch_tensor = torch.rand((8096, 8096), dtype=torch.bfloat16)
+
+    def run():
+        ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+        ttnn.synchronize_device(device)
+
+    benchmark(run)
+
+
+def test_benchmark_from_torch_to_device_tile_layout_with_format_conversion(benchmark):
+    # Host -> device, tile layout (conversion), same dtype
+    device = ttnn.open_device(device_id=0)
+    torch_tensor = torch.rand((8096, 8096), dtype=torch.bfloat16)
+
+    def run():
+        ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+        ttnn.synchronize_device(device)
+
+    benchmark(run)
+
+
+"""
+copy_host_to_device_tensor
+"""
+
+
+def test_benchmark_copy_host_to_device_tensor(benchmark):
+    device = ttnn.open_device(device_id=0)
+    host_tensor = _make_host_tensor((8096, 8096))
+    device_tensor = _make_device_tensor_like(host_tensor, device)
+
+    def run():
+        ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
+        ttnn.synchronize_device(device)
+
+    benchmark(run)
+
+
+def test_benchmark_copy_device_to_host_tensor(benchmark):
+    # Prepare a device tensor by creating on device directly
+    device = ttnn.open_device(device_id=0)
+    torch_tensor = torch.rand((8096, 8096), dtype=torch.bfloat16)
+    device_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    host_tensor = ttnn.allocate_tensor_on_host(device_tensor.shape, device_tensor.dtype, device_tensor.layout, device)
+
+    def run():
+        ttnn.copy_device_to_host_tensor(device_tensor, host_tensor)
+        ttnn.synchronize_device(device)
+
+    benchmark(run)
+
+
+"""
+from_device
+"""
+
+
+def test_benchmark_from_device(benchmark):
+    device = ttnn.open_device(device_id=0)
+    torch_tensor = torch.rand((8096, 8096), dtype=torch.bfloat16)
+    device_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    def run():
+        _ = ttnn.from_device(device_tensor)
+        ttnn.synchronize_device(device)
+
+    benchmark(run)
+
+
+"""
+to_torch (from device)
+"""
+
+
+def test_benchmark_to_torch_from_device(benchmark):
+    device = ttnn.open_device(device_id=0)
+    torch_tensor = torch.rand((8096, 8096), dtype=torch.bfloat16)
+    device_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    def run():
+        _ = ttnn.to_torch(device_tensor)
+        ttnn.synchronize_device(device)
+
+    benchmark(run)

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -18,10 +18,11 @@ DEFAULT_TENSOR_SIZE = (8096, 8096)
     [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
 )
 @pytest.mark.parametrize("dtype", [(torch.bfloat16, ttnn.float32), (torch.float32, ttnn.bfloat16)])
-def test_benchmark_from_torch_with_format_conversion(benchmark, to_layout, dtype):
+@pytest.mark.parametrize("device_id", ttnn.get_device_ids())
+def test_benchmark_from_torch_with_format_conversion(benchmark, to_layout, dtype, device_id):
     from_dtype, to_dtype = dtype
 
-    device = ttnn.open_device(device_id=0)
+    device = ttnn.open_device(device_id=device_id)
     torch_tensor = torch.rand(DEFAULT_TENSOR_SIZE, dtype=from_dtype)
 
     def run():
@@ -37,10 +38,11 @@ def test_benchmark_from_torch_with_format_conversion(benchmark, to_layout, dtype
     [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
 )
 @pytest.mark.parametrize("dtype", [(ttnn.bfloat16, torch.float32), (ttnn.float32, torch.bfloat16)])
-def test_benchmark_to_torch(benchmark, from_layout, dtype):
+@pytest.mark.parametrize("device_id", ttnn.get_device_ids())
+def test_benchmark_to_torch(benchmark, from_layout, dtype, device_id):
     from_dtype, to_dtype = dtype
 
-    device = ttnn.open_device(device_id=0)
+    device = ttnn.open_device(device_id=device_id)
     ttnn_tensor = ttnn.rand(DEFAULT_TENSOR_SIZE, dtype=from_dtype, layout=from_layout, device=device)
 
     def run():
@@ -50,8 +52,9 @@ def test_benchmark_to_torch(benchmark, from_layout, dtype):
     benchmark(run)
 
 
-def test_benchmark_from_device(benchmark):
-    device = ttnn.open_device(device_id=0)
+@pytest.mark.parametrize("device_id", ttnn.get_device_ids())
+def test_benchmark_from_device(benchmark, device_id):
+    device = ttnn.open_device(device_id=device_id)
     ttnn_tensor = ttnn.rand(DEFAULT_TENSOR_SIZE, dtype=DEFAULT_DTYPE, layout=DEFAULT_LAYOUT, device=device)
 
     def run():
@@ -61,8 +64,9 @@ def test_benchmark_from_device(benchmark):
     benchmark(run)
 
 
-def test_benchmark_copy_host_to_device_tensor(benchmark):
-    device = ttnn.open_device(device_id=0)
+@pytest.mark.parametrize("device_id", ttnn.get_device_ids())
+def test_benchmark_copy_host_to_device_tensor(benchmark, device_id):
+    device = ttnn.open_device(device_id=device_id)
     ttnn_tensor = ttnn.rand(DEFAULT_TENSOR_SIZE, dtype=DEFAULT_DTYPE, layout=DEFAULT_LAYOUT, device=device)
     host_tensor = ttnn.allocate_tensor_on_host(ttnn_tensor.spec, device)
 
@@ -73,8 +77,9 @@ def test_benchmark_copy_host_to_device_tensor(benchmark):
     benchmark(run)
 
 
-def test_benchmark_copy_device_to_host_tensor(benchmark):
-    device = ttnn.open_device(device_id=0)
+@pytest.mark.parametrize("device_id", ttnn.get_device_ids())
+def test_benchmark_copy_device_to_host_tensor(benchmark, device_id):
+    device = ttnn.open_device(device_id=device_id)
     device_tensor = ttnn.rand(DEFAULT_TENSOR_SIZE, dtype=DEFAULT_DTYPE, layout=DEFAULT_LAYOUT, device=device)
     host_tensor = ttnn.allocate_tensor_on_host(device_tensor.spec, device)
 

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -2,6 +2,16 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# This file contains a set of benchmark that test the transfer performance between
+# host and device with and without format conversions.
+
+# This is meant to test if any modifications of tt-nn and tt-metal will regress
+# the performance of data transfer.
+
+# Currently the benchmark measures performance in terms of time to operate on a
+# fixed sized tensor. While benchmarking for throughput maybe more appropriate,
+# this is currently not implemented due to the limitations of pytest.benchmark .
+
 import torch
 import ttnn
 import pytest


### PR DESCRIPTION
### Ticket
Closes #26241

### Problem description
Create a benchmark for TTNN side read/write throughput.

### What's changed
A benchmark using pytest.benchmark is created under `tests/ttnn/benchmark/python/benchmark_device_copies.py`.
Due to the limitation of the benchmark, a script is currently being made to transform the timing result to throughput result.

The benchmark is not wired to any CI for now.

### Example output:
```

================================================================= PASSES =================================================================
---------------------- generated xml file: /localdev/riverwu/tt-metal/generated/test_reports/most_recent_tests.xml -----------------------

--------------------------------------------------------------------------------------------------------------------------------------------- benchmark: 22 tests ---------------------------------------------------------------------------------------------------------------------------------------------
Name (time in ms)                                                                                                                               Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_copy_host_to_device_tensor[device_id=0]                                                                                       8.7383 (1.0)        8.7959 (1.0)        8.7644 (1.0)      0.0150 (1.0)        8.7650 (1.0)      0.0230 (1.0)          42;0  114.0983 (1.0)         104           1
test_benchmark_copy_device_to_host_tensor[device_id=0]                                                                                      10.8568 (1.24)      12.1537 (1.38)      11.4647 (1.31)     0.3087 (20.65)     11.4473 (1.31)     0.4695 (20.44)        32;0   87.2245 (0.76)         88           1
test_benchmark_copy_host_to_device_tensor[device_id=1]                                                                                      14.7577 (1.69)      15.1854 (1.73)      14.8443 (1.69)     0.1277 (8.54)      14.8027 (1.69)     0.0393 (1.71)          9;9   67.3659 (0.59)         67           1
test_benchmark_copy_device_to_host_tensor[device_id=1]                                                                                      27.1386 (3.11)      27.5984 (3.14)      27.3158 (3.12)     0.1441 (9.64)      27.2526 (3.11)     0.2026 (8.82)         12;0   36.6088 (0.32)         37           1
test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]      35.9109 (4.11)      37.9559 (4.32)      36.6156 (4.18)     0.5638 (37.70)     36.5140 (4.17)     0.8990 (39.15)         8;0   27.3107 (0.24)         26           1
test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]      36.5172 (4.18)      37.5894 (4.27)      37.0578 (4.23)     0.3492 (23.35)     37.0732 (4.23)     0.7574 (32.98)        15;0   26.9849 (0.24)         27           1
test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]      64.2799 (7.36)      66.9616 (7.61)      65.0643 (7.42)     0.8998 (60.17)     64.6369 (7.37)     0.9335 (40.65)         2;1   15.3694 (0.13)         12           1
test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]      65.0156 (7.44)      70.2494 (7.99)      66.0448 (7.54)     1.4035 (93.85)     65.5413 (7.48)     0.4680 (20.38)         2;2   15.1412 (0.13)         15           1
test_benchmark_from_device[device_id=0]                                                                                                     77.5858 (8.88)      78.8217 (8.96)      78.0763 (8.91)     0.3387 (22.65)     78.0523 (8.91)     0.4168 (18.15)         4;0   12.8080 (0.11)         13           1
test_benchmark_from_device[device_id=1]                                                                                                     93.2224 (10.67)     94.6831 (10.76)     93.9269 (10.72)    0.4376 (29.27)     93.8985 (10.71)    0.5274 (22.97)         3;0   10.6466 (0.09)         11           1
test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]                            117.1528 (13.41)    119.2360 (13.56)    118.0072 (13.46)    0.7947 (53.15)    117.6184 (13.42)    1.2689 (55.25)         3;0    8.4741 (0.07)          9           1
test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]                            136.4744 (15.62)    144.9266 (16.48)    141.4371 (16.14)    2.4333 (162.72)   141.9655 (16.20)    1.3604 (59.24)         2;2    7.0703 (0.06)          8           1
test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]                            143.1577 (16.38)    150.4317 (17.10)    147.7851 (16.86)    3.1231 (208.85)   149.9635 (17.11)    5.3676 (233.73)        2;0    6.7666 (0.06)          7           1
test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]          169.1533 (19.36)    177.1796 (20.14)    171.1508 (19.53)    3.0015 (200.72)   170.3422 (19.43)    0.9845 (42.87)         1;1    5.8428 (0.05)          6           1
test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]          173.3004 (19.83)    181.3848 (20.62)    178.2664 (20.34)    3.7621 (251.58)   180.2408 (20.56)    7.2631 (316.27)        2;0    5.6096 (0.05)          6           1
test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]                            175.5445 (20.09)    184.2485 (20.95)    180.0228 (20.54)    3.2197 (215.31)   180.9535 (20.65)    4.6658 (203.17)        2;0    5.5549 (0.05)          6           1
test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]                                 239.9570 (27.46)    241.0052 (27.40)    240.5523 (27.45)    0.4604 (30.79)    240.8063 (27.47)    0.7570 (32.97)         1;0    4.1571 (0.04)          5           1
test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]                                 260.8104 (29.85)    265.5763 (30.19)    262.9664 (30.00)    1.8899 (126.38)   262.4267 (29.94)    2.8793 (125.38)        2;0    3.8028 (0.03)          5           1
test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]          277.3215 (31.74)    284.9769 (32.40)    279.8040 (31.93)    3.1116 (208.08)   278.1552 (31.73)    3.6061 (157.03)        1;0    3.5739 (0.03)          5           1
test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]          278.1891 (31.84)    279.1910 (31.74)    278.5559 (31.78)    0.3838 (25.66)    278.4889 (31.77)    0.4231 (18.42)         1;0    3.5899 (0.03)          5           1
test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]                                 330.4078 (37.81)    343.1417 (39.01)    338.6620 (38.64)    4.9371 (330.15)   340.0215 (38.79)    5.4419 (236.96)        1;0    2.9528 (0.03)          5           1
test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]                                 363.7503 (41.63)    367.2784 (41.76)    366.1544 (41.78)    1.3999 (93.61)    366.6966 (41.84)    1.3901 (60.53)         1;0    2.7311 (0.02)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
=========================================================== slowest durations ============================================================
5.76s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
5.71s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
4.95s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
2.66s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
2.58s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
2.56s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
2.45s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
2.28s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
1.95s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
1.92s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
1.89s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
1.77s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
1.58s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
1.54s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
1.52s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
1.50s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
1.32s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=1]
1.26s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=0]
1.24s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=1]
1.20s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=1]
1.19s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=0]
1.08s call     tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=0]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=1]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=0]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=1]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=1]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=0]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=0]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
0.00s teardown tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=0]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=0]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=1]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=1]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=0]
0.00s setup    tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=1]
======================================================== short test summary info =========================================================
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=0-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.bfloat16, <DataType.FLOAT32: 1>)-to_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_torch_with_format_conversion[device_id=1-dtype=(torch.float32, <DataType.BFLOAT16: 0>)-to_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=0-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.BFLOAT16: 0>, torch.float32)-from_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.ROW_MAJOR]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_to_torch[device_id=1-dtype=(<DataType.FLOAT32: 1>, torch.bfloat16)-from_layout=Layout.TILE]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=0]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_from_device[device_id=1]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=0]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_host_to_device_tensor[device_id=1]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=0]
PASSED tests/ttnn/benchmark/python/benchmark_device_copies.py::test_benchmark_copy_device_to_host_tensor[device_id=1]
========================================================== 22 passed in 49.98s ===========================================================
2025-08-20 20:16:12.506 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:385)
```

CC @jbaumanTT