### PR TITLE
Use Composite-AG when Gathering on Outer Dims and Outer Dims are Non-One

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -199,7 +199,7 @@ def run_all_gather_impl(
         (8, [1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
         (8, [1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
         (8, [1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        # Tests for training shapes
+        # Composite-AG tests
         (8, [1, 1, 8, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
         (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
         (8, [1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
@@ -212,9 +212,9 @@ def run_all_gather_impl(
         "gather_dim_2",
         "gather_dim_2_padded_dim_3",
         "gather_dim_3_padded_dim_2",
-        "tt_training_test_one",
-        "tt_training_test_two",
-        "tt_training_test_three",
+        "composite_ag_test_one",
+        "composite_ag_test_two",
+        "composite_ag_test_three",
     ],
 )
 @pytest.mark.parametrize(
@@ -287,6 +287,101 @@ def test_all_gather_async(
         num_iters=num_iters,
         use_barrier=use_barrier,
         use_persistent_buffers=use_persistent_buffers,
+    )
+
+
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices, ag_output_shape, dim, layout, ag_input_dtype",
+    [
+        # Gather on dim 0
+        (8, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # Gather on dim 1
+        (8, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # Gather on dim 2
+        (8, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 1, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # # Gather on dim 3
+        (8, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 1, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, [16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+    ids=[
+        "tt_training_test_one",
+        "tt_training_test_two",
+        "tt_training_test_three",
+        "tt_training_test_four",
+        "tt_training_test_five",
+        "tt_training_test_six",
+        "tt_training_test_seven",
+        "tt_training_test_eight",
+        "tt_training_test_nine",
+        "tt_training_test_ten",
+        "tt_training_test_eleven",
+        "tt_training_test_twelve",
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_all_gather_async_training_shapes(
+    t3k_mesh_device,
+    num_devices,
+    ag_output_shape,
+    dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+):
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        use_barrier=True,
+        use_persistent_buffers=False,
     )
 
 

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -203,6 +203,7 @@ def run_all_gather_impl(
         (8, [1, 1, 8, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
         (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
         (8, [1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        (8, [1, 16, 32, 32], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
     ],
     ids=[
         "sd35_spatial",
@@ -215,6 +216,7 @@ def run_all_gather_impl(
         "composite_ag_test_one",
         "composite_ag_test_two",
         "composite_ag_test_three",
+        "composite_ag_test_four",
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -36,8 +36,10 @@ bool use_composite_all_gather(
     }
 
     // Use composite if tiled and padded on the gather dim
-    if ((gather_dim == 2 && input_shape[2] % tile_height != 0) ||
-        (gather_dim == 3 && input_shape[3] % tile_width != 0)) {
+    bool is_tiled_and_padded_on_gather_dim =
+        input_tensor.layout() == Layout::TILE && ((gather_dim == 2 && input_shape[2] % tile_height != 0) ||
+                                                  (gather_dim == 3 && input_shape[3] % tile_width != 0));
+    if (is_tiled_and_padded_on_gather_dim) {
         return true;
     }
 
@@ -49,7 +51,6 @@ bool use_composite_all_gather(
     return false;
 }
 
-// Composite always runs in row-major
 ttnn::Tensor composite_all_gather(
     ttnn::Tensor input_tensor,
     const int32_t dim,
@@ -59,15 +60,25 @@ ttnn::Tensor composite_all_gather(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis) {
-    DataType input_dtype = input_tensor.dtype();
-    bool convert_to_bfloat16_for_composite = input_dtype == DataType::BFLOAT8_B;
-    bool is_tiled = input_tensor.layout() == Layout::TILE;
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_height = tile_shape[0];
+    uint32_t tile_width = tile_shape[1];
+
+    auto input_shape = input_tensor.logical_shape();
 
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;
 
+    bool is_tiled_and_not_tile_aligned = input_tensor.layout() == Layout::TILE &&
+                                         (input_shape[2] % tile_height != 0 || input_shape[3] % tile_width != 0);
+
+    // If we need to convert to row-major, then if the input dtype is bfloat8_b we need to typecast before untilizing
+    // and after re-tilizing
+    DataType input_dtype = input_tensor.dtype();
+    bool convert_to_bfloat16_for_composite = is_tiled_and_not_tile_aligned && input_dtype == DataType::BFLOAT8_B;
+
     // Convert to row major
-    if (is_tiled) {
+    if (is_tiled_and_not_tile_aligned) {
         // If input is tiled bfloat8_b, convert to bfloat16 to do the all_broadcast_async + concat
         if (convert_to_bfloat16_for_composite) {
             input_tensor = ttnn::typecast(input_tensor, DataType::BFLOAT16);
@@ -88,7 +99,7 @@ ttnn::Tensor composite_all_gather(
     ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, gather_dim);
 
     // Convert back to tiled
-    if (is_tiled) {
+    if (is_tiled_and_not_tile_aligned) {
         all_gather_output_tensor = ttnn::to_layout(all_gather_output_tensor, Layout::TILE);
         // If we had to convert the input dtype in order to execute the row-major composite op, convert back to the
         // input dtype

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -20,6 +20,8 @@ bool use_composite_all_gather(
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
 
+    auto input_shape = input_tensor.logical_shape();
+
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;
 
@@ -34,9 +36,13 @@ bool use_composite_all_gather(
     }
 
     // Use composite if tiled and padded on the gather dim
-    auto input_shape = input_tensor.logical_shape();
     if ((gather_dim == 2 && input_shape[2] % tile_height != 0) ||
         (gather_dim == 3 && input_shape[3] % tile_width != 0)) {
+        return true;
+    }
+
+    // Use composite if gathering on dim 0 or dim 1, and input_shape[0] != 1 or input_shape[1] != 1
+    if ((gather_dim == 0 || gather_dim == 1) && (input_shape[0] != 1 || input_shape[1] != 1)) {
         return true;
     }
 


### PR DESCRIPTION
### Problem description
- The native implementation of `all_gather_async` gives bad PCC when gathering on dim 0 or dim 1, and the input shape at dim 0 or dim 1 is non-one

### What's changed
- Route these cases to the composite-AG implementation, which does handle these shape - gather-dim combos

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17030051606
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17030053210
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17030056103
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/17030057598
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/17030059253
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/17041933873
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
- [ ] T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17030065177
- [ ] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17030066355