### PR TITLE
#0: [skip ci] Add specific timeouts for model perf single-card as we're seeing long timeouts on a specific job

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -29,16 +29,19 @@ jobs:
         ]
         model-group:
           - name: llm_javelin
+            timeout: 20
             model-list:
               - models/demos/falcon7b_common/tests
               - models/demos/wormhole/mamba/tests
 
           - name: cnn_javelin
+            timeout: 10
             model-list:
               - models/experimental/functional_unet/tests
               - models/demos/wormhole/stable_diffusion/tests
 
           - name: other
+            timeout: 5
             model-list:
               - models/demos/convnet_mnist/tests/
               # This is bad. These should be referencing .../tests directories
@@ -47,6 +50,7 @@ jobs:
               - models/demos/roberta/tests/test_performance.py
 
           - name: other_magic_env
+            timeout: 45
             model-list:
               - models/demos/yolov10x/tests/perf/
               - models/demos/sentence_bert/tests/perf/
@@ -105,7 +109,7 @@ jobs:
       - name: Enable Performance mode
         run: sudo cpupower frequency-set -g performance
       - name: Run performance regressions
-        timeout-minutes: 35
+        timeout-minutes: ${{ matrix.model-group.timeout }}
         uses: ./.github/actions/docker-run
         env:
           LOGURU_LEVEL: INFO


### PR DESCRIPTION
…
### Ticket

Fix requested by @pavlejosipovic 

### Problem description

From Mr. Bossman himself:

```
https://github.com/tenstorrent/tt-metal/actions/runs/17033477490
on (Single-card) Model perf tests [models-perf / other_magic_env N300 WH B0](https://github.com/tenstorrent/tt-metal/actions/runs/17033477490/job/48281048417#logs) seems to be genuinely timing out.
Should we increase the timeout?
```

### What's changed

Add job specific timeouts.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes