### PR TITLE
Enhance ReLU operations and tests for int32 support

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_relu.h
@@ -38,21 +38,39 @@ inline void llk_math_eltwise_unary_sfpu_lrelu(uint dst_index, uint param0 = 0) {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_relu_max(uint dst_index, uint param0 = 0) {
+inline void llk_math_eltwise_unary_sfpu_relu_max(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::relu_max<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);
+        ckernel::sfpu::_relu_max_<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_relu_min(uint dst_index, uint param0 = 0) {
+inline void llk_math_eltwise_unary_sfpu_relu_max_int32(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::relu_min<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);
+        ckernel::sfpu::_relu_max_<sfpi::vInt, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_relu_min(uint dst_index, uint param0) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_relu_min_int32(uint dst_index, uint param0) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_relu(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::relu_min<APPROXIMATE>, dst_index, (int)VectorMode::RC, 0);
+        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, 0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_relu_int32(uint dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, 0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_relu.h
@@ -38,21 +38,39 @@ inline void llk_math_eltwise_unary_sfpu_lrelu(uint dst_index, uint param0 = 0) {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_relu_max(uint dst_index, uint param0 = 0) {
+inline void llk_math_eltwise_unary_sfpu_relu_max(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::relu_max<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);
+        ckernel::sfpu::_relu_max_<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_relu_min(uint dst_index, uint param0 = 0) {
+inline void llk_math_eltwise_unary_sfpu_relu_max_int32(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::relu_min<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);
+        ckernel::sfpu::_relu_max_<sfpi::vInt, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_relu_min(uint dst_index, uint param0) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_relu_min_int32(uint dst_index, uint param0) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, param0);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_relu(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::relu_min<APPROXIMATE>, dst_index, (int)VectorMode::RC, 0);
+        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, 0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_relu_int32(uint dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROXIMATE, 8, uint32_t>, dst_index, (int)VectorMode::RC, 0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/relu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/relu.h
@@ -26,12 +26,16 @@ namespace ckernel {
  *
  * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | upper_limit    | Upper limit of relu_min                                                    | uint32_t | Greater than 0                                        | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void relu_max_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_relu_max<APPROX>(idst, param0)));
+}
+
+ALWI void relu_max_tile_int32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_relu_max_int32<APPROX>(idst, param0)));
 }
 
 /**
@@ -50,12 +54,16 @@ ALWI void relu_max_tile_init() { MATH((llk_math_eltwise_unary_sfpu_relu_max_init
  *
  * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | lower_limit    | Upper limit of relu_min                                                    | uint32_t | Greater than 0                                        | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void relu_min_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_relu_min<APPROX>(idst, param0)));
+}
+
+ALWI void relu_min_tile_int32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_relu_min_int32<APPROX>(idst, param0)));
 }
 
 /**
@@ -79,6 +87,8 @@ ALWI void relu_min_tile_init() { MATH((llk_math_eltwise_unary_sfpu_relu_min_init
  // clang-format on
 ALWI void relu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_relu<APPROX>(idst))); }
 
+ALWI void relu_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_relu_int32<APPROX>(idst))); }
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -95,10 +105,10 @@ ALWI void relu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_relu_init<APPROX>
  *
  * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | slope          | slope used in leaky relu - will reinterpret unsigned int to float          | uint32_t | Greater than 0                                        | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void leaky_relu_tile(uint32_t idst, uint32_t slope) {
     MATH((llk_math_eltwise_unary_sfpu_lrelu<APPROX>(idst, slope)));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -130,8 +130,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
-                    "relu_min_tile_init();",
-                    fmt::format("relu_min_tile_int32({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+                    "relu_min_tile_init();", fmt::format("relu_min_tile_int32({}, {}u);", idst, (uint)param0)};
             } else {
                 op_init_and_name = {
                     "relu_min_tile_init();",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -113,14 +113,30 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             op_init_and_name = {"rounding_op_tile_init();", fmt::format("round_tile({}, {});", idst, (int)param0)};
             break;
         case UnaryOpType::RELU_MAX:
-            op_init_and_name = {
-                "relu_max_tile_init();",
-                fmt::format("relu_max_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {
+                    "relu_max_tile_init();",
+                    fmt::format("relu_max_tile_int32({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            } else {
+                op_init_and_name = {
+                    "relu_max_tile_init();",
+                    fmt::format("relu_max_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            }
             break;
         case UnaryOpType::RELU_MIN:
-            op_init_and_name = {
-                "relu_min_tile_init();",
-                fmt::format("relu_min_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {
+                    "relu_min_tile_init();",
+                    fmt::format("relu_min_tile_int32({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            } else {
+                op_init_and_name = {
+                    "relu_min_tile_init();",
+                    fmt::format("relu_min_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            }
             break;
         case UnaryOpType::POWER:
             op_init_and_name = {"power_tile_init();", fmt::format("power_tile({}, {}u);", idst, (uint32_t)param0)};
@@ -449,11 +465,19 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::RECIP: op_init_and_name = {"recip_tile_init();", fmt::format("recip_tile({});", idst)}; break;
         case UnaryOpType::GELU: op_init_and_name = {"gelu_tile_init();", fmt::format("gelu_tile({});", idst)}; break;
         case UnaryOpType::RSQRT: op_init_and_name = {"rsqrt_tile_init();", fmt::format("rsqrt_tile({});", idst)}; break;
-        case UnaryOpType::RELU: op_init_and_name = {"relu_tile_init();", fmt::format("relu_tile({});", idst)}; break;
         case UnaryOpType::SQRT: op_init_and_name = {"sqrt_tile_init();", fmt::format("sqrt_tile({});", idst)}; break;
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::LOG1P: op_init_and_name = {"log1p_tile_init();", fmt::format("log1p_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;
+        case UnaryOpType::RELU:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {"relu_tile_init();", fmt::format("relu_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"relu_tile_init();", fmt::format("relu_tile({});", idst)};
+            }
+            break;
         case UnaryOpType::SIGNBIT:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26719

### Problem description
relu doesn't have int32 support

### What's changed
- Updated `test_relu_min` and `test_relu_max` to include int32 data type support in unit tests.
- Modified the implementation of ReLU functions in Metal kernels to handle both float and int32 types.
- Added new functions for int32 ReLU operations in the kernel files.
- Updated utility functions to correctly call the new int32 versions of ReLU operations.

LLK - https://github.com/tenstorrent/tt-llk/pull/592

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/17123601524
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/17123598890
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes