### PR TITLE
#26846: testing sub_core_grid for where device op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -605,3 +605,69 @@ def test_addcdiv_edgcase_fp32(device):
     # golden_tensor tensor([ 0.5000,    -inf,     inf,     nan, -1.5000,  0.0000])
 
     assert torch_equal_nan(output_tensor1, golden_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            (torch.Size([1, 2, 32, 960])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 7, 32, 96])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 8, 32, 128])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 17, 32, 32])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_where_subcore_grid(device, shape, sub_core_grid, dtype):
+    torch.manual_seed(0)
+    tor_dtype = dtype
+
+    ttnn_dtype = ttnn.bfloat16
+    if dtype == torch.float32:
+        ttnn_dtype = ttnn.float32
+
+    C = torch.arange(shape[0] * shape[1] * shape[2] * shape[3], dtype=tor_dtype)
+    C = (C % 2).float()  # Alternates 0, 1, 0, 1, ...
+    C = C.reshape(shape)
+    T = torch.randn(shape, dtype=tor_dtype)
+    F = torch.rand(shape, dtype=tor_dtype) * 10.0
+    golden = torch.where(C != 0, T, F)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_T = ttnn.from_torch(T, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_F = ttnn.from_torch(F, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.where(ttnn_C, ttnn_T, ttnn_F, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(ttnn_result)
+
+    print("result", result)
+    print("golden", golden)
+
+    assert torch.equal(result, golden)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         where/where.cpp
         where/device/where_device_operation.cpp
         where/device/where_program_factory.cpp
+        where/device/where_subgrid_program_factory.cpp
         where/device/where_utils.cpp
 )
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
@@ -144,8 +144,9 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
                const std::variant<float, Tensor>& false_value,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<Tensor> output_tensor,
+               const std::optional<CoreRangeSet>& sub_core_grids,
                QueueId queue_id) {
-                return self(queue_id, predicate, true_value, false_value, memory_config, output_tensor);
+                return self(queue_id, predicate, true_value, false_value, memory_config, output_tensor, sub_core_grids);
             },
             py::arg("predicate"),
             py::arg("true_value"),
@@ -153,6 +154,7 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/where_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/where_device_operation.cpp
@@ -14,6 +14,10 @@ DataType WhereDeviceOperation::operation_attributes_t::get_dtype() const { retur
 WhereDeviceOperation::program_factory_t WhereDeviceOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     TT_FATAL(!tensor_args.predicate.is_sharded(), "WhereDeviceOperation is not implemented for sharded tensors");
+    if (args.sub_core_grids.has_value()) {
+        log_info(tt::LogOp, " ****** WhereSubgridProgramFactory");
+        return WhereSubgridProgramFactory{};
+    }
     return WhereProgramFactory{};
 }
 
@@ -208,13 +212,15 @@ WhereDeviceOperation::invoke(
     const Tensor& value_false,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     operation_attributes_t attributes{
         .where_variant = WhereVariant::TTT,
         .memory_config = memory_config.value_or(predicate.memory_config()),
         .input_dtype = predicate.dtype(),
         .dtype = output_dtype.value_or(value_true.dtype()),
         .compute_kernel_config = std::nullopt,
+        .sub_core_grids = sub_core_grids,
     };
 
     tensor_args_t args{
@@ -233,13 +239,15 @@ WhereDeviceOperation::invoke(
     float value_false_scalar,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     operation_attributes_t attributes{
         .where_variant = WhereVariant::TTS,
         .memory_config = memory_config.value_or(predicate.memory_config()),
         .input_dtype = predicate.dtype(),
         .dtype = output_dtype.value_or(value_true.dtype()),
         .compute_kernel_config = std::nullopt,
+        .sub_core_grids = sub_core_grids,
         .value_false_scalar = value_false_scalar,
     };
 
@@ -259,13 +267,15 @@ WhereDeviceOperation::invoke(
     const Tensor& value_false,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     operation_attributes_t attributes{
         .where_variant = WhereVariant::TST,
         .memory_config = memory_config.value_or(predicate.memory_config()),
         .input_dtype = predicate.dtype(),
         .dtype = output_dtype.value_or(value_false.dtype()),
         .compute_kernel_config = std::nullopt,
+        .sub_core_grids = sub_core_grids,
         .value_true_scalar = value_true_scalar,
     };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/where_subgrid_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/where_subgrid_program_factory.cpp
@@ -1,0 +1,464 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "where_device_operation.hpp"
+#include "where_utils.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/cb_utils.hpp"
+#include <cmath>
+
+namespace ttnn::operations::ternary {
+WhereDeviceOperation::WhereSubgridProgramFactory::cached_program_t
+WhereDeviceOperation::WhereSubgridProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& [predicate_tensor, value_true_tensor, value_false_tensor, optional_output_tensor] = tensor_args;
+
+    WhereVariant variant = operation_attributes.where_variant;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    TT_FATAL(sub_core_grids.has_value(), "sub_core_grids cannot be null");
+
+    // Use WhereKernelConfig to get the appropriate kernel names
+    WhereKernelConfig kernel_config(variant);
+
+    auto program = CreateProgram();
+
+    auto* device = predicate_tensor.device();
+
+    auto predicate_data_format = datatype_to_dataformat_converter(predicate_tensor.dtype());
+    // (predicate_tensor.dtype() == DataType::BFLOAT16) ? DataType::UINT16 : predicate_tensor.dtype());
+
+    // Handle data formats based on variant and tensor availability
+    DataFormat value_true_data_format, value_false_data_format;
+    if (variant == WhereVariant::TTS) {
+        // TTS: only value_true tensor exists
+        value_true_data_format = datatype_to_dataformat_converter(value_true_tensor.value().dtype());
+
+        // the bfloat16 impl of where_llk uses UINT16 instr set.
+        // If the bfloat16 inputs' CBs are set to UINT16 dataformat this will enable us to get 'NaN' for bfloat16 dtype
+        // We need to test the impact of this on the composite ops that use where op and on the models, since bfloat16
+        // packs nan as inf in all other ops.
+
+        // (value_true_tensor.value().dtype() == DataType::BFLOAT16) ? DataType::UINT16
+        //                                                           : value_true_tensor.value().dtype());
+
+        // Use predicate format as fallback for value_false
+        value_false_data_format = predicate_data_format;
+    } else if (variant == WhereVariant::TST) {
+        // TST: only value_false tensor exists
+        value_false_data_format = datatype_to_dataformat_converter(value_false_tensor.value().dtype());
+        // (value_false_tensor.value().dtype() == DataType::BFLOAT16) ? DataType::UINT16
+        //                                                            : value_false_tensor.value().dtype());
+        // Use predicate format as fallback for value_true
+        value_true_data_format = predicate_data_format;
+    } else {
+        // TTT: both tensors exist
+        value_true_data_format = datatype_to_dataformat_converter(value_true_tensor.value().dtype());
+        // (value_true_tensor.value().dtype() == DataType::BFLOAT16) ? DataType::UINT16
+        //                                                           : value_true_tensor.value().dtype());
+        value_false_data_format = datatype_to_dataformat_converter(value_false_tensor.value().dtype());
+        // (value_false_tensor.value().dtype() == DataType::BFLOAT16) ? DataType::UINT16
+        //                                                            : value_false_tensor.value().dtype());
+    }
+
+    auto output_data_format = datatype_to_dataformat_converter(output.dtype());
+    // datatype_to_dataformat_converter((output.dtype() == DataType::BFLOAT16) ? DataType::UINT16 : output.dtype());
+
+    uint32_t predicate_single_tile_size = tt_metal::detail::TileSize(predicate_data_format);
+    uint32_t value_true_single_tile_size = tt_metal::detail::TileSize(value_true_data_format);
+    uint32_t value_false_single_tile_size = tt_metal::detail::TileSize(value_false_data_format);
+    uint32_t output_single_tile_size = tt_metal::detail::TileSize(output_data_format);
+
+    uint32_t num_output_tiles = output.physical_volume() / output.tensor_spec().tile().get_tile_hw();
+    uint32_t num_cores = sub_core_grids->num_cores();
+
+    TT_FATAL(num_cores != 0, "number of cores cannot be 0");
+
+    for (uint32_t core_id = num_cores; core_id >= 1; core_id--) {
+        if (num_output_tiles % core_id == 0) {
+            break;
+        } else {
+            num_cores--;
+        }
+    }
+
+    TT_FATAL(
+        (num_output_tiles % (num_cores) == 0),
+        "{} num of tiles are not split uniformly across {} num of cores",
+        num_output_tiles,
+        num_cores);
+    auto cores = corerange_to_cores(sub_core_grids.value(), num_cores, true);
+    auto all_cores = num_cores_to_corerangeset_in_subcoregrids(cores[0], num_cores, sub_core_grids.value(), true);
+    if (num_cores == 1) {
+        all_cores = ttnn::CoreRangeSet(ttnn::CoreRange(cores[0]));
+    }
+
+    uint32_t ntiles_per_block = num_output_tiles / num_cores;
+    uint32_t nblocks = (num_output_tiles / ntiles_per_block);
+    uint32_t nblocks_per_core = nblocks / num_cores;
+
+    std::vector<CoreCoord> cores_with_rtargs;
+
+    // // we parallelize the computation across the output tiles
+    // constexpr bool row_major = true;
+    // auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    // uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    // uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    // auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    // Number of tiles to store per input CB (double buffer)
+    uint32_t num_tiles_per_cb = ntiles_per_block * 2;
+
+    // Input buffers - Create predicate CB (always c_0)
+    auto [predicate_tensor_cb, predicate_tensor_cb_handle] = create_cb(
+        tt::CBIndex::c_0,
+        program,
+        all_cores,
+        predicate_single_tile_size,
+        num_tiles_per_cb,
+        predicate_data_format);  // predicate_tensor
+
+    // Create c_1 based on variant - this is the primary tensor CB
+    uint32_t value_true_tensor_cb = 0;
+    tt::tt_metal::CBHandle value_true_tensor_cb_handle;
+    uint32_t value_false_tensor_cb = 0;
+    tt::tt_metal::CBHandle value_false_tensor_cb_handle;
+
+    if (variant == WhereVariant::TTS) {
+        // TTS: c_1 = value_true tensor (value_false is scalar)
+        auto [cb, cb_handle] = create_cb(
+            tt::CBIndex::c_1,
+            program,
+            all_cores,
+            value_true_single_tile_size,
+            num_tiles_per_cb,
+            value_true_data_format);
+        value_true_tensor_cb = cb;
+        value_true_tensor_cb_handle = cb_handle;
+    } else if (variant == WhereVariant::TST) {
+        // TST: c_1 = value_false tensor (value_true is scalar)
+        auto [cb, cb_handle] = create_cb(
+            tt::CBIndex::c_1,
+            program,
+            all_cores,
+            value_false_single_tile_size,
+            num_tiles_per_cb,
+            value_false_data_format);
+        value_false_tensor_cb = cb;
+        value_false_tensor_cb_handle = cb_handle;
+    } else {
+        // TTT: c_1 = value_true tensor, c_2 = value_false tensor
+        auto [cb1, cb1_handle] = create_cb(
+            tt::CBIndex::c_1,
+            program,
+            all_cores,
+            value_true_single_tile_size,
+            num_tiles_per_cb,
+            value_true_data_format);
+        value_true_tensor_cb = cb1;
+        value_true_tensor_cb_handle = cb1_handle;
+
+        auto [cb2, cb2_handle] = create_cb(
+            tt::CBIndex::c_2,
+            program,
+            all_cores,
+            value_false_single_tile_size,
+            num_tiles_per_cb,
+            value_false_data_format);
+        value_false_tensor_cb = cb2;
+        value_false_tensor_cb_handle = cb2_handle;
+    }
+
+    // Output buffer
+    auto [output_tensor_cb, output_tensor_cb_handle] = create_cb(
+        tt::CBIndex::c_3,
+        program,
+        all_cores,
+        output_single_tile_size,
+        num_tiles_per_cb,
+        output_data_format);  // output
+
+    // READER KERNEL - Use kernel path from utils
+    tt_metal::ReaderDataMovementConfig reader_config;
+    if (variant == WhereVariant::TTS) {
+        // TTS: c_0 = predicate, c_1 = value_true tensor
+        std::vector<uint32_t> reader_compile_time_args = {
+            (std::uint32_t)predicate_tensor_cb, (std::uint32_t)value_true_tensor_cb};
+        TensorAccessorArgs(*predicate_tensor.buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(*value_true_tensor.value().buffer()).append_to(reader_compile_time_args);
+        reader_config = tt_metal::ReaderDataMovementConfig(reader_compile_time_args);
+
+    } else if (variant == WhereVariant::TST) {
+        // TST: c_0 = predicate, c_1 = value_false tensor
+        std::vector<uint32_t> reader_compile_time_args = {
+            (std::uint32_t)predicate_tensor_cb, (std::uint32_t)value_false_tensor_cb};
+        TensorAccessorArgs(*predicate_tensor.buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(*value_false_tensor.value().buffer()).append_to(reader_compile_time_args);
+        reader_config = tt_metal::ReaderDataMovementConfig(reader_compile_time_args);
+
+    } else {
+        // TTT: c_0 = predicate, c_1 = value_true, c_2 = value_false
+        std::vector<uint32_t> reader_compile_time_args = {
+            (std::uint32_t)predicate_tensor_cb,
+            (std::uint32_t)value_true_tensor_cb,
+            (std::uint32_t)value_false_tensor_cb};
+        TensorAccessorArgs(*predicate_tensor.buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(*value_true_tensor.value().buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(*value_false_tensor.value().buffer()).append_to(reader_compile_time_args);
+        reader_config = tt_metal::ReaderDataMovementConfig(reader_compile_time_args);
+    }
+
+    auto reader_kernel_id =
+        tt_metal::CreateKernel(program, get_kernel_file_path(kernel_config.reader_kernel), all_cores, reader_config);
+
+    // WRITER KERNEL - Use kernel path from utils
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_tensor_cb};
+    tt_metal::TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(kernel_config.writer_kernel),
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    // COMPUTE KERNEL - Use kernel path from utils
+    bool fp32_dest_acc_en = output_data_format == tt::DataFormat::UInt32 ||
+                            output_data_format == tt::DataFormat::Int32 ||
+                            output_data_format == tt::DataFormat::Float32;
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    // c_0 is always predicate
+    unpack_to_dest_mode[tt::CBIndex::c_0] = (predicate_tensor.dtype() == DataType::FLOAT32)
+                                                ? UnpackToDestMode::UnpackToDestFp32
+                                                : UnpackToDestMode::Default;
+
+    // c_1 assignment depends on variant
+    if (variant == WhereVariant::TTS) {
+        // TTS: c_1 = value_true tensor
+        unpack_to_dest_mode[tt::CBIndex::c_1] = (value_true_tensor.value().dtype() == DataType::FLOAT32)
+                                                    ? UnpackToDestMode::UnpackToDestFp32
+                                                    : UnpackToDestMode::Default;
+    } else if (variant == WhereVariant::TST) {
+        // TST: c_1 = value_false tensor
+        unpack_to_dest_mode[tt::CBIndex::c_1] = (value_false_tensor.value().dtype() == DataType::FLOAT32)
+                                                    ? UnpackToDestMode::UnpackToDestFp32
+                                                    : UnpackToDestMode::Default;
+    } else {
+        // TTT: c_1 = value_true tensor, c_2 = value_false tensor
+        unpack_to_dest_mode[tt::CBIndex::c_1] = (value_true_tensor.value().dtype() == DataType::FLOAT32)
+                                                    ? UnpackToDestMode::UnpackToDestFp32
+                                                    : UnpackToDestMode::Default;
+        unpack_to_dest_mode[tt::CBIndex::c_2] = (value_false_tensor.value().dtype() == DataType::FLOAT32)
+                                                    ? UnpackToDestMode::UnpackToDestFp32
+                                                    : UnpackToDestMode::Default;
+    }
+
+    // c_3 is always output
+    unpack_to_dest_mode[tt::CBIndex::c_3] =
+        (output.dtype() == DataType::FLOAT32) ? UnpackToDestMode::UnpackToDestFp32 : UnpackToDestMode::Default;
+
+    constexpr uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
+
+    // All variants use the same compile args now
+    std::vector<uint32_t> compute_kernel_args;
+    if (variant == WhereVariant::TTS) {
+        // auto bit_cast_scalar = pack_scalar_runtime_arg(operation_attributes.value_false_scalar.value(),
+        // output.dtype());
+        compute_kernel_args = {(uint32_t)num_tiles_per_cycle};
+    } else if (variant == WhereVariant::TST) {
+        // auto bit_cast_scalar = pack_scalar_runtime_arg(operation_attributes.value_true_scalar.value(),
+        // output.dtype());
+        compute_kernel_args = {(uint32_t)num_tiles_per_cycle};
+    } else {
+        compute_kernel_args = {(uint32_t)num_tiles_per_cycle};
+    }
+
+    std::map<std::string, std::string> kernel_defines;
+    kernel_defines["WHERE_LLK"] = "where_tile";
+    kernel_defines["FILL_LLK"] = "fill_tile";
+    if (predicate_tensor.dtype() == DataType::FLOAT32) {
+        kernel_defines["WHERE_LLK"] = "where_fp32_tile";
+    }
+    if (predicate_tensor.dtype() == DataType::INT32) {
+        kernel_defines["WHERE_LLK"] = "where_int32_tile";
+        kernel_defines["FILL_LLK"] = "fill_tile_int";
+        kernel_defines["FILL_WITH_VALUE_INT"] = "1";
+    } else {
+        kernel_defines["FILL_WITH_VALUE_FLOAT"] = "1";
+    }
+
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(kernel_config.compute_kernel),
+        all_cores,
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .compile_args = compute_kernel_args,
+            .defines = kernel_defines});
+
+    // auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+    //     tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    // };
+
+    // CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+    //     program,
+    //     reader_kernel_id,
+    //     writer_kernel_id,
+    //     compute_kernel_id,
+    //     compute_with_storage_grid_size,
+    //     operation_attributes,
+    //     tensor_args,
+    //     output,
+    //     set_runtime_args);
+
+    constexpr size_t num_writer_args = 3;
+    constexpr size_t num_kernel_args = 1;
+    constexpr size_t num_reader_args = 5;
+    uint32_t dummy_arg = 0;
+
+    uint32_t start_tile_id = 0;
+    auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
+
+    for (uint32_t i = 0; i < cores.size(); i++) {
+        CoreCoord core = cores[i];
+
+        // tt::tt_metal::SetRuntimeArgs(
+        //     program, typecast_reader_kernel_id, core, {src_buffer->address(), ntiles_per_core, tile_start_id});
+
+        // tt::tt_metal::SetRuntimeArgs(
+        //     program, typecast_writer_kernel_id, core, {dst_buffer->address(), ntiles_per_core, tile_start_id});
+
+        // Set reader runtime arguments based on variant
+        if (variant == WhereVariant::TTS) {
+            // TTS: predicate (arg 0) + value_true tensor (arg 1)
+            std::array reader_runtime_args = {
+                predicate_tensor.buffer()->address(),
+                value_true_tensor.value().buffer()->address(),
+                dummy_arg,
+                ntiles_per_core,
+                start_tile_id,
+            };
+            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        } else if (variant == WhereVariant::TST) {
+            // TST: predicate (arg 0) + value_false tensor (arg 1, maps to c_1)
+            std::array reader_runtime_args = {
+                predicate_tensor.buffer()->address(),
+                value_false_tensor.value().buffer()->address(),
+                dummy_arg,
+                ntiles_per_core,
+                start_tile_id,
+            };
+            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        } else {
+            // TTT: predicate (arg 0) + value_true (arg 1) + value_false (arg 2)
+            std::array reader_runtime_args = {
+                predicate_tensor.buffer()->address(),
+                value_true_tensor.value().buffer()->address(),
+                value_false_tensor.value().buffer()->address(),
+                ntiles_per_core,
+                start_tile_id,
+            };
+            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        }
+
+        std::array writer_runtime_args = {
+            output.buffer()->address(),
+            ntiles_per_core,
+            start_tile_id,
+        };
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+
+        // All variants use same compute runtime args now
+        if (variant == WhereVariant::TTS) {
+            auto bit_cast_scalar =
+                pack_scalar_runtime_arg(operation_attributes.value_false_scalar.value(), output.dtype());
+            std::array compute_runtime_args = {ntiles_per_core, bit_cast_scalar};
+            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        } else if (variant == WhereVariant::TST) {
+            auto bit_cast_scalar =
+                pack_scalar_runtime_arg(operation_attributes.value_true_scalar.value(), output.dtype());
+            std::array compute_runtime_args = {ntiles_per_core, bit_cast_scalar};
+            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        } else {
+            std::array compute_runtime_args = {ntiles_per_core};
+            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        }
+
+        cores_with_rtargs.push_back(core);
+        start_tile_id += ntiles_per_core;
+    }
+
+    return cached_program_t{
+        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, cores_with_rtargs}};
+}
+
+void WhereDeviceOperation::WhereSubgridProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    // auto update_args =
+    //     [](tt::tt_metal::Program& program, tt::tt_metal::KernelHandle kernel_id, CoreCoord core, auto&& args) {
+    //         auto& all_args = GetRuntimeArgs(program, kernel_id);
+    //         auto& core_args = all_args.at(core.x).at(core.y);
+    //         std::copy(args.begin(), args.end(), core_args.data());
+    //     };
+
+    const auto& [predicate_tensor, value_true_tensor, value_false_tensor, optional_output_tensor] = tensor_args;
+    auto& program = cached_program.program;
+    WhereVariant variant = operation_attributes.where_variant;
+    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+    auto& compute_kernel_id = cached_program.shared_variables.compute_kernel_id;
+    auto& cores_with_rtargs = cached_program.shared_variables.cores_with_rtargs;
+
+    // CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+    //     cached_program.program,
+    //     cached_program.shared_variables.reader_kernel_id,
+    //     cached_program.shared_variables.writer_kernel_id,
+    //     cached_program.shared_variables.compute_kernel_id,
+    //     cached_program.shared_variables.cores_with_rtargs,
+    //     operation_attributes,
+    //     tensor_args,
+    //     output,
+    //     update_args);
+
+    // reader
+    {
+        auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        for (const CoreCoord& core : cores_with_rtargs) {
+            auto& runtime_args = runtime_args_by_core[core.x][core.y];
+
+            if (variant == WhereVariant::TTS) {
+                runtime_args[0] = predicate_tensor.buffer()->address();
+                runtime_args[1] = value_true_tensor.value().buffer()->address();
+            } else if (variant == WhereVariant::TST) {
+                runtime_args[0] = predicate_tensor.buffer()->address();
+                runtime_args[1] = value_false_tensor.value().buffer()->address();
+            } else {
+                runtime_args[0] = predicate_tensor.buffer()->address();
+                runtime_args[1] = value_true_tensor.value().buffer()->address();
+                runtime_args[2] = value_false_tensor.value().buffer()->address();
+            }
+        }
+    }
+
+    // writer
+    {
+        auto& runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+        for (const CoreCoord& core : cores_with_rtargs) {
+            auto& runtime_args = runtime_args_by_core[core.x][core.y];
+            runtime_args[0] = output.buffer()->address();
+        }
+    }
+}
+
+}  // namespace ttnn::operations::ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
@@ -68,7 +68,8 @@ Tensor WhereOperation::invoke(
     const std::variant<float, Tensor>& value_true,
     const std::variant<float, Tensor>& value_false,
     const std::optional<MemoryConfig>& memory_config,
-    std::optional<Tensor> output) {
+    std::optional<Tensor> output,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     bool is_value_true_Tensor = std::holds_alternative<Tensor>(value_true);
     bool is_value_false_Tensor = std::holds_alternative<Tensor>(value_false);
 
@@ -97,7 +98,8 @@ Tensor WhereOperation::invoke(
                     t_false,
                     output_dtype,
                     memory_config.value_or(predicate.memory_config()),
-                    output);
+                    output,
+                    sub_core_grids);
             }
         } else if (is_value_true_Tensor && !is_value_false_Tensor) {
             // TTS case: tensor-tensor-scalar
@@ -114,7 +116,8 @@ Tensor WhereOperation::invoke(
                     scalar_false,
                     output_dtype,
                     memory_config.value_or(predicate.memory_config()),
-                    output);
+                    output,
+                    sub_core_grids);
             }
         } else if (!is_value_true_Tensor && is_value_false_Tensor) {
             // TST case: tensor-scalar-tensor
@@ -131,7 +134,8 @@ Tensor WhereOperation::invoke(
                     t_false,
                     output_dtype,
                     memory_config.value_or(predicate.memory_config()),
-                    output);
+                    output,
+                    sub_core_grids);
             }
         } else if (!is_value_true_Tensor && !is_value_false_Tensor && !has_shard_spec) {
             // TSS case: tensor-scalar-scalar

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.hpp
@@ -23,7 +23,8 @@ struct WhereOperation {
         const std::variant<float, Tensor>& value_true,
         const std::variant<float, Tensor>& value_false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt);
+        std::optional<Tensor> output_tensor = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace ternary


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes