### PR TITLE
Moving FlashMLA stress tests to l2 nightly

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -42,6 +42,10 @@ on:
         required: false
         type: boolean
         default: true
+      run_sdpa_stress_tests:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   ttnn-conv-tests:
@@ -284,5 +288,53 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U082L4RSULT # Denys Makoviichuk
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+  ttnn-sdpa-stress-tests:
+    if: ${{ inputs.run_sdpa_stress_tests }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        TT_METAL_HOME: /work
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        ENABLE_SDPA_STRESS_TESTS: 1
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: tt-sdpa-stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+      }}
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: tt-sdpa-stress tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run:
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U03FJB5TM5Y # Colman Glagovich
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -300,7 +300,6 @@ jobs:
         TT_METAL_HOME: /work
         ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO
-        ENABLE_SDPA_STRESS_TESTS: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -312,7 +311,7 @@ jobs:
     name: tt-sdpa-stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((contains('P150b, N150, N300', inputs.runner-label) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        (contains('P150b, N150, N300', inputs.runner-label) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     steps:

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -312,7 +312,7 @@ jobs:
     name: tt-sdpa-stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        ((contains('P150b, N150, N300', inputs.runner-label) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     steps:
@@ -324,7 +324,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: tt-sdpa-stress tests
         timeout-minutes: ${{ inputs.timeout }}
-        run:
+        run: pytest tests/nightly/single_card/sdpa
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -35,6 +35,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_sdpa_stress_tests:
+        description: 'Run TTNN nightly SDPA stress tests'
+        required: false
+        type: boolean
+        default: false
       timeout:
         description: 'Test timeout in minutes'
         required: false
@@ -78,6 +83,7 @@ jobs:
       run_pool_tests: ${{ github.event_name == 'schedule' || inputs.run_pool_tests }}
       run_sdxl_tests: ${{ github.event_name == 'schedule' || inputs.run_sdxl_tests }}
       run_train_tests: ${{ github.event_name == 'schedule' || inputs.run_train_tests }}
+      run_sdpa_stress_tests: ${{ github.event_name == 'schedule' || inputs.run_sdpa_stress_tests }}
   didt-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_didt_tests }}
     needs: build-artifact

--- a/tests/nightly/single_card/sdpa/test_flash_multi_latent_attention_decode_stress.py
+++ b/tests/nightly/single_card/sdpa/test_flash_multi_latent_attention_decode_stress.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import ttnn
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_flash_multi_latent_attention_decode import (
+    run_flash_mla_decode_impl,
+)
+
+
+@pytest.mark.parametrize(
+    "batch",
+    [
+        1,  # Single batch
+        # 2,  # Multiple batches # Removing to reduce CI load
+        8,  # Even larger batch size
+    ],
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    [
+        1 * 1024,  # Long sequence length
+    ],
+)
+@pytest.mark.parametrize(
+    "nh",
+    [
+        16,
+        32,
+        128,
+    ],
+)
+@pytest.mark.parametrize(
+    "nkv",
+    [
+        1,
+        # 8, # Removing to reduce CI load
+        16,
+    ],
+)
+@pytest.mark.parametrize(
+    "kv_lora_rank",
+    [
+        64,
+        512,
+    ],
+)
+@pytest.mark.parametrize(
+    "d_rope",
+    [
+        0,
+        32,
+        128,
+    ],
+)
+@pytest.mark.parametrize(
+    "q_num_cores",
+    [
+        0,  # No sharding
+        8,  # Shard across 8 cores
+        64,  # Shard across all cores
+    ],
+)
+@pytest.mark.parametrize(
+    "q_dtype, dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_paged_attention",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "block_size",
+    [
+        32,
+        128,
+    ],
+)
+def test_flash_mla_decode_stress(
+    device,
+    batch,
+    seq_len,
+    nh,
+    nkv,
+    kv_lora_rank,
+    d_rope,
+    q_num_cores,
+    q_dtype,
+    dtype,
+    use_paged_attention,
+    block_size,
+    function_level_defaults,
+    reset_seeds,
+):
+    # If GQA (nkv > 1), then only batch shard
+    # If nkv == 1, then batch * nh shard, unless q_num_cores is 0 (ie, in DRAM)
+    num_sharding_cores = batch if nkv > 1 else max(batch, q_num_cores)
+    if nh * (kv_lora_rank + d_rope) * nkv / num_sharding_cores >= 8 * 1024:  # found experimentally
+        pytest.skip(
+            f"Skipping test with large values, due to memory constraints. Got {nh=}, {kv_lora_rank=}, {nkv=}, {batch=}, {q_num_cores=}, {d_rope=}"
+        )
+
+    if batch * nh < ttnn.TILE_SIZE and q_num_cores > 0:
+        pytest.skip("Skipping test with small batch and nh with q_num_cores > 0.")
+
+    effective_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    if nkv > 1 and nkv % (effective_num_cores / batch) != 0:
+        pytest.skip(
+            f"Skipping test with nkv {nkv} not divisible by effective_num_cores {effective_num_cores} / batch {batch}."
+        )
+
+    run_flash_mla_decode_impl(
+        device,
+        batch,
+        seq_len,
+        nh,
+        nkv,
+        kv_lora_rank,
+        d_rope,
+        q_num_cores,
+        q_dtype,
+        dtype,
+        use_paged_attention,
+        block_size,
+    )

--- a/tests/nightly/single_card/sdpa/test_flash_multi_latent_attention_prefill_stress.py
+++ b/tests/nightly/single_card/sdpa/test_flash_multi_latent_attention_prefill_stress.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import ttnn
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_flash_multi_latent_attention_prefill import (
+    run_flash_mla_prefill_impl,
+)
+
+
+@pytest.mark.parametrize(
+    "batch",
+    [
+        1,  # Single batch
+        # 2,  # Multiple batches # Removing to reduce CI load
+        8,  # Even larger batch size
+    ],
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    [
+        1 * 1024,  # Long sequence length
+    ],
+)
+@pytest.mark.parametrize(
+    "nh",
+    [
+        16,
+        32,
+        128,
+    ],
+)
+@pytest.mark.parametrize(
+    "nkv",
+    [
+        1,
+        # 8, # Removing to reduce CI load
+        16,
+    ],
+)
+@pytest.mark.parametrize(
+    "kv_lora_rank",
+    [
+        64,
+        512,
+    ],
+)
+@pytest.mark.parametrize(
+    "d_rope",
+    [
+        0,
+        32,
+        128,
+    ],
+)
+@pytest.mark.parametrize(
+    "q_dtype, dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_paged_attention",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "block_size",
+    [
+        32,
+        128,
+    ],
+)
+def test_flash_mla_prefill_stress(
+    device,
+    batch,
+    seq_len,
+    nh,
+    nkv,
+    kv_lora_rank,
+    d_rope,
+    q_dtype,
+    dtype,
+    use_paged_attention,
+    block_size,
+    function_level_defaults,
+    reset_seeds,
+):
+    run_flash_mla_prefill_impl(
+        device,
+        batch,
+        seq_len,
+        nh,
+        nkv,
+        kv_lora_rank,
+        d_rope,
+        q_dtype,
+        dtype,
+        use_paged_attention,
+        block_size,
+    )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -20,8 +20,6 @@ from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
 )
 
-ENABLE_SDPA_STRESS_TESTS = os.getenv("ENABLE_SDPA_STRESS_TESTS", "0") == "1"
-
 
 def scaled_dot_product_attention_reference(Q, K, V, start_indices, padded_layer_len, scale, is_causal=True):
     b, nh, _, _ = Q.shape  # b, nh, 1, d
@@ -397,7 +395,6 @@ def run_flash_mla_decode_impl(
     assert num_program_cache_entries == 2, f"Expected 2 program cache entries, got {num_program_cache_entries}."
 
 
-@pytest.mark.skip_if(ENABLE_SDPA_STRESS_TESTS, reason="Only running stress tests")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope, number of cores to shard q on
@@ -451,129 +448,6 @@ def test_flash_mla_decode(
     function_level_defaults,
     reset_seeds,
 ):
-    run_flash_mla_decode_impl(
-        device,
-        batch,
-        seq_len,
-        nh,
-        nkv,
-        kv_lora_rank,
-        d_rope,
-        q_num_cores,
-        q_dtype,
-        dtype,
-        use_paged_attention,
-        block_size,
-    )
-
-
-@pytest.mark.skipif(not ENABLE_SDPA_STRESS_TESTS, reason="Stress tests are disabled by default.")
-@pytest.mark.parametrize(
-    "batch",
-    [
-        1,  # Single batch
-        # 2,  # Multiple batches # Removing to reduce CI load
-        8,  # Even larger batch size
-    ],
-)
-@pytest.mark.parametrize(
-    "seq_len",
-    [
-        1 * 1024,  # Long sequence length
-    ],
-)
-@pytest.mark.parametrize(
-    "nh",
-    [
-        16,
-        32,
-        128,
-    ],
-)
-@pytest.mark.parametrize(
-    "nkv",
-    [
-        1,
-        # 8, # Removing to reduce CI load
-        16,
-    ],
-)
-@pytest.mark.parametrize(
-    "kv_lora_rank",
-    [
-        64,
-        512,
-    ],
-)
-@pytest.mark.parametrize(
-    "d_rope",
-    [
-        0,
-        32,
-        128,
-    ],
-)
-@pytest.mark.parametrize(
-    "q_num_cores",
-    [
-        0,  # No sharding
-        8,  # Shard across 8 cores
-        64,  # Shard across all cores
-    ],
-)
-@pytest.mark.parametrize(
-    "q_dtype, dtype",
-    [
-        (ttnn.bfloat16, ttnn.bfloat8_b),
-    ],
-)
-@pytest.mark.parametrize(
-    "use_paged_attention",
-    [
-        False,
-        True,
-    ],
-)
-@pytest.mark.parametrize(
-    "block_size",
-    [
-        32,
-        128,
-    ],
-)
-def test_flash_mla_decode_stress(
-    device,
-    batch,
-    seq_len,
-    nh,
-    nkv,
-    kv_lora_rank,
-    d_rope,
-    q_num_cores,
-    q_dtype,
-    dtype,
-    use_paged_attention,
-    block_size,
-    function_level_defaults,
-    reset_seeds,
-):
-    # If GQA (nkv > 1), then only batch shard
-    # If nkv == 1, then batch * nh shard, unless q_num_cores is 0 (ie, in DRAM)
-    num_sharding_cores = batch if nkv > 1 else max(batch, q_num_cores)
-    if nh * (kv_lora_rank + d_rope) * nkv / num_sharding_cores >= 8 * 1024:  # found experimentally
-        pytest.skip(
-            f"Skipping test with large values, due to memory constraints. Got {nh=}, {kv_lora_rank=}, {nkv=}, {batch=}, {q_num_cores=}, {d_rope=}"
-        )
-
-    if batch * nh < ttnn.TILE_SIZE and q_num_cores > 0:
-        pytest.skip("Skipping test with small batch and nh with q_num_cores > 0.")
-
-    effective_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
-    if nkv > 1 and nkv % (effective_num_cores / batch) != 0:
-        pytest.skip(
-            f"Skipping test with nkv {nkv} not divisible by effective_num_cores {effective_num_cores} / batch {batch}."
-        )
-
     run_flash_mla_decode_impl(
         device,
         batch,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -397,7 +397,7 @@ def run_flash_mla_decode_impl(
     assert num_program_cache_entries == 2, f"Expected 2 program cache entries, got {num_program_cache_entries}."
 
 
-@pytest.mark.skip_if(not ENABLE_SDPA_STRESS_TESTS, reason="Only running stress tests")
+@pytest.mark.skip_if(ENABLE_SDPA_STRESS_TESTS, reason="Only running stress tests")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope, number of cores to shard q on
@@ -467,7 +467,7 @@ def test_flash_mla_decode(
     )
 
 
-@pytest.mark.skip_if(ENABLE_SDPA_STRESS_TESTS, reason="Stress tests are disabled by default.")
+@pytest.mark.skipif(not ENABLE_SDPA_STRESS_TESTS, reason="Stress tests are disabled by default.")
 @pytest.mark.parametrize(
     "batch",
     [

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_prefill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_prefill.py
@@ -217,7 +217,7 @@ def run_flash_mla_prefill_impl(
     assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
 
 
-@pytest.mark.skip_if(not ENABLE_SDPA_STRESS_TESTS, reason="Only running stress tests")
+@pytest.mark.skipif(ENABLE_SDPA_STRESS_TESTS, reason="Only running stress tests")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope
@@ -280,7 +280,7 @@ def test_flash_mla_prefill(
     )
 
 
-@pytest.mark.skip_if(ENABLE_SDPA_STRESS_TESTS, reason="Stress tests are disabled by default.")
+@pytest.mark.skipif(not ENABLE_SDPA_STRESS_TESTS, reason="Stress tests are disabled by default.")
 @pytest.mark.parametrize(
     "batch",
     [

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_prefill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_prefill.py
@@ -23,6 +23,8 @@ from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
 )
 
+ENABLE_SDPA_STRESS_TESTS = os.getenv("ENABLE_SDPA_STRESS_TESTS", "0") == "1"
+
 
 def nearest_n(x, n):
     return ((x + n - 1) // n) * n
@@ -215,6 +217,7 @@ def run_flash_mla_prefill_impl(
     assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
 
 
+@pytest.mark.skip_if(not ENABLE_SDPA_STRESS_TESTS, reason="Only running stress tests")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope
@@ -230,8 +233,6 @@ def run_flash_mla_prefill_impl(
     "q_dtype, dtype",
     [
         (ttnn.bfloat16, ttnn.bfloat8_b),
-        (ttnn.bfloat8_b, ttnn.bfloat8_b),
-        (ttnn.bfloat16, ttnn.bfloat4_b),
         (ttnn.bfloat8_b, ttnn.bfloat4_b),
     ],
 )
@@ -279,6 +280,7 @@ def test_flash_mla_prefill(
     )
 
 
+@pytest.mark.skip_if(ENABLE_SDPA_STRESS_TESTS, reason="Stress tests are disabled by default.")
 @pytest.mark.parametrize(
     "batch",
     [


### PR DESCRIPTION
### Problem description
FlashMLA stress tests are long tests, but are currently in APC.

### What's changed
- Create new job in l2 nightly for SDPA stress tests
- Reduce FlashMLA decode APC test size


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17080612453) CI passes
- [x] [TTNN L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/17080732727)