### PR TITLE
Add experimental microbenchmarks for new fabric channel architecture

### DIFF
--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -37,3 +37,5 @@ echo "Running fabric unit tests now...";
 echo "Running fabric sanity tests now...";
 
 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+
+./build/test/tt_metal/tt_fabric/fabric_elastic_channels_host_test 8 2 16 4352 1 4096 10000 4 4

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -35,6 +35,40 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tt_metal/tt_fabric
 )
 
+# Fabric Elastic Channels Test
+add_executable(fabric_elastic_channels_host_test)
+
+target_sources(
+    fabric_elastic_channels_host_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/feature_bringup/fabric_elastic_channels_host_test.cpp
+)
+
+target_link_libraries(
+    fabric_elastic_channels_host_test
+    PRIVATE
+        tt_metal
+        fabric
+        test_common_libs
+)
+
+target_include_directories(
+    fabric_elastic_channels_host_test
+    PRIVATE
+        ${UMD_HOME}
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/feature_bringup
+)
+
+set_target_properties(
+    fabric_elastic_channels_host_test
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal/tt_fabric
+)
+
 add_library(test_system_health_smoke OBJECT)
 add_library(TT::SystemHealth::Smoke ALIAS test_system_health_smoke)
 

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -191,7 +191,7 @@ TestConfig parse_cli_config(int argc, char** argv) {
         throw std::runtime_error("Invalid number of command line arguments");
     }
 
-    TestConfig config;
+    TestConfig config{};
     size_t arg_idx = 1;
     config.n_chunks = std::stoi(argv[arg_idx++]);
     config.chunk_n_pkts = std::stoi(argv[arg_idx++]);
