### PR TITLE
Fix BH APC error 

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -447,7 +447,7 @@ def test_bh_trace_ag(
     output_shard_grid,
     tensor_mem_layout,
 ):
-    if (p150_mesh_device.shape[0] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+    if p150_mesh_device.shape[0] != num_devices:
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
     if p150_mesh_device.shape[0] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -451,6 +451,8 @@ def test_bh_trace_ag(
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
     if p150_mesh_device.shape[0] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")
+    if ttnn.get_num_devices() == 8:
+        pytest.skip("Test requires a torus but rackbox is a mesh")
     profiler = BenchmarkProfiler()
     run_all_gather_impl(
         p150_mesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -449,8 +449,6 @@ def test_bh_trace_ag(
 ):
     if p150_mesh_device.shape[0] != num_devices:
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
-    if p150_mesh_device.shape[0] < num_devices:
-        pytest.skip("Test requires more devices than are available on this platform")
     if ttnn.get_num_devices() == 8:
         pytest.skip("Test requires a torus but rackbox is a mesh")
     profiler = BenchmarkProfiler()

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -447,6 +447,10 @@ def test_bh_trace_ag(
     output_shard_grid,
     tensor_mem_layout,
 ):
+    if (p150_mesh_device.shape[0] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires the entire row or column so it loops around")
+    if p150_mesh_device.shape[0] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
     profiler = BenchmarkProfiler()
     run_all_gather_impl(
         p150_mesh_device,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
A test meant for multi devices was placed in a location that was also being auto run for single devices. This PR adds the appropriate payslips

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/17071741489
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes