### PR TITLE
SDXL: device perf test update

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -9,7 +9,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from models.experimental.stable_diffusion_xl_base.tests.pcc.test_module_tt_unet import run_unet_model
 
-UNET_DEVICE_TEST_TOTAL_ITERATIONS = 3
+UNET_DEVICE_TEST_TOTAL_ITERATIONS = 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What's changed
Reduced `UNET_DEVICE_TEST_TOTAL_ITERATIONS` in device perf test to 1. 

Overall execution is large enough so that device perf time fluctuations can be disregarded and SDXL takes a significant portion of the device perf pipeline; we can decrease this for now and update to larger number of iterations if there is need for that later.

### Checklist
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17035907520) CI passes