### PR TITLE
Adding BH and WH base fw interface + watcher check for link being up

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -31,6 +31,45 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 static void RunTest(WatcherFixture* fixture, IDevice* device) {
+    Program program = Program();
+
+    CoreCoord logical_core, virtual_core;
+    if (device->get_active_ethernet_cores(true).empty()) {
+        log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+        GTEST_SKIP();
+    }
+
+    for (auto core : device->get_active_ethernet_cores(true)) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device->id(), core)) {
+            logical_core = core;
+            break;
+        }
+    }
+
+    virtual_core = device->ethernet_core_from_logical_core(logical_core);
+    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
+
+    auto eth_link_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_eth_link_check.cpp",
+        logical_core,
+        EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+
+    fixture->RunProgram(device, program);
+
+    auto x = MetalContext::instance().watcher_server()->exception_message();
+    // read out link status from L1
+    auto link_up_addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::LINK_UP);
+    uint32_t link_status_rd;
+    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        &link_status_rd, sizeof(uint32_t), tt_cxy_pair(device->id(), virtual_core.x, virtual_core.y), link_up_addr);
+
+    if (x.empty()) {
+        EXPECT_NE(link_status_rd, 0);
+    } else {
+        EXPECT_EQ(link_status_rd, 0);
+    }
 }
 
 TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
@@ -76,4 +115,13 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     DebugToolsFixture::TearDown();  // Call parent teardown so we don't disable watcher
     MetalContext::instance().teardown();
     EXPECT_TRUE(FileContainsAllStrings(this->log_file_name, expected_strings));
