### PR TITLE
[DM] Update Test IDs for visibility

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -16,21 +16,23 @@ Some test suites use slow dispatch mode for reliable program execution. These te
 
 ## Tests in the Test Suite
 
-| Name                        | ID(s)        | Description                                                                             |
-| --------------------------- | ------------ | --------------------------------------------------------------------------------------- |
-| DRAM Unary                  | 0-3          | Transactions between DRAM and a single Tensix core.                                     |
-| One to One                  | 4, 50        | Write transactions between two Tensix cores.                                            |
-| One From One                | 5, 51        | Read transactions between two Tensix cores.                                             |
-| One to all                  | 6-8          | Writes transaction from one core to all cores.                                          |
-| One to all Multicast        | 9-14, 52     | Writes transaction from one core to all cores using multicast.                          |
-| One From All                | 15, 30       | Read transactions between one gatherer Tensix core and multiple sender Tensix cores.    |
-| Loopback                    | 16           | Does a loopback operation where one cores writes to itself.                             |
-| Reshard Hardcoded           | 17-20        | Uses existing reshard tests to analyse their bandwidth and latency. **(Slow Dispatch)** |
-| Conv Hardcoded              | 21-23        | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
-| All to all                  | 60           | Write transactions from multiple cores to multiple cores.                               |
-| All from all                | 70           | Read transactions from multiple cores to multiple cores.                                |
-| Interleaved Page Read/Write | 61-69, 71-75 | Reads and writes pages between interleaved buffers and a Tensix core.                   |
-| Deinterleave                | 200-201      | Tests deinterleaving **(Slow Dispatch)**                                                |
+| Name                        | ID(s)                | Description                                                                             |
+| ----------                  | -----                | ----------------------------------------------------                                    |
+| DRAM Unary                  | 0-3                  | Transactions between DRAM and a single Tensix core.                                     |
+| One to One                  | 4, 50, 150-151       | Write transactions between two Tensix cores.                                            |
+| One From One                | 5, 51, 152-153       | Read transactions between two Tensix cores.                                             |
+| One to all                  | 6-8, 52, 154-155     | Writes transaction from one core to all cores.                                          |
+| One to all Multicast        | 9-14, 53-54, 100-102 | Writes transaction from one core to all cores using multicast.                          |
+| One From All                | 15, 30, 156-157      | Read transactions between one gatherer Tensix core and multiple sender Tensix cores.    |
+| Loopback                    | 16, 55               | Does a loopback operation where one cores writes to itself.                             |
+| Reshard Hardcoded           | 17-20                | Uses existing reshard tests to analyse their bandwidth and latency. **(Slow Dispatch)** |
+| Conv Hardcoded              | 21-23                | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
+| Interleaved Page Read/Write | 61-69, 71-75         | Reads and writes pages between interleaved buffers and a Tensix core.                   |
+| One Packet Read/Write       | 80-83                | Reads or writes packets between two Tensix cores.                                       |
+| Core Bidrectional           | 140-148              | Tensix core reads from and writes to another Tensix core simultaneously.                |
+| Deinterleave                | 200-201              | Tests deinterleaving. **(Slow Dispatch)**                                               |
+| All to all                  | 300-308              | Write transactions from multiple cores to multiple cores.                               |
+| All from all                | 310-318              | Read transactions from multiple cores to multiple cores.                                |
 
 ## Running Tests
 ### C++ Gtests

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -78,7 +78,7 @@ Follow these steps to add new tests to this test suite.
 5. Assign your test a unique test id to make sure your test results are grouped together and are plotted separately from other tests.
     - Refer to the "Tests in the Test Suite" section for already taken test ids.
     - Preferably use the next integer available.
