### PR TITLE
[skip ci] Update CIv2 p150b runner label for tt-train L2 test

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -260,7 +260,7 @@ jobs:
     name: tt-train nightly tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     steps:


### PR DESCRIPTION
### Ticket
None

### What's changed
Fix label on a workflow job with the old label format that was added after the repo-wide change in https://github.com/tenstorrent/tt-metal/commit/3250801aecf626ebd03f8a3d0be94a97b121adaf