### PR TITLE
Add ensure-bh-links-online GH action to check BH multicard eth links are good before running tests

### DIFF
--- a/.github/actions/ensure-bh-links-online/action.yml
+++ b/.github/actions/ensure-bh-links-online/action.yml
@@ -17,7 +17,7 @@ runs:
         # https://tenstorrent.atlassian.net/browse/BH-84
         for i in {1..10}; do
           echo "Health check attempt $i"
-          if tt-smi -r && ./build/test/tt_metal/tt_fabric/test_system_health ${{ inputs.runner-label == 'BH-DeskBox' && '--min-connections 4' || '' }}; then
+          if tt-smi -r >/dev/null 2>&1 && ./build/test/tt_metal/tt_fabric/test_system_health ${{ inputs.runner-label == 'BH-DeskBox' && '--min-connections 4' || '' }}; then
             echo "Health checks passed"
             break
           fi

--- a/.github/actions/ensure-bh-links-online/action.yml
+++ b/.github/actions/ensure-bh-links-online/action.yml
@@ -1,0 +1,30 @@
+name: "Ensure BH Eth links online"
+description: "Perform smi reset and health check in a loop"
+
+inputs:
+  runner-label:
+    required: true
+    description: "Runner label to determine health check parameters"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Ensure Blackhole links are online
+      shell: bash
+      run: |
+        # Health check loop. Needed due to the following issues:
+        # https://tenstorrent.atlassian.net/browse/SYS-1634
+        # https://tenstorrent.atlassian.net/browse/BH-84
+        for i in {1..10}; do
+          echo "Health check attempt $i"
+          if tt-smi -r && ./build/test/tt_metal/tt_fabric/test_system_health ${{ inputs.runner-label == 'BH-DeskBox' && '--min-connections 4' || '' }}; then
+            echo "Health checks passed"
+            break
+          fi
+          if [ $i -eq 10 ]; then
+            echo "Health checks failed after 10 attempts"
+            exit 1
+          fi
+          echo "Health checks failed, retrying..."
+          sleep 5
+        done

--- a/.github/actions/ensure-bh-links-online/action.yml
+++ b/.github/actions/ensure-bh-links-online/action.yml
@@ -11,6 +11,7 @@ runs:
   steps:
     - name: Ensure Blackhole links are online
       shell: bash
+      working-directory: /work
       run: |
         # Health check loop. Needed due to the following issues:
         # https://tenstorrent.atlassian.net/browse/SYS-1634

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -128,6 +128,9 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - uses: ./.github/actions/ensure-bh-links-online
+        with:
+          runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests
         timeout-minutes: 70
         run: |

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -128,7 +128,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: ./.github/actions/ensure-bh-links-online
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -128,7 +128,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: ./.github/actions/ensure-bh-links-online
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -63,6 +63,9 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - uses: ./.github/actions/ensure-bh-links-online
+        with:
+          runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -74,6 +74,9 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - uses: ./.github/actions/ensure-bh-links-online
+        with:
+          runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: ./.github/actions/ensure-bh-links-online
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -121,240 +121,240 @@ jobs:
       build-wheel: true
       version: "22.04"
       build-umd-tests: true
