### PR TITLE
[TESTING] Testing InterleavedAddrGen CI check (should pass)

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -109,6 +109,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for git diff comparison
       - name: Check for new InterleavedAddrGen usages in changed files
         run: |
+          set -euo pipefail
           # Get the base branch for comparison
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
@@ -116,34 +117,59 @@ jobs:
             BASE_REF="HEAD^"
           fi
 
-          # Find all changed C++ files in the current PR/commit
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_REF HEAD | grep -E '\.(cpp|hpp|h|cc|cxx)$' || true)
+          declare -A OLD_FOR_NEW
+          CHANGED=()
 
-          # Check if any changed C++ files contain new InterleavedAddrGen usages
-          NEW_USAGE_FOUND=0
-          if [ -n "$CHANGED_FILES" ]; then
-            for file in $CHANGED_FILES; do
-              if [ -f "$file" ]; then
-                # Check for InterleavedAddrGen, InterleavedAddrGenFast, InterleavedPow2AddrGen, or get_interleaved_addr_gen
-                if git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen" > /dev/null; then
-                  echo "❌ Found new InterleavedAddrGen usage in: $file"
-                  echo "Added lines:"
-                  git diff $BASE_REF HEAD -- "$file" | grep -E "^\+.*Interleaved.*AddrGen|^\+.*get_interleaved_addr_gen"
-                  NEW_USAGE_FOUND=1
+          # Collect changed C/C++ files and map renames (old -> new)
+          while IFS=$'\t' read -r status path1 path2; do
+            case "$status" in
+              A|M)
+                if [[ "$path1" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
+                  CHANGED+=("$path1")
                 fi
-              fi
-            done
-          else
-            echo "No C++ files changed in this PR."
+                ;;
+              R*)
+                if [[ "$path2" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
+                  CHANGED+=("$path2")
+                  OLD_FOR_NEW["$path2"]="$path1"
+                fi
+                ;;
+            esac
+          done < <(git diff --name-status -M "$BASE_REF" HEAD)
+
+          if (( ${#CHANGED[@]} == 0 )); then
+            echo "No C/C++ files changed in this PR."
+            exit 0
           fi
 
-          if [ $NEW_USAGE_FOUND -eq 1 ]; then
+          NEW_USAGE_FOUND=0
+          regex='(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)'
+
+          for file in "${CHANGED[@]}"; do
+            old_path="${OLD_FOR_NEW[$file]:-$file}"
+
+            base_count=$(git show "$BASE_REF:$old_path" 2>/dev/null | grep -E -o "$regex" | wc -l || true)
+            if [ -f "$file" ]; then
+              head_count=$(grep -E -o "$regex" "$file" 2>/dev/null | wc -l || true)
+            else
+              head_count=0
+            fi
+
+            if [ "$head_count" -gt "$base_count" ]; then
+              echo "❌ Increased InterleavedAddrGen usage in: $file (base=$base_count → head=$head_count)"
+              echo "Added matching lines:"
+              git diff "$BASE_REF" HEAD -- "$file" | grep -E '^\+[^+].*(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)' || true
+              NEW_USAGE_FOUND=1
+            fi
+          done
+
+          if [ "$NEW_USAGE_FOUND" -eq 1 ]; then
             echo ""
             echo "❌ New InterleavedAddrGen usages detected!"
             echo "Please use TensorAccessor instead."
             exit 1
           else
-            echo "✅ No new InterleavedAddrGen usages found in changed files."
+            echo "✅ No increase in InterleavedAddrGen usages found in changed files."
           fi
   check-sweeps-workflow:
     runs-on: ubuntu-latest

--- a/tt_metal/hw/inc/accessor/tensor_accessor.h
+++ b/tt_metal/hw/inc/accessor/tensor_accessor.h
@@ -49,6 +49,7 @@ uint64_t get_dram_bank_base_offset(uint32_t bank_id, uint8_t noc) {
 template <typename _DSpec>
 struct TensorAccessor {
     using DSpec = _DSpec;
+    static constexpr bool is_dram = DSpec::is_dram;
 
 private:
     // DSpec can be static or dynamic, so we use a conditional instance

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -266,6 +266,7 @@ std::uint64_t get_noc_addr(std::uint32_t addr, uint8_t noc = noc_index) {
 
 template <bool DRAM>
 struct InterleavedAddrGen {
+    static constexpr bool is_dram = DRAM;
     uint32_t bank_base_address;  // Base address for the whole tensor.
     const uint32_t page_size;    // Num bytes in page.
     const uint32_t aligned_page_size =
@@ -295,6 +296,7 @@ struct InterleavedAddrGen {
 
 template <bool DRAM>
 struct InterleavedPow2AddrGen {
+    static constexpr bool is_dram = DRAM;
     const uint32_t bank_base_address;
     const uint32_t log_base_2_of_page_size;  // WARNING: This struct is used for optimized get_noc_addr in which case
                                              // you know that bank_unit_size is a power of 2
@@ -328,6 +330,7 @@ struct InterleavedPow2AddrGen {
 
 template <bool DRAM, uint32_t tile_hw = 1024>
 struct InterleavedAddrGenFast {
+    static constexpr bool is_dram = DRAM;
     uint32_t bank_base_address;  // Base address for the whole tensor.
     // TODO: Remove page_size from argument list. This can be derived from data_format
     uint32_t page_size;      // Num bytes in bank unit.
@@ -358,6 +361,7 @@ struct InterleavedAddrGenFast {
 // TODO: need static assert + host assert that page size <= 8192, hard constraint
 template <bool DRAM>
 struct InterleavedPow2AddrGenFast {
+    static constexpr bool is_dram = DRAM;
     uint32_t bank_base_address;              // Base address for the whole tensor.
     const uint32_t log_base_2_of_page_size;  // Num bytes in bank unit.
     static constexpr uint32_t log_base_2_of_allocator_alignment =

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -657,7 +657,7 @@ __attribute__((noinline)) void trace_init() {
 
 // null macros when noc tracing is disabled
 #define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)
-#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, num_bytes, vc)
 #define RECORD_NOC_EVENT(type)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes