### PR TITLE
adding mixed case support for ttnn.requantize

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_quantization.py
@@ -519,3 +519,65 @@ def test_quantization_per_tensor_program_cache(device, input_dtype):
 
     assert num_program_cache_entries_list[0] > 0
     assert max(num_program_cache_entries_list) == min(num_program_cache_entries_list)
+
+
+@pytest.mark.parametrize("x0", [32])
+@pytest.mark.parametrize("x1", [32])
+@pytest.mark.parametrize("input_dtype", [ttnn.float32])
+@pytest.mark.parametrize("axis", [0])
+def test_requant_per_tensor_to_per_channel_2d(device, x0, x1, input_dtype, axis):
+    torch.manual_seed(0)
+    input_tr = torch.rand(x0, x1, dtype=torch.float32)
+    input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    in_scale, in_zero_point = calculate_scale_zero_point_per_tensor(input_tr, -128, 127)
+
+    rank = len(input_tr.shape)
+    axis_normalized = (axis + rank) % rank
+    out_scale, out_zero_point = calculate_scale_zero_point_per_channel(input_tr, axis_normalized, -64, 63)
+
+    in_scale_tt = in_scale
+    in_zero_point_tt = in_zero_point
+    out_scale_tt = ttnn.from_torch(out_scale, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_zero_point_tt = ttnn.from_torch(out_zero_point, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    quantized_tt = ttnn.quantize(input_tt, in_scale_tt, in_zero_point_tt)
+    requantized_tt = ttnn.requantize(
+        quantized_tt, in_scale_tt, in_zero_point_tt, out_scale_tt, out_zero_point_tt, axis=axis
+    )
+    derequantized_tt = ttnn.dequantize(requantized_tt, out_scale_tt, out_zero_point_tt, axis=axis, dtype=input_dtype)
+
+    result_tr = ttnn.to_torch(derequantized_tt)
+    check_pcc(input_tr, result_tr, True)
+    check_match_ratio(input_tr, result_tr, input_dtype)
+
+
+@pytest.mark.parametrize("x0", [32])
+@pytest.mark.parametrize("x1", [32])
+@pytest.mark.parametrize("input_dtype", [ttnn.float32])
+@pytest.mark.parametrize("axis", [0])
+def test_requant_per_channel_to_per_tensor_2d(device, x0, x1, input_dtype, axis):
+    torch.manual_seed(0)
+    input_tr = torch.rand(x0, x1, dtype=torch.float32)
+    input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    rank = len(input_tr.shape)
+    axis_normalized = (axis + rank) % rank
+    in_scale, in_zero_point = calculate_scale_zero_point_per_channel(input_tr, axis_normalized, -128, 127)
+
+    out_scale, out_zero_point = calculate_scale_zero_point_per_tensor(input_tr, -64, 63)
+
+    in_scale_tt = ttnn.from_torch(in_scale, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    in_zero_point_tt = ttnn.from_torch(in_zero_point, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_scale_tt = out_scale
+    out_zero_point_tt = out_zero_point
+
+    quantized_tt = ttnn.quantize(input_tt, in_scale_tt, in_zero_point_tt, axis=axis)
+    requantized_tt = ttnn.requantize(
+        quantized_tt, in_scale_tt, in_zero_point_tt, out_scale_tt, out_zero_point_tt, axis=axis
+    )
+    derequantized_tt = ttnn.dequantize(requantized_tt, out_scale_tt, out_zero_point_tt, dtype=input_dtype)
+
+    result_tr = ttnn.to_torch(derequantized_tt)
+    check_pcc(input_tr, result_tr, True)
+    check_match_ratio(input_tr, result_tr, input_dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_quantization.py
@@ -526,6 +526,7 @@ def test_quantization_per_tensor_program_cache(device, input_dtype):
 @pytest.mark.parametrize("input_dtype", [ttnn.float32])
 @pytest.mark.parametrize("axis", [0])
 def test_requant_per_tensor_to_per_channel_2d(device, x0, x1, input_dtype, axis):
+    """Test requantization (per-tensor -> per-channel)"""
     torch.manual_seed(0)
     input_tr = torch.rand(x0, x1, dtype=torch.float32)
     input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -553,6 +554,7 @@ def test_requant_per_tensor_to_per_channel_2d(device, x0, x1, input_dtype, axis)
 @pytest.mark.parametrize("input_dtype", [ttnn.float32])
 @pytest.mark.parametrize("axis", [0])
 def test_requant_per_channel_to_per_tensor_2d(device, x0, x1, input_dtype, axis):
+    """Test requantization (per-channel -> per-tensor)"""
     torch.manual_seed(0)
     input_tr = torch.rand(x0, x1, dtype=torch.float32)
     input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -568,7 +570,79 @@ def test_requant_per_channel_to_per_tensor_2d(device, x0, x1, input_dtype, axis)
 
     quantized_tt = ttnn.quantize(input_tt, in_scale_tt, in_zero_point_tt, axis=axis)
     requantized_tt = ttnn.requantize(quantized_tt, in_scale_tt, in_zero_point_tt, out_scale, out_zero_point, axis=axis)
+    # For per-tensor output (scalar tensors), don't pass axis to dequantize.
     derequantized_tt = ttnn.dequantize(requantized_tt, out_scale, out_zero_point, dtype=input_dtype)
+
+    result_tr = ttnn.to_torch(derequantized_tt)
+    check_pcc(input_tr, result_tr, True)
+    check_match_ratio(input_tr, result_tr, input_dtype)
+
+
+@pytest.mark.parametrize("x0", [32])
+@pytest.mark.parametrize("x1", [32])
+@pytest.mark.parametrize("input_dtype", [ttnn.float32])
+@pytest.mark.parametrize("axis", [0, 1])
+def test_requant_all_tensors_per_tensor_to_per_channel_2d(device, x0, x1, input_dtype, axis):
+    """Test requantization with all parameters as tensors (per-tensor -> per-channel)"""
+    torch.manual_seed(0)
+    input_tr = torch.rand(x0, x1, dtype=torch.float32)
+    input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    rank = len(input_tr.shape)
+    axis_normalized = (axis + rank) % rank
+    in_scale, in_zero_point = calculate_scale_zero_point_per_tensor(input_tr, -128, 127)
+
+    out_scale, out_zero_point = calculate_scale_zero_point_per_channel(input_tr, axis_normalized, -64, 63)
+
+    # Convert all parameters to tensors.
+    in_scale_tt = ttnn.from_torch(torch.tensor(in_scale), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    in_zero_point_tt = ttnn.from_torch(
+        torch.tensor(in_zero_point), dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    out_scale_tt = ttnn.from_torch(out_scale, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_zero_point_tt = ttnn.from_torch(out_zero_point, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    quantized_tt = ttnn.quantize(input_tt, in_scale_tt, in_zero_point_tt)
+    requantized_tt = ttnn.requantize(
+        quantized_tt, in_scale_tt, in_zero_point_tt, out_scale_tt, out_zero_point_tt, axis=axis
+    )
+    derequantized_tt = ttnn.dequantize(requantized_tt, out_scale_tt, out_zero_point_tt, axis=axis, dtype=input_dtype)
+
+    result_tr = ttnn.to_torch(derequantized_tt)
+    check_pcc(input_tr, result_tr, True)
+    check_match_ratio(input_tr, result_tr, input_dtype)
+
+
+@pytest.mark.parametrize("x0", [32])
+@pytest.mark.parametrize("x1", [32])
+@pytest.mark.parametrize("input_dtype", [ttnn.float32])
+@pytest.mark.parametrize("axis", [0, 1])
+def test_requant_all_tensors_per_channel_to_per_tensor_2d(device, x0, x1, input_dtype, axis):
+    """Test requantization with all parameters as tensors (per-channel -> per-tensor)"""
+    torch.manual_seed(0)
+    input_tr = torch.rand(x0, x1, dtype=torch.float32)
+    input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    rank = len(input_tr.shape)
+    axis_normalized = (axis + rank) % rank
+    in_scale, in_zero_point = calculate_scale_zero_point_per_channel(input_tr, axis_normalized, -128, 127)
+
+    out_scale, out_zero_point = calculate_scale_zero_point_per_tensor(input_tr, -64, 63)
+
+    # Convert all parameters to tensors.
+    in_scale_tt = ttnn.from_torch(in_scale, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    in_zero_point_tt = ttnn.from_torch(in_zero_point, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_scale_tt = ttnn.from_torch(torch.tensor(out_scale), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    out_zero_point_tt = ttnn.from_torch(
+        torch.tensor(out_zero_point), dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    quantized_tt = ttnn.quantize(input_tt, in_scale_tt, in_zero_point_tt, axis=axis)
+    requantized_tt = ttnn.requantize(
+        quantized_tt, in_scale_tt, in_zero_point_tt, out_scale_tt, out_zero_point_tt, axis=axis
+    )
+    # For per-tensor output (scalar tensors), don't pass axis to dequantize.
+    derequantized_tt = ttnn.dequantize(requantized_tt, out_scale_tt, out_zero_point_tt, dtype=input_dtype)
 
     result_tr = ttnn.to_torch(derequantized_tt)
     check_pcc(input_tr, result_tr, True)

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -391,7 +391,7 @@ Tensor RequantOp::invoke(
         check_zero_point_tensor_args(input_tensor, out_zero_point_p, axis_v, rank, out_zero_point_is_full_size);
 
         // Shape expansion and typecasting for the scale and zero-point tensors.
-        auto expand_or_cast = [&](const Tensor& v, bool is_per_channel, DataType dt) -> Tensor {
+        auto expand_or_cast = [&](const Tensor& v, bool is_full_size, DataType dt) -> Tensor {
             return is_full_size ? reshape_per_channel_vector_args(v, input_shape, axis_v, dt) : ttnn::typecast(v, dt);
         };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -117,6 +117,51 @@ void check_per_channel_tensor_args(
     TT_FATAL(zero_point_dtype == ttnn::DataType::INT32, "Quantization only takes int32 zero-points for now");
 }
 
+void check_scale_tensor_args(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor* scale_p,
+    const int32_t axis,
+    const int32_t rank,
+    bool is_per_channel) {
+    TT_FATAL(scale_p != nullptr, "Scale tensor cannot be null");
+    TT_FATAL(axis >= -rank && axis < rank, "Axis {} is outside the range [{}, {}]", axis, -rank, rank - 1);
+
+    const auto scale_dtype = scale_p->dtype();
+    TT_FATAL(tt::tt_metal::is_floating_point(scale_dtype), "Quantization only takes floating-point number scales");
+    TT_FATAL(!tt::tt_metal::is_block_float(scale_dtype), "Unsupported quantization scale data type");
+
+    if (is_per_channel) {
+        TT_FATAL(scale_p->logical_shape().rank() == 1, "Per-channel quantization expects 1D scale tensors");
+        TT_FATAL(
+            input_tensor.logical_shape()[axis] == scale_p->logical_volume(),
+            "Size of the scale tensor doesn't match the size of the input tensor along the given axis");
+    } else {
+        TT_FATAL(scale_p->logical_volume() == 1u, "Per-tensor quantization only takes scalar-tensor scales");
+    }
+}
+
+void check_zero_point_tensor_args(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor* zero_point_p,
+    const int32_t axis,
+    const int32_t rank,
+    bool is_per_channel) {
+    TT_FATAL(zero_point_p != nullptr, "Zero-point tensor cannot be null");
+    TT_FATAL(axis >= -rank && axis < rank, "Axis {} is outside the range [{}, {}]", axis, -rank, rank - 1);
+
+    const auto zero_point_dtype = zero_point_p->dtype();
+    TT_FATAL(zero_point_dtype == ttnn::DataType::INT32, "Quantization only takes int32 zero-points for now");
+
+    if (is_per_channel) {
+        TT_FATAL(zero_point_p->logical_shape().rank() == 1, "Per-channel quantization expects 1D zero-point tensors");
+        TT_FATAL(
+            input_tensor.logical_shape()[axis] == zero_point_p->logical_volume(),
+            "Size of the zero-point tensor doesn't match the size of the input tensor along the given axis");
+    } else {
+        TT_FATAL(zero_point_p->logical_volume() == 1u, "Per-tensor quantization only takes scalar-tensor zero-points");
+    }
+}
+
 ttnn::Tensor reshape_per_channel_vector_args(
     const ttnn::Tensor& vector, ttnn::Shape tensor_shape, const int32_t axis, const ttnn::DataType out_dtype) {
     // This function is internal use only, use asserts instead of TT_FATAL to convey intented usage
@@ -302,28 +347,100 @@ Tensor RequantOp::invoke(
 
     constexpr tt::stl::Span<const unary::UnaryWithParam> none{};
 
-    const bool is_per_channel = axis.has_value();
-    if (is_per_channel) {
-        const Tensor* in_scale_p = std::get_if<Tensor>(&in_scale);
-        const Tensor* in_zero_point_p = std::get_if<Tensor>(&in_zero_point);
-        const Tensor* out_scale_p = std::get_if<Tensor>(&out_scale);
-        const Tensor* out_zero_point_p = std::get_if<Tensor>(&out_zero_point);
+    const bool has_axis = axis.has_value();
 
+    const Tensor* in_scale_p = std::get_if<Tensor>(&in_scale);
+    const Tensor* in_zero_point_p = std::get_if<Tensor>(&in_zero_point);
+    const Tensor* out_scale_p = std::get_if<Tensor>(&out_scale);
+    const Tensor* out_zero_point_p = std::get_if<Tensor>(&out_zero_point);
+
+    // Only use optimized per-channel path when axis is provided AND all parameters are tensors
+    // Mixed scalar/tensor cases will fall through to composite fallback.
+    const bool all_params_are_tensors = in_scale_p && in_zero_point_p && out_scale_p && out_zero_point_p;
+
+    if (has_axis && all_params_are_tensors) {
         const int32_t axis_v = axis.value();
         const ttnn::Shape& input_shape = input_tensor.logical_shape();
+        const int32_t rank = input_shape.rank();
 
-        check_per_channel_tensor_args(input_tensor, in_scale_p, in_zero_point_p, axis_v, input_shape.rank());
-        check_per_channel_tensor_args(input_tensor, out_scale_p, out_zero_point_p, axis_v, input_shape.rank());
+        const bool in_scale_is_per_channel = in_scale_p && in_scale_p->logical_volume() == input_shape[axis_v];
+        const bool in_zero_point_is_per_channel =
+            in_zero_point_p && in_zero_point_p->logical_volume() == input_shape[axis_v];
+        const bool out_scale_is_per_channel = out_scale_p && out_scale_p->logical_volume() == input_shape[axis_v];
+        const bool out_zero_point_is_per_channel =
+            out_zero_point_p && out_zero_point_p->logical_volume() == input_shape[axis_v];
 
-        const Tensor in_scale_full =
-            reshape_per_channel_vector_args(*in_scale_p, input_shape, axis_v, DataType::FLOAT32);
-        const Tensor in_zero_point_full =
-            reshape_per_channel_vector_args(*in_zero_point_p, input_shape, axis_v, DataType::FLOAT32);
-        const Tensor out_scale_full =
-            reshape_per_channel_vector_args(*out_scale_p, input_shape, axis_v, DataType::FLOAT32);
-        const Tensor out_zero_point_full =
-            reshape_per_channel_vector_args(*out_zero_point_p, input_shape, axis_v, DataType::FLOAT32);
+        if (in_scale_p && in_zero_point_p) {
+            TT_FATAL(
+                in_scale_is_per_channel == in_zero_point_is_per_channel,
+                "Input scale and input zero-point must both be per-channel or both be per-tensor, but got: "
+                "input scale {} per-channel, input zero-point {} per-channel",
+                in_scale_is_per_channel ? "is" : "is not",
+                in_zero_point_is_per_channel ? "is" : "is not");
+        }
 
+        if (out_scale_p && out_zero_point_p) {
+            TT_FATAL(
+                out_scale_is_per_channel == out_zero_point_is_per_channel,
+                "Output scale and output zero-point must both be per-channel or both be per-tensor, but got: "
+                "output scale {} per-channel, output zero-point {} per-channel",
+                out_scale_is_per_channel ? "is" : "is not",
+                out_zero_point_is_per_channel ? "is" : "is not");
+        }
+
+        if (in_scale_p) {
+            check_scale_tensor_args(input_tensor, in_scale_p, axis_v, rank, in_scale_is_per_channel);
+        }
+        if (in_zero_point_p) {
+            check_zero_point_tensor_args(input_tensor, in_zero_point_p, axis_v, rank, in_zero_point_is_per_channel);
+        }
+        if (out_scale_p) {
+            check_scale_tensor_args(input_tensor, out_scale_p, axis_v, rank, out_scale_is_per_channel);
+        }
+        if (out_zero_point_p) {
+            check_zero_point_tensor_args(input_tensor, out_zero_point_p, axis_v, rank, out_zero_point_is_per_channel);
+        }
+
+        if (in_scale_is_per_channel && in_zero_point_is_per_channel) {
+            TT_FATAL(
+                in_scale_p->logical_shape() == in_zero_point_p->logical_shape(),
+                "Per-channel input scale & zero-point tensors must have matching shapes");
+        }
+        if (out_scale_is_per_channel && out_zero_point_is_per_channel) {
+            TT_FATAL(
+                out_scale_p->logical_shape() == out_zero_point_p->logical_shape(),
+                "Per-channel output scale & zero-point tensors must have matching shapes");
+        }
+
+        Tensor in_scale_full, in_zero_point_full, out_scale_full, out_zero_point_full;
+
+        if (in_scale_p) {
+            in_scale_full = in_scale_is_per_channel
+                                ? reshape_per_channel_vector_args(*in_scale_p, input_shape, axis_v, DataType::FLOAT32)
+                                : ttnn::typecast(*in_scale_p, DataType::FLOAT32);
+        }
+
+        if (in_zero_point_p) {
+            in_zero_point_full =
+                in_zero_point_is_per_channel
+                    ? reshape_per_channel_vector_args(*in_zero_point_p, input_shape, axis_v, DataType::FLOAT32)
+                    : ttnn::typecast(*in_zero_point_p, DataType::FLOAT32);
+        }
+
+        if (out_scale_p) {
+            out_scale_full = out_scale_is_per_channel
+                                 ? reshape_per_channel_vector_args(*out_scale_p, input_shape, axis_v, DataType::FLOAT32)
+                                 : ttnn::typecast(*out_scale_p, DataType::FLOAT32);
+        }
+
+        if (out_zero_point_p) {
+            out_zero_point_full =
+                out_zero_point_is_per_channel
+                    ? reshape_per_channel_vector_args(*out_zero_point_p, input_shape, axis_v, DataType::FLOAT32)
+                    : ttnn::typecast(*out_zero_point_p, DataType::FLOAT32);
+        }
+
+        // Perform the computation using broadcasting.
         const Tensor scale_recip_full = ttnn::divide(
             queue_id, in_scale_full, out_scale_full, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
         const Tensor in_zero_point_scaled_full = ttnn::multiply(


### PR DESCRIPTION
### Problem description
There are often cases (e.g. in a quantized conv2d) when a requantize is performed with per-axis input scale/zero point and per tensor output scale/zero point (an implicit broadcast is performed). 

### What's changed
Relaxed the requirements for ttnn.requantize to support per-axis -> per-tensor requantization and vice versa.
Added new pytest tests to reflect this.

APC: https://github.com/tenstorrent/tt-metal/actions/runs/17305644295