@@ -358,13 +358,13 @@ TimingStats read_timing_stats(tt_metal::IDevice* device, CoreCoord core, uint32_
     // Read timing stats from L1 memory - use same address as calculated in host
     uint32_t timing_stats_addr = handshake_addr + 0x800;
 
-    std::vector<uint32_t> timing_data;
+    std::vector<uint32_t> timing_data{};
     timing_data.resize(sizeof(TimingStats) / sizeof(uint32_t));
     tt_metal::detail::ReadFromDeviceL1(
         device, core, timing_stats_addr, sizeof(TimingStats), timing_data, CoreType::ETH);
 
     constexpr size_t num_words = sizeof(TimingStats) / sizeof(uint32_t);
-    std::array<uint32_t, num_words> arr;
+    std::array<uint32_t, num_words> arr{};
     std::memcpy(arr.data(), timing_data.data(), sizeof(arr));
     stats = std::bit_cast<TimingStats>(arr);
 
@@ -374,13 +374,13 @@ TimingStats read_timing_stats(tt_metal::IDevice* device, CoreCoord core, uint32_
 WorkerTimingStats read_worker_timing_stats(tt_metal::IDevice* device, CoreCoord core, uint32_t timing_stats_addr) {
     WorkerTimingStats stats{};
 
-    std::vector<uint32_t> timing_data;
+    std::vector<uint32_t> timing_data{};
     timing_data.resize(sizeof(WorkerTimingStats) / sizeof(uint32_t));
     tt_metal::detail::ReadFromDeviceL1(
         device, core, timing_stats_addr, sizeof(WorkerTimingStats), timing_data, CoreType::WORKER);
 
     constexpr size_t num_words = sizeof(WorkerTimingStats) / sizeof(uint32_t);
-    std::array<uint32_t, num_words> arr;
+    std::array<uint32_t, num_words> arr{};
     std::memcpy(arr.data(), timing_data.data(), sizeof(arr));
     stats = std::bit_cast<WorkerTimingStats>(arr);
 
@@ -805,7 +805,7 @@ int main(int argc, char** argv) {
 
     } else {
         // Traditional CLI mode: single test from command line arguments
-        TestConfig config;
+        TestConfig config{};
         try {
             config = parse_cli_config(argc, argv);
 

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -1,0 +1,821 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <fmt/base.h>
+#include <stdint.h>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include <cstdlib>
+#include <exception>
+#include <map>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt_stl/span.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "fabric.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/xy_pair.h"
+
+using namespace tt;
+using namespace tt::test_utils;
+
+// Timing stats structure matching kernel side
+struct TimingStats {
+    uint64_t total_acquire_cycles = 0;
+    uint64_t total_release_cycles = 0;
+    uint64_t total_test_cycles = 0;
+    uint64_t total_misc_cycles = 0;
+    uint32_t acquire_count = 0;
+    uint32_t release_count = 0;
+    uint32_t misc_count = 0;
+};
+
+// Worker timing stats structure matching worker kernel side
+struct WorkerTimingStats {
+    uint64_t total_idle_cycles = 0;
+    uint32_t idle_count = 0;
+};
+
+class N300TestDevice {
+public:
+    N300TestDevice() : device_open(false) {
+        tt_fabric::SetFabricConfig(tt_fabric::FabricConfig::DISABLED);
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() >= 2 and
+            tt::tt_metal::GetNumPCIeDevices() >= 1) {
+            std::vector<chip_id_t> ids(num_devices_, 0);
+            std::iota(ids.begin(), ids.end(), 0);
+            devices_ = tt::tt_metal::detail::CreateDevices(ids);
+        } else {
+            TT_THROW("This suite can only be run on N300 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~N300TestDevice() {
+        if (device_open) {
+            log_info(tt::LogAlways, "Tearing down devices");
+            TearDown();
+        }
+        log_info(tt::LogAlways, "Tearing down devices complete");
+    }
+
+    void TearDown() {
+        device_open = false;
+        tt::tt_metal::detail::CloseDevices(devices_);
+    }
+
+    std::map<chip_id_t, tt_metal::IDevice*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+private:
+    bool device_open;
+};
+
+struct TestConfig {
+    uint32_t n_chunks;
+    uint32_t chunk_n_pkts;
+    uint32_t rx_chunk_n_pkts;
+    uint32_t packet_size;
+    bool bidirectional_mode;
+    uint32_t message_size;
+    uint32_t total_messages;
+    uint32_t n_workers;
+    uint32_t fabric_mcast_factor;
+};
+
+/**
+ * Parse a simple JSON string into TestConfig
+ * Expected format: {"n_chunks": 1, "chunk_n_pkts": 2, "rx_chunk_n_pkts": 10, "packet_size": 4352, "bidirectional_mode":
+ * true, "message_size": 16, "total_messages": 10000, "n_workers": 1, "fabric_mcast_factor": 1}
+ */
+TestConfig parse_json_config(const std::string& json_str) {
+    TestConfig config = {};
+
+    // Simple JSON parser - look for key-value pairs
+    auto find_value = [&json_str](const std::string& key) -> std::string {
+        std::string search_key = "\"" + key + "\"";
+        auto pos = json_str.find(search_key);
+        if (pos == std::string::npos) {
+            throw std::runtime_error("Key '" + key + "' not found in JSON");
+        }
+
+        // Find the colon after the key
+        pos = json_str.find(':', pos);
+        if (pos == std::string::npos) {
+            throw std::runtime_error("Malformed JSON - no colon after key '" + key + "'");
+        }
+
+        // Skip whitespace after colon
+        pos++;
+        while (pos < json_str.length() && std::isspace(json_str[pos])) {
+            pos++;
+        }
+
+        // Extract the value until comma or closing brace
+        size_t end_pos = pos;
+        while (end_pos < json_str.length() && json_str[end_pos] != ',' && json_str[end_pos] != '}') {
+            end_pos++;
+        }
+
+        std::string value = json_str.substr(pos, end_pos - pos);
+
+        // Trim whitespace
+        auto trim_start = value.find_first_not_of(" \t\n\r");
+        if (trim_start != std::string::npos) {
+            value = value.substr(trim_start);
+        }
+        auto trim_end = value.find_last_not_of(" \t\n\r");
+        if (trim_end != std::string::npos) {
+            value = value.substr(0, trim_end + 1);
+        }
+
+        return value;
+    };
+
+    try {
+        config.n_chunks = std::stoul(find_value("n_chunks"));
+        config.chunk_n_pkts = std::stoul(find_value("chunk_n_pkts"));
+        config.rx_chunk_n_pkts = std::stoul(find_value("rx_chunk_n_pkts"));
+        config.packet_size = std::stoul(find_value("packet_size"));
+
+        std::string bidir_str = find_value("bidirectional_mode");
+        config.bidirectional_mode = (bidir_str == "true" || bidir_str == "1");
+
+        config.message_size = std::stoul(find_value("message_size"));
+        config.total_messages = std::stoul(find_value("total_messages"));
+        config.n_workers = std::stoul(find_value("n_workers"));
+        config.fabric_mcast_factor = std::stoul(find_value("fabric_mcast_factor"));
+
+    } catch (const std::exception& e) {
+        throw std::runtime_error("Failed to parse JSON config: " + std::string(e.what()));
+    }
+
+    return config;
+}
+
+/**
+ * Parse TestConfig from command line arguments (traditional mode)
+ */
+TestConfig parse_cli_config(int argc, char** argv) {
+    if (argc != 10) {
+        log_error(
+            tt::LogTest,
+            "Usage: {} <n_chunks> <chunk_n_pkts> <rx_chunk_n_pkts> <packet_size> <bidirectional> <message_size> "
+            "<total_messages> <n_workers> <fabric_mcast_factor>",
+            argv[0]);
+        throw std::runtime_error("Invalid number of command line arguments");
+    }
+
+    TestConfig config;
+    size_t arg_idx = 1;
+    config.n_chunks = std::stoi(argv[arg_idx++]);
+    config.chunk_n_pkts = std::stoi(argv[arg_idx++]);
+    config.rx_chunk_n_pkts = std::stoi(argv[arg_idx++]);
+    config.packet_size = std::stoi(argv[arg_idx++]);
+    config.bidirectional_mode = std::stoi(argv[arg_idx++]) != 0;
+    config.message_size = std::stoi(argv[arg_idx++]);
+    config.total_messages = std::stoi(argv[arg_idx++]);
+    config.n_workers = std::stoi(argv[arg_idx++]);
+    config.fabric_mcast_factor = std::stoi(argv[arg_idx++]);
+
+    return config;
+}
+
+struct DeviceTestResources {
+    tt_metal::IDevice* device;
+    CoreRangeSet worker_cores;
+    std::vector<CoreCoord> worker_cores_vec;
+    CoreCoord eth_core;
+    tt_metal::Program program;
+    uint32_t worker_ack_semaphore_id = std::numeric_limits<uint32_t>::max();
+    uint32_t worker_new_chunk_semaphore_id = std::numeric_limits<uint32_t>::max();
+    uint32_t worker_src_buffer_address = std::numeric_limits<uint32_t>::max();
+    std::vector<uint32_t> worker_timing_stats_addresses;
+};
+
+struct TestResources {
+    DeviceTestResources local_device;
+    DeviceTestResources remote_device;
+};
+
+void create_worker_kernels(
+    TestResources& test_resources,
+    std::vector<tt_metal::KernelHandle>& local_sender_worker_kernels,
+    std::vector<tt_metal::KernelHandle>& remote_sender_worker_kernels,
+    const TestConfig& config) {
+    std::vector<uint32_t> ct_args = {config.n_chunks, config.chunk_n_pkts};
+
+    auto local_sender_worker_kernel = tt_metal::CreateKernel(
+        test_resources.local_device.program,
+        "tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channel_sender_worker.cpp",
+        test_resources.local_device.worker_cores,
+        tt::tt_metal::WriterDataMovementConfig(ct_args));
+
+    for (size_t i = 0; i < config.n_workers; i++) {
+        local_sender_worker_kernels.push_back(local_sender_worker_kernel);
+    }
+    log_info(tt::LogAlways, "Local sender worker kernel: {}", local_sender_worker_kernel);
+
+    auto remote_sender_worker_kernel = tt_metal::CreateKernel(
+        test_resources.remote_device.program,
+        "tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channel_sender_worker.cpp",
+        test_resources.remote_device.worker_cores,
+        tt::tt_metal::WriterDataMovementConfig(ct_args));
+
+    for (size_t i = 0; i < config.n_workers; i++) {
+        remote_sender_worker_kernels.push_back(remote_sender_worker_kernel);
+    }
+    log_info(tt::LogAlways, "Remote sender worker kernel: {}", remote_sender_worker_kernel);
+}
+
+void build(
+    TestResources& test_resources,
+    const TestConfig& config,
+    tt_metal::KernelHandle& local_erisc_kernel,
+    tt_metal::KernelHandle& remote_erisc_kernel,
+    std::vector<tt_metal::KernelHandle>& local_sender_worker_kernels,
+    std::vector<tt_metal::KernelHandle>& remote_sender_worker_kernels) {
+    uint32_t rx_n_pkts = config.rx_chunk_n_pkts;
+    std::vector<uint32_t> erisc_kernel_compile_time_args = {
+        config.n_chunks,            // N_CHUNKS
+        rx_n_pkts,                  // RX_N_PKTS
+        config.chunk_n_pkts,        // CHUNK_N_PKTS
+        config.packet_size,         // PACKET_SIZE
+        config.bidirectional_mode,  // BIDIRECTIONAL_MODE
+        config.n_workers,           // N_SRC_CHANS
+        config.fabric_mcast_factor  // FABRIC_MCAST_FACTOR
+    };
+
+    auto erisc_kernel_name =
+        "tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels_erisc_forward_worker_traffic.cpp";
+    log_info(tt::LogAlways, "Erisc kernel name: {}", erisc_kernel_name);
+    local_erisc_kernel = tt_metal::CreateKernel(
+        test_resources.local_device.program,
+        erisc_kernel_name,
+        test_resources.local_device.eth_core,
+        tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_1, .compile_args = erisc_kernel_compile_time_args});
+
+    remote_erisc_kernel = tt_metal::CreateKernel(
+        test_resources.remote_device.program,
+        erisc_kernel_name,
+        test_resources.remote_device.eth_core,
+        tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_1, .compile_args = erisc_kernel_compile_time_args});
+
+    log_info(tt::LogAlways, "Local erisc kernel: {}", local_erisc_kernel);
+    log_info(tt::LogAlways, "Remote erisc kernel: {}", remote_erisc_kernel);
+
+    if (config.n_workers > 0) {
+        create_worker_kernels(test_resources, local_sender_worker_kernels, remote_sender_worker_kernels, config);
+    }
+
+    // Compile programs
+    try {
+        tt::tt_metal::detail::CompileProgram(test_resources.local_device.device, test_resources.local_device.program);
+        tt::tt_metal::detail::CompileProgram(test_resources.remote_device.device, test_resources.remote_device.program);
+    } catch (std::exception& e) {
+        log_error(tt::LogTest, "Failed compile: {}", e.what());
+        throw e;
+    }
+}
+
+void set_worker_runtime_args(
+    DeviceTestResources& device_resources,
+    std::vector<tt_metal::KernelHandle>& worker_kernels,
+    const TestConfig& config) {
+    auto eth_core_virtual = device_resources.device->ethernet_core_from_logical_core(device_resources.eth_core);
+
+    for (size_t i = 0; i < device_resources.worker_cores_vec.size(); i++) {
+        auto worker_core = device_resources.worker_cores_vec[i];
+
+        TT_FATAL(
+            device_resources.worker_ack_semaphore_id != std::numeric_limits<uint32_t>::max(),
+            "worker_ack_semaphore_id is not set");
+        TT_FATAL(
+            device_resources.worker_new_chunk_semaphore_id != std::numeric_limits<uint32_t>::max(),
+            "worker_new_chunk_semaphore_id is not set");
+        TT_FATAL(
+            device_resources.worker_src_buffer_address != std::numeric_limits<uint32_t>::max(),
+            "worker_src_buffer_address is not set");
+        TT_FATAL(
+            i < device_resources.worker_timing_stats_addresses.size(),
+            "worker_timing_stats_addresses not allocated for worker {}",
+            i);
+
+        uint32_t worker_timing_stats_addr = device_resources.worker_timing_stats_addresses[i];
+
+        std::vector<uint32_t> rt_args = {
+            config.total_messages,
+            device_resources.worker_src_buffer_address,
+            eth_core_virtual.x,
+            eth_core_virtual.y,
+            config.message_size,
+            device_resources.worker_new_chunk_semaphore_id,
+            device_resources.worker_ack_semaphore_id,
+            i,
+            worker_timing_stats_addr};
+
+        tt_metal::SetRuntimeArgs(device_resources.program, worker_kernels.at(i), worker_core, rt_args);
+    }
+}
+
+void set_worker_runtime_args(
+    TestResources& test_resources,
+    std::vector<tt_metal::KernelHandle>& local_sender_worker_kernels,
+    std::vector<tt_metal::KernelHandle>& remote_sender_worker_kernels,
+    const TestConfig& config) {
+    set_worker_runtime_args(test_resources.local_device, local_sender_worker_kernels, config);
+    set_worker_runtime_args(test_resources.remote_device, remote_sender_worker_kernels, config);
+}
+
+TimingStats read_timing_stats(tt_metal::IDevice* device, CoreCoord core, uint32_t handshake_addr) {
+    TimingStats stats;
+
+    // Read timing stats from L1 memory - use same address as calculated in host
+    uint32_t timing_stats_addr = handshake_addr + 0x800;
+
+    std::vector<uint32_t> timing_data;
+    timing_data.resize(sizeof(TimingStats) / sizeof(uint32_t));
+    tt_metal::detail::ReadFromDeviceL1(
+        device, core, timing_stats_addr, sizeof(TimingStats), timing_data, CoreType::ETH);
+
+    std::memcpy(&stats, timing_data.data(), sizeof(TimingStats));
+
+    return stats;
+}
+
+WorkerTimingStats read_worker_timing_stats(tt_metal::IDevice* device, CoreCoord core, uint32_t timing_stats_addr) {
+    WorkerTimingStats stats;
+
+    std::vector<uint32_t> timing_data;
+    timing_data.resize(sizeof(WorkerTimingStats) / sizeof(uint32_t));
+    tt_metal::detail::ReadFromDeviceL1(
+        device, core, timing_stats_addr, sizeof(WorkerTimingStats), timing_data, CoreType::WORKER);
+
+    std::memcpy(&stats, timing_data.data(), sizeof(WorkerTimingStats));
+
+    return stats;
+}
+
+void run_test(
+    TestResources& test_resources,
+    tt_metal::KernelHandle local_erisc_kernel,
+    tt_metal::KernelHandle remote_erisc_kernel,
+    std::vector<tt_metal::KernelHandle>& local_sender_worker_kernels,
+    std::vector<tt_metal::KernelHandle>& remote_sender_worker_kernels,
+    const TestConfig& config) {
+    auto rt_args = [&](bool send_channels_at_offset_0, DeviceTestResources& device_resources) -> std::vector<uint32_t> {
+        uint32_t base_addr = static_cast<uint32_t>(tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+            tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED));
+
+        // Calculate buffer sizes and addresses
+        uint32_t send_buffer_size = config.n_chunks * config.chunk_n_pkts * config.packet_size;
+        uint32_t send_buffer_base = base_addr + 0x1000;  // Start after handshake area
+
+        // eth transfers must be 16B aligned
+        uint32_t recv_buffer_base = tt::align(send_buffer_base + send_buffer_size, 16);
+
+        uint32_t timing_stats_addr =
+            base_addr + 0x800;  // allocated definitely more than needed for timing stats... it's a test, relax
+
+        auto handshake_addr = base_addr;
+        std::vector<uint32_t> rt_args = {
+            handshake_addr,
+            config.total_messages,
+            config.message_size,
+            static_cast<uint32_t>(send_channels_at_offset_0),
+            send_buffer_base,
+            recv_buffer_base,
+            timing_stats_addr,
+            device_resources.worker_src_buffer_address};
+
+        for (size_t i = 0; i < config.n_workers; i++) {
+            auto translated =
+                device_resources.device->worker_core_from_logical_core(device_resources.worker_cores_vec[i]);
+            rt_args.push_back(translated.x);
+        }
+        for (size_t i = 0; i < config.n_workers; i++) {
+            auto translated =
+                device_resources.device->worker_core_from_logical_core(device_resources.worker_cores_vec[i]);
+            rt_args.push_back(translated.y);
+        }
+        for (size_t i = 0; i < config.n_workers; i++) {
+            rt_args.push_back(device_resources.worker_ack_semaphore_id);
+        }
+        for (size_t i = 0; i < config.n_workers; i++) {
+            rt_args.push_back(device_resources.worker_new_chunk_semaphore_id);
+        }
+        for (size_t i = 0; i < config.n_workers; i++) {
+            rt_args.push_back(device_resources.worker_src_buffer_address);
+        }
+
+        return rt_args;
+    };
+
+    log_info(tt::LogAlways, "Running Fabric Elastic Channels Test...");
+    log_info(
+        tt::LogTest,
+        "Config: n_chunks={}, chunk_n_pkts={}, packet_size={}, bidirectional={}, message_size={}, total_messages={}, "
+        "num_workers={}",
+        config.n_chunks,
+        config.chunk_n_pkts,
+        config.packet_size,
+        config.bidirectional_mode,
+        config.message_size,
+        config.total_messages,
+        config.n_workers);
+
+    tt_metal::SetRuntimeArgs(
+        test_resources.local_device.program,
+        local_erisc_kernel,
+        test_resources.local_device.eth_core,
+        rt_args(true, test_resources.local_device));
+    tt_metal::SetRuntimeArgs(
+        test_resources.remote_device.program,
+        remote_erisc_kernel,
+        test_resources.remote_device.eth_core,
+        rt_args(false, test_resources.remote_device));
+
+    if (config.n_workers > 0) {
+        log_info(tt::LogAlways, "Setting worker runtime args");
+        set_worker_runtime_args(test_resources, local_sender_worker_kernels, remote_sender_worker_kernels, config);
+    }
+
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    log_info(tt::LogAlways, "Launching programs");
+    if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        std::thread th2 = std::thread([&] {
+            tt_metal::detail::LaunchProgram(test_resources.local_device.device, test_resources.local_device.program);
+        });
+        std::thread th1 = std::thread([&] {
+            tt_metal::detail::LaunchProgram(test_resources.remote_device.device, test_resources.remote_device.program);
+        });
+
+        th2.join();
+        th1.join();
+    } else {
+        tt_metal::EnqueueProgram(
+            test_resources.local_device.device->command_queue(), test_resources.local_device.program, false);
+        tt_metal::EnqueueProgram(
+            test_resources.remote_device.device->command_queue(), test_resources.remote_device.program, false);
+
+        tt_metal::Finish(test_resources.local_device.device->command_queue());
+        tt_metal::Finish(test_resources.remote_device.device->command_queue());
+    }
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
+
+    //
+    // Timing Stats Readback
+    //
+    uint32_t handshake_addr = static_cast<uint32_t>(tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED));
+
+    //
+    // Results Reporting
+    //
+    TimingStats stats0 =
+        read_timing_stats(test_resources.local_device.device, test_resources.local_device.eth_core, handshake_addr);
+    TimingStats stats1 =
+        read_timing_stats(test_resources.remote_device.device, test_resources.remote_device.eth_core, handshake_addr);
+    auto report_erisc_timing_stats = [](TimingStats& stats, const std::string& label) {
+        log_info(tt::LogAlways, "{} Timing Stats:", label);
+        log_info(tt::LogAlways, "  Acquire operations: {}", stats.acquire_count);
+        log_info(tt::LogAlways, "  Total acquire cycles: {}", stats.total_acquire_cycles);
+        log_info(
+            tt::LogTest,
+            "  Average acquire cycles: {:.2f}",
+            stats.acquire_count > 0 ? (double)stats.total_acquire_cycles / stats.acquire_count : 0.0);
+        log_info(tt::LogAlways, "  Release operations: {}", stats.release_count);
+        log_info(tt::LogAlways, "  Total release cycles: {}", stats.total_release_cycles);
+        log_info(
+            tt::LogTest,
+            "  Average release cycles: {:.2f}",
+            stats.release_count > 0 ? (double)stats.total_release_cycles / stats.release_count : 0.0);
+        log_info(tt::LogAlways, "  Misc operations: {}", stats.misc_count);
+        log_info(tt::LogAlways, "  Total misc cycles: {}", stats.total_misc_cycles);
+        log_info(
+            tt::LogTest,
+            "  Average misc cycles: {:.2f}",
+            stats.misc_count > 0 ? (double)stats.total_misc_cycles / stats.misc_count : 0.0);
+    };
+    report_erisc_timing_stats(stats0, "Local Device");
+    report_erisc_timing_stats(stats1, "Remote Device");
+
+    //
+    // Worker Timing Stats Readback + Reporting
+    //
+    if (config.n_workers > 0) {
+        log_info(tt::LogAlways, "Worker Timing Stats:");
+
+        for (auto& [resources, label] :
+             {std::make_pair(&test_resources.local_device, "Local Device"),
+              std::make_pair(&test_resources.remote_device, "Remote Device")}) {
+            for (size_t i = 0; i < config.n_workers; i++) {
+                auto worker_core = resources->worker_cores_vec[i];
+                uint32_t worker_timing_stats_addr = resources->worker_timing_stats_addresses[i];
+                WorkerTimingStats worker_stats =
+                    read_worker_timing_stats(resources->device, worker_core, worker_timing_stats_addr);
+
+                log_info(tt::LogAlways, "  {} Device Worker {}: ", label, i);
+                log_info(tt::LogAlways, "    Idle operations: {}", worker_stats.idle_count);
+                log_info(tt::LogAlways, "    Total idle cycles: {}", worker_stats.total_idle_cycles);
+                log_info(
+                    tt::LogTest,
+                    "    Average idle cycles: {:.2f}",
+                    worker_stats.idle_count > 0 ? (double)worker_stats.total_idle_cycles / worker_stats.idle_count
+                                                : 0.0);
+            }
+        }
+    }
+
+    //
+    // Calculate Throughput
+    //
+    uint32_t total_messages_sent = config.total_messages * config.n_workers;
+    auto total_cycles = stats0.total_test_cycles;
+    auto test_seconds = (double)total_cycles / 1000000000;
+    double throughput_msgs_per_sec = (double)total_messages_sent / test_seconds;
+    double throughput_bytes_per_sec = throughput_msgs_per_sec * config.message_size;
+    double throughput_GB_s = throughput_bytes_per_sec / 1e9;
+    log_info(tt::LogAlways, "Total_cycles: {}", total_cycles);
+
+    log_info(tt::LogAlways, "Performance Metrics:");
+    log_info(tt::LogAlways, "  Total messages sent: {}", total_messages_sent);
+    log_info(tt::LogAlways, "  Throughput: {:.2f} messages/second", throughput_msgs_per_sec);
+    log_info(tt::LogAlways, "  Throughput: {:.2f} GB/s", throughput_GB_s);
+}
+
+TestResources create_test_resources(
+    tt_metal::IDevice* device_0,
+    tt_metal::IDevice* device_1,
+    CoreCoord eth_sender_core,
+    CoreCoord eth_receiver_core,
+    const TestConfig& config) {
+    TestResources resources;
+    resources.local_device.device = device_0;
+    resources.remote_device.device = device_1;
+    resources.local_device.eth_core = eth_sender_core;
+    resources.remote_device.eth_core = eth_receiver_core;
+
+    for (auto& device_resource_reference : {std::ref(resources.local_device), std::ref(resources.remote_device)}) {
+        auto& device_resource = device_resource_reference.get();
+        auto& worker_cores = device_resource.worker_cores;
+        auto& worker_cores_vec = device_resource.worker_cores_vec;
+        worker_cores_vec.reserve(config.n_workers);
+        worker_cores = CoreRange(CoreCoord(0, 0), CoreCoord(0, config.n_workers - 1));
+        worker_cores_vec = corerange_to_cores(worker_cores);
+
+        device_resource.worker_ack_semaphore_id =
+            tt_metal::CreateSemaphore(device_resource.program, device_resource.worker_cores, 0, CoreType::WORKER);
+        device_resource.worker_new_chunk_semaphore_id =
+            tt_metal::CreateSemaphore(device_resource.program, device_resource.worker_cores, 0, CoreType::WORKER);
+
+        auto worker_src_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::InterleavedBufferConfig{
+            .device = device_resource.device,
+            .size = config.n_workers * config.message_size,
+            .page_size = config.n_workers * config.message_size,
+            .buffer_type = tt::tt_metal::BufferType::L1});
+        device_resource.worker_src_buffer_address = worker_src_buffer->address();
+
+        // Allocate timing stats buffers for each worker core
+        device_resource.worker_timing_stats_addresses.reserve(config.n_workers);
+        auto worker_timing_stats_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::InterleavedBufferConfig{
+            .device = device_resource.device,
+            .size = config.n_workers * sizeof(WorkerTimingStats) * 2,
+            .page_size = config.n_workers * sizeof(WorkerTimingStats) * 2,
+            .buffer_type = tt::tt_metal::BufferType::L1});
+        for (uint32_t i = 0; i < config.n_workers; i++) {
+            device_resource.worker_timing_stats_addresses.push_back(worker_timing_stats_buffer->address());
+        }
+    }
+
+    return resources;
+}
+
+void validate_test_config(const TestConfig& config) {
+    if (config.n_workers == 0) {
+        log_error(tt::LogTest, "Number of workers must be greater than 0");
+        exit(-1);
+    }
+    if (config.message_size > config.packet_size) {
+        log_error(
+            tt::LogTest,
+            "Message size ({}) cannot be larger than packet size ({})",
+            config.message_size,
+            config.packet_size);
+        exit(-1);
+    }
+
+    if (config.n_workers > config.n_chunks) {
+        log_error(
+            tt::LogTest,
+            "Number of workers ({}) cannot be greater than number of chunks ({})",
+            config.n_workers,
+            config.n_chunks);
+        exit(-1);
+    }
+
+    if (config.chunk_n_pkts == 0 || config.chunk_n_pkts == 0 || config.n_chunks == 0 || config.packet_size == 0 ||
+        config.message_size == 0 || config.total_messages == 0 || config.n_workers == 0) {
+        log_error(
+            tt::LogTest,
+            "Invalid test config. Found a zero value. The following are all expected to be non-zero: chunk_n_pkts={}, "
+            "packet_size={}, message_size={}, total_messages={}, n_workers={}",
+            config.chunk_n_pkts,
+            config.packet_size,
+            config.message_size,
+            config.total_messages,
+            config.n_workers);
+        exit(-1);
+    }
+
+    if (config.fabric_mcast_factor > 10) {
+        log_error(tt::LogTest, "Fabric mcast factor ({}) cannot be greater than 10", config.fabric_mcast_factor);
+        exit(-1);
+    }
+}
+
+/**
+ * Run a single test case with the given configuration
+ */
+int run_test_case(const TestConfig& config, N300TestDevice& test_fixture) {
+    try {
+        const auto& device_0 = test_fixture.devices_.at(0);
+        const auto& active_eth_cores = device_0->get_active_ethernet_cores(true);
+        auto eth_sender_core_iter = active_eth_cores.begin();
+        TT_FATAL(eth_sender_core_iter != active_eth_cores.end(), "No active ethernet cores found");
+        while (eth_sender_core_iter != active_eth_cores.end() and
+               not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                   device_0->id(), *eth_sender_core_iter)) {
+            eth_sender_core_iter++;
+        }
+        TT_FATAL(eth_sender_core_iter != active_eth_cores.end(), "No active ethernet cores found");
+        auto eth_sender_core = *eth_sender_core_iter;
+        TT_FATAL(device_0->is_active_ethernet_core(eth_sender_core), "Not an active ethernet core {}", eth_sender_core);
+
+        auto [device_id, eth_receiver_core] = device_0->get_connected_ethernet_core(eth_sender_core);
+        const auto& device_1 = test_fixture.devices_.at(device_id);
+
+        log_info(tt::LogAlways, "Building programs...");
+        tt_metal::KernelHandle local_kernel;
+        tt_metal::KernelHandle remote_kernel;
+
+        std::vector<tt_metal::KernelHandle> local_sender_worker_kernels;
+        std::vector<tt_metal::KernelHandle> remote_sender_worker_kernels;
+
+        auto test_resources = create_test_resources(device_0, device_1, eth_sender_core, eth_receiver_core, config);
+
+        build(
+            test_resources,
+            config,
+            local_kernel,
+            remote_kernel,
+            local_sender_worker_kernels,
+            remote_sender_worker_kernels);
+
+        run_test(
+            test_resources,
+            local_kernel,
+            remote_kernel,
+            local_sender_worker_kernels,
+            remote_sender_worker_kernels,
+            config);
+
+        log_info(tt::LogAlways, "Test completed successfully");
+        return 0;
+    } catch (std::exception& e) {
+        log_error(tt::LogTest, "Test failed with exception: {}", e.what());
+        return -1;
+    }
+}
+
+int main(int argc, char** argv) {
+    // Check for pipe mode flag
+    bool pipe_mode = false;
+    if (argc >= 2 && std::string(argv[1]) == "--pipe-mode") {
+        pipe_mode = true;
+        log_info(tt::LogAlways, "Running in pipe mode - reading test configurations from stdin");
+    }
+
+    // Check hardware prerequisites
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices < 2) {
+        log_error(tt::LogTest, "Need at least 2 devices to run this test");
+        return -1;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_error(tt::LogTest, "Test must be run on WH");
+        return -1;
+    }
+
+    N300TestDevice test_fixture;
+
+    if (pipe_mode) {
+        // Pipe mode: read JSON configurations from stdin
+        std::string line;
+        int test_count = 0;
+        int successful_tests = 0;
+
+        log_info(
+            tt::LogAlways, "Ready to receive test configurations. Send JSON configs via stdin, empty line to finish.");
+
+        while (std::getline(std::cin, line)) {
+            // Trim whitespace
+            line.erase(0, line.find_first_not_of(" \t\n\r\f\v"));
+            line.erase(line.find_last_not_of(" \t\n\r\f\v") + 1);
+
+            // Empty line signals end of configurations
+            if (line.empty()) {
+                log_info(tt::LogAlways, "Received empty line - finishing test session");
+                break;
+            }
+
+            // Skip comment lines
+            if (line[0] == '#') {
+                continue;
+            }
+
+            test_count++;
+            log_info(tt::LogAlways, "Processing test case #{}", test_count);
+
+            try {
+                TestConfig config = parse_json_config(line);
+
+                // Align packet size if needed
+                if (config.packet_size % 16 != 0) {
+                    log_warning(tt::LogTest, "Packet size is not aligned to 16 bytes. Aligning to 16 bytes.");
+                    config.packet_size = tt::align(config.packet_size, 16);
+                }
+
+                validate_test_config(config);
+
+                int result = run_test_case(config, test_fixture);
+                if (result == 0) {
+                    successful_tests++;
+                    log_info(tt::LogAlways, "Test case #{} completed successfully", test_count);
+                } else {
+                    log_error(tt::LogTest, "Test case #{} failed", test_count);
+                }
+
+                // Flush output to ensure immediate visibility
+                std::cout.flush();
+                std::cerr.flush();
+
+            } catch (const std::exception& e) {
+                log_error(tt::LogTest, "Failed to parse or run test case #{}: {}", test_count, e.what());
+            }
+        }
+
+        log_info(tt::LogAlways, "Pipe mode finished: {}/{} test cases successful", successful_tests, test_count);
+        return (successful_tests == test_count && test_count > 0) ? 0 : -1;
+
+    } else {
+        // Traditional CLI mode: single test from command line arguments
+        TestConfig config;
+        try {
+            config = parse_cli_config(argc, argv);
+
+            // Align packet size if needed
+            if (config.packet_size % 16 != 0) {
+                log_warning(tt::LogTest, "Packet size is not aligned to 16 bytes. Aligning to 16 bytes.");
+                config.packet_size = tt::align(config.packet_size, 16);
+            }
+
+            validate_test_config(config);
+
+        } catch (const std::exception& e) {
+            log_error(tt::LogTest, "Configuration error: {}", e.what());
+            log_info(tt::LogTest, "For pipe mode, use: {} --pipe-mode", argv[0]);
+            return -1;
+        }
+
+        // Run single test case
+        int result = run_test_case(config, test_fixture);
+        return result;
+    }
+}

