### PR TITLE
Didt test hang N300

### DIFF
--- a/.github/workflows/didt-tests.yaml
+++ b/.github/workflows/didt-tests.yaml
@@ -57,9 +57,9 @@ jobs:
           pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
           pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
           pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -101,7 +101,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      timeout: 20
+      timeout: 30
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -101,7 +101,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      timeout: 30
+      timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
Failing test:
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/actions/runs/17032526819)

### Problem description
N300 version of test runs on all chips (2), and is more sensitive to Didt. Test is failing due to hang causing timeout.

### What's changed
The sdxl tests should be called with TT_MM_THROTTLE_PERF=5 since that was the lowest level of throttle found to help by the customer team, and that is the level they use to run the model.

### Checklist
- [x] Passing L2 Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17103477421/