### PR TITLE
Enable UInt8 for Identity OP when DST_ACCUM_MODE==false

### DIFF
--- a/tech_reports/data_formats/reconfig_data_format.md
+++ b/tech_reports/data_formats/reconfig_data_format.md
@@ -6,22 +6,16 @@ Certain operations may require multiple input or output DataFormats. Since the U
 
 This API reconfigures hardware associated with UNPACK (trisc0) and MATH (trisc1). It consists of the following 6 calls:
 ```
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t srcb_new_operand)
 
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format(const uint32_t srca_old_operand, const uint32_t srca_new_operand, const uint32_t srcb_old_operand, const uint32_t srcb_new_operand)
 
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand)
 
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand)
 
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand)
 
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand)
 ```
 There are 3 different functions (`reconfig_data_format`, `reconfig_data_format_srca`, `reconfig_data_format_srcb`), each overloaded to accept either only the new operand CB index or both the old and new operand CB index.
@@ -29,14 +23,12 @@ There are 3 different functions (`reconfig_data_format`, `reconfig_data_format_s
 2. `reconfig_data_format_srca`: reconfigures the DataFormats for only SrcA register
 3. `reconfig_data_format_srcb`: reconfigures the DataFormats for only SrcB register
 
-The template parameter `to_from_int8` serves to enable reconfiguring between FLOAT and INT8 DataFormats (ex. BFLOAT16 <-> UINT8), and requires that `DST_ACCUM_MODE==true`.
-
 The following DataFormat reconfigurations are currently supported:
-| Old DataFormat                            | New DataFormat                            | Requirements                                 |
-|-------------------------------------------|-------------------------------------------|----------------------------------------------|
-| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None                                         |
-| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | UINT8                                     | `to_from_int8==true`, `DST_ACCUM_MODE==true` |
-| UINT8                                     | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | `to_from_int8==true`, `DST_ACCUM_MODE==true` |
+| Old DataFormat                            | New DataFormat                            | Special Requirements                                   |
+|-------------------------------------------|-------------------------------------------|--------------------------------------------------------|
+| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None                                                   |
+| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | {UINT8, INT8}                             | Int8 FPU Math won't work unless `DST_ACCUM_MODE==true` |
+| {UINT8, INT8}                             | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None                                                   |
 
 ## `pack_reconfig_data_format`
 
@@ -49,11 +41,11 @@ ALWI void pack_reconfig_data_format(const uint32_t old_operand, const uint32_t n
 The function `pack_reconfig_data_format` is overloaded to accept either just the new, or both the old and new operand CB index.
 
 The following DataFormat reconfigurations are currently supported:
-| Old DataFormat                            | New DataFormat                            | Requirements                                 |
-|-------------------------------------------|-------------------------------------------|----------------------------------------------|
-| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None                                         |
-| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | UINT8                                     | None                                         |
-| UINT8                                     | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None                                         |
+| Old DataFormat                            | New DataFormat                            | Requirements |
+|-------------------------------------------|-------------------------------------------|--------------|
+| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None         |
+| {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | UINT8                                     | None         |
+| UINT8                                     | {FLOAT32, BFLOAT16, BFLOAT8_B, BFLOAT4_B} | None         |
 
 ## Usage guidelines
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -75,7 +75,7 @@ void math_main() {
     constexpr bool spill = num_blocks > 1U;
     bool enable_reload = false;
 
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
 
     for (uint32_t block = 0U; block < num_blocks; block++) {
         bool last_out = block == num_blocks - 1U;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -15,7 +15,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -19,7 +19,7 @@ void math_main() {
     int __outer_loop_iter;
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0, 0)));
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 0);
+    llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 0);
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_math_wait_for_dest_available();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -25,7 +25,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -201,8 +201,6 @@ def run_identity_test(device, h, w, data_type):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
 def test_fp32_uint32(device, h, w, dtype):
-    if dtype == ttnn.uint8:
-        pytest.skip(" Need uint8 LLK support without workarounds - see #24571")
     run_identity_test(device, h, w, dtype)
 
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -21,11 +21,11 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-template <bool untilize_en = false, bool skip_inputs = false>
+template <bool is_fp32_dest_acc_en, bool untilize_en = false, bool skip_inputs = false>
 inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-    _llk_math_hw_configure_<untilize_en, skip_inputs>(
+    _llk_math_hw_configure_<is_fp32_dest_acc_en, untilize_en, skip_inputs>(
         unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
@@ -59,28 +59,28 @@ inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -93,33 +93,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<is_fp32_dest_acc_en>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -53,74 +53,70 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srca_operand_id],
         unpack_dst_format[srca_operand_id],
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srcb_operand_id],
         unpack_dst_format[srcb_operand_id],
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srca_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srcb_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srcb_new_operand);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         srcb_old_operand, srcb_new_operand);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -21,12 +21,13 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-template <bool untilize_en = false, bool skip_inputs = false>
+template <bool is_fp32_dest_acc_en, bool untilize_en = false, bool skip_inputs = false>
 inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     if constexpr (skip_inputs == false) {
         std::uint32_t srca_operand_id = get_operand_id(srca_operand);
         std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-        _llk_math_hw_configure_<untilize_en>(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
+        _llk_math_hw_configure_<is_fp32_dest_acc_en, untilize_en>(
+            unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
     }
 }
 
@@ -60,28 +61,28 @@ inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -94,33 +95,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<is_fp32_dest_acc_en>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -53,74 +53,70 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srca_operand_id],
         unpack_dst_format[srca_operand_id],
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srcb_operand_id],
         unpack_dst_format[srcb_operand_id],
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srca_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srcb_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(srcb_new_operand);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         srcb_old_operand, srcb_new_operand);
 }
 

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -36,7 +36,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<data_copy_type, DST_ACCUM_MODE, bcast_type>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
@@ -78,7 +78,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
     }
 
     if (unpacker_dst_format_change) {
-        MATH((llk_math_hw_configure_disaggregated(new_icb, new_icb)));
+        MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(new_icb, new_icb)));
     }
 
     if (unpacker_dst_format_change || bcast_type_change) {
@@ -216,7 +216,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
 }
 
 /*

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -41,7 +41,7 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
     UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated<false /*untilize*/, false /*skip_inputs*/>(icb0, icb1)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE, false /*untilize*/, false /*skip_inputs*/>(icb0, icb1)));
 
     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
     PACK((llk_pack_hw_configure_disaggregated<

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -32,7 +32,7 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -26,7 +26,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb)));
 }
 
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb) { unary_op_init_common(icb, ocb); }

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -36,7 +36,7 @@ ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, co
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
@@ -161,7 +161,7 @@ ALWI void mm_block_init(
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(out_cb_id)));
     PACK((llk_pack_init<false, false>(out_cb_id)));

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -61,7 +61,7 @@ template <
 ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
 #ifdef ARCH_BLACKHOLE
     // Needed for setting swizzle_32b:
-    MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE, true, true>(0, 0)));
 #endif
     // A workaround for tt-metal#17132. Should be addressed more systematically.
     PACK(

--- a/tt_metal/include/compute_kernel_api/reconfig_data_format.h
+++ b/tt_metal/include/compute_kernel_api/reconfig_data_format.h
@@ -11,61 +11,55 @@ namespace ckernel {
 /**
  * Helper function to reconfigure srca and srcb data formats.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(srca_new_operand, srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(srca_new_operand, srcb_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srca/srcb data formats, only if they differ from existing formats.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format(
     const uint32_t srca_old_operand,
     const uint32_t srca_new_operand,
     const uint32_t srcb_old_operand,
     const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(
         srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(
         srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srca data format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_new_operand)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srca input data format, only if it differs from existing format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_old_operand, srca_new_operand)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_old_operand, srca_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srcb input data format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srcb input data format, only if it differs from existing format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_old_operand, srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_old_operand, srcb_new_operand)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -76,7 +76,7 @@ ALWI void tilizeA_B_reduce_init(
 
     MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1_scaler)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1_scaler)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));
@@ -246,7 +246,7 @@ ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
 
 ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(icb, icb)));
-    MATH((llk_math_reconfig_data_format<true, true>(icb, icb)));
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(icb, icb)));
 
     fast_tilize_init(icb, full_dim, ocb);
 }

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -44,7 +44,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, true, icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb)));
 #endif
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -31,7 +31,7 @@ inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
     // UNPACK(( kernel_sleep(100) ));
     UNPACK((llk_unpack_reconfig_data_format(1, 0, 0, 0)));
-    MATH((llk_math_reconfig_data_format(1, 0, 0, 0)));
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(1, 0, 0, 0)));
     tilize_init(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
@@ -172,7 +172,7 @@ void MAIN {
                             // Reconfigure input
                             copy_tile_to_dst_init_short(matmul_partials_cb);
                             UNPACK((llk_unpack_reconfig_data_format(1, matmul_partials_cb, 0, 0)));
-                            MATH((llk_math_reconfig_data_format(1, matmul_partials_cb, 0, 0)));
+                            MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(1, matmul_partials_cb, 0, 0)));
                             cb_wait_front(matmul_partials_cb, out_subblock_num_tiles);
                             for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
                                 copy_tile(matmul_partials_cb, i, i);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -322,13 +322,7 @@ Tensor Identity::invoke(
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::IDENTITY;
     DataType input_dtype = input_tensor.dtype();
-
-    if (input_dtype != DataType::UINT8) {
-        return detail::unary_impl(
-            queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
-    } else {
-        TT_THROW("ttnn.identity doesn't support uint8 datatype");
-    }
+    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor Abs::invoke(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24571)

### Problem description
Identity OP was returning 0's for UInt8 data format when Dest was in 16bit mode, due to conflicting register programming. Although the encouraged way of using int8/uint8 is with 32bit dest since that is how HW was designed, it is possible to workaround this limitation to enable a few special use cases where uint8 would be desired in 16bit Dest.

### What's changed
Update copy_tile, and reconfig_data_format LLKs to support uint8 even if Dest is in 16bit mode. This DOES NOT enable usage of int8 with a 16bit Dest for any FPU OPs, such as binary add/sub/mul/matmul/reduce etc.
Also, data reconfig API no longer requires `to_from_int8` flag to be set

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16999124619) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16999127533) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16999141668) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16999144413) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16999147929) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/runs/16999165095) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16999166598) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16999167958) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes