### PR TITLE
Update AG & RS Barrier to be a Global Sync

### DIFF
--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -447,7 +447,7 @@ def test_multimodal_demo_text(
 
         target_decode_tok_s_u = {
             "N300_Llama-3.2-11B": 21.5,
-            "T3K_Llama-3.2-11B": 34.5,
+            "T3K_Llama-3.2-11B": 34.25,
             "T3K_Llama-3.2-90B": 6,
         }[f"{tt_device_name}_{base_model_name}"]
 

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -447,7 +447,7 @@ def test_multimodal_demo_text(
 
         target_decode_tok_s_u = {
             "N300_Llama-3.2-11B": 21.5,
-            "T3K_Llama-3.2-11B": 35,
+            "T3K_Llama-3.2-11B": 34.5,
             "T3K_Llama-3.2-90B": 6,
         }[f"{tt_device_name}_{base_model_name}"]
 

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -573,6 +573,7 @@ class Attention(LightweightModule):
                     dim=3,
                     multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
                     num_links=1,
+                    topology=self.ccl_topology,
                     memory_config=self.model_config["ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"],
                     barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
                     chunks_per_sync=10,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1259,24 +1259,7 @@ def create_submeshes(mesh_device, data_parallel):
     num_devices = num_rows * num_cols
     assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
 
-    if (
-        num_rows == 8
-        and num_cols == 4
-        and num_rows % data_parallel == 0
-        and ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.TG
-    ):
-        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
-        for submesh in submeshes:
-            submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))
-        return submeshes
-
-    # Submeshes with 8 devices on 8x4 mesh are expected to be in ring topology on 6U galaxy
-    if (
-        num_rows == 8
-        and num_cols == 4
-        and num_cols % data_parallel == 0
-        and ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
-    ):
+    if num_rows == 8 and num_cols == 4 and num_cols % data_parallel == 0:
         submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows, num_cols // data_parallel))
         for submesh in submeshes:
             submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -177,12 +177,21 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
 
     // Get OP Config, topology config
     uint32_t page_size = input_tensor.buffer()->page_size();
-    auto [unicast_forward_args, unicast_backward_args] =
-        ccl::get_forward_backward_line_unicast_configuration(topology, sender_device, forward_device, backward_device);
     auto [num_targets_forward, num_targets_backward] =
         ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, false);
-    auto [mcast_forward_args, mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
-        topology, sender_device, forward_device, backward_device, num_targets_forward, num_targets_backward);
+    auto [unicast_forward_args, unicast_backward_args] =
+        ccl::get_forward_backward_line_unicast_configuration(topology, sender_device, forward_device, backward_device);
+    auto [barrier_mcast_forward_args, barrier_mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
+        topology,
+        sender_device,
+        forward_device,
+        backward_device,
+        topology == ccl::Topology::Linear ? num_targets_forward : ring_size - 1,
+        topology == ccl::Topology::Linear ? num_targets_backward : ring_size - 1);
+
+    auto [ring_barrier_mcast_forward_args, ring_barrier_mcast_backward_args] =
+        ccl::get_forward_backward_line_mcast_configuration(
+            topology, sender_device, forward_device, backward_device, ring_size - 1, ring_size - 1);
     TT_FATAL(
         !((topology == ccl::Topology::Linear) && fuse_op), "linear is not support when using fused for all-gather");
 
@@ -474,12 +483,16 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                     sender_writer_compile_args.insert(
                         sender_writer_compile_args.end(), unicast_backward_args.begin(), unicast_backward_args.end());
                     sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
+                        sender_writer_compile_args.end(),
+                        barrier_mcast_backward_args.begin(),
+                        barrier_mcast_backward_args.end());
                 } else {
                     sender_writer_compile_args.insert(
                         sender_writer_compile_args.end(), unicast_forward_args.begin(), unicast_forward_args.end());
                     sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
+                        sender_writer_compile_args.end(),
+                        barrier_mcast_forward_args.begin(),
+                        barrier_mcast_forward_args.end());
                 }
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -53,8 +53,11 @@ constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_va
 
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
     ccl_routing_utils::get_line_unicast_route_info_from_args<26>();
+constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<26 + ccl_routing_utils::num_line_unicast_args>();
 
-inline constexpr uint32_t sharded_args_start_idx = 26 + ccl_routing_utils::num_line_unicast_args;
+inline constexpr uint32_t sharded_args_start_idx =
+    26 + ccl_routing_utils::num_line_unicast_args + +ccl_routing_utils::num_line_multicast_args;
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -79,8 +82,8 @@ void kernel_main() {
 
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
 
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -169,21 +172,39 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_connect(*mux_connection_handle);
     }
 
-    // Due to the existing direction of fabric connections, forward writers will signal to backward writers
-    // and backward writers will signal to forward writers
-    bool signal_on_barrier_semaphore = use_barrier_sem && ((direction == 1 && num_targets_backward_direction) ||
-                                                           (direction == 0 && num_targets_forward_direction));
-    bool wait_on_barrier_semaphore = use_barrier_sem && ((direction == 1 && num_targets_backward_direction) ||
-                                                         (direction == 0 && num_targets_forward_direction));
-    if (signal_on_barrier_semaphore) {
-        uint64_t sync_sem_noc_addr_in_pkt = safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, tt::tt_fabric::edm_fabric_write_noc_index);
-        pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(
-            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sync_sem_noc_addr_in_pkt, static_cast<uint16_t>(1), 32});
-        ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
-        tt::tt_fabric::fabric_atomic_inc(*mux_connection_handle, pkt_hdr_sem_inc);
-    }
-    if (wait_on_barrier_semaphore) {
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 1);
+    if (use_barrier_sem) {
+        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_sem_inc, multicast_route_info);
+        if (topology == Topology::Linear) {
+            // multicast to both the forward and backward worker on all devices that you write to
+            bool signal_on_barrier_semaphore =
+                (direction == 1 && num_targets_backward_direction) || (direction == 0 && num_targets_forward_direction);
+            if (signal_on_barrier_semaphore) {
+                // device going in the same direction
+                uint64_t same_direction_barrier_sem_noc_addr_in_pkt =
+                    safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, barrier_sem, 0);
+                pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                    same_direction_barrier_sem_noc_addr_in_pkt, static_cast<uint16_t>(1), 32});
+                tt::tt_fabric::fabric_atomic_inc(*mux_connection_handle, pkt_hdr_sem_inc);
+
+                // device going in the opposite direction
+                uint64_t opposite_direction_barrier_sem_noc_addr_in_pkt =
+                    safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, barrier_sem, 0);
+                pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                    opposite_direction_barrier_sem_noc_addr_in_pkt, static_cast<uint16_t>(1), 32});
+                tt::tt_fabric::fabric_atomic_inc(*mux_connection_handle, pkt_hdr_sem_inc);
+            }
+        } else if (topology == Topology::Ring) {
+            // multicast to entire ring of workers going in the same direction
+            uint64_t barrier_sem_noc_addr_in_pkt =
+                safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, barrier_sem, 0);
+            pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                barrier_sem_noc_addr_in_pkt, static_cast<uint16_t>(1), 32});
+            tt::tt_fabric::fabric_atomic_inc(*mux_connection_handle, pkt_hdr_sem_inc);
+        } else {
+            ASSERT(false);
+        }
+
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -53,7 +53,7 @@ constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_va
 
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
     ccl_routing_utils::get_line_unicast_route_info_from_args<26>();
-constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
+constexpr ccl_routing_utils::line_multicast_route_info_t barrier_multicast_route_info =
     ccl_routing_utils::get_line_multicast_route_info_from_args<26 + ccl_routing_utils::num_line_unicast_args>();
 
 inline constexpr uint32_t sharded_args_start_idx =
