### PR TITLE
#0: Move just a small handful of N300 jobs on APC to CIv2, and let these soak for a bit

### DIFF
--- a/.github/workflows/tt-cnn-post-commit.yaml
+++ b/.github/workflows/tt-cnn-post-commit.yaml
@@ -1,4 +1,4 @@
-name: "[internal] tt-cnn uint tests impl"
+name: "[internal] tt-cnn unit tests impl"
 
 on:
   workflow_call:
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 10
       num-groups:
         required: false
         type: number
@@ -70,7 +70,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150, N300', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -33,7 +33,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'N150, N300, P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -33,7 +33,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'N150, N300, P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150, N300', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/ttnn-tutorials-post-commit.yaml
+++ b/.github/workflows/ttnn-tutorials-post-commit.yaml
@@ -59,7 +59,7 @@ jobs:
     name: TTNN tutorials ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'N150, P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/ttnn-tutorials-post-commit.yaml
+++ b/.github/workflows/ttnn-tutorials-post-commit.yaml
@@ -59,7 +59,7 @@ jobs:
     name: TTNN tutorials ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'N150, P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || contains('P150b, N150', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:


### PR DESCRIPTION
…

### Ticket

APC CIv2 move

### Problem description

N300 queues on CIv1 are trash...

### What's changed

We got 10% more runners in CIv2 today (thanks to yours truly aren't I great !!!!)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes  https://github.com/tenstorrent/tt-metal/actions/runs/17073774329
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17080088771
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes