### PR TITLE
Add support for async readout of decode outputs in `tt_transformers`

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -917,8 +917,8 @@ def test_demo_text(
                 and num_layers == 80
             )
             if iteration > 0:
-                ttnn.event_synchronize(read_events.pop(0))
-                tt_out_tok = ttnn.to_torch(ttnn.get_device_tensors(tt_out_toks.pop(0))[0])[0, 0, 0, :32]
+                ttnn.event_synchronize(read_events.pop(0)[0])
+                tt_out_tok = generator.process_decode_output_host(tt_out_toks.pop(0))
 
                 out_tok = tt_out_tok if not teacher_forcing else ref_tokens[max_encoded_prompt_len + iteration + 1]
 

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -486,9 +486,15 @@ class Generator:
         )
         return trace_tok_rm
 
-    def read_decode_output(self, tt_logits, unpadded_batch, is_tokens=True):
-        logits, read_event = self.model.process_output_decode(tt_logits)
-        return logits, read_event
+    def read_decode_output(self, tt_out, async_read=True):
+        if not async_read:
+            return tt_out.cpu()
+
+        logits, read_event = self.model.process_output_decode(tt_out)
+        return logits, [read_event]
+
+    def process_decode_output_host(self, tt_out, is_tokens=True):
+        return ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0])[0, 0, 0, :]
 
     def chat_completion(
         self,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -200,8 +200,12 @@ class Generator:
             return logits
 
     # [INFO] this is called by vLLM
-    def read_decode_output(self, tt_out, unpadded_batch, is_tokens=False):
-        return self._ttt_generator.read_decode_output(tt_out, unpadded_batch, is_tokens)
+    def read_decode_output(self, tt_out, async_read=False):
+        return self._ttt_generator.read_decode_output(tt_out, async_read=async_read)
+
+    # [INFO] this is called by vLLM
+    def process_decode_output_host(self, tt_out, is_tokens=False):
+        return self._ttt_generator.process_decode_output_host(tt_out, is_tokens=is_tokens)
 
     ## Destructor (used to delete ttnn trace if exists)
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -660,8 +660,8 @@ class Generator:
     # Note: This function is called by vLLM
     def process_decode_output_host(self, tt_out, is_tokens=False):
         """
-        Converts the input ttnn host tensor to a torch tensor. The input can be logits (if is_tokens=False) or tokens (if is_tokens=True).
-        If read_from_device=False, the input is expected to be a host tensor; otherwise, it is a device tensor.
+        Converts the input ttnn host tensors to a torch tensor.
+        The input can be logits (if is_tokens=False) or tokens (if is_tokens=True).
         """
         max_batch_size_per_model = self.model_args[0].max_batch_size
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -236,15 +236,15 @@ class Generator:
             "argmax_on_device": argmax_on_device,
         }
         if enable_trace:
-            tt_logits = self._easy_trace_text(**decode_kwargs)
+            tt_decode_output = self._easy_trace_text(**decode_kwargs)
         else:
-            tt_logits = self._decode_forward_no_trace_text(**decode_kwargs)
+            tt_decode_output = self._decode_forward_no_trace_text(**decode_kwargs)
 
         if read_from_device:
-            to_host = self.read_decode_output(tt_logits, B, is_tokens=(sampling_params is not None))
-            return to_host
-        else:
-            return tt_logits
+            to_host = self.read_decode_output(tt_decode_output)
+            return self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+
+        return tt_decode_output
 
     def _decode_forward_no_trace_text(
         self,
@@ -636,15 +636,32 @@ class Generator:
             tt_logits = self._decode_forward_no_trace(**decode_kwargs)
 
         if read_from_device:
-            to_host = self.read_decode_output(tt_logits, B)
-            return to_host
+            to_host = self.read_decode_output(tt_logits)
+            return self.process_decode_output_host(to_host)
         else:
             return tt_logits
 
     # Note: This function is called by vLLM
-    def read_decode_output(self, tt_out, unpadded_batch, is_tokens=False):
+    def read_decode_output(self, tt_out, async_read=False):
         """
-        Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
+        Input tt_out is a list of ttnn device tensors
+        """
+        if not async_read:
+            return [out.cpu() for out in tt_out]
+
+        host_outputs = []
+        read_events = []
+        for i in range(self.data_parallel):
+            host_outputs.append(tt_out[i].cpu(blocking=False))
+            read_events.append(ttnn.record_event(self.model[i].mesh_device, 0))
+
+        return host_outputs, read_events
+
+    # Note: This function is called by vLLM
+    def process_decode_output_host(self, tt_out, is_tokens=False):
+        """
+        Converts the input ttnn host tensor to a torch tensor. The input can be logits (if is_tokens=False) or tokens (if is_tokens=True).
+        If read_from_device=False, the input is expected to be a host tensor; otherwise, it is a device tensor.
         """
         max_batch_size_per_model = self.model_args[0].max_batch_size
 

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -274,7 +274,7 @@ class Transformer(LightweightModule):
         """
         Concatenate the output of the devices into a single tensor.
         """
-        torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out.cpu())]
+        torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out)]
         if self.args.is_galaxy:
             row_dim, col_dim = (3, 1)
         else:
@@ -290,11 +290,11 @@ class Transformer(LightweightModule):
         Input is ttnn device tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
-        return self.concat_device_output(tt_out)[0, 0, last_token_idx, : self.vocab_size]
+        return self.concat_device_output(tt_out.cpu())[0, 0, last_token_idx, : self.vocab_size]
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
         """
-        Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
+        Input is ttnn host tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
         if is_tokens:
             return self.concat_device_output(tt_out)[0, 0, :B, 0]

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -270,9 +270,9 @@ class Transformer(LightweightModule):
         )
         return tt_tokens
 
-    def concat_device_output(self, tt_out):
+    def concat_host_output(self, tt_out):
         """
-        Concatenate the output of the devices into a single tensor.
+        Concatenate the output of the devices into a single host tensor.
         """
         torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out)]
         if self.args.is_galaxy:
@@ -290,14 +290,14 @@ class Transformer(LightweightModule):
         Input is ttnn device tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
-        return self.concat_device_output(tt_out.cpu())[0, 0, last_token_idx, : self.vocab_size]
+        return self.concat_host_output(tt_out.cpu())[0, 0, last_token_idx, : self.vocab_size]
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
         """
         Input is ttnn host tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
         if is_tokens:
-            return self.concat_device_output(tt_out)[0, 0, :B, 0]
+            return self.concat_host_output(tt_out)[0, 0, :B, 0]
 
         if self.args.num_devices > 1:
             tt_out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26341

### Problem description
We want to support async readout to activate existing vllm feature.
https://github.com/tenstorrent/vllm/pull/162

### Checklist
- [x] [all post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17076863078)
- [x] [llama 8B DP=4 on TG](https://github.com/tenstorrent/tt-shield/actions/runs/16994089907)
- [x] [vllm nightly](https://github.com/tenstorrent/tt-metal/actions/runs/17067674360)
- [x] [galaxy demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17065752682)