-  # build-artifact-profiler:
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   permissions:
-  #     packages: write
-  #   secrets: inherit
-  #   with:
-  #     build-type: ${{ inputs.build-type || 'Release' }}
-  #     build-wheel: true
-  #     tracy: true
-  #     version: "22.04"
-  # run-profiler-regression:
-  #   needs: [build-artifact-profiler, generate-matrix]
-  #   uses: ./.github/workflows/run-profiler-regression.yaml
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-  #   with:
-  #     arch: "blackhole"
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # umd-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/umd-unit-tests.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  # sd-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   uses: ./.github/workflows/build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # fd-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     timeout: 40
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # # FD C++ Unit Tests
-  # cpp-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/cpp-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     timeout: 20
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # models-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/models-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     timeout: 20
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # blackhole-demo-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
+      tracy: true
+      version: "22.04"
+  run-profiler-regression:
+    needs: [build-artifact-profiler, generate-matrix]
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: "blackhole"
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  umd-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/umd-unit-tests.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  sd-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    uses: ./.github/workflows/build-and-unit-tests.yaml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  fd-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      timeout: 40
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  # FD C++ Unit Tests
+  cpp-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      timeout: 20
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  models-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/models-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      timeout: 20
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  blackhole-demo-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # ttnn-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/ttnn-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttnn-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # ttnn-stress-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     timeout: 45
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # metalium-smoke-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
-  #   uses: ./.github/workflows/smoke.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-  #     runner: ${{ matrix.platform }}
-  #     product: tt-metalium
-  # ttnn-smoke-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
-  #   uses: ./.github/workflows/smoke.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-  #     runner: ${{ matrix.platform }}
-  #     product: tt-nn
+  ttnn-stress-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      timeout: 45
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  metalium-smoke-tests:
+    needs: [build-artifact, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
+      product: tt-metalium
+  ttnn-smoke-tests:
+    needs: [build-artifact, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
+      product: tt-nn
 
-  # test-ttnn-tutorials:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  test-ttnn-tutorials:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # # LLMBox-only demo tests
-  # blackhole-llmbox-demo-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   if: ${{ inputs.enable-llmbox-tests }}
-  #   secrets: inherit
-  #   uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     extra-tag: pipeline-perf
-  #     num_devices: 4
+  # LLMBox-only demo tests
+  blackhole-llmbox-demo-tests:
+    needs: [build-artifact, generate-matrix]
+    if: ${{ inputs.enable-llmbox-tests }}
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      extra-tag: pipeline-perf
+      num_devices: 4
 
-  # # LLMBox-only unit tests
-  # blackhole-llmbox-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   if: ${{ inputs.enable-llmbox-tests }}
-  #   secrets: inherit
-  #   uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # LLMBox-only unit tests
+  blackhole-llmbox-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    if: ${{ inputs.enable-llmbox-tests }}
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # # TT-CNN Unit Tests
-  # tt-cnn-unit-tests:
-  #   needs: [build-artifact, generate-matrix]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/tt-cnn-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.test-group }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # TT-CNN Unit Tests
+  tt-cnn-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/tt-cnn-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   # Multi-card post-commit tests
   blackhole-multi-card-post-commit-tests:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -121,240 +121,240 @@ jobs:
       build-wheel: true
       version: "22.04"
       build-umd-tests: true
-  build-artifact-profiler:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-type: ${{ inputs.build-type || 'Release' }}
-      build-wheel: true
-      tracy: true
-      version: "22.04"
-  run-profiler-regression:
-    needs: [build-artifact-profiler, generate-matrix]
-    uses: ./.github/workflows/run-profiler-regression.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: "blackhole"
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  umd-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/umd-unit-tests.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  sd-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    uses: ./.github/workflows/build-and-unit-tests.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  fd-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      timeout: 40
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  # FD C++ Unit Tests
-  cpp-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/cpp-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      timeout: 20
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  models-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/models-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      timeout: 20
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  blackhole-demo-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # build-artifact-profiler:
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   permissions:
+  #     packages: write
+  #   secrets: inherit
+  #   with:
+  #     build-type: ${{ inputs.build-type || 'Release' }}
+  #     build-wheel: true
+  #     tracy: true
+  #     version: "22.04"
+  # run-profiler-regression:
+  #   needs: [build-artifact-profiler, generate-matrix]
+  #   uses: ./.github/workflows/run-profiler-regression.yaml
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+  #   with:
+  #     arch: "blackhole"
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # umd-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/umd-unit-tests.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  # sd-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   uses: ./.github/workflows/build-and-unit-tests.yaml
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # fd-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     timeout: 40
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # # FD C++ Unit Tests
+  # cpp-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/cpp-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     timeout: 20
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # models-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/models-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     timeout: 20
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # blackhole-demo-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  ttnn-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # ttnn-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/ttnn-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  ttnn-stress-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      timeout: 45
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  metalium-smoke-tests:
-    needs: [build-artifact, generate-matrix]
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-      runner: ${{ matrix.platform }}
-      product: tt-metalium
-  ttnn-smoke-tests:
-    needs: [build-artifact, generate-matrix]
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-      runner: ${{ matrix.platform }}
-      product: tt-nn
+  # ttnn-stress-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     timeout: 45
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # metalium-smoke-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
+  #   uses: ./.github/workflows/smoke.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+  #     runner: ${{ matrix.platform }}
+  #     product: tt-metalium
+  # ttnn-smoke-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
+  #   uses: ./.github/workflows/smoke.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+  #     runner: ${{ matrix.platform }}
+  #     product: tt-nn
 
-  test-ttnn-tutorials:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # test-ttnn-tutorials:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # LLMBox-only demo tests
-  blackhole-llmbox-demo-tests:
-    needs: [build-artifact, generate-matrix]
-    if: ${{ inputs.enable-llmbox-tests }}
-    secrets: inherit
-    uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      extra-tag: pipeline-perf
-      num_devices: 4
+  # # LLMBox-only demo tests
+  # blackhole-llmbox-demo-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   if: ${{ inputs.enable-llmbox-tests }}
+  #   secrets: inherit
+  #   uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     extra-tag: pipeline-perf
+  #     num_devices: 4
 
-  # LLMBox-only unit tests
-  blackhole-llmbox-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    if: ${{ inputs.enable-llmbox-tests }}
-    secrets: inherit
-    uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # LLMBox-only unit tests
+  # blackhole-llmbox-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   if: ${{ inputs.enable-llmbox-tests }}
+  #   secrets: inherit
+  #   uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # TT-CNN Unit Tests
-  tt-cnn-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/tt-cnn-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # # TT-CNN Unit Tests
+  # tt-cnn-unit-tests:
+  #   needs: [build-artifact, generate-matrix]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/tt-cnn-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.test-group }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   # Multi-card post-commit tests
   blackhole-multi-card-post-commit-tests:

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -52,6 +52,7 @@ jobs:
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          build-artifact-name: ${{ inputs.build-artifact-name }}
 
       - name: Ensure BH Eth links online
         if: ${{ contains(inputs.runner-label, 'BH-') }}

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Ensure BH Eth links online
         if: ${{ contains(inputs.runner-label, 'BH-') }}
-        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
+        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
           runner-label: ${{ inputs.runner-label }}
 

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -37,7 +37,9 @@ jobs:
       env:
         ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO
+        LD_LIBRARY_PATH: /work/build/lib
         PYTHONPATH: /work
+        TT_METAL_HOME: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -53,6 +53,12 @@ jobs:
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
+      - name: Ensure BH Eth links online
+        if: ${{ contains(inputs.runner-label, 'BH-') }}
+        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
+        with:
+          runner-label: ${{ inputs.runner-label }}
+
       - name: Run Stress Tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/stress_tests/

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -41,7 +41,7 @@ jobs:
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 5,
             benchmark-timeout: 5,
-            runner-label: bh-deskbox,
+            runner-label: BH-DeskBox,
             mesh-device: P150x2,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 2}",
@@ -128,6 +128,12 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Ensure BH Eth links online
+        if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}
+        uses: ./.github/actions/ensure-bh-links-online
+        with:
+          runner-label: ${{ matrix.test-group.runner-label }}
 
       - name: ⬇️ Checkout vLLM
         uses: actions/checkout@v4

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Ensure BH Eth links online
         if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}
-        uses: ./.github/actions/ensure-bh-links-online
+        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
         with:
           runner-label: ${{ matrix.test-group.runner-label }}
 

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Ensure BH Eth links online
         if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}
-        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@williamly/bh-health-check-loop
+        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
           runner-label: ${{ matrix.test-group.runner-label }}
 


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/26382
Resolves https://github.com/tenstorrent/tt-metal/issues/26927

### Problem description
Workaround for https://tenstorrent.atlassian.net/browse/SYS-1634

### What's changed
Before running actual BH multi-card tests, run in a loop to confirm all links are online:
- ttsmi reset
- system health check

### Checklist
- [x] BH post commit (multi-device test only) https://github.com/tenstorrent/tt-metal/actions/runs/17000755954/job/48202187889
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/17001727951/job/48204808406#step:5:267
- [x] vLLM nightly https://github.com/tenstorrent/tt-metal/actions/runs/17000902022/job/48202524909
- [x] Upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/17043821867/job/48316025162#step:3:425
