### PR TITLE
Removing more variables from tt_metal files

### DIFF
--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -51,13 +51,13 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
     CircularBufferConfig cb_src0_config =
         CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src0_cb_index, single_tile_size);
-    auto cb_src0 = CreateCircularBuffer(*program, cores_for_program, cb_src0_config);
+    CreateCircularBuffer(*program, cores_for_program, cb_src0_config);
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
     CircularBufferConfig cb_src1_config =
         CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src1_cb_index, single_tile_size);
-    auto cb_src1 = CreateCircularBuffer(*program, cores_for_program, cb_src1_config);
+    CreateCircularBuffer(*program, cores_for_program, cb_src1_config);
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = 2;
@@ -65,7 +65,7 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
         CircularBufferConfig(
             num_output_tiles * single_tile_size, {{output_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(output_cb_index, single_tile_size);
-    auto cb_output = CreateCircularBuffer(*program, cores_for_program, cb_output_config);
+    CreateCircularBuffer(*program, cores_for_program, cb_output_config);
 
     auto binary_reader_kernel = CreateKernel(
         *program,
@@ -83,8 +83,6 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
 
     std::vector<uint32_t> compute_kernel_args = {};
 
-    bool fp32_dest_acc_en = false;
-    bool math_approx_mode = false;
     std::map<std::string, std::string> binary_defines = {
         {"ELTWISE_OP", op_id_to_op_define[eltwise_op_index]},
         {"ELTWISE_OP_TYPE", op_id_to_op_type_define[eltwise_op_index]}};

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -330,7 +330,7 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
     uint32_t seed = tt::parse_env("TT_METAL_SEED", 0);
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
 
-    for (auto buffer_type : {BufferType::L1, BufferType::DRAM}) {
+    for ([[maybe_unused]] auto buffer_type : {BufferType::L1, BufferType::DRAM}) {
         DeviceLocalBufferConfig per_device_buffer_config{
             .page_size = single_tile_size, .buffer_type = BufferType::L1, .bottom_up = false};
 

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -33,8 +33,6 @@ using ::testing::SizeIs;
 using ::tt::tt_metal::distributed::MeshContainer;
 
 TEST(MeshDeviceInitTest, Init1x1Mesh) {
-    auto& sys = SystemMesh::instance();
-
     MeshDeviceConfig config(MeshShape(1, 1));
 
     EXPECT_NO_THROW({

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -63,7 +63,6 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
         // Reads on CQ 1
         for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
             readback_vecs.push_back({});
-            auto shard = buf->get_device_buffer(coord);
             ReadShard(mesh_device_->mesh_command_queue(1), readback_vecs.back(), buf, coord);
         }
 
@@ -238,7 +237,6 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
 
         for (const auto& coord : devices_0) {
             readback_vecs.push_back({});
-            auto shard = buf->get_device_buffer(coord);
             ReadShard(mesh_device_->mesh_command_queue(0), readback_vecs.back(), buf, coord);
         }
 
@@ -248,7 +246,6 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
 
         for (const auto& coord : devices_1) {
             readback_vecs.push_back({});
-            auto shard = buf->get_device_buffer(coord);
             ReadShard(mesh_device_->mesh_command_queue(0), readback_vecs.back(), buf, coord);
         }
         for (auto& vec : readback_vecs) {

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -126,7 +126,7 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
     CircularBufferConfig cb_src0_config =
         CircularBufferConfig(single_tile_size * num_tiles, {{src0_cb_index, DataFormat::UInt32}})
             .set_page_size(src0_cb_index, single_tile_size);
-    CBHandle cb_src0 = CreateCircularBuffer(datacopy_program, datacopy_core, cb_src0_config);
+    CreateCircularBuffer(datacopy_program, datacopy_core, cb_src0_config);
 
     auto syncer_mesh_workload = CreateMeshWorkload();
     auto datacopy_mesh_workload = CreateMeshWorkload();

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -402,7 +402,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
     CircularBufferConfig cb_src0_config =
         CircularBufferConfig(single_tile_size * num_tiles, {{src0_cb_index, DataFormat::UInt32}})
             .set_page_size(src0_cb_index, single_tile_size);
-    CBHandle cb_src0 = CreateCircularBuffer(datacopy_program, datacopy_core, cb_src0_config);
+    CreateCircularBuffer(datacopy_program, datacopy_core, cb_src0_config);
     // Program copies data from DRAM, does addition in RISC once notified
     Program add_program = CreateProgram();
     auto add_kernel = CreateKernel(
@@ -421,7 +421,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
         add_core_phys.y,
         1};
     SetRuntimeArgs(add_program, add_kernel, datacopy_core, add_rt_args);
-    CBHandle add_cb = CreateCircularBuffer(add_program, datacopy_core, cb_src0_config);
+    CreateCircularBuffer(add_program, datacopy_core, cb_src0_config);
     // Same program as above, but runs on different SubDevice. Reads from DRAM, once
     // notified by previous program
     Program add_program_2 = CreateProgram();
@@ -433,7 +433,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
     std::array<uint32_t, 9> add_rt_args_2 = {
         global_sem.address(), 0, 0, output_buf->address(), output_buf->address(), num_tiles, 0, 0, 2};
     SetRuntimeArgs(add_program_2, add_kernel_2, add_core, add_rt_args_2);
-    CBHandle add_cb_2 = CreateCircularBuffer(add_program_2, add_core, cb_src0_config);
+    CreateCircularBuffer(add_program_2, add_core, cb_src0_config);
 
     uint32_t num_cols_in_workload = mesh_device_->num_cols() / 2;
     MeshCoordinateRange devices(mesh_device_->shape());

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -84,19 +84,19 @@ std::vector<CBHandle> initialize_dummy_circular_buffers(
 }
 
 void initialize_dummy_kernels(Program& program, const CoreRangeSet& cr_set) {
-    auto dummy_reader_kernel = CreateKernel(
+    CreateKernel(
         program,
         "tt_metal/kernels/dataflow/blank.cpp",
         cr_set,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    auto dummy_writer_kernel = CreateKernel(
+    CreateKernel(
         program,
         "tt_metal/kernels/dataflow/blank.cpp",
         cr_set,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    auto dummy_compute_kernel = CreateKernel(program, "tt_metal/kernels/compute/blank.cpp", cr_set, ComputeConfig{});
+    CreateKernel(program, "tt_metal/kernels/compute/blank.cpp", cr_set, ComputeConfig{});
 }
 
 std::shared_ptr<Program> initialize_dummy_program(CoreCoord worker_grid_size) {
@@ -220,7 +220,6 @@ TEST_F(MeshWorkloadTestSuite, OverlappingProgramRanges) {
 
     auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
         /*num_programs=*/2, mesh_device_->compute_with_storage_grid_size(), /*seed=*/0);
-    uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
     auto mesh_workload = CreateMeshWorkload();
 
     MeshCoordinate zero_coord = MeshCoordinate::zero_coordinate(mesh_device_->shape().dims());
@@ -568,7 +567,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
                  constants::TILE_WIDTH,
                  scaling_sem_idx,
                  scaling_height_toggle});
-            CBHandle cb_src0 = CreateCircularBuffer(program, curr_core, cb_src0_config);
+            CreateCircularBuffer(program, curr_core, cb_src0_config);
         }
     }
     auto program_1 = initialize_dummy_program(worker_grid_size);

--- a/tests/tt_metal/distributed/test_thread_pool.cpp
+++ b/tests/tt_metal/distributed/test_thread_pool.cpp
@@ -42,7 +42,6 @@ TEST(ThreadPoolTest, StressDeviceBound) {
 
 // Test that an exception generated in the thread pool is propagated to the main thread
 TEST(ThreadPoolTest, Exception) {
-    uint32_t num_threads = MetalContext::instance().get_cluster().number_of_user_devices();
     auto thread_pool = create_device_bound_thread_pool(MetalContext::instance().get_cluster().number_of_user_devices());
     auto exception_fn = []() { TT_THROW("Failed"); };
     thread_pool->enqueue(exception_fn);

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -84,14 +84,14 @@ std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
             tt_metal::CircularBufferConfig(
                 num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(src0_cb_index, single_tile_size);
-        auto cb_src0 = tt_metal::CreateCircularBuffer(program, full_grid, cb_src0_config);
+        tt_metal::CreateCircularBuffer(program, full_grid, cb_src0_config);
 
         uint32_t src1_cb_index = tt::CBIndex::c_1;
         tt_metal::CircularBufferConfig cb_src1_config =
             tt_metal::CircularBufferConfig(
                 num_input_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(src1_cb_index, single_tile_size);
-        auto cb_src1 = tt_metal::CreateCircularBuffer(program, full_grid, cb_src1_config);
+        tt_metal::CreateCircularBuffer(program, full_grid, cb_src1_config);
 
         uint32_t ouput_cb_index = tt::CBIndex::c_16;
         uint32_t num_output_tiles = 2;
@@ -99,7 +99,7 @@ std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
             tt_metal::CircularBufferConfig(
                 num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(ouput_cb_index, single_tile_size);
-        auto cb_output = tt_metal::CreateCircularBuffer(program, full_grid, cb_output_config);
+        tt_metal::CreateCircularBuffer(program, full_grid, cb_output_config);
 
         auto binary_reader_kernel = tt_metal::CreateKernel(
             program,
@@ -117,8 +117,6 @@ std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
 
         std::vector<uint32_t> compute_kernel_args = {};
 
-        bool fp32_dest_acc_en = false;
-        bool math_approx_mode = false;
         std::map<std::string, std::string> binary_defines = {
             {"ELTWISE_OP", op_id_to_op_define[eltwise_op]}, {"ELTWISE_OP_TYPE", op_id_to_op_type_define[eltwise_op]}};
         auto eltwise_binary_kernel = tt_metal::CreateKernel(
@@ -200,13 +198,12 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
         for (uint32_t j = 0; j < NUM_CBS; j++) {
             CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}})
                                                  .set_page_size(j, page_size * (j + 1));
-            auto cb = CreateCircularBuffer(program, cr_set, cb_config);
+            CreateCircularBuffer(program, cr_set, cb_config);
         }
 
         // Create Semaphores
         for (uint32_t j = 0; j < NUM_SEMS; j++) {
             CreateSemaphore(program, cr_set, j + 1);
-            uint32_t curr_idx = 0;
             if (active_eth_cores.size()) {
                 auto active_eth_core = active_eth_cores.begin();
                 for (int k = 0; k < max_eth_cores && active_eth_core != active_eth_cores.end();

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -82,11 +82,8 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     TT_FATAL(topology == Topology::Mesh, "Intermesh Routing tests need Dynamic Routing enabled.");
-    const auto& edm_config = fabric_context.get_fabric_router_config();
 
     auto devices = fixture->get_devices();
-    auto num_devices = devices.size();
-    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
 
     // Synchronize seeds across hosts (sender and receiver must use the same seed for randomization)
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -208,7 +205,6 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     const auto topology = fabric_context.get_fabric_topology();
     TT_FATAL(topology == Topology::Mesh, "Intermesh Routing tests need Dynamic Routing enabled.");
     auto devices = fixture->get_devices();
-    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
 
     // Synchronize seeds across hosts (sender and receiver must use the same seed for randomization)
     uint32_t time_seed = 0;
@@ -227,7 +223,6 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     // Randomly select an rx core
     const auto& worker_grid_size = receiver_device->compute_with_storage_grid_size();
     auto recv_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
-    auto recv_y = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.y - 2)(global_rng);
     CoreCoord receiver_logical_core = {recv_x, recv_x};
 
     // Send the randomized rx core to the sender host, so it can send packets to the correct destination
@@ -305,7 +300,6 @@ void run_mcast_sender_step(
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     TT_FATAL(topology == Topology::Mesh, "Intermesh Routing tests need Dynamic Routing enabled.");
-    const auto& edm_config = fabric_context.get_fabric_router_config();
 
     // Synchronize seeds across hosts (sender and receiver must use the same seed for randomization)
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -422,7 +416,6 @@ void run_mcast_recv_step(
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     TT_FATAL(topology == Topology::Mesh, "Intermesh Routing tests need Dynamic Routing enabled.");
-    const auto& edm_config = fabric_context.get_fabric_router_config();
 
     // Synchronize seeds across hosts (sender and receiver must use the same seed for randomization)
     uint32_t time_seed = 0;
@@ -438,7 +431,6 @@ void run_mcast_recv_step(
     // Randomly select an mcast receiver core
     const auto& worker_grid_size = mcast_start_device->compute_with_storage_grid_size();
     auto recv_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
-    auto recv_y = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.y - 2)(global_rng);
     CoreCoord receiver_logical_core = {recv_x, recv_x};
 
     // Send the randomized receiver core to the sender host, so it can send packets to the correct destination

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -152,8 +152,7 @@ bool test_socket_send_recv(
                         2 * packet_header_size_bytes, {{reserved_packet_header_CB_index, tt::DataFormat::UInt32}})
                         .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
 
-                auto sender_packet_header_CB_handle =
-                    CreateCircularBuffer(sender_program, sender_core, sender_cb_reserved_packet_header_config);
+                CreateCircularBuffer(sender_program, sender_core, sender_cb_reserved_packet_header_config);
 
                 std::vector<uint32_t> sender_rtas;
                 tt_fabric::append_fabric_connection_rt_args(
@@ -191,7 +190,6 @@ bool test_socket_send_recv(
                 auto recv_program = CreateProgram();
 
                 auto recv_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
-                auto output_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
 
                 KernelHandle recv_kernel = CreateKernel(
                     recv_program,

--- a/tests/tt_metal/multihost/single_host_mp_tests/test_context.cpp
+++ b/tests/tt_metal/multihost/single_host_mp_tests/test_context.cpp
@@ -255,12 +255,12 @@ TEST(DistributedContextExtraTest, IsendIrecvWait) {
     if (*ctx->rank() == 0) {
         auto req = ctx->isend(
             tt::stl::as_writable_bytes(tt::stl::Span<int>{buf_send.data(), buf_send.size()}), Rank{1}, Tag{7});
-        auto status = req->wait();
+        [[maybe_unused]] auto status = req->wait();
         // EXPECT_EQ(status.count, buf_send.size());
     } else if (*ctx->rank() == 1) {
         auto req = ctx->irecv(
             tt::stl::as_writable_bytes(tt::stl::Span<int>{buf_recv.data(), buf_recv.size()}), Rank{0}, Tag{7});
-        auto status = req->wait();
+        [[maybe_unused]] auto status = req->wait();
         // EXPECT_EQ(status.count, buf_send.size());
         for (int i = 0; i < 4; ++i) {
             EXPECT_EQ(buf_recv[i], i);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -468,7 +468,6 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
     } else {
         // Need to handle N300/T3000 separately from TG/TGG since they have different templates/tunnel depths
         // If using fabric, upstream would have already initalized to the proper config for dispatch
-        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
         if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             // For Galaxy, we always init all remote devices associated with an mmio device.
             std::vector<DispatchKernelNode> nodes_for_one_mmio =

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -522,7 +522,7 @@ void DataMovementKernel::read_binaries(IDevice* device) {
     const ll_api::memory& binary_mem =
         llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
     binaries.push_back(&binary_mem);
-    uint32_t binary_size = binary_mem.get_packed_size();
+    [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
@@ -579,7 +579,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
             }
         });
     binaries.push_back(&binary_mem);
-    uint32_t binary_size = binary_mem.get_packed_size();
+    [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC={}, name={}, size={} (bytes)", erisc_id, this->name(), binary_size);
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -36,7 +36,6 @@ static const char* TT_METAL_KERNEL_PATH_ENV_VAR = "TT_METAL_KERNEL_PATH";
 // Set this var to change the cache dir.
 static const char* TT_METAL_CACHE_ENV_VAR = "TT_METAL_CACHE";
 // Used for demonstration purposes and will be removed in the future.
-static const char* TT_METAL_FD_FABRIC_DEMO = "TT_METAL_FD_FABRIC";
 static const char* TT_METAL_VISIBLE_DEVICES_ENV_VAR = "TT_METAL_VISIBLE_DEVICES";
 
 RunTimeOptions::RunTimeOptions() {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1012,7 +1012,6 @@ void Cluster::disable_ethernet_cores_with_retrain() {
 }
 
 void Cluster::initialize_ethernet_cores_router_mode() {
-    const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     for (const auto& [assoc_mmio_device, devices] : this->cluster_desc_->get_chips_grouped_by_closest_mmio()) {
         for (const auto &chip_id : devices) {
             if (this->device_eth_routing_info_.find(chip_id) == this->device_eth_routing_info_.end()) {
@@ -1039,7 +1038,7 @@ std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_device_ids(chip_id
     std::unordered_set<chip_id_t> device_ids;
     const auto &connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
     for (const auto &[other_chip_id, eth_cores] : connected_chips) {
-        for (const auto &eth_core : eth_cores) {
+        for ([[maybe_unused]] const auto& eth_core : eth_cores) {
             device_ids.insert(other_chip_id);
         }
     }

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -48,9 +48,6 @@ int main() {
     std::shared_ptr<Buffer> src_dram_buffer = CreateBuffer(dram_config);  // Input buffer
     std::shared_ptr<Buffer> dst_dram_buffer = CreateBuffer(dram_config);  // Output buffer
 
-    const bool input_tensor_is_dram = src_dram_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    const bool output_tensor_is_dram = dst_dram_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
     // Core synchronization semaphore setup
     const uint32_t sem_id = CreateSemaphore(program, sem_core_range, 0);
 

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -181,8 +181,8 @@ int main(int argc, char **argv) {
         uint32_t dram_bank_id = 0;
         auto src0_dram_buffer = MakeBufferBFP16(device, num_tiles, false);
         auto output_dram_buffer = MakeBufferBFP16(device, num_dests * num_tiles, false);
-        auto cb_src0 = MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_0, num_tiles);
-        auto cb_output = MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_16, num_tiles);
+        MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_0, num_tiles);
+        MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_16, num_tiles);
 
         ////////// DATA MOVEMENT CONFIG SETUP //////////
         DataMovementConfig DataMovementConfigIn = {.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -113,7 +113,6 @@ int main(int argc, char** argv) {
 
     const uint32_t tile_size = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
     std::map<CoreCoord, uint32_t> core_tile_idx;
-    const uint32_t core_to_print = 4;
 
     // Create 3 buffers on DRAM. These will hold the input and output data. A
     // and B are the input buffers, C is the output buffer.
@@ -133,7 +132,6 @@ int main(int argc, char** argv) {
     auto core_grid = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = core_grid.x;
     uint32_t num_cores_y = core_grid.y;
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
     // CoreRnge uses inclusive start and exclusive end coordinates so range is [0, 0] to [num_cores_x - 1, num_cores_y -
     // 1]. instead of the more intuitive [0, num_cores_x) and [0, num_cores_y).
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -226,7 +226,7 @@ int main(int argc, char** argv) {
     size_t print_per_core = std::min((size_t)10, element_per_core);
 
     int core_idx = 0;
-    for (auto& core : cores) {
+    for ([[maybe_unused]] auto& core : cores) {
         const auto core_offset = core_idx * element_per_core;
         fmt::print("Core {}:\n", core_idx);
         for (int index = 0; index < print_per_core; index++) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23444

### Problem description
unused variables cause compile warnings 

### What's changed
removing unused variables

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17043428068
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes