### PR TITLE
#26842: Changed log level to debug in Conv DRAM

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -222,7 +222,7 @@ Result conv2d_DRAM(
             current_num_slices <= output_sliced_dim,
             "Could not find a suitable number of slices for Conv2D DRAM Slicing. "
             "Either increase the number of slices or reduce the output dimension being sliced.");
-        log_info(tt::LogOp, "Conv2D DRAM Slicing: Automatically determined number of slices: {}", current_num_slices);
+        log_debug(tt::LogOp, "Conv2D DRAM Slicing: Automatically determined number of slices: {}", current_num_slices);
     }
     TT_FATAL(dram_slice_config.num_slices > 1, " Number of slices should be greater than 1 for Conv2D DRAM Slicing");
     TT_FATAL(


### PR DESCRIPTION
### Ticket
#26842 

### Problem description
Logger level is set to info in Conv DRAM, which is too verbose

### What's changed
Changed logger level to Debug

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17035959020)
- [x] New/Existing tests provide coverage for changes