### PR TITLE
#25407: Migrate clamp scalar version to llk

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1474,3 +1474,49 @@ def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
     golden_tensor = golden_function(in_data1, threshold, value)
 
     assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([64, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
+)
+@pytest.mark.parametrize(
+    "min_val, max_val",
+    [
+        (None, None),
+        (-29.4, None),
+        (None, 18.0),
+        (-10.5, 34.5),
+        (12.5, 82.5),
+        (1, -1),
+        (0, 0),
+        (0, 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+    ],
+)
+def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device):
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    min = min_val
+    max = max_val
+    if min is None and max is None:
+        with pytest.raises(RuntimeError, match="Only one of 'min' or 'max' can be None. Please provide one value"):
+            ttnn.clamp(input_tensor1, min, max)
+    else:
+        output_tensor = ttnn.clamp(input_tensor1, min, max)
+        golden_function = ttnn.get_golden_function(ttnn.clamp)
+        golden_tensor = golden_function(in_data1, min, max)
+        assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
+        assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -5,38 +5,21 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
+#include "ckernel_sfpu_unary_max_min.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_clamp(uint param0, uint param1, uint param2) {
-    // All params are in FP16 format
-    // param0 = min
-    // param1 = max
-
-    // uint format = (param0 >> 16)&0x1;
-    s2vFloat16::Format format = s2vFloat16::fp16a;
-
+// out = min(max(x, min_val), max_val)
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_clamp(uint param0, uint param1) {
     // SFPU microcode
-    vFloat min = s2vFloat16(param0, format);
-    vFloat max = s2vFloat16(param1, format);
-#pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-
-        v_if(val < min) { val = s2vFloat16(param0, format); }
-        v_elseif(val >= max) { val = s2vFloat16(param1, format); }
-        v_endif;
-
-        dst_reg[0] = val + s2vFloat16b(param2);  // 12 bits
-
-        dst_reg++;
+        load_value_param_float(param0);
+        calculate_unary_max_min_float_body<true>();
+        load_value_param_float(param1);
+        calculate_unary_max_min_float_body<false>();
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -10,30 +10,36 @@
 namespace ckernel {
 namespace sfpu {
 
+sfpi_inline void load_value_param_float(uint value) {
+    TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
+}
+template <bool IS_MAX_OP>
+sfpi_inline void calculate_unary_max_min_float_body() {
+    // Load input to lreg0
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+
+    // Copy value param to lreg1
+    TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
+    // Swap and store maximum in lreg1, minimum in lreg0
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+    if constexpr (IS_MAX_OP) {
+        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+    }
+}
+
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min(uint value) {
     // Load value param to lreg2
-    TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
-    TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
-
-#pragma GCC unroll 0
+    load_value_param_float(value);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-
-        // Load input to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-
-        // Copy value param to lreg1
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-
-        // Swap and store maximum in lreg1, minimum in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-        if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-        }
-        dst_reg++;
+        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        sfpi::dst_reg++;
     }
 }
 
@@ -67,7 +73,7 @@ inline void calculate_unary_max_min_int32(uint value) {
            TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
        }
 
-       dst_reg++;
+       sfpi::dst_reg++;
    }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -17,11 +17,11 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::clamp, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
-    uint dst_index, uint param0, uint param1, uint param2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp<APPROXIMATE>, dst_index, vector_mode, param0, param1, param2);
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -5,39 +5,21 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_unary_max_min.h"
 
-using namespace sfpi;
+namespace ckernel::sfpu {
 
-namespace ckernel {
-namespace sfpu {
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_clamp(uint param0, uint param1, uint param2) {
-    // All params are in FP16 format
-    // param0 = min
-    // param1 = max
-
-    // uint format = (param0 >> 16)&0x1;
-    s2vFloat16::Format format = s2vFloat16::fp16a;
-
+// out = min(max(x, min_val), max_val)
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_clamp(uint param0, uint param1) {
     // SFPU microcode
-    vFloat min = s2vFloat16(param0, format);
-    vFloat max = s2vFloat16(param1, format);
-#pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-
-        v_if(val < min) { val = s2vFloat16(param0, format); }
-        v_elseif(val >= max) { val = s2vFloat16(param1, format); }
-        v_endif;
-
-        dst_reg[0] = val + s2vFloat16b(param2);  // 12 bits
-
-        dst_reg++;
+        load_value_param_float(param0);
+        calculate_unary_max_min_float_body<true>();
+        load_value_param_float(param1);
+        calculate_unary_max_min_float_body<false>();
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -10,31 +10,37 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min(uint value) {
-
-    // Load value param to lreg2
+sfpi_inline void load_value_param_float(uint value) {
     TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
+}
+template <bool IS_MAX_OP>
+sfpi_inline void calculate_unary_max_min_float_body() {
+    // Load input to lreg0
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
 
-#pragma GCC unroll 0
+    // Copy value param to lreg1
+    TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
+    // Swap and store maximum in lreg1, minimum in lreg0
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+    if constexpr (IS_MAX_OP) {
+        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+    }
+}
+
+template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max_min(uint value) {
+    // Load value param to lreg2
+    load_value_param_float(value);
+
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-
-        // Load input to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-
-        // Copy value param to lreg1
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-
-        // Swap and store maximum in lreg1, minimum in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-        if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-        }
-        dst_reg++;
+        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        sfpi::dst_reg++;
     }
 }
 
@@ -67,7 +73,7 @@ inline void calculate_unary_max_min_int32(uint value) {
         } else {
             TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
         }
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -17,11 +17,11 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::clamp, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
-    uint dst_index, uint param0, uint param1, uint param2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp<APPROXIMATE>, dst_index, vector_mode, param0, param1, param2);
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/clamp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/clamp.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_clamp.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs element-wise clamp operation for float. The DST
+ * register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
+ * compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The min value for the clamp function                                       | uint32_t |                                                       | True     |
+ * | param1          | The max value for the clamp function                                       | uint32_t |                                                       | True     |
+*/
+// clang-format on
+ALWI void clamp_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_clamp<APPROX>(idst, param0, param1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void clamp_tile_init() { MATH((llk_math_eltwise_unary_sfpu_clamp_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -148,6 +148,10 @@
 #include "compute_kernel_api/eltwise_unary/where.h"
 #endif
 
+#if SFPU_OP_CLAMP_INCLUDE
+#include "compute_kernel_api/eltwise_unary/clamp.h"
+#endif
+
 #if SFPU_OP_HARDTANH_INCLUDE
 #include "compute_kernel_api/eltwise_unary/hardtanh.h"
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -112,6 +112,7 @@ enum class UnaryOpType {
     WHERE_TSS,
     SOFTSIGN,
     CELU,
+    CLAMP_TSS,
 };
 
 enum class VecMode {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "unary_op_utils.hpp"
 
+#include <optional>
 #include <tt-metalium/assert.hpp>
 #include "ttnn/tensor/types.hpp"
 
@@ -80,6 +81,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::GEZ:
         case UnaryOpType::NEZ: return "SFPU_OP_UNARY_COMP_INCLUDE";
         case UnaryOpType::WHERE_TSS: return "SFPU_OP_WHERE_INCLUDE";
+        case UnaryOpType::CLAMP_TSS: return "SFPU_OP_CLAMP_INCLUDE";
         case UnaryOpType::SOFTSHRINK:
         case UnaryOpType::SOFTSIGN:
         case UnaryOpType::HARDSIGMOID:
@@ -425,6 +427,14 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 where_call = fmt::format("where_tile({0}, {1}, {2}, {0});", idst, 1, 2);
             }
             op_init_and_name = std::make_pair("where_tile_init();", where_call);
+            break;
+        }
+        case UnaryOpType::CLAMP_TSS: {
+            float param1 = params[1];
+            op_init_and_name = {
+                "clamp_tile_init();",
+                fmt::format(
+                    "clamp_tile({}, {}, {});", idst, std::bit_cast<uint32_t>(param0), std::bit_cast<uint32_t>(param1))};
             break;
         }
         case UnaryOpType::HARDTANH: {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -85,7 +85,8 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::WHERE_TSS:
         case UnaryOpType::CELU:
         case UnaryOpType::HARDTANH:
-        case UnaryOpType::THRESHOLD: return true;
+        case UnaryOpType::THRESHOLD:
+        case UnaryOpType::CLAMP_TSS: return true;
         default: return false;
     }
     return false;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -426,11 +426,19 @@ Tensor Hardtanh::invoke(
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::HARDTANH;
     return detail::unary_impl(
-        queue_id,
-        input_tensor,
-        {UnaryWithParam{op_type, std::vector<float>{static_cast<float>(min_val), static_cast<float>(max_val)}}},
-        memory_config,
-        optional_output_tensor);
+        queue_id, input_tensor, {UnaryWithParam{op_type, {min_val, max_val}}}, memory_config, optional_output_tensor);
+}
+
+Tensor Clamp::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float min_val,
+    const float max_val,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::CLAMP_TSS;
+    return detail::unary_impl(
+        queue_id, input_tensor, {UnaryWithParam{op_type, {min_val, max_val}}}, memory_config, optional_output_tensor);
 }
 
 Tensor Softshrink::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -328,6 +328,16 @@ struct Tanh {
         bool accuracy = false);
 };
 
+struct Clamp {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        float min_val,
+        float max_val,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 }  // namespace unary
 }  // namespace operations
 
@@ -476,6 +486,7 @@ constexpr auto hardtanh = ttnn::register_operation<"ttnn::hardtanh", ttnn::opera
 constexpr auto softshrink = ttnn::register_operation<"ttnn::softshrink", ttnn::operations::unary::Softshrink>();
 constexpr auto deg2rad = ttnn::register_operation<"ttnn::deg2rad", ttnn::operations::unary::Deg2Rad>();
 constexpr auto rad2deg = ttnn::register_operation<"ttnn::rad2deg", ttnn::operations::unary::Rad2Deg>();
+constexpr auto clamp_tss = ttnn::register_operation<"ttnn::clamp_tss", ttnn::operations::unary::Clamp>();
 constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();
 constexpr auto tanh = ttnn::register_operation<"ttnn::tanh", ttnn::operations::unary::Tanh>();
 constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();


### PR DESCRIPTION
### Ticket
Link to Github Issue #25407 

### What's changed
Update TSS version of clamp op to use llk instead of composite.

### Perf Results:

In Main:
1 tile                   - 3680ns
[1,1,8192,8192] - 2764901ns

Updated version:
1 tile                   - 2072ns (~44% faster)
[1,1,8192,8192] - 1381892ns (~50% faster)

### Checklist
- [x] All post commit
- [x] Blackhole Post commit