--- a/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channel_sender_worker.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channel_sender_worker.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+#include <cstdint>
+namespace tt::tt_fabric {
+// temporary to avoid a decent chunk of conflicting code reorg that would be better done as an isolated change
+constexpr uint8_t worker_handshake_noc = 0;
+}  // namespace tt::tt_fabric
+
+#include "tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels.hpp"
+#include "core_config.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
+#include "tensix.h"
+
+// Timing tracking structure for worker operations
+struct WorkerTimingStats {
+    uint64_t total_idle_cycles;
+    uint32_t idle_count;
+
+    WorkerTimingStats() : total_idle_cycles(0), idle_count(0) {}
+};
+
+// Global timing stats stored in L1 - will be initialized in kernel_main
+volatile WorkerTimingStats* worker_timing_stats = nullptr;
+
+inline uint64_t read_wall_clock() {
+    uint32_t low = memory_read(RISCV_DEBUG_REG_WALL_CLOCK_L);  // latches high
+    uint32_t high = memory_read(RISCV_DEBUG_REG_WALL_CLOCK_H);
+
+    return ((uint64_t)high << 32) | low;
+}
+
+void kernel_main() {
+    constexpr size_t N_CHUNKS = get_compile_time_arg_val(0);
+    constexpr size_t CHUNK_N_PKTS = get_compile_time_arg_val(1);
+
+    size_t arg_idx = 0;
+    size_t n_pkts = get_arg_val<size_t>(arg_idx++);
+    size_t src_addr = get_arg_val<size_t>(arg_idx++);
+    uint32_t dest_eth_noc_x = get_arg_val<size_t>(arg_idx++);
+    uint32_t dest_eth_noc_y = get_arg_val<size_t>(arg_idx++);
+    size_t payload_size_bytes = get_arg_val<size_t>(arg_idx++);
+    size_t payload_size_words = payload_size_bytes / sizeof(uint32_t);
+
+    auto next_chunk_ptr = reinterpret_cast<volatile uint32_t*>(
+        get_semaphore<ProgrammableCoreType::TENSIX>(get_arg_val<uint32_t>(arg_idx++)));
+    auto from_eth_flow_control_ptr = reinterpret_cast<volatile uint32_t*>(
+        get_semaphore<ProgrammableCoreType::TENSIX>(get_arg_val<uint32_t>(arg_idx++)));
+    size_t to_eth_flow_control_stream_id = get_arg_val<size_t>(arg_idx++);
+    const uint32_t timing_stats_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    // Initialize timing stats at address provided by host
+    worker_timing_stats = reinterpret_cast<volatile WorkerTimingStats*>(timing_stats_addr);
+    worker_timing_stats->total_idle_cycles = 0;
+    worker_timing_stats->idle_count = 0;
+
+    tt::tt_fabric::WorkerFabricWriterAdapter fabric_writer_adapter(next_chunk_ptr, CHUNK_N_PKTS, payload_size_bytes);
+
+    const uint64_t dest_sem_noc_addr =
+        get_noc_addr(dest_eth_noc_x, dest_eth_noc_y, get_stream_reg_write_addr(to_eth_flow_control_stream_id));
+    size_t pkts_sent = 0;
+
+    bool sent_once = false;
+    bool timer_open = false;
+    uint64_t idle_start_cycles = 0;
+    while (pkts_sent < n_pkts) {
+        if (fabric_writer_adapter.has_valid_destination()) {
+            auto dest_bank_addr = fabric_writer_adapter.get_next_write_address();
+            auto dest_noc_addr = get_noc_addr(dest_eth_noc_x, dest_eth_noc_y, dest_bank_addr);
+            noc_async_write(src_addr, dest_noc_addr, payload_size_bytes);
+            noc_inline_dw_write(dest_sem_noc_addr, pack_value_for_inc_on_write_stream_reg_write(1));
+
+            fabric_writer_adapter.advance_to_next_buffer_slot();
+            pkts_sent++;
+
+            sent_once = true;
+        } else if (fabric_writer_adapter.new_chunk_is_available()) {
+            if (sent_once && timer_open) {
+                timer_open = false;
+                uint64_t idle_end_cycles = read_wall_clock();
+                worker_timing_stats->total_idle_cycles += (idle_end_cycles - idle_start_cycles);
+                worker_timing_stats->idle_count++;
+            }
+            fabric_writer_adapter.update_to_new_chunk();
+        } else if (sent_once && !timer_open) {
+            timer_open = true;
+            // Idle time - waiting for new chunk or valid destination
+            idle_start_cycles = read_wall_clock();
+        }
+    }
+}

