### PR TITLE
Add persistent buffers to LM Head and prefill output CCL ops

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -30,10 +30,10 @@ jobs:
           { name: "Galaxy Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "Galaxy Llama3 long context demo tests", arch: wormhole_b0, model: llama3_long_context, timeout: 45, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "Galaxy Llama3 evals tests", arch: wormhole_b0, model: llama3_evals, timeout: 45, owner_id: U03PUAKE719}, # Miguel Tairum
-          # { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          # { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          # { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
-          # { name: "Galaxy Stable Diffusion 3.5 Large demo tests", arch: wormhole_b0, model: sd35, timeout: 30, owner_id: U03FJB5TM5Y}, # Colman Glagovich
+          { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
+          { name: "Galaxy Stable Diffusion 3.5 Large demo tests", arch: wormhole_b0, model: sd35, timeout: 30, owner_id: U03FJB5TM5Y}, # Colman Glagovich
         ]
     runs-on:
       - arch-wormhole_b0

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -30,10 +30,10 @@ jobs:
           { name: "Galaxy Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "Galaxy Llama3 long context demo tests", arch: wormhole_b0, model: llama3_long_context, timeout: 45, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "Galaxy Llama3 evals tests", arch: wormhole_b0, model: llama3_evals, timeout: 45, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
-          { name: "Galaxy Stable Diffusion 3.5 Large demo tests", arch: wormhole_b0, model: sd35, timeout: 30, owner_id: U03FJB5TM5Y}, # Colman Glagovich
+          # { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          # { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          # { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
+          # { name: "Galaxy Stable Diffusion 3.5 Large demo tests", arch: wormhole_b0, model: sd35, timeout: 30, owner_id: U03FJB5TM5Y}, # Colman Glagovich
         ]
     runs-on:
       - arch-wormhole_b0

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -523,7 +523,7 @@ class TT_CCL:
                 "FF2": [(1, 1, seqlen, 2048)],
                 "LAYERNORM": [(1, 1, seqlen, 128)],
                 "LM_HEAD": [(1, 1, 32, 16384)],
-                "SAMPLING": [(1, 1, 32, 128 * 1024)]
+                "SAMPLING": [(1, 1, 32, 128 * 1024)],
             }
             for key, shape in buffers_dict.items():
                 tt_buffer = ttnn.as_tensor(

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -522,7 +522,8 @@ class TT_CCL:
                 "FF3": [(1, 1, seqlen, 3584)],
                 "FF2": [(1, 1, seqlen, 2048)],
                 "LAYERNORM": [(1, 1, seqlen, 128)],
-                # "SAMPLING": [(1, 1, 32, 128 * 1024)]
+                "LM_HEAD": [(1, 1, 32, 16384)],
+                "SAMPLING": [(1, 1, 32, 128 * 1024)]
             }
             for key, shape in buffers_dict.items():
                 tt_buffer = ttnn.as_tensor(
@@ -1016,7 +1017,8 @@ class TT_CCL:
         )
         if self.mode == "prefill" and buffer_key is not None:
             # reshape input back
-            ttnn_tensor_out = ttnn.reshape(ttnn_tensor_out, (1, B, seqlen // B, ttnn_tensor_out.shape[-1]))
+            if buffer_key != "LM_HEAD":
+                ttnn_tensor_out = ttnn.reshape(ttnn_tensor_out, (1, B, seqlen // B, ttnn_tensor_out.shape[-1]))
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
         return ttnn_tensor_out
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -985,7 +985,8 @@ class TT_CCL:
         )
         if self.mode == "prefill" and buffer_key is not None:
             # reshape input back
-            ttnn_tensor_out = ttnn.reshape(ttnn_tensor_out, (1, B, seqlen // B, ttnn_tensor_out.shape[-1]))
+            if buffer_key != "LM_HEAD":
+                ttnn_tensor_out = ttnn.reshape(ttnn_tensor_out, (1, B, seqlen // B, ttnn_tensor_out.shape[-1]))
 
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
         return ttnn_tensor_out

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -359,7 +359,7 @@ class TtTransformer(LightweightModule):
             num_links=3,
             cluster_axis=0,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            # buffer_key="SAMPLING",
+            buffer_key="SAMPLING",
         )
 
         tt_logits = ttnn.untilize(tt_logits, use_multicore=True)

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -219,7 +219,12 @@ class LMHead(LightweightModule):
         outputs_reduced = []
         for output in outputs:
             output_reduced = self.tt_ccl.line_all_reduce(
-                output, cluster_axis=1, num_links=num_links, memory_config=output.memory_config(), lm_head=True, buffer_key="LM_HEAD",
+                output,
+                cluster_axis=1,
+                num_links=num_links,
+                memory_config=output.memory_config(),
+                lm_head=True,
+                buffer_key="LM_HEAD",
             )  # self.output_memory_config
             outputs_reduced.append(ttnn.sharded_to_interleaved(output_reduced, memory_config=ttnn.DRAM_MEMORY_CONFIG))
         return outputs_reduced

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -219,8 +219,7 @@ class LMHead(LightweightModule):
         outputs_reduced = []
         for output in outputs:
             output_reduced = self.tt_ccl.line_all_reduce(
-                output, cluster_axis=1, num_links=num_links, memory_config=output.memory_config(), lm_head=True
+                output, cluster_axis=1, num_links=num_links, memory_config=output.memory_config(), lm_head=True, buffer_key="LM_HEAD",
             )  # self.output_memory_config
             outputs_reduced.append(ttnn.sharded_to_interleaved(output_reduced, memory_config=ttnn.DRAM_MEMORY_CONFIG))
-
         return outputs_reduced


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/26423

This PR adds persistent buffers to the prefill lm-head and to prefill output AG in Llama-3.3-70B on galaxy. This fixes the occasional bad outputs we were seeing before.

- [x] TG demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/17046891649
- [x] Galaxy demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/17045361443
- [x] TG APC: https://github.com/tenstorrent/tt-metal/actions/runs/17046835498