+}
+
+TEST_F(WatcherFixture, ActiveEthTestWatcherDetectLinkUp) {
+    if (this->arch_ != tt::ARCH::WORMHOLE_B0) {
+        GTEST_SKIP()
+            << "Enable this test on BH when base FW updated to flush data cache and invalidate instruction cache";
+    }
+    this->RunTestOnDevice(
+        [](WatcherFixture* fixture, IDevice* device) { RunTest(fixture, device); }, this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_eth_link_check.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_eth_link_check.cpp
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "debug/eth_link_status.h"
+
+void kernel_main() { WATCHER_CHECK_ETH_LINK_STATUS(); }

--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -45,6 +45,7 @@ enum class HalL1MemAddrType : uint8_t {
     CRC_ERR,    // Link status - CRC error count
     CORR_CW,    // Link status - Corrected Codewords count
     UNCORR_CW,  // Link status - Uncorrected Codewords count
+    LINK_UP,    // Link status - Link up status
     FABRIC_ROUTER_CONFIG,
     ETH_FW_MAILBOX,
     ETH_LINK_REMOTE_INFO,

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -309,6 +309,7 @@ target_sources(
             inc/blackhole/core_config.h
             inc/blackhole/dev_mem_map.h
             inc/blackhole/eth_chan_noc_mapping.h
+            inc/blackhole/eth_fw_api.h
             inc/blackhole/eth_l1_address_map.h
             inc/blackhole/noc/noc.h
             inc/blackhole/noc/noc_overlay_parameters.h
@@ -332,6 +333,7 @@ target_sources(
             inc/debug/dprint_buffer.h
             inc/debug/dprint_pages.h
             inc/debug/dprint_tile.h
+            inc/debug/eth_link_status.h
             inc/debug/fw_debug.h
             inc/debug/noc_logging.h
             inc/debug/ring_buffer.h
@@ -360,6 +362,7 @@ target_sources(
             inc/wormhole/core_config.h
             inc/wormhole/dev_mem_map.h
             inc/wormhole/eth_chan_noc_mapping.h
+            inc/wormhole/eth_fw_api.h
             inc/wormhole/eth_l1_address_map.h
             inc/wormhole/noc/noc.h
             inc/wormhole/noc/noc_overlay_parameters.h

--- a/tt_metal/hw/inc/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/blackhole/eth_fw_api.h
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
+#include <cstddef>
 #include <cstdint>
 
 #define MEM_SYSENG_ETH_MSG_STATUS_MASK 0xFFFF0000
@@ -12,6 +15,158 @@
 #define MEM_SYSENG_ETH_MSG_RELEASE_CORE 0x0002
 #define MEM_SYSENG_ETH_MAILBOX_ADDR 0x7D000
 #define MEM_SYSENG_ETH_MAILBOX_NUM_ARGS 3
+#define MEM_SYSENG_BOOT_RESULTS_BASE 0x7CC00
+#define NUM_SERDES_LANES 8
+
+enum link_train_status_e : uint32_t {
+    LINK_TRAIN_TRAINING,
+    LINK_TRAIN_SKIP,
+    LINK_TRAIN_PASS,
+    LINK_TRAIN_INT_LB,
+    LINK_TRAIN_EXT_LB,
+    LINK_TRAIN_TIMEOUT_MANUAL_EQ,
+    LINK_TRAIN_TIMEOUT_ANLT,
+    LINK_TRAIN_TIMEOUT_CDR_LOCK,
+    LINK_TRAIN_TIMEOUT_BIST_LOCK,
+    LINK_TRAIN_TIMEOUT_LINK_UP,
+    LINK_TRAIN_TIMEOUT_CHIP_INFO,
+};
+
+enum port_status_e : uint32_t {
+    PORT_UNKNOWN,
+    PORT_UP,
+    PORT_DOWN,
+    PORT_UNUSED,
+};
+
+struct fw_version_t {
+    uint32_t patch : 8;
+    uint32_t minor : 8;
+    uint32_t major : 8;
+    uint32_t unused : 8;
+};
+
+struct chip_info_t {
+    uint8_t pcb_type;
+    uint8_t asic_location;
+    uint8_t eth_id;
+    uint8_t logical_eth_id;
+    uint32_t board_id_hi;
+    uint32_t board_id_lo;
+    uint32_t mac_addr_org;
+    uint32_t mac_addr_id;
+    uint32_t spare[2];
+    uint32_t ack;
+};
+
+struct serdes_rx_bist_results_t {
+    uint32_t bist_mode;
+    uint32_t test_time; // Test time in cycles for bist mode 0 and ms for bist mode 1
+    uint32_t error_cnt_nt[NUM_SERDES_LANES];
+    uint32_t error_cnt_55t32_nt[NUM_SERDES_LANES];
+    uint32_t error_cnt_overflow_nt[NUM_SERDES_LANES];
+};
+
+struct eth_status_t {
+    // Basic status
+    uint32_t postcode;
+    port_status_e port_status;
+    link_train_status_e train_status;
+    uint32_t train_speed;   // Actual resulting speed from training
+
+    uint32_t spare[28 - 4];
+
+    // Heartbeat
+    uint32_t heartbeat[4];
+};
+
+struct serdes_results_t {
+    uint32_t postcode;
+    uint32_t serdes_inst;
+    uint32_t serdes_lane_mask;
+    uint32_t target_speed;       // Target speed from the boot params
+    uint32_t data_rate;
+    uint32_t data_width;
+    uint32_t spare_main[8 - 6];
+
+    // Training retries
+    uint32_t anlt_retry_cnt;
+    uint32_t spare[16 - 9];
+
+    // BIST
+    uint32_t bist_mode;
+    uint32_t bist_test_time; // Test time in cycles for bist mode 0 and ms for bist mode 1
+    uint32_t bist_err_cnt_nt[NUM_SERDES_LANES];
+    uint32_t bist_err_cnt_55t32_nt[NUM_SERDES_LANES];
+    uint32_t bist_err_cnt_overflow_nt[NUM_SERDES_LANES];
+
+    uint32_t cdr_unlocked_cnt;
+    uint32_t cdr_unlock_transitions;
+
+    uint32_t spare2[48 - 44];
+
+    // Training times
+    uint32_t man_eq_cmn_pstate_time;
+    uint32_t man_eq_tx_ack_time;
+    uint32_t man_eq_rx_ack_time;
+    uint32_t man_eq_rx_eq_assert_time;
+    uint32_t man_eq_rx_eq_deassert_time;
+    uint32_t anlt_auto_neg_time;
+    uint32_t anlt_link_train_time;
+    uint32_t anlt_retrain_time;
+    uint32_t cdr_lock_time;
+    uint32_t bist_lock_time;
+
+    uint32_t spare_time[64 - 58];
+};
+
+struct macpcs_results_t {
+    uint32_t postcode;
+
+    uint32_t macpcs_retry_cnt;
+
+    uint32_t spare[24 - 2];
+
+    // Training times
+    uint32_t link_up_time;
+    uint32_t chip_info_time;
+
+    uint32_t spare_time[32 - 26];
+};
+
+struct eth_live_status_t {
+    uint32_t retrain_count;
+    uint32_t rx_link_up;     // MAC/PCS RX Link Up
+
+    uint32_t spare[8 - 2];
+
+    // Snapshot registers
+    uint64_t frames_txd;          // Cumulative TX Packets Transmitted count
+    uint64_t frames_txd_ok;       // Cumulative TX Packets Transmitted OK count
+    uint64_t frames_txd_badfcs;   // Cumulative TX Packets Transmitted with BAD FCS count
+    uint64_t bytes_txd;           // Cumulative TX Bytes Transmitted count
+    uint64_t bytes_txd_ok;        // Cumulative TX Bytes Transmitted OK count
+    uint64_t bytes_txd_badfcs;    // Cumulative TX Bytes Transmitted with BAD FCS count
+    uint64_t frames_rxd;          // Cumulative Packets Received count
+    uint64_t frames_rxd_ok;       // Cumulative Packets Received OK count
+    uint64_t frames_rxd_badfcs;   // Cumulative Packets Received with BAD FCS count
+    uint64_t frames_rxd_dropped;  // Cumulative Dropped Packets Received count
+    uint64_t bytes_rxd;           // Cumulative Bytes received count
+    uint64_t bytes_rxd_ok;        // Cumulative Bytes received OK count
+    uint64_t bytes_rxd_badfcs;    // Cumulative Bytes received with BAD FCS count
+    uint64_t bytes_rxd_dropped;   // Cumulative Bytes received and dropped count
+    uint64_t corr_cw;             // Cumulative Corrected Codeword count
+    uint64_t uncorr_cw;           // Cumulative Uncorrected Codeword count
+
+    uint32_t spare2[64 - 40];
+};
+
+struct eth_api_table_t {
+    uint32_t* send_eth_msg_ptr;           // Pointer to the send eth msg function
+    uint32_t* service_eth_msg_ptr;        // Pointer to the service eth msg function
+    uint32_t* eth_link_status_check_ptr;  // Pointer to the eth link status check function
+    uint32_t spare[16 - 3];
+};
 
 enum eth_mailbox_e : uint32_t {
     MAILBOX_HOST,
@@ -21,19 +176,43 @@ enum eth_mailbox_e : uint32_t {
     NUM_ETH_MAILBOX,
 };
 
-struct eth_api_table_t {
-    uint32_t* send_eth_msg_ptr;           // 0 - Pointer to the send eth msg function
-    uint32_t* service_eth_msg_ptr;        // 1 - Pointer to the service eth msg function
-    uint32_t* eth_link_status_check_ptr;  // 2 - Pointer to the eth link status check function
-
-    uint32_t spare[16 - 3];  // 3-15
-};
-
 struct eth_mailbox_t {
-    uint32_t msg;     // 0 - Message type. Defined with MEM_SYSENG_ETH_MSG_* macros
-    uint32_t arg[3];  // 1-3 - Arguments to the message (not all need to be used)
+    uint32_t msg;     // Message type. Defined with MEM_SYSENG_ETH_MSG_* macros
+    uint32_t arg[3];  // Arguments to the message (not all need to be used)
 };
 
 struct all_eth_mailbox_t {
-    eth_mailbox_t mailbox[4];  // 0-16 - 4 mailbox entries, 0 - Host, 1 - RSIC1, 2 - CMFW, 3 - Other
+    eth_mailbox_t mailbox[4];  // 4 mailbox entries, 0 - Host, 1 - RSIC1, 2 - CMFW, 3 - Other
 };
+
+struct boot_results_t {
+    eth_status_t eth_status;
+    serdes_results_t serdes_results;
+    macpcs_results_t macpcs_results;
+
+    eth_live_status_t eth_live_status;
+    eth_api_table_t eth_api_table;
+
+    uint32_t spare[238 - 208];
+
+    fw_version_t serdes_fw_ver;
+    fw_version_t eth_fw_ver;
+    chip_info_t local_info;
+    chip_info_t remote_info;
+};
+
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+#include "risc_common.h"
+
+FORCE_INLINE bool is_link_up() {
+    constexpr uint32_t MEM_SYSENG_ETH_API_TABLE =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_api_table);
+    invalidate_l1_cache();
+    // Collect current link states
+    reinterpret_cast<void (*)(uint32_t)>(
+        (uint32_t)(((eth_api_table_t*)(MEM_SYSENG_ETH_API_TABLE))->eth_link_status_check_ptr))(0xFFFFFFFF);
+    volatile eth_live_status_t* link_status =
+        (volatile eth_live_status_t*)(MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status));
+    return link_status->rx_link_up == 1;
+}
+#endif

--- a/tt_metal/hw/inc/debug/eth_link_status.h
+++ b/tt_metal/hw/inc/debug/eth_link_status.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "watcher_common.h"
+#include "eth_fw_api.h"
+
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ETH_LINK_STATUS) && !defined(FORCE_WATCHER_OFF) && \
+    defined(COMPILE_FOR_ERISC)
+
+void hang_on_down_link() {
+    debug_eth_link_t tt_l1_ptr* v = GET_MAILBOX_ADDRESS_DEV(watcher.eth_status);
+    v->link_down = 1;
+
+    // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
+    // still running and try to make it exit.
+    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+    go_message_ptr->signal = RUN_MSG_DONE;
+
+    // This exits to base FW
+    internal_::disable_erisc_app();
+    erisc_exit();
+
+    while (1) {
+        ;
+    }
+}
+
+// The do... while(0) in this macro allows for it to be called more flexibly, e.g. in an if-else
+// without {}s.
+#define WATCHER_CHECK_ETH_LINK_STATUS() \
+    do {                                \
+        if (not(is_link_up()))          \
+            hang_on_down_link();        \
+    } while (0)
+
+#define WATCHER_ETH_LINK_STATUS_ENABLED 1
+
+#else  // !WATCHER_ENABLED or !COMPILE_FOR_ERISC
+
+#define WATCHER_CHECK_ETH_LINK_STATUS()
+
+#define WATCHER_ETH_LINK_STATUS_ENABLED 0
+
+#endif  // WATCHER_ENABLED

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -298,6 +298,10 @@ struct debug_stack_usage_t {
     } cpu[DebugNumUniqueRiscs];
 };
 
+struct debug_eth_link_t {
+    uint8_t link_down;
+};
+
 enum watcher_enable_msg_t {
     WatcherDisabled = 2,
     WatcherEnabled = 3,
@@ -311,7 +315,8 @@ struct watcher_msg_t {
     struct debug_waypoint_msg_t debug_waypoint[MAX_RISCV_PER_CORE];
     struct debug_sanitize_noc_addr_msg_t sanitize_noc[MAX_NUM_NOCS_PER_CORE];
     std::atomic<bool> noc_linked_status[MAX_NUM_NOCS_PER_CORE];
-    uint8_t pad_0[2];
+    struct debug_eth_link_t eth_status;
+    uint8_t pad0;
     struct debug_assert_msg_t assert_status;
     struct debug_pause_msg_t pause_status;
     struct debug_stack_usage_t stack_usage;

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -8,6 +8,7 @@
 #include "erisc.h"
 #include "eth_l1_address_map.h"
 #include "noc_nonblocking_api.h"
+#include "debug/eth_link_status.h"
 
 inline void RISC_POST_STATUS(uint32_t status) {
     volatile uint32_t* ptr = (volatile uint32_t*)(NOC_CFG(ROUTER_CFG_2));
@@ -68,6 +69,7 @@ FORCE_INLINE bool eth_txq_is_busy(uint32_t q_num) {
 
 template <bool ctx_switch = true>
 FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
+    WATCHER_CHECK_ETH_LINK_STATUS();
     while (eth_txq_is_busy(q_num)) {
         // Note, this is overly eager... Kills perf on allgather
         if constexpr (ctx_switch) {
@@ -82,6 +84,7 @@ FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32
 
 FORCE_INLINE
 void eth_send_packet_byte_addr(uint32_t q_num, uint32_t src_addr, uint32_t dest_addr, uint32_t num_words) {
+    WATCHER_CHECK_ETH_LINK_STATUS();
     while (eth_txq_is_busy(q_num));
     volatile uint32_t* ptr = (volatile uint32_t*)(ETH_TXQ0_REGS_START + (q_num * ETH_TXQ_REGS_SIZE));
     ptr[ETH_TXQ_TRANSFER_START_ADDR >> 2] = src_addr;
@@ -92,6 +95,7 @@ void eth_send_packet_byte_addr(uint32_t q_num, uint32_t src_addr, uint32_t dest_
 
 FORCE_INLINE
 void eth_send_packet_unsafe(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
+    WATCHER_CHECK_ETH_LINK_STATUS();
     ASSERT(!eth_txq_is_busy(q_num));
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_START_ADDR, src_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_word_addr << 4);
@@ -101,6 +105,7 @@ void eth_send_packet_unsafe(uint32_t q_num, uint32_t src_word_addr, uint32_t des
 
 FORCE_INLINE
 void eth_send_packet_bytes_unsafe(uint32_t q_num, uint32_t src_addr, uint32_t dest_addr, uint32_t num_bytes) {
+    WATCHER_CHECK_ETH_LINK_STATUS();
     ASSERT(eth_txq_reg_read(q_num, ETH_TXQ_CMD) == 0);
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_START_ADDR, src_addr);
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_addr);
@@ -110,6 +115,7 @@ void eth_send_packet_bytes_unsafe(uint32_t q_num, uint32_t src_addr, uint32_t de
 
 template <bool ctx_switch = true>
 FORCE_INLINE void eth_write_remote_reg(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
+    WATCHER_CHECK_ETH_LINK_STATUS();
     while (eth_txq_is_busy(q_num)) {
         if constexpr (ctx_switch) {
             risc_context_switch();
@@ -121,6 +127,7 @@ FORCE_INLINE void eth_write_remote_reg(uint32_t q_num, uint32_t reg_addr, uint32
 }
 FORCE_INLINE
 void eth_write_remote_reg_no_txq_check(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
+    WATCHER_CHECK_ETH_LINK_STATUS();
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, reg_addr);
     eth_txq_reg_write(q_num, ETH_TXQ_REMOTE_REG_DATA, val);
     eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_REG);

--- a/tt_metal/hw/inc/wormhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/wormhole/eth_fw_api.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#define MEM_SYSENG_BOOT_RESULTS_BASE 0x1EC0
+
+struct boot_results_t {
+    uint32_t reserved_0_4[5];
+    uint32_t link_status;
+    uint32_t reserved_6;
+    uint32_t retrain_cnt;
+    uint32_t reserved_8_15[8];
+    uint32_t packet_send_0;
+    uint32_t packet_send_1;
+    uint32_t packet_send_2;
+    uint32_t packet_send_3;
+    uint32_t packet_recv_0;
+    uint32_t packet_recv_1;
+    uint32_t packet_recv_2;
+    uint32_t packet_recv_3;
+    uint32_t reserved_24_44[21];
+    uint32_t rx_link_up_time;
+    uint32_t dummy_packet_time;
+    uint32_t crc_err;
+    uint32_t reserved_48;
+    uint32_t pcs_faults;
+    uint32_t retrain_trigger_link;
+    uint32_t retrain_trigger_crc;
+    uint32_t corr_cw_hi;
+    uint32_t corr_cw_lo;
+    uint32_t uncorr_cw_hi;
+    uint32_t uncorr_cw_lo;
+    uint32_t reserved_56_63[8];
+    uint32_t local_board_id_lo;
+    uint32_t local_board_id_hi;
+    uint32_t local_x_y_coord;
+    uint32_t local_rack_shelf;
+    uint32_t local_eth_id;
+    uint32_t local_board_type;
+    uint32_t spare_0;
+    uint32_t ack_local;
+    uint32_t remote_board_id_lo;
+    uint32_t remote_board_id_hi;
+    uint32_t remote_x_y_coord;
+    uint32_t remote_rack_shelf;
+    uint32_t remote_eth_id;
+    uint32_t remote_board_type;
+    uint32_t spare_1;
+    uint32_t ack_remote;
+};
+
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+#include "ethernet/erisc.h"
+
+FORCE_INLINE bool is_link_up() {
+    internal_::risc_context_switch_without_noc_sync();
+    volatile boot_results_t* link_stats = (volatile boot_results_t*)(MEM_SYSENG_BOOT_RESULTS_BASE);
+    return link_stats->link_status == 0x6;
+}
+#endif

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -465,6 +465,10 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
         if (!rtoptions.watcher_pause_disabled()) {
             DumpPauseStatus(virtual_core, core_str, mbox_data);
         }
+
+        if (is_eth_core && !rtoptions.watcher_eth_link_status_disabled()) {
+            DumpEthLinkStatus(virtual_core, core_str, mbox_data);
+        }
     }
 
     // Dump state always available
@@ -741,6 +745,26 @@ void WatcherDeviceReader::DumpPauseStatus(CoreDescriptor& core, const string& co
             TT_THROW("{}", error_reason);
         }
     }
+}
+
+void WatcherDeviceReader::DumpEthLinkStatus(
+    CoreDescriptor& core, const string& core_str, const mailboxes_t* mbox_data) {
+    const debug_eth_link_t* eth_link_status = &mbox_data->watcher.eth_status;
+    if (eth_link_status->link_down == 0) {
+        return;
+    }
+    auto noc0_core = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).translate_coord_to(
+        core.coord, CoordSystem::TRANSLATED, CoordSystem::NOC0);
+    string error_msg = fmt::format(
+        "Watcher detected that active eth link on virtual core {} (noc0 core: {}) went down after training.\n",
+        core.coord.str(),
+        noc0_core.str());
+    log_warning(tt::LogMetal, "{}", error_msg);
+    DumpWaypoints(core, mbox_data, true);
+    DumpRingBuffer(core, mbox_data, true);
+    LogRunningKernels(core, get_valid_launch_message(mbox_data));
+    MetalContext::instance().watcher_server()->set_exception_message(fmt::format("{}: {}", core_str, error_msg));
+    TT_THROW("{}: {}", core_str, error_msg);
 }
 
 void WatcherDeviceReader::DumpRingBuffer(CoreDescriptor& /*core*/, const mailboxes_t* mbox_data, bool to_stdout) {

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -48,6 +48,7 @@ private:
     void DumpAssertStatus(CoreDescriptor& core, const std::string& core_str, const mailboxes_t* mbox_data);
     void DumpAssertTrippedDetails(CoreDescriptor& core, const std::string& error_msg, const mailboxes_t* mbox_data);
     void DumpPauseStatus(CoreDescriptor& core, const std::string& core_str, const mailboxes_t* mbox_data);
+    void DumpEthLinkStatus(CoreDescriptor& core, const std::string& core_str, const mailboxes_t* mbox_data);
     void DumpRingBuffer(CoreDescriptor& core, const mailboxes_t* mbox_data, bool to_stdout);
     void DumpRunState(CoreDescriptor& core, const launch_msg_t* launch_msg, uint32_t state);
     void DumpLaunchMessage(CoreDescriptor& core, const mailboxes_t* mbox_data);

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -300,6 +300,7 @@ public:
         return this->virtualized_core_types_;
     }
 
+    bool get_supports_eth_fw_mailbox() const;
     uint32_t get_eth_fw_mailbox_val(FWMailboxMsg msg) const;
     uint32_t get_eth_fw_mailbox_arg_addr(uint32_t arg_index) const;
     uint32_t get_eth_fw_mailbox_arg_count() const;
@@ -491,6 +492,10 @@ inline const HalJitBuildConfig& Hal::get_jit_build_config(
 }
 
 uint32_t generate_risc_startup_addr(uint32_t firmware_base);  // used by Tensix initializers to build HalJitBuildConfig
+
+inline bool Hal::get_supports_eth_fw_mailbox() const {
+    return this->get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::ETH_FW_MAILBOX) != 0;
+}
 
 inline uint32_t Hal::get_eth_fw_mailbox_val(FWMailboxMsg msg) const {
     const auto index = utils::underlying_type<HalProgrammableCoreType>(HalProgrammableCoreType::ACTIVE_ETH);

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -63,6 +63,9 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_ROUTER_CONFIG)] =
         MEM_ERISC_FABRIC_ROUTER_CONFIG_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ETH_FW_MAILBOX)] = MEM_SYSENG_ETH_MAILBOX_ADDR;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LINK_UP)] = MEM_SYSENG_BOOT_RESULTS_BASE +
+                                                                         offsetof(boot_results_t, eth_live_status) +
+                                                                         offsetof(eth_live_status_t, rx_link_up);
 
     std::vector<std::uint32_t> mem_map_sizes;
     mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT), 0);
@@ -89,6 +92,7 @@ HalCoreInfoType create_active_eth_mem_map() {
         MEM_ERISC_FABRIC_ROUTER_CONFIG_SIZE;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::ETH_FW_MAILBOX)] =
         sizeof(uint32_t) + (sizeof(uint32_t) * MEM_SYSENG_ETH_MAILBOX_NUM_ARGS);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LINK_UP)] = sizeof(uint32_t);
 
     std::vector<uint32_t> fw_mailbox_addr(static_cast<std::size_t>(FWMailboxMsg::COUNT), 0);
     fw_mailbox_addr[utils::underlying_type<FWMailboxMsg>(FWMailboxMsg::ETH_MSG_STATUS_MASK)] =

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -11,6 +11,7 @@
 
 #include "core_config.h"
 #include "eth_l1_address_map.h"
+#include "eth_fw_api.h"
 #include "llrt_common/mailbox.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
@@ -60,6 +61,8 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CRC_ERR)] = eth_l1_mem::address_map::CRC_ERR_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORR_CW)] = eth_l1_mem::address_map::CORR_CW_HI_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNCORR_CW)] = eth_l1_mem::address_map::UNCORR_CW_HI_ADDR;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LINK_UP)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, link_status);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_ROUTER_CONFIG)] =
         eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE;
 
@@ -92,6 +95,7 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_FORCE)] = sizeof(uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_ROUTER_CONFIG)] =
         eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LINK_UP)] = sizeof(uint32_t);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ETH_LINK_REMOTE_INFO)] =
         eth_l1_mem::address_map::ETH_LINK_REMOTE_INFO_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG)] =

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -315,7 +315,8 @@ void RunTimeOptions::ParseWatcherEnv() {
         watcher_pause_str,
         watcher_ring_buffer_str,
         watcher_stack_usage_str,
-        watcher_dispatch_str};
+        watcher_dispatch_str,
+        watcher_eth_link_status_str};
     for (const std::string& feature : all_features) {
         std::string env_var("TT_METAL_WATCHER_DISABLE_");
         env_var += feature;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -258,6 +258,7 @@ public:
     bool watcher_ring_buffer_disabled() const { return watcher_feature_disabled(watcher_ring_buffer_str); }
     bool watcher_stack_usage_disabled() const { return watcher_feature_disabled(watcher_stack_usage_str); }
     bool watcher_dispatch_disabled() const { return watcher_feature_disabled(watcher_dispatch_str); }
+    bool watcher_eth_link_status_disabled() const { return watcher_feature_disabled(watcher_eth_link_status_str); }
 
     // Info from inspector environment variables, setters included so that user
     // can override with a SW call.
@@ -494,6 +495,7 @@ private:
     const std::string watcher_ring_buffer_str = "RING_BUFFER";
     const std::string watcher_stack_usage_str = "STACK_USAGE";
     const std::string watcher_dispatch_str = "DISPATCH";
+    const std::string watcher_eth_link_status_str = "ETH_LINK_STATUS";
     std::set<std::string> watcher_disabled_features;
     bool watcher_feature_disabled(const std::string& name) const {
         return watcher_disabled_features.find(name) != watcher_disabled_features.end();


### PR DESCRIPTION
### Problem description
https://github.com/tenstorrent/tt-metal/issues/26734 uncovered that some BH were hanging because the link goes down after being successfully trained. 

### What's changed
Add a watcher check to make sure link is up before transmitting. This gets triggered on IRD 8xp150s 
added arch specific base fw [structs](https://tenstorrent.sharepoint.com/:x:/s/SystemsEngineering/EcPrc_2xNahKr8O-eGP35sgBPHhBWFVRttp9dN59I51krQ?e=x2ObCb) to reinterpret link results. 

@tt-aho / @nhuang-tt I think both of you are  looking at similar areas - as a follow up we could maybe remove some of the addresses that are taken from these struct like:
```
    static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC;
    static constexpr std::uint32_t RETRAIN_FORCE_ADDR = 0x1EFC;

    static constexpr std::uint32_t CRC_ERR_ADDR = 0x1F7C;

    // The following access 64-bit values, low bits located at +4 Byte offset
    static constexpr std::uint32_t CORR_CW_HI_ADDR = 0x1F90;
    static constexpr std::uint32_t UNCORR_CW_HI_ADDR = 0x1F98;
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17223159732) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17223162781) CI with demo tests passes (if applicable)