### PR TITLE
Delete Kernel::processor() from API.

### DIFF
--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -104,7 +104,6 @@ public:
 
     const std::map<std::string, std::string>& defines() const { return defines_; }
 
-    virtual RISCV processor() const = 0;
     uint32_t dispatch_class() { return this->dispatch_class_; }
 
     virtual bool configure(IDevice* device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const = 0;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -648,26 +648,6 @@ std::vector<std::string> ComputeKernel::file_paths(IDevice& device) const {
     return file_paths;
 }
 
-RISCV DataMovementKernel::processor() const {
-    switch (this->config_.processor) {
-        case DataMovementProcessor::RISCV_0: return RISCV::BRISC;
-        case DataMovementProcessor::RISCV_1: return RISCV::NCRISC;
-        default: TT_THROW("Unsupported data movement processor");
-    }
-    return RISCV::BRISC;
-}
-
-RISCV EthernetKernel::processor() const {
-    switch (this->config_.processor) {
-        case DataMovementProcessor::RISCV_0: return RISCV::ERISC;
-        case DataMovementProcessor::RISCV_1: return RISCV::ERISC1;
-        default: TT_THROW("Unsupported data movement processor");
-    }
-    return RISCV::ERISC;
-}
-
-RISCV ComputeKernel::processor() const { return RISCV::COMPUTE; }
-
 bool DataMovementKernel::configure(
     IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const {
     if (not is_on_logical_core(logical_core)) {

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -80,8 +80,6 @@ public:
 
     ~DataMovementKernel() override = default;
 
-    RISCV processor() const override;
-
     uint32_t get_kernel_processor_type(int index) const override;
     void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
     bool binaries_exist_on_disk(const IDevice* device) const override;
@@ -125,8 +123,6 @@ public:
 
     ~EthernetKernel() override = default;
 
-    RISCV processor() const override;
-
     uint32_t get_kernel_processor_type(int index) const override;
     void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
     bool binaries_exist_on_disk(const IDevice* device) const override;
@@ -167,8 +163,6 @@ public:
     }
 
     ~ComputeKernel() override = default;
-
-    RISCV processor() const override;
 
     uint32_t get_kernel_processor_type(int index) const override;
     void set_build_options(JitBuildOptions& build_options) const override;


### PR DESCRIPTION
### Ticket
#17275

### Problem description

All internal uses have been removed.  `enum RISCV` will not be compatible with Quasar, making this method not useful.

### What's changed
Deleted.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17054471191) passed
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17054474086/job/48352732435) `ttnn group 1` complaining about MeshShape; should be unrelated.