@@ -173,7 +173,7 @@ void kernel_main() {
     }
 
     if (use_barrier_sem) {
-        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_sem_inc, multicast_route_info);
+        ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_sem_inc, barrier_multicast_route_info);
         if (topology == Topology::Linear) {
             // multicast to both the forward and backward worker on all devices that you write to
             bool signal_on_barrier_semaphore =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -573,9 +573,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                     barrier_semaphore.has_value() && !using_persistent_buffers,  // use synchronize barrier semaphore
                     barrier_semaphore.has_value()                                // synchronize barrier semaphore
                         ? barrier_semaphore.value().address()
-                        : 0,
-                    opposite_core_coord.x,
-                    opposite_core_coord.y};
+                        : 0};
                 append_fabric_mux_connection_rt_args(
                     true, core, program, termination_master_virtual_core, num_workers_per_direction, writer_rt_args);
                 if (intermediate_is_sharded) {
@@ -891,7 +889,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
 
     // Kernel Runtime Args
     uint32_t fwd_bwd_semaphore_address = tt::tt_metal::CreateSemaphore(program, sender_worker_core_range_set, 0);
-    bool use_barrier_sem = barrier_semaphore.has_value();
+    bool use_barrier_sem = barrier_semaphore.has_value() && !using_persistent_buffers;
     const uint32_t l1_unreserved_base_address =
         sender_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
@@ -1109,8 +1107,6 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                     {core},
                     tt::tt_metal::WriterDataMovementConfig(sender_writer_compile_args, writer_compute_defines));
                 writer_kernel_ids.push_back(worker_sender_writer_kernel_id);
-                bool signal_on_barrier_sem = use_barrier_sem && !using_persistent_buffers && num_targets_in_direction;
-                bool wait_on_barrier_sem = use_barrier_sem && !using_persistent_buffers && num_targets_in_direction;
                 std::vector<uint32_t> writer_rt_args = {
                     intermediate_tensor.buffer()->address(),  // intermediate_tensor_address
                     output_tensor.buffer()->address(),        // output_tensor_address
@@ -1124,8 +1120,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                     fwd_bwd_semaphore_address,
                     opposite_core_coord.x,
                     opposite_core_coord.y,
-                    signal_on_barrier_sem,         // signal_on_barrier_sem
-                    wait_on_barrier_sem,           // wait_on_barrier_sem
+                    use_barrier_sem,               // use_barrier_sem
                     barrier_semaphore.has_value()  // synchronize barrier semaphore
                         ? barrier_semaphore.value().address()
                         : 0};
@@ -1218,7 +1213,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                         worker_writer_sender_runtime_args[6] = semaphore.at(2).address();
 
                         if (barrier_semaphore.has_value()) {
-                            worker_writer_sender_runtime_args[14] = barrier_semaphore.value().address();
+                            worker_writer_sender_runtime_args[13] = barrier_semaphore.value().address();
                         }
 
                         core_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -889,7 +889,6 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
 
     // Kernel Runtime Args
     uint32_t fwd_bwd_semaphore_address = tt::tt_metal::CreateSemaphore(program, sender_worker_core_range_set, 0);
-    bool use_barrier_sem = barrier_semaphore.has_value() && !using_persistent_buffers;
     const uint32_t l1_unreserved_base_address =
         sender_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
@@ -1120,8 +1119,8 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                     fwd_bwd_semaphore_address,
                     opposite_core_coord.x,
                     opposite_core_coord.y,
-                    use_barrier_sem,               // use_barrier_sem
-                    barrier_semaphore.has_value()  // synchronize barrier semaphore
+                    barrier_semaphore.has_value() && !using_persistent_buffers,  // use_barrier_sem
+                    barrier_semaphore.has_value()                                // synchronize barrier semaphore
                         ? barrier_semaphore.value().address()
                         : 0};
                 append_fabric_mux_connection_rt_args(


### PR DESCRIPTION
### Problem description
To internalize semaphore creation for AG & RS, we have to update the barrier synchronization at the beginning of the op (that prevents clobbering) to be a global barrier that syncs with all devices (not just it's neighbours)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17052237240
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17052248541
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17052251017
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/17088444013
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/17052268322
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)  https://github.com/tenstorrent/tt-metal/actions/runs/17082485232
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/17052273609
- [ ] New/Existing tests provide coverage for changes
- [ ] T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17054209087
- [ ] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17054225492