### PR TITLE
Migrating Moreh Microbenchmarks to use TT Mesh APIs

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -54,6 +54,8 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 
 using std::vector;
 using namespace tt;
@@ -107,9 +109,9 @@ void get_max_page_size_and_num_pages(
     num_pages = total_size / page_size;
 }
 
-std::tuple<std::vector<tt_metal::Program>, tt_metal::experimental::GlobalCircularBuffer>
-create_programs(
-    tt_metal::IDevice* device,
+std::tuple<std::vector<tt_metal::distributed::MeshWorkload>, tt_metal::experimental::GlobalCircularBuffer>
+create_mesh_workloads(
+    tt_metal::distributed::MeshDevice* device,
     const CoreRangeSet& dram_reader_core,
     const CoreRangeSet& l1_receiver_cores,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
@@ -122,7 +124,7 @@ create_programs(
     uint32_t num_receivers,
     uint32_t num_mixed_df_layers,
     uint32_t cb_padding,
-    const std::shared_ptr<tt::tt_metal::Buffer>& input_buffer,
+    const std::shared_ptr<tt_metal::distributed::MeshBuffer>& input_buffer,
     bool use_sub_devices) {
     log_info(tt::LogTest, "created program");
     std::vector<tt_metal::Program> programs;
@@ -331,7 +333,15 @@ create_programs(
         tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, l1_receiver_core_coords[i], receiver_rt_args);
     }
 
-    return {std::move(programs), std::move(global_cb)};
+    std::vector<tt_metal::distributed::MeshWorkload> mesh_workloads;
+    for (auto& program : programs) {
+        auto mesh_workload = tt_metal::distributed::CreateMeshWorkload();
+        tt_metal::distributed::AddProgramToMeshWorkload(
+            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workloads.push_back(std::move(mesh_workload));
+    }
+
+    return {std::move(mesh_workloads), std::move(global_cb)};
 }
 
 float to_float(bfloat16 bfloat16_num) { return bfloat16_num.to_float(); }
@@ -374,7 +384,8 @@ bool validation_bfp8_b(
     uint32_t cb_num_blocks,
     uint32_t kt,
     uint32_t nt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer) {
+    const std::shared_ptr<tt_metal::distributed::MeshBuffer>& out_buffer,
+    tt_metal::distributed::MeshDevice* device) {
     bool pass = true;
     std::vector<float> golden_vec(kt * nt * 32 * 32 / num_blocks * cb_num_blocks, 0);  // Initialize with zeros
     std::vector<float> result_vec(kt * nt * 32 * 32 / num_blocks * cb_num_blocks, 0);
@@ -382,7 +393,7 @@ bool validation_bfp8_b(
 
     std::vector<float> result_untilized;
     std::vector<uint32_t> result;
-    tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
+    tt_metal::distributed::ReadShard(device->mesh_command_queue(), result, out_buffer, tt_metal::distributed::MeshCoordinate(0, 0), true);
     auto result_bfp8 = unpack_bfp8_tiles_into_float_vec(result, true, false);
     result_untilized = untilize_swizzled(result_bfp8, kt * 32 / num_blocks * cb_num_blocks, nt * 32);
 
@@ -416,14 +427,15 @@ bool validation_fp16(
     uint32_t cb_num_blocks,
     uint32_t kt,
     uint32_t nt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer) {
+    const std::shared_ptr<tt_metal::distributed::MeshBuffer>& out_buffer,
+    tt_metal::distributed::MeshDevice* device) {
     bool pass = true;
     std::vector<float> golden_vec(kt * nt * 32 * 32 / num_blocks * cb_num_blocks, 0);  // Initialize with zeros
     std::vector<float> result_vec(kt * nt * 32 * 32 / num_blocks * cb_num_blocks, 0);
     auto num_datums_per_cb = kt * nt * 32 * 32 / num_blocks * cb_num_blocks;
 
     std::vector<uint32_t> result;
-    tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
+    tt_metal::distributed::ReadShard(device->mesh_command_queue(), result, out_buffer, tt_metal::distributed::MeshCoordinate(0, 0), true);
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
     auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
     auto result_untilized = untilize_swizzled(result_flat_layout, kt * 32 / num_blocks * cb_num_blocks, nt * 32);
@@ -459,13 +471,14 @@ bool validation_mixed_df(
     uint32_t cb_num_blocks,
     uint32_t kt,
     uint32_t nt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer,
+    const std::shared_ptr<tt_metal::distributed::MeshBuffer>& out_buffer,
     uint32_t num_mixed_df_layers,
-    uint32_t num_receivers) {
+    uint32_t num_receivers,
+    tt_metal::distributed::MeshDevice* device) {
     bool pass = true;
 
     std::vector<uint32_t> result;
-    tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
+    tt_metal::distributed::ReadShard(device->mesh_command_queue(), result, out_buffer, tt_metal::distributed::MeshCoordinate(0, 0), true);
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
     auto result_untilized_fp16 = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
@@ -573,8 +586,8 @@ bool validation_mixed_df(
     return pass;
 }
 
-std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
-    tt_metal::IDevice* device,
+std::shared_ptr<tt_metal::distributed::MeshBuffer> create_and_transfer_data_sharded_cb(
+    tt_metal::distributed::MeshDevice* device,
     const vector<uint32_t>& input_vec,
     uint32_t ht,
     uint32_t wt,
@@ -600,26 +613,26 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
         {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
         {ht, wt});
 
+    BufferShardingArgs sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::WIDTH_SHARDED);
     log_info(tt::LogTest, "cores: {}", cores);
     log_info(tt::LogTest, "size_bytes: {}", size_bytes);
     log_info(tt::LogTest, "page_size_bytes: {}", page_size_bytes);
 
-    auto config = tt::tt_metal::ShardedBufferConfig{
-        .device = device,
-        .size = size_bytes,
+    auto device_local_config = tt_metal::distributed::DeviceLocalBufferConfig{
         .page_size = page_size_bytes,
         .buffer_type = buffer_type,
-        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-        .shard_parameters = shard_spec};
+        .sharding_args = sharding_args};
 
-    std::shared_ptr<Buffer> input_buffer;
+    tt_metal::distributed::ReplicatedBufferConfig global_buf{.size = size_bytes};
+
+    std::shared_ptr<tt_metal::distributed::MeshBuffer> input_buffer;
     if (address.has_value()) {
-        input_buffer = CreateBuffer(config, address.value());
+        input_buffer = tt_metal::distributed::MeshBuffer::create(global_buf, device_local_config, device, address.value());
     } else {
-        input_buffer = CreateBuffer(config);
+        input_buffer = tt_metal::distributed::MeshBuffer::create(global_buf, device_local_config, device);
     }
-    tt::tt_metal::detail::WriteToBuffer(input_buffer, input_vec);
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+    tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+    tt_metal::distributed::Finish(device->mesh_command_queue());
 
     log_info(tt::LogTest, "created sharded tensor");
 
@@ -729,7 +742,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
+        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
         [[maybe_unused]] CoreCoord dram_bank_coord = CoreCoord{0, 0};
         CoreCoord dram_reader_core_coord = CoreCoord{0, 0};
@@ -755,8 +768,8 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Input Setup
         ////////////////////////////////////////////////////////////////////////////
-        std::vector<std::shared_ptr<tt::tt_metal::Buffer>> input_buffers(num_mixed_df_layers);
-        std::shared_ptr<tt::tt_metal::Buffer> output_buffer;
+        std::vector<std::shared_ptr<tt_metal::distributed::MeshBuffer>> input_buffers(num_mixed_df_layers);
+        std::shared_ptr<tt_metal::distributed::MeshBuffer> output_buffer;
         auto input_shape = SHAPE{1, 1, k, n};
         tt::deprecated::Tensor<bfloat16> tensor_fp16 = tt::deprecated::initialize_tensor<bfloat16>(
             input_shape,
@@ -777,7 +790,7 @@ int main(int argc, char** argv) {
                     std::vector<uint32_t> packed_input_vec_tile_layout =
                         pack_fp32_vec_as_bfp8_tiles(input_vec_tilized, true, false);
                     input_buffers[i] = create_and_transfer_data_sharded_cb(
-                        device,
+                        device.get(),
                         packed_input_vec_tile_layout,
                         kt,
                         nt,
@@ -791,7 +804,7 @@ int main(int argc, char** argv) {
                     vector<uint32_t> packed_input_vec_tile_layout =
                         pack_bfloat16_vec_into_uint32_vec(input_vec_tile_layout);
                     input_buffers[i] = create_and_transfer_data_sharded_cb(
-                        device,
+                        device.get(),
                         packed_input_vec_tile_layout,
                         kt,
                         nt,
@@ -809,7 +822,7 @@ int main(int argc, char** argv) {
                     vector<uint32_t> packed_input_vec_tile_layout =
                         pack_bfloat16_vec_into_uint32_vec(input_vec_tile_layout);
                     input_buffers[i] = create_and_transfer_data_sharded_cb(
-                        device,
+                        device.get(),
                         packed_input_vec_tile_layout,
                         kt,
                         nt,
@@ -822,7 +835,7 @@ int main(int argc, char** argv) {
                     std::vector<uint32_t> packed_input_vec_tile_layout =
                         pack_fp32_vec_as_bfp8_tiles(input_vec_tilized, true, false);
                     input_buffers[i] = create_and_transfer_data_sharded_cb(
-                        device,
+                        device.get(),
                         packed_input_vec_tile_layout,
                         kt,
                         nt,
@@ -841,8 +854,8 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup
         ////////////////////////////////////////////////////////////////////////////
-        auto [programs, global_cb] = create_programs(
-            device,
+        auto [mesh_workloads, global_cb] = create_mesh_workloads(
+            device.get(),
             dram_reader_core,
             l1_receiver_core,
             sender_receiver_core_mapping,
@@ -861,7 +874,7 @@ int main(int argc, char** argv) {
             // output
             vector<uint32_t> outputs = create_constant_vector_of_bfp8(output_size, 0, true);
             output_buffer = create_and_transfer_data_sharded_cb(
-                device,
+                device.get(),
                 outputs,
                 kt / num_blocks * cb_num_blocks,
                 nt,
@@ -875,7 +888,7 @@ int main(int argc, char** argv) {
             // output
             vector<uint32_t> outputs = create_constant_vector_of_bfloat16(output_size, 0);
             output_buffer = create_and_transfer_data_sharded_cb(
-                device,
+                device.get(),
                 outputs,
                 kt / num_blocks * cb_num_blocks,
                 nt,
@@ -889,28 +902,24 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execution Application
         ////////////////////////////////////////////////////////////////////////////
-        for (auto& program : programs) {
-            tt_metal::detail::CompileProgram(device, program);
-        }
-
         log_info(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             if (use_sub_devices) {
                 // Enqueue the sender program
-                EnqueueProgram(device->command_queue(), programs[0], false);
+                tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workloads[0], false);
                 device->set_sub_device_stall_group(receiver_sub_device_ids);
-                for (uint32_t j = 1; j < programs.size(); ++j) {
-                    EnqueueProgram(device->command_queue(), programs[j], false);
+                for (uint32_t j = 1; j < mesh_workloads.size(); ++j) {
+                    tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workloads[j], false);
                 }
                 device->reset_sub_device_stall_group();
             } else {
-                for (auto& program : programs) {
-                    EnqueueProgram(device->command_queue(), program, false);
+                for (auto& mesh_workload : mesh_workloads) {
+                    tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
                 }
             }
-            Finish(device->command_queue());
-            for ([[maybe_unused]] auto& program : programs) {
-                tt_metal::detail::ReadDeviceProfilerResults(device);
+            tt_metal::distributed::Finish(device->mesh_command_queue());
+            for ([[maybe_unused]] auto& mesh_workload : mesh_workloads) {
+                tt_metal::detail::ReadDeviceProfilerResults(device->get_devices()[0]);
             }
         }
 
@@ -919,9 +928,9 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         if (num_mixed_df_layers == 1) {
             if (tile_format == tt::DataFormat::Bfp8_b) {
-                pass = validation_bfp8_b(tensor_fp8, tile_format, num_blocks, cb_num_blocks, kt, nt, output_buffer);
+                pass = validation_bfp8_b(tensor_fp8, tile_format, num_blocks, cb_num_blocks, kt, nt, output_buffer, device.get());
             } else {
-                pass = validation_fp16(tensor_fp16, tile_format, num_blocks, cb_num_blocks, kt, nt, output_buffer);
+                pass = validation_fp16(tensor_fp16, tile_format, num_blocks, cb_num_blocks, kt, nt, output_buffer, device.get());
             }
         } else {
             pass = validation_mixed_df(
@@ -934,10 +943,11 @@ int main(int argc, char** argv) {
                 nt,
                 output_buffer,
                 num_mixed_df_layers,
-                num_receivers);
+                num_receivers,
+                device.get());
         }
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= device->close();
     } catch (const std::exception& e) {
         pass = false;
         log_error(LogTest, "{}", e.what());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -16,6 +16,12 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tt_metal_profiler.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <hostdevcommon/common_values.hpp>
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -140,7 +146,7 @@ template <typename T>
 std::vector<T> get_col_slice(std::vector<T> data, int start_col_index, int num_cols, int rows, int cols);
 
 void prepare_inputs(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     CoreCoord core_range,
     uint32_t Mt,
     uint32_t Nt,
@@ -157,7 +163,7 @@ void prepare_inputs(
     std::vector<std::vector<float>>& in1_bfp8_unpack_slice);
 
 tt_metal::Program create_program_single_core(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     tt::DataFormat cb_data_format,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -168,16 +174,16 @@ tt_metal::Program create_program_single_core(
     uint32_t Kt,
     uint32_t out_subblock_h,
     uint32_t out_subblock_w,
-    const std::shared_ptr<tt::tt_metal::Buffer>& in0_cb_addr,
-    const std::shared_ptr<tt::tt_metal::Buffer>& in1_cb_addr,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_cb_addr,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& in0_cb_addr,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& in1_cb_addr,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& out_cb_addr,
     bool matmul_block,
     bool packer_l1,
     uint32_t num_blocks,
     uint32_t interm_cb_dtype);
 
 tt_metal::Program create_program(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     tt::DataFormat cb_data_format,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -202,16 +208,17 @@ tt_metal::Program create_program(
     bool packer_l1_acc);
 
 bool validation_single_core(
+    tt_metal::distributed::MeshDevice* device,
     const tt::deprecated::Tensor<bfloat16>& tensor_in0,
     const tt::deprecated::Tensor<bfloat16>& tensor_in1,
     uint32_t num_blocks,
     uint32_t Mt,
     uint32_t Nt,
     uint32_t Kt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer);
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& out_buffer);
 
 bool validation(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     CoreCoord core_range,
     uint32_t Mt,
     uint32_t Nt,
@@ -226,19 +233,20 @@ bool validation(
     std::vector<std::vector<float>>& in1_bfp8_unpack_slice);
 
 bool validation_single_core_fp8(
+    tt_metal::distributed::MeshDevice* device,
     const tt::deprecated::Tensor<float>& tensor_in0,
     const tt::deprecated::Tensor<float>& tensor_in1,
     uint32_t num_blocks,
     uint32_t Mt,
     uint32_t Nt,
     uint32_t Kt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer);
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& out_buffer);
 
-std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
-    tt_metal::IDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt);
+std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_and_transfer_data_sharded_cb(
+    tt_metal::distributed::MeshDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt);
 
-std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb_fp8(
-    tt_metal::IDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt);
+std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_and_transfer_data_sharded_cb_fp8(
+    tt_metal::distributed::MeshDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt);
 
 ////////////////////////////////////////////////////////////////////////////
 //                      Main
@@ -331,7 +339,14 @@ int main(int argc, char** argv) {
         }
 
         int pci_express_slot = 0;
-        tt_metal::IDevice* device = tt_metal::CreateDevice(pci_express_slot);
+        auto mesh_device_map = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(
+            {pci_express_slot},
+            DEFAULT_L1_SMALL_SIZE,
+            DEFAULT_TRACE_REGION_SIZE,
+            1 /* num_command_queues */,
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config());
+
+        const std::shared_ptr<tt_metal::distributed::MeshDevice>& device = mesh_device_map.at(pci_express_slot);
         uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         const tt::ARCH arch = device->arch();
         ////////////////////////////////////////////////////////////////////////////
@@ -387,9 +402,9 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Tensor Setup
         ////////////////////////////////////////////////////////////////////////////
-        std::shared_ptr<tt::tt_metal::Buffer> input_buffer0;
-        std::shared_ptr<tt::tt_metal::Buffer> input_buffer1;
-        std::shared_ptr<tt::tt_metal::Buffer> output_buffer;
+        std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> input_buffer0;
+        std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> input_buffer1;
+        std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> output_buffer;
         SHAPE shape_in0 = {1, 1, M, K};
         tt::deprecated::Tensor<bfloat16> tensor_in0_fp16 = tt::deprecated::initialize_tensor<bfloat16>(
             shape_in0,
@@ -424,14 +439,14 @@ int main(int argc, char** argv) {
                 auto activations_tile_layout =
                     convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
                 vector<uint32_t> activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-                input_buffer0 = create_and_transfer_data_sharded_cb(device, activations, Mt, Kt);
+                input_buffer0 = create_and_transfer_data_sharded_cb(device.get(), activations, Mt, Kt);
 
                 // in1
                 auto identity_tilized = tilize_swizzled(tensor_in1_fp16.get_values(), K, N);
                 auto weights_tile_layout =
                     convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
                 auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-                input_buffer1 = create_and_transfer_data_sharded_cb(device, weights, Kt, Nt);
+                input_buffer1 = create_and_transfer_data_sharded_cb(device.get(), weights, Kt, Nt);
 
                 // output
                 SHAPE output_hsape = {1, 1, M, N};
@@ -442,18 +457,18 @@ int main(int argc, char** argv) {
                     100,
                     std::chrono::system_clock::now().time_since_epoch().count());
                 vector<uint32_t> outputs = pack_bfloat16_vec_into_uint32_vec(out_tensor.get_values());
-                output_buffer = create_and_transfer_data_sharded_cb(device, outputs, Mt, Nt);
+                output_buffer = create_and_transfer_data_sharded_cb(device.get(), outputs, Mt, Nt);
 
             } else {
                 // in0
                 auto activations_tilized = tilize_swizzled(tensor_in0_fp8.get_values(), M, K);
                 std::vector<uint32_t> activations = pack_fp32_vec_as_bfp8_tiles(activations_tilized, true, false);
-                input_buffer0 = create_and_transfer_data_sharded_cb_fp8(device, activations, Mt, Kt);
+                input_buffer0 = create_and_transfer_data_sharded_cb_fp8(device.get(), activations, Mt, Kt);
 
                 // in1
                 auto identity_tilized = tilize_swizzled(tensor_in1_fp8.get_values(), K, N);
                 auto weights = pack_fp32_vec_as_bfp8_tiles(identity_tilized, true, false);
-                input_buffer1 = create_and_transfer_data_sharded_cb_fp8(device, weights, Kt, Nt);
+                input_buffer1 = create_and_transfer_data_sharded_cb_fp8(device.get(), weights, Kt, Nt);
 
                 // output
                 SHAPE output_hsape = {1, 1, M, N};
@@ -465,7 +480,7 @@ int main(int argc, char** argv) {
                     std::chrono::system_clock::now().time_since_epoch().count());
                 auto output_tilized = tilize_swizzled(out_tensor.get_values(), M, N);
                 auto outputs = pack_fp32_vec_as_bfp8_tiles(output_tilized, true, false);
-                output_buffer = create_and_transfer_data_sharded_cb_fp8(device, outputs, Mt, Nt);
+                output_buffer = create_and_transfer_data_sharded_cb_fp8(device.get(), outputs, Mt, Nt);
             }
         }
 
@@ -504,7 +519,7 @@ int main(int argc, char** argv) {
         tt::tt_metal::Program program;
         if (single_core) {
             program = create_program_single_core(
-                device,
+                device.get(),
                 data_format,
                 math_fidelity,
                 fp32_dest_acc_en,
@@ -524,7 +539,7 @@ int main(int argc, char** argv) {
                 interm_cb_dtype);
         } else {
             program = create_program(
-                device,
+                device.get(),
                 data_format,
                 math_fidelity,
                 fp32_dest_acc_en,
@@ -557,7 +572,7 @@ int main(int argc, char** argv) {
         std::vector<std::vector<float>> in1_bfp8_unpack_slice;
         if (not single_core) {
             prepare_inputs(
-                device,
+                device.get(),
                 core_range,
                 Mt,
                 Nt,
@@ -577,11 +592,9 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Kernel Execution and Perf Profiling
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::detail::CompileProgram(device, program);
-
         constexpr int giga_byte = 1000000;
         constexpr long long tera_byte = 1000000000000LL;
-        int tt_npu_clock = get_tt_npu_clock(device);
+        int tt_npu_clock = get_tt_npu_clock(device->get_devices()[0]);
         double rpeak_tflops = get_tt_npu_rpeak_tflops(arch, grid_size, tt_npu_clock);
         std::vector<double> rmax_tflops;
         uint64_t num_of_matmul_ops =
@@ -589,13 +602,19 @@ int main(int argc, char** argv) {
         log_debug(LogTest, "number of matmul ops: {}", num_of_matmul_ops);
 
         log_info(LogTest, "Num tests {}", num_tests);
+        // Create MeshWorkload
+        auto mesh_workload = tt_metal::distributed::CreateMeshWorkload();
+        tt_metal::distributed::AddProgramToMeshWorkload(
+            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+
         for (uint32_t i = 0; i < num_tests; ++i) {
             if (!fast_dispatch_mode) {
-                log_debug(LogTest, "calling detail::LaunchProgram");
-                detail::LaunchProgram(device, program);
-                log_debug(LogTest, "detail::LaunchProgram done");
+                log_debug(LogTest, "calling EnqueueMeshWorkload");
+                tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, true);
+                log_debug(LogTest, "EnqueueMeshWorkload done");
 
-                uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(device, program);
+                uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(
+                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
                 double cycle_time = 1 / static_cast<double>(tt_npu_clock) / giga_byte;
                 auto execution_time = t0_to_any_riscfw_end * cycle_time;
                 rmax_tflops.push_back(static_cast<double>(num_of_matmul_ops) / execution_time / tera_byte);
@@ -609,14 +628,18 @@ int main(int argc, char** argv) {
                     t0_to_any_riscfw_end,
                     rmax_tflops[i]);
             } else {
-                log_debug(LogTest, "calling EnqueueProgram");
-                EnqueueProgram(device->command_queue(), program, false);
-                Finish(device->command_queue());
-                log_debug(LogTest, "EnqueProgram done");
-                tt_metal::detail::ReadDeviceProfilerResults(device);
+                log_debug(LogTest, "calling EnqueueMeshWorkload");
+                std::chrono::duration<double, std::nano> duration{};
+                auto t_begin = std::chrono::high_resolution_clock::now();
+                tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
+                tt_metal::distributed::Finish(device->mesh_command_queue());
+                auto t_end = std::chrono::high_resolution_clock::now();
+                log_debug(LogTest, "EnqueueMeshWorkload done");
+                tt_metal::detail::ReadDeviceProfilerResults(device->get_devices()[0]);
 
                 if (single_core) {
-                    uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(device, program);
+                    uint64_t t0_to_any_riscfw_end =
+                        get_t0_to_any_riscfw_end_cycle(device.get(), mesh_workload.get_programs().begin()->second);
                     double cycle_time = 1 / static_cast<double>(tt_npu_clock) / giga_byte;
                     auto execution_time = t0_to_any_riscfw_end * cycle_time;
                     rmax_tflops.push_back(static_cast<double>(num_of_matmul_ops) / execution_time / tera_byte);
@@ -630,13 +653,6 @@ int main(int argc, char** argv) {
                         t0_to_any_riscfw_end,
                         rmax_tflops[i]);
                 } else {
-                    log_debug(LogTest, "calling EnqueueProgram");
-                    std::chrono::duration<double, std::nano> duration{};
-                    auto t_begin = std::chrono::high_resolution_clock::now();
-                    EnqueueProgram(device->command_queue(), program, false);
-                    Finish(device->command_queue());
-                    log_debug(LogTest, "EnqueProgram done");
-                    auto t_end = std::chrono::high_resolution_clock::now();
                     duration = t_end - t_begin;
                     rmax_tflops.push_back(static_cast<double>(num_of_matmul_ops) / duration.count() / 1000);
                     log_info(LogTest, "time duration: {:.5} ns, rmax_tflops {:.2f}", duration.count(), rmax_tflops[i]);
@@ -663,15 +679,15 @@ int main(int argc, char** argv) {
         bool validation_result = true;
         if (single_core) {
             if (dtype == 1) {
-                validation_result =
-                    validation_single_core(tensor_in0_fp16, tensor_in1_fp16, num_blocks, Mt, Nt, Kt, output_buffer);
+                validation_result = validation_single_core(
+                    device.get(), tensor_in0_fp16, tensor_in1_fp16, num_blocks, Mt, Nt, Kt, output_buffer);
             } else {
-                validation_result =
-                    validation_single_core_fp8(tensor_in0_fp8, tensor_in1_fp8, num_blocks, Mt, Nt, Kt, output_buffer);
+                validation_result = validation_single_core_fp8(
+                    device.get(), tensor_in0_fp8, tensor_in1_fp8, num_blocks, Mt, Nt, Kt, output_buffer);
             }
         } else {
             validation_result = validation(
-                device,
+                device.get(),
                 core_range,
                 Mt,
                 Nt,
@@ -695,7 +711,7 @@ int main(int argc, char** argv) {
             pass = false;
         }
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= device->close();
 
         // for csv
         log_info(tt::LogTest, "CSV_MICROBENCHMARK:title:test_compute_mm");
@@ -894,7 +910,7 @@ std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t>
 }
 
 tt_metal::Program create_program_single_core(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     tt::DataFormat cb_data_format,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -905,9 +921,9 @@ tt_metal::Program create_program_single_core(
     uint32_t Kt,
     uint32_t out_subblock_h,
     uint32_t out_subblock_w,
-    const std::shared_ptr<tt::tt_metal::Buffer>& in0_cb_addr,
-    const std::shared_ptr<tt::tt_metal::Buffer>& in1_cb_addr,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_cb_addr,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& in0_cb_addr,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& in1_cb_addr,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& out_cb_addr,
     bool matmul_block,
     bool packer_l1,
     uint32_t num_blocks,
@@ -990,15 +1006,15 @@ tt_metal::Program create_program_single_core(
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(in0_CB_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
             .set_page_size(src0_cb_index, single_tile_size)
-            .set_globally_allocated_address(*in0_cb_addr);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+            .set_globally_allocated_address(*in0_cb_addr->get_backing_buffer());
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(in1_CB_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
             .set_page_size(src1_cb_index, single_tile_size)
-            .set_globally_allocated_address(*in1_cb_addr);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+            .set_globally_allocated_address(*in1_cb_addr->get_backing_buffer());
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     uint32_t out_cb_index = tt::CBIndex::c_16;
     uint32_t interm0_cb_index = tt::CBIndex::c_24;
@@ -1019,8 +1035,8 @@ tt_metal::Program create_program_single_core(
         tt_metal::CircularBufferConfig cb_out_config =
             tt_metal::CircularBufferConfig(out_CB_size, {{out_cb_index, cb_data_format}})
                 .set_page_size(out_cb_index, single_tile_size)
-                .set_globally_allocated_address(*out_cb_addr);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+                .set_globally_allocated_address(*out_cb_addr->get_backing_buffer());
+        auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
     } else if (packer_l1 and cb_data_format == tt::DataFormat::Bfp8_b) {
         tt_metal::CircularBufferConfig cb_interm_config =
             tt_metal::CircularBufferConfig(out_CB_tiles * 2048, {{interm0_cb_index, tt::DataFormat::Float16_b}})
@@ -1030,8 +1046,8 @@ tt_metal::Program create_program_single_core(
         tt_metal::CircularBufferConfig cb_out_config =
             tt_metal::CircularBufferConfig(out_CB_size, {{out_cb_index, cb_data_format}})
                 .set_page_size(out_cb_index, single_tile_size)
-                .set_globally_allocated_address(*out_cb_addr);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+                .set_globally_allocated_address(*out_cb_addr->get_backing_buffer());
+        auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
     } else {
         std::map<uint8_t, tt::DataFormat> partials_and_out_data_format_spec = {
             {out_cb_index, cb_data_format}, {interm0_cb_index, cb_data_format}};
@@ -1039,8 +1055,8 @@ tt_metal::Program create_program_single_core(
             tt_metal::CircularBufferConfig(out_CB_size, partials_and_out_data_format_spec)
                 .set_page_size(interm0_cb_index, single_tile_size)
                 .set_page_size(out_cb_index, single_tile_size)
-                .set_globally_allocated_address(*out_cb_addr);
-        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), cb_out_config);
+                .set_globally_allocated_address(*out_cb_addr->get_backing_buffer());
+        auto cb_out = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), cb_out_config);
     }
 
     log_debug(tt::LogTest, "in0_CB_size: {}", in0_CB_tiles * single_tile_size);
@@ -1101,7 +1117,7 @@ tt_metal::Program create_program_single_core(
 }
 
 tt_metal::Program create_program(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     tt::DataFormat cb_data_format,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1410,7 +1426,7 @@ std::vector<T> get_col_slice(std::vector<T> data, int start_col_index, int num_c
 }
 
 void prepare_inputs(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     CoreCoord core_range,
     uint32_t Mt,
     uint32_t Nt,
@@ -1464,11 +1480,12 @@ void prepare_inputs(
 
             // copy in0, in1, in2 to L1
             CoreCoord core = {(std::size_t)c, (std::size_t)r};
-            pass &= tt_metal::detail::WriteToDeviceL1(device, core, in0_addr, in0);
+            auto target_device = device->get_devices()[0];
+            pass &= tt_metal::detail::WriteToDeviceL1(target_device, core, in0_addr, in0);
             TT_ASSERT(pass);
-            pass &= tt_metal::detail::WriteToDeviceL1(device, core, in1_addr, in1);
+            pass &= tt_metal::detail::WriteToDeviceL1(target_device, core, in1_addr, in1);
             TT_ASSERT(pass);
-            pass &= tt_metal::detail::WriteToDeviceL1(device, core, in2_cb_addr, in2);
+            pass &= tt_metal::detail::WriteToDeviceL1(target_device, core, in2_cb_addr, in2);
             TT_ASSERT(pass);
         }
     }
@@ -1477,17 +1494,18 @@ void prepare_inputs(
 float to_float(bfloat16 bfloat16_num) { return bfloat16_num.to_float(); }
 
 bool validation_single_core(
+    tt_metal::distributed::MeshDevice* device,
     const tt::deprecated::Tensor<bfloat16>& tensor_in0,
     const tt::deprecated::Tensor<bfloat16>& tensor_in1,
     uint32_t num_blocks,
     uint32_t Mt,
     uint32_t Nt,
     uint32_t Kt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer) {
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& out_buffer) {
     bool pass = true;
 
     std::vector<uint32_t> result;
-    tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
+    tt_metal::distributed::ReadShard(device->mesh_command_queue(), result, out_buffer, {0, 0}, true);
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
     auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
@@ -1525,17 +1543,18 @@ bool validation_single_core(
 }
 
 bool validation_single_core_fp8(
+    tt_metal::distributed::MeshDevice* device,
     const tt::deprecated::Tensor<float>& tensor_in0,
     const tt::deprecated::Tensor<float>& tensor_in1,
     uint32_t num_blocks,
     uint32_t Mt,
     uint32_t Nt,
     uint32_t Kt,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer) {
+    const std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>& out_buffer) {
     bool pass = true;
 
     std::vector<uint32_t> result;
-    tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
+    tt_metal::distributed::ReadShard(device->mesh_command_queue(), result, out_buffer, {0, 0}, true);
 
     auto result_bfp8 = unpack_bfp8_tiles_into_float_vec(result, true, false);
     auto result_untilized = untilize_swizzled(result_bfp8, Mt * 32, Nt * 32);
@@ -1566,7 +1585,7 @@ bool validation_single_core_fp8(
 }
 
 bool validation(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     CoreCoord core_range,
     uint32_t Mt,
     uint32_t Nt,
@@ -1598,7 +1617,9 @@ bool validation(
             std::vector<uint32_t> result_vec;
             uint32_t num_r = (r == num_cores_y - 1) ? (last_block_h) : (per_core_Mt);
             uint32_t num_c = (c == num_cores_x - 1) ? (last_block_w) : (per_core_Nt);
-            tt_metal::detail::ReadFromDeviceL1(device, core, out_addr, num_r * num_c * single_tile_size, result_vec);
+            auto target_device = device->get_devices()[0];
+            tt_metal::detail::ReadFromDeviceL1(
+                target_device, core, out_addr, num_r * num_c * single_tile_size, result_vec);
             auto result_flat_layout = unpack_bfp8_tiles_into_float_vec(result_vec, true, false);
             auto result_untilized = untilize_swizzled(result_flat_layout, num_r * 32, num_c * 32);
 
@@ -1636,8 +1657,8 @@ bool validation(
     return pass;
 }
 
-std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
-    tt_metal::IDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt) {
+std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_and_transfer_data_sharded_cb(
+    tt_metal::distributed::MeshDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt) {
     uint32_t size_bytes = Mt * tt::constants::TILE_HEIGHT * Nt * tt::constants::TILE_WIDTH * 2;
     uint32_t page_size_bytes = tt::constants::TILE_HW * 2;
 
@@ -1651,19 +1672,24 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
     log_debug(tt::LogTest, "size_bytes: {}", size_bytes);
     log_debug(tt::LogTest, "page_size_bytes: {}", page_size_bytes);
 
-    auto input_buffer = CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-        .device = device,
-        .size = size_bytes,
+    // Create MeshBuffer configuration
+    auto mesh_buffer_config = tt::tt_metal::distributed::ReplicatedBufferConfig{.size = size_bytes};
+    auto device_local_config = tt::tt_metal::distributed::DeviceLocalBufferConfig{
         .page_size = page_size_bytes,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = shard_spec});
-    tt::tt_metal::detail::WriteToBuffer(input_buffer, activations);
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED)};
+
+    auto input_buffer = tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, device_local_config, device);
+
+    // Write data to the mesh buffer
+    auto& mesh_cq = device->mesh_command_queue();
+    tt::tt_metal::distributed::EnqueueWriteMeshBuffer(mesh_cq, input_buffer, activations, true);
 
     return input_buffer;
 }
 
-std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb_fp8(
-    tt_metal::IDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt) {
+std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_and_transfer_data_sharded_cb_fp8(
+    tt_metal::distributed::MeshDevice* device, const vector<uint32_t>& activations, uint32_t Mt, uint32_t Nt) {
     uint32_t size_bytes = Mt * Nt * 1088;
     uint32_t page_size_bytes = 1088;
 
@@ -1677,13 +1703,18 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb_fp8(
     log_debug(tt::LogTest, "size_bytes: {}", size_bytes);
     log_debug(tt::LogTest, "page_size_bytes: {}", page_size_bytes);
 
-    auto input_buffer = CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-        .device = device,
-        .size = size_bytes,
+    // Create MeshBuffer configuration
+    auto mesh_buffer_config = tt::tt_metal::distributed::ReplicatedBufferConfig{.size = size_bytes};
+    auto device_local_config = tt::tt_metal::distributed::DeviceLocalBufferConfig{
         .page_size = page_size_bytes,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = shard_spec});
-    tt::tt_metal::detail::WriteToBuffer(input_buffer, activations);
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED)};
+
+    auto input_buffer = tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, device_local_config, device);
+
+    // Write data to the mesh buffer
+    auto& mesh_cq = device->mesh_command_queue();
+    tt::tt_metal::distributed::EnqueueWriteMeshBuffer(mesh_cq, input_buffer, activations, true);
 
     return input_buffer;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -36,6 +36,7 @@
 #include "test_common.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
+#include <tt-metalium/distributed.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -158,9 +159,9 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
+        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
-        int clock_freq_mhz = get_tt_npu_clock(device);
+        int clock_freq_mhz = get_tt_npu_clock(device->get_devices()[0]);
         auto grid_coord = device->compute_with_storage_grid_size();
         num_cores_c = (num_cores_c == 0) ? grid_coord.x : num_cores_c;
         num_cores_r = (num_cores_r == 0) ? grid_coord.y : num_cores_r;
@@ -237,13 +238,15 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::detail::CompileProgram(device, program);
-
         log_info(LogTest, "Num tests {}", num_tests);
+        auto mesh_workload = tt_metal::distributed::CreateMeshWorkload();
+        tt_metal::distributed::AddProgramToMeshWorkload(
+            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
-            EnqueueProgram(device->command_queue(), program, false);
-            Finish(device->command_queue());
+            tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
+            tt_metal::distributed::Finish(device->mesh_command_queue());
             auto t_end = std::chrono::steady_clock::now();
             unsigned long elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             unsigned long elapsed_cc = clock_freq_mhz * elapsed_us;
@@ -251,7 +254,8 @@ int main(int argc, char** argv) {
             log_info(LogTest, "Time elapsed for NOC transfers: {}us ({}cycles)", elapsed_us, elapsed_cc);
 
             if (use_device_profiler) {
-                elapsed_cc = get_t0_to_any_riscfw_end_cycle(device, program);
+                elapsed_cc = get_t0_to_any_riscfw_end_cycle(
+                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
                 elapsed_us = (double)elapsed_cc / clock_freq_mhz;
                 log_info(LogTest, "Time elapsed using device profiler: {}us ({}cycles)", elapsed_us, elapsed_cc);
             }
@@ -263,7 +267,7 @@ int main(int argc, char** argv) {
             log_info(LogTest, "Measured NOC bandwidth: {:.3f}B/cc", measured_bandwidth[i]);
         }
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= device->close();
     } catch (const std::exception& e) {
         pass = false;
         log_error(LogTest, "{}", e.what());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -36,6 +36,8 @@
 #include "test_common.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -137,9 +139,9 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
+        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
-        int clock_freq_mhz = get_tt_npu_clock(device);
+        int clock_freq_mhz = get_tt_npu_clock(device->get_devices()[0]);
         auto grid_coord = device->compute_with_storage_grid_size();
         num_cores_c = (num_cores_c == 0) ? grid_coord.x : num_cores_c;
         num_cores_r = (num_cores_r == 0) ? grid_coord.y : num_cores_r;
@@ -149,7 +151,13 @@ int main(int argc, char** argv) {
 
         // limit size of the L1 buffer to do not exceed global L1 size
         uint32_t l1_buffer_size = num_cores_r * num_cores_c * (num_tiles > 256 ? 256 : num_tiles) * page_size;
-        auto l1_buffer = tt_metal::Buffer::create(device, l1_buffer_size, page_size, tt_metal::BufferType::L1);
+        tt::tt_metal::distributed::DeviceLocalBufferConfig device_local_config{
+            .page_size = page_size,
+            .buffer_type = tt_metal::BufferType::L1,
+        };
+        tt::tt_metal::distributed::ReplicatedBufferConfig global_buffer_config{.size = l1_buffer_size};
+        auto l1_mesh_buffer =
+            tt::tt_metal::distributed::MeshBuffer::create(global_buffer_config, device_local_config, device.get());
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup
@@ -188,7 +196,7 @@ int main(int argc, char** argv) {
             for (int j = 0; j < num_cores_c; j++) {
                 CoreCoord core = {(std::size_t)j, (std::size_t)i};
                 uint32_t core_index = i * num_cores_c + j;
-                uint32_t l1_buffer_addr = l1_buffer->address();
+                uint32_t l1_buffer_addr = l1_mesh_buffer->address();
 
                 const std::array noc_runtime_args = {core_index, l1_buffer_addr, num_tiles, num_cores_r * num_cores_c};
                 SetRuntimeArgs(program, noc_kernel, core, noc_runtime_args);
@@ -198,26 +206,29 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::detail::CompileProgram(device, program);
-
         log_info(LogTest, "Num tests {}", num_tests);
+        auto mesh_workload = tt_metal::distributed::CreateMeshWorkload();
+        tt_metal::distributed::AddProgramToMeshWorkload(
+            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
-            EnqueueProgram(device->command_queue(), program, false);
-            Finish(device->command_queue());
+            tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
+            tt_metal::distributed::Finish(device->mesh_command_queue());
             auto t_end = std::chrono::steady_clock::now();
             elapsed_us.push_back(duration_cast<microseconds>(t_end - t_begin).count());
 
             log_info(LogTest, "Time elapsed for NOC transfers: {}us", elapsed_us[i]);
 
             if (use_device_profiler) {
-                elapsed_cc = get_t0_to_any_riscfw_end_cycle(device, program);
+                elapsed_cc = get_t0_to_any_riscfw_end_cycle(
+                    device->get_devices()[0], mesh_workload.get_programs().begin()->second);
                 elapsed_us.push_back((double)elapsed_cc / clock_freq_mhz);
                 log_info(LogTest, "Time elapsed uisng device profiler: {}us ({}cycles)", elapsed_us[i], elapsed_cc);
             }
         }
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= device->close();
     } catch (const std::exception& e) {
         pass = false;
         log_error(LogTest, "{}", e.what());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/sweep_rw_buffer.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/sweep_rw_buffer.sh
@@ -8,7 +8,7 @@
 
 function run_one() {
     echo "Running $@"
-    build/test/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer_${ARCH_NAME} $@
+    build/test/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer $@
 }
 
 function run_set() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
@@ -32,6 +32,7 @@
 #include "test_common.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
+#include <tt-metalium/distributed.hpp>
 
 using std::vector;
 using namespace tt;
@@ -94,7 +95,7 @@ int main(int argc, char** argv) {
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     int device_id = 0;
-    tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
+    auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
     auto grid_coord = device->compute_with_storage_grid_size();
     num_cores_c = (num_cores_c == 0) ? grid_coord.x : num_cores_c;
@@ -200,20 +201,22 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::detail::CompileProgram(device, program);
+        auto mesh_workload = tt_metal::distributed::CreateMeshWorkload();
+        tt_metal::distributed::AddProgramToMeshWorkload(
+            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
 
         log_info(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
-            EnqueueProgram(device->command_queue(), program, false);
-            Finish(device->command_queue());
+            tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
+            tt_metal::distributed::Finish(device->mesh_command_queue());
             auto t_end = std::chrono::steady_clock::now();
             elapsed_us.push_back(duration_cast<microseconds>(t_end - t_begin).count());
 
             log_info(LogTest, "Time elapsed for executing empty kernels: {}us", elapsed_us[i]);
         }
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= device->close();
     } catch (const std::exception& e) {
         pass = false;
         log_error(LogTest, "{}", e.what());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -45,6 +45,7 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
+#include <tt-metalium/distributed.hpp>
 
 using namespace tt;
 using std::chrono::duration_cast;
@@ -97,7 +98,7 @@ void get_max_page_size_and_num_pages(uint32_t num_tiles, uint32_t tile_size, uin
 }
 
 std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
-    tt_metal::IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     const CoreRangeSet& all_cores,
     const uint32_t& single_tile_size,
     const tt::DataFormat& tile_format,
@@ -174,7 +175,6 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
 
 bool validation(
     tt_metal::IDevice* device,
-    tt_metal::Buffer& input_buffer,
     std::vector<uint32_t>& input_vec,
     const uint32_t& num_cores,
     std::vector<CoreCoord>& all_cores,
@@ -255,7 +255,7 @@ uint32_t get_dram_bandwidth(tt::ARCH arch) {
 }
 
 void get_optimal_dram_bank_to_reader_assignment(
-    IDevice* device,
+    tt_metal::distributed::MeshDevice* device,
     std::vector<CoreCoord>& all_worker_cores_ordered,
     CoreRangeSet& all_worker_cores,
     tt_metal::NOC noc) {
@@ -373,7 +373,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
+        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
         dram_bandwidth_spec = get_dram_bandwidth(device->arch());
 
         TT_ASSERT(
@@ -385,7 +385,7 @@ int main(int argc, char** argv) {
 
         CoreRangeSet all_cores;
         std::vector<CoreCoord> all_cores_list;
-        get_optimal_dram_bank_to_reader_assignment(device, all_cores_list, all_cores, tt_metal::NOC::NOC_0);
+        get_optimal_dram_bank_to_reader_assignment(device.get(), all_cores_list, all_cores, tt_metal::NOC::NOC_0);
 
         uint32_t num_tiles_per_core = num_tiles / num_cores;
         uint32_t num_tiles_cb = num_tiles_per_core / num_blocks;
@@ -418,14 +418,19 @@ int main(int argc, char** argv) {
             input_vec = create_random_vector_of_bfloat16(input_size, 100, 1234);
         }
 
-        auto input_buffer = tt_metal::Buffer::create(
-            device, input_vec.size() * sizeof(uint32_t), single_tile_size, tt_metal::BufferType::DRAM);
+        // Create MeshBuffer for DRAM
+        tt_metal::distributed::DeviceLocalBufferConfig device_local{
+            .page_size = single_tile_size,
+            .buffer_type = tt_metal::BufferType::DRAM,
+        };
+        tt_metal::distributed::ReplicatedBufferConfig global_buf{.size = input_vec.size() * sizeof(uint32_t)};
+        auto input_buffer = tt_metal::distributed::MeshBuffer::create(global_buf, device_local, device.get());
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup
         ////////////////////////////////////////////////////////////////////////////
         auto [program, kernel, cb_addr] = create_program(
-            device,
+            device.get(),
             all_cores,
             single_tile_size,
             tile_format,
@@ -442,19 +447,22 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Copy Input To DRAM or L1
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::detail::WriteToBuffer(*input_buffer, input_vec);
+        tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+        tt_metal::distributed::Finish(device->mesh_command_queue());
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Execution Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::detail::CompileProgram(device, program);
+        auto mesh_workload = tt_metal::distributed::CreateMeshWorkload();
+        tt_metal::distributed::AddProgramToMeshWorkload(
+            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
 
         log_info(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
-            EnqueueProgram(device->command_queue(), program, false);
-            Finish(device->command_queue());
-            tt_metal::detail::ReadDeviceProfilerResults(device);
+            tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
+            tt_metal::distributed::Finish(device->mesh_command_queue());
+            tt_metal::detail::ReadDeviceProfilerResults(device->get_devices()[0]);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
@@ -470,8 +478,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
 
         pass = validation(
-            device,
-            *input_buffer,
+            device.get(),
             input_vec,
             num_cores,
             all_cores_list,
@@ -486,7 +493,7 @@ int main(int argc, char** argv) {
             block_w,
             num_datum_per_slice);
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= device->close();
     } catch (const std::exception& e) {
         pass = false;
         // Capture the exception error message

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "hostdevcommon/dprint_common.h"
 #include "impl/context/metal_context.hpp"
@@ -49,15 +50,17 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
             uint32_t step = (end_index - MARKER_DATA_START) / TIMER_DATA_UINT32_SIZE;
             uint32_t timer_id = 1;
             for (int i = MARKER_DATA_START; i < end_index; i += TIMER_DATA_UINT32_SIZE, timer_id++) {
-                uint64_t cycle =
-                    ((static_cast<uint64_t>(profile_buffer[i + TIMER_VAL_H]) << 32) | profile_buffer[i + TIMER_VAL_L]);
+                if (i + TIMER_VAL_H < profile_buffer.size()) {
+                    uint64_t cycle =
+                        ((static_cast<uint64_t>(profile_buffer[i + TIMER_VAL_H]) << 32) |
+                         profile_buffer[i + TIMER_VAL_L]);
+                    if (timer_id == 1 && cycle < min_cycle) {
+                        min_cycle = cycle;
+                    }
 
-                if (timer_id == 1 && cycle < min_cycle) {
-                    min_cycle = cycle;
-                }
-
-                if (timer_id == step && cycle > max_cycle) {
-                    max_cycle = cycle;
+                    if (timer_id == step && cycle > max_cycle) {
+                        max_cycle = cycle;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22835)

### Problem description
This PR is one of many that migrates tests to use new TT-Mesh APIs instead of legacy APIs.

### What's changed
This PR migrates many of the metal microbenchmark tests inside `tests/tt_metal/tt_metal/perf_microbenchmark`, which are used inside the `N300 Moreh ubench` section of the metal microbenchmark CI suite.

### Checklist
- [ ] [Metal microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/16978516554)