### PR TITLE
Reintroduce ring topology for T3K submesh on 6U galaxy in `tt_transformers`

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1259,11 +1259,24 @@ def create_submeshes(mesh_device, data_parallel):
     num_devices = num_rows * num_cols
     assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
 
-    # Check if the mesh is 8x4 (expected shape for TG) and perfer column split for DP=4
-    # Submeshes with 8 devices are expected to be in ring topology on 6U galaxy, hence the column split
-    if num_rows == 8 and num_cols == 4 and num_cols % data_parallel == 0:
-        assert data_parallel != 2, "DP=2 is currently not supported for 8x4 mesh"
+    if (
+        num_rows == 8
+        and num_cols == 4
+        and num_rows % data_parallel == 0
+        and ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.TG
+    ):
+        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
+        for submesh in submeshes:
+            submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))
+        return submeshes
 
+    # Submeshes with 8 devices on 8x4 mesh are expected to be in ring topology on 6U galaxy
+    if (
+        num_rows == 8
+        and num_cols == 4
+        and num_cols % data_parallel == 0
+        and ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
+    ):
         submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows, num_cols // data_parallel))
         for submesh in submeshes:
             submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1259,10 +1259,12 @@ def create_submeshes(mesh_device, data_parallel):
     num_devices = num_rows * num_cols
     assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
 
-    # Check if the mesh is 8x4 (expected shape for TG) and perfer row split
-    # Submeshes with 8 devices are expected to be in ring topology hence the row split
-    if num_rows == 8 and num_cols == 4 and num_rows % data_parallel == 0:
-        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
+    # Check if the mesh is 8x4 (expected shape for TG) and perfer column split for DP=4
+    # Submeshes with 8 devices are expected to be in ring topology on 6U galaxy, hence the column split
+    if num_rows == 8 and num_cols == 4 and num_cols % data_parallel == 0:
+        assert data_parallel != 2, "DP=2 is currently not supported for 8x4 mesh"
+
+        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows, num_cols // data_parallel))
         for submesh in submeshes:
             submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))
         return submeshes

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1294,7 +1294,11 @@ class ModelArgs:
         return False
 
     def ccl_topology(self):
-        if self.num_devices == 8 and ttnn.GetNumAvailableDevices() == 8:  # T3K
+        # Use ring on a T3K or 6U galaxy submesh
+        if self.num_devices == 8 and ttnn.cluster.get_cluster_type() in [
+            ttnn.cluster.ClusterType.T3K,
+            ttnn.cluster.ClusterType.GALAXY,
+        ]:
             return ttnn.Topology.Ring
         elif self.num_devices > 1:  # All other multi chip devices
             return ttnn.Topology.Linear


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26750

Perf improvement on 6U 51 t/s/u -> 55 t/s/u for llama 8B, DP=4

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [Galaxy demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17013923477)
- [x] [TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17013925319) 