### PR TITLE
SDXL: VAE gn update

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -79,7 +79,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_perf_device():
-    expected_device_perf_cycles_per_iteration = 1_639_807_311
+    expected_device_perf_cycles_per_iteration = 1_614_292_067
     command = (
         f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -79,7 +79,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_perf_device():
-    expected_device_perf_cycles_per_iteration = 2_131_006_456
+    expected_device_perf_cycles_per_iteration = 1_639_807_311
     command = (
         f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -1038,6 +1038,12 @@ class ModelOptimisations:
                 return self.conv_configs["ABH_64_NO_ADB_DRAM"]  # should be 128, OOM in demo
             elif "decoder.conv_out" == conv_path:
                 return self.conv_configs["ABH_512_NO_ADB_DRAM"]
+            elif (
+                "decoder.mid_block.resnet" in conv_path
+                or "decoder.up_blocks.0.resnet" in conv_path
+                and not "upsampler" in conv_path
+            ):
+                return self.conv_configs["ABH_128_NO_ADB_BS"]
             else:
                 return self.conv_configs["DEFAULT_DRAM"]
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -103,19 +103,44 @@ class TtResnetBlock2D(nn.Module):
     def forward(self, input_tensor, input_shape):
         B, C, H, W = input_shape
 
-        hidden_states = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
-        hidden_states = ttnn.group_norm(
-            hidden_states,
-            num_groups=self.norm_groups,
-            input_mask=self.input_mask_1,
-            weight=self.gamma_t_1,
-            bias=self.beta_t_1,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            core_grid=self.norm_core_grid_1,
-            epsilon=self.norm_eps,
-            inplace=False,
-            num_out_blocks=self.norm_blocks_1,
-        )
+        if self.norm_blocks_1 == -1:
+            shard_shape = B * H * W // self.norm_core_grid_1.x, C // self.norm_core_grid_1.y
+            sharded_mem_config = ttnn.create_sharded_memory_config(
+                shard_shape,
+                core_grid=self.norm_core_grid_1,
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            hidden_states = ttnn.to_memory_config(input_tensor, sharded_mem_config)
+
+            hidden_states = ttnn.group_norm(
+                hidden_states,
+                num_groups=self.norm_groups,
+                input_mask=self.input_mask_1,
+                weight=self.gamma_t_1,
+                bias=self.beta_t_1,
+                memory_config=sharded_mem_config,
+                core_grid=self.norm_core_grid_1,
+                epsilon=self.norm_eps,
+                negative_mask=None,
+                inplace=False,  # We are working with tiled sharded GN
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            hidden_states = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+            hidden_states = ttnn.group_norm(
+                hidden_states,
+                num_groups=self.norm_groups,
+                input_mask=self.input_mask_1,
+                weight=self.gamma_t_1,
+                bias=self.beta_t_1,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                core_grid=self.norm_core_grid_1,
+                epsilon=self.norm_eps,
+                inplace=False,
+                num_out_blocks=self.norm_blocks_1,
+            )
 
         hidden_states = ttnn.silu(hidden_states)
 
@@ -144,19 +169,44 @@ class TtResnetBlock2D(nn.Module):
         )
         C = self.conv1_params["output_channels"]
 
-        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
-        hidden_states = ttnn.group_norm(
-            hidden_states,
-            num_groups=self.norm_groups,
-            input_mask=self.input_mask_2,
-            weight=self.gamma_t_2,
-            bias=self.beta_t_2,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            core_grid=self.norm_core_grid_2,
-            epsilon=self.norm_eps,
-            inplace=False,
-            num_out_blocks=self.norm_blocks_2,
-        )
+        if self.norm_blocks_2 == -1:
+            shard_shape = B * H * W // self.norm_core_grid_2.x, C // self.norm_core_grid_2.y
+            sharded_mem_config = ttnn.create_sharded_memory_config(
+                shard_shape,
+                core_grid=self.norm_core_grid_2,
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config)
+
+            hidden_states = ttnn.group_norm(
+                hidden_states,
+                num_groups=self.norm_groups,
+                input_mask=self.input_mask_2,
+                weight=self.gamma_t_2,
+                bias=self.beta_t_2,
+                memory_config=sharded_mem_config,
+                core_grid=self.norm_core_grid_2,
+                epsilon=self.norm_eps,
+                negative_mask=None,
+                inplace=False,  # We are working with tiled sharded GN
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+            hidden_states = ttnn.group_norm(
+                hidden_states,
+                num_groups=self.norm_groups,
+                input_mask=self.input_mask_2,
+                weight=self.gamma_t_2,
+                bias=self.beta_t_2,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                core_grid=self.norm_core_grid_2,
+                epsilon=self.norm_eps,
+                inplace=False,
+                num_out_blocks=self.norm_blocks_2,
+            )
 
         hidden_states = ttnn.silu(hidden_states)  # note: silu hangs if not tile
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -126,7 +126,9 @@ class TtResnetBlock2D(nn.Module):
                 negative_mask=None,
                 inplace=False,  # We are working with tiled sharded GN
             )
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+
+            if self.conv1_slice_config is not None:
+                hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         else:
             hidden_states = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
             hidden_states = ttnn.group_norm(
@@ -192,7 +194,8 @@ class TtResnetBlock2D(nn.Module):
                 negative_mask=None,
                 inplace=False,  # We are working with tiled sharded GN
             )
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+            if self.conv2_slice_config is not None:
+                hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         else:
             hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
             hidden_states = ttnn.group_norm(

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -8,12 +8,11 @@ import ttnn
 def get_DRAM_GN_config(module_path, idx):
     core_x = 8
     if module_path is None:
-        core_x = 4
         core_y = 4
-        num_out_blocks = 96
+        num_out_blocks = 64
     elif "mid_block" in module_path or "up_blocks.0" in module_path:
-        core_y = 4
-        num_out_blocks = 4
+        core_y = 8
+        num_out_blocks = -1  # BS VAE group norm
     else:
         parts = module_path.split(".")
         block_id = int(parts[parts.index("up_blocks") + 1])
@@ -30,9 +29,8 @@ def get_DRAM_GN_config(module_path, idx):
                 core_y = 8
                 num_out_blocks = 48
             else:
-                core_x = 4
                 core_y = 4
-                num_out_blocks = 96
+                num_out_blocks = 64
 
     return core_x, core_y, num_out_blocks
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -42,7 +42,6 @@ from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
         # Current in SDXL VAE 1024x1024
         (1, 256, 1024, 1024, 32, 48, 8, 8),  # 62ms
         (1, 256, 512, 512, 32, 12, 8, 8),  # 15.7ms
-        (1, 512, 128, 128, 32, 4, 8, 8),  # 1.57 ms
         (1, 512, 256, 256, 32, 4, 8, 8),  # 6.1ms
         (1, 512, 512, 512, 32, 12, 8, 8),  # 24ms
         (1, 128, 1024, 1024, 32, 64, 4, 8),  # 100ms (6 of these in total)


### PR DESCRIPTION
### What's changed
VAE changes:

- Increased number of cores used and decreased `num_out_blocks` for DRAM version where possible
- Moved case [1, 512, 128, 128] to block sharded version
- Keeping the tensor sharded for as long as possible

Updated group norm unit tests
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17045050257) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17044998202) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17045008823) CI passes