### PR TITLE
Fix AG segmentation fault

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -7,6 +7,7 @@ import pytest
 from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from ttnn import ShardTensor2dMesh, ConcatMesh2dToTensor
 from models.utility_functions import skip_for_grayskull
 
 from tests.ttnn.unit_tests.operations.ccl.test_all_gather_TG_post_commit import (
@@ -761,3 +762,69 @@ def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabr
         cluster_axis=1,
         use_all_gather_async=True,
     )
+
+
+# Related to issue #26672
+@pytest.mark.parametrize("device", [pytest.param((1, 4), id="1x4_grid")], indirect=True)
+def test_all_gather_async_segfault(device):
+    num_devices = 4
+    if mesh_device.get_num_devices() < 4:
+        pytest.skip("Not enough devices for this test!")
+
+    input_tensor = torch.arange(32 * 32).reshape(1, 1, 32, 32)
+    output_tensor = input_tensor.repeat([1, 1, 1, num_devices])
+    tensor = ttnn.from_torch(
+        input_tensor,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    memory_config = ttnn.create_sharded_memory_config(
+        shape=(
+            32,
+            32,
+        ),
+        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_devices - 1, 0))}),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    tensor_ag = ttnn.experimental.all_gather_async(
+        tensor,
+        mesh_device=device,
+        cluster_axis=1,
+        dim=-1,
+        topology=ttnn.Topology.Linear,
+        memory_config=memory_config,
+        barrier_semaphore=ttnn.create_global_semaphore(
+            device,
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device.core_grid.x - 1, device.core_grid.y - 1))}
+            ),
+            0,
+        ),
+        multi_device_global_semaphore=ttnn.create_global_semaphore(
+            device,
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device.core_grid.x - 1, device.core_grid.y - 1))}
+            ),
+            0,
+        ),
+    )
+
+    tt_output_tensor = ttnn.to_torch(
+        tensor_ag, mesh_composer=ConcatMesh2dToTensor(device, mesh_shape=(1, num_devices), dims=(0, 3))
+    )
+    output_golden = torch.zeros(tt_output_tensor.shape)
+    repeat_factor = [1, 1, 1, num_devices]
+    output_golden[:, :, :, :] = output_tensor.repeat(repeat_factor)
+
+    eq, output = comp_pcc(tt_output_tensor, output_golden)
+    if not eq:
+        logger.error(f"output mismatch for tensor: {output}")
+
+    assert eq, f"FAILED: {output}"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -14,7 +14,7 @@
 
 namespace ttnn::operations::experimental::ccl {
 
-bool use_composite_all_gather(const ttnn::Tensor& input_tensor, const int32_t dim) {
+bool use_composite_all_gather(const ttnn::Tensor& input_tensor, const int32_t dim, const uint32_t semaphore_size) {
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
@@ -23,6 +23,12 @@ bool use_composite_all_gather(const ttnn::Tensor& input_tensor, const int32_t di
 
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;
+
+    auto input_memory_config = input_tensor.memory_config();
+    auto output_memory_config = memory_config.value_or(input_memory_config);
+    if (input_memory_config != output_memory_config && semaphore_size < 2) {
+        return true;
+    }
 
     // Use composite for row-major tensors
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
@@ -68,6 +74,8 @@ ttnn::Tensor composite_all_gather(
     // and after re-tilizing
     DataType input_dtype = input_tensor.dtype();
     bool convert_to_bfloat16_for_composite = is_tiled_and_not_tile_aligned && input_dtype == DataType::BFLOAT8_B;
+    auto input_memory_config = input_tensor.memory_config();
+    auto output_memory_config = memory_config.value_or(input_memory_config);
 
     // Convert to row major
     if (is_tiled_and_not_tile_aligned) {
@@ -79,10 +87,9 @@ ttnn::Tensor composite_all_gather(
     }
 
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor, num_links, memory_config, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
+        input_tensor, num_links, input_memory_config, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
 
     ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, gather_dim);
-
     // Convert back to tiled
     if (is_tiled_and_not_tile_aligned) {
         all_gather_output_tensor = ttnn::to_layout(all_gather_output_tensor, Layout::TILE);
@@ -91,6 +98,10 @@ ttnn::Tensor composite_all_gather(
         if (convert_to_bfloat16_for_composite) {
             all_gather_output_tensor = ttnn::typecast(all_gather_output_tensor, input_dtype);
         }
+    }
+
+    if (input_memory_config != output_memory_config) {
+        all_gather_output_tensor = ttnn::to_memory_config(all_gather_output_tensor, output_memory_config);
     }
 
     return all_gather_output_tensor;
@@ -123,7 +134,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensor, dim)) {
+    if (use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size())) {
         return composite_all_gather(
             input_tensor,
             dim,
@@ -160,7 +171,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
-    if (use_composite_all_gather(input_tensor, dim)) {
+    if (use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size())) {
         return composite_all_gather(input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
         return ttnn::operations::experimental::ccl::all_gather_async(
@@ -191,7 +202,7 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensors[0], dim)) {
+    if (use_composite_all_gather(input_tensors[0], dim, multi_device_global_semaphore.size())) {
         return composite_all_gather(
             input_tensors,
             dim,
@@ -226,7 +237,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensor, dim)) {
+    if (use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size())) {
         return composite_all_gather(
             input_tensor, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
@@ -259,7 +270,7 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensors[0], dim)) {
+    if (use_composite_all_gather(input_tensors[0], dim, multi_device_global_semaphore.size())) {
         return composite_all_gather(
             input_tensors, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/26672

### Problem description
All gather async causes segmentation fault with a sharded output memory configuration

### What's changed
Update all gather async composite op to account for cases where the input and output memory configurations are different: all_broadcast with same memory configuration -> concat -> to_memory_config

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17049000070
- [x] TG frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/17049013405
- [x] T3K frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/17049053345
- [x] T3K unit tests https://github.com/tenstorrent/tt-metal/actions/runs/17049064429
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes