### PR TITLE
Pump efficientnetb0 perf threshold

### DIFF
--- a/models/experimental/efficientnetb0/tests/perf/test_perf.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_perf.py
@@ -15,7 +15,7 @@ from models.utility_functions import (
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 84],
+        [1, 86],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### What's changed
Pumping the device kernel runtime threshold from 84 to 86

### Checklist
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)