### PR TITLE
Add Experimental Support for Gemma-3-4b-it

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,7 +255,6 @@ models/demos/yolov4 @dvartaniansTT @mbahnasTT @rdraskicTT @mbezuljTT @tenstorren
 models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions @mradosavljevicTT
 models/experimental/ @sminakov-tt @dgomezTT @jmalone-tt @ayerofieiev-tt @uaydonat
 models/experimental/functional_unet @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions
-models/experimental/gemma3* @ppetrovicTT @handrewsTT @mtairum @rdraskicTT
 models/demos/ufld_v2 @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/demos/vgg_unet @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/experimental/openpdn_mnist @tenstorrent/cse-developer-ttnn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,6 +255,7 @@ models/demos/yolov4 @dvartaniansTT @mbahnasTT @rdraskicTT @mbezuljTT @tenstorren
 models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions @mradosavljevicTT
 models/experimental/ @sminakov-tt @dgomezTT @jmalone-tt @ayerofieiev-tt @uaydonat
 models/experimental/functional_unet @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions
+models/experimental/gemma3* @ppetrovicTT @handrewsTT @mtairum @rdraskicTT
 models/demos/ufld_v2 @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/demos/vgg_unet @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/experimental/openpdn_mnist @tenstorrent/cse-developer-ttnn

--- a/models/demos/qwen25_vl/conftest.py
+++ b/models/demos/qwen25_vl/conftest.py
@@ -1,19 +1,6 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 
-import ttnn
-
-
-@pytest.fixture
-def device_params(request, galaxy_type):
-    # Get param dict passed in from test parametrize (or default to empty dict)
-    params = getattr(request, "param", {}).copy()
-
-    if "fabric_config" in params and params["fabric_config"] == True:
-        params["fabric_config"] = (
-            ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
-        )
-
-    return params
+# Import the device_params fixture from tt_transformers
+from models.tt_transformers.conftest import device_params  # noqa: F401

--- a/models/experimental/gemma3_4b/conftest.py
+++ b/models/experimental/gemma3_4b/conftest.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Import the device_params fixture from tt_transformers
+from models.tt_transformers.conftest import device_params  # noqa: F401

--- a/models/experimental/gemma3_4b/tests/test_attention.py
+++ b/models/experimental/gemma3_4b/tests/test_attention.py
@@ -1,0 +1,279 @@
+"""Gemma-3-4b-it Test for Text Attention"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.gemma3_4b.tt.attention import Attention
+from models.tt_transformers.tt.common import PagedAttentionConfig, precompute_freqs
+from models.tt_transformers.tt.rope import RotarySetup
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+from models.tt_transformers.tt.model_config import ModelArgs
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "paged_attention",
+    (
+        True,
+        # False,
+    ),
+    ids=(
+        "paged_attention",
+        # "default_attention",
+    ),
+)
+@pytest.mark.parametrize(
+    "page_params",
+    [{"page_block_size": 32, "page_max_num_blocks": 1024}],
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize(
+    "max_seq_len",
+    (1,),  # For decode-only unit test, there's no need to run with large sequence lengths
+)
+def test_attention_inference(
+    max_seq_len,
+    batch_size,
+    paged_attention,
+    page_params,
+    mesh_device,
+    reset_seeds,
+    # ensure_gc,
+):
+    dtype = ttnn.bfloat16
+    pcc = 0.99
+
+    model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=128)
+    model_args.n_layers = 1  # For the unit test, just run a single layer
+
+    state_dict = model_args.load_state_dict()
+
+    first_layer_prefix = model_args.get_state_dict_prefix("Attention", 0) + "."
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+
+    reference_model = model_args.reference_attention()
+    # reference_model.load_state_dict(partial_state_dict)
+
+    seq_len = 1
+
+    generation_start_pos = 0
+    generation_length = 10
+    all_tests_pass = True
+
+    # Setup RoPE transformation matrices
+    rope_setup = RotarySetup(
+        mesh_device,
+        batch_size,
+        model_args.head_dim,
+        model_args.max_seq_len,
+        model_args.rope_theta,
+        model_args.rope_scaling,
+    )
+
+    transformation_mats = rope_setup.get_both_trans_mats()
+
+    page_table_tt = None
+    paged_attention_config = None
+
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
+
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtual blocks to physical
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, -2) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+    tt_model = Attention(
+        mesh_device,
+        state_dict,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        layer_num=0,
+        dtype=dtype,
+        transformation_mats=transformation_mats,
+        configuration=model_args,
+        paged_attention_config=paged_attention_config,
+    )
+
+    cos, sin = precompute_freqs(
+        model_args.head_dim,
+        model_args.max_seq_len * 2,
+        model_args.rope_theta,
+        model_args.rope_scaling.factor if model_args.rope_scaling else None,
+        model_args.rope_scaling.original_max_position_embeddings if model_args.rope_scaling else None,
+    )
+    freqs_cis = torch.complex(cos, sin)
+
+    # Initial positions
+    current_pos = torch.tensor([generation_start_pos for _ in range(batch_size)])
+    current_pos_tensor = ttnn.from_torch(
+        current_pos,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            mesh_shape=model_args.cluster_shape,
+        ),
+    )
+
+    for i in range(generation_length):
+        # 70B attention block typically sees tensors with mean 0 and std 0.03 - 0.05 in layer 1
+        pt_attention_input = torch.randn(batch_size, seq_len, model_args.dim)  # Qwen2.5 0.5B sees 0.1 to 2.1
+
+        tt_attention_input = pt_attention_input.clone()
+
+        attention_input = model_args.prepare_residual_tensor_decode(
+            tt_attention_input,
+            model_args.model_config["SHARDED_ATTN_INPUT_MEMCFG"],
+            force_replicated=False if model_args.is_galaxy else True,
+        )
+
+        # Get cos/sin matrices for the current position of each user
+        rot_mats = rope_setup.get_rot_mats(current_pos)
+
+        tt_out = tt_model(
+            attention_input,
+            current_pos_tensor,
+            rot_mats=rot_mats,
+            mode="decode",
+            page_table=page_table_tt,
+        )
+        # multi-device attention module returns replicated output
+        tt_out = ttnn.to_torch(
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=model_args.cluster_shape),
+        )
+        tt_output_torch = tt_out[:, 0:1, : model_args.max_batch_size, : model_args.dim].view(-1, 1, model_args.dim)
+
+        # In this test all users have the same position (if using batch > 1)
+        freqs_cis_i = freqs_cis[current_pos[0], :].unsqueeze(0)
+
+        reference_output = reference_model(pt_attention_input, current_pos[0], freqs_cis_i, mask=None)
+
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
+
+        logger.info(comp_allclose(reference_output, tt_output_torch))
+        logger.info(f"PCC: {pcc_message}")
+        if passing:
+            logger.info(f"[pos={current_pos[0]}] Attention Passed!")
+        else:
+            logger.warning(f"[pos={current_pos[0]}] Attention Failed!")
+            all_tests_pass = False
+
+        # Increment position
+        current_pos = torch.tensor([generation_start_pos + i + 1 for _ in range(batch_size)])
+        current_pos_tensor = ttnn.from_torch(
+            current_pos,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+        check_kv_cache = True
+        if check_kv_cache:
+            # PyTorch output --------------------------------------------------------------------
+            pytorch_layer_present = [
+                reference_model.cache_k.clone().permute(0, 2, 1, 3),  # [batch_size, n_kv_heads, seq, head_dim]
+                reference_model.cache_v.clone().permute(0, 2, 1, 3),  # [batch_size, n_kv_heads, seq, head_dim]
+            ]
+            # TT hardware execution -------------------------------------------------------------
+            if paged_attention:
+                tt_layer_present = [
+                    (
+                        ttnn.to_torch(
+                            cache,
+                            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                                mesh_device,
+                                dims=(1, 3) if model_args.is_galaxy else (0, 1),
+                                mesh_shape=model_args.cluster_shape,
+                            ),
+                        )[reverse_permutation][:, : model_args.n_kv_heads, :, : model_args.head_dim]
+                        .reshape(
+                            model_args.max_batch_size,
+                            paged_attention_config.max_num_blocks // model_args.max_batch_size,
+                            model_args.n_kv_heads,
+                            paged_attention_config.block_size,
+                            model_args.head_dim,
+                        )
+                        .transpose(1, 2)
+                        .reshape(model_args.max_batch_size, model_args.n_kv_heads, -1, model_args.head_dim)[
+                            :batch_size, ...
+                        ]
+                    )
+                    for cache in tt_model.layer_past
+                ]
+            else:
+                tt_layer_present = [
+                    ttnn.to_torch(
+                        cache,
+                        mesh_composer=ttnn.ConcatMesh2dToTensor(
+                            mesh_device,
+                            dims=(1, 0) if model_args.is_galaxy else (0, 1),
+                            mesh_shape=model_args.cluster_shape,
+                        ),
+                    )[:batch_size, :, :, :]
+                    for cache in tt_model.layer_past
+                ]
+            for label, cache_pt, cache_tt in zip(["K", "V"], pytorch_layer_present, tt_layer_present):
+                cache_length_to_check = min(model_args.max_seq_len, generation_start_pos + i + 1)
+                cache_pt = cache_pt[:, :, generation_start_pos:cache_length_to_check, :]
+                cache_tt = cache_tt[:, :, generation_start_pos:cache_length_to_check, :]
+                does_pass, output_pcc = comp_pcc(cache_pt, cache_tt, pcc)
+                logger.info(f"{label} cache output: {output_pcc}")
+                if does_pass:
+                    logger.info(f"{label} cache Passed!")
+                else:
+                    logger.warning(f"{label} Cache Failed! PCC value is lower than {pcc}")
+                    all_tests_pass = False
+
+    if all_tests_pass:
+        logger.info("Attention output Passed!")
+    else:
+        logger.warning("Attention output Failed!")
+        assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/test_attention.py
+++ b/models/experimental/gemma3_4b/tests/test_attention.py
@@ -14,6 +14,7 @@ import ttnn
 from models.experimental.gemma3_4b.tt.attention import Attention
 from models.tt_transformers.tt.common import PagedAttentionConfig, precompute_freqs
 from models.tt_transformers.tt.rope import RotarySetup
+from models.tt_transformers.tt.ccl import TT_CCL
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
 from models.tt_transformers.tt.model_config import ModelArgs
@@ -65,6 +66,7 @@ def test_attention_inference(
     dtype = ttnn.bfloat16
     pcc = 0.99
 
+    tt_ccl = TT_CCL(mesh_device)
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=128)
     model_args.n_layers = 1  # For the unit test, just run a single layer
 
@@ -127,6 +129,7 @@ def test_attention_inference(
 
     tt_model = Attention(
         mesh_device,
+        tt_ccl,
         state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),
         layer_num=0,

--- a/models/experimental/gemma3_4b/tests/test_attention.py
+++ b/models/experimental/gemma3_4b/tests/test_attention.py
@@ -96,7 +96,6 @@ def test_attention_inference(
         model_args.rope_theta,
         model_args.rope_scaling,
     )
-
     transformation_mats = rope_setup.get_both_trans_mats()
 
     page_table_tt = None

--- a/models/experimental/gemma3_4b/tests/test_decoder.py
+++ b/models/experimental/gemma3_4b/tests/test_decoder.py
@@ -10,6 +10,7 @@ from loguru import logger
 import os
 import ttnn
 from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.ccl import TT_CCL
 from models.experimental.gemma3_4b.tt.decoder import TransformerBlock
 from models.utility_functions import (
     comp_pcc,
@@ -63,6 +64,7 @@ def test_decoder_inference(
     reset_seeds,
 ):
     dtype = ttnn.bfloat16
+    tt_ccl = TT_CCL(mesh_device)
 
     pcc_required = 0.85
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
@@ -118,6 +120,7 @@ def test_decoder_inference(
     tt_model = TransformerBlock(
         args=model_args,
         mesh_device=mesh_device,
+        tt_ccl=tt_ccl,
         dtype=dtype,
         state_dict=state_dict,
         layer_num=0,
@@ -160,7 +163,8 @@ def test_decoder_inference(
         tt_out = tt_model(
             decode_input,
             current_pos_tensor,
-            rot_mats=[rot_mat_global, rot_mat_local],
+            rot_mats_global=rot_mat_global,
+            rot_mats_local=rot_mat_local,
             mode="decode",
             page_table=page_table_tt,
         )

--- a/models/experimental/gemma3_4b/tests/test_decoder.py
+++ b/models/experimental/gemma3_4b/tests/test_decoder.py
@@ -1,0 +1,208 @@
+"""Gemma-3-4b-it Test for Text Decoder"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import os
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.experimental.gemma3_4b.tt.decoder import TransformerBlock
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+from models.utility_functions import skip_for_grayskull
+from models.tt_transformers.tt.common import PagedAttentionConfig
+from models.tt_transformers.tt.rope import RotarySetup
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "paged_attention",
+    (
+        True,
+        # False
+    ),
+    ids=(
+        "paged_attention",
+        # "default_attention"
+    ),
+)
+@pytest.mark.parametrize(
+    "page_params",
+    [{"page_block_size": 32, "page_max_num_blocks": 1024}],
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize(
+    "max_seq_len",
+    (256,),  # For decode-only unit test, there's no need to run with large sequence lengths
+)
+def test_decoder_inference(
+    max_seq_len,
+    batch_size,
+    paged_attention,
+    page_params,
+    mesh_device,
+    reset_seeds,
+):
+    dtype = ttnn.bfloat16
+
+    pcc_required = 0.85
+    model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
+    model_args.n_layers = 1
+
+    state_dict = model_args.load_state_dict()
+
+    reference_model = model_args.reference_decoder()
+
+    generation_start_pos = 0
+    generation_length = 3
+    all_tests_pass = False
+
+    rope_setup = RotarySetup(
+        mesh_device,
+        batch_size,
+        model_args.head_dim,
+        model_args.max_seq_len,
+        model_args.rope_theta,
+        model_args.rope_scaling,
+    )
+    transformation_mats = rope_setup.get_both_trans_mats()
+
+    # Prepare page table for paged attention
+    page_table_tt = None
+    paged_attention_config = None
+
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtual blocks to physical
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, -2) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+    # Initialize TT model
+    tt_model = TransformerBlock(
+        args=model_args,
+        mesh_device=mesh_device,
+        dtype=dtype,
+        state_dict=state_dict,
+        layer_num=0,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        transformation_mats=transformation_mats,
+        paged_attention_config=paged_attention_config,
+    )
+
+    seqlen = 1
+
+    # Initial positions
+    current_pos = torch.tensor([generation_start_pos for _ in range(batch_size)])
+    current_pos_tensor = ttnn.from_torch(
+        current_pos,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            mesh_shape=model_args.cluster_shape,
+        ),
+    )
+    for i in range(generation_length):
+        pt_decode_input = (torch.rand(batch_size, seqlen, model_args.dim) * 2) - 1
+        logger.info(f"[Decoder] Generating token {i}")
+
+        tt_decode_input = pt_decode_input.clone()
+
+        decode_input = model_args.prepare_residual_tensor_decode(
+            tt_decode_input,
+            # ttnn.DRAM_MEMORY_CONFIG,
+            model_args.model_config["DECODE_RESIDUAL_MEMCFG"],
+        )
+
+        # Get cos/sin matrices for the current position of each user
+        rot_mat_global = rope_setup.get_rot_mats(current_pos)
+        rot_mat_local = rope_setup.get_rot_mats(current_pos)
+
+        # Run TT model
+        tt_out = tt_model(
+            decode_input,
+            current_pos_tensor,
+            rot_mats=[rot_mat_global, rot_mat_local],
+            mode="decode",
+            page_table=page_table_tt,
+        )
+        tt_out = ttnn.to_torch(
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=model_args.cluster_shape),
+        )
+
+        tt_output_torch = tt_out[:, 0:1, : model_args.max_batch_size, : model_args.dim].view(-1, 1, model_args.dim)
+
+        # Reference model
+        ref_output = reference_model(pt_decode_input, current_pos[0], None, mask=None)
+        non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+        tt_output_torch = tt_output_torch[non_zero_indices]
+        ref_output = ref_output[non_zero_indices]
+
+        passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc_required)
+
+        logger.info(comp_allclose(ref_output, tt_output_torch))
+        logger.info(f"PCC: {pcc_message}")
+
+        if passing:
+            logger.info("Decoder Block Passed!")
+        else:
+            logger.warning("Decoder Block Failed!")
+            # all_tests_pass = False
+
+        # Increment position
+        current_pos = torch.tensor([generation_start_pos + i + 1 for _ in range(batch_size)])
+        current_pos_tensor = ttnn.from_torch(
+            current_pos,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+    # if all_tests_pass:
+    #     logger.info(f"All {generation_length} decode iterations Passed!")
+    # else:
+    #     logger.warning("One or more iterations of decode Failed!")
+    #     assert all_tests_pass, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/test_decoder.py
+++ b/models/experimental/gemma3_4b/tests/test_decoder.py
@@ -1,6 +1,6 @@
 """Gemma-3-4b-it Test for Text Decoder"""
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -55,6 +55,7 @@ from models.tt_transformers.tt.rope import RotarySetup
     "max_seq_len",
     (256,),  # For decode-only unit test, there's no need to run with large sequence lengths
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_decoder_inference(
     max_seq_len,
     batch_size,

--- a/models/experimental/gemma3_4b/tests/test_embedding.py
+++ b/models/experimental/gemma3_4b/tests/test_embedding.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it test for Text Embedding"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/models/experimental/gemma3_4b/tests/test_embedding.py
+++ b/models/experimental/gemma3_4b/tests/test_embedding.py
@@ -1,0 +1,87 @@
+"""Gemma-3-4b-it test for Text Embedding"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.embedding import Embedding
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize(
+    "max_seq_len",
+    (128,),  # For decode-only unit test, there's no need to run with large sequence lengths
+)
+def test_embedding(max_seq_len, batch_size, mesh_device, reset_seeds):
+    dtype = ttnn.bfloat16
+
+    model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
+    model_args.n_layers = 1
+
+    state_dict = model_args.load_state_dict()
+    tokenizer = model_args.tokenizer
+    reference_emb = model_args.reference_embedding()
+    layer_name = "tok_embeddings.weight"
+    reference_emb.load_state_dict({"emb.weight": state_dict[layer_name]})
+
+    tt_emb = Embedding(
+        mesh_device=mesh_device,
+        args=model_args,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        state_dict=state_dict,
+        dtype=dtype,
+    )
+
+    prompts = ["Joy"] * 32
+    pt_input = torch.tensor([model_args.encode_prompt(prompt, instruct=False) for prompt in prompts])
+    reference_output = reference_emb(pt_input)
+    logger.info(f"reference_output: {reference_output.shape}")
+
+    tt_input = ttnn.from_torch(
+        pt_input.squeeze(1),
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+    tt_output = tt_emb(tt_input)
+    tt_output = ttnn.multiply(tt_output, model_args.embed_scale)
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=model_args.cluster_shape),
+    )[:32].view(reference_output.shape)
+    logger.info(f"tt_output_torch: {tt_output_torch.shape}")
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+    if passing:
+        logger.info("embedding Passed!")
+    else:
+        logger.warning("embedding Failed!")
+
+    assert passing, f"embedding output does not meet PCC requirement {0.99}."

--- a/models/experimental/gemma3_4b/tests/test_lm_head.py
+++ b/models/experimental/gemma3_4b/tests/test_lm_head.py
@@ -14,6 +14,7 @@ from loguru import logger
 import ttnn
 from models.experimental.gemma3_4b.tt.lm_head import LMHead
 from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.ccl import TT_CCL
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
 
@@ -52,10 +53,11 @@ def test_lm_head_inference(seq_len, batch_size, mesh_device, reset_seeds):
     model_args.WEIGHTS_DTYPE = dtype
     reference_model = model_args.reference_lm_head()
     reference_model.load_state_dict(partial_state_dict)
-
+    tt_ccl = TT_CCL(mesh_device)
     tt_model = LMHead(
         args=model_args,
         mesh_device=mesh_device,
+        tt_ccl=tt_ccl,
         dtype=dtype,
         state_dict=state_dict,
         state_dict_prefix=state_dict_prefix,

--- a/models/experimental/gemma3_4b/tests/test_lm_head.py
+++ b/models/experimental/gemma3_4b/tests/test_lm_head.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it Test for lm_head"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -37,6 +37,7 @@ from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
     ],
     indirect=True,
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_lm_head_inference(seq_len, batch_size, mesh_device, reset_seeds):
     dtype = ttnn.bfloat16
 

--- a/models/experimental/gemma3_4b/tests/test_lm_head.py
+++ b/models/experimental/gemma3_4b/tests/test_lm_head.py
@@ -1,0 +1,103 @@
+"""Gemma-3-4b-it Test for lm_head"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.gemma3_4b.tt.lm_head import LMHead
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "seq_len",
+    (32,),
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+def test_lm_head_inference(seq_len, batch_size, mesh_device, reset_seeds):
+    dtype = ttnn.bfloat16
+
+    model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=seq_len)
+    model_args.n_layers = 1
+    state_dict = model_args.load_state_dict()
+
+    state_dict_prefix = model_args.get_state_dict_prefix("", None)
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    partial_state_dict = {
+        "weight": state_dict[f"{state_dict_prefix}output.weight"],
+    }
+
+    model_args.WEIGHTS_DTYPE = dtype
+    reference_model = model_args.reference_lm_head()
+    reference_model.load_state_dict(partial_state_dict)
+
+    tt_model = LMHead(
+        args=model_args,
+        mesh_device=mesh_device,
+        dtype=dtype,
+        state_dict=state_dict,
+        state_dict_prefix=state_dict_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        max_columns_per_device=model_args.max_columns_per_device_lm_head,
+    )
+
+    torch_input = torch.randn(1, 1, seq_len, model_args.dim)
+    reference_output = reference_model(torch_input)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, dims=(None, 3) if model_args.is_galaxy else (None, None), mesh_shape=model_args.cluster_shape
+        ),
+        dtype=ttnn.bfloat16,
+        memory_config=model_args.model_config["LM_HEAD_INPUT_MEMCFG"],
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    logger.info("Run LM_Head")
+    tt_output = tt_model(tt_input)
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(
+            mesh_device, model_args.cluster_shape, dims=(3, 1) if model_args.is_galaxy else (1, 3)
+        ),
+    )
+    tt_output_torch = tt_output_torch[:, 0:1, :, : model_args.vocab_size]
+
+    pcc_required = 0.99
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+    if passing:
+        logger.info("LM_Head Passed!")
+    else:
+        logger.warning("LM_Head Failed!")
+
+    assert passing, f"LM_Head output does not meet PCC requirement {pcc_required}: {pcc_message}."

--- a/models/experimental/gemma3_4b/tests/test_mlp.py
+++ b/models/experimental/gemma3_4b/tests/test_mlp.py
@@ -1,0 +1,104 @@
+"""Gemma-3-4b-it Test for Text MLP"""
+
+from loguru import logger
+
+import torch
+import pytest
+import os
+import ttnn
+
+from models.experimental.gemma3_4b.tt.mlp import MLP
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+from models.tt_transformers.tt.model_config import ModelArgs
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("device"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    (2560,),
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+def test_mlp_inference(seq_len, batch_size, reset_seeds, device):
+    dtype = ttnn.bfloat16
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    # tt_model_args = ModelArgs(
+    #     device,
+    #     max_batch_size=batch_size,
+    #     max_seq_len=128,
+    # )
+    tt_model_args = ModelArgs(device, max_batch_size=batch_size, max_seq_len=128)
+
+    tt_model_args.n_layers = 1
+    state_dict = tt_model_args.load_state_dict()
+
+    # # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    # first_layer_prefix = "layers.0.feed_forward"
+    first_layer_prefix = tt_model_args.get_state_dict_prefix("MLP", 0)
+
+    partial_state_dict = {
+        k[len(first_layer_prefix) + 1 :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    }
+
+    reference_model = tt_model_args.reference_mlp()  # Gemma3 MLP
+    reference_model.load_state_dict(partial_state_dict)
+
+    tt_model = MLP(
+        mesh_device=device,
+        args=tt_model_args,
+        state_dict=state_dict,
+        weight_cache_path=tt_model_args.weight_cache_path(dtype),
+        layer_num=0,
+        dtype=dtype,
+        model_config=tt_model_args.get_model_config(),
+        state_dict_prefix=first_layer_prefix,
+    )
+    torch_input = torch.randn(1, 1, seq_len)
+    reference_output = reference_model(torch_input)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            device, dims=(None, 3) if tt_model_args.is_galaxy else (None, None), mesh_shape=tt_model_args.cluster_shape
+        ),  # When both dims are None, the mapper used is `ReplicateTensorToMesh`
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    logger.info("Run MLP")
+    tt_output = tt_model(tt_input, mode)
+
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(device, dims=(1, 3), mesh_shape=tt_model_args.cluster_shape),
+    )
+
+    # tt_output_torch = tt_output_torch[:, :1, :, :]
+
+    pcc_required = 0.99
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch[0]))
+    logger.info(f"PCC: {pcc_message}")
+    if passing:
+        logger.info("MLP Passed!")
+    else:
+        logger.warning("MLP Failed!")
+
+    assert passing, f"MLP output does not meet PCC requirement {pcc_required}: {pcc_message}."

--- a/models/experimental/gemma3_4b/tests/test_mlp.py
+++ b/models/experimental/gemma3_4b/tests/test_mlp.py
@@ -1,5 +1,9 @@
 """Gemma-3-4b-it Test for Text MLP"""
 
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 from loguru import logger
 
 import torch

--- a/models/experimental/gemma3_4b/tests/test_mlp.py
+++ b/models/experimental/gemma3_4b/tests/test_mlp.py
@@ -11,6 +11,7 @@ from models.experimental.gemma3_4b.tt.mlp import MLP
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
 from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.ccl import TT_CCL
 
 
 @torch.no_grad()
@@ -57,8 +58,11 @@ def test_mlp_inference(seq_len, batch_size, reset_seeds, device):
     reference_model = tt_model_args.reference_mlp()  # Gemma3 MLP
     reference_model.load_state_dict(partial_state_dict)
 
+    tt_ccl = TT_CCL(device)
+
     tt_model = MLP(
         mesh_device=device,
+        tt_ccl=tt_ccl,
         args=tt_model_args,
         state_dict=state_dict,
         weight_cache_path=tt_model_args.weight_cache_path(dtype),

--- a/models/experimental/gemma3_4b/tests/test_mmp.py
+++ b/models/experimental/gemma3_4b/tests/test_mmp.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it Test for multi-modal-projector"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tests/test_mmp.py
+++ b/models/experimental/gemma3_4b/tests/test_mmp.py
@@ -72,7 +72,7 @@ def test_multi_modal_inference(seq_len, batch_size, reset_seeds, device):
     tt_model = TtGemma3MultiModalProjector(
         mesh_device=device,
         state_dict=state_dict,
-        state_dict_prefix="model.multi_modal_projector",
+        state_dict_prefix="multi_modal_projector",
         image_size=tt_model_args.vision_chunk_size,
         patch_size=tt_model_args.vision_patch_size,
         hidden_size=tt_model_args.vision_hidden_dim,

--- a/models/experimental/gemma3_4b/tests/test_mmp.py
+++ b/models/experimental/gemma3_4b/tests/test_mmp.py
@@ -1,0 +1,98 @@
+"""Gemma-3-4b-it Test for multi-modal-projector"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.experimental.gemma3_4b.tt.mmp import TtGemma3MultiModalProjector
+
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("device"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    (1152,),
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+def test_multi_modal_inference(seq_len, batch_size, reset_seeds, device):
+    dtype = ttnn.bfloat16
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    tt_model_args = ModelArgs(
+        device,
+        max_batch_size=batch_size,
+        max_seq_len=128,
+    )
+
+    tt_model_args.n_layers = 1
+    state_dict = tt_model_args.load_state_dict()
+
+    reference_model = tt_model_args.reference_vision_multi_modal()
+
+    # create input tensor for multi_modal_projector layer
+    patches_per_image = 64
+    num_patches = patches_per_image * patches_per_image
+    input = torch.randn((batch_size, num_patches, seq_len))
+    reference_output = reference_model(input)
+
+    # DistributedNorm inputs are fractured across devices and interleaved in DRAM (for prefill) and L1 (for decode)
+    tt_input = ttnn.from_torch(
+        input,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(None, -1), mesh_shape=tt_model_args.cluster_shape),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_model = TtGemma3MultiModalProjector(
+        mesh_device=device,
+        state_dict=state_dict,
+        state_dict_prefix="model.multi_modal_projector",
+        image_size=tt_model_args.vision_chunk_size,
+        patch_size=tt_model_args.vision_patch_size,
+        hidden_size=tt_model_args.vision_hidden_dim,
+        mm_tokens_per_image=tt_model_args.mm_tokens_per_image,
+        weight_cache_path=tt_model_args.weight_cache_path(dtype),
+        layer_norm_eps=1e-06,  # layer_norm_eps
+        dtype=dtype,
+        configuration=tt_model_args,
+    )
+    tt_output = tt_model(tt_input)
+
+    tt_output_torch = ttnn.to_torch(tt_output)
+    tt_output_torch = tt_output_torch.view(reference_output.shape)
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    pcc_required = 0.9999
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/test_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/test_rmsnorm.py
@@ -1,6 +1,6 @@
 """Gemma-3-4b-it Test for Text RMSNorm"""
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tests/test_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/test_rmsnorm.py
@@ -1,0 +1,133 @@
+"""Gemma-3-4b-it Test for Text RMSNorm"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import torch
+import pytest
+import os
+
+import ttnn
+from models.experimental.gemma3_4b.tt.rmsnorm import RMSNorm
+from models.tt_transformers.tt.distributed_norm import DistributedNorm
+
+
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+from models.tt_transformers.tt.model_config import ModelArgs
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("device"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "tt_layer_name, torch_layer_name, dim",
+    (
+        ("norm", "norm", 2560),
+        ("layers.0.attention_norm", "layers.0.input_layernorm", 2560),
+        ("layers.0.ffn_norm", "layers.0.post_attention_layernorm", 2560),
+        ("layers.0.pre_feedforward_layernorm", "layers.0.pre_feedforward_layernorm", 2560),
+        ("layers.0.post_feedforward_layernorm", "layers.0.post_feedforward_layernorm", 2560),
+        ("layers.0.attention.q_norm", "layers.0.self_attn.q_norm", 256),
+        ("layers.0.attention.k_norm", "layers.0.self_attn.k_norm", 256),
+    ),
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    (128,),
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+def test_rmsnorm_inference(seq_len, batch_size, reset_seeds, device, tt_layer_name, torch_layer_name, dim):
+    dtype = ttnn.bfloat16
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    tt_model_args = ModelArgs(
+        device,
+        max_batch_size=batch_size,
+        max_seq_len=128,
+    )
+
+    tt_model_args.n_layers = 1
+    state_dict = tt_model_args.load_state_dict()
+    reference_model = tt_model_args.reference_transformer(wrap=False)  # Gemma3 Entire Model
+    reference_model = reference_model.model.get_submodule(torch_layer_name)
+
+    state_dict_prefix = ""
+    first_layer_prefix = state_dict_prefix + tt_layer_name + "."
+    partial_state_dict = {
+        k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    }
+
+    reference_model.load_state_dict(partial_state_dict)
+
+    tt_inner_norm = RMSNorm(
+        device=device,
+        dim=dim,
+        state_dict=state_dict,
+        state_dict_prefix=state_dict_prefix,
+        weight_key=tt_layer_name,
+        weight_dtype=dtype,
+        is_distributed=tt_model_args.is_distributed_norm,
+        sharded_program_config=tt_model_args.get_model_config()["SHARDED_NORM_ATTN_PRGM_CFG"],
+        sharded_output_config=tt_model_args.get_model_config()["SHARDED_ATTN_INPUT_MEMCFG"],
+    )
+
+    # Wrap it in DistributedNorm
+    tt_model = DistributedNorm(tt_inner_norm, tt_model_args, TG=tt_model_args.is_galaxy)
+
+    input = torch.rand(1, 1, dim)
+
+    reference_output = reference_model(input)
+
+    # DistributedNorm inputs are fractured across devices and interleaved in DRAM (for prefill) and L1 (for decode)
+    tt_input = ttnn.from_torch(
+        input,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(None, -1), mesh_shape=tt_model_args.cluster_shape),
+        memory_config=(
+            tt_model_args.get_model_config()["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
+        ),
+    )
+
+    tt_output = tt_model(tt_input, mode=mode)
+
+    # DistributedNorm outputs are replicated across devices
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(
+            device, dims=(0, 2) if tt_model_args.is_galaxy else (2, 0), mesh_shape=tt_model_args.cluster_shape
+        ),
+    )[:1, :, :]
+
+    tt_output_torch = tt_output_torch.view(1, 1, dim)
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch[0])
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {torch_layer_name} , {pcc_message}")
+
+    if passing:
+        logger.info("rms_norm Passed!")
+    else:
+        logger.warning("rms_norm Failed!")
+
+    assert passing, f"rms_norm output does not meet PCC requirement {0.99}."

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -1,0 +1,750 @@
+""" End-to-end test for Gemma-3-4B-it vision-text pipeline."""
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from loguru import logger
+import os
+import ttnn
+from models.tt_transformers.tt.common import (
+    encode_prompt_hf,
+    sample_host,
+    PagedAttentionConfig,
+    preprocess_inputs_prefill,
+)
+from models.tt_transformers.tt.model_config import DecodersPrecision
+
+from models.experimental.gemma3_4b.tt.text_model import Gemma3_4BTransformer
+from models.experimental.gemma3_4b.tt.gemma_vision_crossattention import TtGemmaTransformerVision
+from models.experimental.gemma3_4b.tt.gemma3_generator import Gemma3Generator
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+from models.utility_functions import skip_for_grayskull, skip_for_blackhole
+from models.tt_transformers.tt.model_config import HfModelWrapper
+
+from models.tt_transformers.tt.model_config import ModelArgs
+from transformers import AutoProcessor
+
+import re
+
+
+def parse_chat_output(text):
+    """Parse chat output format from generated text."""
+    pattern = r"<\|(?P<role>user|assistant)\|>\s*(?P<message>.*?)(?=<\|(?:user|assistant|end)\|>|$)"
+    matches = re.finditer(pattern, text, re.DOTALL)
+    return [(match.group("role"), match.group("message").strip()) for match in matches]
+
+
+def display_chat(logger, conversation):
+    """Display chat conversation in formatted output."""
+    for role, message in conversation:
+        if role == "user":
+            logger.info(f"👤 User: {message}")
+        elif role == "assistant":
+            logger.info(f"🤖 Assistant: {message}")
+
+
+def setup_model_args(weights, max_seq_len, batch_size, mesh_device, optimizations):
+    """Setup model arguments and configuration."""
+    instruct = True if weights == "instruct" else False
+
+    model_args = ModelArgs(
+        mesh_device=mesh_device,
+        instruct=instruct,
+        optimizations=optimizations,
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+    )
+
+    return model_args, instruct
+
+
+def setup_prompts_and_tokenizer(model_args, instruct):
+    """Setup prompts and tokenizer for the test."""
+    prompts = ["Write a essay about Lion"] * model_args.max_batch_size
+    tokenizer = model_args.tokenizer
+
+    if instruct:
+        encoded_prompts = encode_prompt_hf(tokenizer=tokenizer, prompt_text=prompts[0])
+    else:
+        encoded_prompts = [model_args.encode_prompt(prompt, instruct=False) for prompt in prompts]
+
+    return prompts, tokenizer, encoded_prompts
+
+
+def setup_reference_model(model_args, run_ref_pt):
+    """Setup reference PyTorch model and embedding."""
+    if run_ref_pt:
+        reference_transformer_model = model_args.reference_transformer(wrap=False)
+        reference_model = HfModelWrapper(reference_transformer_model, model_args.head_dim)
+        logger.info("Finished loading reference model.")
+        embd = model_args.reference_embedding(reference_transformer_model)
+    else:
+        reference_model = None
+        embd = model_args.reference_embedding()
+
+    return reference_model, embd
+
+
+def setup_paged_attention(paged_attention, page_params, model_args, mesh_device):
+    """Setup paged attention configuration and page table."""
+    page_table_tt = None
+    paged_attention_config = None
+
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtual blocks to physical
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, -2) if model_args.max_batch_size > 1 else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+    return paged_attention_config, page_table_tt
+
+
+def load_tt_model(model_args, mesh_device, dtype, paged_attention_config):
+    """Load the TT model with state dict."""
+    state_dict = model_args.load_state_dict()
+
+    tt_model = Gemma3_4BTransformer(
+        args=model_args,
+        mesh_device=mesh_device,
+        dtype=dtype,
+        state_dict=state_dict,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        paged_attention_config=paged_attention_config,
+    )
+
+    logger.info("Model and caches loaded.")
+    return tt_model
+
+
+# =============================================================================
+# NEW E2E PIPELINE COMPONENTS - Following SOLID Principles
+# =============================================================================
+
+
+def setup_vision_model_args(weights, max_seq_len, batch_size, mesh_device, optimizations):
+    """Setup model arguments for vision-enabled model (Single Responsibility)."""
+    instruct = True if weights == "instruct" else False
+
+    model_args = ModelArgs(
+        mesh_device=mesh_device,
+        instruct=instruct,
+        optimizations=optimizations,
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+    )
+    return model_args, instruct
+
+
+def setup_vision_prompts_and_tokenizer(model_args, instruct):
+    """Setup multimodal prompts and tokenizer for vision-enabled model."""
+    # Create multimodal messages similar to test_end2end.py
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Write about Marvel in detail for 1000 words."},
+            ],
+        }
+    ]
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg",
+                },
+                {"type": "text", "text": "Describe this image in detail."},
+            ],
+        }
+    ]
+
+    tokenizer = model_args.tokenizer
+    return messages, tokenizer
+
+
+def setup_vision_reference_model(model_args, run_ref_pt):
+    """Setup reference vision-enabled model (Open/Closed Principle)."""
+    if run_ref_pt:
+        reference_transformer_model = model_args.reference_vision_transformer(wrap=False)
+        reference_model = HfModelWrapper(reference_transformer_model, model_args.head_dim)
+        logger.info("Finished loading reference vision model.")
+        embd = model_args.reference_embedding(reference_transformer_model)
+    else:
+        reference_model = None
+        embd = model_args.reference_embedding()
+
+    return reference_model, embd
+
+
+def process_real_vision_inputs(messages, model_args):
+    """Process real image inputs using AutoProcessor (Interface Segregation)."""
+    model_id = "google/gemma-3-4b-it"
+    processor = AutoProcessor.from_pretrained(model_id)
+
+    # Process the multimodal messages similar to test_end2end.py
+    encoded = processor.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=True, return_dict=True, return_tensors="pt"
+    ).to(dtype=torch.bfloat16)
+
+    input_ids = encoded["input_ids"]
+    pixel_values = encoded["pixel_values"]
+    attention_mask = encoded["attention_mask"]
+
+    # logger.info(f"Processed vision inputs - input_ids: {input_ids.shape}, pixel_values: {pixel_values.shape}")
+
+    return {
+        "input_ids": input_ids,
+        "pixel_values": pixel_values,
+        "attention_mask": attention_mask,
+        "processor": processor,
+        "input_prompts": messages,
+    }
+
+
+# Legacy function removed - vision model now part of multimodal model
+
+
+def load_separate_models_like_test_end2end(model_args, mesh_device, dtype, paged_attention, page_params):
+    """Load separate vision and text models following test_end2end.py pattern."""
+    state_dict = model_args.load_state_dict()
+    vision_prefix = "vision_tower.vision_model."
+
+    # Setup paged attention config (exactly like test_end2end.py)
+    paged_attention_config = None
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
+
+    # Load vision model (exactly like test_end2end.py)
+    vision_model = TtGemmaTransformerVision(
+        mesh_device=mesh_device,
+        state_dict=state_dict,
+        state_dict_prefix=vision_prefix,
+        dtype=dtype,
+        configuration=model_args,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+    )
+
+    # Load text model (exactly like test_end2end.py)
+    text_model = Gemma3_4BTransformer(
+        args=model_args,
+        mesh_device=mesh_device,
+        dtype=dtype,
+        state_dict=state_dict,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        paged_attention_config=paged_attention_config,
+    )
+
+    logger.info("Separate vision and text models loaded like test_end2end.py")
+    return vision_model, text_model
+
+
+def run_generation_exactly_like_test_end2end(
+    vision_model, text_model, processed_inputs, model_args, page_table=None, paged_attention_config=None, max_gen_len=20
+):
+    """Run generation following the EXACT pattern from test_end2end.py."""
+    input_ids = processed_inputs["input_ids"]
+    pixel_values = processed_inputs["pixel_values"]
+    input_prompts = processed_inputs["input_prompts"]
+
+    logger.info("Running generation exactly like test_end2end.py...")
+
+    # Process vision (exactly like test_end2end.py)
+    logger.info("Running Vision Model...")
+
+    # Create Generator (exactly like test_end2end.py)
+    generator = Gemma3Generator([text_model], [model_args], vision_model.mesh_device, tokenizer=model_args.tokenizer)
+
+    # Setup KV cache (exactly like test_end2end.py)
+    tt_kv_cache = [[l.attention.layer_past for l in text_model.layers]] if paged_attention_config else None
+
+    # Get embeddings and combine with vision (exactly like test_end2end.py)
+    # host_embedding = model_args.reference_embedding()
+
+    # # Text generation setup (exactly like test_end2end.py)
+    input_tokens_prefill = input_ids
+    batch_size = input_tokens_prefill.shape[0]
+    # seq_len = input_tokens_prefill.shape[1]
+
+    (
+        input_tokens_prefill_pt,
+        encoded_prompts,
+        decoding_pos,
+        prefill_lens,
+    ) = preprocess_inputs_prefill(
+        input_prompts,
+        model_args.tokenizer,
+        [model_args],
+        instruct=True,
+        max_generated_tokens=max_gen_len,
+        max_prefill_len=8192,
+    )
+
+    input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(batch_size, -1)
+
+    logger.info("Running prefill...")
+    logits = generator.prefill_forward_text(
+        input_tokens_prefill_pt,
+        page_table=page_table,
+        kv_cache=tt_kv_cache,
+        prompt_lens=decoding_pos,
+        vision_model=vision_model,
+        processed_inputs=processed_inputs,
+    )
+
+    # Get first token (exactly like test_end2end.py)
+    prefilled_token = torch.argmax(logits, dim=-1)
+    logger.info(f"Prefilled token: {prefilled_token}")
+
+    # Initialize generation (exactly like test_end2end.py)
+    all_outputs = [encoded_prompts[0][: prefill_lens[0]]]
+    all_outputs[0].append(int(prefilled_token[0].item()))
+
+    current_pos = torch.tensor([decoding_pos[0]])
+    out_tok = prefilled_token
+    generation_length = 150
+
+    results = []
+
+    # Decode loop (exactly like test_end2end.py)
+    logger.info("Starting decode loop...")
+    for iteration in range(generation_length):
+        logger.info(f"[Text] Decoding token {iteration}, current_pos: {current_pos.item()}")
+
+        # Run decode (exactly like test_end2end.py)
+        logits = generator.decode_forward_text(
+            out_tok,
+            current_pos,
+            enable_trace=False,
+            page_table=page_table,
+            kv_cache=tt_kv_cache,
+        )
+
+        # Sample next token (exactly like test_end2end.py)
+        _, out_tok = sample_host(
+            logits,
+            temperature=0,
+            top_p=0.9,
+        )
+
+        token_id = out_tok[0].item()
+        decoded_token = model_args.tokenizer.decode([token_id])
+        logger.info(f"Generated token {iteration}: ID={token_id}, text='{decoded_token}'")
+
+        # Create result object
+        result = type("TokenResult", (), {"token": token_id, "text": decoded_token})()
+
+        results.append(result)
+
+        all_outputs[0].append(token_id)
+        current_pos += 1
+
+        # Early stopping (exactly like test_end2end.py)
+        if len(all_outputs[0]) >= 5 and all(t == all_outputs[0][-1] for t in all_outputs[0][-5:]):
+            logger.warning(f"Detected exact repetition of token {all_outputs[0][-1]} five times in a row. Stopping.")
+            break
+
+    # Final response (exactly like test_end2end.py)
+    response = model_args.tokenizer.decode(all_outputs[0], skip_special_tokens=True)
+    logger.info(f"📝 Final Generated Response:\n{response}")
+    logger.info(f"📝 Generated {len(all_outputs[0])} tokens: {all_outputs[0]}")
+    chat = parse_chat_output(response)
+    display_chat(logger, chat)
+
+    logger.info(f"Generated {len(results)} tokens successfully")
+    return results
+
+
+# Legacy function removed - vision processing now handled in multimodal model
+
+
+def validate_e2e_outputs(results, expected_min_tokens=1):
+    """Validate end-to-end pipeline outputs."""
+    if not results:
+        logger.error("No results generated from E2E pipeline")
+        return False
+
+    if len(results) < expected_min_tokens:
+        logger.warning(f"Generated only {len(results)} tokens, expected at least {expected_min_tokens}")
+        return False
+
+    # Check if tokens are valid
+    for result in results:
+        if not hasattr(result, "token") or not hasattr(result, "text"):
+            logger.error("Invalid result format")
+            return False
+
+    logger.info("E2E pipeline validation passed")
+    return True
+
+
+# =============================================================================
+# EXISTING FUNCTIONS (Unchanged for backward compatibility)
+# =============================================================================
+
+
+def create_position_tensor(current_pos, model_args, mesh_device):
+    """Create position tensor for the model."""
+    return ttnn.from_torch(
+        current_pos,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, 0) if (model_args.is_galaxy and model_args.max_batch_size > 1) else (None, None),
+            mesh_shape=model_args.cluster_shape,
+        ),
+    )
+
+
+def convert_tt_output_to_torch(tt_out, model_args, mesh_device):
+    """Convert TTNN tensor to PyTorch tensor."""
+    mesh_composer = ttnn.ConcatMesh2dToTensor(
+        mesh_device, dims=(3, 1) if model_args.is_galaxy else (1, -1), mesh_shape=model_args.cluster_shape
+    )
+    tt_output_torch = (
+        ttnn.to_torch(tt_out, mesh_composer=mesh_composer)
+        .permute(2, 1, 0, 3)
+        .squeeze(2)[: model_args.max_batch_size, 0:1, : model_args.vocab_size]
+    )
+    ttnn.deallocate(tt_out)
+    return tt_output_torch
+
+
+def process_token_generation(
+    i,
+    encoded_prompts,
+    encoded_prompts_tensor,
+    embd,
+    batch,
+    seqlen,
+    all_outputs,
+    all_outputs_ref,
+    run_ref_pt,
+    ref_output,
+    tt_output_torch,
+):
+    """Process token generation for both prefill and decode phases."""
+    if i in range(len(encoded_prompts)):
+        # While in "prefill" mode, use the prompt tokens as the output
+        all_outputs.append(encoded_prompts[i])
+        if run_ref_pt:
+            all_outputs_ref.append(encoded_prompts[i])
+
+        tt_decode_input = embd(encoded_prompts_tensor[:, i]).view(batch, seqlen, -1)
+        if run_ref_pt:
+            pt_decode_input = embd(encoded_prompts_tensor[:, i]).view(batch, seqlen, -1)
+        else:
+            pt_decode_input = None
+    else:
+        # Greedy decode (temperature = 0) the generated token and save it to print out later
+        # Exact copy of original logic (including commented sections)
+        # if run_ref_pt:
+        #     # Sample from reference model first
+        _, pt_out_tok = sample_host(ref_output, temperature=0, top_p=0.8)
+        pt_decode_input = embd(pt_out_tok)
+        all_outputs_ref.append(pt_out_tok.squeeze(1).tolist()[0])
+
+        # Use the same token for TT model (teacher forcing)
+        tt_decode_input = pt_decode_input
+        # all_outputs.append(pt_out_tok.squeeze(1).tolist()[0])
+        # else:
+        # If not running reference model, sample from TT model directly
+        _, tt_out_tok = sample_host(tt_output_torch, temperature=0, top_p=0.8)
+        tt_decode_input = embd(tt_out_tok)
+        all_outputs.append(tt_out_tok.squeeze(1).tolist()[0])
+
+    return tt_decode_input, pt_decode_input
+
+
+def validate_outputs(run_ref_pt, ref_output, tt_output_torch, pcc, all_outputs, all_outputs_ref, tokenizer, logger):
+    """Validate model outputs and compute PCC."""
+    if run_ref_pt:
+        passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc)
+
+        # Decode the output tokens back to text
+        decoded_texts = [tokenizer.decode(output, skip_special_tokens=True) for output in all_outputs]
+        logger.info(f'TTNN Decoded Outputs: {"".join(decoded_texts)}')
+        decoded_texts = [tokenizer.decode(output, skip_special_tokens=True) for output in all_outputs_ref]
+        logger.info(f'Torch Decoded Outputs: {"".join(decoded_texts)}')
+
+        logger.info(comp_allclose(ref_output, tt_output_torch))
+        logger.info(f"PCC: {pcc_message}")
+
+        if passing:
+            logger.info("Model Passed!")
+        else:
+            logger.warning("Model Failed!")
+
+        return passing
+    return True
+
+
+def run_generation_loop(
+    tt_model,
+    model_args,
+    mesh_device,
+    reference_model,
+    embd,
+    encoded_prompts_tensor,
+    generation_length,
+    generation_start_pos,
+    batch,
+    seqlen,
+    page_table_tt,
+    run_ref_pt,
+    pcc,
+    tokenizer,
+    logger,
+    parse_chat,
+    encoded_prompts,
+):
+    """Run the main token generation loop."""
+    all_outputs = []
+    all_outputs_ref = [] if run_ref_pt else []
+    if run_ref_pt:
+        all_tests_pass = True
+
+    # Initial setup
+    current_pos = torch.tensor([generation_start_pos for _ in range(batch)])
+    current_pos_tensor = create_position_tensor(current_pos, model_args, mesh_device)
+
+    # Select the first token from the prompts for initial decoding
+    pt_decode_input = embd(encoded_prompts_tensor[:, 0]).view(batch, seqlen, -1)
+    tt_decode_input = pt_decode_input
+
+    for i in range(generation_length):
+        logger.info(f"[Model] Generating token {i}")
+
+        # Prepare input
+        decode_input = model_args.prepare_residual_tensor_decode(
+            tt_decode_input,
+            model_args.model_config["DECODE_RESIDUAL_MEMCFG"],
+        )
+
+        # Get rotation matrices
+        rot_mats_global = tt_model.rope_setup.get_rot_mats(current_pos)
+        rot_mats_local = tt_model.rope_setup_local.get_rot_mats(current_pos)
+        rot_mats = [rot_mats_global, rot_mats_local]
+
+        # Run TT model
+        tt_out = tt_model(
+            decode_input,
+            current_pos_tensor,
+            rot_mats=rot_mats,
+            mode="decode",
+            page_table=page_table_tt,
+        )
+
+        # Convert output
+        tt_output_torch = convert_tt_output_to_torch(tt_out, model_args, mesh_device)
+
+        # Run reference model if needed
+        ref_output = None
+        if run_ref_pt:
+            ref_output = reference_model(pt_decode_input, current_pos[0])
+
+        # Update position
+        current_pos = torch.tensor([generation_start_pos + i + 1 for _ in range(batch)])
+        current_pos_tensor = create_position_tensor(current_pos, model_args, mesh_device)
+
+        # Process token generation
+        tt_decode_input, pt_decode_input = process_token_generation(
+            i,
+            encoded_prompts,
+            encoded_prompts_tensor,
+            embd,
+            batch,
+            seqlen,
+            all_outputs,
+            all_outputs_ref,
+            run_ref_pt,
+            ref_output,
+            tt_output_torch,
+        )
+
+        # Validate outputs
+        passing = validate_outputs(
+            run_ref_pt, ref_output, tt_output_torch, pcc, all_outputs, all_outputs_ref, tokenizer, logger
+        )
+
+        # Note: Individual PCC failures don't affect overall test result (matching original behavior)
+        # if not passing:
+        #     all_tests_pass = False
+
+        # Display chat if enabled
+        if parse_chat:
+            conversation = parse_chat_output(tokenizer.decode(all_outputs).replace("\n", "\\n"))
+            display_chat(logger, conversation)
+
+    if run_ref_pt:
+        return all_tests_pass
+    else:
+        return True  # If not running reference model, always pass
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Failing on DRAM harvested P100a, see #21419")
+@pytest.mark.timeout(1800)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "weights, layers",
+    [
+        ("instruct", None),
+    ],
+    ids=["full"],
+)
+@pytest.mark.parametrize(
+    "paged_attention",
+    (
+        True,
+        # False,
+    ),
+    ids=(
+        "paged_attention",
+        # "default_attention",
+    ),
+)
+@pytest.mark.parametrize(
+    "page_params",
+    [{"page_block_size": 32, "page_max_num_blocks": 1024}],
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize(
+    "max_seq_len",
+    (2048,),  # Use smaller seq_len like test_end2end.py to avoid memory issues
+)
+@pytest.mark.parametrize(
+    "optimizations",
+    [
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
+    ],
+    ids=["accuracy"],
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+def test_e2e_vision_text_pipeline(
+    weights,
+    layers,
+    max_seq_len,
+    batch_size,
+    paged_attention,
+    page_params,
+    optimizations,
+    mesh_device,
+    reset_seeds,
+    request,
+    device_params,
+):
+    """Test end-to-end vision-text pipeline using proper Generator methods."""
+    logger.info("Starting E2E vision-text pipeline test")
+
+    # Use bfloat8_b like test_end2end.py for better memory efficiency
+    dtype = ttnn.bfloat16
+
+    # Setup vision-enabled model configuration
+    model_args, instruct = setup_vision_model_args(weights, max_seq_len, batch_size, mesh_device, optimizations)
+
+    if layers is not None:
+        model_args.n_layers = layers
+
+    # Setup vision prompts and tokenizer
+    messages, tokenizer = setup_vision_prompts_and_tokenizer(model_args, instruct)
+
+    # Process real vision inputs from images
+    processed_inputs = process_real_vision_inputs(messages, model_args)
+
+    # Load separate models following test_end2end.py pattern
+    logger.info("Loading separate vision and text models like test_end2end.py...")
+    vision_model, text_model = load_separate_models_like_test_end2end(
+        model_args, mesh_device, dtype, paged_attention, page_params
+    )
+
+    # Setup page table for paged attention (exactly like test_end2end.py)
+    page_table_tt = None
+    paged_attention_config = None
+
+    # Prepare page table for paged attention (exactly like test_end2end.py)
+    page_table = None
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtual blocks to physical
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, -2) if batch_size > 1 else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+    # Run generation following EXACT test_end2end.py pattern
+    logger.info("Running generation following EXACT test_end2end.py pattern...")
+    results = run_generation_exactly_like_test_end2end(
+        vision_model, text_model, processed_inputs, model_args, page_table, paged_attention_config, max_gen_len=10
+    )
+
+    # Validate results
+    validation_passed = validate_e2e_outputs(results, expected_min_tokens=1)
+
+    # Final validation
+    if validation_passed and len(results) > 0:
+        logger.info("✅ E2E vision-text pipeline test PASSED!")
+        logger.info(f"Successfully generated {len(results)} tokens")
+
+        # Log generated tokens for debugging
+        for i, result in enumerate(results[:5]):
+            logger.info(f"Token {i}: {result.token} -> '{result.text}'")
+    else:
+        logger.error("❌ E2E pipeline test failed")
+        assert False, f"E2E pipeline failed - generated {len(results)} tokens, validation: {validation_passed}"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -303,7 +303,7 @@ def run_generation_exactly_like_test_end2end(
         decoding_pos,
         prefill_lens,
     ) = preprocess_inputs_prefill(
-        input_prompts,
+        [input_prompts],
         model_args.tokenizer,
         [model_args],
         instruct=True,

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -232,7 +232,7 @@ def process_real_vision_inputs(messages, model_args):
 def load_separate_models_like_test_end2end(model_args, mesh_device, dtype, paged_attention, page_params):
     """Load separate vision and text models following test_end2end.py pattern."""
     state_dict = model_args.load_state_dict()
-    vision_prefix = "vision_tower.vision_model."
+    vision_prefix = model_args.state_dict_vision_prefix
 
     # Setup paged attention config (exactly like test_end2end.py)
     paged_attention_config = None

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -8,7 +8,7 @@ from loguru import logger
 import os
 import ttnn
 from models.tt_transformers.tt.common import (
-    encode_prompt_hf,
+    encode_multimodal_prompt_hf,
     sample_host,
     PagedAttentionConfig,
     preprocess_inputs_prefill,
@@ -64,11 +64,12 @@ def setup_model_args(weights, max_seq_len, batch_size, mesh_device, optimization
 
 def setup_prompts_and_tokenizer(model_args, instruct):
     """Setup prompts and tokenizer for the test."""
+    model_id = "google/gemma-3-4b-it"
     prompts = ["Write a essay about Lion"] * model_args.max_batch_size
     tokenizer = model_args.tokenizer
 
     if instruct:
-        encoded_prompts = encode_prompt_hf(tokenizer=tokenizer, prompt_text=prompts[0])
+        encoded_prompts = encode_multimodal_prompt_hf(tokenizer=tokenizer, model_id=model_id, prompt_text=prompts[0])
     else:
         encoded_prompts = [model_args.encode_prompt(prompt, instruct=False) for prompt in prompts]
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -1,5 +1,5 @@
 """End-to-end test for Gemma-3-4B-it vision-text pipeline."""
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
@@ -7,6 +7,7 @@ import pytest
 from loguru import logger
 import os
 import ttnn
+from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.common import (
     encode_prompt_hf,
     sample_host,
@@ -241,9 +242,12 @@ def load_separate_models_like_test_end2end(model_args, mesh_device, dtype, paged
             max_num_blocks=page_params["page_max_num_blocks"],
         )
 
+    tt_ccl = TT_CCL(mesh_device)
+
     # Load vision model (exactly like test_end2end.py)
     vision_model = TtGemmaTransformerVision(
         mesh_device=mesh_device,
+        tt_ccl=tt_ccl,
         state_dict=state_dict,
         state_dict_prefix=vision_prefix,
         dtype=dtype,
@@ -255,6 +259,7 @@ def load_separate_models_like_test_end2end(model_args, mesh_device, dtype, paged
     text_model = Gemma3_4BTransformer(
         args=model_args,
         mesh_device=mesh_device,
+        tt_ccl=tt_ccl,
         dtype=dtype,
         state_dict=state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_patch_embedding.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_patch_embedding.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it test for Vision Patch Embedding"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_patch_embedding.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_patch_embedding.py
@@ -40,8 +40,8 @@ def test_conv2d_inference(
     state_dict = model_args.load_state_dict()
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
-    tt_layer_prefix = "model.vision_tower.vision_model.embeddings.patch_embedding."
-    first_layer_prefix = "model.vision_tower.vision_model.embeddings.patch_embedding._linear."
+    tt_layer_prefix = "visual.embeddings.patch_embedding."
+    first_layer_prefix = "visual.embeddings.patch_embedding._linear."
     partial_state_dict = {
         k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
     }

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_patch_embedding.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_patch_embedding.py
@@ -1,0 +1,111 @@
+"""Gemma-3-4b-it test for Vision Patch Embedding"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+from loguru import logger
+
+import ttnn
+import torch
+from models.tt_transformers.tt.model_config import ModelArgs
+
+from models.experimental.gemma3_4b.tt.gemma_conv2d_patch import TtGemmaConv2dPatch
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+from ttnn import ConcatMeshToTensor
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+def test_conv2d_inference(
+    mesh_device,
+    reset_seeds,
+):
+    pcc_required = 0.9999
+    dtype = ttnn.bfloat16
+
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    tt_layer_prefix = "model.vision_tower.vision_model.embeddings.patch_embedding."
+    first_layer_prefix = "model.vision_tower.vision_model.embeddings.patch_embedding._linear."
+    partial_state_dict = {
+        k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    }
+    num_devices = model_args.num_devices
+
+    B, NCH, H, W = (1, 3, model_args.vision_chunk_size, model_args.vision_chunk_size)
+    in_channels, out_channels, kernel_size, stride, bias = (
+        3,
+        model_args.vision_dim,
+        model_args.vision_patch_size,
+        model_args.vision_patch_size,
+        True,
+    )
+
+    assert NCH == in_channels, "Number of channels in input tensor should match in_channels for the Conv2d patch."
+    assert type(kernel_size) == int, "Only symmetric kernel_size is currently supported."
+    assert kernel_size == stride, "Only same kernel_size and stride are currently supported."
+
+    assert H % kernel_size == 0, "Height should be divisible by kernel_size."
+    assert W % kernel_size == 0, "Width should be divisible by kernel_size."
+
+    input_tensor = torch.randn((B, NCH, H, W))
+    logger.info(f"Input tensor shape: {input_tensor.shape}")
+
+    ##### Perform the torch ops #####
+    reference_model = model_args.reference_siglip_patch_embed()
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_output = reference_model(input_tensor)
+    del reference_model
+
+    tt_model = TtGemmaConv2dPatch(
+        mesh_device,
+        state_dict,
+        tt_layer_prefix,
+        dtype,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        bias,
+    )
+    tt_output = tt_model(input_tensor)
+
+    logger.info("Checking outputs")
+    out = ttnn.from_device(tt_output)
+    tt_output_torch = ttnn.to_torch(out, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
+
+    tt_output_torch = tt_output_torch[0, ..., :out_channels]
+
+    logger.info(f"Reference output shape: {reference_output.shape}")
+    logger.info(f"TT output shape: {tt_output_torch.shape}")
+
+    # TT output: [B, HW, C]
+    B, HW, C = tt_output_torch.shape
+    H = W = int(HW**0.5)
+    assert H * W == HW, "HW is not a perfect square — can't reshape"
+    tt_output_torch = tt_output_torch.permute(0, 2, 1)
+    tt_output_torch = tt_output_torch.reshape(B, C, H, W)
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_attention.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_attention.py
@@ -1,0 +1,95 @@
+"""Gemma-3-4b-it Test for Vision Attention"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.load_checkpoints import (  # convert_vision_hf_to_meta,
+    convert_hf_qkv_to_meta_format,
+    convert_vision_hf_to_meta,
+)
+from models.tt_transformers.tt.model_config import ModelArgs
+
+
+from models.experimental.gemma3_4b.tt.gemma_image_attention import TtGemmaImageAttention
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "batch, num_chunks",
+    ((1, 4),),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+def test_attention_inference(batch, num_chunks, mesh_device, reset_seeds):
+    dtype = ttnn.bfloat16
+    pcc_required = 0.99
+
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0.attn."
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+
+    dim = model_args.vision_dim
+
+    reference_model = model_args.reference_vision_attention()
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_model.eval()
+
+    hidden_size = model_args.vision_dim
+    n_heads = model_args.vision_attn_n_heads
+    head_dim = hidden_size // n_heads
+    seq_len = model_args.vision_chunk_ntok
+
+    tt_model = TtGemmaImageAttention(
+        mesh_device,
+        state_dict,
+        state_dict_prefix=first_layer_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        dtype=dtype,
+        configuration=model_args,
+    )
+
+    pt_attention_input = torch.randn(batch, seq_len, dim)
+
+    attention_input = model_args.prepare_residual_tensor_prefill(
+        pt_attention_input,
+        force_replicated=True,
+    )
+
+    tt_out = tt_model(attention_input)
+
+    # Doing contract in tt is correct!!
+    tt_output_torch = ttnn.to_torch(tt_out, device=mesh_device)[0, :, :, :]
+
+    reference_output = reference_model(pt_attention_input)[0]
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_attention.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_attention.py
@@ -46,7 +46,7 @@ def test_attention_inference(batch, num_chunks, mesh_device, reset_seeds):
     state_dict = model_args.load_state_dict()
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
-    first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0.attn."
+    first_layer_prefix = "visual.encoder.layers.0.attn."
     # partial_state_dict = {
     #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
     # }
@@ -60,7 +60,7 @@ def test_attention_inference(batch, num_chunks, mesh_device, reset_seeds):
     hidden_size = model_args.vision_dim
     n_heads = model_args.vision_attn_n_heads
     head_dim = hidden_size // n_heads
-    seq_len = model_args.vision_chunk_ntok
+    seq_len = model_args.image_size
 
     tt_ccl = TT_CCL(mesh_device)
     tt_model = TtGemmaImageAttention(

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_cross_attention_transformer.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_cross_attention_transformer.py
@@ -1,0 +1,126 @@
+"""Gemma-3-4b-it Test for Vision Transformer"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+
+from models.experimental.gemma3_4b.tt.gemma_vision_crossattention import TtGemmaTransformerVision
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("bsz", [1])
+def test_gemma_vision(
+    mesh_device,
+    reset_seeds,
+    bsz,
+):
+    pcc_required = 0.90
+    dtype = ttnn.bfloat16
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    vision_first_layer_prefix = "vision_tower.vision_model."
+    vision_partial_state_dict = {
+        k[len(vision_first_layer_prefix) :]: v
+        for k, v in state_dict.items()
+        if (k.startswith(vision_first_layer_prefix))
+    }
+
+    reference_vision_model = model_args.reference_vision_model()
+    # reference_vision_model.load_state_dict(vision_partial_state_dict)
+
+    mmp_first_layer_prefix = "multi_modal_projector."
+    # mmp_partial_state_dict = {
+    #     k[len(mmp_first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(mmp_first_layer_prefix))
+    # }
+
+    image_size = model_args.vision_chunk_size
+    in_channels = model_args.vision_in_channels
+
+    # model_id = "google/gemma-3-4b-it"
+    # processor = AutoProcessor.from_pretrained(model_id)
+    # messages = [
+    #     {
+    #         "role": "user",
+    #         "content": [
+    #             {
+    #                 "type": "image",
+    #                 "image": "https://www.talkesport.com/wp-content/uploads/eentity-1024x574.jpg",
+    #             },
+    #             {"type": "text", "text": "Describe this?"},
+    #         ],
+    #     }
+    # ]
+
+    # inputs = processor.apply_chat_template(
+    #     messages, add_generation_prompt=True, tokenize=True, return_dict=True, return_tensors="pt"
+    # ).to(dtype=torch.bfloat16)
+
+    # input_tensor = inputs["pixel_values"]
+
+    input_tensor = torch.rand((bsz, in_channels, image_size, image_size))
+
+    reference_mmp = model_args.reference_vision_multi_modal()
+    # reference_mmp.load_state_dict(mmp_partial_state_dict)
+
+    reference_output = get_image_features(
+        reference_vision_model,
+        reference_mmp,
+        input_tensor,
+    )
+
+    test_gemma_vision = TtGemmaTransformerVision(
+        mesh_device,
+        state_dict,
+        state_dict_prefix="vision_tower.vision_model.",
+        dtype=dtype,
+        configuration=model_args,
+        return_intermediate=False,
+    )
+
+    test_output = test_gemma_vision(input_tensor)
+
+    logger.info("Checking outputs")
+    out = ttnn.from_device(test_output)
+    tt_output_torch = ttnn.to_torch(out)
+    tt_output_torch = tt_output_torch.view(1, 256, 2560)
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"
+
+
+def get_image_features(vision_tower, projector, input_tensor):
+    """
+    Get image features from the vision tower and projector.
+    """
+    vision_token = vision_tower(input_tensor).last_hidden_state
+    image_features = projector(vision_token)
+    return image_features

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_cross_attention_transformer.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_cross_attention_transformer.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it Test for Vision Transformer"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,13 +13,14 @@ from loguru import logger
 
 import ttnn
 from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.ccl import TT_CCL
 
 from models.experimental.gemma3_4b.tt.gemma_vision_crossattention import TtGemmaTransformerVision
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "fabric_config": True}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     [
@@ -90,8 +91,10 @@ def test_gemma_vision(
         input_tensor,
     )
 
+    tt_ccl = TT_CCL(mesh_device)
     test_gemma_vision = TtGemmaTransformerVision(
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix="vision_tower.vision_model.",
         dtype=dtype,

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_embedding.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_embedding.py
@@ -40,7 +40,7 @@ def test_vision_embedding_integration(
     model_args = ModelArgs(mesh_device)
     state_dict = model_args.load_state_dict()
 
-    first_layer_prefix = "model.vision_tower.vision_model.embeddings."
+    first_layer_prefix = "visual.embeddings."
     # partial_state_dict = {
     #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
     # }

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_embedding.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_embedding.py
@@ -1,0 +1,89 @@
+"""Gemma-3-4b-it Test for Vision Embedding"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+
+from models.experimental.gemma3_4b.tt.siglip_vision_embedding import TtSiglipVisionEmbeddings
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+from ttnn import ConcatMeshToTensor
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("bsz", [1])
+def test_vision_embedding_integration(
+    mesh_device,
+    reset_seeds,
+    bsz,
+):
+    pcc_required = 0.9999
+    dtype = ttnn.bfloat16
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    first_layer_prefix = "model.vision_tower.vision_model.embeddings."
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+
+    image_size = model_args.vision_chunk_size
+    patch_size = model_args.vision_patch_size
+    hidden_dim = model_args.vision_dim
+    dim = model_args.vision_dim
+    in_channels = 3
+
+    input_tensor = torch.randn((bsz, in_channels, image_size, image_size))
+
+    reference_model = model_args.reference_vision_embedding()
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_output = reference_model(input_tensor)
+
+    vision_embed = TtSiglipVisionEmbeddings(
+        mesh_device=mesh_device,
+        state_dict=state_dict,
+        state_dict_prefix=first_layer_prefix,
+        dtype=dtype,
+        image_size=image_size,
+        patch_size=patch_size,
+        num_channels=in_channels,
+        hidden_dim=hidden_dim,
+        bias=True,
+    )
+
+    embeddings = vision_embed(input_tensor)
+    ##### Check the outputs #####
+    logger.info("Checking outputs")
+    out = ttnn.from_device(embeddings)
+    tt_output_torch = ttnn.to_torch(out, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
+
+    # Only select output from one device
+    tt_output_torch = tt_output_torch[..., :dim]
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+
+    # To get RTOL values
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_embedding.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_embedding.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it Test for Vision Embedding"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_layernorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_layernorm.py
@@ -1,0 +1,100 @@
+"""Gemma-3-4b-it Test for Vision Layernorm"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.multimodal.llama_layernorm import TtLayerNorm  # Updated import for LayerNorm
+from models.utility_functions import comp_allclose, comp_pcc, nearest_32, skip_for_grayskull
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("layer_name", [("layer_norm1"), ("layer_norm2")])
+def test_layernorm_inference(mesh_device, reset_seeds, layer_name):
+    dtype = ttnn.bfloat16
+
+    model_args = ModelArgs(mesh_device)
+    width = model_args.vision_dim
+    num_chunks = 4
+    seq_len = nearest_32(model_args.vision_chunk_ntok) * num_chunks
+
+    # Load full state dict
+    state_dict = model_args.load_state_dict()
+
+    # Prefix for vision MLP weights — consistent with HF checkpoint
+    if layer_name == "layer_norm1":
+        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0.ln_1."
+    else:
+        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0.ln_2."
+
+    model_args.WEIGHTS_DTYPE = dtype
+    # Reference HF MLP (from Gemma3 vision tower)
+    reference_model = model_args.reference_vision_layernorm(layer_name)
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_model.eval()
+
+    # Initialize the custom LayerNorm model
+    tt_model = TtLayerNorm(
+        device=mesh_device,
+        dim=width,
+        state_dict=state_dict,
+        state_dict_prefix=first_layer_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        weight_dtype=dtype,
+        eps=model_args.norm_eps,
+    )
+
+    # Generate random input
+    torch_input = torch.rand(1, seq_len, width)  # Adjusted dimensions for LayerNorm
+
+    # Reference output using PyTorch's LayerNorm
+    reference_output = reference_model(torch_input)
+
+    # Convert input to ttnn tensor
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    logger.info("Compilation pass for LayerNorm")
+    tt_output = tt_model(tt_input)
+
+    tt_output_torch = ttnn.to_torch(
+        tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1)
+    )  # Adjusted dim for LayerNorm
+    tt_outputs = torch.chunk(tt_output_torch, model_args.num_devices, dim=-1)
+
+    # Compare outputs
+    pcc_required = 0.99
+    for idx, tt_output_torch in enumerate(tt_outputs):
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+        non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+        tt_output_torch = tt_output_torch[non_zero_indices]
+        reference_output = reference_output[non_zero_indices]
+
+        logger.info(comp_allclose(reference_output, tt_output_torch))
+        logger.info(f"PCC: {pcc_message}")
+        assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_layernorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_layernorm.py
@@ -34,16 +34,16 @@ def test_layernorm_inference(mesh_device, reset_seeds, layer_name):
     model_args = ModelArgs(mesh_device)
     width = model_args.vision_dim
     num_chunks = 4
-    seq_len = nearest_32(model_args.vision_chunk_ntok) * num_chunks
+    seq_len = nearest_32(model_args.image_size) * num_chunks
 
     # Load full state dict
     state_dict = model_args.load_state_dict()
 
     # Prefix for vision MLP weights — consistent with HF checkpoint
     if layer_name == "layer_norm1":
-        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0.ln_1."
+        first_layer_prefix = "visual.encoder.layers.0.ln_1."
     else:
-        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0.ln_2."
+        first_layer_prefix = "visual.encoder.layers.0.ln_2."
 
     model_args.WEIGHTS_DTYPE = dtype
     # Reference HF MLP (from Gemma3 vision tower)

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_layernorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_layernorm.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it Test for Vision Layernorm"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_mlp.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_mlp.py
@@ -46,7 +46,7 @@ def test_mlp_inference(batch, num_chunks, mesh_device, reset_seeds):
     model_args.WEIGHTS_DTYPE = dtype
 
     dim = model_args.vision_dim
-    seq_len = nearest_32(model_args.vision_chunk_ntok) * num_chunks
+    seq_len = nearest_32(model_args.image_size) * num_chunks
     reference_model = model_args.reference_vision_mlp()
     # reference_model.load_state_dict(partial_state_dict)
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_mlp.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_mlp.py
@@ -1,0 +1,86 @@
+"""Gemma-3-4b-it Test for Vision MLP"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.experimental.gemma3_4b.tt.gemma_image_mlp import TtGemmaImageFeedForward
+from models.utility_functions import comp_allclose, comp_pcc, nearest_32, skip_for_grayskull
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "batch, num_chunks",
+    ((1, 4),),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+def test_mlp_inference(batch, num_chunks, mesh_device, reset_seeds):
+    dtype = ttnn.bfloat16
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    first_layer_prefix = model_args.get_state_dict_prefix("MLP", 0, is_vision=True)
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+    model_args.WEIGHTS_DTYPE = dtype
+
+    dim = model_args.vision_dim
+    seq_len = nearest_32(model_args.vision_chunk_ntok) * num_chunks
+    reference_model = model_args.reference_vision_mlp()
+    # reference_model.load_state_dict(partial_state_dict)
+
+    tt_model = TtGemmaImageFeedForward(
+        mesh_device=mesh_device,
+        args=model_args,
+        state_dict=state_dict,
+        state_dict_prefix=first_layer_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        dtype=dtype,
+    )
+    torch_input = torch.randn(1, batch, seq_len, dim)
+    reference_output = reference_model(torch_input).squeeze()
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    tt_output = tt_model(tt_input)
+
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1))[
+        :, :1, :, :
+    ].squeeze()
+
+    pcc_required = 0.99
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_pipeline.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_pipeline.py
@@ -41,7 +41,7 @@ def test_gemma_vision(
     model_args = ModelArgs(mesh_device)
     state_dict = model_args.load_state_dict()
 
-    first_layer_prefix = "model.vision_tower.vision_model."
+    first_layer_prefix = "visual."
     # partial_state_dict = {
     #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
     # }

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_pipeline.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_pipeline.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it Test for Vision Model"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +13,7 @@ from loguru import logger
 
 import ttnn
 from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.ccl import TT_CCL
 
 from models.experimental.gemma3_4b.tt.gemma_vision_model import TtSiglipGemmaVisionModel
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
@@ -29,6 +30,7 @@ from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
     indirect=True,
 )
 @pytest.mark.parametrize("bsz", [1])
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_gemma_vision(
     mesh_device,
     reset_seeds,
@@ -53,8 +55,10 @@ def test_gemma_vision(
     # reference_model.load_state_dict(partial_state_dict)
     reference_output = reference_model(input_tensor).last_hidden_state
 
+    tt_ccl = TT_CCL(mesh_device)
     test_gemma_vision = TtSiglipGemmaVisionModel(
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix=first_layer_prefix,
         dtype=dtype,

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_pipeline.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_pipeline.py
@@ -1,0 +1,79 @@
+"""Gemma-3-4b-it Test for Vision Model"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+
+from models.experimental.gemma3_4b.tt.gemma_vision_model import TtSiglipGemmaVisionModel
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("bsz", [1])
+def test_gemma_vision(
+    mesh_device,
+    reset_seeds,
+    bsz,
+):
+    pcc_required = 0.94
+    dtype = ttnn.bfloat16
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    first_layer_prefix = "model.vision_tower.vision_model."
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+
+    image_size = model_args.vision_chunk_size
+    in_channels = model_args.vision_in_channels
+
+    input_tensor = torch.rand((bsz, in_channels, image_size, image_size))
+
+    reference_model = model_args.reference_vision_model()
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_output = reference_model(input_tensor).last_hidden_state
+
+    test_gemma_vision = TtSiglipGemmaVisionModel(
+        mesh_device,
+        state_dict,
+        state_dict_prefix=first_layer_prefix,
+        dtype=dtype,
+        configuration=model_args,
+        return_intermediate=False,
+    )
+
+    test_output = test_gemma_vision(input_tensor)
+
+    logger.info("Checking outputs")
+    out = ttnn.from_device(test_output)
+    tt_output_torch = ttnn.to_torch(out).squeeze(0)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
@@ -1,5 +1,9 @@
 """Gemma-3-4b-it test for Vision RMSNorm"""
 
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 from loguru import logger
 
 import torch

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
@@ -1,0 +1,114 @@
+"""Gemma-3-4b-it test for Vision RMSNorm"""
+
+from loguru import logger
+
+import torch
+import pytest
+import os
+
+import ttnn
+from models.experimental.gemma3_4b.tt.rmsnorm import RMSNorm
+
+from models.tt_transformers.tt.distributed_norm import DistributedNorm
+
+
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+from models.tt_transformers.tt.model_config import ModelArgs
+
+
+@torch.no_grad()
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("device"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    (128,),
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+def test_rmsnorm_inference(seq_len, batch_size, reset_seeds, device):
+    dtype = ttnn.bfloat16
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    tt_model_args = ModelArgs(
+        device,
+        max_batch_size=batch_size,
+        max_seq_len=128,
+    )
+
+    tt_model_args.n_layers = 1
+    state_dict = tt_model_args.load_state_dict()
+
+    reference_model = tt_model_args.reference_vision_rms_norm()  # Gemma3 RMSNorm
+    first_layer_prefix = "multi_modal_projector.mm_soft_emb_norm."
+
+    partial_state_dict = {
+        k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    }
+
+    # reference_model.load_state_dict(partial_state_dict)
+
+    tt_inner_norm = RMSNorm(
+        device=device,
+        dim=1152,
+        state_dict=state_dict,
+        state_dict_prefix="",
+        weight_key="model.multi_modal_projector.mm_soft_emb_norm",
+        weight_dtype=dtype,
+        is_distributed=False,
+        sharded_program_config=tt_model_args.get_model_config()["SHARDED_NORM_ATTN_PRGM_CFG"],
+        sharded_output_config=tt_model_args.get_model_config()["SHARDED_ATTN_INPUT_MEMCFG"],
+    )
+
+    # Wrap it in DistributedNorm
+    tt_model = DistributedNorm(tt_inner_norm, tt_model_args, TG=tt_model_args.is_galaxy)
+
+    input = torch.rand(1, 1, 1152)
+
+    reference_output = reference_model(input)
+
+    # DistributedNorm inputs are fractured across devices and interleaved in DRAM (for prefill) and L1 (for decode)
+    tt_input = ttnn.from_torch(
+        input,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(None, -1), mesh_shape=tt_model_args.cluster_shape),
+        memory_config=(
+            tt_model_args.get_model_config()["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
+        ),
+    )
+
+    tt_output = tt_model(tt_input, mode=mode)
+
+    # DistributedNorm outputs are replicated across devices
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(
+            device, dims=(0, 2) if tt_model_args.is_galaxy else (2, 0), mesh_shape=tt_model_args.cluster_shape
+        ),
+    )[:1, :, :]
+    tt_output_torch = tt_output_torch.view(1, 1, 1152)
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+
+    if passing:
+        logger.info("rms_norm Passed!")
+    else:
+        logger.warning("rms_norm Failed!")
+
+    assert passing, f"rms_norm output does not meet PCC requirement {0.99}."

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
@@ -1,6 +1,6 @@
 """Gemma-3-4b-it test for Vision RMSNorm"""
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
@@ -10,6 +10,7 @@ import ttnn
 from models.experimental.gemma3_4b.tt.rmsnorm import RMSNorm
 
 from models.tt_transformers.tt.distributed_norm import DistributedNorm
+from models.tt_transformers.tt.ccl import TT_CCL
 
 
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
@@ -56,9 +57,10 @@ def test_rmsnorm_inference(seq_len, batch_size, reset_seeds, device):
     }
 
     # reference_model.load_state_dict(partial_state_dict)
-
+    tt_ccl = TT_CCL(device)
     tt_inner_norm = RMSNorm(
         device=device,
+        tt_ccl=tt_ccl,
         dim=1152,
         state_dict=state_dict,
         state_dict_prefix="",
@@ -70,7 +72,7 @@ def test_rmsnorm_inference(seq_len, batch_size, reset_seeds, device):
     )
 
     # Wrap it in DistributedNorm
-    tt_model = DistributedNorm(tt_inner_norm, tt_model_args, TG=tt_model_args.is_galaxy)
+    tt_model = DistributedNorm(tt_inner_norm, tt_model_args, tt_ccl, TG=tt_model_args.is_galaxy)
 
     input = torch.rand(1, 1, 1152)
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_rmsnorm.py
@@ -68,7 +68,7 @@ def test_rmsnorm_inference(seq_len, batch_size, reset_seeds, device):
         dim=1152,
         state_dict=state_dict,
         state_dict_prefix="",
-        weight_key="model.multi_modal_projector.mm_soft_emb_norm",
+        weight_key="multi_modal_projector.mm_soft_emb_norm",
         weight_dtype=dtype,
         is_distributed=False,
         sharded_program_config=tt_model_args.get_model_config()["SHARDED_NORM_ATTN_PRGM_CFG"],

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer.py
@@ -1,7 +1,7 @@
 """Gemma-3-4b-it test for Vision Transformer submodule"""
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 import os
@@ -11,6 +11,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.model_config import ModelArgs
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
@@ -31,6 +32,7 @@ from models.experimental.gemma3_4b.tt.gemma_image_transformer import TtGemmaImag
     ],
     indirect=True,
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_image_transformer_inference(batch, num_chunks, mesh_device):
     pcc_required = 0.99
 
@@ -58,8 +60,10 @@ def test_image_transformer_inference(batch, num_chunks, mesh_device):
 
     all_tests_pass = True
 
+    tt_ccl = TT_CCL(mesh_device)
     tt_model = TtGemmaImageTransformer(
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix=first_layer_prefix,
         weight_cache_path=model_args.weight_cache_path(dtype),

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer.py
@@ -43,7 +43,7 @@ def test_image_transformer_inference(batch, num_chunks, mesh_device):
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     n_layers = model_args.vision_n_layers
-    first_layer_prefix = "model.vision_tower.vision_model.encoder."
+    first_layer_prefix = "visual.encoder."
 
     # gated = True
 
@@ -52,7 +52,7 @@ def test_image_transformer_inference(batch, num_chunks, mesh_device):
     # }
 
     dim = model_args.vision_dim
-    seq_len = model_args.vision_chunk_ntok - 1
+    seq_len = model_args.image_size
 
     reference_model = model_args.reference_vision_encoder()
     # reference_model.load_state_dict(partial_state_dict)

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer.py
@@ -1,0 +1,111 @@
+"""Gemma-3-4b-it test for Vision Transformer submodule"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+from models.experimental.gemma3_4b.tt.gemma_image_transformer import TtGemmaImageTransformer
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "batch, num_chunks",
+    ((1, 4),),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+def test_image_transformer_inference(batch, num_chunks, mesh_device):
+    pcc_required = 0.99
+
+    model_args = ModelArgs(mesh_device)
+    dtype = ttnn.bfloat16
+
+    state_dict = model_args.load_state_dict()
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    n_layers = model_args.vision_n_layers
+    first_layer_prefix = "model.vision_tower.vision_model.encoder."
+
+    # gated = True
+
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+
+    dim = model_args.vision_dim
+    seq_len = model_args.vision_chunk_ntok - 1
+
+    reference_model = model_args.reference_vision_encoder()
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_model.eval()
+
+    all_tests_pass = True
+
+    tt_model = TtGemmaImageTransformer(
+        mesh_device,
+        state_dict,
+        state_dict_prefix=first_layer_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        dtype=dtype,
+        configuration=model_args,
+        layers=n_layers,
+        block_key="layers",
+    )
+
+    # Create PT input
+    pt_attention_input = torch.randn(batch, seq_len, dim)
+    attention_mask = torch.zeros(batch, 1, seq_len, seq_len)
+
+    attention_input = model_args.prepare_residual_tensor_prefill(
+        pt_attention_input,
+        force_replicated=True,
+    )
+    tt_mask = ttnn.from_torch(
+        attention_mask,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    with torch.no_grad():
+        tt_out = tt_model(attention_input, mask=tt_mask)
+
+        tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[0, :, :, :]
+
+        reference_output = reference_model(pt_attention_input, attention_mask=attention_mask)[0]
+
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+        if not passing:
+            logger.warning(f"PCC value -- {pcc_message} -- is lower than {pcc_required} for the output.")
+        else:
+            logger.info(f"PCC: {pcc_message}")
+
+        non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+        tt_output_torch = tt_output_torch[non_zero_indices]
+        reference_output = reference_output[non_zero_indices]
+
+        logger.info(comp_allclose(reference_output, tt_output_torch))
+
+        all_tests_pass = all_tests_pass and passing
+
+        assert all_tests_pass, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer_block.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer_block.py
@@ -1,0 +1,101 @@
+"""Gemma-3-4b-it Test for Vision Transformer block"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.model_config import ModelArgs
+from models.experimental.gemma3_4b.tt.gemma_image_block import TtGemmaImageTransformerBlock
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "batch, num_chunks",
+    ((1, 4),),
+)
+@pytest.mark.parametrize(
+    "gated",
+    (True, False),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+def test_block_inference(batch, num_chunks, mesh_device, reset_seeds, gated):
+    dtype = ttnn.bfloat16
+    pcc_required = 0.99
+    gated = False
+
+    model_args = ModelArgs(mesh_device)
+    state_dict = model_args.load_state_dict()
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    if gated:
+        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0."
+    else:
+        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0."
+    # partial_state_dict = {
+    #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
+    # }
+
+    dim = model_args.vision_dim
+    heads = model_args.vision_attn_n_heads
+    seq_len = model_args.vision_chunk_ntok - 1
+
+    reference_model = model_args.reference_vision_encoder_block()
+    # reference_model.load_state_dict(partial_state_dict)
+    reference_model.eval()
+
+    tt_model = TtGemmaImageTransformerBlock(
+        mesh_device,
+        state_dict=state_dict,
+        state_dict_prefix=first_layer_prefix,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        dtype=dtype,
+        configuration=model_args,
+        gated=gated,
+    )
+
+    pt_attention_input = torch.randn(batch, seq_len, dim)
+    attention_mask = torch.zeros(batch, 1, seq_len, seq_len)
+
+    attention_input = model_args.prepare_residual_tensor_prefill(
+        pt_attention_input,
+        force_replicated=True,
+    )
+    tt_mask = ttnn.from_torch(
+        attention_mask,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    tt_out = tt_model(attention_input, mask=tt_mask)
+    tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[0, :, :, :]
+
+    reference_output = reference_model(pt_attention_input, attention_mask=attention_mask)[0]
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    non_zero_indices = tt_output_torch.ne(0).nonzero(as_tuple=True)
+    tt_output_torch = tt_output_torch[non_zero_indices]
+    reference_output = reference_output[non_zero_indices]
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"PCC: {pcc_message}")
+    assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer_block.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer_block.py
@@ -46,16 +46,16 @@ def test_block_inference(batch, num_chunks, mesh_device, reset_seeds, gated):
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     if gated:
-        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0."
+        first_layer_prefix = "visual.encoder.layers.0."
     else:
-        first_layer_prefix = "model.vision_tower.vision_model.encoder.layers.0."
+        first_layer_prefix = "visual.encoder.layers.0."
     # partial_state_dict = {
     #     k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
     # }
 
     dim = model_args.vision_dim
     heads = model_args.vision_attn_n_heads
-    seq_len = model_args.vision_chunk_ntok - 1
+    seq_len = model_args.image_size
 
     reference_model = model_args.reference_vision_encoder_block()
     # reference_model.load_state_dict(partial_state_dict)

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer_block.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_vision_transformer_block.py
@@ -1,6 +1,6 @@
 """Gemma-3-4b-it Test for Vision Transformer block"""
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.model_config import ModelArgs
 from models.experimental.gemma3_4b.tt.gemma_image_block import TtGemmaImageTransformerBlock
 from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
@@ -34,6 +35,7 @@ from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
     ],
     indirect=True,
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_block_inference(batch, num_chunks, mesh_device, reset_seeds, gated):
     dtype = ttnn.bfloat16
     pcc_required = 0.99
@@ -59,8 +61,10 @@ def test_block_inference(batch, num_chunks, mesh_device, reset_seeds, gated):
     # reference_model.load_state_dict(partial_state_dict)
     reference_model.eval()
 
+    tt_ccl = TT_CCL(mesh_device)
     tt_model = TtGemmaImageTransformerBlock(
         mesh_device,
+        tt_ccl,
         state_dict=state_dict,
         state_dict_prefix=first_layer_prefix,
         weight_cache_path=model_args.weight_cache_path(dtype),

--- a/models/experimental/gemma3_4b/tt/attention.py
+++ b/models/experimental/gemma3_4b/tt/attention.py
@@ -9,7 +9,7 @@ Sliding Window support.
 
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/attention.py
+++ b/models/experimental/gemma3_4b/tt/attention.py
@@ -107,9 +107,6 @@ class Attention(LightweightModule):
         self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
 
         self.transformation_mats = transformation_mats
-        self.is_sliding = (
-            configuration.layer_types[layer_num] == "sliding_window" if configuration.layer_types else False
-        )
 
         self.model_config = configuration.get_model_config()
         self.ccl_topology = configuration.ccl_topology()

--- a/models/experimental/gemma3_4b/tt/attention.py
+++ b/models/experimental/gemma3_4b/tt/attention.py
@@ -39,7 +39,7 @@ class Attention(LightweightModule):
         use_paged_kv_cache=False,
     ):
         super().__init__()
-        self.is_sliding = bool((layer_num + 1) % configuration.sliding_window_pattern)
+        self.is_sliding = configuration.sliding_window_pattern[layer_num]
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device

--- a/models/experimental/gemma3_4b/tt/attention.py
+++ b/models/experimental/gemma3_4b/tt/attention.py
@@ -29,6 +29,7 @@ class Attention(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         weight_cache_path,
         layer_num,
@@ -39,10 +40,10 @@ class Attention(LightweightModule):
         use_paged_kv_cache=False,
     ):
         super().__init__()
-        self.is_sliding = configuration.sliding_window_pattern[layer_num]
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.num_devices = configuration.num_devices
         self.TG = self.num_devices == 32
         self.hidden_size = configuration.dim
@@ -106,6 +107,9 @@ class Attention(LightweightModule):
         self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
 
         self.transformation_mats = transformation_mats
+        self.is_sliding = (
+            configuration.layer_types[layer_num] == "sliding_window" if configuration.layer_types else False
+        )
 
         self.model_config = configuration.get_model_config()
         self.ccl_topology = configuration.ccl_topology()
@@ -275,6 +279,7 @@ class Attention(LightweightModule):
                 is_distributed=False,
                 sharded_program_config=None,  # FIXME: add height-sharded support. self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
                 sharded_output_config=None,  # FIXME: add height-sharded support. self.model_config["CREATE_QKV_DECODE_SHARD"]
+                tt_ccl=self.tt_ccl,
             )
             self.q_norm = lambda x, mode: norm_reshard(x, fn_q_norm, mode)
         else:
@@ -294,6 +299,7 @@ class Attention(LightweightModule):
                 is_distributed=False,
                 sharded_program_config=None,  # FIXME: add height-sharded support. self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
                 sharded_output_config=None,  # FIXME: add height-sharded support. self.model_config["CREATE_QKV_DECODE_SHARD"],
+                tt_ccl=self.tt_ccl,
             )
             self.k_norm = lambda x, mode: norm_reshard(x, fn_k_norm, mode)
         else:
@@ -426,6 +432,7 @@ class Attention(LightweightModule):
         xqkv_fused = tt_all_reduce(
             xqkv_fused_sharded,
             self.mesh_device,
+            self.tt_ccl,
             cluster_axis=1,
             num_reduce_scatter_links=self.num_reduce_scatter_links,
             num_all_gather_links=self.num_all_gather_links,
@@ -511,7 +518,6 @@ class Attention(LightweightModule):
         # For example, a prompt w/ 1 user vs, the same prompt repeated N times for N users, will produce different outputs
         # This is because the SDPA op in decode mode has different number of reductions depending on batch size
         # Which leads to slightly different outputs from attention (due to accumulated errors)
-        q_heads_1BQD = ttnn.to_memory_config(q_heads_1BQD, ttnn.DRAM_MEMORY_CONFIG)
         if page_table:
             attn_output_1G4D = ttnn.transformer.paged_scaled_dot_product_attention_decode(
                 q_heads_1BQD,
@@ -553,17 +559,33 @@ class Attention(LightweightModule):
             attn_output_cat = ttnn.to_memory_config(
                 attn_output_cat, self.model_config["ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"]
             )
-            _, dense_out_sharded, _ = ttnn.experimental.all_gather_matmul(
+
+            # TODO: #26349
+            # Fused AGMM currently has a PCC bug on small shapes
+            # Using the non-fused version is a temporary workaround
+
+            all_gather_output = ttnn.experimental.all_gather_async(
                 attn_output_cat,
-                self.wo,
+                persistent_output_buffer=None,
                 dim=3,
-                all_gather_core_grid_offset=(0, 4),
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
                 num_links=1,
+                memory_config=self.model_config["ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"],
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+                chunks_per_sync=10,
+                num_workers_per_link=2,
+                num_buffers_per_channel=2,
+            )
+
+            dense_out_sharded = ttnn.linear(
+                all_gather_output,
+                self.wo,
+                memory_config=self.model_config["DECODE_RESIDUAL_MEMCFG"],
                 program_config=self.model_config["ATTN_ALL_GATHER_MATMUL_PROGCFG"],
                 compute_kernel_config=self.li_o_decode_compute_kernel_cfg,
-                memory_config_ag=self.model_config["ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"],
-                memory_config_mm=self.model_config["DECODE_RESIDUAL_MEMCFG"],
             )
+
+            ttnn.deallocate(all_gather_output)
             ttnn.deallocate(attn_output_cat)
             dense_out_sharded = ttnn.to_memory_config(dense_out_sharded, self.model_config["DECODE_RESIDUAL_MEMCFG"])
             return dense_out_sharded
@@ -572,6 +594,7 @@ class Attention(LightweightModule):
             attn_output = tt_all_gather(
                 attn_output_cat,
                 self.mesh_device,
+                self.tt_ccl,
                 dim=2,
                 cluster_axis=1,
                 num_links=2,
@@ -608,6 +631,7 @@ class Attention(LightweightModule):
             dense_out_reduced = tt_all_reduce(
                 dense_out_sharded,
                 self.mesh_device,
+                self.tt_ccl,
                 cluster_axis=0,
                 num_reduce_scatter_links=self.num_reduce_scatter_links,
                 num_all_gather_links=self.num_all_gather_links,
@@ -672,6 +696,7 @@ class Attention(LightweightModule):
         xqkv_fused = tt_all_reduce(
             xqkv_fused,
             self.mesh_device,
+            self.tt_ccl,
             cluster_axis=1,
             num_reduce_scatter_links=self.num_reduce_scatter_links,
             num_all_gather_links=self.num_all_gather_links,
@@ -831,12 +856,18 @@ class Attention(LightweightModule):
 
         # Non fused All Gather Matmul
         if self.use_fused_all_gather_matmul:  # is true for Ring topology
-            attn_output_11SH = ttnn.all_gather(
+            attn_output_11SH = ttnn.experimental.all_gather_async(
                 attn_output_11SH,
+                persistent_output_buffer=None,
                 dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
                 num_links=1,
                 topology=self.ccl_topology,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+                chunks_per_sync=10,
+                num_workers_per_link=2,
+                num_buffers_per_channel=2,
             )
 
         output_11SH = ttnn.linear(
@@ -857,6 +888,7 @@ class Attention(LightweightModule):
             output_11SH = tt_all_reduce(
                 output_11SH,
                 self.mesh_device,
+                self.tt_ccl,
                 cluster_axis=0,
                 dim=0 if self.TG else 3,
                 num_reduce_scatter_links=self.num_reduce_scatter_links,

--- a/models/experimental/gemma3_4b/tt/attention.py
+++ b/models/experimental/gemma3_4b/tt/attention.py
@@ -1,0 +1,893 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.common.rmsnorm import RMSNorm
+from models.tt_transformers.tt.ccl import tt_all_gather, tt_all_reduce
+from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
+
+
+class Attention(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        weight_cache_path,
+        layer_num,
+        dtype,
+        transformation_mats,
+        configuration,
+        paged_attention_config=None,
+        use_paged_kv_cache=False,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.num_devices = configuration.num_devices
+        self.TG = self.num_devices == 32
+        self.hidden_size = configuration.dim
+        self.n_heads = configuration.n_heads
+        self.head_dim = configuration.head_dim
+        self.max_seq_len = configuration.max_seq_len
+        self.max_batch_size = configuration.max_batch_size
+        self.n_kv_heads = configuration.n_kv_heads
+        self.paged_attention_config = paged_attention_config
+        self.min_kv_prefill_shard_seqlen = configuration.min_kv_prefill_shard_seqlen
+        self.ccl_dtype = configuration.ccl_dtype
+        self.num_reduce_scatter_links = configuration.num_reduce_scatter_links
+        self.num_all_gather_links = configuration.num_all_gather_links
+        self.MAX_QKV_MM_SEQ_LEN = configuration.MAX_QKV_MM_SEQ_LEN
+        self.tile_size = configuration.tile_size
+        self.rms_norm_add_unit_offset = configuration.rms_norm_add_unit_offset
+        self.num_device_groups = self.num_devices // self.n_kv_heads
+        self.num_devices_per_group = self.n_kv_heads if self.TG else self.num_devices
+        self.batch_size_per_device_group = (
+            max(self.max_batch_size // self.num_device_groups, 1) if self.TG else self.max_batch_size
+        )
+
+        self.n_local_heads = self.n_heads // self.num_devices_per_group
+        self.n_local_kv_heads = self.n_kv_heads // self.num_devices_per_group
+
+        self.arch_name = configuration.arch_name
+        # TODO: Fix this once all-gather supports < tile_size
+        if self.TG:
+            weight = torch.zeros(1, 32, 8, 32)
+            for i in range(32):
+                col = i % 4  # This determines which group of 8 to select
+                weight[:, i, :, col * 8 : (col + 1) * 8] = torch.eye(8)
+
+            self.slice_mat = ttnn.from_torch(
+                weight,
+                dtype=ttnn.bfloat4_b,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=1),
+            )
+            user_selection_matrix = torch.eye(8, 8)
+            user_selection_matrix = torch.nn.functional.pad(user_selection_matrix, (0, 24), "constant", 0)  # (8, 32)
+            user_selection_matrix = [user_selection_matrix] * 4
+            user_selection_matrix = torch.block_diag(*user_selection_matrix)  # (32, 128)
+            self.user_selection_matrix = ttnn.from_torch(
+                user_selection_matrix,
+                dtype=ttnn.bfloat4_b,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+
+        self.dtype = dtype
+
+        self.max_seq_len = configuration.max_seq_len
+        self.grid_size = configuration.max_grid_size
+
+        self.compute_kernel_config_hifi2 = configuration.compute_kernel_config_hifi2
+        self.compute_kernel_config_hifi2_fp16 = configuration.compute_kernel_config_hifi2_fp16
+
+        self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
+
+        self.transformation_mats = transformation_mats
+
+        self.model_config = configuration.get_model_config()
+        self.ccl_topology = configuration.ccl_topology()
+        self.is_multichip = configuration.is_multichip
+        self.activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.ACTIVATION
+        )
+        self.wqkv_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.WQKV
+        )
+        self.wo_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.WO
+        )
+        self.kv_cache_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.KV_CACHE
+        )
+        self.li_qkv_decode_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_QKV_DECODE, configuration=configuration
+        )
+        self.sdpa_decode_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.SDPA_DECODE, configuration=configuration
+        )
+        self.li_o_decode_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_O_DECODE, configuration=configuration
+        )
+        self.sdpa_prefill_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.SDPA_PREFILL, configuration=configuration
+        )
+        self.li_qkv_prefill_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_QKV_PREFILL, configuration=configuration
+        )
+        self.li_o_prefill_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_O_PREFILL, configuration=configuration
+        )
+
+        layer_name = configuration.get_state_dict_prefix(self.__class__.__name__, layer_num)
+        if configuration.dummy_weights or (weight_cache_path is None):
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: weight_cache_path / (f"{layer_name}.{name}")
+
+        wq_str = f"{layer_name}.wq"
+        wk_str = f"{layer_name}.wk"
+        wv_str = f"{layer_name}.wv"
+        wo_str = f"{layer_name}.wo"
+        q_norm_str = f"{layer_name}.q_norm"
+        k_norm_str = f"{layer_name}.k_norm"
+
+        # Initialize bias tensors as None
+        self.wqkv_bias_decode = None
+        self.wqkv_bias_prefill = None
+
+        # Create combined QKV bias if present in state dict
+        if f"{wq_str}.bias" in self.state_dict:
+            qkv_bias = torch.concat(
+                [
+                    torch.concat(
+                        [
+                            torch.chunk(self.state_dict[f"{wq_str}.bias"], configuration.num_devices)[i],
+                            torch.chunk(self.state_dict[f"{wk_str}.bias"], configuration.num_devices)[i],
+                            torch.chunk(self.state_dict[f"{wv_str}.bias"], configuration.num_devices)[i],
+                        ],
+                        dim=-1,
+                    )
+                    for i in range(configuration.num_devices)
+                ],
+                dim=-1,
+            )
+            # Prefill can use broadcasting on the bias add so wants a 1d tensor
+            self.wqkv_bias_prefill = ttnn.as_tensor(
+                qkv_bias,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.TILE_LAYOUT,
+                cache_file_name=cache_name("wqkv_bias_prefill_sharded"),
+            )
+            # as_tensor returns (32, dim) which is incorrect, this reshape updates the padded size to the correct size
+            self.wqkv_bias_prefill = ttnn.reshape(
+                self.wqkv_bias_prefill,
+                (1, 1, 1, self.wqkv_bias_prefill.shape[-1]),
+                (1, 1, self.wqkv_bias_prefill.shape[-2], self.wqkv_bias_prefill.shape[-1]),
+            )
+
+            # Broadcasting does not seem to be supported inside execute_trace so expand to the whole batch size
+            # Create a list of bias tensors for each multiple of tile_size up to max_batch_size
+            self.wqkv_bias_decode = []
+            for batch_size in range(
+                configuration.tile_size,
+                configuration.tile_padded_batch_rows + configuration.tile_size,
+                configuration.tile_size,
+            ):
+                qkv_bias_decode = qkv_bias.unsqueeze(0).expand(batch_size, -1)
+                bias_tensor = ttnn.as_tensor(
+                    qkv_bias_decode,
+                    device=self.mesh_device,
+                    mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                    dtype=ttnn.bfloat16,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    layout=ttnn.TILE_LAYOUT,
+                    cache_file_name=cache_name(f"wqkv_bias_decode_sharded_{batch_size}"),
+                )
+                self.wqkv_bias_decode.append(bias_tensor)
+
+        # when splitting the devices, we need to make sure that the number of heads is divisible by the number of devices
+        assert self.n_heads % self.num_devices_per_group == 0
+        assert self.n_kv_heads % self.num_devices_per_group == 0
+        assert configuration.qkv_size % self.num_devices_per_group == 0
+        assert configuration.dim % self.num_devices_per_group == 0
+
+        # wqkv: 4096 x 3072 (2 devices): width-sharded on 12 banks, 3072 over 12 banks.
+        wqkv_mem_config = configuration.create_dram_sharded_mem_config(
+            configuration.dim, configuration.qkv_size // configuration.num_devices
+        )
+
+        qkv_list = []
+        for i in range(self.num_devices_per_group):
+            # Chunk weights
+            wq_selected = torch.chunk(self.state_dict[f"{wq_str}.weight"], self.num_devices_per_group, dim=0)[i]
+            wk_selected = torch.chunk(self.state_dict[f"{wk_str}.weight"], self.num_devices_per_group, dim=0)[i]
+            wv_selected = torch.chunk(self.state_dict[f"{wv_str}.weight"], self.num_devices_per_group, dim=0)[i]
+
+            # Transpose the selected chunks
+            wq = torch.transpose(wq_selected, -2, -1)
+            wk = torch.transpose(wk_selected, -2, -1)
+            wv = torch.transpose(wv_selected, -2, -1)
+
+            qkv = torch.cat([wq, wk, wv], dim=-1)
+            qkv_list.append(qkv)
+
+        qkv_cat = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
+
+        self.wqkv = ttnn.as_tensor(
+            qkv_cat,
+            dtype=self.wqkv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG if self.TG else wqkv_mem_config,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, dims=(3, 2) if self.TG else (2, 3), mesh_shape=configuration.cluster_shape
+            ),
+            cache_file_name=cache_name("wqkv_sharded_2d"),
+        )
+
+        def norm_reshard(x, norm, mode):
+            """Hack until RMSNorm supports height-sharded output config"""
+            if mode == "decode":
+                mem_cfg = x.memory_config()
+                x = ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG, dtype=x.dtype)
+            x = norm(x, mode)
+            if mode == "decode":
+                x = ttnn.to_memory_config(x, mem_cfg, dtype=x.dtype)
+            return x
+
+        if f"{q_norm_str}.weight" in self.state_dict:
+            fn_q_norm = RMSNorm(
+                device=self.mesh_device,
+                dim=self.head_dim,
+                eps=configuration.norm_eps,
+                state_dict=self.state_dict,
+                state_dict_prefix=None,  # we already prefix q_norm_str
+                weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key=q_norm_str,
+                add_unit_offset=self.rms_norm_add_unit_offset,
+                is_distributed=False,
+                sharded_program_config=None,  # FIXME: add height-sharded support. self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
+                sharded_output_config=None,  # FIXME: add height-sharded support. self.model_config["CREATE_QKV_DECODE_SHARD"]
+            )
+            self.q_norm = lambda x, mode: norm_reshard(x, fn_q_norm, mode)
+        else:
+            self.q_norm = lambda x, mode: x
+
+        if f"{k_norm_str}.weight" in self.state_dict:
+            fn_k_norm = RMSNorm(
+                device=self.mesh_device,
+                dim=self.head_dim,
+                eps=configuration.norm_eps,
+                state_dict=self.state_dict,
+                state_dict_prefix=None,  # we already prefix k_norm_str
+                weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key=k_norm_str,
+                add_unit_offset=self.rms_norm_add_unit_offset,
+                is_distributed=False,
+                sharded_program_config=None,  # FIXME: add height-sharded support. self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
+                sharded_output_config=None,  # FIXME: add height-sharded support. self.model_config["CREATE_QKV_DECODE_SHARD"],
+            )
+            self.k_norm = lambda x, mode: norm_reshard(x, fn_k_norm, mode)
+        else:
+            self.k_norm = lambda x, mode: x
+
+        # For ring topology we can use all gather matmul for wo
+        self.use_fused_all_gather_matmul = self.model_config["USE_FUSED_ALL_GATHER_MATMUL"]
+        pt_wo = self.state_dict[f"{wo_str}.weight"].transpose(-1, -2).unsqueeze(0).unsqueeze(0)
+
+        wo_mem_config = configuration.create_dram_sharded_mem_config(
+            (configuration.n_heads * configuration.head_dim) // configuration.num_devices, configuration.dim
+        )
+
+        self.wo = ttnn.as_tensor(
+            pt_wo,
+            dtype=self.wo_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG if (self.use_fused_all_gather_matmul or self.TG) else wo_mem_config,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=(2, 3) if (self.use_fused_all_gather_matmul or self.TG) else (3, 2),
+                mesh_shape=configuration.cluster_shape,
+            ),
+            cache_file_name=(
+                cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo")
+            ),
+        )
+        if not use_paged_kv_cache:
+            # vLLM provides its own kv cache
+            self.init_kv_cache(configuration, weight_cache_path)
+
+        if configuration.query_pre_attn_scalar is not None:
+            self.scale = configuration.query_pre_attn_scalar**-0.5
+        else:
+            self.scale = self.head_dim**-0.5
+
+    def init_kv_cache(self, configuration, weight_cache_path):
+        """
+        Generates empty KV cache and pushed to device memory
+        """
+
+        if self.paged_attention_config:
+            cache_k = torch.zeros(
+                (
+                    self.paged_attention_config.max_num_blocks,
+                    self.n_local_kv_heads,
+                    self.paged_attention_config.block_size,
+                    self.head_dim,
+                )
+            )
+            cache_v = torch.zeros(
+                (
+                    self.paged_attention_config.max_num_blocks,
+                    self.n_local_kv_heads,
+                    self.paged_attention_config.block_size,
+                    self.head_dim,
+                )
+            )
+        else:
+            cache_k = torch.zeros(
+                (
+                    self.batch_size_per_device_group,
+                    self.n_local_kv_heads,
+                    self.max_seq_len,
+                    self.head_dim,
+                )
+            )
+            cache_v = torch.zeros(
+                (
+                    self.batch_size_per_device_group,
+                    self.n_local_kv_heads,
+                    self.max_seq_len,
+                    self.head_dim,
+                )
+            )
+
+        self.layer_past = [
+            ttnn.as_tensor(
+                k_or_v,
+                dtype=self.kv_cache_dtype,
+                layout=self.model_config["ATTN_W_LAYOUT_TILE"],
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                cache_file_name=(
+                    f"{weight_cache_path}/kvcache_{k_or_v.shape}"
+                    if weight_cache_path and not configuration.dummy_weights
+                    else None
+                ),
+            )
+            for k_or_v in [cache_k, cache_v]
+        ]
+
+    def forward_decode(
+        self,
+        x: ttnn.Tensor,
+        current_pos,
+        rot_mats=None,
+        page_table=None,
+        kv_cache=None,
+    ) -> ttnn.Tensor:
+        """
+        x: (seq_len, 1, batch, dim)
+        current_pos: (batch_size), current token position in the sequence for each user
+        """
+
+        ###
+        # QKV matmuls
+        # Use HiFi2 for DRAM-sharded matmuls as they are otherwise flop-bound. Loses 1 bit of activation precision.
+        ###
+
+        xqkv_fused_sharded = ttnn.linear(
+            x,
+            self.wqkv,
+            # bias=self.wqkv_bias,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            program_config=self.model_config["XQKV_DECODE_PROGCFG"],
+            compute_kernel_config=self.li_qkv_decode_compute_kernel_cfg,
+            dtype=self.ccl_dtype if self.TG else self.activation_dtype or ttnn.bfloat16,
+        )
+        # FIXME: File bug against dram-sharded matmuls with bias
+        if self.wqkv_bias_decode:
+            # select the bias tensor based on the number of tiles in the rows
+            # WARNING: must not change the batch size between compiling and executing a trace
+            num_tiles = int(math.ceil(xqkv_fused_sharded.shape[-2] / self.tile_size))
+            xqkv_fused_sharded = xqkv_fused_sharded + self.wqkv_bias_decode[num_tiles - 1]
+
+        ttnn.deallocate(x)
+        xqkv_fused = tt_all_reduce(
+            xqkv_fused_sharded,
+            self.mesh_device,
+            cluster_axis=1,
+            num_reduce_scatter_links=self.num_reduce_scatter_links,
+            num_all_gather_links=self.num_all_gather_links,
+            memory_config=self.model_config["QKV_OUT_GATHERED_MEMCFG"](list(self.mesh_device.shape)[1]),
+            sharded=True,
+            dtype=self.ccl_dtype,
+            topology=self.ccl_topology,
+        )
+
+        if self.TG:
+            # TODO: Slice the fused_query_key_value tensor get batch=8
+            xqkv_fused = ttnn.matmul(
+                self.slice_mat,
+                xqkv_fused,
+                dtype=ttnn.bfloat16,
+                memory_config=self.model_config["CREATE_HEAD_INPUT_MEMCFG"],
+            )
+        else:
+            # bfloat16 is required by nlp_create_qkv_heads_decode
+            xqkv_fused = ttnn.sharded_to_interleaved(xqkv_fused_sharded, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16)
+
+        ttnn.deallocate(xqkv_fused_sharded)
+
+        # Reshape such that true unpadded batch is tracked in shape
+        fqkv_shape = xqkv_fused.shape
+        xqkv_fused = ttnn.reshape(
+            xqkv_fused, (1, 1, self.batch_size_per_device_group, fqkv_shape[3]), (1, 1, 32, fqkv_shape[3])
+        )
+
+        ###
+        # Reshape and rotary embeddings
+        ###
+        (
+            q_heads_pre_rot_1BQD,
+            k_heads_pre_rot_1BKD,
+            v_heads_1BKD,
+        ) = ttnn.experimental.nlp_create_qkv_heads_decode(
+            xqkv_fused,
+            num_heads=self.n_local_heads,
+            num_kv_heads=self.n_local_kv_heads,
+            memory_config=self.model_config["CREATE_QKV_DECODE_SHARD"],
+        )
+
+        q_heads_pre_rot_1BQD = self.q_norm(q_heads_pre_rot_1BQD, mode="decode")
+        k_heads_pre_rot_1BKD = self.k_norm(k_heads_pre_rot_1BKD, mode="decode")
+
+        ttnn.deallocate(xqkv_fused)
+
+        # Q Rotary Embeddings
+        q_heads_1BQD = ttnn.experimental.rotary_embedding_llama(
+            q_heads_pre_rot_1BQD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
+        )
+
+        # K Rotary Embeddings
+        k_heads_1BKD = ttnn.experimental.rotary_embedding_llama(
+            k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
+        )
+
+        ttnn.deallocate(q_heads_pre_rot_1BQD)
+        ttnn.deallocate(k_heads_pre_rot_1BKD)
+
+        ###
+        # KV update
+        ###
+        if kv_cache:
+            keys = kv_cache[0]
+            values = kv_cache[1]
+        else:
+            keys = self.layer_past[0]
+            values = self.layer_past[1]
+        # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
+        # v_heads [seqlen, n_kv_heads, bsz, head_dim]
+        # keys, [max_batch_size, n_kv_heads // configuration.num_devices, max_seq_len, head_dim]
+        ttnn.experimental.paged_update_cache(keys, k_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table)
+        ttnn.experimental.paged_update_cache(
+            values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+        )
+
+        ttnn.deallocate(k_heads_1BKD)
+        ttnn.deallocate(v_heads_1BKD)
+
+        # NOTE: Varying the batch size will result in slightly different outputs.
+        # For example, a prompt w/ 1 user vs, the same prompt repeated N times for N users, will produce different outputs
+        # This is because the SDPA op in decode mode has different number of reductions depending on batch size
+        # Which leads to slightly different outputs from attention (due to accumulated errors)
+        if page_table:
+            attn_output_1G4D = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q_heads_1BQD,
+                keys,
+                values,
+                cur_pos_tensor=current_pos,
+                page_table_tensor=page_table,
+                scale=self.scale,
+                program_config=self.model_config["SDPA_DECODE_PROGCFG"],
+                compute_kernel_config=self.sdpa_decode_compute_kernel_cfg,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        else:
+            attn_output_1G4D = ttnn.transformer.scaled_dot_product_attention_decode(
+                q_heads_1BQD,
+                keys,
+                values,
+                cur_pos_tensor=current_pos,
+                scale=self.scale,
+                program_config=self.model_config["SDPA_DECODE_PROGCFG"],
+                compute_kernel_config=self.sdpa_decode_compute_kernel_cfg,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,  # FIXME: why not L1 height sharded e.g. SCORES_BATCHED_MM_OUTPUT_MEMCFG?
+            )
+
+        ttnn.deallocate(q_heads_1BQD)
+
+        attn_output_11BH = ttnn.to_memory_config(
+            attn_output_1G4D,
+            memory_config=self.model_config["SCORES_BATCHED_MM_OUTPUT_MEMCFG"](self.batch_size_per_device_group),
+        )
+        attn_output_cat = ttnn.experimental.nlp_concat_heads_decode(
+            attn_output_11BH,
+            num_heads=self.n_local_heads,
+        )
+        ttnn.deallocate(attn_output_11BH)
+        ttnn.deallocate(attn_output_1G4D)
+
+        if self.use_fused_all_gather_matmul:
+            attn_output_cat = ttnn.to_memory_config(
+                attn_output_cat, self.model_config["ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"]
+            )
+            _, dense_out_sharded, _ = ttnn.experimental.all_gather_matmul(
+                attn_output_cat,
+                self.wo,
+                dim=3,
+                all_gather_core_grid_offset=(0, 4),
+                num_links=1,
+                program_config=self.model_config["ATTN_ALL_GATHER_MATMUL_PROGCFG"],
+                compute_kernel_config=self.li_o_decode_compute_kernel_cfg,
+                memory_config_ag=self.model_config["ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"],
+                memory_config_mm=self.model_config["DECODE_RESIDUAL_MEMCFG"],
+            )
+            ttnn.deallocate(attn_output_cat)
+            dense_out_sharded = ttnn.to_memory_config(dense_out_sharded, self.model_config["DECODE_RESIDUAL_MEMCFG"])
+            return dense_out_sharded
+
+        else:
+            attn_output = tt_all_gather(
+                attn_output_cat,
+                self.mesh_device,
+                dim=2,
+                cluster_axis=1,
+                num_links=2,
+                memory_config=self.model_config["GATHER_USERS_MEMCFG"](list(self.mesh_device.shape)[1]),
+                sharded=True,
+                # dtype=self.ccl_dtype,  # Running bf16 until we have SDPA output bfp8 df; otherwise we have two sharded to interleaved/interleaved to sharded conversions
+            )
+            if self.TG:
+                attn_output = ttnn.to_memory_config(attn_output, ttnn.L1_MEMORY_CONFIG)
+                # user_selection_matrix = [1, 1, 32, 128]
+                # user_selection_matrix @ activation -> [1, 1, 32, 128] * [1, 1, 128, 2048] -> [1, 1, 32, 2048]
+                attn_output = ttnn.matmul(
+                    self.user_selection_matrix,
+                    attn_output,
+                    core_grid=ttnn.CoreGrid(y=4, x=8),
+                    dtype=ttnn.bfloat16,
+                    memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                )
+
+            # TODO: Fix this once self.TG supports dram-sharded matmuls
+            dense_out_sharded = ttnn.matmul(
+                attn_output,
+                self.wo,
+                core_grid=ttnn.CoreGrid(y=4, x=8) if self.TG else None,
+                program_config=self.model_config["ATTN_OUTPUT_PROGCFG"] if not self.TG else None,
+                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                dtype=ttnn.bfloat8_b if self.TG else None,
+                compute_kernel_config=self.li_o_decode_compute_kernel_cfg,
+            )
+
+            ttnn.deallocate(attn_output_cat)
+
+            # All reduce
+            dense_out_reduced = tt_all_reduce(
+                dense_out_sharded,
+                self.mesh_device,
+                cluster_axis=0,
+                num_reduce_scatter_links=self.num_reduce_scatter_links,
+                num_all_gather_links=self.num_all_gather_links,
+                dim=0 if (self.TG and self.hidden_size < 8192) else 3,
+                topology=self.ccl_topology,
+                memory_config=(
+                    (
+                        self.model_config["SELF_OUT_REDUCE_SCATTER_MEMCFG"]
+                        if self.hidden_size == 8192
+                        else self.model_config["SELF_OUT_GATHERED_MEMCFG"](list(self.mesh_device.shape)[0])
+                    )
+                    if self.TG
+                    else self.model_config["DECODE_RESIDUAL_MEMCFG"]
+                ),
+                sharded=True,
+                dtype=self.ccl_dtype,
+                use_composite=True if self.hidden_size == 8192 else False,
+            )
+
+            if not self.TG:
+                dense_out_reduced = ttnn.to_memory_config(
+                    dense_out_reduced, self.model_config["DECODE_RESIDUAL_MEMCFG"]
+                )
+
+            return dense_out_reduced
+
+    def forward_prefill(
+        self,
+        x_11SH,
+        rot_mats,
+        user_id: int = 0,
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+    ):
+        seq_len = x_11SH.shape[-2]
+        assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
+        ###
+        # QKV matmuls
+        ###
+
+        # reshaping long sequence to matmul fit on device
+        if seq_len > self.MAX_QKV_MM_SEQ_LEN:
+            if seq_len % self.MAX_QKV_MM_SEQ_LEN != 0:
+                raise ValueError(f"seq_len {seq_len} must be divisible by {self.MAX_QKV_MM_SEQ_LEN}")
+            x_11SH = ttnn.reshape(x_11SH, [1, seq_len // self.MAX_QKV_MM_SEQ_LEN, self.MAX_QKV_MM_SEQ_LEN, -1])
+
+        xqkv_fused = ttnn.linear(
+            x_11SH,
+            self.wqkv,
+            dtype=self.ccl_dtype if self.TG else self.activation_dtype or ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.li_qkv_prefill_compute_kernel_cfg,
+            program_config=self.model_config["XQKV_PREFILL_PROGCFG"](seq_len),
+        )
+
+        # FIXME: surely ttnn.linear bias should work?
+        if self.wqkv_bias_prefill is not None:
+            xqkv_fused = xqkv_fused + self.wqkv_bias_prefill
+
+        xqkv_fused = tt_all_reduce(
+            xqkv_fused,
+            self.mesh_device,
+            cluster_axis=1,
+            num_reduce_scatter_links=self.num_reduce_scatter_links,
+            num_all_gather_links=self.num_all_gather_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=self.ccl_dtype,
+        )
+
+        if seq_len > self.MAX_QKV_MM_SEQ_LEN:
+            xqkv_fused = ttnn.reshape(xqkv_fused, [1, 1, seq_len, -1])
+
+        ttnn.deallocate(x_11SH)
+
+        # split qkv into heads
+        (
+            q_heads_1QSD_pre_rot,
+            k_heads_1KSD_pre_rot,
+            v_heads_1VSD,
+        ) = ttnn.experimental.nlp_create_qkv_heads(
+            xqkv_fused,
+            num_heads=self.n_local_heads,
+            num_kv_heads=self.n_local_kv_heads,
+            transpose_k_heads=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        q_heads_1QSD_pre_rot = self.q_norm(q_heads_1QSD_pre_rot, mode="prefill")
+        k_heads_1KSD_pre_rot = self.k_norm(k_heads_1KSD_pre_rot, mode="prefill")
+
+        ttnn.deallocate(xqkv_fused)
+
+        ###
+        # Rotary embeddings
+        ###
+
+        if q_heads_1QSD_pre_rot.dtype != ttnn.bfloat16:  # Rotary embeddings require bfloat16 inputs
+            q_heads_1QSD_pre_rot = ttnn.typecast(q_heads_1QSD_pre_rot, dtype=ttnn.bfloat16)
+
+        q_heads_1QSD = ttnn.experimental.rotary_embedding_llama(
+            q_heads_1QSD_pre_rot,
+            rot_mats[0],
+            rot_mats[1],
+            self.transformation_mats["prefill"],
+            is_decode_mode=False,
+        )
+        ttnn.deallocate(q_heads_1QSD_pre_rot)
+
+        if k_heads_1KSD_pre_rot.dtype != ttnn.bfloat16:  # Rotary embeddings require bfloat16 inputs
+            k_heads_1KSD_pre_rot = ttnn.typecast(k_heads_1KSD_pre_rot, dtype=ttnn.bfloat16)
+
+        k_heads_1KSD = ttnn.experimental.rotary_embedding_llama(
+            k_heads_1KSD_pre_rot,
+            rot_mats[0],
+            rot_mats[1],
+            self.transformation_mats["prefill"],
+            is_decode_mode=False,
+        )
+        ttnn.deallocate(k_heads_1KSD_pre_rot)
+
+        # Fill KV-Cache
+        if kv_cache:
+            keys_BKSD, values_BKSD = kv_cache[0], kv_cache[1]
+        else:
+            keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
+        k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=keys_BKSD.dtype)
+        ttnn.deallocate(k_heads_1KSD)
+
+        # sharding k_fill to deal with update_cache memory limitation
+        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and not page_table:
+            k_fill = ttnn.interleaved_to_sharded(k_heads_1KSD_8b, self.model_config["KV_PREFILL_MEM_CFG"](seq_len))
+        else:
+            k_fill = k_heads_1KSD_8b
+
+        v_heads_1VSD_8b = ttnn.typecast(v_heads_1VSD, dtype=values_BKSD.dtype)
+
+        ttnn.deallocate(v_heads_1VSD)
+
+        # sharding v_fill to deal with update_cache memory limitation
+        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and not page_table:
+            v_fill = ttnn.interleaved_to_sharded(v_heads_1VSD_8b, self.model_config["KV_PREFILL_MEM_CFG"](seq_len))
+        else:
+            v_fill = v_heads_1VSD_8b
+
+        if self.TG:
+            k_fill = self.prefill_prepare_tensor_for_kv_cache(k_fill, user_id)
+            v_fill = self.prefill_prepare_tensor_for_kv_cache(v_fill, user_id)
+        if page_table:
+            # In the case that the tokens have been padded along the seq len dimension, we need to fill the cache with the unpadded k/v values.
+            # Assume that the page table does not have padding, so we can use it to get the unpadded page len.
+            block_size = keys_BKSD.shape[2]
+            # If chunked prefill, use chunk_page_table if given, otherwise use page_table.
+            fill_page_table = chunk_page_table if chunk_page_table is not None else page_table
+
+            page_len = fill_page_table.shape[1] * block_size
+            k_fill_sliced = k_fill[:, :, :page_len, :] if page_len < k_fill.shape[2] else k_fill
+            v_fill_sliced = v_fill[:, :, :page_len, :] if page_len < v_fill.shape[2] else v_fill
+            ttnn.experimental.paged_fill_cache(keys_BKSD, k_fill_sliced, fill_page_table, batch_idx=user_id)
+            ttnn.experimental.paged_fill_cache(values_BKSD, v_fill_sliced, fill_page_table, batch_idx=user_id)
+        else:
+            ttnn.fill_cache(
+                keys_BKSD,
+                k_fill,
+                user_id % self.batch_size_per_device_group,
+            )
+            ttnn.fill_cache(
+                values_BKSD,
+                v_fill,
+                user_id % self.batch_size_per_device_group,
+            )
+
+        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and not page_table:
+            ttnn.deallocate(k_fill)
+            ttnn.deallocate(v_fill)
+
+        # SDPA
+        q_heads_1QSD_8b = ttnn.typecast(q_heads_1QSD, dtype=self.activation_dtype or ttnn.bfloat8_b)
+        ttnn.deallocate(q_heads_1QSD)
+
+        if chunk_start_idx is not None:
+            attn_output_84SD = ttnn.transformer.chunked_scaled_dot_product_attention(
+                q_heads_1QSD_8b,
+                keys_BKSD,
+                values_BKSD,
+                page_table,
+                chunk_start_idx,
+                compute_kernel_config=self.sdpa_prefill_compute_kernel_cfg,
+                program_config=self.model_config["SDPA_PROGCFG"](seq_len),
+            )
+        else:
+            attn_output_84SD = ttnn.transformer.scaled_dot_product_attention(
+                q_heads_1QSD_8b,
+                k_heads_1KSD_8b,
+                v_heads_1VSD_8b,
+                is_causal=True,
+                scale=self.scale,
+                compute_kernel_config=self.sdpa_prefill_compute_kernel_cfg,
+                program_config=self.model_config["SDPA_PROGCFG"](seq_len),
+            )
+
+        # deallocate keys and values
+        ttnn.deallocate(q_heads_1QSD_8b)
+        ttnn.deallocate(k_heads_1KSD_8b)
+        ttnn.deallocate(v_heads_1VSD_8b)
+
+        attn_output_1QSD = ttnn.reshape(attn_output_84SD, [1, self.n_local_heads, -1, self.head_dim])
+
+        ###
+        # Output matmul
+        ###
+        attn_output_11SH = ttnn.experimental.nlp_concat_heads(
+            attn_output_1QSD,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(attn_output_1QSD)
+        # reshaping long sequence to matmul fit on device
+        if seq_len > 1024:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 1024, 1024, -1])
+
+        # Non fused All Gather Matmul
+        if self.use_fused_all_gather_matmul:  # is true for Ring topology
+            attn_output_11SH = ttnn.all_gather(
+                attn_output_11SH,
+                dim=3,
+                num_links=1,
+                topology=self.ccl_topology,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+        output_11SH = ttnn.linear(
+            attn_output_11SH,
+            self.wo,
+            compute_kernel_config=self.li_o_prefill_compute_kernel_cfg,
+            dtype=self.activation_dtype or ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=self.model_config["WO_PREFILL_PROGCFG"](seq_len),
+        )
+
+        if seq_len > 1024:
+            output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])
+        ttnn.deallocate(attn_output_11SH)
+
+        # Reduce-scatter
+        if not self.use_fused_all_gather_matmul:
+            output_11SH = tt_all_reduce(
+                output_11SH,
+                self.mesh_device,
+                cluster_axis=0,
+                dim=0 if self.TG else 3,
+                num_reduce_scatter_links=self.num_reduce_scatter_links,
+                num_all_gather_links=self.num_all_gather_links,
+                topology=self.ccl_topology,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                dtype=self.ccl_dtype,
+            )
+
+        return output_11SH
+
+    def forward(
+        self,
+        x,
+        current_pos,
+        rot_mats=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+    ):
+        if mode == "prefill":
+            return self.forward_prefill(
+                x,
+                rot_mats,
+                user_id,
+                page_table=page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                kv_cache=kv_cache,
+            )
+        else:
+            return self.forward_decode(x, current_pos, rot_mats, page_table=page_table, kv_cache=kv_cache)
+
+    def prefill_prepare_tensor_for_kv_cache(self, key_or_value_layer, user_id):
+        tensor_copy = ttnn.clone(key_or_value_layer)
+        # key_or_value_layer.deallocate(True)
+        # Get all tensors from multi-device tensor
+        tensors = ttnn.get_device_tensors(tensor_copy)
+        # Get only tensors from specific column chips
+        # Get every 4th tensor starting from user_id // 8
+        single_column_tensors = tensors[user_id // self.batch_size_per_device_group :: 4]
+        # Create multi-device tensor
+        multi_device_tensor = ttnn.combine_device_tensors(single_column_tensors)
+
+        return multi_device_tensor

--- a/models/experimental/gemma3_4b/tt/decoder.py
+++ b/models/experimental/gemma3_4b/tt/decoder.py
@@ -8,7 +8,7 @@ In Gemma-3-4b-it, The decoder Block has Additional pre_feedforward_layernorm and
 And the logic of implementation is different from the existing implementation in TT-Transformers.
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/decoder.py
+++ b/models/experimental/gemma3_4b/tt/decoder.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.common.rmsnorm import RMSNorm
+from models.tt_transformers.tt.attention import Attention as DefaultAttention
+from models.tt_transformers.tt.distributed_norm import DistributedNorm
+from models.tt_transformers.tt.mlp import MLP
+from models.tt_transformers.tt.model_config import TensorGroup
+
+
+class TransformerBlock(LightweightModule):
+    def __init__(
+        self,
+        args,
+        mesh_device,
+        dtype,
+        state_dict,
+        layer_num,
+        weight_cache_path,
+        transformation_mats,
+        paged_attention_config=None,
+        use_paged_kv_cache=False,
+        attention_class=None,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+
+        self.args = args
+        self.hidden_size = args.dim
+        self.n_heads = args.n_heads
+        self.head_dim = self.hidden_size // self.n_heads
+        self.max_seq_len = args.max_seq_len
+        self.dim = args.dim
+        self.max_batch_size = args.max_batch_size
+        self.n_kv_heads = args.n_kv_heads
+        self.current = 0
+        self.model_config = args.get_model_config()
+
+        self.layer_num = layer_num
+
+        ActualAttentionClass = attention_class if attention_class is not None else DefaultAttention
+
+        self.attention = ActualAttentionClass(
+            mesh_device=mesh_device,
+            state_dict=state_dict,
+            weight_cache_path=weight_cache_path,
+            layer_num=layer_num,
+            dtype=dtype,
+            transformation_mats=transformation_mats,
+            configuration=args,
+            paged_attention_config=paged_attention_config,
+            use_paged_kv_cache=use_paged_kv_cache,
+        )
+        self.feed_forward = MLP(
+            mesh_device=mesh_device,
+            args=args,
+            state_dict=state_dict,
+            weight_cache_path=weight_cache_path,
+            layer_num=layer_num,
+            dtype=dtype,
+            model_config=self.model_config,
+        )
+        self.attention_norm = DistributedNorm(
+            RMSNorm(
+                device=mesh_device,
+                dim=args.dim,
+                eps=args.norm_eps,
+                state_dict=state_dict,
+                state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key="attention_norm",
+                is_distributed=self.args.is_distributed_norm,
+                add_unit_offset=self.args.rms_norm_add_unit_offset,
+                sharded_program_config=self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
+                sharded_output_config=self.model_config["SHARDED_ATTN_INPUT_MEMCFG"],
+                ccl_topology=self.args.ccl_topology(),
+            ),
+            args,
+            TG=args.is_galaxy,
+        )
+        self.ff_norm = DistributedNorm(
+            RMSNorm(
+                device=mesh_device,
+                dim=args.dim,
+                eps=args.norm_eps,
+                state_dict=state_dict,
+                state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key="ffn_norm",
+                is_distributed=self.args.is_distributed_norm,
+                add_unit_offset=self.args.rms_norm_add_unit_offset,
+                sharded_program_config=self.model_config["SHARDED_NORM_MLP_PRGM_CFG"],
+                sharded_output_config=self.model_config["SHARDED_MLP_INPUT_MEMCFG"],
+                ccl_topology=self.args.ccl_topology(),
+            ),
+            args,
+            TG=args.is_galaxy,
+        )
+
+    def forward(
+        self,
+        x: ttnn.Tensor,
+        current_pos,
+        rot_mats=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+    ) -> ttnn.Tensor:
+        TG = self.args.is_galaxy
+        # x is fractured across devices and interleaved in DRAM (for prefill) and sharded in L1 (for decode)
+        skip_mem_cfg = self.model_config["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
+        assert (
+            x.memory_config() == skip_mem_cfg
+        ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
+        # Norms take fractured inputs and output replicated across devices
+        attn_in = self.attention_norm(x, mode)
+        # Attention takes replicated inputs and produces fractured outputs
+        attn_out = self.attention.forward(
+            attn_in,
+            current_pos,
+            rot_mats,
+            user_id,
+            mode,
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
+            kv_cache=kv_cache,
+        )
+        # Here x and attn_out are both fractured across devices
+        h = ttnn.add(x, attn_out, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None)
+        ttnn.deallocate(attn_out)
+        if mode == "prefill":
+            x.deallocate(True)
+
+        # Norms take fractured inputs and output replicated across devices
+        ff_in = self.ff_norm(h, mode)
+        if TG and mode == "decode":
+            ff_in = ttnn.to_memory_config(ff_in, memory_config=self.model_config["MLP_ACT_MEMCFG"])
+        # MLP takes replicated inputs and produces fractured outputs
+        ff_out = self.feed_forward.forward(ff_in, mode)
+        # ff_out and h are both fractured across devices
+        activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+        )
+        out = ttnn.add(
+            h,
+            ff_out,
+            memory_config=skip_mem_cfg,
+            dtype=self.args.ccl_dtype
+            if TG and not self.args.is_distributed_norm(mode)
+            else activation_dtype or ttnn.bfloat16,
+        )
+        return out  # fractured across devices

--- a/models/experimental/gemma3_4b/tt/gemma3_generator.py
+++ b/models/experimental/gemma3_4b/tt/gemma3_generator.py
@@ -269,17 +269,25 @@ class Gemma3Generator:
 
         tt_tokens = []
         tt_current_pos = []
-        tt_rot_mats = []
+        tt_rot_mat_idxs_global = []
+        tt_rot_mat_idxs_local = []
+
         tt_page_table = []
 
         for i in range(self.data_parallel):
             user_page_table = page_table[i] if page_table is not None else None
-            tt_tokens_i, tt_current_pos_i, tt_rot_mats_i, tt_page_table_i = self.model[i].prepare_inputs_decode(
-                tokens[i], current_pos[i], user_page_table
-            )
+            model_i = self.model[i]
+            (
+                tt_tokens_i,
+                tt_current_pos_i,
+                tt_rot_mat_idxs_global_i,
+                tt_rot_mat_idxs_local_i,
+                tt_page_table_i,
+            ) = model_i.prepare_inputs_decode(tokens[i], current_pos[i], user_page_table)
             tt_tokens.append(tt_tokens_i)
             tt_current_pos.append(tt_current_pos_i)
-            tt_rot_mats.append(tt_rot_mats_i)
+            tt_rot_mat_idxs_global.append(tt_rot_mat_idxs_global_i)
+            tt_rot_mat_idxs_local.append(tt_rot_mat_idxs_local_i)
             tt_page_table.append(tt_page_table_i)
 
         for i in range(self.data_parallel):
@@ -287,7 +295,8 @@ class Gemma3Generator:
             tt_logits_i = self.model[i].ttnn_decode_forward(
                 tt_tokens[i],
                 tt_current_pos[i],
-                rot_mats=tt_rot_mats[i],
+                rot_mat_idxs_global=tt_rot_mat_idxs_global[i],
+                rot_mat_idxs_local=tt_rot_mat_idxs_local[i],
                 page_table=tt_page_table[i],
                 kv_cache=user_kv_cache,
                 argmax_on_device=argmax_on_device,

--- a/models/experimental/gemma3_4b/tt/gemma3_generator.py
+++ b/models/experimental/gemma3_4b/tt/gemma3_generator.py
@@ -167,7 +167,8 @@ class Gemma3Generator:
 
                 (
                     chunk_prefill_input,
-                    chunk_rot_mats_prefill,
+                    chunk_rot_mats_global_prefill,
+                    chunk_rot_mats_local_prefill,
                     page_table_tt,
                     chunk_page_table_tt,
                 ) = self.model[model_id].prepare_inputs_prefill(
@@ -179,7 +180,8 @@ class Gemma3Generator:
                 )
                 tt_logits = self.model[model_id].ttnn_prefill_forward(
                     chunk_prefill_input,
-                    rot_mats=chunk_rot_mats_prefill,
+                    rot_mats_global=chunk_rot_mats_global_prefill,
+                    rot_mats_local=chunk_rot_mats_local_prefill,
                     user_id=CHUNK_USER_ID,
                     page_table=page_table_tt,
                     chunk_page_table=chunk_page_table_tt,
@@ -193,7 +195,9 @@ class Gemma3Generator:
                 else:
                     del tt_logits
         else:
-            prefill_input, rot_mats_prefill, page_table_tt, _ = self.model[model_id].prepare_inputs_prefill(
+            (prefill_input, rot_mats_global_prefill, rot_mats_local_prefill, page_table_tt, _) = self.model[
+                model_id
+            ].prepare_inputs_prefill(
                 tokens,
                 page_table=page_table,
                 **kwargs,
@@ -201,7 +205,8 @@ class Gemma3Generator:
 
             tt_logits = self.model[model_id].ttnn_prefill_forward(
                 prefill_input,
-                rot_mats=rot_mats_prefill,
+                rot_mats_global=rot_mats_global_prefill,
+                rot_mats_local=rot_mats_local_prefill,
                 user_id=user_id,
                 page_table=page_table_tt,
                 get_last_token=(last_token_idx // 32) * 32,

--- a/models/experimental/gemma3_4b/tt/gemma3_generator.py
+++ b/models/experimental/gemma3_4b/tt/gemma3_generator.py
@@ -1,0 +1,1209 @@
+"""
+source: models/tt_transformers/tt/generator.py
+
+This is the Replica version of the Generator class for the Gemma Model.
+This adds support for kwargs that contains the procesed inputs and the vision submodule of the model.
+
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import torch
+from llama_models.llama3.api.datatypes import InterleavedTextMedia, StopReason
+from llama_models.llama3.reference_impl.generation import (
+    ChatPrediction,
+    CompletionPrediction,
+    TokenResult,
+    sample_top_p,
+)
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.common import (
+    copy_host_to_device,
+    get_block_size,
+    get_max_prefill_chunk_size,
+    get_padded_prefill_len,
+    num_blocks_in_seq,
+)
+
+
+@dataclass(frozen=True)
+class SamplingParams:
+    """
+    Used in Generator decode forward functions for greedy decoding / sampling on device.
+    The same data class exists in vLLM at vllm/worker/tt_model_runner.py.
+    """
+
+    temperature: float
+    top_k: int
+    top_p: float
+
+
+class Gemma3Generator:
+    def __init__(self, model, model_args, mesh_device, tokenizer=None, formatter=None):
+        """
+        Creating a LlamaVision wrapper requires only a mesh_device and model_args.
+        With model_args you have the checkpoint location, can specify max batch size
+        and max seqlen, and other model specific parameters.
+
+        LlamaVision is general to text and chat.
+
+        For bringup, make this class general to any backend implementation, as long as it takes torch tensors and returns torch tensors.
+
+        """
+        self.model = model
+        self.model_args = model_args
+        self.mesh_device = mesh_device
+        self.tokenizer = tokenizer
+        self.formatter = formatter
+        self.data_parallel = len(self.model)
+
+    # Note: This function is called by vLLM
+    def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None, **kwargs):
+        batch, batch_seq_len = tokens.shape
+
+        # Each model expected to run the same model, safe to use 1st vocab size
+        output_logits = torch.zeros(batch, 1, self.model_args[0].vocab_size)
+        prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch)
+
+        data_parallel = min(batch, self.data_parallel)
+        batch_per_device = batch // data_parallel
+
+        if page_table is not None:
+            assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
+            page_table = torch.chunk(page_table, self.data_parallel, 0)
+
+        out_list = []
+        for group_user_id in range(batch_per_device):
+            for model_id in range(data_parallel):
+                user_id = group_user_id + model_id * batch_per_device
+
+                logger.info(f"Prefilling User {user_id + 1}")
+                seq_len = int(prompt_lens[user_id])
+                last_token_idx = seq_len - 1
+
+                prefill_seq_len = get_padded_prefill_len(seq_len)
+                prefill_ids = torch.cat(
+                    [tokens[user_id : user_id + 1, :seq_len], torch.zeros(1, prefill_seq_len - seq_len).long()], dim=-1
+                )
+                if page_table is not None:
+                    page_table_user = self._get_prefill_user_page_table(
+                        page_table[model_id], kv_cache[model_id], seq_len
+                    )
+
+                logits = self.prefill_forward_single_user_text(
+                    prefill_ids,
+                    page_table=page_table_user if page_table is not None else None,
+                    user_id=group_user_id,
+                    last_token_idx=last_token_idx,
+                    kv_cache=kv_cache[model_id] if kv_cache is not None else None,
+                    model_id=model_id,
+                    **kwargs,
+                )
+                out_list.append(logits)
+
+        # We gather data back to how at the end of prefill
+        for idx, out in enumerate(out_list):
+            model_id = idx % self.data_parallel
+            group_user_id = idx // self.data_parallel
+            user_id = group_user_id + model_id * batch_per_device
+
+            seq_len = int(prompt_lens[user_id])
+            last_token_idx = seq_len - 1
+
+            # Since we give unpadded_seq_len, only the tile containing the last token is returned
+            output_logits[user_id] = self.model[model_id].process_output_prefill(
+                out, last_token_idx=(last_token_idx % 32)
+            )
+
+        logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
+        return output_logits
+
+    def prefill_forward_single_user_text(
+        self, tokens, page_table, user_id, last_token_idx, kv_cache=None, model_id=-1, **kwargs
+    ):
+        seq_len = tokens.shape[-1]
+        use_chunked_prefill = seq_len > self.model_args[model_id].max_prefill_chunk_size
+        if use_chunked_prefill:
+            """
+            Chunked prefill requires paged attention. There are some strange constraints which we must meet:
+             - page_table, which is used in SDPA, must match batch size of inputs, which is 1. This is because SDPA
+             checks that page table batch dim matches input batch dim. Therefore we must slice the page table for the current user.
+             - page_table must also have enough entries in each chunk, so it will be padded with zeros if necessary.
+             - chunked_page_table is the slice of the page table for the current chunk. This is used by paged_fill_cache
+             to keep it otherwise unaware that it is operating on a chunk.
+             - due to the above point, we must always set user_id to 0 for chunked prefill.
+            """
+            assert page_table is not None, "page_table must be provided for chunked prefill"
+            assert kv_cache is not None, "kv_cache must be provided for chunked prefill"
+            assert (
+                last_token_idx is not None and last_token_idx < seq_len
+            ), "last_token_idx must be provided and less than seq_len"
+            chunk_size = get_max_prefill_chunk_size(seq_len, self.model_args[model_id].max_prefill_chunk_size)
+            block_size = get_block_size(kv_cache)
+            last_token_idx_in_chunk = last_token_idx % chunk_size
+            # Calculate which chunk contains the last_token_idx
+            last_chunk_start = (last_token_idx // chunk_size) * chunk_size
+            page_table_user = page_table[user_id : user_id + 1, :]
+            # Pad page table to match number of blocks in seq_len
+            num_padding_blocks = num_blocks_in_seq(seq_len, block_size) - page_table_user.shape[1]
+            page_table_user_padded = torch.cat(
+                [page_table_user, torch.zeros(1, num_padding_blocks, dtype=torch.int32)], dim=-1
+            )
+            CHUNK_USER_ID = 0
+
+            for chunk_start in range(0, seq_len, chunk_size):
+                chunk_end = chunk_start + chunk_size
+                assert (
+                    chunk_end <= seq_len
+                ), f"Chunk end should be less than seq_len, got chunk_end={chunk_end} and seq_len={seq_len}"
+                chunk_tokens = tokens[:, chunk_start:chunk_end]
+                chunk_page_table = page_table_user[:, chunk_start // block_size : chunk_end // block_size]
+
+                (
+                    chunk_prefill_input,
+                    chunk_rot_mats_prefill,
+                    page_table_tt,
+                    chunk_page_table_tt,
+                ) = self.model[model_id].prepare_inputs_prefill(
+                    chunk_tokens,
+                    start_pos=chunk_start,
+                    page_table=page_table_user_padded,
+                    chunk_page_table=chunk_page_table,
+                    **kwargs,
+                )
+                tt_logits = self.model[model_id].ttnn_prefill_forward(
+                    chunk_prefill_input,
+                    rot_mats=chunk_rot_mats_prefill,
+                    user_id=CHUNK_USER_ID,
+                    page_table=page_table_tt,
+                    chunk_page_table=chunk_page_table_tt,
+                    chunk_start_idx=chunk_start,
+                    get_last_token=(last_token_idx_in_chunk // 32) * 32,
+                    kv_cache=kv_cache,
+                )
+
+                if chunk_start == last_chunk_start:
+                    return tt_logits
+                else:
+                    del tt_logits
+        else:
+            prefill_input, rot_mats_prefill, page_table_tt, _ = self.model[model_id].prepare_inputs_prefill(
+                tokens,
+                page_table=page_table,
+                **kwargs,
+            )
+
+            tt_logits = self.model[model_id].ttnn_prefill_forward(
+                prefill_input,
+                rot_mats=rot_mats_prefill,
+                user_id=user_id,
+                page_table=page_table_tt,
+                get_last_token=(last_token_idx // 32) * 32,
+                kv_cache=kv_cache,
+            )
+            return tt_logits
+
+    # Note: This function is called by vLLM
+    def decode_forward_text(
+        self,
+        tokens,
+        start_pos,
+        page_table=None,
+        kv_cache=None,
+        enable_trace=True,
+        read_from_device=True,
+        sampling_params: SamplingParams = None,  # Should be None if not greedy decoding / sampling on device.
+    ):
+        assert (
+            sampling_params is None or sampling_params.temperature == 0
+        ), "Currently only supporting greedy decoding (temperature=0) on device"
+        argmax_on_device = sampling_params is not None and sampling_params.temperature == 0
+
+        B = tokens.shape[0]
+        tokens = torch.chunk(tokens, self.data_parallel, 0)
+        start_pos = torch.chunk(start_pos, self.data_parallel, 0)
+        page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
+
+        decode_kwargs = {
+            "current_pos": start_pos,
+            "tokens": tokens,
+            "page_table": page_table,
+            "kv_cache": kv_cache,
+            "argmax_on_device": argmax_on_device,
+        }
+        if enable_trace:
+            tt_logits = self._easy_trace_text(**decode_kwargs)
+        else:
+            tt_logits = self._decode_forward_no_trace_text(**decode_kwargs)
+
+        if read_from_device:
+            to_host = self.read_decode_output(tt_logits, B, is_tokens=(sampling_params is not None))
+            return to_host
+        else:
+            return tt_logits
+
+    def _decode_forward_no_trace_text(
+        self,
+        tokens,
+        current_pos,
+        page_table=None,
+        kv_cache=None,
+        argmax_on_device=False,
+    ):
+        """
+        Performs text decode step.
+        Returns tt_logits on device
+        """
+        tt_logits = []
+
+        tt_tokens = []
+        tt_current_pos = []
+        tt_rot_mats = []
+        tt_page_table = []
+
+        for i in range(self.data_parallel):
+            user_page_table = page_table[i] if page_table is not None else None
+            tt_tokens_i, tt_current_pos_i, tt_rot_mats_i, tt_page_table_i = self.model[i].prepare_inputs_decode(
+                tokens[i], current_pos[i], user_page_table
+            )
+            tt_tokens.append(tt_tokens_i)
+            tt_current_pos.append(tt_current_pos_i)
+            tt_rot_mats.append(tt_rot_mats_i)
+            tt_page_table.append(tt_page_table_i)
+
+        for i in range(self.data_parallel):
+            user_kv_cache = kv_cache[i] if kv_cache is not None else None
+            tt_logits_i = self.model[i].ttnn_decode_forward(
+                tt_tokens[i],
+                tt_current_pos[i],
+                rot_mats=tt_rot_mats[i],
+                page_table=tt_page_table[i],
+                kv_cache=user_kv_cache,
+                argmax_on_device=argmax_on_device,
+            )
+            tt_logits.append(tt_logits_i)
+
+        return tt_logits
+
+    def _capture_trace_text(
+        self,
+        tokens,
+        current_pos,
+        page_table=None,
+        kv_cache=None,
+        argmax_on_device=False,
+    ):
+        """
+        Captures a trace for the decode_forward method.
+        """
+
+        # Compile run
+        self._decode_forward_no_trace_text(
+            tokens, current_pos, page_table=page_table, kv_cache=kv_cache, argmax_on_device=argmax_on_device
+        )
+        logger.info("Done Compiling Model")
+
+        # Get inputs ready for trace run
+        device_inputs = []
+        tt_out_trace = []
+        trace_ids = {}
+        for i in range(self.data_parallel):
+            user_page_table = page_table[i] if page_table is not None else None
+            host_inputs = self.model[i].prepare_decode_inputs_host(
+                tokens[i], current_pos[i], page_table=user_page_table
+            )
+
+            device_inputs_i = copy_host_to_device(host_inputs, mesh_device=self.model_args[i].mesh_device)
+            device_inputs.append(device_inputs_i)
+
+        for i in range(self.data_parallel):
+            trace_id = ttnn.begin_trace_capture(self.model_args[i].mesh_device, cq_id=0)
+            trace_ids[i] = trace_id
+            user_kv_cache = kv_cache[i] if kv_cache is not None else None
+            transformed_inputs = self.model[i].transform_decode_inputs_device(*(device_inputs[i]))
+            tt_out_trace.append(
+                self.model[i].ttnn_decode_forward(
+                    *transformed_inputs, kv_cache=user_kv_cache, argmax_on_device=argmax_on_device
+                )
+            )
+            ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
+        logger.info("Done Capturing Decode Trace")
+        return trace_ids, tt_out_trace, *device_inputs
+
+    def _decode_forward_trace_text(
+        self,
+        trace_ids,
+        device_inputs,
+        tt_out_trace,
+        tokens,
+        current_pos,
+        page_table=None,
+    ):
+        """
+        Executes the trace for the decode_forward method but does not read back outputs.
+        """
+        host_inputs = []
+        for i in range(self.data_parallel):
+            user_page_table = page_table[i] if page_table is not None else None
+            host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
+            host_inputs.append(host_inputs_i)
+
+        to_device = []
+        for i in range(self.data_parallel):
+            to_device.append(
+                copy_host_to_device(
+                    host_tensors=host_inputs[i],
+                    device_tensors=device_inputs[i],
+                )
+            )
+        device_inputs = to_device
+        for i, trace_id in trace_ids.items():
+            ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
+
+        return tt_out_trace
+
+    def _easy_trace_text(
+        self,
+        tokens,
+        current_pos,
+        page_table=None,
+        kv_cache=None,
+        argmax_on_device=False,
+    ):
+        """
+        Tracing is easy! Just call this method and we'll handle tracing for you.
+        """
+        if not hasattr(self, "trace_ids_text"):
+            trace_ids, tt_out_trace, *device_inputs = self._capture_trace_text(
+                tokens, current_pos, page_table=page_table, kv_cache=kv_cache, argmax_on_device=argmax_on_device
+            )
+            self.trace_ids_text = trace_ids
+            self.trace_inputs_text = device_inputs
+            self.trace_output_text = tt_out_trace
+
+        trace_logits_rm = self._decode_forward_trace_text(
+            self.trace_ids_text,
+            self.trace_inputs_text,
+            self.trace_output_text,
+            tokens,
+            current_pos,
+            page_table=page_table,
+        )
+
+        return trace_logits_rm
+
+    def _prefill_forward_single_user(
+        self,
+        vision_images,
+        vision_mask,
+        tokens,
+        xattn_caches,
+        user_id,
+        total_len,
+        prefill_len,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+        model_id=-1,
+    ):
+        """
+        Performs vision encode step then text prefill.
+        Returns (xattn_caches, cross_attention_masks, full_text_row_masked_out_mask, logits)
+        """
+        B = tokens.shape[0]
+        last_token_idx = prefill_len - 1
+
+        text_only_inference = vision_images is None
+        if not text_only_inference:
+            (
+                vision_tokens,
+                cross_attention_masks,
+                full_text_row_masked_out_mask,
+            ) = self.model[model_id].compute_vision_tokens_masks(
+                batch_images=[vision_images],
+                batch_masks=[vision_mask],
+                total_len=total_len,
+            )
+
+            if cross_page_table is not None:
+                num_vision_tokens = vision_tokens.shape[2]
+                cross_page_table = self._get_prefill_user_page_table(cross_page_table, kv_cache, num_vision_tokens)
+        else:
+            vision_tokens, cross_attention_masks, full_text_row_masked_out_mask = None, None, None
+
+        if page_table is not None:
+            page_table = self._get_prefill_user_page_table(page_table, kv_cache, prefill_len)
+
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            rot_mats,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = self.model[model_id].prepare_inputs_prefill(
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            prefill_len=prefill_len,
+            page_table=page_table,
+            cross_page_table=cross_page_table,
+            text_only_inference=text_only_inference,
+        )
+
+        tt_logits = self.model[model_id].ttnn_prefill_forward(
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            xattn_caches,
+            rot_mats,
+            user_id,
+            vision_tokens,
+            page_table=tt_page_table,
+            kv_cache=kv_cache,
+            get_last_token=(last_token_idx // 32) * 32,
+            cross_page_table=tt_cross_page_table,
+            text_only_inference=text_only_inference,
+        )
+
+        del tt_page_table
+        del tt_cross_page_table
+
+        return xattn_caches, cross_attention_masks, full_text_row_masked_out_mask, tt_logits
+
+    # Note: This function is called by vLLM
+    def prefill_forward(
+        self,
+        vision_images,
+        vision_masks,
+        tokens: torch.Tensor,
+        xattn_caches,
+        total_lens,
+        prompt_lens,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Batched version of _prefill_forward_single_user for vision model.
+        """
+        batch, batch_seq_len = tokens.shape
+        output_logits = torch.zeros(batch, 1, self.model_args[0].vocab_size)
+
+        data_parallel = min(batch, self.data_parallel)
+        batch_per_device = batch // data_parallel
+
+        out_list = [[] for _ in range(data_parallel)]
+        output_xattn_masks = [None for _ in range(batch)]
+        output_full_text_row_masked_out_masks = [None for _ in range(batch)]
+
+        if page_table is not None:
+            assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
+            page_table = torch.chunk(page_table, self.data_parallel, 0)  # cross_page_table
+        if cross_page_table is not None:
+            assert isinstance(cross_page_table, torch.Tensor), "cross_page_table mush be torch.Tensor"
+            cross_page_table = torch.chunk(cross_page_table, self.data_parallel, 0)
+
+        for group_user_id in range(batch_per_device):
+            for model_id in range(data_parallel):
+                user_id = group_user_id + model_id * batch_per_device
+
+                logger.info(f"Prefilling User {user_id + 1}")
+                seq_len = int(prompt_lens[user_id])
+                user_page_table = page_table[model_id] if page_table is not None else None
+                user_kv_cache = kv_cache[model_id] if kv_cache is not None else None
+                user_cross_page_table = cross_page_table[model_id] if kv_cache is not None else None
+                xattn_cache = xattn_caches[model_id] if xattn_caches is not None else None
+                (
+                    xattn_cache,
+                    cross_attention_masks,
+                    full_text_row_masked_out_mask,
+                    logits,
+                ) = self._prefill_forward_single_user(
+                    vision_images=vision_images[user_id],
+                    vision_mask=vision_masks[user_id],
+                    tokens=tokens[user_id : user_id + 1, :seq_len],  # Keep batch dimension
+                    xattn_caches=xattn_cache,
+                    user_id=group_user_id,
+                    total_len=total_lens[user_id],
+                    prefill_len=seq_len,
+                    page_table=user_page_table,
+                    kv_cache=user_kv_cache,
+                    cross_page_table=user_cross_page_table,
+                    model_id=model_id,
+                )
+                if xattn_caches is not None:
+                    xattn_caches[model_id] = xattn_cache
+                out_list[model_id].append(logits)
+                output_xattn_masks[user_id] = cross_attention_masks
+                output_full_text_row_masked_out_masks[user_id] = full_text_row_masked_out_mask
+
+        # We gather prefill output at the end of prefill to reduce unnecessary device sync
+        for group_user_id in range(batch_per_device):
+            for model_id in range(data_parallel):
+                user_id = group_user_id + model_id * batch_per_device
+                last_token_idx = prompt_lens[user_id] - 1
+                output_logits[user_id] = self.model[model_id].process_output_prefill(
+                    out_list[model_id][group_user_id], 1, last_token_idx=(last_token_idx % 32)
+                )
+
+        logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
+
+        return output_logits, output_xattn_masks, output_full_text_row_masked_out_masks
+
+    # Note: This function is called by vLLM
+    def decode_forward(
+        self,
+        start_pos,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches=None,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+        enable_trace=True,
+        read_from_device=True,
+    ):
+        B = tokens.shape[0]
+        data_parallel = min(B, self.data_parallel)
+        batch_per_device = B // data_parallel
+        tokens = torch.chunk(tokens, self.data_parallel, 0)
+        start_pos = torch.chunk(start_pos, self.data_parallel, 0)
+        cross_attention_masks = [
+            cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device] for i in range(data_parallel)
+        ]
+        full_text_row_masked_out_mask = [
+            full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]
+            for i in range(data_parallel)
+        ]
+        page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
+        cross_page_table = (
+            torch.chunk(cross_page_table, self.data_parallel, 0) if cross_page_table is not None else None
+        )
+
+        decode_kwargs = {
+            "position_id": start_pos,
+            "tokens": tokens,
+            "cross_attention_masks": cross_attention_masks,
+            "full_text_row_masked_out_mask": full_text_row_masked_out_mask,
+            "xattn_caches": xattn_caches,
+            "page_table": page_table,
+            "kv_cache": kv_cache,
+            "cross_page_table": cross_page_table,
+        }
+        if enable_trace:
+            tt_logits = self._easy_trace(**decode_kwargs)
+        else:
+            tt_logits = self._decode_forward_no_trace(**decode_kwargs)
+
+        if read_from_device:
+            to_host = self.read_decode_output(tt_logits, B)
+            return to_host
+        else:
+            return tt_logits
+
+    # Note: This function is called by vLLM
+    def read_decode_output(self, tt_out, unpadded_batch, is_tokens=False):
+        """
+        Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
+        """
+        logits = []
+        for i in range(self.data_parallel):
+            logits_i = self.model[i].process_output_decode(
+                tt_out[i], B=self.model_args[i].max_batch_size, S=1, is_tokens=is_tokens
+            )
+            logits.append(logits_i)
+        logits = torch.cat(logits, 0)
+        return logits[:unpadded_batch]
+
+    def _decode_forward_no_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches=None,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Performs text decode step.
+        Returns tt_logits on device
+        """
+
+        # forward_decode should be traced callable
+        # decorator does compilation, capture, execute
+        tt_h = []
+        tt_xattn_mask = []
+        tt_full_text_mask_expand_1NSH = []
+        tt_full_text_mask_expand_11SD = []
+        tt_position_id = []
+        tt_rot_mats = []
+        tt_page_table = []
+        tt_cross_page_table = []
+
+        for i in range(self.data_parallel):
+            B, S = tokens[i].shape
+            assert S == 1
+
+            user_page_table = page_table[i] if page_table is not None else None
+            user_cross_page_table = cross_page_table[i] if cross_page_table is not None else None
+            (
+                tt_h_i,
+                tt_xattn_mask_i,
+                tt_full_text_mask_expand_1NSH_i,
+                tt_full_text_mask_expand_11SD_i,
+                tt_position_id_i,
+                tt_rot_mats_i,
+                tt_page_table_i,
+                tt_cross_page_table_i,
+            ) = self.model[i].prepare_inputs_decode(
+                tokens[i],
+                cross_attention_masks[i],
+                full_text_row_masked_out_mask[i],
+                position_id=position_id[i],
+                page_table=user_page_table,
+                cross_page_table=user_cross_page_table,
+            )
+
+            tt_h.append(tt_h_i)
+            tt_xattn_mask.append(tt_xattn_mask_i)
+            tt_full_text_mask_expand_1NSH.append(tt_full_text_mask_expand_1NSH_i)
+            tt_full_text_mask_expand_11SD.append(tt_full_text_mask_expand_11SD_i)
+            tt_position_id.append(tt_position_id_i)
+            tt_rot_mats.append(tt_rot_mats_i)
+            tt_page_table.append(tt_page_table_i)
+            tt_cross_page_table.append(tt_cross_page_table_i)
+
+        tt_logits = []
+        for i in range(self.data_parallel):
+            user_kv_cache = kv_cache[i] if kv_cache is not None else None
+            xattn_cache = xattn_caches[i] if xattn_caches is not None else None
+            tt_logits_i = self.model[i].ttnn_decode_forward(
+                tt_h[i],
+                tt_xattn_mask[i],
+                tt_full_text_mask_expand_1NSH[i],
+                tt_full_text_mask_expand_11SD[i],
+                xattn_cache,
+                tt_position_id[i],
+                tt_rot_mats[i],
+                page_table=tt_page_table[i],
+                kv_cache=user_kv_cache,
+                cross_page_table=tt_cross_page_table[i],
+            )
+            tt_logits.append(tt_logits_i)
+
+        return tt_logits
+
+    def _capture_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Captures a trace for the decode_forward method.
+        """
+        tt_h = []
+        tt_xattn_mask = []
+        tt_full_text_mask_expand_1NSH = []
+        tt_full_text_mask_expand_11SD = []
+        tt_position_id = []
+        tt_rot_mats = []
+        tt_page_table = []
+        tt_cross_page_table = []
+        for i in range(self.data_parallel):
+            user_page_table = page_table[i] if page_table is not None else None
+            user_cross_page_table = cross_page_table[i] if cross_page_table is not None else None
+            (
+                tt_h_i,
+                tt_xattn_mask_i,
+                tt_full_text_mask_expand_1NSH_i,
+                tt_full_text_mask_expand_11SD_i,
+                tt_position_id_i,
+                tt_rot_mats_i,
+                tt_page_table_i,
+                tt_cross_page_table_i,
+            ) = self.model[i].prepare_inputs_decode(
+                tokens[i],
+                cross_attention_masks[i],
+                full_text_row_masked_out_mask[i],
+                position_id=position_id[i],
+                page_table=user_page_table,
+                cross_page_table=user_cross_page_table,
+            )
+
+            tt_h.append(tt_h_i)
+            tt_xattn_mask.append(tt_xattn_mask_i)
+            tt_full_text_mask_expand_1NSH.append(tt_full_text_mask_expand_1NSH_i)
+            tt_full_text_mask_expand_11SD.append(tt_full_text_mask_expand_11SD_i)
+            tt_position_id.append(tt_position_id_i)
+            tt_rot_mats.append(tt_rot_mats_i)
+            tt_page_table.append(tt_page_table_i)
+            tt_cross_page_table.append(tt_cross_page_table_i)
+
+        # Compile run
+        for i in range(self.data_parallel):
+            user_kv_cache = kv_cache[i] if kv_cache is not None else None
+            xattn_cache = xattn_caches[i] if xattn_caches is not None else None
+            # tt_logits_rm unused later, no need to make a list
+            tt_logits_rm = self.model[i].ttnn_decode_forward(
+                tt_h[i],
+                tt_xattn_mask[i],
+                tt_full_text_mask_expand_1NSH[i],
+                tt_full_text_mask_expand_11SD[i],
+                xattn_cache,
+                tt_position_id[i],
+                tt_rot_mats[i],
+                page_table=tt_page_table[i],
+                kv_cache=user_kv_cache,
+                cross_page_table=tt_cross_page_table[i],
+            )
+        logger.info("Done Compiling Model")
+
+        # Get inputs ready for trace run
+        tt_h = []
+        tt_xattn_mask = []
+        tt_full_text_mask_expand_1NSH = []
+        tt_full_text_mask_expand_11SD = []
+        tt_position_id = []
+        tt_rope_id = []
+        tt_page_table = []
+        tt_cross_page_table = []
+        for i in range(self.data_parallel):
+            user_page_table = page_table[i] if page_table is not None else None
+            user_cross_page_table = cross_page_table[i] if cross_page_table is not None else None
+            (
+                tt_h_i,
+                tt_xattn_mask_i,
+                tt_full_text_mask_expand_1NSH_i,
+                tt_full_text_mask_expand_11SD_i,
+                tt_position_id_i,
+                tt_rope_id_i,
+                tt_page_table_i,
+                tt_cross_page_table_i,
+            ) = self.model[i].prepare_decode_inputs_host(
+                tokens[i],
+                cross_attention_masks[i],
+                full_text_row_masked_out_mask[i],
+                position_id[i],
+                page_table=user_page_table,
+                cross_page_table=user_cross_page_table,
+            )
+
+            (
+                tt_h_i,
+                tt_xattn_mask_i,
+                tt_full_text_mask_expand_1NSH_i,
+                tt_full_text_mask_expand_11SD_i,
+                tt_position_id_i,
+                tt_rope_id_i,
+                tt_page_table_i,
+                tt_cross_page_table_i,
+            ) = copy_host_to_device(
+                (
+                    tt_h_i,
+                    tt_xattn_mask_i,
+                    tt_full_text_mask_expand_1NSH_i,
+                    tt_full_text_mask_expand_11SD_i,
+                    tt_position_id_i,
+                    tt_rope_id_i,
+                    tt_page_table_i,
+                    tt_cross_page_table_i,
+                ),
+                mesh_device=self.model_args[i].mesh_device,
+            )
+
+            tt_h.append(tt_h_i)
+            tt_xattn_mask.append(tt_xattn_mask_i)
+            tt_full_text_mask_expand_1NSH.append(tt_full_text_mask_expand_1NSH_i)
+            tt_full_text_mask_expand_11SD.append(tt_full_text_mask_expand_11SD_i)
+            tt_position_id.append(tt_position_id_i)
+            tt_rope_id.append(tt_rope_id_i)
+            tt_page_table.append(tt_page_table_i)
+            tt_cross_page_table.append(tt_cross_page_table_i)
+
+        tt_h_trace_input = tt_h
+
+        tt_logits_rm = []
+        trace_ids = {}
+        # Do on-device transformations of inputs before forward
+        for i in range(self.data_parallel):
+            trace_id = ttnn.begin_trace_capture(self.model_args[i].mesh_device, cq_id=0)
+            trace_ids[i] = trace_id
+            B = tokens[i].shape[0]
+            user_kv_cache = kv_cache[i] if kv_cache is not None else None
+            xattn_cache = xattn_caches[i] if xattn_caches is not None else None
+            (
+                tt_h_transform,
+                tt_rot_mats,
+                tt_xattn_mask_transform,
+                tt_full_text_mask_expand_1NSH_transform,
+                tt_full_text_mask_expand_11SD_transform,
+            ) = self.model[i].transform_decode_inputs_device(
+                tt_h[i],
+                tt_rope_id[i],
+                tt_xattn_mask[i],
+                tt_full_text_mask_expand_1NSH[i],
+                tt_full_text_mask_expand_11SD[i],
+                B=B,
+            )
+
+            tt_logits_rm_i = self.model[i].ttnn_decode_forward(
+                tt_h_transform,
+                tt_xattn_mask_transform,
+                tt_full_text_mask_expand_1NSH_transform,
+                tt_full_text_mask_expand_11SD_transform,
+                xattn_cache,
+                tt_position_id[i],
+                tt_rot_mats,
+                page_table=tt_page_table[i],
+                kv_cache=user_kv_cache,
+                cross_page_table=tt_cross_page_table[i],
+            )
+            tt_logits_rm.append(tt_logits_rm_i)
+            ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
+        logger.info("Done Capturing Decode Trace")
+
+        return (
+            trace_ids,
+            tt_logits_rm,
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rope_id,
+            tt_page_table,
+            tt_cross_page_table,
+        )
+
+    def _decode_forward_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        page_table,
+        cross_page_table,
+        trace_ids,
+        trace_logits_rm,
+        trace_h,
+        trace_xattn_mask,
+        trace_full_text_mask_expand_1NSH,
+        trace_full_text_mask_expand_11SD,
+        trace_position_id,
+        trace_rope_id,
+        trace_page_table,
+        trace_cross_page_table,
+    ):
+        """
+        Executes the trace for the decode_forward method but does not read back outputs.
+        """
+        for i in range(self.data_parallel):
+            user_page_table = page_table[i] if page_table is not None else None
+            user_cross_page_table = cross_page_table[i] if cross_page_table is not None else None
+            (
+                tt_h,
+                tt_xattn_mask,
+                tt_full_text_mask_expand_1NSH,
+                tt_full_text_mask_expand_11SD,
+                tt_position_id,
+                tt_rope_id,
+                tt_page_table,
+                tt_cross_page_table,
+            ) = self.model[i].prepare_decode_inputs_host(
+                tokens[i],
+                cross_attention_masks[i],
+                full_text_row_masked_out_mask[i],
+                position_id=position_id[i],
+                page_table=user_page_table,
+                cross_page_table=user_cross_page_table,
+            )
+
+            copy_host_to_device(
+                host_tensors=(
+                    tt_h,
+                    tt_xattn_mask,
+                    tt_full_text_mask_expand_1NSH,
+                    tt_full_text_mask_expand_11SD,
+                    tt_position_id,
+                    tt_rope_id,
+                    tt_page_table,
+                    tt_cross_page_table,
+                ),
+                device_tensors=(
+                    trace_h[i],
+                    trace_xattn_mask[i],
+                    trace_full_text_mask_expand_1NSH[i],
+                    trace_full_text_mask_expand_11SD[i],
+                    trace_position_id[i],
+                    trace_rope_id[i],
+                    trace_page_table[i],
+                    trace_cross_page_table[i],
+                ),
+            )
+        for i, trace_id in trace_ids.items():
+            ttnn.execute_trace(self.mesh_device, trace_id, cq_id=0, blocking=False)
+
+        return trace_logits_rm
+
+    def _easy_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches=None,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Tracing is easy! Just call this method and we'll handle tracing for you.
+        """
+        if not hasattr(self, "trace_ids"):
+            (
+                trace_ids,
+                tt_logits_rm,
+                tt_h,
+                tt_xattn_mask,
+                tt_full_text_mask_expand_1NSH,
+                tt_full_text_mask_expand_11SD,
+                tt_position_id,
+                tt_rope_id,
+                tt_page_table,
+                tt_cross_page_table,
+            ) = self._capture_trace(
+                position_id,
+                tokens,
+                cross_attention_masks,
+                full_text_row_masked_out_mask,
+                xattn_caches,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                cross_page_table=cross_page_table,
+            )
+            self.trace_ids = trace_ids
+            self.trace_inputs = {
+                "tt_h": tt_h,
+                "tt_xattn_mask": tt_xattn_mask,
+                "tt_full_text_mask_expand_1NSH": tt_full_text_mask_expand_1NSH,
+                "tt_full_text_mask_expand_11SD": tt_full_text_mask_expand_11SD,
+                "tt_position_id": tt_position_id,
+                "tt_rope_id": tt_rope_id,
+                "tt_page_table": tt_page_table,
+                "tt_cross_page_table": tt_cross_page_table,
+            }
+            self.trace_outputs = {
+                "tt_logits_rm": tt_logits_rm,
+            }
+
+        trace_logits_rm = self._decode_forward_trace(
+            position_id,
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            page_table,
+            cross_page_table,
+            self.trace_ids,
+            self.trace_outputs["tt_logits_rm"],
+            self.trace_inputs["tt_h"],
+            self.trace_inputs["tt_xattn_mask"],
+            self.trace_inputs["tt_full_text_mask_expand_1NSH"],
+            self.trace_inputs["tt_full_text_mask_expand_11SD"],
+            self.trace_inputs["tt_position_id"],
+            self.trace_inputs["tt_rope_id"],
+            self.trace_inputs["tt_page_table"],
+            self.trace_inputs["tt_cross_page_table"],
+        )
+
+        return trace_logits_rm
+
+    def generate(
+        self,
+        model_input,
+        max_gen_len: int,
+        temperature: float = 0.6,
+        top_p: float = 0.9,
+    ):
+        # Do initial prefill
+        vision_images = model_input.vision.images
+        vision_mask = model_input.vision.mask
+        prompt_tokens = model_input.tokens
+        prefill_len = len(prompt_tokens)
+        total_len = prefill_len + max_gen_len  # Prepares mask for full length of output
+
+        prompt_tokens_tensor = torch.tensor(prompt_tokens, dtype=torch.long).reshape(1, -1)  # B, S
+        # Suboptimal to allocate caches every time
+        model_id = 0
+        xattn_caches = self.model[model_id].setup_cache(self.model_args[model_id].max_batch_size)
+        (
+            xattn_caches,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            logits,
+        ) = self._prefill_forward_single_user(
+            vision_images,
+            vision_mask,
+            prompt_tokens_tensor,
+            xattn_caches,
+            user_id=0,
+            total_len=total_len,
+            prefill_len=prefill_len,
+            model_id=model_id,
+        )
+
+        last_token_idx = prefill_len - 1
+        logits = self.model[model_id].process_output_prefill(logits, 1, last_token_idx=(last_token_idx % 32))
+        logits = logits.view(1, 1, self.model_args[model_id].vocab_size)
+
+        output_xattn_masks = [[] for _ in range(self.data_parallel)]
+        output_full_text_row_masked_out_masks = [[] for _ in range(self.data_parallel)]
+        output_xattn_masks[model_id].append(cross_attention_masks)
+        output_full_text_row_masked_out_masks[model_id].append(full_text_row_masked_out_mask)
+
+        def sample(logits):
+            if temperature > 0:
+                probs = torch.softmax(logits[:, -1] / temperature, dim=-1)
+                next_token = sample_top_p(probs, top_p)
+            else:
+                next_token = torch.argmax(logits[:, -1], dim=-1)
+            next_token = next_token.reshape(-1)
+            return next_token, self.tokenizer.decode(next_token.tolist())
+
+        next_token, text = sample(logits)
+
+        yield TokenResult(
+            token=next_token[0].item(),
+            text=text,
+        )
+
+        for gen_idx in range(max_gen_len - 1):
+            position_id = torch.tensor([prefill_len + gen_idx])
+            next_token_tensor = next_token.reshape(1, 1)  # B, S
+
+            logits = self.decode_forward(
+                position_id,
+                next_token_tensor,
+                output_xattn_masks,
+                output_full_text_row_masked_out_masks,
+                [xattn_caches],
+                enable_trace=False,
+            )
+            next_token, text = sample(logits)
+            yield TokenResult(
+                token=next_token[0].item(),
+                text=text,
+            )
+
+    def chat_completion(
+        self,
+        messages,
+        temperature=0.6,
+        top_p: float = 0.9,
+        max_gen_len=None,
+    ):
+        model_id = 0
+        if max_gen_len is None or max_gen_len == 0 or max_gen_len >= self.model[model_id].configuration.max_seq_len:
+            max_gen_len = self.model[model_id].configuration.max_seq_len - 1
+
+        tokens = []
+
+        stop_reason = None
+        for result in self.generate(
+            model_input=self.formatter.encode_dialog_prompt(messages, tool_prompt_format=False),
+            max_gen_len=max_gen_len,
+            temperature=temperature,
+            top_p=top_p,
+        ):
+            tokens.append(result.token)
+            if result.text == "<|eot_id|>":
+                stop_reason = StopReason.end_of_turn
+            elif result.text == "<|eom_id|>":
+                stop_reason = StopReason.end_of_message
+
+        if stop_reason is None:
+            stop_reason = StopReason.out_of_tokens
+
+        message = self.formatter.decode_assistant_message(tokens, stop_reason)
+
+        return ChatPrediction(generation=message)
+
+    def text_completion(
+        self,
+        content: InterleavedTextMedia,
+        temperature: float = 0.6,
+        top_p: float = 0.9,
+        max_gen_len=None,
+    ):
+        model_id = 0
+        if max_gen_len is None or max_gen_len == 0 or max_gen_len >= self.model[model_id].configuration.max_seq_len:
+            max_gen_len = self.model[model_id].configuration.max_seq_len - 1
+
+        model_input = self.formatter.encode_content(content)
+
+        tokens = []
+
+        for result in self.generate(
+            model_input=model_input,
+            max_gen_len=max_gen_len,
+            temperature=temperature,
+            top_p=top_p,
+        ):
+            tokens.append(result.token)
+
+        generation = self.tokenizer.decode(tokens)
+
+        return CompletionPrediction(generation=generation)
+
+    def _get_prefill_user_page_table(self, page_table, kv_cache, prefill_len):
+        # Ensure page_table is not padded with extra blocks for paged_fill_cache to work properly
+        block_size = get_block_size(kv_cache)
+        num_blocks = num_blocks_in_seq(prefill_len, block_size)
+        return page_table[:, :num_blocks]
+
+    ## Destructor
+
+    def __del__(self):
+        # Workaround for issue #19052
+        if self.data_parallel > 1:
+            for m in self.model:
+                ttnn.close_mesh_device(m.mesh_device)
+
+        if hasattr(super(Gemma3Generator, self), "__del__"):
+            super().__del__()
+
+
+def create_submeshes(mesh_device, data_parallel):
+    if not isinstance(mesh_device, ttnn.MeshDevice) or data_parallel == 1:
+        return [mesh_device]
+
+    num_rows, num_cols = mesh_device.shape
+    num_devices = num_rows * num_cols
+    assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
+
+    # Check if the mesh is 8x4 (expected shape for TG) and perfer row split
+    # Submeshes with 8 devices are expected to be in ring topology hence the row split
+    if num_rows == 8 and num_cols == 4 and num_rows % data_parallel == 0:
+        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
+        for submesh in submeshes:
+            submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))
+        return submeshes
+
+    return mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))

--- a/models/experimental/gemma3_4b/tt/gemma_conv2d_patch.py
+++ b/models/experimental/gemma3_4b/tt/gemma_conv2d_patch.py
@@ -5,7 +5,7 @@ We have reused the exisiting Conv2dPath of TtLlamaConv2dPath with few modificati
 We have added a check for weight to convert 4D to 2D
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/gemma_conv2d_patch.py
+++ b/models/experimental/gemma3_4b/tt/gemma_conv2d_patch.py
@@ -1,0 +1,122 @@
+"""
+source: models/tt_transformers/tt/multimodal/llama_conv2d_patch.py
+This is the Conv2dPath of Gemma-3-4b-it
+We have reused the exisiting Conv2dPath of TtLlamaConv2dPath with few modifications.
+We have added a check for weight to convert 4D to 2D
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.utility_functions import nearest_32
+
+
+class TtGemmaConv2dPatch(LightweightModule):
+    """Conv2D Patching layer.
+    Column parallel over unfolded input.
+    Arguments:
+        in_channels: Input channels.
+        out_channels: Output channels.
+        kernel_size: Size of convolution kernel.
+        stride (default 1): Stride for convolution.
+        bias (default False): Use bias in Conv2d.
+    Input: (bsz, in_channels, width, height)
+    Output: (bsz, num_tokens, out_channels)
+    """
+
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        dtype,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int,
+        bias,
+    ):
+        super().__init__()
+
+        self.mesh_device = mesh_device
+        self.num_devices = self.mesh_device.get_num_devices()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+
+        self.bias = (
+            ttnn.as_tensor(
+                torch.reshape(state_dict[f"{state_dict_prefix}_linear.bias"], (1, -1)),
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+            if bias
+            else None
+        )
+
+        self._unfold = torch.nn.Unfold(kernel_size=self.kernel_size, stride=self.stride)
+
+        weight = state_dict[f"{state_dict_prefix}_linear.weight"]
+        if weight.ndim == 4:
+            weight = weight.view(out_channels, -1)
+        pad_len = nearest_32(weight.shape[-1]) - weight.shape[-1]
+        padding = torch.zeros(self.out_channels, pad_len, dtype=weight.dtype)
+        padded_weight = torch.cat([weight, padding], dim=-1)
+        padded_weight = padded_weight.permute(1, 0).reshape(1, 1, -1, self.out_channels)
+
+        self._linear_weight = ttnn.as_tensor(
+            padded_weight,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    def forward(self, x: torch.Tensor):
+        x = self._unfold(x)
+        x = x.permute(0, 2, 1)
+
+        # Need to pad the last dimension of x to be a multiple of a tile
+        pad_len = nearest_32(x.shape[-1]) - x.shape[-1]
+        padding = torch.zeros((x.shape[0], x.shape[1], pad_len), dtype=x.dtype, device=x.device)
+        x = torch.cat([x, padding], dim=-1)
+
+        x = ttnn.as_tensor(
+            x,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        out = ttnn.linear(
+            x,
+            self._linear_weight,
+            bias=self.bias,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config,
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+        )
+
+        return out

--- a/models/experimental/gemma3_4b/tt/gemma_image_attention.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_attention.py
@@ -1,0 +1,422 @@
+"""
+source: models/tt_transformers/tt/multimodal/llama_image_attention.py
+
+This is the ImageAttention block for Gemma-3-4b-it
+We have reused the TTLlamaImageAttention with some modification.
+We have made the linears (Q,K,V) to be executed separately and added bias support for O_projection, along with few
+configuration changes.
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.utility_functions import nearest_32
+
+
+class TtGemmaImageAttention(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        weight_cache_path,
+        dtype,
+        configuration,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.num_devices = configuration.num_devices
+
+        self.hidden_size = configuration.vision_dim
+        self.n_heads = configuration.vision_attn_n_heads
+        self.head_dim = self.hidden_size // self.n_heads
+        self.n_kv_heads = self.n_heads
+
+        self.n_local_heads = self.n_heads // configuration.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // configuration.num_devices
+
+        self.dtype = dtype
+
+        self.grid_size = configuration.max_grid_size
+
+        self.compute_kernel_config_hifi2 = configuration.compute_kernel_config_hifi2
+        self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
+        self.compute_kernel_config_sdpa = configuration.compute_kernel_config_sdpa
+        self.configuration = configuration
+
+        self.model_config = configuration.get_model_config()
+
+        if configuration.dummy_weights or (weight_cache_path is None):
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: weight_cache_path / (f"{state_dict_prefix}{name}")
+
+        wq_str = f"{state_dict_prefix}wq.weight"
+        wk_str = f"{state_dict_prefix}wk.weight"
+        wv_str = f"{state_dict_prefix}wv.weight"
+        wo_str = f"{state_dict_prefix}wo.weight"
+
+        # when splitting the devices, we need to make sure that the number of heads is divisible by the number of devices
+        assert self.n_heads % configuration.num_devices == 0
+        assert self.n_kv_heads % configuration.num_devices == 0
+
+        # Pad head_dim to multiple of 32
+        def pad_head_dim(weight, heads_out=True):
+            # Pad head dim to multiple of 32
+            # heads_out means that the output dim of this weight contains heads.
+            dim = weight.shape[1]
+            assert weight.shape[0] == dim
+            padded_head_dim = nearest_32(self.head_dim)
+            padding_size = padded_head_dim - self.head_dim
+            if padding_size > 0:
+                if heads_out:
+                    weight = weight.transpose(-1, -2)
+                weight = weight.reshape(dim, self.n_heads, self.head_dim)
+                padding = torch.zeros(dim, self.n_heads, padding_size, dtype=weight.dtype)
+                weight = torch.cat([weight, padding], dim=-1)
+                weight = weight.reshape(dim, self.n_heads * padded_head_dim)
+                if heads_out:
+                    weight = weight.transpose(-1, -2)
+            return weight
+
+        wq_padded = pad_head_dim(self.state_dict[wq_str])
+        wk_padded = pad_head_dim(self.state_dict[wk_str])
+        wv_padded = pad_head_dim(self.state_dict[wv_str])
+        wo_padded = pad_head_dim(self.state_dict[wo_str], heads_out=False)
+        wq_chunked, wk_chunked, wv_chunked = (
+            torch.chunk(w, configuration.num_devices) for w in [wq_padded, wk_padded, wv_padded]
+        )
+
+        # for Gemma
+        self.wq = ttnn.as_tensor(
+            tensor=wq_padded,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+            cache_file_name=cache_name("wq_sharded"),
+            preprocess=lambda x: x.transpose(-2, -1),
+        )
+
+        self.wk = ttnn.as_tensor(
+            tensor=wk_padded,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+            cache_file_name=cache_name("wk_sharded"),
+            preprocess=lambda x: x.transpose(-2, -1),
+        )
+
+        self.wv = ttnn.as_tensor(
+            tensor=wv_padded,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+            cache_file_name=cache_name("wv_sharded"),
+            preprocess=lambda x: x.transpose(-2, -1),
+        )
+
+        self.wqkv = ttnn.as_tensor(
+            torch.concat(
+                [
+                    torch.concat(
+                        [
+                            torch.transpose(
+                                wq_chunked[i],
+                                -2,
+                                -1,
+                            ),
+                            torch.transpose(
+                                wk_chunked[i],
+                                -2,
+                                -1,
+                            ),
+                            torch.transpose(
+                                wv_chunked[i],
+                                -2,
+                                -1,
+                            ),
+                        ],
+                        dim=-1,
+                    )
+                    for i in range(configuration.num_devices)
+                ],
+                dim=-1,
+            ),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+            dtype=self.dtype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.TILE_LAYOUT,
+            cache_file_name=cache_name("wqkv_sharded"),
+        )
+
+        bq_str = f"{state_dict_prefix}wq.bias"
+        bk_str = f"{state_dict_prefix}wk.bias"
+        bv_str = f"{state_dict_prefix}wv.bias"
+        bo_str = f"{state_dict_prefix}wo.bias"
+
+        if bq_str in self.state_dict:
+
+            def pad_head_dim_bias(bias):
+                # Pad 1D bias to match padded head dim
+                dim = bias.shape[0]
+                assert (
+                    dim == self.n_heads * self.head_dim
+                ), f"Expected bias of shape ({self.n_heads} * {self.head_dim}) = {self.n_heads * self.head_dim}, but got {dim}"
+
+                padded_head_dim = nearest_32(self.head_dim)
+                padding_size = padded_head_dim - self.head_dim
+
+                if padding_size > 0:
+                    bias = bias.view(self.n_heads, self.head_dim)
+                    padding = torch.zeros(self.n_heads, padding_size, dtype=bias.dtype)
+                    bias = torch.cat([bias, padding], dim=-1)
+                    bias = bias.view(self.n_heads * padded_head_dim)
+
+                return bias
+
+            bq_padded = pad_head_dim_bias(self.state_dict[bq_str])
+            bk_padded = pad_head_dim_bias(self.state_dict[bk_str])
+            bv_padded = pad_head_dim_bias(self.state_dict[bv_str])
+
+            bq_chunked, bk_chunked, bv_chunked = (
+                torch.chunk(b, configuration.num_devices) for b in [bq_padded, bk_padded, bv_padded]
+            )
+
+            self.bqkv = ttnn.as_tensor(
+                torch.concat(
+                    [
+                        torch.concat(
+                            [
+                                bq_chunked[i],
+                                bk_chunked[i],
+                                bv_chunked[i],
+                            ],
+                            dim=-1,
+                        )
+                        for i in range(configuration.num_devices)
+                    ],
+                    dim=-1,
+                ),
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                dtype=self.dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.TILE_LAYOUT,
+                cache_file_name=cache_name("bqkv_sharded"),
+            )
+
+            # for Gemma
+            self.bq = ttnn.as_tensor(
+                tensor=bq_padded,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                cache_file_name=cache_name("bq_sharded"),
+            )
+
+            self.bk = ttnn.as_tensor(
+                tensor=bk_padded,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                cache_file_name=cache_name("bk_sharded"),
+            )
+
+            self.bv = ttnn.as_tensor(
+                tensor=bv_padded,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                cache_file_name=cache_name("bv_sharded"),
+            )
+
+        else:
+            self.bqkv = None
+
+        self.wo = ttnn.as_tensor(
+            torch.transpose(
+                wo_padded,
+                -2,
+                -1,
+            ),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-2),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=self.dtype,
+            layout=ttnn.TILE_LAYOUT,
+            cache_file_name=cache_name("wo_sharded"),
+        )
+
+        if bo_str in self.state_dict:
+            self.bo = ttnn.as_tensor(
+                self.state_dict[bo_str],
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                dtype=self.dtype,
+                layout=ttnn.TILE_LAYOUT,
+                cache_file_name=cache_name("bo_sharded"),
+            )
+        else:
+            self.bo = None
+
+        self.scale = self.head_dim**-0.5
+
+    def forward(self, x_11SH, mask=None):
+        seq_len = x_11SH.shape[-2]
+
+        MAX_MM_SEQ_LEN = (
+            seq_len if "gemma-3" in self.configuration.base_model_name else self.configuration.VISION_MAX_MM_SEQ
+        )
+
+        if seq_len > MAX_MM_SEQ_LEN:
+            x_11SH = ttnn.reshape(x_11SH, [1, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, -1])
+
+        if "gemma-3" in self.configuration.base_model_name:
+            q_heads_1QSD = ttnn.linear(
+                x_11SH,
+                self.wq,
+                bias=self.bq,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=self.compute_kernel_config_hifi4,
+                program_config=None
+                if "gemma-3" in self.configuration.base_model_name
+                else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            )
+
+            q_heads_1QSD = ttnn.transpose(ttnn.reshape(q_heads_1QSD, (1, seq_len, self.n_local_heads, -1)), 1, 2)
+
+            k_heads_1KSD = ttnn.linear(
+                x_11SH,
+                self.wk,
+                bias=self.bk,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=self.compute_kernel_config_hifi4,
+                program_config=None
+                if "gemma-3" in self.configuration.base_model_name
+                else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            )
+
+            k_heads_1KSD = ttnn.transpose(ttnn.reshape(k_heads_1KSD, (1, seq_len, self.n_local_heads, -1)), 1, 2)
+
+            v_heads_1VSD = ttnn.linear(
+                x_11SH,
+                self.wv,
+                bias=self.bv,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=self.compute_kernel_config_hifi4,
+                program_config=None
+                if "gemma-3" in self.configuration.base_model_name
+                else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            )
+            v_heads_1VSD = ttnn.transpose(ttnn.reshape(v_heads_1VSD, (1, seq_len, self.n_local_heads, -1)), 1, 2)
+
+        else:
+            xqkv_fused = ttnn.linear(
+                x_11SH,
+                self.wqkv,
+                bias=self.bqkv,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=self.compute_kernel_config_hifi4,
+                program_config=None
+                if "gemma-3" in self.configuration.base_model_name
+                else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            )
+
+            if seq_len > MAX_MM_SEQ_LEN:
+                xqkv_fused = ttnn.reshape(xqkv_fused, [1, 1, seq_len, -1])
+
+            # split qkv into heads
+            (
+                q_heads_1QSD,
+                k_heads_1KSD,
+                v_heads_1VSD,
+            ) = ttnn.experimental.nlp_create_qkv_heads(
+                xqkv_fused,
+                num_heads=self.n_local_heads,
+                num_kv_heads=self.n_local_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            ttnn.deallocate(xqkv_fused)
+        # TODO: get this from model_config
+        sdpa_cfg = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 8), q_chunk_size=128, k_chunk_size=128, exp_approx_mode=False
+        )
+        attn_output_1QSD = ttnn.transformer.scaled_dot_product_attention(
+            q_heads_1QSD,
+            k_heads_1KSD,
+            v_heads_1VSD,
+            is_causal=False,
+            scale=self.scale,
+            attn_mask=mask,
+            program_config=sdpa_cfg,
+            compute_kernel_config=self.compute_kernel_config_sdpa,
+        )
+        # deallocate keys and values
+        ttnn.deallocate(q_heads_1QSD)
+        ttnn.deallocate(k_heads_1KSD)
+        ttnn.deallocate(v_heads_1VSD)
+
+        ###
+        # Output matmul
+        ###
+        attn_output_11SH = ttnn.experimental.nlp_concat_heads(
+            attn_output_1QSD,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(attn_output_1QSD)
+
+        # reshaping long sequence to matmul fit on device
+        if seq_len > MAX_MM_SEQ_LEN:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, -1])
+
+        output_11SH = ttnn.linear(
+            attn_output_11SH,
+            self.wo,
+            bias=self.bo,
+            compute_kernel_config=self.compute_kernel_config_hifi4,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=None
+            if "gemma-3" in self.configuration.base_model_name
+            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+        )
+        if seq_len > MAX_MM_SEQ_LEN:
+            output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])
+        ttnn.deallocate(attn_output_11SH)
+
+        # All reduce
+        if self.num_devices > 1:  # replace with reduce_scatter and all_gather
+            dense_out_gathered = ttnn.all_gather(output_11SH, dim=1, num_links=1, topology=ttnn.Topology.Linear)
+            dense_out_reduced = ttnn.experimental.fast_reduce_nc(
+                dense_out_gathered, dims=[1], output=None, compute_kernel_config=None
+            )
+            return dense_out_reduced
+        else:
+            return output_11SH

--- a/models/experimental/gemma3_4b/tt/gemma_image_attention.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_attention.py
@@ -7,7 +7,7 @@ We have made the linears (Q,K,V) to be executed separately and added bias suppor
 configuration changes.
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,13 +15,14 @@ import torch
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-from models.utility_functions import nearest_32
+from models.utility_functions import is_blackhole, nearest_32
 
 
 class TtGemmaImageAttention(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix,
         weight_cache_path,
@@ -32,6 +33,7 @@ class TtGemmaImageAttention(LightweightModule):
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.num_devices = configuration.num_devices
 
         self.hidden_size = configuration.vision_dim
@@ -413,7 +415,23 @@ class TtGemmaImageAttention(LightweightModule):
 
         # All reduce
         if self.num_devices > 1:  # replace with reduce_scatter and all_gather
-            dense_out_gathered = ttnn.all_gather(output_11SH, dim=1, num_links=1, topology=ttnn.Topology.Linear)
+            # TODO: 26411
+            # Remove this blackhole condition once fabric CCLs are working on blackhole
+            if is_blackhole():
+                dense_out_gathered = ttnn.all_gather(output_11SH, dim=1, num_links=1, topology=ttnn.Topology.Linear)
+            else:
+                dense_out_gathered = ttnn.experimental.all_gather_async(
+                    output_11SH,
+                    persistent_output_buffer=None,
+                    dim=1,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                    num_links=1,
+                    topology=ttnn.Topology.Linear,
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+                    chunks_per_sync=10,
+                    num_workers_per_link=2,
+                    num_buffers_per_channel=2,
+                )
             dense_out_reduced = ttnn.experimental.fast_reduce_nc(
                 dense_out_gathered, dims=[1], output=None, compute_kernel_config=None
             )

--- a/models/experimental/gemma3_4b/tt/gemma_image_block.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_block.py
@@ -1,0 +1,113 @@
+"""
+source: models/tt_transformers/tt/multimodal/llama_image_block.py
+
+This is the ImageTransformer block for Gemma-3-4b-it.
+We have reused the TtLlamaImageTransformerBlock with incorporating the
+TtGemmaImageAttention and TtGemmaImageFeedForward
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+
+from models.experimental.gemma3_4b.tt.gemma_image_attention import TtGemmaImageAttention
+from models.experimental.gemma3_4b.tt.gemma_image_mlp import TtGemmaImageFeedForward
+from models.tt_transformers.tt.multimodal.llama_layernorm import TtLayerNorm
+
+
+class TtGemmaImageTransformerBlock(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        weight_cache_path,
+        dtype,
+        configuration,
+        gated=False,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.num_devices = configuration.num_devices
+        self.hidden_size = configuration.vision_dim
+        self.gated = gated
+
+        self.ln_1 = TtLayerNorm(
+            device=mesh_device,
+            dim=configuration.vision_dim,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}ln_1.",
+            weight_cache_path=weight_cache_path,
+            weight_dtype=dtype,
+            eps=configuration.norm_eps,
+        )
+
+        self.attn = TtGemmaImageAttention(
+            mesh_device,
+            state_dict,
+            state_dict_prefix=f"{state_dict_prefix}attn.",
+            weight_cache_path=weight_cache_path,
+            dtype=dtype,
+            configuration=configuration,
+        )
+
+        self.ln_2 = TtLayerNorm(
+            device=mesh_device,
+            dim=configuration.vision_dim,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}ln_2.",
+            weight_cache_path=weight_cache_path,
+            weight_dtype=dtype,
+            eps=configuration.norm_eps,
+        )
+
+        self.mlp = TtGemmaImageFeedForward(
+            mesh_device=mesh_device,
+            args=configuration,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}mlp.",
+            weight_cache_path=weight_cache_path,
+            dtype=dtype,
+        )
+
+        if gated:
+            # Gate tensors must be expanded to hidden dim or we get a PCC error
+            self.gate_attn = ttnn.as_tensor(
+                state_dict[f"{state_dict_prefix}gate_attn"].unsqueeze(0).expand(1, self.hidden_size),
+                dtype=ttnn.bfloat16,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self.gate_ffn = ttnn.as_tensor(
+                state_dict[f"{state_dict_prefix}gate_ffn"].unsqueeze(0).expand(1, self.hidden_size),
+                dtype=ttnn.bfloat16,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+    def forward(self, x_11SH, mask=None):
+        seq_len = x_11SH.shape[-2]
+        assert seq_len % 32 == 0 and seq_len > 0, "Seqlen must be divisible by 32"
+
+        attn_out = self.attn(self.ln_1(x_11SH), mask=mask)
+        if self.gated:
+            attn_out = ttnn.mul(attn_out, ttnn.tanh(self.gate_attn))
+
+        res = ttnn.add(x_11SH, attn_out)
+        mlp_out = self.mlp(self.ln_2(res))
+        if self.gated:
+            mlp_out = ttnn.mul(mlp_out, ttnn.tanh(self.gate_ffn))
+        out = ttnn.add(res, mlp_out)
+        ttnn.deallocate(mlp_out)
+        ttnn.deallocate(attn_out)
+        ttnn.deallocate(res)
+        return out

--- a/models/experimental/gemma3_4b/tt/gemma_image_block.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_block.py
@@ -6,7 +6,7 @@ We have reused the TtLlamaImageTransformerBlock with incorporating the
 TtGemmaImageAttention and TtGemmaImageFeedForward
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -22,6 +22,7 @@ class TtGemmaImageTransformerBlock(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix,
         weight_cache_path,
@@ -33,6 +34,7 @@ class TtGemmaImageTransformerBlock(LightweightModule):
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.num_devices = configuration.num_devices
         self.hidden_size = configuration.vision_dim
         self.gated = gated
@@ -49,6 +51,7 @@ class TtGemmaImageTransformerBlock(LightweightModule):
 
         self.attn = TtGemmaImageAttention(
             mesh_device,
+            tt_ccl,
             state_dict,
             state_dict_prefix=f"{state_dict_prefix}attn.",
             weight_cache_path=weight_cache_path,
@@ -68,6 +71,7 @@ class TtGemmaImageTransformerBlock(LightweightModule):
 
         self.mlp = TtGemmaImageFeedForward(
             mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
             args=configuration,
             state_dict=state_dict,
             state_dict_prefix=f"{state_dict_prefix}mlp.",

--- a/models/experimental/gemma3_4b/tt/gemma_image_mlp.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_mlp.py
@@ -1,0 +1,121 @@
+"""
+source: models/tt_transformers/tt/multimodal/llama_image_mlp.py
+This is the FeedForward submodule for vision block in Gemma-3-4b-it
+We have reused the TtLlamaImageFeedForward with few changes in CoreGrid and program_config configurations
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+
+
+class TtGemmaImageFeedForward(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        args,
+        state_dict,
+        state_dict_prefix,
+        weight_cache_path,
+        dtype,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.args = args
+        self.model_config = args.get_model_config()
+        torch_weight = lambda name, suffix: torch.transpose(
+            self.state_dict[f"{state_dict_prefix}{name}.{suffix}"], -2, -1
+        )
+        torch_bias = lambda name, suffix: self.state_dict[f"{state_dict_prefix}{name}.{suffix}"]
+
+        if args.dummy_weights:
+            cache_name = lambda *_: None
+        else:
+            cache_name = lambda name, suffix: weight_cache_path / (state_dict_prefix + f"{name}.{suffix}")
+
+        as_interleaved_tensor = lambda name, suffix, type, dim: ttnn.as_tensor(
+            (
+                torch_weight(name, suffix) if suffix == "weight" else torch_bias(name, suffix)
+            ),  # Grab only the wX part of the name
+            dtype=type,
+            device=self.mesh_device,
+            mesh_mapper=(
+                ttnn.ShardTensorToMesh(self.mesh_device, dim=dim)
+                if dim is not None
+                else ttnn.ReplicateTensorToMesh(self.mesh_device)
+            ),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_file_name=cache_name(name, suffix),
+        )
+
+        # Sharded weights
+        self.c_fc_weight = as_interleaved_tensor("c_fc", "weight", dtype, dim=-1)
+        self.c_fc_bias = as_interleaved_tensor("c_fc", "bias", ttnn.bfloat16, dim=-1)
+        self.c_fc_bias = ttnn.reshape(self.c_fc_bias, [1, -1])
+        self.c_proj_weight = as_interleaved_tensor("c_proj", "weight", dtype, dim=-2)
+        self.c_proj_bias = as_interleaved_tensor("c_proj", "bias", ttnn.bfloat16, dim=None)
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        w1 -> gate_proj
+        w2 -> down_proj
+        w3 -> up_proj
+        HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        """
+        seq_len = x.shape[-2]
+
+        # Depends on whether we are padding or not
+        MAX_MM_SEQ_LEN = seq_len if "gemma-3" in self.args.base_model_name else self.args.VISION_MAX_MM_SEQ
+
+        x_in = x
+        if seq_len >= MAX_MM_SEQ_LEN:  # Too big to compute. Set different program configs based on seqlen
+            # Reshape input to to fit on device and parallelize computation
+            x_in = ttnn.reshape(x_in, [1, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, -1])
+        pc_1 = self.model_config["IMAGE_MLP_FC_PROGCFG"](seq_len, MAX_MM_SEQ_LEN)
+        pc_2 = self.model_config["IMAGE_MLP_PROJ_PROGCFG"](seq_len, MAX_MM_SEQ_LEN)
+
+        # These use HiFi2; this drops 1 bit of the activations but would be FLOP-bound on 12 cores with HiFi4
+        c_fc_out = ttnn.linear(
+            x_in,
+            self.c_fc_weight,
+            bias=self.c_fc_bias,
+            compute_kernel_config=self.args.compute_kernel_config_hifi4,
+            # core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
+            dtype=ttnn.bfloat16,
+            # program_config=pc_1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            activation="gelu",  # NOTE: activation must be passed to linear here, not in program config! Bad output otherwise
+        )
+
+        c_proj_out = ttnn.linear(
+            c_fc_out,
+            self.c_proj_weight,
+            compute_kernel_config=self.args.compute_kernel_config_hifi4,
+            # core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
+            dtype=ttnn.bfloat16,
+            # program_config=pc_2,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # NOTE: Need to reshape to 4D so that fast_reduce_nc hsa a dim1 to work on
+        c_proj_out = ttnn.reshape(c_proj_out, [1, 1, seq_len, -1])
+
+        # All reduce
+        if self.args.num_devices > 1:  # replace with reduce_scatter and all_gather
+            w2_out_gathered = ttnn.all_gather(c_proj_out, dim=1, num_links=1, topology=ttnn.Topology.Linear)
+            pre_bias_output = ttnn.experimental.fast_reduce_nc(
+                w2_out_gathered, dims=[1], output=None, compute_kernel_config=None
+            )
+        else:
+            pre_bias_output = c_proj_out
+
+        output = ttnn.add(pre_bias_output, self.c_proj_bias)
+        return output

--- a/models/experimental/gemma3_4b/tt/gemma_image_transformer.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_transformer.py
@@ -5,7 +5,7 @@ This is the Entire ImageTransformer for Gemma-3-4b-it.
 We have adapted the TtGemmaImageTransformerBlock from TtLlamaImageTransformerBlock
 with changes incorporating the GemmaImageAttention and GemmaImageFeedForward
 """
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +19,7 @@ class TtGemmaImageTransformer(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix,
         weight_cache_path,
@@ -32,11 +33,13 @@ class TtGemmaImageTransformer(LightweightModule):
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.gated = gated
 
         self.resblocks = [
             TtGemmaImageTransformerBlock(
                 mesh_device=mesh_device,
+                tt_ccl=self.tt_ccl,
                 state_dict=state_dict,
                 state_dict_prefix=f"{state_dict_prefix}{block_key}.{i}.",
                 weight_cache_path=weight_cache_path,

--- a/models/experimental/gemma3_4b/tt/gemma_image_transformer.py
+++ b/models/experimental/gemma3_4b/tt/gemma_image_transformer.py
@@ -1,0 +1,66 @@
+"""
+source: models/tt_transformers/tt/multimodal/llama_image_transformer.py
+
+This is the Entire ImageTransformer for Gemma-3-4b-it.
+We have adapted the TtGemmaImageTransformerBlock from TtLlamaImageTransformerBlock
+with changes incorporating the GemmaImageAttention and GemmaImageFeedForward
+"""
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from tqdm import tqdm
+
+from models.common.lightweightmodule import LightweightModule
+from models.experimental.gemma3_4b.tt.gemma_image_block import TtGemmaImageTransformerBlock
+
+
+class TtGemmaImageTransformer(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        weight_cache_path,
+        dtype,
+        configuration,
+        layers,
+        block_key="resblocks",
+        gated=False,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.gated = gated
+
+        self.resblocks = [
+            TtGemmaImageTransformerBlock(
+                mesh_device=mesh_device,
+                state_dict=state_dict,
+                state_dict_prefix=f"{state_dict_prefix}{block_key}.{i}.",
+                weight_cache_path=weight_cache_path,
+                dtype=dtype,
+                configuration=configuration,
+                gated=gated,
+            )
+            for i in tqdm(range(layers), desc=f"Loading vision transformer layers")
+        ]
+
+    def forward(self, x, return_intermediate=None, mask=None):
+        """
+        Different from reference impl in that if return_intermediates, it returns
+        a list of intermediate tensors rather than a stack of intermediates.
+        Outer code will have to be aware and handle this correctly.
+        """
+        seq_len = x.shape[-2]
+        assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
+
+        out = []
+        for idx, r in enumerate(self.resblocks):
+            if return_intermediate is not None and idx in return_intermediate:
+                out.append(x)
+            x = r(x, mask=mask)
+        if return_intermediate is not None:
+            return x, out
+        return x

--- a/models/experimental/gemma3_4b/tt/gemma_vision_crossattention.py
+++ b/models/experimental/gemma3_4b/tt/gemma_vision_crossattention.py
@@ -3,7 +3,7 @@ This is the Vision Transformer Block for Gemma-3-4b-it.
 This involves vision followed by MultiModalProjector processing
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,6 +17,7 @@ class TtGemmaTransformerVision(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix,
         dtype,
@@ -28,6 +29,7 @@ class TtGemmaTransformerVision(LightweightModule):
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.model_config = configuration.get_model_config()
 
         self.dim = configuration.dim
@@ -38,11 +40,12 @@ class TtGemmaTransformerVision(LightweightModule):
 
         self.vision_encoder = TtSiglipGemmaVisionModel(
             mesh_device,
+            self.tt_ccl,
             state_dict,
             f"model.{state_dict_prefix}",
-            weight_cache_path=configuration.weight_cache_path(dtype),
             dtype=dtype,
             configuration=configuration,
+            weight_cache_path=configuration.weight_cache_path(dtype),
             return_intermediate=return_intermediate,
         )
 

--- a/models/experimental/gemma3_4b/tt/gemma_vision_crossattention.py
+++ b/models/experimental/gemma3_4b/tt/gemma_vision_crossattention.py
@@ -34,7 +34,7 @@ class TtGemmaTransformerVision(LightweightModule):
 
         self.dim = configuration.dim
         self.vision_dim = configuration.vision_dim
-        self.image_res = configuration.vision_chunk_size
+        self.image_res = configuration.image_size
         self.patch_size = configuration.vision_patch_size
         self.configuration = configuration
 
@@ -42,7 +42,7 @@ class TtGemmaTransformerVision(LightweightModule):
             mesh_device,
             self.tt_ccl,
             state_dict,
-            f"model.{state_dict_prefix}",
+            state_dict_prefix,
             dtype=dtype,
             configuration=configuration,
             weight_cache_path=configuration.weight_cache_path(dtype),
@@ -52,8 +52,8 @@ class TtGemmaTransformerVision(LightweightModule):
         self.mmp = TtGemma3MultiModalProjector(
             mesh_device=mesh_device,
             state_dict=state_dict,
-            state_dict_prefix="model.multi_modal_projector",
-            image_size=configuration.vision_chunk_size,
+            state_dict_prefix="multi_modal_projector",
+            image_size=configuration.image_size,
             patch_size=configuration.vision_patch_size,
             hidden_size=configuration.vision_hidden_dim,
             mm_tokens_per_image=configuration.mm_tokens_per_image,

--- a/models/experimental/gemma3_4b/tt/gemma_vision_crossattention.py
+++ b/models/experimental/gemma3_4b/tt/gemma_vision_crossattention.py
@@ -1,0 +1,67 @@
+"""
+This is the Vision Transformer Block for Gemma-3-4b-it.
+This involves vision followed by MultiModalProjector processing
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from models.common.lightweightmodule import LightweightModule
+from models.experimental.gemma3_4b.tt.gemma_vision_model import TtSiglipGemmaVisionModel
+from models.experimental.gemma3_4b.tt.mmp import TtGemma3MultiModalProjector
+
+
+class TtGemmaTransformerVision(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        dtype,
+        configuration,
+        weight_cache_path=None,
+        return_intermediate=None,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.model_config = configuration.get_model_config()
+
+        self.dim = configuration.dim
+        self.vision_dim = configuration.vision_dim
+        self.image_res = configuration.vision_chunk_size
+        self.patch_size = configuration.vision_patch_size
+        self.configuration = configuration
+
+        self.vision_encoder = TtSiglipGemmaVisionModel(
+            mesh_device,
+            state_dict,
+            f"model.{state_dict_prefix}",
+            weight_cache_path=configuration.weight_cache_path(dtype),
+            dtype=dtype,
+            configuration=configuration,
+            return_intermediate=return_intermediate,
+        )
+
+        self.mmp = TtGemma3MultiModalProjector(
+            mesh_device=mesh_device,
+            state_dict=state_dict,
+            state_dict_prefix="model.multi_modal_projector",
+            image_size=configuration.vision_chunk_size,
+            patch_size=configuration.vision_patch_size,
+            hidden_size=configuration.vision_hidden_dim,
+            mm_tokens_per_image=configuration.mm_tokens_per_image,
+            weight_cache_path=configuration.weight_cache_path(dtype),
+            layer_norm_eps=1e-06,  # layer_norm_eps
+            dtype=dtype,
+            configuration=configuration,
+        )
+
+    def forward(self, images):
+        vision_tokens = self.vision_encoder(images)[0, :, :, :]
+
+        vision_tokens = self.mmp(vision_tokens)
+        return vision_tokens

--- a/models/experimental/gemma3_4b/tt/gemma_vision_model.py
+++ b/models/experimental/gemma3_4b/tt/gemma_vision_model.py
@@ -2,7 +2,7 @@
 This is the Vision Tower Model for Gemma-3-4b-it.
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -18,6 +18,7 @@ class TtSiglipGemmaVisionModel(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         state_dict_prefix,
         dtype,
@@ -28,6 +29,7 @@ class TtSiglipGemmaVisionModel(LightweightModule):
         super().__init__()
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
 
         self.image_size = configuration.vision_chunk_size
         self.patch_size = configuration.vision_patch_size
@@ -56,6 +58,7 @@ class TtSiglipGemmaVisionModel(LightweightModule):
         # transformer
         self.encoder = TtGemmaImageTransformer(
             mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
             state_dict=state_dict,
             state_dict_prefix=f"{state_dict_prefix}encoder.",
             weight_cache_path=configuration.weight_cache_path(dtype),

--- a/models/experimental/gemma3_4b/tt/gemma_vision_model.py
+++ b/models/experimental/gemma3_4b/tt/gemma_vision_model.py
@@ -1,0 +1,111 @@
+"""
+This is the Vision Tower Model for Gemma-3-4b-it.
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.experimental.gemma3_4b.tt.siglip_vision_embedding import TtSiglipVisionEmbeddings
+from models.experimental.gemma3_4b.tt.gemma_image_transformer import TtGemmaImageTransformer
+from models.tt_transformers.tt.multimodal.llama_layernorm import TtLayerNorm
+
+
+class TtSiglipGemmaVisionModel(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        dtype,
+        configuration,
+        weight_cache_path=None,
+        return_intermediate=None,
+    ):
+        super().__init__()
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+
+        self.image_size = configuration.vision_chunk_size
+        self.patch_size = configuration.vision_patch_size
+
+        self.width = configuration.vision_dim
+        self.layers = configuration.vision_n_layers
+        self.heads = configuration.vision_attn_n_heads
+        self.mlp_ratio = configuration.vision_mlp_ratio
+        self.act_layer = configuration.vision_act_layer
+        self.in_channels = configuration.vision_in_channels
+        self.n_global_layers = configuration.vision_n_global_layers
+        self.return_intermediate = return_intermediate
+
+        self.embeddings = TtSiglipVisionEmbeddings(
+            mesh_device=mesh_device,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}embeddings.",
+            dtype=dtype,
+            image_size=self.image_size,
+            patch_size=self.patch_size,
+            num_channels=self.in_channels,
+            hidden_dim=self.width,
+            bias=True,
+        )
+
+        # transformer
+        self.encoder = TtGemmaImageTransformer(
+            mesh_device=mesh_device,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}encoder.",
+            weight_cache_path=configuration.weight_cache_path(dtype),
+            dtype=dtype,
+            configuration=configuration,
+            layers=self.layers,
+            block_key="layers",
+        )
+
+        self.prepare_residual_tensor_prefill = configuration.prepare_residual_tensor_prefill
+
+        self.ln_post = TtLayerNorm(
+            device=mesh_device,
+            dim=self.width,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}ln_post.",
+            weight_cache_path=configuration.weight_cache_path(dtype),
+            weight_dtype=dtype,
+            eps=configuration.norm_eps,
+        )
+
+    def forward(self, images):
+        assert isinstance(
+            images, torch.Tensor
+        ), "VisionEncoder input must be a torch tensor because of unfold in self.conv1"
+
+        bsz, in_channel, h, w = images.shape
+
+        x = self.embeddings(images)
+
+        x = ttnn.to_torch(x)
+        attention_mask = torch.zeros(bsz, 1, x.shape[1], x.shape[1])
+        attention_input = self.prepare_residual_tensor_prefill(
+            x,
+            force_replicated=True,
+        )
+
+        tt_mask = ttnn.from_torch(
+            attention_mask,
+            device=self.mesh_device,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        x = self.encoder(
+            attention_input,
+            mask=tt_mask,
+        )
+
+        x = self.ln_post(x)
+
+        return x

--- a/models/experimental/gemma3_4b/tt/gemma_vision_model.py
+++ b/models/experimental/gemma3_4b/tt/gemma_vision_model.py
@@ -31,7 +31,7 @@ class TtSiglipGemmaVisionModel(LightweightModule):
         self.mesh_device = mesh_device
         self.tt_ccl = tt_ccl
 
-        self.image_size = configuration.vision_chunk_size
+        self.image_size = configuration.image_size
         self.patch_size = configuration.vision_patch_size
 
         self.width = configuration.vision_dim

--- a/models/experimental/gemma3_4b/tt/lm_head.py
+++ b/models/experimental/gemma3_4b/tt/lm_head.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.tt_transformers.tt.ccl import tt_all_reduce
+
+
+class LMHead(LightweightModule):
+    def __init__(
+        self,
+        args,
+        mesh_device,
+        dtype,
+        state_dict,
+        state_dict_prefix,
+        weight_cache_path,
+        max_columns_per_device,  # too many columns per device lead to L1 OOM
+    ):
+        super().__init__()
+        self.args = args
+        self.mesh_device = mesh_device
+        self.dtype = dtype
+        self.vocab_size = args.vocab_size
+        self.padded_vocab_size = args.padded_vocab_size
+        self.num_devices = args.num_devices
+
+        size_per_device = self.vocab_size // self.num_devices
+
+        if args.is_galaxy:
+            size_per_device = self.padded_vocab_size // self.num_devices
+        num_splits = math.ceil(size_per_device / max_columns_per_device)
+
+        split_sizes = [min(size_per_device, max_columns_per_device)] * (num_splits - 1)
+        split_sizes.append(size_per_device - sum(split_sizes))  # remaining columns
+
+        # Split the output weights
+        torch_output_weights = state_dict[f"{state_dict_prefix}output.weight"].permute(1, 0)
+
+        self.output_weights = []
+        if args.is_galaxy:
+            cache_file_name = (
+                None if args.dummy_weights else weight_cache_path / f"output_lm_head_{num_splits}_split_shard_0"
+            )
+            padded_lm_head = torch.zeros(1, 1, args.dim, self.padded_vocab_size)
+            padded_lm_head[:, :, :, : self.vocab_size] = torch_output_weights
+
+            memory_config = (
+                ttnn.DRAM_MEMORY_CONFIG
+                if args.dim == 2048
+                else args.create_dram_sharded_mem_config(k=args.dim // 4, n=self.padded_vocab_size // 8)
+            )
+            self.output_weights.append(  # (2k, 16k) 128* 1024
+                ttnn.as_tensor(
+                    padded_lm_head,
+                    device=mesh_device,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(3, 2), mesh_shape=args.cluster_shape),
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=dtype,
+                    memory_config=memory_config,
+                    cache_file_name=cache_file_name,
+                )
+            )
+        else:
+            for i, split_size in enumerate(split_sizes):
+                # Create a list to store the split tensors for each device
+                device_splits = []
+                for device in range(self.num_devices):
+                    start = device * size_per_device + sum(split_sizes[:i])
+                    end = start + split_size
+                    device_splits.append(torch_output_weights[:, start:end])
+
+                # Concatenate the splits from all devices
+                combined_split = torch.cat(device_splits, dim=-1)
+
+                cache_file_name = (
+                    None
+                    if args.dummy_weights
+                    else weight_cache_path / f"output_lm_head_{num_splits}_split_shard_{i}_{combined_split.shape[-1]}"
+                )
+                memory_config = args.create_dram_sharded_mem_config(
+                    k=args.dim, n=math.ceil(combined_split.shape[-1] / self.num_devices)
+                )
+                self.output_weights.append(
+                    ttnn.as_tensor(
+                        combined_split,
+                        device=mesh_device,
+                        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=-1),
+                        layout=ttnn.TILE_LAYOUT,
+                        dtype=dtype,
+                        memory_config=memory_config,
+                        cache_file_name=cache_file_name,
+                    )
+                )
+
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+        if args.is_galaxy:
+            self.program_configs = [
+                (
+                    None
+                    if args.dim == 2048
+                    else args.dram_matmul_config(
+                        args.tile_padded_batch_rows,  # (8k, 128k) -> (2k, 16k)
+                        args.dim // 4,
+                        16 * 1024,
+                        args.lm_head_core_grid.num_cores,
+                    )
+                )
+            ]
+
+        else:
+            self.program_configs = [
+                args.dram_matmul_config(
+                    args.tile_padded_batch_rows,
+                    args.dim,
+                    split_size,
+                    args.lm_head_core_grid.num_cores,
+                )
+                for split_size in split_sizes
+            ]
+
+    def forward(self, x: ttnn.Tensor):
+        outputs = []
+        for weight, pc in zip(self.output_weights, self.program_configs):
+            output = ttnn.linear(
+                x,
+                weight,
+                compute_kernel_config=self.compute_kernel_config,
+                program_config=pc,
+                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                dtype=ttnn.bfloat8_b,
+            )
+            outputs.append(ttnn.sharded_to_interleaved(output, memory_config=ttnn.L1_MEMORY_CONFIG))
+
+        # Concatenate the outputs
+        output = ttnn.concat(outputs, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        output = tt_all_reduce(
+            output,
+            mesh_device=self.mesh_device,
+            cluster_axis=1,
+            dim=3 if self.args.is_galaxy else 0,
+            num_reduce_scatter_links=self.args.num_reduce_scatter_links,
+            num_all_gather_links=self.args.num_all_gather_links,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            dtype=self.args.ccl_dtype,
+            sharded=False,
+            use_composite=True,
+        )
+
+        return output

--- a/models/experimental/gemma3_4b/tt/lm_head.py
+++ b/models/experimental/gemma3_4b/tt/lm_head.py
@@ -21,6 +21,7 @@ class LMHead(LightweightModule):
         self,
         args,
         mesh_device,
+        tt_ccl,
         dtype,
         state_dict,
         state_dict_prefix,
@@ -34,7 +35,7 @@ class LMHead(LightweightModule):
         self.vocab_size = args.vocab_size
         self.padded_vocab_size = args.padded_vocab_size
         self.num_devices = args.num_devices
-
+        self.tt_ccl = tt_ccl
         size_per_device = self.vocab_size // self.num_devices
 
         if args.is_galaxy:
@@ -153,6 +154,7 @@ class LMHead(LightweightModule):
         output = tt_all_reduce(
             output,
             mesh_device=self.mesh_device,
+            tt_ccl=self.tt_ccl,
             cluster_axis=1,
             dim=3 if self.args.is_galaxy else 0,
             num_reduce_scatter_links=self.args.num_reduce_scatter_links,

--- a/models/experimental/gemma3_4b/tt/lm_head.py
+++ b/models/experimental/gemma3_4b/tt/lm_head.py
@@ -1,4 +1,9 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+"""
+source: models/tt_transformers/tt/lm_head.py
+
+This is the LMHead module for the Gemma-3-4B-it model.
+"""
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/mlp.py
+++ b/models/experimental/gemma3_4b/tt/mlp.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.tt_transformers.tt.ccl import tt_all_reduce
+from models.tt_transformers.tt.common import pad_to_size
+from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
+
+
+class MLP(LightweightModule):
+    def __init__(
+        self, mesh_device, args, state_dict, weight_cache_path, layer_num, dtype, model_config, state_dict_prefix=None
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.mesh_device = mesh_device
+        self.args = args
+        self.dim = args.dim
+        self.model_config = model_config
+        self.layer_num = layer_num
+        state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
+        torch_weight = lambda name: torch.transpose(self.state_dict[f"{state_dict_prefix}.{name}.weight"], -2, -1)
+        pad_hidden_dim = lambda tensor, dim: pad_to_size(tensor, dim=dim, size=args.hidden_dim)
+        # If pading was applied (e.g. via env var), add the unpadded hidden dim to the cache name to avoid loading incorrect weights
+        hidden_dim_string = f".hidden_dim_{args.hidden_dim}" if args.hidden_dim != args.unpadded_hidden_dim else ""
+
+        if args.dummy_weights:
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: weight_cache_path / f"{state_dict_prefix}.{name}{hidden_dim_string}"
+
+        w1_w3_mem_config = args.create_dram_sharded_mem_config(args.dim, args.hidden_dim // args.num_devices)
+        w2_mem_config = args.create_dram_sharded_mem_config(args.hidden_dim // args.num_devices, args.dim)
+
+        # TODO Clean up this code. With sharding, we load the normal weights and then shard them
+        as_sharded_tensor = lambda name, type, dims: ttnn.as_tensor(
+            pad_hidden_dim(
+                torch_weight(name[:2]), dims[0] if args.is_galaxy else dims[-1]
+            ),  # Grab only the wX part of the name
+            dtype=type,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=args.cluster_shape),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=(
+                ttnn.DRAM_MEMORY_CONFIG if args.is_galaxy else w2_mem_config if "w2" in name else w1_w3_mem_config
+            ),
+            cache_file_name=cache_name(name),
+        )
+
+        # Sharded weights
+        w1_dims = (-1, -2) if args.is_galaxy else (-2, -1)
+        w2_dims = (-2, -1) if args.is_galaxy else (-1, -2)
+
+        layer_num = max(layer_num, 0)  # cross_block uses the configutation of the first decoder
+
+        ff1_3_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.FF1_FF3
+        )
+        ff2_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.FF2
+        )
+
+        self.w1 = as_sharded_tensor(
+            "w1_sharded", ff1_3_dtype, dims=w1_dims
+        )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
+        self.w2 = as_sharded_tensor("w2_sharded", ff2_dtype, dims=w2_dims)
+        self.w3 = as_sharded_tensor("w3_sharded", ff1_3_dtype, dims=w1_dims)
+
+        # Default activation is SILU
+        self.activation_type = self.args.mlp_activation_type
+
+    def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
+        """
+        w1 -> gate_proj
+        w2 -> down_proj
+        w3 -> up_proj
+        HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        """
+        seq_len = x.shape[-2]
+        TG = self.args.is_galaxy
+        layer_num = max(self.layer_num, 0)  # cross_block uses the configutation of the first decoder
+        activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.ACTIVATION
+        )
+        li_ff1_3_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_FF1_FF3, configuration=self.args
+        )
+
+        if mode == "decode":  # Sharded config
+            if TG:  # TODO: Fix this when TG supports DRAM sharded matmuls
+                pc_1 = self.model_config["FF1_3_TG_PROGCFG"] if self.dim >= 4096 else None
+                pc_2 = self.model_config["FF2_TG_PROGCFG"] if self.dim >= 4096 else None
+                pc_3 = self.model_config["FF1_3_TG_PROGCFG"] if self.dim >= 4096 else None
+            else:
+                pc_1 = self.model_config["DECODE_MLP_W1_W3_PRG_CONFIG"]
+                pc_2 = self.model_config["DECODE_MLP_W2_PRG_CONFIG"]
+                pc_3 = self.model_config["DECODE_MLP_W1_W3_PRG_CONFIG"]
+        else:  # Update the program configs based for prefill
+            if seq_len >= self.args.prefill_len_cutoff:  # 512 if Blackhole, 1024 if Wormhole
+                # Reshape input to to fit on device and parallelize computation
+                x = ttnn.reshape(x, [1, seq_len // self.args.prefill_len_cutoff, self.args.prefill_len_cutoff, -1])
+            pc_1 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
+            pc_2 = self.model_config["PREFILL_MLP_W2_PRG_CONFIG"](seq_len)
+            pc_3 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
+
+        # In decode mode (seqlen <= 32) do DRAM sharded matmuls
+        # These use HiFi2; this drops 1 bit of the activations but would be FLOP-bound on 12 cores with HiFi4
+        memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
+        w1_out = ttnn.linear(
+            x,
+            self.w1,
+            dtype=ttnn.bfloat8_b if TG else activation_dtype or ttnn.bfloat16,
+            core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
+            compute_kernel_config=li_ff1_3_compute_kernel_cfg,
+            program_config=pc_1,
+            memory_config=memory_config,
+        )
+
+        w3_out = ttnn.linear(
+            x,
+            self.w3,
+            dtype=ttnn.bfloat8_b if TG else activation_dtype or ttnn.bfloat16,
+            core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
+            compute_kernel_config=li_ff1_3_compute_kernel_cfg,
+            program_config=pc_3,
+            memory_config=memory_config,
+        )
+        ttnn.deallocate(x)
+
+        if TG:
+            # if mode == "decode" and self.dim!=8192:
+            #     w1_out = ttnn.to_memory_config(w1_out, ttnn.DRAM_MEMORY_CONFIG)
+            #     w3_out = ttnn.to_memory_config(w3_out, ttnn.DRAM_MEMORY_CONFIG)
+            if self.dim == 8192 or mode == "prefill":
+                input_mem_cfg = w1_out.memory_config()
+                w1_out = ttnn.reduce_scatter(
+                    w1_out,
+                    dim=3,
+                    math_op=ttnn.ReduceType.Sum,
+                    num_links=self.args.num_reduce_scatter_links,
+                    cluster_axis=1,
+                    mesh_device=self.mesh_device,
+                    topology=ttnn.Topology.Linear,
+                    memory_config=self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] if mode == "decode" else None,
+                )
+                w3_out = ttnn.reduce_scatter(
+                    w3_out,
+                    dim=3,
+                    math_op=ttnn.ReduceType.Sum,
+                    num_links=1,
+                    cluster_axis=1,
+                    mesh_device=self.mesh_device,
+                    topology=ttnn.Topology.Linear,
+                    memory_config=self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] if mode == "decode" else None,
+                )
+            else:
+                w1_out = tt_all_reduce(
+                    w1_out,
+                    self.mesh_device,
+                    cluster_axis=1,
+                    num_all_gather_links=2,
+                    sharded=True if mode == "decode" else False,
+                    topology=self.args.ccl_topology(),
+                    memory_config=self.model_config["FF1_OUT_GATHERED_MEMCFG"] if mode == "decode" else None,
+                )
+                w3_out = tt_all_reduce(
+                    w3_out,
+                    self.mesh_device,
+                    cluster_axis=1,
+                    num_all_gather_links=2,
+                    sharded=True if mode == "decode" else False,
+                    topology=self.args.ccl_topology(),
+                    memory_config=self.model_config["FF1_OUT_GATHERED_MEMCFG"] if mode == "decode" else None,
+                )
+
+        w2_in = ttnn.mul(
+            w1_out,
+            w3_out,
+            input_tensor_a_activations=[self.activation_type],
+            dtype=activation_dtype or ttnn.bfloat8_b,
+            memory_config=w1_out.memory_config(),
+        )
+
+        if mode == "decode" and not TG:
+            # w2 may use a different core grid, this is a no-op if they already match
+            w2_in = ttnn.to_memory_config(w2_in, self.model_config["SHARDED_MLP2_INPUT_MEMCFG"])
+
+        ttnn.deallocate(w3_out)
+        ttnn.deallocate(w1_out)
+
+        if TG and (self.dim == 8192 or mode == "prefill"):
+            w2_in = ttnn.all_gather(
+                w2_in,
+                3,
+                num_links=2,
+                cluster_axis=1,
+                mesh_device=self.mesh_device,
+                topology=ttnn.Topology.Linear,
+                memory_config=input_mem_cfg,
+            )
+            if mode == "decode":
+                w2_in = ttnn.to_memory_config(w2_in, ttnn.L1_MEMORY_CONFIG)
+
+        li_ff2_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_FF2, configuration=self.args
+        )
+        w2_out = ttnn.linear(
+            w2_in,
+            self.w2,
+            compute_kernel_config=li_ff2_compute_kernel_cfg,
+            dtype=self.args.ccl_dtype if TG else activation_dtype or ttnn.bfloat16,
+            program_config=pc_2,
+            memory_config=memory_config,
+            core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
+        )
+        ttnn.deallocate(w2_in)
+        # if mode == "decode" and not TG:
+        #     w2_out = ttnn.sharded_to_interleaved(w2_out, ttnn.DRAM_MEMORY_CONFIG)
+        w2_out_reduced = tt_all_reduce(
+            w2_out,
+            self.mesh_device,
+            cluster_axis=0,
+            dim=0 if (TG and self.dim < 8192) else 3,
+            num_reduce_scatter_links=self.args.num_reduce_scatter_links,
+            num_all_gather_links=self.args.num_all_gather_links,
+            sharded=(mode == "decode"),
+            memory_config=(
+                (self.model_config["FF2_OUT_REDUCE_SCATTER_MEMCFG"] if TG else w2_out.memory_config())
+                if mode == "decode"
+                else ttnn.DRAM_MEMORY_CONFIG
+            ),
+            dtype=self.args.ccl_dtype,
+            use_composite=True if self.dim == 8192 else False,
+            topology=self.args.ccl_topology(),
+        )
+
+        # Ensure dim 0 and 1 are 1
+        original_shape = w2_out_reduced.shape
+        w2_out_reduced = ttnn.reshape(
+            w2_out_reduced, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])
+        )
+        if mode == "decode":
+            w2_out_reduced = ttnn.to_memory_config(
+                w2_out_reduced,
+                self.model_config["SHARDED_ATTN_INPUT_MEMCFG"] if TG else self.model_config["DECODE_RESIDUAL_MEMCFG"],
+            )
+
+        # ttnn.deallocate(w2_out)
+        return w2_out_reduced

--- a/models/experimental/gemma3_4b/tt/mlp.py
+++ b/models/experimental/gemma3_4b/tt/mlp.py
@@ -1,4 +1,14 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+"""
+source: models/tt_transformers/tt/mlp.py
+
+This is the implementation of MLP (feed-forward) submodule of Gemma-3-4b-it.
+
+We have re-used the MLP implementation of the TT-Transformers library with few modifications.
+This implementation has changes in Data Type (bfloat16).
+"""
+
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -72,7 +82,9 @@ class MLP(LightweightModule):
         self.w3 = as_sharded_tensor("w3_sharded", ff1_3_dtype, dims=w1_dims)
 
         # Default activation is SILU
-        self.activation_type = self.args.mlp_activation_type
+        self.activation_type = (
+            args.mlp_activation_type if hasattr(args, "mlp_activation_type") else ttnn.UnaryOpType.SILU
+        )
 
     def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
         """
@@ -88,7 +100,7 @@ class MLP(LightweightModule):
             decoder_id=layer_num, tensor=TensorGroup.ACTIVATION
         )
         li_ff1_3_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
-            decoder_id=layer_num, op=OpGroup.LI_FF1_FF3, configuration=self.args
+            decoder_id=layer_num, op=OpGroup.ACCURACY, configuration=self.args
         )
 
         if mode == "decode":  # Sharded config
@@ -182,7 +194,7 @@ class MLP(LightweightModule):
             w1_out,
             w3_out,
             input_tensor_a_activations=[self.activation_type],
-            dtype=activation_dtype or ttnn.bfloat8_b,
+            dtype=activation_dtype or ttnn.bfloat16,
             memory_config=w1_out.memory_config(),
         )
 
@@ -207,7 +219,7 @@ class MLP(LightweightModule):
                 w2_in = ttnn.to_memory_config(w2_in, ttnn.L1_MEMORY_CONFIG)
 
         li_ff2_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
-            decoder_id=layer_num, op=OpGroup.LI_FF2, configuration=self.args
+            decoder_id=layer_num, op=OpGroup.ACCURACY, configuration=self.args
         )
         w2_out = ttnn.linear(
             w2_in,

--- a/models/experimental/gemma3_4b/tt/mlp.py
+++ b/models/experimental/gemma3_4b/tt/mlp.py
@@ -23,12 +23,22 @@ from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
 
 class MLP(LightweightModule):
     def __init__(
-        self, mesh_device, args, state_dict, weight_cache_path, layer_num, dtype, model_config, state_dict_prefix=None
+        self,
+        mesh_device,
+        tt_ccl,
+        args,
+        state_dict,
+        weight_cache_path,
+        layer_num,
+        dtype,
+        model_config,
+        state_dict_prefix=None,
     ):
         super().__init__()
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.args = args
         self.dim = args.dim
         self.model_config = model_config
@@ -82,9 +92,7 @@ class MLP(LightweightModule):
         self.w3 = as_sharded_tensor("w3_sharded", ff1_3_dtype, dims=w1_dims)
 
         # Default activation is SILU
-        self.activation_type = (
-            args.mlp_activation_type if hasattr(args, "mlp_activation_type") else ttnn.UnaryOpType.SILU
-        )
+        self.activation_type = self.args.mlp_activation_type
 
     def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
         """
@@ -150,30 +158,44 @@ class MLP(LightweightModule):
             #     w3_out = ttnn.to_memory_config(w3_out, ttnn.DRAM_MEMORY_CONFIG)
             if self.dim == 8192 or mode == "prefill":
                 input_mem_cfg = w1_out.memory_config()
-                w1_out = ttnn.reduce_scatter(
+
+                cluster_axis = 1
+                w1_out = ttnn.experimental.reduce_scatter_minimal_async(
                     w1_out,
+                    persistent_output_buffers=None,
                     dim=3,
-                    math_op=ttnn.ReduceType.Sum,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis),
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
                     num_links=self.args.num_reduce_scatter_links,
-                    cluster_axis=1,
-                    mesh_device=self.mesh_device,
-                    topology=ttnn.Topology.Linear,
+                    cluster_axis=cluster_axis,
                     memory_config=self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] if mode == "decode" else None,
+                    intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    topology=ttnn.Topology.Linear,
+                    chunks_per_sync=10,
+                    num_workers_per_link=2,
+                    num_buffers_per_channel=2,
                 )
-                w3_out = ttnn.reduce_scatter(
+
+                w3_out = ttnn.experimental.reduce_scatter_minimal_async(
                     w3_out,
+                    persistent_output_buffers=None,
                     dim=3,
-                    math_op=ttnn.ReduceType.Sum,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis),
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
                     num_links=1,
-                    cluster_axis=1,
-                    mesh_device=self.mesh_device,
-                    topology=ttnn.Topology.Linear,
+                    cluster_axis=cluster_axis,
                     memory_config=self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] if mode == "decode" else None,
+                    intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    topology=ttnn.Topology.Linear,
+                    chunks_per_sync=10,
+                    num_workers_per_link=2,
+                    num_buffers_per_channel=2,
                 )
             else:
                 w1_out = tt_all_reduce(
                     w1_out,
                     self.mesh_device,
+                    self.tt_ccl,
                     cluster_axis=1,
                     num_all_gather_links=2,
                     sharded=True if mode == "decode" else False,
@@ -183,6 +205,7 @@ class MLP(LightweightModule):
                 w3_out = tt_all_reduce(
                     w3_out,
                     self.mesh_device,
+                    self.tt_ccl,
                     cluster_axis=1,
                     num_all_gather_links=2,
                     sharded=True if mode == "decode" else False,
@@ -206,15 +229,22 @@ class MLP(LightweightModule):
         ttnn.deallocate(w1_out)
 
         if TG and (self.dim == 8192 or mode == "prefill"):
-            w2_in = ttnn.all_gather(
+            cluster_axis = 1
+            w2_in = ttnn.experimental.all_gather_async(
                 w2_in,
-                3,
+                persistent_output_buffer=None,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
                 num_links=2,
                 cluster_axis=1,
-                mesh_device=self.mesh_device,
                 topology=ttnn.Topology.Linear,
                 memory_config=input_mem_cfg,
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                chunks_per_sync=10,
+                num_workers_per_link=2,
+                num_buffers_per_channel=2,
             )
+
             if mode == "decode":
                 w2_in = ttnn.to_memory_config(w2_in, ttnn.L1_MEMORY_CONFIG)
 
@@ -236,6 +266,7 @@ class MLP(LightweightModule):
         w2_out_reduced = tt_all_reduce(
             w2_out,
             self.mesh_device,
+            self.tt_ccl,
             cluster_axis=0,
             dim=0 if (TG and self.dim < 8192) else 3,
             num_reduce_scatter_links=self.args.num_reduce_scatter_links,

--- a/models/experimental/gemma3_4b/tt/mlp.py
+++ b/models/experimental/gemma3_4b/tt/mlp.py
@@ -8,7 +8,7 @@ This implementation has changes in Data Type (bfloat16).
 """
 
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/mmp.py
+++ b/models/experimental/gemma3_4b/tt/mmp.py
@@ -3,7 +3,7 @@ This is the implmentation of MultiModalprojector for Gemma-3-4b-it model.
 There is no Independent MultiModalprojector support in TT-Transformers.
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/mmp.py
+++ b/models/experimental/gemma3_4b/tt/mmp.py
@@ -1,0 +1,129 @@
+"""
+This is the implmentation of MultiModalprojector for Gemma-3-4b-it model.
+There is no Independent MultiModalprojector support in TT-Transformers.
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+
+from models.experimental.gemma3_4b.tt.rmsnorm import RMSNorm
+
+
+class TtGemma3MultiModalProjector(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        image_size,
+        patch_size,
+        hidden_size,
+        mm_tokens_per_image,
+        weight_cache_path,
+        layer_norm_eps,
+        dtype,
+        configuration,
+    ):
+        super().__init__()
+        self.mesh_device = mesh_device
+        self.dtype = dtype
+
+        self.patches_per_image = int(image_size // patch_size)
+        self.tokens_per_side = int(mm_tokens_per_image**0.5)
+        self.kernel_size = self.patches_per_image // self.tokens_per_side
+        self.hidden_size = hidden_size
+
+        weight_key = state_dict_prefix + ".mm_input_projection_weight"
+        weight = state_dict[weight_key]
+
+        if configuration.dummy_weights or (weight_cache_path is None):
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: weight_cache_path / (f"{state_dict_prefix}{name}")
+
+        # Pad dimensions to multiples of 32
+        padded_vision_size = ((hidden_size + 31) // 32) * 32
+
+        if padded_vision_size != hidden_size:
+            padding = torch.zeros(hidden_size, padded_vision_size - hidden_size, dtype=weight.dtype)
+            weight = torch.cat([weight, padding], dim=-1)
+
+        self.mm_input_projection_weight = ttnn.as_tensor(
+            weight,
+            dtype=dtype,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            # cache_file_name=cache_name("mm_input_projection_weight"), # pcc drop fix later
+        )
+
+        # # Create RMSNorm layer
+        weight_key = state_dict_prefix + ".mm_soft_emb_norm"
+        self.mm_soft_emb_norm = RMSNorm(
+            device=mesh_device,
+            dim=1152,
+            state_dict=state_dict,
+            state_dict_prefix="",
+            weight_key=weight_key,
+            weight_dtype=dtype,
+            is_distributed=False,
+            # sharded_program_config=tt_model_args.get_model_config()["SHARDED_NORM_ATTN_PRGM_CFG"],
+            # sharded_output_config=tt_model_args.get_model_config()["SHARDED_ATTN_INPUT_MEMCFG"],
+        )
+
+    def forward(self, vision_outputs: ttnn.Tensor) -> ttnn.Tensor:
+        batch_size, _, seq_length = vision_outputs.shape
+        mode = "decode" if seq_length <= 32 else "prefill"
+
+        # Reshape: [batch, seq, hidden] -> [batch, hidden, seq]
+        reshaped_vision_outputs = ttnn.transpose(vision_outputs, 1, 2)
+
+        ttnn.deallocate(vision_outputs)
+
+        reshaped_vision_outputs = ttnn.reshape(
+            reshaped_vision_outputs, (batch_size, seq_length, self.patches_per_image, self.patches_per_image)
+        )
+
+        in_n, in_c, in_h, in_w = reshaped_vision_outputs.shape
+        reshaped_vision_outputs = ttnn.to_layout(reshaped_vision_outputs, ttnn.ROW_MAJOR_LAYOUT)
+        reshaped_vision_outputs = ttnn.permute(reshaped_vision_outputs, (0, 2, 3, 1))
+        reshaped_vision_outputs = ttnn.reshape(reshaped_vision_outputs, (1, 1, in_n * in_h * in_w, in_c))
+        pooled_vision_outputs = ttnn.avg_pool2d(
+            reshaped_vision_outputs,
+            batch_size=in_n,
+            input_h=in_h,
+            input_w=in_w,
+            channels=in_c,
+            kernel_size=(self.kernel_size, self.kernel_size),
+            stride=(self.kernel_size, self.kernel_size),
+            padding=(0, 0),
+            ceil_mode=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            applied_shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        )
+        # transpose
+        HOUT = ((in_h - self.kernel_size) // self.kernel_size) + 1
+        WOUT = ((in_w - self.kernel_size) // self.kernel_size) + 1
+        pooled_vision_outputs = ttnn.reshape(pooled_vision_outputs, (in_n, HOUT, WOUT, in_c))
+
+        pooled_vision_outputs = ttnn.permute(pooled_vision_outputs, (0, 3, 1, 2))
+        pooled_vision_outputs = ttnn.to_layout(pooled_vision_outputs, ttnn.TILE_LAYOUT)
+
+        pooled_vision_outputs = ttnn.reshape(
+            pooled_vision_outputs, (pooled_vision_outputs.shape[0], pooled_vision_outputs.shape[1], -1)
+        )
+
+        # # Flatten(2)
+        pooled_vision_outputs = ttnn.transpose(pooled_vision_outputs, 1, 2)
+        normed_vision_outputs = self.mm_soft_emb_norm(pooled_vision_outputs, mode=mode)
+        self.mm_input_projection_weight = ttnn.to_layout(self.mm_input_projection_weight, ttnn.TILE_LAYOUT)
+        projected_vision_outputs = ttnn.matmul(normed_vision_outputs, self.mm_input_projection_weight)
+
+        return projected_vision_outputs

--- a/models/experimental/gemma3_4b/tt/rmsnorm.py
+++ b/models/experimental/gemma3_4b/tt/rmsnorm.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+
+TILE = 32
+SHARD_HEIGHT = TILE  # Current ttnn.rms_norm implementation requires shard height to be a single tile
+
+
+class RMSNorm(LightweightModule):
+    """
+    RMSNorm supporting replication over a MeshDevice and sharding within devices.
+
+    This class implements a Root Mean Square Normalization (RMSNorm) that can be
+    distributed across multiple devices and cores. If the `device` parameter is a
+    MeshDevice, the weights and computations are replicated across all devices in
+    the mesh. Expects an interleaved input tensor, can optionally output a sharded tensor.
+
+    Args:
+        device: The device or MeshDevice on which to perform the computations.
+        state_dict: The state dictionary containing the model parameters.
+        dim: Input dimension (e.g. model hidden dimension size).
+        layer_num: The layer number to determine the weight key in the state dictionary.
+        weight_key: The key for retrieving the weight from the state dictionary.
+        weight_cache_path: Optional path for caching the tilized weights.
+        weight_memory_config: Configuration for the weight memory, default is DRAM_MEMORY_CONFIG.
+        weight_dtype: The data type for the tensors, bfp8_b hits >0.999 PCC in the models we tested.
+        model_config: Optional configuration dictionary for the model.
+        eps (float): Small value to avoid division by zero in normalization, default is 1e-05.
+
+    If model_config is provided, it must specify SHARDED_NORM_INPUT_MEMCFG, SHARDED_NORM_PRGM_CFG
+    and SHARDED_NORM_OUTPUT_MEMCFG. If not provided, default configurations will be generated.
+    """
+
+    def __init__(
+        self,
+        device,
+        dim,
+        state_dict,
+        weight_key,
+        layer_num=None,
+        state_dict_prefix=None,
+        weight_cache_path=None,
+        weight_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        weight_dtype=ttnn.bfloat16,
+        is_distributed=None,
+        eps: float = 1e-05,
+        add_unit_offset=False,
+        sharded_program_config=None,
+        sharded_output_config=None,
+        output_mem_config=None,
+        ccl_topology=ttnn.Topology.Ring,
+        tt_ccl=None,
+    ):
+        super().__init__()
+        self.device = device
+        self.eps = eps
+        self.is_distributed = is_distributed
+        self.ccl_topology = ccl_topology
+        self.tt_ccl = tt_ccl
+
+        if state_dict_prefix:
+            weight_name = f"{state_dict_prefix}{weight_key}.weight"
+        else:
+            if layer_num is None:
+                weight_name = f"{weight_key}.weight"
+            else:
+                weight_name = f"layers.{layer_num}.{weight_key}.weight"
+
+        torch_weight = (
+            state_dict[weight_name].unsqueeze(0).view(1, 1, dim).reshape([1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT])
+        )
+
+        # Add offset before caching
+        if add_unit_offset:
+            torch_weight = torch_weight + 1.0
+
+        cache_name = None if weight_cache_path is None else weight_cache_path / weight_name
+
+        # Compatibility with models that don't use mesh devices (e.g. single-chip Mistral-7b)
+        is_mesh_device = device.__class__.__name__ == "MeshDevice"
+
+        self.weight = ttnn.as_tensor(
+            torch_weight,
+            device=device,
+            dtype=weight_dtype,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=weight_memory_config,
+            cache_file_name=cache_name,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(device) if is_mesh_device else None,
+        )
+
+        if self.is_distributed:
+            self.weight_distributed = ttnn.as_tensor(
+                torch_weight,
+                device=device,
+                dtype=weight_dtype,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=weight_memory_config,
+                cache_file_name=cache_name,
+                mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(None, 2), mesh_shape=list(device.shape))
+                if is_mesh_device
+                else None,
+            )
+
+        self.sharded_output_config = sharded_output_config
+        self.sharded_program_config = sharded_program_config
+        self.output_mem_config = output_mem_config
+
+        self.compute_kernel_config_hifi2 = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    def forward(self, x: ttnn.Tensor, mode, in_sharded=False, out_sharded=False) -> ttnn.Tensor:
+        # If input is sharded do sharded RMSNorm and optionally return sharded output
+        program_config = self.sharded_program_config if in_sharded else None
+        memory_config = self.sharded_output_config if out_sharded else None
+        distributed = self.is_distributed and self.is_distributed(mode)
+        norm = self._distributed_rmsnorm if distributed else ttnn.rms_norm
+        weight = self.weight_distributed if distributed else self.weight
+
+        if in_sharded:
+            assert not distributed, "Distributed RMSNorm does not support sharded inputs"
+        else:
+            assert not out_sharded, "Non-sharded version of RMSNorm cannot output a sharded tensor"
+
+        x = norm(
+            x,
+            epsilon=self.eps,
+            weight=weight,
+            program_config=program_config,
+            memory_config=memory_config,
+            compute_kernel_config=self.compute_kernel_config_hifi2,
+        )
+
+        if in_sharded and not out_sharded:
+            return ttnn.sharded_to_interleaved(x)
+        else:
+            return x
+
+    def _distributed_rmsnorm(
+        self, inp, epsilon=None, weight=None, program_config=None, memory_config=None, compute_kernel_config=None
+    ):
+        assert program_config is None, "Distributed RMSNorm does not support sharded inputs"
+        assert memory_config is None, "Distributed RMSNorm does not support sharded outputs"
+
+        # Run distributed rmsnorm part 1
+        tt_stats = ttnn.rms_norm_pre_all_gather(inp, compute_kernel_config=compute_kernel_config, dtype=ttnn.bfloat16)
+        # AllGather stats
+        if self.tt_ccl:
+            tt_stats = ttnn.experimental.all_gather_async(
+                tt_stats,
+                persistent_output_buffer=None,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                num_links=1,
+                topology=self.ccl_topology,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+                chunks_per_sync=10,
+                num_workers_per_link=2,
+                num_buffers_per_channel=2,
+            )
+        else:
+            tt_stats = ttnn.all_gather(
+                tt_stats,
+                dim=3,
+                num_links=1,
+                topology=self.ccl_topology,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        # Run distributed rmsnorm part 2
+        tt_out = ttnn.rms_norm_post_all_gather(
+            inp,
+            tt_stats,
+            epsilon=epsilon,
+            weight=weight,
+            compute_kernel_config=compute_kernel_config,
+        )
+        tt_stats.deallocate(True)
+
+        return tt_out

--- a/models/experimental/gemma3_4b/tt/rmsnorm.py
+++ b/models/experimental/gemma3_4b/tt/rmsnorm.py
@@ -7,7 +7,7 @@ We have modified the RMSNorm implementation equivalent to RMSNorm in Gemma-3-4b-
 We have handled the unit offset addition in the RMSNorm implementation directly into the TTNN Weights
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/siglip_vision_embedding.py
+++ b/models/experimental/gemma3_4b/tt/siglip_vision_embedding.py
@@ -3,7 +3,7 @@ This is the VisionEmbedding implementation for the Gemma-3-4b-it
 This implementation combines patch_conv followed by Embeddings as a submodule.
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/gemma3_4b/tt/siglip_vision_embedding.py
+++ b/models/experimental/gemma3_4b/tt/siglip_vision_embedding.py
@@ -1,0 +1,79 @@
+"""
+This is the VisionEmbedding implementation for the Gemma-3-4b-it
+This implementation combines patch_conv followed by Embeddings as a submodule.
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+
+from models.experimental.gemma3_4b.tt.gemma_conv2d_patch import TtGemmaConv2dPatch
+
+
+class TtSiglipVisionEmbeddings(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        state_dict,
+        state_dict_prefix,
+        dtype,
+        image_size,
+        patch_size,
+        num_channels,
+        hidden_dim,
+        bias=True,
+    ):
+        super().__init__()
+
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_dim = hidden_dim
+        self.num_channels = num_channels
+        self.mesh_device = mesh_device
+
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.num_positions = self.num_patches
+        self.position_ids = ttnn.arange(0, self.num_positions, 1, dtype=ttnn.uint32, device=self.mesh_device)
+        self.position_ids = ttnn.reshape(self.position_ids, (1, -1))
+
+        self.patch_embed = TtGemmaConv2dPatch(
+            mesh_device=mesh_device,
+            state_dict=state_dict,
+            state_dict_prefix=f"{state_dict_prefix}patch_embedding.",
+            dtype=dtype,
+            in_channels=num_channels,
+            out_channels=hidden_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+            bias=bias,
+        )
+
+        # Positional embedding
+        positional_embedding = state_dict[f"{state_dict_prefix}position_embedding.positional_embedding"]
+
+        self.pos_emb_weights = ttnn.as_tensor(
+            positional_embedding,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+    def forward(self, pixel_values: torch.Tensor) -> ttnn.Tensor:
+        """
+        Args:
+            pixel_values: torch.Tensor of shape (B, C, H, W)
+        Returns:
+            embeddings: ttnn.Tensor of shape (B, num_patches, hidden_dim)
+        """
+        patch_embeddings = self.patch_embed(pixel_values)  # [B, num_patches, hidden_dim]
+        patch_embeddings = ttnn.reshape(patch_embeddings, (1, -1, self.hidden_dim))
+        positional_embeddings = ttnn.embedding(self.position_ids, self.pos_emb_weights, layout=ttnn.TILE_LAYOUT)
+        embeddings = ttnn.add(patch_embeddings, positional_embeddings)
+        return embeddings

--- a/models/experimental/gemma3_4b/tt/text_model.py
+++ b/models/experimental/gemma3_4b/tt/text_model.py
@@ -4,7 +4,7 @@ This is the end-to-end implementation of the Gemma-3-4b-it model.
 
 """
 
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +15,6 @@ from models.experimental.gemma3_4b.tt.rmsnorm import RMSNorm
 from models.common.lightweightmodule import LightweightModule
 from models.tt_transformers.tt.embedding import Embedding
 from models.tt_transformers.tt.rope import RotarySetup
-from models.tt_transformers.tt.ccl import TT_CCL
 
 from models.experimental.gemma3_4b.tt.decoder import TransformerBlock
 from models.tt_transformers.tt.distributed_norm import DistributedNorm
@@ -33,6 +32,7 @@ class Gemma3_4BTransformer(LightweightModule):
         args,
         dtype,
         mesh_device,
+        tt_ccl,
         state_dict,
         weight_cache_path,
         paged_attention_config=None,
@@ -44,12 +44,11 @@ class Gemma3_4BTransformer(LightweightModule):
         assert self.vocab_size > 0
         self.n_layers = args.n_layers
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.dtype = dtype
         self.model_config = args.get_model_config()
         self.grid_size = self.args.max_grid_size
         state_dict_prefix = args.get_state_dict_prefix("", None)
-
-        self.tt_ccl = TT_CCL(self.mesh_device)
 
         self.embd = Embedding(
             mesh_device=mesh_device,

--- a/models/experimental/gemma3_4b/tt/text_model.py
+++ b/models/experimental/gemma3_4b/tt/text_model.py
@@ -135,7 +135,7 @@ class Gemma3_4BTransformer(LightweightModule):
         self.cache_is_setup = True
 
         # Prepare xattn_caches
-        chunk_length = nearest_32(self.args.vision_chunk_ntok)
+        chunk_length = nearest_32(self.args.image_size)
         vision_seq_len = self.args.vision_max_num_chunks * chunk_length
         xattn_cache = [
             [

--- a/models/experimental/gemma3_4b/tt/text_model.py
+++ b/models/experimental/gemma3_4b/tt/text_model.py
@@ -473,7 +473,8 @@ class Gemma3_4BTransformer(LightweightModule):
             ttnn.copy(tt_logits.reshape(x.shape), x)
         elif not self.args.is_galaxy:
             # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations
-            tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
+            # tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
+            pass
 
         return tt_logits
 

--- a/models/experimental/gemma3_4b/tt/text_model.py
+++ b/models/experimental/gemma3_4b/tt/text_model.py
@@ -1,0 +1,493 @@
+"""
+
+This is the end-to-end implementation of the Gemma-3-4b-it model.
+
+"""
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.gemma3_4b.tt.rmsnorm import RMSNorm
+
+# from models.tt_transformers.tt.model import Transformer
+from models.common.lightweightmodule import LightweightModule
+from models.tt_transformers.tt.embedding import Embedding
+from models.tt_transformers.tt.rope import RotarySetup
+
+from models.experimental.gemma3_4b.tt.decoder import TransformerBlock
+from models.tt_transformers.tt.distributed_norm import DistributedNorm
+from tqdm import tqdm
+import torch
+from models.experimental.gemma3_4b.tt.lm_head import LMHead
+from models.tt_transformers.tt.model_config import TensorGroup
+from models.tt_transformers.tt.common import copy_host_to_device
+from models.utility_functions import nearest_32
+
+
+class Gemma3_4BTransformer(LightweightModule):
+    def __init__(
+        self,
+        args,
+        dtype,
+        mesh_device,
+        state_dict,
+        weight_cache_path,
+        paged_attention_config=None,
+        use_paged_kv_cache=False,
+    ):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        assert self.vocab_size > 0
+        self.n_layers = args.n_layers
+        self.mesh_device = mesh_device
+        self.dtype = dtype
+        self.model_config = args.get_model_config()
+        self.grid_size = self.args.max_grid_size
+        state_dict_prefix = args.get_state_dict_prefix("", None)
+
+        self.embd = Embedding(
+            mesh_device=mesh_device,
+            args=args,
+            weight_cache_path=args.weight_cache_path(dtype),
+            state_dict=state_dict,
+            dtype=ttnn.bfloat16,  # Row major layout requires bfloat16
+        )
+
+        self.rope_setup = RotarySetup(
+            mesh_device,
+            args.max_batch_size,
+            args.head_dim,
+            args.max_seq_len,
+            args.rope_theta,
+            args.rope_scaling,
+        )
+
+        self.rope_setup_local = RotarySetup(
+            mesh_device,
+            args.max_batch_size,
+            args.head_dim,
+            args.max_seq_len,
+            10000,
+            None,
+        )
+
+        self.trans_mats_dict = self.rope_setup.get_both_trans_mats()
+
+        self.layers = [
+            TransformerBlock(
+                args=args,
+                mesh_device=mesh_device,
+                dtype=dtype,
+                state_dict=state_dict,
+                weight_cache_path=weight_cache_path,
+                layer_num=i,
+                transformation_mats=self.trans_mats_dict,
+                paged_attention_config=paged_attention_config,
+                use_paged_kv_cache=use_paged_kv_cache,
+            )
+            for i in tqdm(range(self.n_layers))
+        ]
+        self.cross_attention_layers = self.layers
+        self.norm = DistributedNorm(
+            RMSNorm(
+                device=mesh_device,
+                dim=args.dim,
+                eps=args.norm_eps,
+                state_dict=state_dict,
+                state_dict_prefix=args.get_state_dict_prefix("", None),
+                weight_cache_path=None if args.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key="norm",
+                is_distributed=self.args.is_distributed_norm,
+                sharded_program_config=self.model_config["SHARDED_NORM_LM_HEAD_PRGM_CFG"],
+                sharded_output_config=self.model_config["LM_HEAD_INPUT_MEMCFG"],
+                ccl_topology=self.args.ccl_topology(),
+            ),
+            args,
+            args.is_galaxy,
+        )
+
+        self.lm_head = LMHead(
+            args=args,
+            mesh_device=mesh_device,
+            dtype=dtype,
+            state_dict=state_dict,
+            state_dict_prefix=state_dict_prefix,
+            weight_cache_path=weight_cache_path,
+            max_columns_per_device=args.max_columns_per_device_lm_head,
+        )
+
+        self.embed_scale = args.dim**0.5
+
+        self.host_embed = self.args.reference_embedding()
+
+    def setup_cache(self, max_batch_size):
+        self.cache_is_setup = True
+
+        # Prepare xattn_caches
+        chunk_length = nearest_32(self.args.vision_chunk_ntok)
+        vision_seq_len = self.args.vision_max_num_chunks * chunk_length
+        xattn_cache = [
+            [
+                ttnn.from_torch(
+                    torch.zeros(max_batch_size, self.args.n_kv_heads, vision_seq_len, self.args.head_dim),
+                    device=self.mesh_device,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    dtype=ttnn.bfloat16,
+                    mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=1),
+                )
+                for _ in range(2)
+            ]
+            for l in range(len(self.cross_attention_layers))
+        ]
+
+        return xattn_cache
+
+    def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None, **kwargs):
+        """
+        Inputs are torch tensors or python types. This function returns ttnn
+        tensors on device.
+        TODO: Debate whether this function is responsible for padding
+        """
+        if not kwargs.get("processed_inputs", None):
+            tokens = tokens.reshape(1, 1, 1, -1)
+            S = tokens.shape[-1]
+            tokens = ttnn.from_torch(
+                tokens,
+                device=self.mesh_device,
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+            tokens_embd = self.embd(tokens)
+            tokens_embd = ttnn.multiply(tokens_embd, self.embed_scale)
+        else:
+            S = tokens.shape[-1]
+            tokens_embd = self.host_embed(tokens)
+
+            tokens_embd = ttnn.from_torch(
+                tokens_embd,
+                device=self.mesh_device,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+
+            pixel_values = kwargs["processed_inputs"]["pixel_values"]
+            if pixel_values is not None:
+                vision_model = kwargs["vision_model"]
+                input_ids = kwargs["processed_inputs"]["input_ids"]
+
+                vision_output = vision_model(pixel_values)
+
+                tokens_embd = ttnn.to_torch(tokens_embd)
+                comp_vision_output = ttnn.to_torch(ttnn.from_device(vision_output))
+                comp_vision_output = torch.nn.functional.pad(
+                    comp_vision_output, (0, 0, 0, tokens_embd.shape[1] - comp_vision_output.shape[1]), "constant", 0
+                )
+
+                input_ids = torch.nn.functional.pad(
+                    input_ids, (0, tokens_embd.shape[1] - input_ids.shape[1]), "constant", 0
+                )
+                image_features = comp_vision_output.squeeze(0)
+                special_image_mask = (input_ids == self.args.image_token_index).unsqueeze(-1)
+                special_image_mask = special_image_mask.expand_as(tokens_embd)
+                image_features = image_features.to(tokens_embd.device, tokens_embd.dtype)
+                tokens_embd = tokens_embd.masked_scatter(special_image_mask, image_features)
+                tokens_embd = ttnn.from_torch(
+                    tokens_embd,
+                    dtype=ttnn.bfloat16,
+                    device=self.mesh_device,
+                    layout=ttnn.TILE_LAYOUT,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                )
+
+        tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
+        # Slice the rot mats to the prefill seqlen
+        assert (
+            self.rope_setup.cos_matrix.shape[2] >= start_pos + S
+        ), f"Padded prefill end idx {start_pos + S} exceeds max seq len {self.rope_setup.cos_matrix.shape[2]}"
+
+        tt_rot_mats_prefill_global = [
+            self.rope_setup.cos_matrix[:, :, start_pos : start_pos + S, :],
+            self.rope_setup.sin_matrix[:, :, start_pos : start_pos + S, :],
+        ]
+
+        tt_rot_mats_prefill_local = [
+            self.rope_setup_local.cos_matrix[:, :, start_pos : start_pos + S, :],
+            self.rope_setup_local.sin_matrix[:, :, start_pos : start_pos + S, :],
+        ]
+
+        if page_table is not None:
+            tt_page_table = ttnn.from_torch(
+                page_table,
+                device=self.mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+        else:
+            tt_page_table = None
+
+        if chunk_page_table is not None:
+            tt_chunk_page_table = ttnn.from_torch(
+                chunk_page_table,
+                device=self.mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+        else:
+            tt_chunk_page_table = None
+
+        return tokens_embd, [tt_rot_mats_prefill_global, tt_rot_mats_prefill_local], tt_page_table, tt_chunk_page_table
+
+    def prepare_inputs_decode(self, *inputs):
+        """
+        Inputs are torch tensors or python types. This function returns ttnn
+        tensors on device.
+        Its implementation can take advantage of a few other functions which the
+        model must implement.
+        """
+        host_inputs = self.prepare_decode_inputs_host(*inputs)
+        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)  # Helper function
+        transformed_device_inputs = self.transform_decode_inputs_device(*device_inputs)
+        return transformed_device_inputs
+
+    def prepare_decode_inputs_host(self, tokens, current_pos, page_table=None):
+        """
+        Inputs are torch tensors or python types. Outputs are ttnn tensors on host.
+        NOTE: Tokens and current_pos are padded to batch
+        """
+        B = tokens.shape[0]
+        assert current_pos.shape[0] == B, "Batch size mismatch"
+        assert B == self.args.max_batch_size, "Batch size must be equal to max_batch_size"
+
+        # Necessary padding to be full tile sized when on device
+        tokens = torch.nn.functional.pad(tokens.view(-1), (0, 32 - len(tokens)), "constant", 0)
+        tokens = ttnn.from_torch(
+            tokens,
+            device=None,
+            dtype=ttnn.uint32,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        tokens = ttnn.unsqueeze_to_4D(tokens)
+
+        rot_current_pos = torch.maximum(
+            current_pos, torch.tensor(0, dtype=torch.int64)
+        )  # Ensure position indices are non-negative
+        rope_idxs = self.rope_setup.get_rot_idxs(rot_current_pos, on_host=True)
+        current_pos_tt = ttnn.from_torch(
+            current_pos,
+            device=None,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=(None, 0) if (self.args.is_galaxy and B > 1) else (None, None),
+                mesh_shape=self.args.cluster_shape,
+            ),
+        )
+
+        if page_table is not None:
+            page_table = ttnn.from_torch(
+                page_table,
+                device=None,
+                dtype=ttnn.int32,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=(None, -2) if (self.args.is_galaxy and B > 1) else (None, None),
+                    mesh_shape=self.args.cluster_shape,
+                ),
+            )
+        return tokens, current_pos_tt, rope_idxs, page_table
+
+    def transform_decode_inputs_device(self, tokens, current_pos, rope_idxs, page_table=None):
+        """
+        Inputs are ttnn tensors on device. This function applies any on-device
+        transformations which should happen before forward decode.
+        For example: tilize, reshape, shard.
+        Return transformed device tensors
+
+        Get rope sin/cos
+        Embed tokens
+        """
+        tt_rot_mats = self.rope_setup.get_rot_mats(rope_idxs)
+        tt_rot_mats_local = self.rope_setup_local.get_rot_mats(rope_idxs)
+
+        tt_tokens = self.embd(tokens)
+        tt_tokens = ttnn.multiply(tt_tokens, self.embed_scale)
+        tt_tokens = ttnn.unsqueeze_to_4D(tt_tokens)
+        tt_tokens = ttnn.to_memory_config(
+            tt_tokens,
+            self.args.model_config["DECODE_RESIDUAL_MEMCFG"],
+        )
+        return tt_tokens, current_pos, [tt_rot_mats, tt_rot_mats_local], page_table
+
+    def process_output_prefill(self, tt_out, last_token_idx):
+        """
+        Input is ttnn device tensor of logits. Output is torch logits tensor.
+        NOTE: In this model, prefill always uses get_last_token
+        """
+        logits = ttnn.to_torch(
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                self.mesh_device, dims=(3, 1) if self.args.is_galaxy else (1, -1), mesh_shape=self.args.cluster_shape
+            ),
+        )[0, 0, last_token_idx, : self.vocab_size]
+        return logits
+
+    def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
+        """
+        Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
+        """
+        if is_tokens:
+            tt_out = ttnn.to_torch(
+                tt_out,  # tt_out.cpu(blocking=True, cq_id=1),
+                mesh_composer=ttnn.ConcatMesh2dToTensor(
+                    self.mesh_device,
+                    dims=(3, 1) if self.args.is_galaxy else (1, -1),
+                    mesh_shape=self.args.cluster_shape,
+                ),
+            )[0, 0, 0, :B]
+            return tt_out
+
+        if self.args.num_devices > 1:
+            tt_out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()
+        else:
+            tt_out = ttnn.to_torch(tt_out).float()
+        tt_out = tt_out[:, :, :B, : self.vocab_size].view(B, S, -1)
+        return tt_out
+
+    def ttnn_prefill_forward(
+        self,
+        x,
+        rot_mats,
+        user_id,
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        get_last_token=-1,
+        kv_cache=None,
+    ):
+        """
+        This method will take device tensors and any other args to run forward.
+        It returns ttnn device tensors.
+        """
+        return self.forward(
+            x,
+            current_pos=None,
+            rot_mats=rot_mats,
+            user_id=user_id,
+            mode="prefill",
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
+            get_last_token=get_last_token,
+            kv_cache=kv_cache,
+        )
+
+    def ttnn_decode_forward(
+        self,
+        x,
+        current_pos,
+        rot_mats,
+        page_table=None,
+        kv_cache=None,
+        argmax_on_device=False,
+    ):
+        """
+        This method will take device tensors and any other args to run forward.
+        It returns ttnn device tensors.
+        """
+        tt_logits = self.forward(
+            x,
+            current_pos,
+            rot_mats=rot_mats,
+            mode="decode",
+            page_table=page_table,
+            kv_cache=kv_cache,
+        )
+
+        # Gather the output across all devices and untilize the tensor (for argmax)
+        if self.args.num_devices > 1:
+            if self.args.is_galaxy:
+                tt_logits = ttnn.all_gather(
+                    tt_logits,
+                    dim=3,
+                    num_links=2,
+                    cluster_axis=0,
+                    mesh_device=self.mesh_device,
+                    topology=self.args.ccl_topology(),
+                )
+            else:
+                tt_logits = ttnn.all_gather(tt_logits, dim=3, num_links=1, topology=self.args.ccl_topology())
+        tt_logits = ttnn.untilize(tt_logits, use_multicore=True)
+
+        if argmax_on_device:
+            tt_logits = ttnn.argmax(  # TODO Add multicore support to batch > 1
+                tt_logits,
+                dim=3,
+                keepdim=True,
+                use_multicore=False if self.args.max_batch_size > 1 else True,  # ,output_tensor=tokens
+            )
+
+        return tt_logits
+
+    def forward(
+        self,
+        x: ttnn.Tensor,
+        current_pos,
+        rot_mats=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        get_last_token=-1,
+        kv_cache=None,
+    ):
+        for i, layer in enumerate(self.layers):
+            # No-op if callers already provide the right memory config
+            activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+                decoder_id=i, tensor=TensorGroup.ACTIVATION
+            )
+            if mode == "decode" and not self.args.is_galaxy:
+                x = ttnn.to_memory_config(x, self.model_config["DECODE_RESIDUAL_MEMCFG"], activation_dtype)
+            elif activation_dtype is not None and x.dtype != activation_dtype:
+                x = ttnn.typecast(x, activation_dtype)
+
+            x = layer(
+                x,
+                current_pos,
+                rot_mats,
+                user_id,
+                mode,
+                page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                kv_cache=kv_cache[i] if kv_cache is not None else None,
+            )
+
+        if mode == "prefill" and get_last_token == -1:
+            return x
+
+        # Slicing the tensor to the nearest ceiling/floor multiples of 32 for the prefill_len, to get the last token
+        if get_last_token != -1:
+            x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, x.shape[-1]))
+
+        # Output norm
+        x = self.norm(x, mode=mode)
+
+        if mode == "prefill" and self.model_config["LM_HEAD_INPUT_MEMCFG"].is_sharded():
+            x = ttnn.interleaved_to_sharded(x, self.model_config["LM_HEAD_INPUT_MEMCFG"])
+
+        x = self.lm_head(x)
+
+        if mode == "prefill":
+            x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)
+            # x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return x

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -45,7 +45,6 @@ class RopeScalingType(str, Enum):
 
     LINEAR = "linear"
     # DYNAMIC = "dynamic"
-    LINEAR = "linear"
     YARN = "yarn"
     LLAMA3 = "llama3"
     DEFAULT = "default"
@@ -91,8 +90,6 @@ def rope_scaling_model_factory(rope_scaling_params: dict) -> RopeScaling:
         return RopeScalingLlama3(**rope_scaling_params)
     elif rope_scaling_type == RopeScalingType.YARN:
         return RopeScalingYarn(**rope_scaling_params)
-    elif rope_scaling_type == RopeScalingType.LINEAR:
-        return RopeScalingLinear(**rope_scaling_params)
     elif rope_scaling_type in ["default", "mrope"]:
         logger.warning(
             f"Rope scaling type was set to {rope_scaling_type}, defaulting to no rope scaling as this rope type is not supported yet by TTT"

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -224,14 +224,6 @@ def preprocess_inputs_prefill(
     )
 
 
-def encode_multimodal_prompt_hf(tokenizer, model_id, prompt_text, system_prompt_text=None):
-    """See https://huggingface.co/docs/transformers/main/en/chat_templating"""
-    from transformers import AutoProcessor
-
-    processor = AutoProcessor.from_pretrained(model_id)
-    return processor.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)[0]
-
-
 def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
     """See https://huggingface.co/docs/transformers/main/en/chat_templating"""
     chat = []
@@ -241,6 +233,8 @@ def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
         if prompt_text:
             chat.append({"role": "user", "content": prompt_text})
         return tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
+    else:
+        return tokenizer.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)
 
 
 def freqs_to_rotation_matrix(cos_freqs, sin_freqs):

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -234,7 +234,7 @@ def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
             chat.append({"role": "user", "content": prompt_text})
         return tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
     else:
-        return tokenizer.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)
+        return tokenizer.apply_chat_template(prompt_text, add_generation_prompt=True, tokenize=True)
 
 
 def freqs_to_rotation_matrix(cos_freqs, sin_freqs):

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -224,6 +224,14 @@ def preprocess_inputs_prefill(
     )
 
 
+def encode_multimodal_prompt_hf(tokenizer, model_id, prompt_text, system_prompt_text=None):
+    """See https://huggingface.co/docs/transformers/main/en/chat_templating"""
+    from transformers import AutoProcessor
+
+    processor = AutoProcessor.from_pretrained(model_id)
+    return processor.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)[0]
+
+
 def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
     """See https://huggingface.co/docs/transformers/main/en/chat_templating"""
     chat = []
@@ -233,12 +241,6 @@ def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
         if prompt_text:
             chat.append({"role": "user", "content": prompt_text})
         return tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
-    else:
-        from transformers import AutoProcessor
-
-        model_id = "google/gemma-3-4b-it"
-        processor = AutoProcessor.from_pretrained(model_id)
-        return processor.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)[0]
 
 
 def compute_llama3_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -237,6 +237,48 @@ def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
         return tokenizer.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)
 
 
+def apply_scaling(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
+    # FIXME: Llama-3.x specific scaling - we need to support yarn for Qwen2.5 models
+    # Values obtained from grid search
+    low_freq_factor = 1
+    high_freq_factor = 4
+
+    low_freq_wavelen = orig_context_len / low_freq_factor
+    high_freq_wavelen = orig_context_len / high_freq_factor
+    new_freqs = []
+    for freq in freqs:
+        wavelen = 2 * math.pi / freq
+        if wavelen < high_freq_wavelen:
+            new_freqs.append(freq)
+        elif wavelen > low_freq_wavelen:
+            new_freqs.append(freq / scale_factor)
+        else:
+            assert low_freq_wavelen != high_freq_wavelen
+            smooth = (orig_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
+            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+
+
+def precompute_freqs(dim: int, end: int, theta, scale_factor, orig_context_len):
+    """
+    Precompute the frequency tensor for sine and cosine values with given dimensions.
+
+    Args:
+        dim (int): Dimension of the frequency tensor.
+        end (int): End index for precomputing frequencies.
+        theta (float, optional): Scaling factor for frequency computation. Defaults to 500000.0.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: Tensors containing cosine and sine values.
+    """
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end)
+    if scale_factor is not None:
+        freqs = apply_scaling(freqs, scale_factor, orig_context_len)
+    freqs = torch.outer(t, freqs).float()
+    return torch.cos(freqs), torch.sin(freqs)
+
+
 def freqs_to_rotation_matrix(cos_freqs, sin_freqs):
     """
     Transform cos/sin frequencies to a rotation matrix.

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-import os
 import re
 from enum import Enum
 from typing import Optional
@@ -587,11 +586,7 @@ def create_tt_model(
     state_dict=None,
     num_layers=None,
 ):
-    if "HF_MODEL" in os.environ and "gemma-3" in os.environ["HF_MODEL"].lower():
-        from models.experimental.gemma3_4b.tt.text_model import Gemma3_4BTransformer as Transformer
-    else:
-        from models.tt_transformers.tt.model import Transformer
-
+    from models.tt_transformers.tt.model import Transformer
     from models.tt_transformers.tt.model_config import ModelArgs
 
     tt_model_args = ModelArgs(

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
 import re
 from enum import Enum
 from typing import Optional
@@ -44,6 +45,7 @@ class RopeScalingType(str, Enum):
 
     LINEAR = "linear"
     # DYNAMIC = "dynamic"
+    LINEAR = "linear"
     YARN = "yarn"
     LLAMA3 = "llama3"
     DEFAULT = "default"
@@ -55,7 +57,7 @@ class RopeScaling(BaseModel):
     rope_type: RopeScalingType = Field(
         validation_alias=AliasChoices("rope_type", "type"), exclude=True, description="RoPE scaling type"
     )
-    factor: float
+    factor: Optional[float]
     original_max_position_embeddings: Optional[int] = None
 
 
@@ -89,6 +91,8 @@ def rope_scaling_model_factory(rope_scaling_params: dict) -> RopeScaling:
         return RopeScalingLlama3(**rope_scaling_params)
     elif rope_scaling_type == RopeScalingType.YARN:
         return RopeScalingYarn(**rope_scaling_params)
+    elif rope_scaling_type == RopeScalingType.LINEAR:
+        return RopeScalingLinear(**rope_scaling_params)
     elif rope_scaling_type in ["default", "mrope"]:
         logger.warning(
             f"Rope scaling type was set to {rope_scaling_type}, defaulting to no rope scaling as this rope type is not supported yet by TTT"
@@ -226,16 +230,22 @@ def preprocess_inputs_prefill(
 def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
     """See https://huggingface.co/docs/transformers/main/en/chat_templating"""
     chat = []
-    if system_prompt_text:
-        chat.append({"role": "system", "content": system_prompt_text})
-    if prompt_text:
-        chat.append({"role": "user", "content": prompt_text})
-    return tokenizer.apply_chat_template(chat, tokenize=True, add_generation_prompt=True)
+    if isinstance(prompt_text, str):
+        if system_prompt_text:
+            chat.append({"role": "system", "content": system_prompt_text})
+        if prompt_text:
+            chat.append({"role": "user", "content": prompt_text})
+        return tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
+    else:
+        from transformers import AutoProcessor
+
+        model_id = "google/gemma-3-4b-it"
+        processor = AutoProcessor.from_pretrained(model_id)
+        return processor.apply_chat_template([prompt_text], add_generation_prompt=True, tokenize=True)[0]
 
 
-def apply_scaling(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
-    # FIXME: Llama-3.x specific scaling - we need to support yarn for Qwen2.5 models
-    # Values obtained from grid search
+def compute_llama3_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
+    """Llama-3.x specific scaling for rotary embeddings."""
     low_freq_factor = 1
     high_freq_factor = 4
 
@@ -253,6 +263,30 @@ def apply_scaling(freqs: torch.Tensor, scale_factor: float, orig_context_len: in
             smooth = (orig_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
             new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
     return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+
+
+def compute_linear_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
+    """Linear scaling for rotary embeddings."""
+    freqs /= scale_factor
+    return freqs
+
+
+def compute_default_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
+    """Default scaling for rotary embeddings."""
+    return freqs
+
+
+def apply_scaling(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
+    # FIXME: Llama-3.x specific scaling - we need to support yarn for Qwen2.5 models
+
+    hf_model_env = os.getenv("HF_MODEL")
+
+    if hf_model_env == "google/gemma-3-4b-it":
+        freqs = compute_linear_parameters(freqs, scale_factor, orig_context_len)
+    elif "LLAMA_DIR" in os.environ or (hf_model_env and "llama" in hf_model_env.lower()):
+        freqs = compute_llama3_parameters(freqs, scale_factor, orig_context_len)
+
+    return freqs
 
 
 def precompute_freqs(dim: int, end: int, theta, scale_factor, orig_context_len):
@@ -610,7 +644,11 @@ def create_tt_model(
     state_dict=None,
     num_layers=None,
 ):
-    from models.tt_transformers.tt.model import Transformer
+    if "HF_MODEL" in os.environ and "gemma-3" in os.environ["HF_MODEL"].lower():
+        from models.experimental.gemma3_4b.tt.text_model import Gemma3_4BTransformer as Transformer
+    else:
+        from models.tt_transformers.tt.model import Transformer
+
     from models.tt_transformers.tt.model_config import ModelArgs
 
     tt_model_args = ModelArgs(

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -243,71 +243,6 @@ def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
         return tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=True)
 
 
-def compute_llama3_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
-    """Llama-3.x specific scaling for rotary embeddings."""
-    low_freq_factor = 1
-    high_freq_factor = 4
-
-    low_freq_wavelen = orig_context_len / low_freq_factor
-    high_freq_wavelen = orig_context_len / high_freq_factor
-    new_freqs = []
-    for freq in freqs:
-        wavelen = 2 * math.pi / freq
-        if wavelen < high_freq_wavelen:
-            new_freqs.append(freq)
-        elif wavelen > low_freq_wavelen:
-            new_freqs.append(freq / scale_factor)
-        else:
-            assert low_freq_wavelen != high_freq_wavelen
-            smooth = (orig_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
-            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
-
-
-def compute_linear_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
-    """Linear scaling for rotary embeddings."""
-    freqs /= scale_factor
-    return freqs
-
-
-def compute_default_parameters(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
-    """Default scaling for rotary embeddings."""
-    return freqs
-
-
-def apply_scaling(freqs: torch.Tensor, scale_factor: float, orig_context_len: int):
-    # FIXME: Llama-3.x specific scaling - we need to support yarn for Qwen2.5 models
-
-    hf_model_env = os.getenv("HF_MODEL")
-
-    if hf_model_env == "google/gemma-3-4b-it":
-        freqs = compute_linear_parameters(freqs, scale_factor, orig_context_len)
-    elif "LLAMA_DIR" in os.environ or (hf_model_env and "llama" in hf_model_env.lower()):
-        freqs = compute_llama3_parameters(freqs, scale_factor, orig_context_len)
-
-    return freqs
-
-
-def precompute_freqs(dim: int, end: int, theta, scale_factor, orig_context_len):
-    """
-    Precompute the frequency tensor for sine and cosine values with given dimensions.
-
-    Args:
-        dim (int): Dimension of the frequency tensor.
-        end (int): End index for precomputing frequencies.
-        theta (float, optional): Scaling factor for frequency computation. Defaults to 500000.0.
-
-    Returns:
-        Tuple[torch.Tensor, torch.Tensor]: Tensors containing cosine and sine values.
-    """
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
-    t = torch.arange(end)
-    if scale_factor is not None:
-        freqs = apply_scaling(freqs, scale_factor, orig_context_len)
-    freqs = torch.outer(t, freqs).float()
-    return torch.cos(freqs), torch.sin(freqs)
-
-
 def freqs_to_rotation_matrix(cos_freqs, sin_freqs):
     """
     Transform cos/sin frequencies to a rotation matrix.
@@ -331,33 +266,6 @@ def gather_cos_sin(position_ids, cos, sin):
     cos = torch.stack([cos, cos], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
     sin = torch.stack([sin, sin], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
     return cos, sin
-
-
-def get_prefill_rot_mat(head_dim, mesh_device, seq_len, theta, scale_factor, orig_context_len, start_pos=0):
-    cos, sin = precompute_freqs(
-        head_dim, seq_len * 2, theta=theta, scale_factor=scale_factor, orig_context_len=orig_context_len
-    )
-    cos_gathered, sin_gathered = gather_cos_sin(torch.arange(start_pos, start_pos + seq_len), cos, sin)
-    assert cos_gathered.size() == (1, 1, seq_len, head_dim)
-    assert sin_gathered.size() == (1, 1, seq_len, head_dim)
-
-    cos_gathereds = ttnn.from_torch(
-        cos_gathered,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-    sin_gathereds = ttnn.from_torch(
-        sin_gathered,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-
-    rot_mats = [cos_gathereds, sin_gathereds]
-    return rot_mats
 
 
 #  Add-Multiply method of rotary embeddings for prefill
@@ -606,7 +514,7 @@ def pad_to_size(x: torch.Tensor, dim: int, size: int) -> torch.Tensor:
     if dim < 0:
         dim = x.dim() + dim
     assert isinstance(x, torch.Tensor), "Input must be a torch.Tensor"
-    assert -x.dim() <= dim < x.dim(), f"Dimension {dim} out of range (expected between {-x.dim()} and {x.dim()-1})"
+    assert -x.dim() <= dim < x.dim(), f"Dimension {dim} out of range (expected between {-x.dim()} and {x.dim() - 1})"
     dim = x.dim() + dim if dim < 0 else dim
 
     current_size = x.size(dim)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -58,7 +58,13 @@ class Generator:
 
     # Note: This function is called by vLLM
     def prefill_forward_text(
-        self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None, empty_slots=None
+        self,
+        tokens: torch.Tensor,
+        page_table=None,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        **kwargs,
     ):
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
@@ -102,6 +108,7 @@ class Generator:
                 last_token_idx=last_token_idx,
                 kv_cache=model_kv_cache,
                 model_id=model_id,
+                **kwargs,
             )
             out_list.append(logits)
 
@@ -117,7 +124,9 @@ class Generator:
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         return output_logits
 
-    def prefill_forward_single_user_text(self, tokens, page_table, user_id, last_token_idx, kv_cache=None, model_id=-1):
+    def prefill_forward_single_user_text(
+        self, tokens, page_table, user_id, last_token_idx, kv_cache=None, model_id=-1, **kwargs
+    ):
         seq_len = tokens.shape[-1]
         use_chunked_prefill = seq_len > self.model_args[model_id].max_prefill_chunk_size
         if use_chunked_prefill:
@@ -167,6 +176,7 @@ class Generator:
                     start_pos=chunk_start,
                     page_table=page_table_user_padded,
                     chunk_page_table=chunk_page_table,
+                    **kwargs,
                 )
                 tt_logits = self.model[model_id].ttnn_prefill_forward(
                     chunk_prefill_input,
@@ -194,6 +204,7 @@ class Generator:
             ) = self.model[model_id].prepare_inputs_prefill(
                 tokens,
                 page_table=page_table,
+                **kwargs,
             )
 
             tt_logits = self.model[model_id].ttnn_prefill_forward(

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -87,7 +87,6 @@ def convert_hf_to_meta(state_dict, head_dim):
 
 def convert_vision_hf_to_meta(state_dict, head_dim):
     state_dict = split_hf_keys(state_dict)
-    # state_dict = convert_hf_qkv_to_meta_format(state_dict, head_dim)
     state_dict = map_vision_hf_to_meta_keys(state_dict, head_dim)
     return state_dict
 
@@ -265,27 +264,27 @@ def map_vision_meta_to_hf_keys(loaded_weights):
         "_linear.weight": "weight",  # patch_embedding
         "_linear.bias": "bias",  # patch_embedding
         "positional_embedding": "weight",  # pos_emb
-        "model.vision_tower.vision_model.embeddings.patch_embedding._linear.weight": "vision_tower.vision_model.embeddings.patch_embedding.weight",
-        "model.vision_tower.vision_model.embeddings.patch_embedding._linear.bias": "vision_tower.vision_model.embeddings.patch_embedding._linear.bias",
-        "model.vision_tower.vision_model.embeddings.position_embedding.positional_embedding": "vision_tower.vision_model.embeddings.position_embedding.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.weight": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.bias": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.weight": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.bias": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.weight": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.bias": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.weight": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.bias": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.bias",
-        "model.vision_tower.vision_model.ln_post.weight": "vision_tower.vision_model.post_layernorm.weight",
-        "model.vision_tower.vision_model.ln_post.bias": "vision_tower.vision_model.post_layernorm.bias",
+        "visual.embeddings.patch_embedding._linear.weight": "visual.embeddings.patch_embedding.weight",
+        "visual.embeddings.patch_embedding._linear.bias": "visual.embeddings.patch_embedding._linear.bias",
+        "visual.embeddings.position_embedding.positional_embedding": "visual.embeddings.position_embedding.weight",
+        "visual.encoder.layers.{layer}.attn.wq.weight": "visual.encoder.layers.{layer}.self_attn.q_proj.weight",
+        "visual.encoder.layers.{layer}.attn.wk.weight": "visual.encoder.layers.{layer}.self_attn.k_proj.weight",
+        "visual.encoder.layers.{layer}.attn.wv.weight": "visual.encoder.layers.{layer}.self_attn.v_proj.weight",
+        "visual.encoder.layers.{layer}.attn.wo.weight": "visual.encoder.layers.{layer}.self_attn.out_proj.weight",
+        "visual.encoder.layers.{layer}.attn.wq.bias": "visual.encoder.layers.{layer}.self_attn.q_proj.bias",
+        "visual.encoder.layers.{layer}.attn.wk.bias": "visual.encoder.layers.{layer}.self_attn.k_proj.bias",
+        "visual.encoder.layers.{layer}.attn.wv.bias": "visual.encoder.layers.{layer}.self_attn.v_proj.bias",
+        "visual.encoder.layers.{layer}.attn.wo.bias": "visual.encoder.layers.{layer}.self_attn.out_proj.bias",
+        "visual.encoder.layers.{layer}.ln_1.weight": "visual.encoder.layers.{layer}.layer_norm1.weight",
+        "visual.encoder.layers.{layer}.ln_1.bias": "visual.encoder.layers.{layer}.layer_norm1.bias",
+        "visual.encoder.layers.{layer}.ln_2.weight": "visual.encoder.layers.{layer}.layer_norm2.weight",
+        "visual.encoder.layers.{layer}.ln_2.bias": "visual.encoder.layers.{layer}.layer_norm2.bias",
+        "visual.encoder.layers.{layer}.mlp.c_fc.weight": "visual.encoder.layers.{layer}.mlp.fc1.weight",
+        "visual.encoder.layers.{layer}.mlp.c_fc.bias": "visual.encoder.layers.{layer}.mlp.fc1.bias",
+        "visual.encoder.layers.{layer}.mlp.c_proj.weight": "visual.encoder.layers.{layer}.mlp.fc2.weight",
+        "visual.encoder.layers.{layer}.mlp.c_proj.bias": "visual.encoder.layers.{layer}.mlp.fc2.bias",
+        "visual.ln_post.weight": "visual.post_layernorm.weight",
+        "visual.ln_post.bias": "visual.post_layernorm.bias",
     }
 
     for key, tensor in loaded_weights.items():
@@ -339,14 +338,14 @@ def map_vision_hf_to_meta_keys(loaded_weights, head_dim):
         "fc2.weight": "c_proj.weight",
         "fc2.bias": "c_proj.bias",
         # vision attention
-        # "q_proj.weight": "wq.weight",
-        # "k_proj.weight": "wk.weight",
-        # "v_proj.weight": "wv.weight",
-        # "out_proj.weight": "wo.weight",
-        # "q_proj.bias": "wq.bias",
-        # "k_proj.bias": "wk.bias",
-        # "v_proj.bias": "wv.bias",
-        # "out_proj.bias": "wo.bias",
+        "q_proj.weight": "wq.weight",
+        "k_proj.weight": "wk.weight",
+        "v_proj.weight": "wv.weight",
+        "out_proj.weight": "wo.weight",
+        "q_proj.bias": "wq.bias",
+        "k_proj.bias": "wk.bias",
+        "v_proj.bias": "wv.bias",
+        "out_proj.bias": "wo.bias",
         # vision encoder
         "self_attn.q_proj.weight": "attn.wq.weight",
         "self_attn.k_proj.weight": "attn.wk.weight",
@@ -379,49 +378,46 @@ def map_vision_hf_to_meta_keys(loaded_weights, head_dim):
         "weight": "_linear.weight",
         "bias": "_linear.bias",
         "weight": "positional_embedding",  # pos_emb
-        "model.vision_tower.vision_model.embeddings.patch_embedding.weight": "model.vision_tower.vision_model.embeddings.patch_embedding._linear.weight",
-        "model.vision_tower.vision_model.embeddings.patch_embedding.bias": "model.vision_tower.vision_model.embeddings.patch_embedding._linear.bias",
-        "model.vision_tower.vision_model.embeddings.position_embedding.weight": "model.vision_tower.vision_model.embeddings.position_embedding.positional_embedding",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.bias",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.weight",
-        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.bias",
-        "model.vision_tower.vision_model.post_layernorm.weight": "model.vision_tower.vision_model.ln_post.weight",
-        "model.vision_tower.vision_model.post_layernorm.bias": "model.vision_tower.vision_model.ln_post.bias",
+        "visual.embeddings.patch_embedding.weight": "visual.embeddings.patch_embedding._linear.weight",
+        "visual.embeddings.patch_embedding.bias": "visual.embeddings.patch_embedding._linear.bias",
+        "visual.embeddings.position_embedding.weight": "visual.embeddings.position_embedding.positional_embedding",
+        "visual.encoder.layers.{layer}.self_attn.q_proj.weight": "visual.encoder.layers.{layer}.attn.wq.weight",
+        "visual.encoder.layers.{layer}.self_attn.k_proj.weight": "visual.encoder.layers.{layer}.attn.wk.weight",
+        "visual.encoder.layers.{layer}.self_attn.v_proj.weight": "visual.encoder.layers.{layer}.attn.wv.weight",
+        "visual.encoder.layers.{layer}.self_attn.out_proj.weight": "visual.encoder.layers.{layer}.attn.wo.weight",
+        "visual.encoder.layers.{layer}.self_attn.q_proj.bias": "visual.encoder.layers.{layer}.attn.wq.bias",
+        "visual.encoder.layers.{layer}.self_attn.k_proj.bias": "visual.encoder.layers.{layer}.attn.wk.bias",
+        "visual.encoder.layers.{layer}.self_attn.v_proj.bias": "visual.encoder.layers.{layer}.attn.wv.bias",
+        "visual.encoder.layers.{layer}.self_attn.out_proj.bias": "visual.encoder.layers.{layer}.attn.wo.bias",
+        "visual.encoder.layers.{layer}.layer_norm1.weight": "visual.encoder.layers.{layer}.ln_1.weight",
+        "visual.encoder.layers.{layer}.layer_norm1.bias": "visual.encoder.layers.{layer}.ln_1.bias",
+        "visual.encoder.layers.{layer}.layer_norm2.weight": "visual.encoder.layers.{layer}.ln_2.weight",
+        "visual.encoder.layers.{layer}.layer_norm2.bias": "visual.encoder.layers.{layer}.ln_2.bias",
+        "visual.encoder.layers.{layer}.mlp.fc1.weight": "visual.encoder.layers.{layer}.mlp.c_fc.weight",
+        "visual.encoder.layers.{layer}.mlp.fc1.bias": "visual.encoder.layers.{layer}.mlp.c_fc.bias",
+        "visual.encoder.layers.{layer}.mlp.fc2.weight": "visual.encoder.layers.{layer}.mlp.c_proj.weight",
+        "visual.encoder.layers.{layer}.mlp.fc2.bias": "visual.encoder.layers.{layer}.mlp.c_proj.bias",
+        "visual.post_layernorm.weight": "visual.ln_post.weight",
+        "visual.post_layernorm.bias": "visual.ln_post.bias",
     }
 
     remapped = {}
     for key, tensor in loaded_weights.items():
         if key in hf_to_meta:
             remapped[hf_to_meta[key]] = tensor
-        elif "model.vision_tower.vision_model.encoder.layers." in key:
+        elif "visual.encoder.layers." in key:
             parts = key.split(".")
-            layer_num = parts[5]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
-            template_key = "model.vision_tower.vision_model.encoder.layers.{layer}." + ".".join(parts[6:])
+            layer_num = parts[3]  # e.g. "0" in "visual.encoder.layers.0.layer_norm1.weight"
+            template_key = "visual.encoder.layers.{layer}." + ".".join(parts[4:])
             if template_key in hf_to_meta:
                 remapped[hf_to_meta[template_key].format(layer=layer_num)] = tensor
         else:
             remapped[key] = tensor
 
     # Remove language_model keys
-    non_text_weights = {k: v for k, v in remapped.items() if not k.startswith("model.language_model.")}
-    text_weights = {
-        k: v for k, v in loaded_weights.items() if k.startswith("model.language_model.") or k.startswith("lm_head.")
-    }
+    non_text_weights = {k: v for k, v in remapped.items() if not k.startswith("model.")}
+    text_weights = {k: v for k, v in loaded_weights.items() if k.startswith("model.") or k.startswith("lm_head.")}
     text_weights = convert_hf_qkv_to_meta_format(text_weights, head_dim)
-    # remapped_text = map_hf_to_meta_keys(text_weights, prefix="model.language_model.")
     remapped_text = map_hf_to_meta_keys(text_weights)
     return {**non_text_weights, **remapped_text}
 

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -85,6 +85,347 @@ def convert_hf_to_meta(state_dict, head_dim):
     return state_dict
 
 
+def convert_vision_hf_to_meta(state_dict, head_dim):
+    state_dict = split_hf_keys(state_dict)
+    # state_dict = convert_hf_qkv_to_meta_format(state_dict, head_dim)
+    state_dict = map_vision_hf_to_meta_keys(state_dict, head_dim)
+    return state_dict
+
+
+def map_hf_to_meta_keys(loaded_weights):
+    hf_to_meta = {
+        # Top level mappings
+        "model.embed_tokens.weight": "tok_embeddings.weight",
+        "model.norm.weight": "norm.weight",
+        "lm_head.weight": "output.weight",
+        # Layer level mappings
+        "input_layernorm.weight": "attention_norm.weight",
+        "post_attention_layernorm.weight": "ffn_norm.weight",
+        # Attention module mappings
+        "self_attn.q_proj.weight": "attention.wq.weight",
+        "self_attn.k_proj.weight": "attention.wk.weight",
+        "self_attn.v_proj.weight": "attention.wv.weight",
+        "self_attn.o_proj.weight": "attention.wo.weight",
+        "self_attn.q_proj.bias": "attention.wq.bias",
+        "self_attn.k_proj.bias": "attention.wk.bias",
+        "self_attn.v_proj.bias": "attention.wv.bias",
+        "self_attn.q_norm.weight": "attention.q_norm.weight",
+        "self_attn.k_norm.weight": "attention.k_norm.weight",
+        "self_attn.o_proj.bias": "attention.wo.bias",
+        # Feed forward module mappings
+        "mlp.gate_proj.weight": "feed_forward.w1.weight",
+        "mlp.up_proj.weight": "feed_forward.w3.weight",
+        "mlp.down_proj.weight": "feed_forward.w2.weight",
+        # MLP bias mappings
+        "mlp.gate_proj.bias": "feed_forward.w1.bias",
+        "mlp.up_proj.bias": "feed_forward.w3.bias",
+        "mlp.down_proj.bias": "feed_forward.w2.bias",
+        # === Additional FFN layernorms (Gemma3 specific) ===
+        "pre_feedforward_layernorm.weight": "pre_feedforward_layernorm.weight",
+        "post_feedforward_layernorm.weight": "post_feedforward_layernorm.weight",
+        # Direct module mappings
+        "gate_proj.weight": "w1.weight",
+        "down_proj.weight": "w2.weight",
+        "up_proj.weight": "w3.weight",
+        "q_proj.weight": "wq.weight",
+        "k_proj.weight": "wk.weight",
+        "v_proj.weight": "wv.weight",
+        "o_proj.weight": "wo.weight",
+        "q_proj.bias": "wq.bias",
+        "k_proj.bias": "wk.bias",
+        "v_proj.bias": "wv.bias",
+        "q_norm.weight": "q_norm.weight",
+        "k_norm.weight": "k_norm.weight",
+        "o_proj.bias": "wo.bias",
+        # Direct MLP bias mappings
+        "gate_proj.bias": "w1.bias",
+        "up_proj.bias": "w3.bias",
+        "down_proj.bias": "w2.bias",
+        "weight": "emb.weight",  # For host embeddings
+        # Full path layer mappings
+        "model.layers.{layer}.input_layernorm.weight": "layers.{layer}.attention_norm.weight",
+        "model.layers.{layer}.post_attention_layernorm.weight": "layers.{layer}.ffn_norm.weight",
+        "model.layers.{layer}.self_attn.q_proj.weight": "layers.{layer}.attention.wq.weight",
+        "model.layers.{layer}.self_attn.k_proj.weight": "layers.{layer}.attention.wk.weight",
+        "model.layers.{layer}.self_attn.v_proj.weight": "layers.{layer}.attention.wv.weight",
+        "model.layers.{layer}.self_attn.o_proj.weight": "layers.{layer}.attention.wo.weight",
+        "model.layers.{layer}.self_attn.q_proj.bias": "layers.{layer}.attention.wq.bias",
+        "model.layers.{layer}.self_attn.k_proj.bias": "layers.{layer}.attention.wk.bias",
+        "model.layers.{layer}.self_attn.v_proj.bias": "layers.{layer}.attention.wv.bias",
+        "model.layers.{layer}.self_attn.q_norm.weight": "layers.{layer}.attention.q_norm.weight",
+        "model.layers.{layer}.self_attn.k_norm.weight": "layers.{layer}.attention.k_norm.weight",
+        "model.layers.{layer}.self_attn.o_proj.bias": "layers.{layer}.attention.wo.bias",
+        "model.layers.{layer}.mlp.gate_proj.weight": "layers.{layer}.feed_forward.w1.weight",
+        "model.layers.{layer}.mlp.up_proj.weight": "layers.{layer}.feed_forward.w3.weight",
+        "model.layers.{layer}.mlp.down_proj.weight": "layers.{layer}.feed_forward.w2.weight",
+        # Full path MLP bias mappings
+        "model.layers.{layer}.mlp.gate_proj.bias": "layers.{layer}.feed_forward.w1.bias",
+        "model.layers.{layer}.mlp.up_proj.bias": "layers.{layer}.feed_forward.w3.bias",
+        "model.layers.{layer}.mlp.down_proj.bias": "layers.{layer}.feed_forward.w2.bias",
+        "model.layers.{layer}.pre_feedforward_layernorm.weight": "layers.{layer}.pre_feedforward_layernorm.weight",
+        "model.layers.{layer}.post_feedforward_layernorm.weight": "layers.{layer}.post_feedforward_layernorm.weight",
+    }
+
+    meta_state_dict = {}
+    for key, tensor in loaded_weights.items():
+        # Remove known prefix if present
+        prefix = next((p for p in _get_known_prefixes_mapping().keys() if key.startswith(p)), "")
+        key = key.replace(prefix, _get_known_prefixes_mapping().get(prefix, ""), 1)
+
+        new_key = key
+        if key in hf_to_meta:
+            # Direct match for top-level keys
+            new_key = hf_to_meta[key]
+        elif key.startswith("model.layers."):
+            # Extract layer number and form a template key
+            parts = key.split(".")
+            layer_num = parts[2]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
+            template_key = "model.layers.{layer}." + ".".join(parts[3:])
+            if template_key in hf_to_meta:
+                new_key = hf_to_meta[template_key].format(layer=layer_num)
+            else:
+                new_key = key[len("model.") :]  # Remove "model." prefix
+
+        meta_state_dict[new_key] = tensor
+
+    return meta_state_dict
+
+
+def map_vision_meta_to_hf_keys(loaded_weights):
+    language_weights = {
+        key[len("language_model.") :]: tensor
+        for key, tensor in loaded_weights.items()
+        if key.startswith("language_model.")
+    }
+    mapped_language_weights = map_meta_to_hf_keys(language_weights, language_prefix="language_model.")
+    other_weights = {key: tensor for key, tensor in loaded_weights.items() if not key.startswith("language_model.")}
+    hf_state_dict = {**mapped_language_weights}
+    loaded_weights = {**other_weights}
+    meta_to_hf_mappings = {
+        # vision MLP
+        "c_fc.weight": "fc1.weight",
+        "c_fc.bias": "fc1.bias",
+        "c_proj.weight": "fc2.weight",
+        "c_proj.bias": "fc2.bias",
+        # vision attention
+        # "wq.weight": "q_proj.weight",
+        # "wk.weight": "k_proj.weight",
+        # "wv.weight": "v_proj.weight",
+        # "wo.weight": "out_proj.weight",
+        # "wq.bias": "q_proj.bias",
+        # "wk.bias": "k_proj.bias",
+        # "wv.bias": "v_proj.bias",
+        # "wo.bias": "out_proj.bias",
+        # vision encoder block
+        "attn.wq.weight": "self_attn.q_proj.weight",
+        "attn.wk.weight": "self_attn.k_proj.weight",
+        "attn.wv.weight": "self_attn.v_proj.weight",
+        "attn.wo.weight": "self_attn.out_proj.weight",
+        "attn.wq.bias": "self_attn.q_proj.bias",
+        "attn.wk.bias": "self_attn.k_proj.bias",
+        "attn.wv.bias": "self_attn.v_proj.bias",
+        "attn.wo.bias": "self_attn.out_proj.bias",
+        "ln_1.weight": "layer_norm1.weight",
+        "ln_1.bias": "layer_norm1.bias",
+        "ln_2.weight": "layer_norm2.weight",
+        "ln_2.bias": "layer_norm2.bias",
+        "mlp.c_fc.weight": "mlp.fc1.weight",
+        "mlp.c_fc.bias": "mlp.fc1.bias",
+        "mlp.c_proj.weight": "mlp.fc2.weight",
+        "mlp.c_proj.bias": "mlp.fc2.bias",
+        # vision encoder
+        "layers.{layer}.attn.wq.weight": "layers.{layer}.self_attn.q_proj.weight",
+        "layers.{layer}.attn.wk.weight": "layers.{layer}.self_attn.k_proj.weight",
+        "layers.{layer}.attn.wv.weight": "layers.{layer}.self_attn.v_proj.weight",
+        "layers.{layer}.attn.wo.weight": "layers.{layer}.self_attn.out_proj.weight",
+        "layers.{layer}.attn.wq.bias": "layers.{layer}.self_attn.q_proj.bias",
+        "layers.{layer}.attn.wk.bias": "layers.{layer}.self_attn.k_proj.bias",
+        "layers.{layer}.attn.wv.bias": "layers.{layer}.self_attn.v_proj.bias",
+        "layers.{layer}.attn.wo.bias": "layers.{layer}.self_attn.out_proj.bias",
+        "layers.{layer}.ln_1.weight": "layers.{layer}.layer_norm1.weight",
+        "layers.{layer}.ln_1.bias": "layers.{layer}.layer_norm1.bias",
+        "layers.{layer}.ln_2.weight": "layers.{layer}.layer_norm2.weight",
+        "layers.{layer}.ln_2.bias": "layers.{layer}.layer_norm2.bias",
+        "layers.{layer}.mlp.c_fc.weight": "layers.{layer}.mlp.fc1.weight",
+        "layers.{layer}.mlp.c_fc.bias": "layers.{layer}.mlp.fc1.bias",
+        "layers.{layer}.mlp.c_proj.weight": "layers.{layer}.mlp.fc2.weight",
+        "layers.{layer}.mlp.c_proj.bias": "layers.{layer}.mlp.fc2.bias",
+        # vision transformer
+        "encoder.layers.{layer}.attn.wq.weight": "encoder.layers.{layer}.self_attn.q_proj.weight",
+        "encoder.layers.{layer}.attn.wk.weight": "encoder.layers.{layer}.self_attn.k_proj.weight",
+        "encoder.layers.{layer}.attn.wv.weight": "encoder.layers.{layer}.self_attn.v_proj.weight",
+        "encoder.layers.{layer}.attn.wo.weight": "encoder.layers.{layer}.self_attn.out_proj.weight",
+        "encoder.layers.{layer}.attn.wq.bias": "encoder.layers.{layer}.self_attn.q_proj.bias",
+        "encoder.layers.{layer}.attn.wk.bias": "encoder.layers.{layer}.self_attn.k_proj.bias",
+        "encoder.layers.{layer}.attn.wv.bias": "encoder.layers.{layer}.self_attn.v_proj.bias",
+        "encoder.layers.{layer}.attn.wo.bias": "encoder.layers.{layer}.self_attn.out_proj.bias",
+        "ln_post.weight": "post_layernorm.weight",
+        "ln_post.bias": "post_layernorm.bias",
+        # Top level
+        "_linear.weight": "weight",  # patch_embedding
+        "_linear.bias": "bias",  # patch_embedding
+        "positional_embedding": "weight",  # pos_emb
+        "model.vision_tower.vision_model.embeddings.patch_embedding._linear.weight": "vision_tower.vision_model.embeddings.patch_embedding.weight",
+        "model.vision_tower.vision_model.embeddings.patch_embedding._linear.bias": "vision_tower.vision_model.embeddings.patch_embedding._linear.bias",
+        "model.vision_tower.vision_model.embeddings.position_embedding.positional_embedding": "vision_tower.vision_model.embeddings.position_embedding.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.weight": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.bias": "vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.weight": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.bias": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.weight": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.bias": "vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.weight": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.bias": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.weight": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.bias": "vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.bias",
+        "model.vision_tower.vision_model.ln_post.weight": "vision_tower.vision_model.post_layernorm.weight",
+        "model.vision_tower.vision_model.ln_post.bias": "vision_tower.vision_model.post_layernorm.bias",
+    }
+
+    for key, tensor in loaded_weights.items():
+        # Handle full model paths with layer numbers
+        if "model.vision_tower.vision_model.encoder.layers." in key:
+            parts = key.split(".")
+            layer_num = parts[5]
+            remainder = ".".join(parts[6:])
+            if remainder in meta_to_hf_mappings:
+                new_key = f"model.vision_tower.vision_model.encoder.layers.{layer_num}.{meta_to_hf_mappings[remainder]}"
+                hf_state_dict[new_key] = tensor
+            continue
+
+        # Handle full vision encoder paths with layer numbers
+        if "layers." in key:
+            parts = key.split(".")
+            layer_num = parts[1]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
+            template_key = "layers.{layer}." + ".".join(parts[2:])
+            if template_key in meta_to_hf_mappings:
+                hf_state_dict[meta_to_hf_mappings[template_key].format(layer=layer_num)] = tensor
+                continue
+
+        # Try exact matches first
+        if key in meta_to_hf_mappings:
+            hf_state_dict[meta_to_hf_mappings[key]] = tensor
+            continue
+
+        # For submodule state dicts, try matching the end of the key
+        matched = False
+        for meta_pattern, hf_pattern in meta_to_hf_mappings.items():
+            if key.endswith("." + meta_pattern):
+                # Replace only the matching part at the end
+                prefix = key[: -len(meta_pattern)]
+                new_key = prefix + hf_pattern
+                hf_state_dict[new_key] = tensor
+                matched = True
+                break
+
+        # If no mapping found, keep the original key
+        if not matched:
+            hf_state_dict[key] = tensor
+
+    return hf_state_dict
+
+
+def map_vision_hf_to_meta_keys(loaded_weights, head_dim):
+    hf_to_meta = {
+        # vision MLP
+        "fc1.weight": "c_fc.weight",
+        "fc1.bias": "c_fc.bias",
+        "fc2.weight": "c_proj.weight",
+        "fc2.bias": "c_proj.bias",
+        # vision attention
+        # "q_proj.weight": "wq.weight",
+        # "k_proj.weight": "wk.weight",
+        # "v_proj.weight": "wv.weight",
+        # "out_proj.weight": "wo.weight",
+        # "q_proj.bias": "wq.bias",
+        # "k_proj.bias": "wk.bias",
+        # "v_proj.bias": "wv.bias",
+        # "out_proj.bias": "wo.bias",
+        # vision encoder
+        "self_attn.q_proj.weight": "attn.wq.weight",
+        "self_attn.k_proj.weight": "attn.wk.weight",
+        "self_attn.v_proj.weight": "attn.wv.weight",
+        "self_attn.out_proj.weight": "attn.wo.weight",
+        "self_attn.q_proj.bias": "attn.wq.bias",
+        "self_attn.k_proj.bias": "attn.wk.bias",
+        "self_attn.v_proj.bias": "attn.wv.bias",
+        "self_attn.out_proj.bias": "attn.wo.bias",
+        "layer_norm1.weight": "ln_1.weight",
+        "layer_norm1.bias": "ln_1.bias",
+        "layer_norm2.weight": "ln_2.weight",
+        "layer_norm2.bias": "ln_2.bias",
+        "mlp.fc1.weight": "mlp.c_fc.weight",
+        "mlp.fc1.bias": "mlp.c_fc.bias",
+        "mlp.fc2.weight": "mlp.c_proj.weight",
+        "mlp.fc2.bias": "mlp.c_proj.bias",
+        # Top level
+        # vision transformer
+        "encoder.layers.{layer}.self_attn.q_proj.weight": "encoder.layers.{layer}.attn.wq.weight",
+        "encoder.layers.{layer}.self_attn.k_proj.weight": "encoder.layers.{layer}.attn.wk.weight",
+        "encoder.layers.{layer}.self_attn.v_proj.weight": "encoder.layers.{layer}.attn.wv.weight",
+        "encoder.layers.{layer}.self_attn.out_proj.weight": "encoder.layers.{layer}.attn.wo.weight",
+        "encoder.layers.{layer}.self_attn.q_proj.bias": "encoder.layers.{layer}.attn.wq.bias",
+        "encoder.layers.{layer}.self_attn.k_proj.bias": "encoder.layers.{layer}.attn.wk.bias",
+        "encoder.layers.{layer}.self_attn.v_proj.bias": "encoder.layers.{layer}.attn.wv.bias",
+        "encoder.layers.{layer}.self_attn.out_proj.bias": "encoder.layers.{layer}.attn.wo.bias",
+        "post_layernorm.weight": "ln_post.weight",
+        "post_layernorm.bias": "ln_post.bias",
+        "weight": "_linear.weight",
+        "bias": "_linear.bias",
+        "weight": "positional_embedding",  # pos_emb
+        "model.vision_tower.vision_model.embeddings.patch_embedding.weight": "model.vision_tower.vision_model.embeddings.patch_embedding._linear.weight",
+        "model.vision_tower.vision_model.embeddings.patch_embedding.bias": "model.vision_tower.vision_model.embeddings.patch_embedding._linear.bias",
+        "model.vision_tower.vision_model.embeddings.position_embedding.weight": "model.vision_tower.vision_model.embeddings.position_embedding.positional_embedding",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.q_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wq.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.k_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wk.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.v_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wv.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.self_attn.out_proj.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.attn.wo.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm1.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_1.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.layer_norm2.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.ln_2.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc1.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_fc.bias",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.weight": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.weight",
+        "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.fc2.bias": "model.vision_tower.vision_model.encoder.layers.{layer}.mlp.c_proj.bias",
+        "model.vision_tower.vision_model.post_layernorm.weight": "model.vision_tower.vision_model.ln_post.weight",
+        "model.vision_tower.vision_model.post_layernorm.bias": "model.vision_tower.vision_model.ln_post.bias",
+    }
+
+    remapped = {}
+    for key, tensor in loaded_weights.items():
+        if key in hf_to_meta:
+            remapped[hf_to_meta[key]] = tensor
+        elif "model.vision_tower.vision_model.encoder.layers." in key:
+            parts = key.split(".")
+            layer_num = parts[5]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
+            template_key = "model.vision_tower.vision_model.encoder.layers.{layer}." + ".".join(parts[6:])
+            if template_key in hf_to_meta:
+                remapped[hf_to_meta[template_key].format(layer=layer_num)] = tensor
+        else:
+            remapped[key] = tensor
+
+    # Remove language_model keys
+    non_text_weights = {k: v for k, v in remapped.items() if not k.startswith("model.language_model.")}
+    text_weights = {
+        k: v for k, v in loaded_weights.items() if k.startswith("model.language_model.") or k.startswith("lm_head.")
+    }
+    text_weights = convert_hf_qkv_to_meta_format(text_weights, head_dim)
+    # remapped_text = map_hf_to_meta_keys(text_weights, prefix="model.language_model.")
+    remapped_text = map_hf_to_meta_keys(text_weights)
+    return {**non_text_weights, **remapped_text}
+
+
 def load_meta_state_dict(ckpt_dir, n_layers=None, start_layer_idx=0):
     checkpoints = sorted(Path(ckpt_dir).glob("*.pth"))
     assert len(checkpoints) > 0, f"no checkpoint files found in {ckpt_dir}"
@@ -238,6 +579,7 @@ def map_hf_to_meta_keys(loaded_weights):
     """
     replacements = [
         ("^emb.weight", "weight"),
+        ("model.language_model.", ""),
         ("model.", ""),
         ("embed_tokens", "tok_embeddings"),
         ("lm_head", "output"),
@@ -252,11 +594,19 @@ def map_hf_to_meta_keys(loaded_weights):
         ("k_proj", "wk"),
         ("v_proj", "wv"),
         ("o_proj", "wo"),
+        ("q_norm", "q_norm"),
+        ("k_norm", "k_norm"),
     ]
     return replace_keys(loaded_weights, replacements)
 
 
-def map_meta_to_hf_keys(loaded_weights):
+def convert_vision_meta_to_hf(state_dict, head_dim):
+    # state_dict = convert_meta_qkv_to_hf_format(state_dict, head_dim)
+    state_dict = map_vision_meta_to_hf_keys(state_dict)
+    return state_dict
+
+
+def map_meta_to_hf_keys(loaded_weights, language_prefix=""):
     # Define mappings at each level of the hierarchy
     meta_to_hf_mappings = {
         # Top level
@@ -266,6 +616,8 @@ def map_meta_to_hf_keys(loaded_weights):
         # Layer level
         "attention_norm.weight": "input_layernorm.weight",
         "ffn_norm.weight": "post_attention_layernorm.weight",
+        "pre_feedforward_layernorm.weight": "pre_feedforward_layernorm.weight",
+        "post_feedforward_layernorm.weight": "post_feedforward_layernorm.weight",
         # Attention module
         "attention.wq.weight": "self_attn.q_proj.weight",
         "attention.wk.weight": "self_attn.k_proj.weight",

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1695,14 +1695,14 @@ class ModelArgs:
 
             if "text_config" in self.hf_config or "vision_config" in self.hf_config:
                 if "gemma-3-4b" in self.base_model_name:
-                    merged_text_config = merge_text_config(self.hf_config)
-                    self._set_params_from_dict(merged_text_config, is_hf=True)
-                    self._set_vision_params(self.hf_config)
+                    self._set_params_from_dict(self.hf_config, is_hf=True)
+                    if "vision_config" in self.hf_config:
+                        merged_vision_config = merge_vision_config(self.hf_config)
+                        self._set_vision_params(merged_vision_config)
                 else:
                     merged_text_config = merge_text_config(self.hf_config)
                     self._set_params_from_dict(merged_text_config, is_hf=True)
                     if "vision_config" in self.hf_config:
-                        print("Setting vision params from HF config")
                         merged_vision_config = merge_vision_config(self.hf_config)
                         self._set_vision_params(merged_vision_config)
             else:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1248,7 +1248,7 @@ class ModelArgs:
 
             self.model_config["XATTN_KV_PREFILL_MEM_CFG"] = _get_xattn_kv_prefill_mem_cfg
 
-            if self.is_vision():
+            if self.is_multimodal:
                 self.VISION_MAX_MM_SEQ = (
                     self.vision_chunk_ntok if "gemma-3" in self.base_model_name else nearest_32(self.vision_chunk_ntok)
                 )

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -871,7 +871,8 @@ class ModelArgs:
                 out_subblock_h=1,  # Must be divisible by per_core_M
                 out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
                 per_core_M=max(
-                    1, 8 if seq_len >= self.MAX_QKV_MM_SEQ_LEN else math.ceil(seq_len / self.tile_size / 8)  # 8 rows
+                    1,
+                    8 if seq_len >= self.MAX_QKV_MM_SEQ_LEN else math.ceil(seq_len / self.tile_size / 8),  # 8 rows
                 ),  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
                 per_core_N=math.ceil(
                     self.qkv_size / self.cluster_shape[1] / 32 / dram_shard_grid_width
@@ -1818,7 +1819,7 @@ class ModelArgs:
 
                 model = AutoModelForCausalLM.from_pretrained(
                     self.CKPT_DIR,
-                    torch_dtype="auto"
+                    torch_dtype="auto",
                     # Note that the default setting is torch.dtype.float32, but model weights are
                     # may come in any dtype. If the model's weights are in torch.dtype.bfloat16, this would result in 2x memory usage from an
                     # unnecessary cast.
@@ -2176,6 +2177,7 @@ class ModelArgs:
             # Mapping of base model names to their known tokenizer paths
             # These are the original models that have proper tokenizers
             base_model_tokenizer_mapping = {
+                "gemma-3-4b-it": "google/gemma-3-4b-it",
                 "Qwen2.5-0.5B": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
                 "Qwen2.5-1.5B": "Qwen/Qwen2.5-1.5B-Instruct",
                 "Qwen2.5-3B": "Qwen/Qwen2.5-3B-Instruct",

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1431,18 +1431,18 @@ class ModelArgs:
         # Try to get text_config, if it doesn't exist everything is text config
         text_config = config.get("text_config", config)
         self.eos_token_id = None if isinstance(eos_token_id, int) else eos_token_id
-
-        self.sliding_window_pattern = (
-            len(text_config["layer_types"])
-            if "layer_types" in text_config and text_config["layer_types"] is not None
-            else 1
-        )
+        layer_types = text_config["layer_types"] if "layer_types" in text_config else None
 
         # Common params with different names between Meta and HF
         self.dim = text_config.get("dim", text_config.get("hidden_size"))
         self.n_heads = text_config.get("n_heads", text_config.get("num_attention_heads"))
         self.n_kv_heads = text_config.get("n_kv_heads", text_config.get("num_key_value_heads"))
         self.n_layers = text_config.get("n_layers", text_config.get("num_hidden_layers"))
+
+        self.sliding_window_pattern = (
+            [lt == "sliding_attention" for lt in layer_types] if layer_types is not None else [False] * self.n_layers
+        )
+
         self.full_model_n_layers = self.n_layers
         self.norm_eps = text_config.get("norm_eps", text_config.get("rms_norm_eps"))
         self.vocab_size = text_config["vocab_size"]

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -58,6 +58,8 @@ class RotaryEmbedding(nn.Module):
         emb = torch.cat((freqs, freqs), dim=-1)
         cos = emb.cos()
         sin = emb.sin()
+        self.register_buffer("freqs_cis", torch.complex(cos.to(dtype), sin.to(dtype)), persistent=False)
+
         cos, sin = self.permute_to_meta_format(cos, sin)
         self.register_buffer("cos_cached", cos.to(dtype), persistent=False)
         self.register_buffer("sin_cached", sin.to(dtype), persistent=False)
@@ -99,8 +101,9 @@ class ScaledRotaryEmbedding(RotaryEmbedding, ABC):
         freqs = torch.outer(t, freqs).float()
         cos = torch.cos(freqs)
         sin = torch.sin(freqs)
-        cos, sin = gather_cos_sin(torch.arange(seq_len), cos, sin)
+        self.register_buffer("freqs_cis", torch.complex(cos.to(dtype), sin.to(dtype)), persistent=False)
 
+        cos, sin = gather_cos_sin(torch.arange(seq_len), cos, sin)
         self.register_buffer("cos_cached", cos.to(dtype), persistent=False)
         self.register_buffer("sin_cached", sin.to(dtype), persistent=False)
 
@@ -269,6 +272,15 @@ def rotary_embedding_factory(
             base=base,
             **rope_scaling.model_dump(exclude_none=True),
         )
+
+
+def compute_freqs_cis(
+    dhead: int, end: int, theta: float, rope_scaling: Optional[RopeScaling]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    rotary_embedding = rotary_embedding_factory(
+        dim=dhead, max_position_embeddings=end // 2, base=theta, rope_scaling=rope_scaling
+    )
+    return rotary_embedding.freqs_cis
 
 
 def compute_gather_cos_sin(

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -245,46 +245,13 @@ class LlamaRotaryEmbedding(ScaledRotaryEmbedding):
         return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
-class LinearRotaryEmbedding(RotaryEmbedding):
-    def __init__(
-        self,
-        dim: int,
-        max_position_embeddings: int,
-        base: float,
-        factor: float,
-        original_max_position_embeddings: int,
-        device: Optional[Any] = None,
-    ) -> None:
-        self.base = base
-        self.orig_context_len = original_max_position_embeddings
-        self.scaling_factor = factor
-        super().__init__(dim, max_position_embeddings, base, device)
-
-    def apply_scaling(self, freqs: torch.Tensor) -> torch.Tensor:
-        freqs = freqs / self.scaling_factor
-        return freqs
-
-    def _set_cos_sin_cache(self, seq_len: int, device: Any, dtype: torch.dtype) -> None:
-        self.max_seq_len_cached = seq_len
-        freqs = 1.0 / (self.base ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim))
-        t = torch.arange(seq_len * 2.0)
-        freqs = self.apply_scaling(freqs)
-        freqs = torch.outer(t, freqs).float()
-        cos = torch.cos(freqs)
-        sin = torch.sin(freqs)
-        cos, sin = gather_cos_sin(torch.arange(seq_len), cos, sin)
-
-        self.register_buffer("cos_cached", cos.to(dtype), persistent=False)
-        self.register_buffer("sin_cached", sin.to(dtype), persistent=False)
-
-
 def rotary_embedding_factory(
     dim: int,
     max_position_embeddings: int,
     base: float,
     rope_scaling: Optional[RopeScaling] = None,
     device: Optional[Any] = None,
-) -> Union[RotaryEmbedding, YarnRotaryEmbedding, LlamaRotaryEmbedding, LinearRotaryEmbedding]:
+) -> Union[RotaryEmbedding, YarnRotaryEmbedding, LlamaRotaryEmbedding, LinearScaledRotaryEmbedding]:
     if rope_scaling is None:
         return RotaryEmbedding(dim, max_position_embeddings, base, device)
     else:
@@ -294,8 +261,6 @@ def rotary_embedding_factory(
             rotary_embedding = LlamaRotaryEmbedding
         elif rope_scaling.rope_type.value == "yarn":
             rotary_embedding = YarnRotaryEmbedding
-        elif rope_scaling.rope_type.value == "linear":
-            rotary_embedding = LinearRotaryEmbedding
         else:
             raise ValueError(f"Invalid rope_scaling: {rope_scaling}")
         return rotary_embedding(

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -245,13 +245,46 @@ class LlamaRotaryEmbedding(ScaledRotaryEmbedding):
         return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
+class LinearRotaryEmbedding(RotaryEmbedding):
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int,
+        base: float,
+        factor: float,
+        original_max_position_embeddings: int,
+        device: Optional[Any] = None,
+    ) -> None:
+        self.base = base
+        self.orig_context_len = original_max_position_embeddings
+        self.scaling_factor = factor
+        super().__init__(dim, max_position_embeddings, base, device)
+
+    def apply_scaling(self, freqs: torch.Tensor) -> torch.Tensor:
+        freqs = freqs / self.scaling_factor
+        return freqs
+
+    def _set_cos_sin_cache(self, seq_len: int, device: Any, dtype: torch.dtype) -> None:
+        self.max_seq_len_cached = seq_len
+        freqs = 1.0 / (self.base ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim))
+        t = torch.arange(seq_len * 2.0)
+        freqs = self.apply_scaling(freqs)
+        freqs = torch.outer(t, freqs).float()
+        cos = torch.cos(freqs)
+        sin = torch.sin(freqs)
+        cos, sin = gather_cos_sin(torch.arange(seq_len), cos, sin)
+
+        self.register_buffer("cos_cached", cos.to(dtype), persistent=False)
+        self.register_buffer("sin_cached", sin.to(dtype), persistent=False)
+
+
 def rotary_embedding_factory(
     dim: int,
     max_position_embeddings: int,
     base: float,
     rope_scaling: Optional[RopeScaling] = None,
     device: Optional[Any] = None,
-) -> Union[RotaryEmbedding, YarnRotaryEmbedding, LlamaRotaryEmbedding]:
+) -> Union[RotaryEmbedding, YarnRotaryEmbedding, LlamaRotaryEmbedding, LinearRotaryEmbedding]:
     if rope_scaling is None:
         return RotaryEmbedding(dim, max_position_embeddings, base, device)
     else:
@@ -261,6 +294,8 @@ def rotary_embedding_factory(
             rotary_embedding = LlamaRotaryEmbedding
         elif rope_scaling.rope_type.value == "yarn":
             rotary_embedding = YarnRotaryEmbedding
+        elif rope_scaling.rope_type.value == "linear":
+            rotary_embedding = LinearRotaryEmbedding
         else:
             raise ValueError(f"Invalid rope_scaling: {rope_scaling}")
         return rotary_embedding(


### PR DESCRIPTION
### Ticket


### Problem description
Enable Support for Gemma-3-4b-it Model.


### What's changed
 - Added support for gemma-3-4b-it model
 - Updated model_config.py to support gemma-3-4b-it, including end-of-sequence (EoS) token handling.
 - Updated load_checkpoints.py to support gemma-3-4b-it weight loading.
Modified apply_scaling logic to handle both LLaMA and gemma-3-4b-it model.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) 
- [ ] [Frequent model tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml)