### PR TITLE
#26832: Use `optional_refence` when passing `MemoryConfig` to `to_device`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -192,7 +192,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
 
     Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
 
-    Tensor device_tensor = tensor_impl::to_device_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
+    Tensor device_tensor = tensor_impl::to_device_wrapper(input_host_tensor, mesh_device_.get());
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.storage());
     ASSERT_NE(device_storage, nullptr);
     EXPECT_NE(device_storage->mesh_buffer, nullptr);
@@ -229,8 +229,8 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
 
     Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
 
-    Tensor device_tensor1 = tensor_impl::to_device_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
-    Tensor device_tensor2 = tensor_impl::to_device_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
+    Tensor device_tensor1 = tensor_impl::to_device_wrapper(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor2 = tensor_impl::to_device_wrapper(input_host_tensor, mesh_device_.get());
 
     auto device_tensors1 = get_device_tensors(device_tensor1);
     auto device_tensors2 = get_device_tensors(device_tensor2);
@@ -317,7 +317,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
             write_tensor(input_host_tensor_sharded, device_tensor, /*blocking=*/false);
             return device_tensor;
         } else {
-            return tensor_impl::to_device_wrapper(input_host_tensor_sharded, mesh_device_.get(), MemoryConfig{});
+            return tensor_impl::to_device_wrapper(input_host_tensor_sharded, mesh_device_.get());
         }
     }();
 

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         test_any_range.cpp
         test_cleanup.cpp
         test_indestructible.cpp
+        test_optional_reference.cpp
         test_slotmap.cpp
         test_span.cpp
         test_strong_type.cpp

--- a/tt_stl/tests/test_optional_reference.cpp
+++ b/tt_stl/tests/test_optional_reference.cpp
@@ -137,15 +137,6 @@ TEST(OptionalReferenceTest, ValueMethod) {
     EXPECT_EQ(val, 100);
 }
 
