### PR TITLE
Upsample: Align CB based on input/output buffer's alignment.

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -196,7 +196,8 @@ def upsample_multicore_common(
                     break
                 nshards_w -= 1
             if nshards_w == 0 or nshards_h == 0:
-                raise ValueError("nshards_h or nshards_w is 0")
+                pytest.skip("nshards_h or nshards_w is 0")
+
             ncores = (nshards_h, nshards_w)
         shard_grid = get_shard_grid_from_num_cores(device, ncores)
 
@@ -264,6 +265,7 @@ def upsample_multicore_common(
         [1, 32, 5, 4],
         [1, 64, 128, 17],
         [1, 64, 132, 19],
+        [1, 8, 28, 28],
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
@@ -249,7 +249,7 @@ operation::ProgramWithCallbacks upsample_multi_core_sharded(
 
     uint32_t next_cb_index = CBIndex::c_0;
     const uint32_t buffering_factor = 1;  // data is already fully buffered in the CBs since its sharded
-    const uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
+    const uint32_t aligned_input_stick_nbytes = tt::round_up(input_stick_nbytes, input.buffer()->alignment());
     const uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
     const uint32_t in_cb_npages = input_nsticks_per_core * buffering_factor;
 
@@ -257,7 +257,8 @@ operation::ProgramWithCallbacks upsample_multi_core_sharded(
         next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, input.buffer());
 
     // output sharded CB with upsampled data
-    uint32_t out_cb_pagesize = round_up_to_mul32(output_stick_nbytes);  // aligned output stick n bytes
+    uint32_t out_cb_pagesize =
+        tt::round_up(output_stick_nbytes, output.buffer()->alignment());  // aligned output stick n bytes
     uint32_t out_cb_npages = output_nsticks_per_core * buffering_factor;
 
     auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27067

### Problem description
Currently input/output CBs are aligned to 32 multiple which can cause issue in case of channels are not

### What's changed
Align CBs based on buffer's alignment requirement.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/17065900183)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/17065903016)
- [ ] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/17065917748)
- [ ] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/17066126346)