### PR TITLE
Disable tt-train tests in APC until nanollama issue is fixed

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -175,22 +175,22 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  tt-train-cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/tt-train-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  # tt-train-cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/tt-train-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
     needs: build-artifact


### PR DESCRIPTION
tt-train tests failing since commit https://github.com/tenstorrent/tt-metal/commit/40f8e0ae4d6744b9405fb6305d166899782e114a

@dmakoviichuk-tt already attempted to disable test in APC [[TT-Train] disabled nightly tests in APC (#26877)](https://github.com/tenstorrent/tt-metal/commit/e8d5d1b4d0363de23aee0c1ae2bd47170ace33ca) but APC still failing

Temporarily disable all tt-train tests until this is fixed