### PR TITLE
Update InterleavedAddrGen CI check

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -109,6 +109,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for git diff comparison
       - name: Check for new InterleavedAddrGen usages in changed files
         run: |
+          set -euo pipefail
           # Get the base branch for comparison
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
@@ -116,34 +117,59 @@ jobs:
             BASE_REF="HEAD^"
           fi
 
-          # Find all changed C++ files in the current PR/commit
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD | grep -E '\.(cpp|hpp|h|cc|cxx)$' || true)
+          declare -A OLD_FOR_NEW
+          CHANGED=()
 
-          # Check if any changed C++ files contain new InterleavedAddrGen usages
-          NEW_USAGE_FOUND=0
-          if [ -n "$CHANGED_FILES" ]; then
-            for file in $CHANGED_FILES; do
-              if [ -f "$file" ]; then
-                # Check for InterleavedAddrGen, InterleavedAddrGenFast, InterleavedPow2AddrGen, or get_interleaved_addr_gen
-                if git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen" > /dev/null; then
-                  echo "❌ Found new InterleavedAddrGen usage in: $file"
-                  echo "Added lines:"
-                  git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen"
-                  NEW_USAGE_FOUND=1
+          # Collect changed C/C++ files and map renames (old -> new)
+          while IFS=$'\t' read -r status path1 path2; do
+            case "$status" in
+              A|M)
+                if [[ "$path1" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
+                  CHANGED+=("$path1")
                 fi
-              fi
-            done
-          else
-            echo "No C++ files changed in this PR."
+                ;;
+              R*)
+                if [[ "$path2" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
+                  CHANGED+=("$path2")
+                  OLD_FOR_NEW["$path2"]="$path1"
+                fi
+                ;;
+            esac
+          done < <(git diff --name-status -M "$BASE_REF" HEAD)
+
+          if (( ${#CHANGED[@]} == 0 )); then
+            echo "No C/C++ files changed in this PR."
+            exit 0
           fi
 
-          if [ $NEW_USAGE_FOUND -eq 1 ]; then
+          NEW_USAGE_FOUND=0
+          regex='(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)'
+
+          for file in "${CHANGED[@]}"; do
+            old_path="${OLD_FOR_NEW[$file]:-$file}"
+
+            base_count=$(git show "$BASE_REF:$old_path" 2>/dev/null | grep -E -o "$regex" | wc -l || true)
+            if [ -f "$file" ]; then
+              head_count=$(grep -E -o "$regex" "$file" 2>/dev/null | wc -l || true)
+            else
+              head_count=0
+            fi
+
+            if [ "$head_count" -gt "$base_count" ]; then
+              echo "❌ Increased InterleavedAddrGen usage in: $file (base=$base_count → head=$head_count)"
+              echo "Added matching lines:"
+              git diff "$BASE_REF" HEAD -- "$file" | grep -E '^\+[^+].*(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)' || true
+              NEW_USAGE_FOUND=1
+            fi
+          done
+
+          if [ "$NEW_USAGE_FOUND" -eq 1 ]; then
             echo ""
             echo "❌ New InterleavedAddrGen usages detected!"
             echo "Please use TensorAccessor instead."
             exit 1
           else
-            echo "✅ No new InterleavedAddrGen usages found in changed files."
+            echo "✅ No increase in InterleavedAddrGen usages found in changed files."
           fi
   check-sweeps-workflow:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Ticket

### Problem description
Currently the check for not introducing InterleavedAddrGen is too restrictive, which causes false positives on PRs like https://github.com/tenstorrent/tt-metal/pull/26884, which simply refactor code touching InterleavedAddrGen

### What's changed
Now we count how many entries of InterleavedAddrGen there are in the old and new version of the file, forbidding the number to increase

### Checklist
- [x] Checked that the change from https://github.com/tenstorrent/tt-metal/pull/26884 passes with new CI check: https://github.com/tenstorrent/tt-metal/actions/runs/17053223473/job/48345549243?pr=27043
- [x] Checked that manually adding InterleavedAddrGen fails with new CI check: https://github.com/tenstorrent/tt-metal/actions/runs/17053252816/job/48345641131?pr=27044
- [x] New/Existing tests provide coverage for changes