### PR TITLE
#27009: [skip ci] Skip test_vad2 because of an allocation issue on frequent models + ttnn

### DIFF
--- a/models/experimental/vadv2/tests/pcc/test_tt_vad.py
+++ b/models/experimental/vadv2/tests/pcc/test_tt_vad.py
@@ -17,6 +17,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.vadv2.common import load_torch_model
 
 
+@pytest.mark.skip("#27009: Failure about banks")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 10 * 1024}], indirect=True)
 def test_vadv2(
     device,


### PR DESCRIPTION
…

### Ticket

#27009

### Problem description

Allocation issue.

Why are the codeowners these people by the way? Hmm..

Did we really review 11k lines for this PR?

<img width="354" height="199" alt="Screenshot 2025-08-18 at 8 07 02 AM" src="https://github.com/user-attachments/assets/64a717aa-5e58-4fcc-8939-da8563ea1d0e" />

### What's changed

Skip and file issue.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