-    - Update the `test_id_to_name` and `test_bounds` objects with the test id, test name and test bounds.
+    - Add the test id and test name to this README and to `/python/test_mappings/test_information.yaml`. If test bounds are relevant, add these to `/python/test_mappings/test_bounds.yaml`
 6. Create a README file within the test directory that describes:
     1. What your test does,
     2. What the test parameters are,

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -17,7 +17,7 @@ using namespace test_utils;
 
 namespace unit_tests::dm::all_from_all {
 
-constexpr uint32_t START_ID = 70;
+constexpr uint32_t START_ID = 310;
 
 // Test Config (i.e. test parameters)
 struct AllFromAllConfig {

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -16,7 +16,7 @@ using namespace test_utils;
 
 namespace unit_tests::dm::all_to_all {
 
-constexpr uint32_t START_ID = 60;
+constexpr uint32_t START_ID = 300;
 
 // Test Config (i.e. test parameters)
 struct AllToAllConfig {
@@ -229,7 +229,7 @@ void directed_ideal_test(
     // Test config
     unit_tests::dm::all_to_all::AllToAllConfig test_config = {
 
-        .test_id = unit_tests::dm::all_to_all::START_ID + test_case_id,
+        .test_id = test_case_id,
 
         .mst_logical_start_coord = mst_start_coord,
         .sub_logical_start_coord = sub_start_coord,
@@ -279,7 +279,7 @@ void packet_sizes_test(
             // Test config
             unit_tests::dm::all_to_all::AllToAllConfig test_config = {
 
-                .test_id = unit_tests::dm::all_to_all::START_ID + test_case_id,
+                .test_id = test_case_id,
 
                 .mst_logical_start_coord = mst_start_coord,
                 .sub_logical_start_coord = sub_start_coord,

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -340,7 +340,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalSameVCDiffer
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepSameKernel) {
     // Test ID base
-    uint32_t test_id_base = 146;
+    uint32_t test_id_base = 144;
     bool same_kernel = true;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
@@ -356,7 +356,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweep
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweepDifferentKernels) {
     // Test ID base
-    uint32_t test_id_base = 150;
+    uint32_t test_id_base = 145;
     bool same_kernel = false;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};
@@ -374,7 +374,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalWriteVCSweep
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesSameKernel) {
     // Test ID
-    uint32_t test_id = 144;
+    uint32_t test_id = 146;
     bool same_kernel = true;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {1, 1};
@@ -385,7 +385,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesS
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesDifferentKernels) {
     // Test ID
-    uint32_t test_id = 145;
+    uint32_t test_id = 147;
     bool same_kernel = false;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {1, 1};
@@ -398,7 +398,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalPacketSizesD
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementCoreBidirectionalCustom) {
     // Test ID
-    uint32_t test_id = 147;
+    uint32_t test_id = 148;
     bool same_kernel = true;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {0, 1};

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -358,10 +358,12 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
+    
     // Test ID (Arbitrary)
-    uint32_t test_id = 153;
+    uint32_t test_id = 156;
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
+
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -373,9 +375,11 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
-    uint32_t test_id = 160;
+
+    uint32_t test_id = 157;
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
+
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -358,7 +358,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
-    
+
     // Test ID (Arbitrary)
     uint32_t test_id = 156;
     auto mesh_device = get_mesh_device();

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -316,7 +316,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
     // Test ID (Arbitrary)
-    uint32_t test_id = 151;
+    uint32_t test_id = 152;
 
     unit_tests::dm::core_from_core::virtual_channels_test(
         get_mesh_device(),
@@ -328,7 +328,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneVirtualChannels) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromOneCustom) {
     GTEST_SKIP() << "Skipping test";
-    uint32_t test_id = 160;
+    uint32_t test_id = 153;
 
     // Parameters
     uint32_t num_of_transactions = 256;

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -198,7 +198,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemesNoLoo
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle) {
     GTEST_SKIP() << "Skipping test";
 
-    uint32_t test_case_id = 110;
+    uint32_t test_case_id = 102;
 
     auto mesh_device = get_mesh_device();
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -722,7 +722,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastVirtualChannel
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
-    uint32_t test_case_id = 152;
+    uint32_t test_case_id = 154;
 
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -754,7 +754,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastCustom) {
     GTEST_SKIP() << "Skipping test";
 
     // Parameters
-    uint32_t test_case_id = 160;
+    uint32_t test_case_id = 155;
 
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -351,7 +351,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneVirtualChannels) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneCustom) {
     GTEST_SKIP() << "Skipping test";
-    uint32_t test_id = 160;
+    uint32_t test_id = 151;
 
     // Parameters
     uint32_t num_of_transactions = 256;

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -10,7 +10,7 @@ tests:
   3:
     name: "DRAM Directed Ideal"
     comment: |
-      This test shows the ideal read and write bandwidth when transfering multiple 8KB packets.
+      This test shows the ideal read and write bandwidth when transferring multiple 8KB packets.
       The read bandwidth is what is expected, however write bandwidth is expected to be 64
       B/cycle rather than 35 B/cycle. There may be some configuration problem with the dram
       controller/phy or this may be the physical limit of the dram.
@@ -215,17 +215,17 @@ tests:
   200:
     name: "Deinterleave Single Core"
     comment: |
-      With a single core the graphs shows performance increases as the theshold increases.
-      This is because frequent flushes dont hide the round trip latency.
+      With a single core the graphs shows performance increases as the threshold increases.
+      This is because frequent flushes don't hide the round trip latency.
 
   201:
     name: "Deinterleave Multi Core"
     comment: |
-      With multiple cores the graph shows that a small theshold always provides bad performance.
-      This is because frequent flushes dont hide the round trip latency. At larger thesholds,
+      With multiple cores the graph shows that a small threshold always provides bad performance.
+      This is because frequent flushes don't hide the round trip latency. At larger thresholds,
       the performance starts to fluctuate due to head-of-line blocking and unfairness in the NOC.
-      Performance fluctuates because the flush disturbes the steady state and will randomly create
-      traffic that sometimes has head of line blocking, and sometimes not.
+      Performance fluctuates because the flush disturbs the steady state and will randomly create
+      traffic that sometimes has head of line blocking, and sometimes does not.
 
   300:
     name: "All to All Directed Ideal"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -197,7 +197,7 @@ tests:
   101:
     name: "Multicast Schemes (Loopback Disabled)"
 
-  110:
+  102:
     name: "1 Multicast Scheme"
 
   140:
@@ -207,7 +207,7 @@ tests:
     name: "Core Bidirectional Directed Ideal Different Kernels"
 
   142:
-    name: Core Bidirectional Same Virtual Channel Same Kernel"
+    name: "Core Bidirectional Same Virtual Channel Same Kernel"
 
   143:
     name: "Core Bidirectional Same Virtual Channel Different Kernels"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -198,7 +198,7 @@ tests:
     name: "Multicast Schemes (Loopback Disabled)"
 
   102:
-    name: "1 Multicast Scheme"
+    name: "Multicast Single Scheme"
 
   140:
     name: "Core Bidirectional Directed Ideal Same Kernel"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -7,6 +7,9 @@ tests:
     comment: |
       This test appears to be broken. The graph is showing numbers that dont make sense.
 
+  2:
+    name: "DRAM Channels"
+
   3:
     name: "DRAM Directed Ideal"
     comment: |
@@ -194,23 +197,59 @@ tests:
   101:
     name: "Multicast Schemes (Loopback Disabled)"
 
+  110:
+    name: "1 Multicast Scheme"
+
+  140:
+    name: "Core Bidirectional Directed Ideal Same Kernel"
+
+  141:
+    name: "Core Bidirectional Directed Ideal Different Kernels"
+
+  142:
+    name: Core Bidirectional Same Virtual Channel Same Kernel"
+
+  143:
+    name: "Core Bidirectional Same Virtual Channel Different Kernels"
+
+  144:
+    name: "Core Bidirectional Write Virtual Channel Sweep Same Kernel"
+
+  145:
+    name: "Core Bidirectional Write Virtual Channel Sweep Different Kernels"
+
+  146:
+    name: "Core Bidirectional Packet Sizes Same Kernel"
+
+  147:
+    name: "Core Bidirectional Packet Sizes Different Kernels"
+
+  148:
+    name: "Core Bidirectional Custom"
+
   150:
     name: "One to One Virtual Channels"
 
   151:
-    name: "One from One Virtual Channels"
+    name: "One to One Custom"
 
   152:
-    name: "One to All Unicast Virtual Channels"
+    name: "One from One Virtual Channels"
 
   153:
-    name: "One from All Virtual Channels"
+    name: "One from One Custom"
 
   154:
-    name: "All to All Virtual Channels"
+    name: "One to All Unicast Virtual Channels"
 
   155:
-    name: "All from All Virtual Channels"
+    name: "One to All Unicast Custom"
+
+  156:
+    name: "One from All Virtual Channels"
+
+  157:
+    name: "One from All Custom"
 
   200:
     name: "Deinterleave Single Core"
@@ -233,8 +272,50 @@ tests:
   301:
     name: "All to All Packet Sizes"
 
+  302:
+    name: "All to All 2x2 To 1x1 Directed Ideal"
+
+  303:
+    name: "All to All 4x4 To 1x1 Directed Ideal"
+
+  304:
+    name: "All to All 1x1 To 2x2 Directed Ideal"
+
+  305:
+    name: "All to All 1x1 To 4x4 Directed Ideal"
+
+  306:
+    name: "All to All 2x2 To 2x2 Directed Ideal"
+
+  307:
+    name: "All to All Virtual Channels"
+
+  308:
+    name: "All to All Custom"
+
   310:
     name: "All from All Directed Ideal"
 
   311:
     name: "All from All Packet Sizes"
+
+  312:
+    name: "All from All 2x2 From 1x1 Directed Ideal"
+
+  313:
+    name: "All from All 4x4 From 1x1 Directed Ideal"
+
+  314:
+    name: "All from All 1x1 From 2x2 Directed Ideal"
+
+  315:
+    name: "All from All 1x1 From 4x4 Directed Ideal"
+
+  316:
+    name: "All from All 2x2 From 2x2 Directed Ideal"
+
+  317:
+    name: "All from All Virtual Channels"
+
+  318:
+    name: "All from All Custom"


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27041)

### Problem description
Some test IDs aren't reported in the data movement readme or the test mapping yamls used by the Python scripts. This can result in pushing tests which have overlapping test IDs without noticing, which causes the data from running the entire test suite (e.g. in the pipelines) to appear buggy.

### What's changed
- added the missing tests to the readme and test_information.yaml
- reordered a few of the IDs where it made sense
Going forward, when adding a new data movement test, the ID used should be added to these files so other developers don't accidentally use the same ones when pushing their changes.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes