### PR TITLE
Remove unused `MetalContext::reinitialize(...)` function

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -48,11 +48,6 @@ void validate_worker_l1_size(size_t& worker_l1_size, Hal& hal) {
 
 }  // namespace
 
-void MetalContext::reinitialize() {
-    force_reinit_ = true;
-    initialize(dispatch_core_config_, num_hw_cqs_, l1_bank_remap_, worker_l1_size_, false);
-}
-
 void MetalContext::initialize(
     const DispatchCoreConfig& dispatch_core_config,
     uint8_t num_hw_cqs,

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -68,7 +68,6 @@ public:
         const BankMapping& l1_bank_remap,
         size_t worker_l1_size,
         bool minimal = false);
-    void reinitialize();
     void teardown();
 
     // Control plane accessors


### PR DESCRIPTION
### Ticket
None

### Problem description
Simple change to remove the unused MetalContext::reinitialize() method and its declaration. This method appears to be dead code that is no longer called anywhere in the codebase.

### What's changed
- Removed MetalContext::reinitialize() method implementation from tt_metal/impl/context/metal_context.cpp
- Removed method declaration from tt_metal/impl/context/metal_context.hpp

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17005315406