### PR TITLE
remove legacy llama3-70b demo from CI

### DIFF
--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -32,8 +32,6 @@ run_t3000_llama3_70b_tests() {
 
   LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 1800 -k "not performance-ci-stress-1"; fail+=$?
 
-  # Output verification demo for old llama3-70b codebase, to be removed once old codebase is deleted
-  env pytest models/demos/t3000/llama3_70b/demo/demo.py::test_LlamaModel_demo[wormhole_b0-True-device_params0-short_context-check_enabled-greedy-tt-70b-T3000-80L-decode_only-trace_mode_off-text_completion-llama3] --timeout=900 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Ticket
In an effort of deleting legacy llama 70b codebase [See this Issue
](https://github.com/tenstorrent/tt-metal/issues/27005)

This PR first removes old demo which is failing on [T3K CI](https://github.com/tenstorrent/tt-metal/actions/runs/16986976622/job/48289024153)

Next Steps:
Move reference llama codebase to TT-Transformers

<img width="787" height="475" alt="Screenshot 2025-08-18 at 2 16 48 PM" src="https://github.com/user-attachments/assets/6d53d50a-ad92-401c-b51a-5e957b85bf07" />