### PR TITLE
#11406: Tensor visualization with shard-color mapping and shard dim slices

### DIFF
--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -26,6 +26,7 @@
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/distributed/tensor_topology.hpp"
 
 // This is required for automatic conversions, as in the creation of mesh devices
 // https://github.com/tenstorrent/tt-metal/issues/18082
@@ -83,6 +84,7 @@ void py_module_types(py::module& module) {
         module, "MeshCoordinateRangeSet", "Set of coordinate ranges within a mesh device.");
     py::class_<SystemMeshDescriptor>(module, "SystemMeshDescriptor");
     py::class_<DistributedHostBuffer>(module, "DistributedHostBuffer");
+    py::class_<TensorTopology>(module, "TensorTopology");
 }
 
 void py_module(py::module& module) {
@@ -447,11 +449,14 @@ void py_module(py::module& module) {
 
     auto py_placement_shard = static_cast<py::class_<MeshMapperConfig::Shard>>(module.attr("PlacementShard"));
     py_placement_shard.def(py::init([](int dim) { return MeshMapperConfig::Shard{dim}; }))
-        .def("__repr__", [](const MeshMapperConfig::Shard& shard) {
-            std::ostringstream str;
-            str << shard;
-            return str.str();
-        });
+        .def(
+            "__repr__",
+            [](const MeshMapperConfig::Shard& shard) {
+                std::ostringstream str;
+                str << shard;
+                return str.str();
+            })
+        .def_readwrite("dim", &MeshMapperConfig::Shard::dim);
     auto py_placement_replicate =
         static_cast<py::class_<MeshMapperConfig::Replicate>>(module.attr("PlacementReplicate"));
     py_placement_replicate.def(py::init([]() { return MeshMapperConfig::Replicate{}; }))
@@ -557,6 +562,11 @@ void py_module(py::module& module) {
         static_cast<py::class_<DistributedHostBuffer>>(module.attr("DistributedHostBuffer"));
     py_distributed_host_buffer.def("is_local", &DistributedHostBuffer::is_local, py::arg("coord"))
         .def("shape", &DistributedHostBuffer::shape, py::return_value_policy::reference_internal);
+
+    auto py_tensor_topology = static_cast<py::class_<TensorTopology>>(module.attr("TensorTopology"));
+    py_tensor_topology.def("mesh_shape", &TensorTopology::mesh_shape, py::return_value_policy::reference_internal)
+        .def("placements", &TensorTopology::placements, py::return_value_policy::reference_internal)
+        .def("mesh_coords", &TensorTopology::mesh_coords, py::return_value_policy::reference_internal);
 
     module.def(
         "get_device_tensors",

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -456,7 +456,7 @@ void py_module(py::module& module) {
                 str << shard;
                 return str.str();
             })
-        .def_readwrite("dim", &MeshMapperConfig::Shard::dim);
+        .def_readonly("dim", &MeshMapperConfig::Shard::dim);
     auto py_placement_replicate =
         static_cast<py::class_<MeshMapperConfig::Replicate>>(module.attr("PlacementReplicate"));
     py_placement_replicate.def(py::init([]() { return MeshMapperConfig::Replicate{}; }))

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1639,6 +1639,16 @@ void pytensor_module(py::module& m_tensor) {
 
                     py_list = tt_tensor.to_list()
             )doc")
+        .def(
+            "tensor_topology",
+            [](const Tensor& self) { return self.tensor_topology(); },
+            R"doc(
+                Get the topology of the tensor.
+
+                .. code-block:: python
+
+                    topology = tt_tensor.tensor_topology()
+            )doc")
         .def_property(
             "tensor_id",
             [](const Tensor& self) { return self.tensor_id; },

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -115,15 +115,68 @@ def visualize_mesh_device(mesh_device: "ttnn.MeshDevice"):
     Console().print(mesh_table)
 
 
+def get_placement_info(tensor_topology):
+    """Extract placement patterns from topology"""
+    placements = tensor_topology.placements()
+    placement_info = []
+    for i, placement in enumerate(placements):
+        placement_type = type(placement).__name__
+        if "Replicate" in placement_type:
+            placement_info.append(f"Tensor shards REPLICATED across mesh dim {i}")
+        elif "Shard" in placement_type:
+            placement_info.append(f"Tensor dim {placement.dim} SHARDED across mesh dim {i}")
+
+    return placement_info
+
+
+def calculate_shard_number(device_id, topology):
+    """Calculate the actual shard number based on sharding pattern, not device ID"""
+    mesh_shape = topology.mesh_shape()
+    placements = topology.placements()
+
+    # Convert device_id to mesh coordinates
+    if hasattr(mesh_shape, "__len__") and len(mesh_shape) >= 2:
+        mesh_rows, mesh_cols = mesh_shape[0], mesh_shape[1]
+        row = device_id // mesh_cols
+        col = device_id % mesh_cols
+        coord = [row, col]
+    else:
+        # Handle 1D or other cases
+        coord = [device_id]
+
+    # Calculate shard number by only considering sharded dimensions
+    shard_num = 0
+    shard_multiplier = 1
+
+    for i, placement in enumerate(placements):
+        placement_type = type(placement).__name__
+        if "Shard" in placement_type and i < len(coord):
+            # This dimension is sharded, so coordinate matters for shard number
+            shard_num += coord[i] * shard_multiplier
+            if hasattr(mesh_shape, "__len__") and i < len(mesh_shape):
+                shard_multiplier *= mesh_shape[i]
+        # If replicated, this dimension doesn't affect shard number
+
+    return shard_num
+
+
 def visualize_tensor(tensor: "ttnn.Tensor"):
     """
     Visualize tensor distribution across the mesh.
     """
     from rich.console import Console
+    from rich.panel import Panel
+    from rich.columns import Columns
     from loguru import logger
+
+    console = Console()
 
     try:
         shards = ttnn.get_device_tensors(tensor)
+        topology = tensor.tensor_topology()
+        placement_info = get_placement_info(topology)
+
+        placement_panel = Panel("\n".join(placement_info), title="Placement Configuration", border_style="blue")
 
         def annotate_with_shard_info(device_id):
             """Add shard information to device cells"""
@@ -133,9 +186,10 @@ def visualize_tensor(tensor: "ttnn.Tensor"):
                 dtype_str = str(shard.dtype).split(".")[-1]
                 layout_str = str(shard.layout).split(".")[-1]
 
-                # TODO: #11406 - Shard number is same as device id for now, this will break when shards are replicated
-                #       Need to update this when we can group devices by shard
-                return f"Shard {device_id}\nShape: {shape_str}\nDtype: {dtype_str}\nLayout: {layout_str}"
+                # Calculate actual shard number based on topology
+                shard_num = calculate_shard_number(device_id, topology)
+
+                return f"Shard {shard_num}\nShape: {shape_str}\nDtype: {dtype_str}\nLayout: {layout_str}"
             return ""
 
         # Generate the mesh table with shard annotations
@@ -146,7 +200,8 @@ def visualize_tensor(tensor: "ttnn.Tensor"):
             storage_type=tensor.storage_type(),
         )
 
-        Console().print(mesh_table)
+        console.print(placement_panel)
+        console.print(mesh_table)
 
     except Exception as e:
         logger.error(f"Error visualizing tensor: {e}")


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11406#event-18815197009)

### Problem description
Current tensor visualization does not have enough info to determine shard placement and replication. 

### What's changed

- Now utilizing TensorTopology to determine sharding scheme and shard replication
  - Placement configuration to display this information
- Colors in the visual indicate replicated shards
- Tensor dimension slices to indicate which tensor data lives where

### Example Visualizations

2x4 device-side sharded across cols
<img width="2102" height="530" alt="image" src="https://github.com/user-attachments/assets/c732f757-c8af-4119-bb8c-16fbd2fb2a28" />

8x1 host-side sharded across rows
<img width="2122" height="1510" alt="image" src="https://github.com/user-attachments/assets/9606d923-b71c-4dbd-aaf5-c5b927f00803" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/17077355092))