-TEST(OptionalReferenceTest, ValueOr) {
-    int val = 42;
-    optional_reference<int> ref(val);
-    EXPECT_EQ(ref.value_or(100), 42);
-
-    optional_reference<int> empty_ref;
-    EXPECT_EQ(empty_ref.value_or(100), 100);
-}
-
 TEST(OptionalReferenceTest, EqualityOperators) {
     int value1 = 42;
     int value2 = 42;

--- a/tt_stl/tests/test_optional_reference.cpp
+++ b/tt_stl/tests/test_optional_reference.cpp
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+
+#include <tt_stl/optional_reference.hpp>
+
+namespace ttsl {
+namespace {
+
+using ::testing::ElementsAre;
+
+TEST(OptionalReferenceTest, DefaultConstruction) {
+    optional_reference<int> ref;
+    EXPECT_FALSE(ref.has_value());
+    EXPECT_FALSE(ref);
+}
+
+TEST(OptionalReferenceTest, NulloptConstruction) {
+    optional_reference<int> ref(std::nullopt);
+    EXPECT_FALSE(ref.has_value());
+    EXPECT_FALSE(ref);
+}
+
+TEST(OptionalReferenceTest, LvalueConstruction) {
+    int value = 42;
+    optional_reference<int> ref(value);
+    EXPECT_TRUE(ref.has_value());
+    EXPECT_TRUE(ref);
+    EXPECT_EQ(&*ref, &value);
+    EXPECT_EQ(*ref, 42);
+}
+
+TEST(OptionalReferenceTest, ConstLvalueConstruction) {
+    const int value = 42;
+    optional_reference<const int> ref(value);
+    EXPECT_TRUE(ref.has_value());
+    EXPECT_EQ(*ref, 42);
+}
+
+TEST(OptionalReferenceTest, ImplicitConversionToConst) {
+    int value = 42;
+    optional_reference<const int> ref(value);
+    EXPECT_TRUE(ref.has_value());
+    EXPECT_EQ(*ref, 42);
+
+    // Modify original value
+    value = 100;
+    EXPECT_EQ(*ref, 100);  // Reference should see the change
+}
+
+TEST(OptionalReferenceTest, OptionalConstruction) {
+    std::optional<int> opt = 42;
+    optional_reference<int> ref(opt);
+    EXPECT_TRUE(ref.has_value());
+    EXPECT_EQ(*ref, 42);
+
+    // Modify through optional
+    opt.value() = 100;
+    EXPECT_EQ(*ref, 100);
+}
+
+TEST(OptionalReferenceTest, ConstOptionalConstruction) {
+    const std::optional<int> opt = 42;
+    optional_reference<const int> ref(opt);
+    EXPECT_TRUE(ref.has_value());
+    EXPECT_EQ(*ref, 42);
+}
+
+TEST(OptionalReferenceTest, EmptyOptionalConstruction) {
+    std::optional<int> opt;
+    optional_reference<int> ref(opt);
+    EXPECT_FALSE(ref.has_value());
+}
+
+TEST(OptionalReferenceTest, CopyConstruction) {
+    int value = 42;
+    optional_reference<int> ref1(value);
+    optional_reference<int> ref2(ref1);
+
+    EXPECT_TRUE(ref2.has_value());
+    EXPECT_EQ(&*ref1, &*ref2);
+    EXPECT_EQ(*ref2, 42);
+}
+
+TEST(OptionalReferenceTest, MoveConstruction) {
+    int value = 42;
+    optional_reference<int> ref1(value);
+    optional_reference<int> ref2(std::move(ref1));
+
+    EXPECT_TRUE(ref2.has_value());
+    EXPECT_EQ(*ref2, 42);
+    // Note: ref1 should still be valid after move (it's just a pointer copy)
+    EXPECT_TRUE(ref1.has_value());
+}
+
+TEST(OptionalReferenceTest, CopyAssignment) {
+    int value1 = 42;
+    int value2 = 100;
+    optional_reference<int> ref1(value1);
+    optional_reference<int> ref2(value2);
+
+    ref2 = ref1;
+    EXPECT_EQ(&*ref1, &*ref2);
+    EXPECT_EQ(*ref2, 42);
+}
+
+TEST(OptionalReferenceTest, Reset) {
+    int value = 42;
+    optional_reference<int> ref(value);
+    EXPECT_TRUE(ref.has_value());
+
+    ref.reset();
+    EXPECT_FALSE(ref.has_value());
+}
+
+TEST(OptionalReferenceTest, ArrowOperator) {
+    struct TestStruct {
+        int value = 42;
+        int get() const { return value; }
+    };
+
+    TestStruct obj;
+    optional_reference<TestStruct> ref(obj);
+    EXPECT_EQ(ref->value, 42);
+    EXPECT_EQ(ref->get(), 42);
+}
+
+TEST(OptionalReferenceTest, ValueMethod) {
+    int val = 42;
+    optional_reference<int> ref(val);
+    EXPECT_EQ(ref.value(), 42);
+
+    // Modify through value()
+    ref.value() = 100;
+    EXPECT_EQ(val, 100);
+}
+
+TEST(OptionalReferenceTest, ValueOr) {
+    int val = 42;
+    optional_reference<int> ref(val);
+    EXPECT_EQ(ref.value_or(100), 42);
+
+    optional_reference<int> empty_ref;
+    EXPECT_EQ(empty_ref.value_or(100), 100);
+}
+
+TEST(OptionalReferenceTest, EqualityOperators) {
+    int value1 = 42;
+    int value2 = 42;
+
+    optional_reference<int> ref1(value1);
+    optional_reference<int> ref2(value1);  // Same object
+    optional_reference<int> ref3(value2);  // Different object
+    optional_reference<int> empty1;
+    optional_reference<int> empty2;
+
+    // Same reference
+    EXPECT_EQ(ref1, ref2);
+
+    // Different objects (even with same value)
+    EXPECT_NE(ref1, ref3);
+
+    // Empty references are equal
+    EXPECT_EQ(empty1, empty2);
+
+    // Empty vs non-empty
+    EXPECT_NE(ref1, empty1);
+}
+
+TEST(OptionalReferenceTest, ModifyThroughReference) {
+    int value = 42;
+    optional_reference<int> ref(value);
+
+    *ref = 100;
+    EXPECT_EQ(value, 100);
+
+    ref.value() = 200;
+    EXPECT_EQ(value, 200);
+}
+
+TEST(OptionalReferenceTest, ConstCorrectness) {
+    int value = 42;
+    const optional_reference<int> ref(value);
+
+    // Can still modify through const optional_reference
+    *ref = 100;
+    EXPECT_EQ(value, 100);
+}
+
+TEST(OptionalReferenceTest, UseCaseExample) {
+    auto test_function = [](optional_reference<const int> val) {
+        if (val) {
+            EXPECT_GE(*val, 0);
+        }
+    };
+
+    test_function(3);
+
+    int a = 5;
+    test_function(a);
+
+    test_function(std::nullopt);
+}
+
+TEST(OptionalReferenceTest, TemporaryBindingToConst) {
+    auto test_function = [](optional_reference<const int> val) { EXPECT_EQ(*val, 42); };
+    test_function(42);
+    test_function(std::make_optional(42));
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tt_stl/optional_reference.hpp
+++ b/tt_stl/tt_stl/optional_reference.hpp
@@ -9,6 +9,37 @@
 
 namespace ttsl {
 
+// `optional_reference` is a trivially copyable wrapper around a pointer to a value.
+// This is useful for creating functions that accept optional parameters without the overhead of copying values.
+// The main use case is to allow convenient and efficient passing of optional values to functions:
+// 1. `optional_reference<T>` binds to `T&`, `optional<T>&`
+// 2. `optional_reference<const T>` binds to `const T&`, `const optional<T>&`, and temporaries.
+//
+// Be aware retaining `optional_reference<T>` is dangerous, as the ownership of the value is not guaranteed!
+// Copy the value if you need to retain it.
+//
+//
+// Example usage:
+//
+// void process_config(optional_reference<const Config> config) {
+//     if (config) {
+//         apply_settings(config->get_settings());
+//     } else {
+//         apply_default_settings();
+//     }
+// }
+//
+// // Can be called with various types:
+// Config my_config;
+// process_config(my_config);                    // Pass a reference
+// process_config(Config());                     // Pass a temporary
+//
+// std::optional<Config> maybe_config = load_config();
+// process_config(maybe_config);                 // Pass an optional
+// process_config(load_config());                // Pass a temporary optional
+//
+// process_config(std::nullopt);                 // Pass nullopt
+//
 template <typename T>
 class optional_reference {
 public:

--- a/tt_stl/tt_stl/optional_reference.hpp
+++ b/tt_stl/tt_stl/optional_reference.hpp
@@ -81,7 +81,6 @@ public:
     T* operator->() const { return value_; }
     T& operator*() const { return *value_; }
     T& value() const { return *value_; }
-    T& value_or(const T& default_value) const { return value_ ? *value_ : default_value; }
 
     friend bool operator==(const optional_reference& lhs, const optional_reference& rhs) {
         return lhs.value_ == rhs.value_;

--- a/tt_stl/tt_stl/optional_reference.hpp
+++ b/tt_stl/tt_stl/optional_reference.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+#include <optional>
+
+namespace ttsl {
+
+template <typename T>
+class optional_reference {
+public:
+    optional_reference() : value_(nullptr) {}
+    optional_reference(std::nullopt_t) : value_(nullptr) {}
+
+    // Moveable and copyable.
+    optional_reference(const optional_reference& other) = default;
+    optional_reference(optional_reference&& other) = default;
+    optional_reference& operator=(const optional_reference& other) = default;
+    optional_reference& operator=(optional_reference&& other) = default;
+
+    // Constructors from lvalues.
+    optional_reference(T& value) noexcept : value_(std::addressof(value)) {}
+    optional_reference(std::optional<T>& value) {
+        if (value.has_value()) {
+            value_ = std::addressof(value.value());
+        }
+    }
+
+    // Constructors that may bind to temporaries.
+    template <typename U>
+        requires std::is_const_v<T> && std::same_as<std::remove_const_t<T>, U>
+    optional_reference(const U& value) noexcept : value_(std::addressof(value)) {}
+
+    template <typename U>
+        requires std::is_const_v<T> && std::same_as<std::remove_const_t<T>, U>
+    optional_reference(const std::optional<U>& value) {
+        if (value.has_value()) {
+            value_ = std::addressof(value.value());
+        }
+    }
+
+    bool has_value() const { return value_ != nullptr; }
+    operator bool() const { return has_value(); }
+
+    void reset() { value_ = nullptr; }
+
+    T* operator->() const { return value_; }
+    T& operator*() const { return *value_; }
+    T& value() const { return *value_; }
+    T& value_or(const T& default_value) const { return value_ ? *value_ : default_value; }
+
+    friend bool operator==(const optional_reference& lhs, const optional_reference& rhs) {
+        return lhs.value_ == rhs.value_;
+    }
+    friend bool operator!=(const optional_reference& lhs, const optional_reference& rhs) { return !(lhs == rhs); }
+
+private:
+    T* value_ = nullptr;
+};
+
+}  // namespace ttsl

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -166,7 +166,6 @@ public:
     template <typename T>
     [[nodiscard]] T item(ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
 
-    // TODO: #26832 - Use `mem_config` argument as an optional argument.
     [[nodiscard]] Tensor to_device(
         distributed::MeshDevice* mesh_device,
         ttsl::optional_reference<const MemoryConfig> mem_config = std::nullopt,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -28,6 +28,7 @@
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt_stl/reflection.hpp>
+#include <tt_stl/optional_reference.hpp>
 #include "types.hpp"
 
 namespace tt {
@@ -168,7 +169,7 @@ public:
     // TODO: #26832 - Use `mem_config` argument as an optional argument.
     [[nodiscard]] Tensor to_device(
         distributed::MeshDevice* mesh_device,
-        const MemoryConfig& mem_config = MemoryConfig{},
+        ttsl::optional_reference<const MemoryConfig> mem_config = std::nullopt,
         ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
 
     [[nodiscard]] Tensor to_layout(Layout target_layout) const;

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -190,7 +190,7 @@ template <typename T>
 Tensor to_device(
     const Tensor& tensor,
     distributed::MeshDevice* mesh_device,
-    const MemoryConfig& memory_config,
+    ttsl::optional_reference<const MemoryConfig> memory_config = std::nullopt,
     QueueId cq_id = ttnn::DefaultQueueId);
 
 template <typename T>

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -461,7 +461,10 @@ template uint8_t Tensor::item<uint8_t>(ttnn::QueueId cq_id) const;
 template uint16_t Tensor::item<uint16_t>(ttnn::QueueId cq_id) const;
 template uint32_t Tensor::item<uint32_t>(ttnn::QueueId cq_id) const;
 
-Tensor Tensor::to_device(distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id) const {
+Tensor Tensor::to_device(
+    distributed::MeshDevice* mesh_device,
+    ttsl::optional_reference<const MemoryConfig> mem_config,
+    QueueId cq_id) const {
     return tensor_ops::tensor_to_device(*this, mesh_device, mem_config, cq_id);
 }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -30,7 +30,10 @@
 namespace tt::tt_metal::tensor_ops {
 
 Tensor tensor_to_device(
-    const Tensor& input_tensor, distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id) {
+    const Tensor& input_tensor,
+    distributed::MeshDevice* mesh_device,
+    ttsl::optional_reference<const MemoryConfig> mem_config,
+    QueueId cq_id) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to_device", input_tensor, mesh_device, mem_config);
     if (input_tensor.storage_type() == StorageType::DEVICE) {

--- a/ttnn/core/tensor/tensor_ops.hpp
+++ b/ttnn/core/tensor/tensor_ops.hpp
@@ -18,7 +18,10 @@ class MeshDevice;
 namespace tt::tt_metal::tensor_ops {
 
 Tensor tensor_to_device(
-    const Tensor& input_tensor, distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id);
+    const Tensor& input_tensor,
+    distributed::MeshDevice* mesh_device,
+    ttsl::optional_reference<const MemoryConfig> mem_config,
+    QueueId cq_id);
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout);
 

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -953,9 +953,11 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             "to",
-            py::overload_cast<MeshDevice*, const MemoryConfig&, QueueId>(&Tensor::to_device, py::const_),
+            [](const Tensor& self, MeshDevice* device, std::optional<const MemoryConfig>& mem_config, QueueId cq_id) {
+                return self.to_device(device, mem_config, cq_id);
+            },
             py::arg("device").noconvert(),
-            py::arg("mem_config").noconvert() = MemoryConfig{},
+            py::arg("mem_config").noconvert() = std::nullopt,
             py::arg("cq_id") = ttnn::DefaultQueueId,
             py::keep_alive<0, 2>(),
             R"doc(
@@ -963,7 +965,7 @@ void pytensor_module(py::module& m_tensor) {
 
             Only BFLOAT16 (in ROW_MAJOR or TILE layout) and BFLOAT8_B, BFLOAT4_B (in TILE layout) are supported on device.
 
-            If ``arg1`` is not supplied, default ``MemoryConfig`` with ``interleaved`` set to ``True``.
+            If ``arg1`` is not supplied, memory config from the source tensor will be used.
 
             +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
             | Argument  | Description                                     | Data type                  | Valid range           | Required |


### PR DESCRIPTION
### Ticket
#26832

### Problem description
`tensor.to_device(device)` by default uses default constructed `MemoryConfig{}`. This is confusing behavior, since `tensor` itself already has `MemoryConfig`.

### What's changed
* Implement `optional_reference` to bind `T` / `optional<T>` types conveniently.
* Switch the default to using `MemoryConfig` from `tensor`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17080438362)
- [x] [TG quick](https://github.com/tenstorrent/tt-metal/actions/runs/16998977721)
- [x] [T3K demos](https://github.com/tenstorrent/tt-metal/actions/runs/16998968590)
- [x] [T3K unit](https://github.com/tenstorrent/tt-metal/actions/runs/16998967050)
- [X] New/Existing tests provide coverage for changes