--- a/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels.hpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels.hpp
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+#include <limits>
+
+namespace tt::tt_fabric {
+
+constexpr bool is_next_power_of_2(size_t n) { return n > 0 && (n & (n - 1)) == 0; }
+constexpr size_t get_next_power_of_2(size_t n) {
+    if (n <= 1) {
+        return 1;
+    }
+    if (is_power_of_2(n)) {
+        return n;
+    }
+    size_t power = 1;
+    while (power < n) {
+        power <<= 1;
+    }
+    return power;
+}
+
+template <typename T, size_t MAX_SIZE>
+struct Stack {
+    static constexpr size_t REAL_SIZE = MAX_SIZE + 1;
+    using top_idx_t = int8_t;
+    static constexpr top_idx_t EMPTY_VALUE = 0;
+    static_assert(REAL_SIZE < std::numeric_limits<top_idx_t>::max());
+    std::array<T, REAL_SIZE> data;
+    top_idx_t top;
+
+    Stack() : top(EMPTY_VALUE) {}
+
+    FORCE_INLINE bool is_empty() const { return top == EMPTY_VALUE; }
+
+    FORCE_INLINE bool is_full() const {
+        // Should only need calling for validation/debugging purposes
+        return top == REAL_SIZE - 1;
+    }
+
+    FORCE_INLINE void push(T value) {
+        ASSERT(!is_full());
+        data[top] = value;
+        top++;
+    }
+
+    FORCE_INLINE T pop() {
+        ASSERT(!is_empty());
+        T value = data[top];
+        top--;
+        return value;
+    }
+
+    FORCE_INLINE T peek() const {
+        ASSERT(!is_empty());
+        return data[top];
+    }
+};
+
+// around 40% faster on WH compared to the default implementation
+// pop about (14 vs 12 cycles) 20% faster, push about (16 vs 10 cycles) 40% faster
+// not an exact cycle count given how timestamping works
+template <typename T, size_t MAX_SIZE>
+struct WormholeEfficientStack {
+    static constexpr size_t REAL_SIZE = MAX_SIZE + 1;
+    using top_idx_t = int8_t;
+    static constexpr top_idx_t EMPTY_VALUE = 0;
+    static_assert(REAL_SIZE < std::numeric_limits<top_idx_t>::max());
+    std::array<T, REAL_SIZE> data;
+    T* top;
+
+    WormholeEfficientStack() : data({}), top(&data[0]) {}
+
+    FORCE_INLINE bool is_empty() const { return top == &data[0]; }
+
+    FORCE_INLINE bool is_full() const {
+        // Should only need calling for validation/debugging purposes
+        return top == &data[REAL_SIZE - 1];
+    }
+
+    FORCE_INLINE void push(T value) {
+        ASSERT(!is_full());
+        *top = value;
+        top++;
+    }
+
+    FORCE_INLINE T pop() {
+        ASSERT(!is_empty());
+        --top;
+        T value = *top;
+        return value;
+    }
+
+    FORCE_INLINE T peek() const {
+        ASSERT(!is_empty());
+        return *top;
+    }
+};
+
+template <typename T, typename INHERITED_TYPE>
+struct OnePassIteratorBase {
+    T* current_ptr;
+    T* end_ptr;
+
+    OnePassIteratorBase() : current_ptr(nullptr), end_ptr(nullptr) {}
+
+    FORCE_INLINE T* get_current_ptr() const { return current_ptr; }
+    FORCE_INLINE void increment() { static_cast<INHERITED_TYPE*>(this)->increment_impl(); }
+
+    FORCE_INLINE bool is_done() const { return current_ptr == end_ptr; }
+
+    FORCE_INLINE void reset_to(T* base_ptr) { static_cast<INHERITED_TYPE*>(this)->reset_to_impl(base_ptr); }
+};
+
+template <typename T, size_t NUM_ENTRIES, size_t ENTRY_SIZE_BYTES>
+struct OnePassIteratorStaticSizes
+    : public OnePassIteratorBase<T, OnePassIteratorStaticSizes<T, NUM_ENTRIES, ENTRY_SIZE_BYTES>> {
+    OnePassIteratorStaticSizes() :
+        OnePassIteratorBase<T, OnePassIteratorStaticSizes<T, NUM_ENTRIES, ENTRY_SIZE_BYTES>>() {}
+
+    FORCE_INLINE void increment_impl() { this->current_ptr += ENTRY_SIZE_BYTES; }
+
+    FORCE_INLINE void reset_to_impl(T* base_ptr) {
+        this->current_ptr = base_ptr;
+        this->end_ptr = base_ptr + (NUM_ENTRIES * ENTRY_SIZE_BYTES);
+    }
+};
+
+template <typename T>
+struct OnePassIterator : public OnePassIteratorBase<T, OnePassIterator<T>> {
+    uint32_t num_entries;
+    uint32_t increment_size;
+    OnePassIterator(uint32_t num_entries, uint32_t entry_size_bytes) :
+        OnePassIteratorBase<T, OnePassIterator<T>>(), num_entries(num_entries), increment_size(entry_size_bytes) {}
+
+    FORCE_INLINE void increment_impl() { this->current_ptr += increment_size; }
+
+    FORCE_INLINE void reset_to_impl(T* base_ptr) {
+        this->current_ptr = base_ptr;
+        this->end_ptr = base_ptr + (num_entries * increment_size);
+    }
+};
+
+template <typename T, size_t SIZE>
+struct BarrelIterator {
+    T* base_ptr;
+    uint8_t current_idx;
+
+    BarrelIterator(T* base_ptr) : base_ptr(base_ptr), current_idx(0) {}
+
+    FORCE_INLINE T* get_current_ptr() const { return base_ptr + current_idx; }
+    FORCE_INLINE T get_current_value() const { return *(base_ptr + current_idx); }
+    FORCE_INLINE void increment() { current_idx = wrap_increment<SIZE, T>(); }
+};
+
+template <size_t N_CHUNKS, size_t CHUNK_N_PKTS>
+struct ChannelBuffersPool {
+    using chunk_t = EthChannelBuffer<PACKET_HEADER_TYPE, CHUNK_N_PKTS>;
+    using free_chunks_stack_t =
+#if defined(ARCH_WORMHOLE)
+        WormholeEfficientStack<chunk_t*, N_CHUNKS>;
+#else
+        Stack<chunk_t*, N_CHUNKS>;
+#endif
+
+    std::array<chunk_t, N_CHUNKS> all_buffers;
+    free_chunks_stack_t free_chunks;
+
+    // using chunk_base_address_t = std::initializer_list<std::tuple<size_t, uint8_t>>;
+    using chunk_base_address_t = std::array<size_t, N_CHUNKS>;
+
+    void init(const chunk_base_address_t& buffer_regions, size_t buffer_size_bytes, size_t header_size_bytes) {
+        size_t idx = 0;
+        for (const auto& chunk_base_address : buffer_regions) {
+            ASSERT(idx < N_CHUNKS);
+            new (&all_buffers[idx]) chunk_t(chunk_base_address, buffer_size_bytes, header_size_bytes, idx);
+            free_chunks.push(&all_buffers[idx]);
+            idx++;
+        }
+    }
+
+    FORCE_INLINE chunk_t* get_free_chunk() {
+        ASSERT(!free_chunks.is_empty());
+        return free_chunks.pop();
+    }
+
+    FORCE_INLINE void return_chunk(chunk_t* chunk) { free_chunks.push(chunk); }
+
+    FORCE_INLINE bool is_empty() const { return free_chunks.is_empty(); }
+
+    FORCE_INLINE bool is_full() const { return free_chunks.is_full(); }
+};
+
+template <typename T, size_t REQUESTED_SIZE>
+struct CircularBuffer {
+    // we pad up to the next power of 2 to get nicer arithmetic
+    static constexpr size_t CAPACITY = get_next_power_of_2(REQUESTED_SIZE);
+    static_assert(is_power_of_2(CAPACITY), "CAPACITY must be a power of 2");
+
+    std::array<T, CAPACITY> data;
+
+    ChannelBufferPointer<CAPACITY> wr_ptr;
+    ChannelBufferPointer<CAPACITY> rd_ptr;
+
+    CircularBuffer() = default;
+
+    FORCE_INLINE void push(const T value) {
+        data[wr_ptr.get_buffer_index()] = value;
+        wr_ptr.increment();
+    }
+
+    FORCE_INLINE T pop() {
+        T value = data[rd_ptr.get_buffer_index()];
+        rd_ptr.increment();
+        return value;
+    }
+
+    FORCE_INLINE T peek_front() const {
+        // The rd_ptr points to the oldest element in the CB (aka the front since we are
+        // pushing to the "back")
+        return data[rd_ptr.get_buffer_index()];
+    }
+
+    FORCE_INLINE bool is_empty() const { return rd_ptr.is_caught_up_to(wr_ptr); }
+
+    FORCE_INLINE bool is_full() const { return wr_ptr.distance_behind(rd_ptr) == 1; }
+};
+
+template <typename T, size_t REQUESTED_SIZE>
+struct WormholeEfficientCircularBuffer {
+    // we pad up to the next power of 2 to get nicer arithmetic
+    static constexpr size_t CAPACITY = get_next_power_of_2(REQUESTED_SIZE);
+    static constexpr size_t CAPACITY_M1 = CAPACITY - 1;
+    static_assert(is_power_of_2(CAPACITY), "CAPACITY must be a power of 2");
+
+    std::array<T, CAPACITY> data;
+    T* wrptr;
+    T* rdptr;
+    T* end;
+    T* end_m1;
+    uint8_t cnt;
+
+    WormholeEfficientCircularBuffer() :
+        data({}), wrptr(&data[0]), rdptr(&data[0]), end(&data[CAPACITY]), end_m1(&data[CAPACITY - 1]), cnt(0) {}
+
+    FORCE_INLINE void incr_wrap_ptr(T*& ptr) {
+        // ptr++;
+        // if (ptr == end) {
+        //     ptr = &data[0];
+        // }
+
+        // 2x faster for release?
+        bool last = ptr == end_m1;
+        // ptr += last * -CAPACITY + !last;
+        ptr += 1 - last * CAPACITY;
+    }
+
+    FORCE_INLINE void push(const T value) {  // acquire
+        auto wrptr_old = wrptr;
+
+        // 6.5
+        // bool last = wrptr == end_m1;
+        // wrptr += !last - (last * CAPACITY_M1);
+
+        // 8.00
+        // bool last = wrptr == end_m1;
+        // wrptr += 1 - (last * CAPACITY);
+
+        // 7.00
+        // bool last = wrptr == end_m1;
+        // wrptr += !last + (last * -CAPACITY_M1);
+
+        // 7.00
+        // bool last = wrptr == end_m1;
+        // wrptr += (last * -CAPACITY_M1) + !last;
+
+        // 8.00
+        // bool last = wrptr == end_m1;
+        // wrptr = wrptr - (last * CAPACITY) + 1;
+
+        // 6.00
+        bool last = wrptr == end_m1;
+        wrptr = wrptr - (last * CAPACITY_M1) + !last;
+
+        cnt++;
+        *wrptr_old = value;
+    }
+
+    FORCE_INLINE T pop() {  // release
+        // T value = *rdptr;
+        // incr_wrap_ptr(rdptr);
+        // cnt--;
+        // return value;
+        auto rdptr_old = rdptr;
+
+        // 9.5
+        bool last = rdptr == end_m1;
+        rdptr += 1 - last * CAPACITY;
+
+        // 9.5
+        // bool last = rdptr == end_m1;
+        // rdptr = rdptr - last * CAPACITY + 1;
+
+        // 9.00 (negatively affects push performance - from the store??? - up to 8.00)
+        // bool last = rdptr == end_m1;
+        // rdptr = rdptr - last * CAPACITY_M1 + !last;
+
+        // 9.50
+        // bool last = rdptr == end_m1;
+        // rdptr = rdptr - last * CAPACITY + 1;
+
+        cnt--;
+        return *rdptr_old;
+    }
+
+    FORCE_INLINE T peek_front() const {
+        // The rd_ptr points to the oldest element in the CB (aka the front since we are
+        // pushing to the "back")
+        return *rdptr;
+    }
+
+    FORCE_INLINE bool is_empty() const { return cnt == 0; }
+
+    FORCE_INLINE bool is_full() const { return cnt == CAPACITY; }
+};
+
+// Shares chunks with remote sources (workers or fabric routers)
+struct FabricChunkMessageAvailableMessage {
+    static constexpr uint32_t NEXT_CHUNK_VALID_FLAG = 1 << 31;
+    static constexpr uint32_t NEXT_CHUNK_VALUE_MASK = NEXT_CHUNK_VALID_FLAG - 1;
+    FORCE_INLINE static uint32_t pack(uint32_t chunk_base_address) {
+        return chunk_base_address | NEXT_CHUNK_VALID_FLAG;
+    }
+
+    FORCE_INLINE static uint32_t unpack(uint32_t message) { return message & ~NEXT_CHUNK_VALID_FLAG; }
+};
+
+struct SenderChannelView {
+    volatile uint32_t* next_chunk_ptr;
+
+    SenderChannelView(volatile uint32_t* next_chunk_ptr) : next_chunk_ptr(next_chunk_ptr) {}
+
+    FORCE_INLINE void wait_for_new_chunk() {
+        while (!*next_chunk_ptr) {
+        }
+    }
+
+    FORCE_INLINE bool has_new_chunk() {
+        return *next_chunk_ptr & FabricChunkMessageAvailableMessage::NEXT_CHUNK_VALID_FLAG;
+    }
+
+    FORCE_INLINE void clear_new_chunk_flag() { *next_chunk_ptr = 0; }
+
+    FORCE_INLINE uint32_t get_next_chunk() {
+        uint32_t value = *next_chunk_ptr;
+        return FabricChunkMessageAvailableMessage::unpack(value);
+    }
+};
+
+// Used by the worker to know where to send packets to next
+// TODO: export constants via JIT_BUILD for better performance (fewer RT args and literals)
+struct WorkerFabricWriterAdapter {
+    SenderChannelView sender_channel_view;
+    // We have a uint8_t (byte) iterator with a step size of buffer slot. The uint8_t is the type because then we can
+    // safely due byte address increments
+    tt::tt_fabric::OnePassIterator<uint8_t> current_chunk;
+
+    WorkerFabricWriterAdapter(
+        volatile uint32_t* next_chunk_ptr, uint32_t num_buffer_slots_per_chunk, uint32_t max_payload_size_bytes) :
+        sender_channel_view(next_chunk_ptr), current_chunk(num_buffer_slots_per_chunk, max_payload_size_bytes) {}
+
+    FORCE_INLINE bool has_valid_destination() { return !current_chunk.is_done(); }
+
+    FORCE_INLINE void advance_to_next_buffer_slot() { current_chunk.increment(); }
+
+    FORCE_INLINE bool new_chunk_is_available() { return sender_channel_view.has_new_chunk(); }
+
+    FORCE_INLINE size_t get_next_write_address() const { return (size_t)current_chunk.get_current_ptr(); }
+
+    // return true if the new chunk was updated
+    FORCE_INLINE void update_to_new_chunk() {
+        //...
+        ASSERT(sender_channel_view.has_new_chunk());
+        ASSERT(current_chunk.is_done());
+        auto chunk_base_address = sender_channel_view.get_next_chunk();
+        auto new_chunk_base_address = chunk_base_address;
+        sender_channel_view.clear_new_chunk_flag();
+        current_chunk.reset_to(reinterpret_cast<uint8_t*>(new_chunk_base_address));
+    }
+};
+
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels_erisc_forward_worker_traffic.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels_erisc_forward_worker_traffic.cpp
@@ -1,0 +1,553 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+namespace tt::tt_fabric {
+// temporary to avoid a decent chunk of conflicting code reorg that would be better done as an isolated change
+constexpr uint8_t worker_handshake_noc = 0;
+}  // namespace tt::tt_fabric
+
+#include <array>
+#include <tuple>
+#include "dataflow_api.h"
+#include "fabric_elastic_channels.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
+
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp"
+#include "tt_metal/hw/inc/compile_time_args.h"
+#include "core_config.h"
+
+// Compile-time configuration - passed as compile_args from host
+constexpr size_t N_CHUNKS = get_compile_time_arg_val(0);
+constexpr size_t RX_N_PKTS = get_compile_time_arg_val(1);
+constexpr size_t CHUNK_N_PKTS = get_compile_time_arg_val(2);
+constexpr size_t PACKET_SIZE_BYTES = get_compile_time_arg_val(3);
+constexpr bool BIDIRECTIONAL_MODE = get_compile_time_arg_val(4);
+constexpr size_t N_SRC_CHANS = get_compile_time_arg_val(5);
+constexpr size_t FABRIC_MCAST_FACTOR = get_compile_time_arg_val(6);
+
+constexpr bool CHANGE_CMD_BUF_AND_NOC = false;
+constexpr bool CHANGE_CMD_BUF = false;
+constexpr bool CHANGE_NOC = true;
+using noc_addr_t = uint64_t;
+
+enum class WRITE_OUT_MODE {
+    ALL_AT_ONCE,
+    ONE_AT_A_TIME,
+};
+
+constexpr WRITE_OUT_MODE write_out_mode = WRITE_OUT_MODE::ALL_AT_ONCE;
+
+// pkts received (from worker) stream IDs are [0, N_SRC_CHANS-1]
+// pkts acked (to sender from receiver) stream IDs are [N_SRC_CHANS, 2*N_SRC_CHANS-1]
+
+constexpr int32_t pkts_received_stream_id = 2 * N_SRC_CHANS;  // read by receiver, written by sender
+
+static_assert(pkts_received_stream_id < 32, "pkts_received_stream_id must be less than 10");
+static_assert(PACKET_SIZE_BYTES % sizeof(uint32_t) == 0, "PACKET_SIZE_BYTES must be a multiple of sizeof(uint32_t)");
+
+using tt::tt_fabric::BufferIndex;
+
+// Points to a chunk and steps through the addresses
+using chunk_forward_iterator_t =
+    tt::tt_fabric::OnePassIteratorStaticSizes<uint32_t, CHUNK_N_PKTS, PACKET_SIZE_BYTES / sizeof(uint32_t)>;
+
+// Timing tracking structure
+struct TimingStats {
+    uint64_t total_acquire_cycles;
+    uint64_t total_release_cycles;
+    uint64_t total_test_cycles;
+    uint64_t total_misc_cycles;
+    uint32_t acquire_count;
+    uint32_t release_count;
+    uint32_t misc_count;
+
+    TimingStats() :
+        total_acquire_cycles(0),
+        total_release_cycles(0),
+        total_test_cycles(0),
+        total_misc_cycles(0),
+        acquire_count(0),
+        release_count(0),
+        misc_count(0) {}
+};
+
+// Global timing stats stored in L1 - will be initialized in kernel_main
+volatile TimingStats* timing_stats = nullptr;
+
+FORCE_INLINE int32_t get_receiver_num_unprocessed_packets() { return get_ptr_val(pkts_received_stream_id); }
+
+FORCE_INLINE void receiver_mark_packet_processed() { increment_local_update_ptr_val(pkts_received_stream_id, -1); }
+
+FORCE_INLINE void notify_remote_receiver_of_new_packet() { remote_update_ptr_val<pkts_received_stream_id, 0>(1); }
+
+FORCE_INLINE int32_t get_sender_num_unprocessed_acks(int32_t stream_id) { return get_ptr_val(stream_id); }
+
+FORCE_INLINE void sender_mark_ack_processed(int32_t stream_id) { increment_local_update_ptr_val(stream_id, -1); }
+
+FORCE_INLINE void send_ack_to_sender(int32_t stream_id) { remote_update_ptr_val<0>(stream_id, 1); }
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        erisc_info->channels[0].bytes_sent = 0;
+        erisc_info->channels[0].receiver_ack = 0;
+        while (eth_txq_is_busy()) {
+        }
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        while (eth_txq_is_busy()) {
+        }
+        internal_::eth_send_packet(
+            0,
+            ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+            ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+            1);
+        while (erisc_info->channels[0].bytes_sent != 0) {
+        }
+    } else {
+        while (erisc_info->channels[0].bytes_sent == 0) {
+        }
+        eth_receiver_channel_done(0);
+    }
+}
+
+template <typename OpenChunksCbT, typename SendPoolT>
+void process_send_side(
+    volatile TimingStats* timing_stats,
+    // For now we can keep these flat?
+
+    uint32_t local_src_ch_flow_control_stream_id,  // check this for new messages
+    uint32_t local_src_ch_ack_stream_id,           // check this for acks from receiver
+    uint64_t remote_src_ch_semaphore_ack_addr,     // send acks back here
+    uint64_t remote_src_new_chunk_noc_addr,        // send new chunk info here
+
+    chunk_forward_iterator_t& current_chunk_ptr,
+    BufferIndex& current_chunk_ack_index,
+    OpenChunksCbT& open_chunks_cb,
+    SendPoolT& send_pool,
+    uint32_t& unacked_sends,
+    uint32_t& messages_sent,
+    uint32_t& messages_acked,
+    uint32_t messages_to_send,
+    std::array<size_t, RX_N_PKTS>& receiver_buffer_addresses,
+    tt::tt_fabric::ChannelBufferPointer<RX_N_PKTS>& sender_view_rx_buf_wr_ptr,
+    uint32_t message_size) {
+    // Process Ack
+
+    auto n_unsent_messages = get_ptr_val(local_src_ch_flow_control_stream_id);
+    // Try to send from current chunk
+    if (unacked_sends < RX_N_PKTS && n_unsent_messages > 0 && !eth_txq_is_busy()) {
+        ASSERT(!open_chunks_cb.is_empty());    // should not be possible to receive a message if this is false
+        ASSERT(!current_chunk_ptr.is_done());  // should not be possible to receive a message if this is false
+
+        auto current_buffer = open_chunks_cb.peek_front();
+
+        // Fill packet data
+        auto src_addr = current_chunk_ptr.get_current_ptr();
+        reinterpret_cast<volatile uint32_t*>(src_addr)[0] = local_src_ch_ack_stream_id;
+        auto dest_addr = receiver_buffer_addresses[sender_view_rx_buf_wr_ptr.get_buffer_index()];
+
+        // Send packet using the buffer's channel ID
+        eth_send_bytes_over_channel_payload_only_unsafe_one_packet((uint32_t)src_addr, dest_addr, message_size);
+        while (eth_txq_is_busy()) {
+        }
+        notify_remote_receiver_of_new_packet();
+
+        current_chunk_ptr.increment();
+        increment_local_update_ptr_val(local_src_ch_flow_control_stream_id, -1);
+        sender_view_rx_buf_wr_ptr.increment();
+
+        messages_sent++;
+        unacked_sends++;
+    }
+
+    auto num_unprocessed_acks = get_sender_num_unprocessed_acks(local_src_ch_ack_stream_id);
+    if (num_unprocessed_acks > 0) {
+        uint64_t start_cycles = eth_read_wall_clock();
+        bool can_release_chunk = current_chunk_ack_index.get() == CHUNK_N_PKTS - 1;
+        if (can_release_chunk) {  // 22 cycles!??!?! (44 -> 22 if I don't include the branch condition in the timing)
+            auto chunk = open_chunks_cb.pop();  // avg 7.3 cycles
+            send_pool.return_chunk(chunk);      // 16 cycles
+            current_chunk_ack_index = BufferIndex{0};
+        } else {
+            current_chunk_ack_index = BufferIndex{static_cast<uint8_t>(current_chunk_ack_index.get() + 1)};
+        }
+        sender_mark_ack_processed(local_src_ch_ack_stream_id);
+
+        uint64_t end_cycles = eth_read_wall_clock();
+        timing_stats->release_count++;
+        timing_stats->total_release_cycles += (end_cycles - start_cycles);
+        messages_acked++;
+        unacked_sends--;
+    }
+
+    // Acquire new chunk if current chunk is full
+    if ((open_chunks_cb.is_empty() || current_chunk_ptr.is_done()) && !send_pool.is_empty()) {
+        // Acquire new chunk - measure timing
+        uint64_t start_cycles = eth_read_wall_clock();
+        auto new_chunk = send_pool.get_free_chunk();
+
+        // Currently we only support one-deep open chunks
+        size_t new_chunk_base_address = new_chunk->get_buffer_address(BufferIndex{0});
+        size_t new_chunk_field_for_sender =
+            tt::tt_fabric::FabricChunkMessageAvailableMessage::pack(new_chunk_base_address);
+        // notify the worker about new chunk availability
+        auto start_misc = eth_read_wall_clock();
+        noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
+            remote_src_new_chunk_noc_addr, new_chunk_field_for_sender);  // 34 cycles?
+        auto end_misc = eth_read_wall_clock();
+        timing_stats->total_misc_cycles += (end_misc - start_misc);
+        timing_stats->misc_count++;
+
+        current_chunk_ptr.reset_to(reinterpret_cast<uint32_t*>(new_chunk_base_address));
+
+        open_chunks_cb.push(new_chunk);
+        uint64_t end_cycles = eth_read_wall_clock();
+        timing_stats->total_acquire_cycles += (end_cycles - start_cycles);
+        timing_stats->acquire_count++;
+    }
+}
+
+void main_loop(
+    volatile TimingStats* timing_stats,
+    bool is_sender_offset_0,
+    uint32_t total_messages_target,
+    std::array<size_t, RX_N_PKTS>& recv_buffer_addresses,
+    uint32_t message_size,
+    std::array<noc_addr_t, N_SRC_CHANS>& remote_src_ch_semaphore_ack_addrs,
+    std::array<noc_addr_t, N_SRC_CHANS>& src_ch_new_chunk_addrs,
+    std::array<noc_addr_t, N_SRC_CHANS>& dest_noc_write_addrs,
+    std::array<noc_addr_t, 10>& fabric_fwd_addrs,
+    tt::tt_fabric::ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS>& send_pool) {
+#if defined(ARCH_WORMHOLE)
+    // acq: 6.00
+    // rel: 9.5
+    std::array<
+        tt::tt_fabric::WormholeEfficientCircularBuffer<
+            typename tt::tt_fabric::ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS>::chunk_t*,
+            N_CHUNKS>,
+        N_SRC_CHANS>
+        open_chunks_cbs;
+#else
+    // acq: 17
+    // rel: 4
+    std::array<
+        tt::tt_fabric::
+            CircularBuffer<typename tt::tt_fabric::ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS>::chunk_t*, N_CHUNKS>,
+        N_SRC_CHANS>
+        open_chunks_cbs;
+#endif
+
+    uint32_t messages_acked = 0;
+    uint32_t messages_sent = 0;
+    uint32_t messages_received = 0;
+    uint32_t unacked_sends = 0;
+    uint32_t n_sender_channels_done = 0;
+    uint32_t idle_count = 0;
+    const uint32_t idle_max = 100000;
+    std::array<chunk_forward_iterator_t, N_SRC_CHANS> sender_channel_wrptrs;
+    tt::tt_fabric::ChannelBufferPointer<RX_N_PKTS> sender_view_rx_buf_wr_ptr;
+    tt::tt_fabric::ChannelBufferPointer<RX_N_PKTS> receiver_rd_ptr;
+    tt::tt_fabric::ChannelBufferPointer<RX_N_PKTS> receiver_wr_ptr;
+    std::array<bool, N_SRC_CHANS> completed_sender_channels;
+    std::array<size_t, N_SRC_CHANS> sender_channels_acks_received;
+    std::array<BufferIndex, N_SRC_CHANS> current_chunk_ack_indices;
+    for (size_t i = 0; i < N_SRC_CHANS; i++) {
+        completed_sender_channels[i] = false;
+        sender_channels_acks_received[i] = 0;
+        current_chunk_ack_indices[i] = BufferIndex{0};
+    }
+    size_t write_outs_remaining = 0;
+    bool send_ack = false;
+
+    while (n_sender_channels_done < N_SRC_CHANS || messages_received < total_messages_target) {
+        bool made_progress = false;
+        for (size_t l = 0; l < 32; l++) {
+            for (size_t i = 0; i < N_SRC_CHANS; i++) {
+                if (!completed_sender_channels[i]) {
+                    process_send_side(
+                        timing_stats,
+
+                        i,                                     // check this stream autoinc registert for new messages
+                        N_SRC_CHANS + i,                       // send acks back here
+                        remote_src_ch_semaphore_ack_addrs[i],  // send acks back here
+                        src_ch_new_chunk_addrs[i],             // send new chunk info here
+
+                        sender_channel_wrptrs[i],
+                        current_chunk_ack_indices[i],
+                        open_chunks_cbs[i],
+                        send_pool,
+                        unacked_sends,
+                        messages_sent,
+                        messages_acked,
+                        total_messages_target,
+
+                        recv_buffer_addresses,
+                        sender_view_rx_buf_wr_ptr,
+                        message_size);
+
+                    if (messages_acked >= total_messages_target) {
+                        completed_sender_channels[i] = true;
+                        n_sender_channels_done++;
+                    }
+                }
+
+                // Put the receiver channel servicing here to keep the processing balanced
+                if (BIDIRECTIONAL_MODE || !is_sender_offset_0) {
+                    // Receiver logic - also use ChannelBuffersPool
+                    auto num_unprocessed_packets = get_receiver_num_unprocessed_packets();
+                    bool start_sends = num_unprocessed_packets > 0 && !eth_txq_is_busy() && write_outs_remaining == 0;
+                    if constexpr (write_out_mode != WRITE_OUT_MODE::ALL_AT_ONCE) {
+                        start_sends = start_sends && !send_ack;
+                    }
+                    if (start_sends) {
+                        size_t packet_src_addr = recv_buffer_addresses[receiver_wr_ptr.get_buffer_index()];
+                        auto remote_src_ack_stream_id = *reinterpret_cast<volatile uint32_t*>(packet_src_addr);
+                        receiver_mark_packet_processed();
+
+                        if constexpr (write_out_mode == WRITE_OUT_MODE::ALL_AT_ONCE) {
+                            auto buffer_index = receiver_wr_ptr.get_buffer_index();
+                            size_t packet_src_addr = recv_buffer_addresses[buffer_index];
+                            auto trid = buffer_index;
+
+                            auto start_misc = eth_read_wall_clock();
+                            auto cmd_buf = write_cmd_buf;
+                            auto noc_id = noc_index;
+                            if constexpr (FABRIC_MCAST_FACTOR > 0) {
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC || CHANGE_CMD_BUF) {
+                                    cmd_buf = write_cmd_buf;
+                                }
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC || CHANGE_NOC) {
+                                    noc_id = noc_index;
+                                }
+                                noc_async_write_one_packet_with_trid(
+                                    packet_src_addr, fabric_fwd_addrs[0], message_size, trid, cmd_buf, noc_id);
+                            }
+                            if constexpr (FABRIC_MCAST_FACTOR > 1) {
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC) {
+                                    cmd_buf = write_cmd_buf;
+                                }
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC || CHANGE_NOC) {
+                                    noc_id = 1 - noc_index;
+                                }
+                                if constexpr (CHANGE_CMD_BUF) {
+                                    cmd_buf = read_cmd_buf;
+                                }
+                                noc_async_write_one_packet_with_trid(
+                                    packet_src_addr, fabric_fwd_addrs[1], message_size, trid, cmd_buf, noc_id);
+                            }
+                            if constexpr (FABRIC_MCAST_FACTOR > 2) {
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC) {
+                                    cmd_buf = read_cmd_buf;
+                                    noc_id = noc_index;
+                                } else if constexpr (CHANGE_CMD_BUF) {
+                                    cmd_buf = write_cmd_buf;
+                                } else if constexpr (CHANGE_NOC) {
+                                    noc_id = noc_index;
+                                }
+                                noc_async_write_one_packet_with_trid(
+                                    packet_src_addr, fabric_fwd_addrs[2], message_size, trid, cmd_buf, noc_id);
+                            }
+                            if constexpr (FABRIC_MCAST_FACTOR > 3) {
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC || CHANGE_CMD_BUF) {
+                                    cmd_buf = read_cmd_buf;
+                                }
+                                if constexpr (CHANGE_CMD_BUF_AND_NOC || CHANGE_NOC) {
+                                    noc_id = 1 - noc_index;
+                                }
+                                noc_async_write_one_packet_with_trid(
+                                    packet_src_addr, fabric_fwd_addrs[3], message_size, trid, cmd_buf, noc_id);
+                            }
+                            for (size_t i = 4; i < FABRIC_MCAST_FACTOR; i++) {
+                                noc_async_write_one_packet_with_trid(
+                                    packet_src_addr, fabric_fwd_addrs[i], message_size, trid, cmd_buf, noc_id);
+                            }
+                            auto end_misc = eth_read_wall_clock();
+                            timing_stats->total_misc_cycles += (end_misc - start_misc);
+                            timing_stats->misc_count++;
+                            send_ack_to_sender(remote_src_ack_stream_id);
+                            receiver_wr_ptr.increment();
+                            messages_received++;
+
+                        } else {
+                            write_outs_remaining = FABRIC_MCAST_FACTOR;
+                            send_ack = write_outs_remaining == 0;
+                            if (send_ack) {
+                                receiver_wr_ptr.increment();
+                            }
+                        }
+
+                        made_progress = true;
+                    }
+
+                    if constexpr (write_out_mode == WRITE_OUT_MODE::ALL_AT_ONCE) {
+                        if (send_ack && !eth_txq_is_busy() &&
+                            ncrisc_noc_nonposted_write_with_transaction_id_sent(
+                                noc_index, receiver_rd_ptr.get_buffer_index())) {
+                            size_t packet_src_addr = recv_buffer_addresses[receiver_rd_ptr.get_buffer_index()];
+                            auto remote_src_ack_stream_id = *reinterpret_cast<volatile uint32_t*>(packet_src_addr);
+                            send_ack_to_sender(remote_src_ack_stream_id);
+                            receiver_rd_ptr.increment();
+                            send_ack = false;
+                        }
+                    }
+
+                    if constexpr (write_out_mode == WRITE_OUT_MODE::ONE_AT_A_TIME) {
+                        while (write_outs_remaining > 0 && noc_cmd_buf_ready(noc_index, write_cmd_buf)) {
+                            auto buffer_index = receiver_wr_ptr.get_buffer_index();
+                            size_t packet_src_addr = recv_buffer_addresses[buffer_index];
+                            auto trid = buffer_index;
+                            noc_async_write_one_packet_with_trid(
+                                packet_src_addr, fabric_fwd_addrs[0], message_size, trid);
+
+                            write_outs_remaining--;
+                            made_progress = true;
+                            send_ack = write_outs_remaining == 0;
+                            if (send_ack) {
+                                receiver_wr_ptr.increment();
+                            }
+                        }
+                    }
+                    if constexpr (write_out_mode == WRITE_OUT_MODE::ONE_AT_A_TIME) {
+                        if (send_ack && !eth_txq_is_busy()) {
+                            auto buffer_index = receiver_rd_ptr.get_buffer_index();
+                            auto trid = buffer_index;
+                            if (ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid)) {
+                                size_t packet_src_addr = recv_buffer_addresses[receiver_rd_ptr.get_buffer_index()];
+                                auto remote_src_ack_stream_id = *reinterpret_cast<volatile uint32_t*>(packet_src_addr);
+                                send_ack_to_sender(remote_src_ack_stream_id);
+                                receiver_rd_ptr.increment();
+                                send_ack = false;
+                                messages_received++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Idle management
+        if (made_progress) {
+            idle_count = 0;
+        } else {
+            idle_count++;
+            if (idle_count > idle_max) {
+                run_routing();
+                idle_count = 0;
+            }
+        }
+    }
+}
+
+void init_stream_regs() {
+    init_ptr_val(pkts_received_stream_id, 0);
+
+    for (size_t i = 0; i < N_SRC_CHANS; i++) {
+        init_ptr_val(i, 0);
+        init_ptr_val(N_SRC_CHANS + i, 0);
+    }
+
+    eth_txq_reg_write(0, ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD, 32);
+}
+
+void kernel_main() {
+    init_stream_regs();
+
+    uint32_t arg_idx = 0;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t total_messages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
+    bool is_sender_offset_0 = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t send_buffer_base = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t recv_buffer_base = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t timing_stats_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    // Where receiver will write to
+    uint32_t receiver_channel_write_out_l1_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    auto remote_src_noc_x_ords = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+    arg_idx += N_SRC_CHANS;
+    auto remote_src_noc_y_ords = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+    arg_idx += N_SRC_CHANS;
+    auto remote_src_semaphore_ack_addrs = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+    arg_idx += N_SRC_CHANS;
+    auto remote_src_new_chunk_addrs = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+    arg_idx += N_SRC_CHANS;
+    auto dest_noc_buffer_addrs = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+    arg_idx += N_SRC_CHANS;
+
+    std::array<noc_addr_t, N_SRC_CHANS> remote_src_ch_semaphore_ack_addrs;
+    std::array<noc_addr_t, N_SRC_CHANS> src_ch_new_chunk_addrs;
+    std::array<noc_addr_t, N_SRC_CHANS> dest_noc_write_addrs;
+    std::array<noc_addr_t, 10> fabric_fwd_addrs;
+    for (size_t i = 0; i < N_SRC_CHANS; i++) {
+        remote_src_ch_semaphore_ack_addrs[i] = get_noc_addr(
+            remote_src_noc_x_ords[i],
+            remote_src_noc_y_ords[i],
+            get_semaphore<ProgrammableCoreType::TENSIX>(remote_src_semaphore_ack_addrs[i]));
+        src_ch_new_chunk_addrs[i] = get_noc_addr(
+            remote_src_noc_x_ords[i],
+            remote_src_noc_y_ords[i],
+            get_semaphore<ProgrammableCoreType::TENSIX>(remote_src_new_chunk_addrs[i]));
+        dest_noc_write_addrs[i] =
+            get_noc_addr(remote_src_noc_x_ords[i], remote_src_noc_y_ords[i], dest_noc_buffer_addrs[i]);
+    }
+    for (size_t i = 0; i < FABRIC_MCAST_FACTOR; i++) {
+        fabric_fwd_addrs[i] = get_noc_addr(
+            remote_src_noc_x_ords[i % N_SRC_CHANS],
+            remote_src_noc_y_ords[i % N_SRC_CHANS],
+            receiver_channel_write_out_l1_bank_addr);
+    }
+
+    // Initialize timing stats at address provided by host
+    timing_stats = reinterpret_cast<volatile TimingStats*>(timing_stats_addr);
+    timing_stats->total_acquire_cycles = 0;
+    timing_stats->total_release_cycles = 0;
+    timing_stats->acquire_count = 0;
+    timing_stats->release_count = 0;
+    timing_stats->total_misc_cycles = 0;
+    timing_stats->misc_count = 0;
+
+    // Initialize pools dynamically based on N_CHUNKS
+    std::array<size_t, N_CHUNKS> send_chunk_base_addresses;
+    for (uint32_t i = 0; i < N_CHUNKS; i++) {
+        send_chunk_base_addresses[i] = send_buffer_base + i * PACKET_SIZE_BYTES * CHUNK_N_PKTS;
+    }
+
+    std::array<size_t, RX_N_PKTS> recv_buffer_addresses;
+    for (uint32_t i = 0; i < RX_N_PKTS; i++) {
+        recv_buffer_addresses[i] = recv_buffer_base + i * PACKET_SIZE_BYTES;
+    }
+
+    tt::tt_fabric::ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS> send_pool;
+    send_pool.init(send_chunk_base_addresses, PACKET_SIZE_BYTES, sizeof(eth_channel_sync_t));
+
+    // Set up channels for bidirectional communication if enabled
+    const uint32_t messages_per_direction = N_SRC_CHANS == 0 ? total_messages : total_messages * N_SRC_CHANS;
+
+    // Setup handshake between both ethernet cores - mandatory step before main test loop
+    eth_setup_handshake(handshake_addr, is_sender_offset_0);
+
+    uint32_t total_messages_target = messages_per_direction;
+    {
+        DeviceZoneScopedN("FABRIC-ELASTIC-CHANNELS-TEST");
+
+        auto test_start_cycles = eth_read_wall_clock();
+
+        main_loop(
+            timing_stats,
+            is_sender_offset_0,
+            total_messages_target,
+            recv_buffer_addresses,
+            message_size,
+            remote_src_ch_semaphore_ack_addrs,
+            src_ch_new_chunk_addrs,
+            dest_noc_write_addrs,
+            fabric_fwd_addrs,
+            send_pool);
+
+        auto test_end_cycles = eth_read_wall_clock();
+        timing_stats->total_test_cycles = test_end_cycles - test_start_cycles;
+    }
+}

