### PR TITLE
Bump yolov8s device perf target

### DIFF
--- a/models/demos/yolov8s/tests/perf/test_perf_yolov8s.py
+++ b/models/demos/yolov8s/tests/perf/test_perf_yolov8s.py
@@ -12,7 +12,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 225],
+        [1, 236.95],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Problem description
The yolov8s device perf is not up to date, which is causing the device perf pipeline to fail. Bump it.