--- a/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/kernels/fabric_elastic_channels_test.cpp
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <array>
+#include <tuple>
+#include "dataflow_api.h"
+#include "kernels/fabric_elastic_channels.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp"
+#include "tt_metal/hw/inc/compile_time_args.h"
+
+// Compile-time configuration - passed as compile_args from host
+constexpr size_t N_CHUNKS = get_compile_time_arg_val(0);
+constexpr size_t RX_N_PKTS = get_compile_time_arg_val(1);
+constexpr size_t CHUNK_N_PKTS = get_compile_time_arg_val(2);
+constexpr size_t PACKET_SIZE = get_compile_time_arg_val(3);
+constexpr bool BIDIRECTIONAL_MODE = get_compile_time_arg_val(4);
+
+constexpr int32_t pkts_received_stream_id = 0;  // read by receiver, written by sender
+constexpr int32_t pkts_acked_stream_id = 1;     // read by sender, written by receiver
+
+using namespace tt::tt_fabric;
+
+// Timing tracking structure
+struct TimingStats {
+    uint64_t total_acquire_cycles;
+    uint64_t total_release_cycles;
+    uint64_t total_test_cycles;
+    uint32_t acquire_count;
+    uint32_t release_count;
+
+    TimingStats() :
+        total_acquire_cycles(0), total_release_cycles(0), total_test_cycles(0), acquire_count(0), release_count(0) {}
+};
+
+// Global timing stats stored in L1 - will be initialized in kernel_main
+volatile TimingStats* timing_stats = nullptr;
+
+FORCE_INLINE int32_t get_receiver_num_unprocessed_packets() { return get_ptr_val(pkts_received_stream_id); }
+
+FORCE_INLINE void receiver_mark_packet_processed() { increment_local_update_ptr_val(pkts_received_stream_id, -1); }
+
+FORCE_INLINE void notify_remote_receiver_of_new_packet() { remote_update_ptr_val<pkts_received_stream_id, 0>(1); }
+
+FORCE_INLINE int32_t get_sender_num_unprocessed_acks() { return get_ptr_val(pkts_acked_stream_id); }
+
+FORCE_INLINE void sender_mark_ack_processed() { increment_local_update_ptr_val(pkts_acked_stream_id, -1); }
+
+FORCE_INLINE void send_ack_to_sender() { remote_update_ptr_val<pkts_acked_stream_id, 0>(1); }
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        erisc_info->channels[0].bytes_sent = 0;
+        erisc_info->channels[0].receiver_ack = 0;
+        while (eth_txq_is_busy()) {
+        }
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        while (eth_txq_is_busy()) {
+        }
+        internal_::eth_send_packet(
+            0,
+            ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+            ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
+            1);
+        while (erisc_info->channels[0].bytes_sent != 0) {
+        }
+    } else {
+        while (erisc_info->channels[0].bytes_sent == 0) {
+        }
+        eth_receiver_channel_done(0);
+    }
+}
+
+template <typename OpenChunksCbT, typename SendPoolT>
+void process_send_side(
+    volatile TimingStats* timing_stats,
+    BufferIndex& current_chunk_slot_index,
+    BufferIndex& current_chunk_ack_index,
+    OpenChunksCbT& open_chunks_cb,
+    SendPoolT& send_pool,
+    size_t& unacked_sends,
+    size_t& messages_sent,
+    size_t& messages_acked,
+    size_t messages_to_send,
+    std::array<size_t, RX_N_PKTS>& receiver_buffer_addresses,
+    ChannelBufferPointer<RX_N_PKTS>& sender_view_rx_buf_wr_ptr,
+    size_t message_size) {
+    // Process Ack
+    auto num_unprocessed_acks = get_sender_num_unprocessed_acks();
+    if (num_unprocessed_acks > 0) {
+        current_chunk_ack_index = BufferIndex{static_cast<uint8_t>(current_chunk_ack_index.get() + 1)};
+        bool can_release_chunk = current_chunk_ack_index.get() == CHUNK_N_PKTS;
+        uint64_t start_cycles;
+        uint64_t end_cycles;
+        if (can_release_chunk) {  // 22 cycles!??!?! (44 -> 22 if I don't include the branch condition in the timing)
+
+            start_cycles = eth_read_wall_clock();
+            auto chunk = open_chunks_cb.pop();  // avg 7.3 cycles
+            send_pool.return_chunk(chunk);      // 16 cycles
+            current_chunk_ack_index = BufferIndex{0};
+            end_cycles = eth_read_wall_clock();
+        }
+        sender_mark_ack_processed();
+        if (can_release_chunk) {
+            timing_stats->release_count++;
+            timing_stats->total_release_cycles += (end_cycles - start_cycles);
+        }
+        messages_acked++;
+        unacked_sends--;
+    }
+
+    // Try to send from current chunk
+    if (!eth_txq_is_busy() && unacked_sends < RX_N_PKTS && messages_sent < messages_to_send &&
+        !open_chunks_cb.is_empty() && current_chunk_slot_index < CHUNK_N_PKTS) {
+        auto current_buffer = open_chunks_cb.peek_front();
+
+        // Fill packet data
+        auto src_addr = current_buffer->get_buffer_address(current_chunk_slot_index);
+        auto dest_addr = receiver_buffer_addresses[sender_view_rx_buf_wr_ptr.get_buffer_index()];
+
+        // Send packet using the buffer's channel ID
+        eth_send_bytes_over_channel_payload_only_unsafe_one_packet(src_addr, dest_addr, message_size);
+
+        while (eth_txq_is_busy()) {
+        }
+        notify_remote_receiver_of_new_packet();
+
+        current_chunk_slot_index = BufferIndex{static_cast<uint8_t>(current_chunk_slot_index.get() + 1)};
+        messages_sent++;
+
+        sender_view_rx_buf_wr_ptr.increment();
+        unacked_sends++;
+    }
+
+    // Acquire new chunk if current chunk is full
+    if ((open_chunks_cb.is_empty() || current_chunk_slot_index == CHUNK_N_PKTS) && !send_pool.is_empty()) {
+        current_chunk_slot_index = BufferIndex{0};
+        // Acquire new chunk - measure timing
+        uint64_t start_cycles = eth_read_wall_clock();
+        auto new_chunk = send_pool.get_free_chunk();
+        open_chunks_cb.push(new_chunk);
+        uint64_t end_cycles = eth_read_wall_clock();
+
+        timing_stats->total_acquire_cycles += (end_cycles - start_cycles);
+        timing_stats->acquire_count++;
+    }
+}
+
+void kernel_main() {
+    init_ptr_val(pkts_received_stream_id, 0);
+    init_ptr_val(pkts_acked_stream_id, 0);
+
+    uint32_t arg_idx = 0;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t total_messages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
+    bool is_sender_offset_0 = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t send_buffer_base = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t recv_buffer_base = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t timing_stats_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    // Initialize timing stats at address provided by host
+    timing_stats = reinterpret_cast<volatile TimingStats*>(timing_stats_addr);
+    timing_stats->total_acquire_cycles = 0;
+    timing_stats->total_release_cycles = 0;
+    timing_stats->acquire_count = 0;
+    timing_stats->release_count = 0;
+
+    // Initialize separate channel buffer pools for send and receive
+
+    // Initialize pools dynamically based on N_CHUNKS
+    std::array<std::tuple<size_t, uint8_t>, N_CHUNKS> send_buffers;
+    std::array<size_t, RX_N_PKTS> recv_buffer_addresses;
+
+    for (uint32_t i = 0; i < N_CHUNKS; i++) {
+        send_buffers[i] = std::make_tuple(send_buffer_base + i * PACKET_SIZE * CHUNK_N_PKTS, static_cast<uint8_t>(i));
+    }
+    for (uint32_t i = 0; i < RX_N_PKTS; i++) {
+        recv_buffer_addresses[i] = recv_buffer_base + i * PACKET_SIZE;
+    }
+
+    ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS> send_pool;
+    send_pool.init(send_buffers, PACKET_SIZE, sizeof(eth_channel_sync_t));
+
+    // Set up channels for bidirectional communication if enabled
+    const uint32_t messages_per_direction = total_messages;
+
+    // Setup handshake
+
+    eth_setup_handshake(handshake_addr, is_sender_offset_0);
+
+    size_t messages_acked = 0;
+    size_t messages_sent = 0;
+    size_t messages_received = 0;
+    size_t total_messages_target = messages_per_direction;
+
+    uint32_t idle_count = 0;
+    const uint32_t idle_max = 100000;
+
+    BufferIndex current_chunk_slot_index = BufferIndex{0};
+    BufferIndex current_chunk_ack_index = BufferIndex{0};
+#if defined(ARCH_WORMHOLE)
+    // acq: 6.00
+    // rel: 9.5
+    WormholeEfficientCircularBuffer<typename ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS>::chunk_t*, N_CHUNKS>
+        open_chunks_cb;
+#else
+    // acq: 17
+    // rel: 4
+    CircularBuffer<typename ChannelBuffersPool<N_CHUNKS, CHUNK_N_PKTS>::chunk_t*, N_CHUNKS> open_chunks_cb;
+#endif
+
+    ChannelBufferPointer<RX_N_PKTS> sender_view_rx_buf_wr_ptr;
+    size_t unacked_sends = 0;
+    {
+        DeviceZoneScopedN("FABRIC-ELASTIC-CHANNELS-TEST");
+
+        auto test_start_cycles = eth_read_wall_clock();
+
+        while (messages_acked < total_messages_target || messages_received < total_messages_target) {
+            bool made_progress = false;
+
+            if (BIDIRECTIONAL_MODE || is_sender_offset_0) {
+                process_send_side(
+                    timing_stats,
+                    current_chunk_slot_index,
+                    current_chunk_ack_index,
+                    open_chunks_cb,
+                    send_pool,
+                    unacked_sends,
+                    messages_sent,
+                    messages_acked,
+                    total_messages_target,
+
+                    recv_buffer_addresses,
+                    sender_view_rx_buf_wr_ptr,
+                    message_size);
+            }
+            if (BIDIRECTIONAL_MODE || !is_sender_offset_0) {
+                // Receiver logic - also use ChannelBuffersPool
+                auto num_unprocessed_packets = get_receiver_num_unprocessed_packets();
+                if (num_unprocessed_packets > 0 && !eth_txq_is_busy()) {
+                    receiver_mark_packet_processed();
+                    sender_view_rx_buf_wr_ptr.increment();
+                    messages_received++;
+                    send_ack_to_sender();
+                }
+            }
+
+            // Idle management
+            if (made_progress) {
+                idle_count = 0;
+            } else {
+                idle_count++;
+                if (idle_count > idle_max) {
+                    run_routing();
+                    idle_count = 0;
+                }
+            }
+        }
+
+        auto test_end_cycles = eth_read_wall_clock();
+        timing_stats->total_test_cycles = test_end_cycles - test_start_cycles;
+    }
+}

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp
@@ -64,6 +64,10 @@ FORCE_INLINE uint32_t get_stream_reg_write_addr(uint8_t stream_id) {
     return STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
 }
 
+FORCE_INLINE int32_t pack_value_for_inc_on_write_stream_reg_write(int32_t val) {
+    return val << REMOTE_DEST_BUF_WORDS_FREE_INC;
+}
+
 template <uint32_t stream_id, uint32_t txq_id>
 FORCE_INLINE void remote_update_ptr_val(int32_t val) {
     constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);


### PR DESCRIPTION
### Ticket
#26311 

elastic channel architecture seems worthwhile and we can expect up to a 35% uplift in the buffering limited cases.

This uplift is from measuring single sender fabric unicast performance in a channel setup that mirrors the current fabric config for 2D and comparing it to what the equivalent elastic channel configuration would be for 2D. In such a case I measured 9.7 GB/s (new)vs 7.1 GB/s (old) or ~35% improvement.

The next bottleneck for fabric mcasting scenarios is noc cmd issue rate.

The new test kernel also exposes knobs to experiment with different back-to-back noc write configurations. In general, from a per erisc kernel perspective (ignoring global effects like noc congestion); the best performing configuration is where back-to-back noc writes use different nocs and command buffers. For example, send0: {noc0, write_cmd_buf}, send1: {noc1, write_cmd_buf}, send2: {noc0, read_cmd_buf}, and so on.

The below table outlines then performance changes when applying various schemes and for various mcast factors, for a 4k packet size (IRAM enabled). Note that without IRAM enabled, we were IPC limited.

| BW (GB/s/dir) | Fabric Mcast Factor = 4 | Fabric Mcast Factor = 3 | Fabric Mcast Factor = 2 |
|-|-|-|-|
| baseline | 6 | 7.45 | 9.65 |
| cmd buf changes | 6.2 | 7.65 |  10 |
| noc changes | 9.1 | 9.8 | 11.3 |
| cmd buf + noc changes | 9.2 | 10.2 | 11.3 |

Note that the script: `tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_sweep.py` is a helper to easily sweep over different channel configurations to report performance


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/17252220967
- [x] New/Existing tests provide coverage for changes