### PR TITLE
Add fabric mux test into test infra

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
@@ -198,3 +198,73 @@ Tests:
 
     patterns:
       - type: one_to_all
+
+  - name: "FabricMuxLinearMulticast"
+    fabric_setup:
+      topology: Linear
+      fabric_tensix_config: Mux
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+
+    defaults:
+      ftype: mcast
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: all_to_all
+
+  - name: "FabricMuxFullRingMulticast"
+    sync: true
+    fabric_setup:
+      topology: Ring
+      fabric_tensix_config: Mux
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+
+    defaults:
+      ftype: mcast
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: full_ring
+
+  - name: "FabricMuxMeshMulticast"
+    fabric_setup:
+      topology: Mesh
+      fabric_tensix_config: Mux
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+
+    defaults:
+      ftype: mcast
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: all_to_all
+
+  - name: "FabricMuxMeshMulticastDynamic"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      fabric_tensix_config: Mux
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+
+    defaults:
+      ftype: mcast
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: all_to_all

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
@@ -66,7 +66,6 @@ Tests:
       - type: one_to_all
 
   - name: "FullRingMulticast"
-    sync: true
     fabric_setup:
       topology: Ring
 
@@ -217,7 +216,6 @@ Tests:
       - type: all_to_all
 
   - name: "FabricMuxFullRingMulticast"
-    sync: true
     fabric_setup:
       topology: Ring
       fabric_tensix_config: Mux

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -354,7 +354,6 @@ Tests:
       - type: all_to_all
 
   - name: "FabricMuxSimpleUnicastWriteLinear"
-    sync: true
     fabric_setup:
       topology: Linear
       fabric_tensix_config: Mux

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -368,3 +368,32 @@ Tests:
             num_packets: 100
             destination:
               device: [0, 1]
+
+  - name: "FabricMuxAllToAllUnicastMesh"
+    fabric_setup:
+      topology: Mesh
+      fabric_tensix_config: Mux
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: all_to_all
+
+  - name: "FabricMuxAllToAllUnicastMeshDynamic"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      fabric_tensix_config: Mux
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: all_to_all

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -352,3 +352,19 @@ Tests:
 
     patterns:
       - type: all_to_all
+
+  - name: "FabricMuxSimpleUnicastWriteLinear"
+    sync: true
+    fabric_setup:
+      topology: Linear
+      fabric_tensix_config: Mux
+
+    senders:
+      - device: [0, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 1024
+            num_packets: 100
+            destination:
+              device: [0, 1]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -127,7 +127,13 @@ int main(int argc, char** argv) {
 
         const auto& topology = test_config.fabric_setup.topology;
         const auto& routing_type = test_config.fabric_setup.routing_type.value();
-        log_info(tt::LogTest, "Opening devices with topology: {} and routing type: {}", topology, routing_type);
+        const auto& fabric_tensix_config = test_config.fabric_setup.fabric_tensix_config.value();
+        log_info(
+            tt::LogTest,
+            "Opening devices with topology: {}, routing type: {}, and fabric_tensix_config: {}",
+            topology,
+            routing_type,
+            fabric_tensix_config);
         test_context.open_devices(test_config.fabric_setup);
 
         log_info(tt::LogTest, "Building tests");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -101,6 +101,7 @@ public:
     void open_devices(const TestFabricSetup& fabric_setup) {
         const auto& topology = fabric_setup.topology;
         const auto& routing_type = fabric_setup.routing_type.value();
+        const auto& fabric_tensix_config = fabric_setup.fabric_tensix_config.value();
 
         FabricConfig new_fabric_config;
         if (topology == Topology::Torus) {
@@ -123,12 +124,12 @@ public:
             new_fabric_config = it->second;
         }
 
-        if (new_fabric_config != current_fabric_config_) {
+        if (new_fabric_config != current_fabric_config_ || fabric_tensix_config != current_fabric_tensix_config_) {
             if (are_devices_open_) {
                 log_info(tt::LogTest, "Closing devices and switching to new fabric config: {}", new_fabric_config);
                 close_devices();
             }
-            open_devices_internal(new_fabric_config);
+            open_devices_internal(new_fabric_config, fabric_tensix_config);
 
             topology_ = topology;
             routing_type_ = routing_type;
@@ -165,6 +166,7 @@ public:
         mesh_device_.reset();
         mesh_workload_.reset();
         current_fabric_config_ = tt::tt_fabric::FabricConfig::DISABLED;
+        current_fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
         are_devices_open_ = false;
     }
 
@@ -1255,6 +1257,7 @@ private:
     std::vector<FabricNodeId> local_available_node_ids_;
     std::vector<FabricNodeId> global_available_node_ids_;
     tt::tt_fabric::FabricConfig current_fabric_config_{FabricConfig::DISABLED};
+    tt_fabric::FabricTensixConfig current_fabric_tensix_config_;
     std::shared_ptr<MeshDevice> mesh_device_;
     std::shared_ptr<MeshWorkload> mesh_workload_;
     MeshId local_mesh_id_;
@@ -1295,9 +1298,11 @@ private:
         local_host_rank_ = tt::tt_metal::MetalContext::instance().get_control_plane().get_local_host_rank_id_binding();
     }
 
-    void open_devices_internal(tt::tt_fabric::FabricConfig fabric_config) {
+    void open_devices_internal(
+        tt::tt_fabric::FabricConfig fabric_config, tt_fabric::FabricTensixConfig fabric_tensix_config) {
         // Set fabric config FIRST, before any control plane access, this will reset control plane in metal context
-        tt::tt_fabric::SetFabricConfig(fabric_config);
+        tt::tt_fabric::SetFabricConfig(
+            fabric_config, FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, std::nullopt, fabric_tensix_config);
 
         // Now it's safe to initialize control plane (will use correct mesh graph descriptor)
         // first need to re-init contorl plane so that it checks out the latest fabric config.
@@ -1338,6 +1343,7 @@ private:
         TT_FATAL(mesh_device_ != nullptr, "Failed to create MeshDevice with shape {}", mesh_shape_);
 
         current_fabric_config_ = fabric_config;
+        current_fabric_tensix_config_ = fabric_tensix_config;
         are_devices_open_ = true;
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -1257,7 +1257,7 @@ private:
     std::vector<FabricNodeId> local_available_node_ids_;
     std::vector<FabricNodeId> global_available_node_ids_;
     tt::tt_fabric::FabricConfig current_fabric_config_{FabricConfig::DISABLED};
-    tt_fabric::FabricTensixConfig current_fabric_tensix_config_;
+    tt_fabric::FabricTensixConfig current_fabric_tensix_config_{tt_fabric::FabricTensixConfig::DISABLED};
     std::shared_ptr<MeshDevice> mesh_device_;
     std::shared_ptr<MeshWorkload> mesh_workload_;
     MeshId local_mesh_id_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -102,6 +102,7 @@ enum class HighLevelTrafficPattern {
 struct TestFabricSetup {
     tt::tt_fabric::Topology topology{0};
     std::optional<RoutingType> routing_type;
+    std::optional<tt_fabric::FabricTensixConfig> fabric_tensix_config;
     uint32_t num_links{};
     std::optional<std::string> torus_config;  // For Torus topology: "X", "Y", or "XY"
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -56,6 +56,7 @@ using ParsedTestConfig = tt::tt_fabric::fabric_tests::ParsedTestConfig;
 using Topology = tt::tt_fabric::Topology;
 using FabricConfig = tt::tt_fabric::FabricConfig;
 using RoutingType = tt::tt_fabric::fabric_tests::RoutingType;
+using FabricTensixConfig = tt::tt_fabric::FabricTensixConfig;
 
 // Bandwidth measurement result structures
 struct BandwidthResult {

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
@@ -12,17 +12,17 @@ galaxy:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 7]
+        end: [7, 8]
 
       storage_cores:
         []
 
       # First half for fabric mux, second half for dispatch
       fabric_mux_cores:
-        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+        [[0, -1], [1, -1], [2, -1], [3, -1]]
 
       dispatch_cores:
-        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+        [[4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -30,17 +30,17 @@ galaxy:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 7]
+        end: [7, 8]
 
       storage_cores:
         []
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
-        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+        [[0, -1], [1, -1], [2, -1], [3, -1]]
 
       dispatch_cores:
-        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+        [[4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -49,16 +49,16 @@ galaxy:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [5, 9]
+        end: [6, 9]
 
       storage_cores:
         []
 
       fabric_mux_cores:
-        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
@@ -66,16 +66,16 @@ galaxy:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [5, 9]
+        end: [6, 9]
 
       storage_cores:
         []
 
       fabric_mux_cores:
-        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
@@ -85,7 +85,7 @@ nebula_x1:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 6]
+        end: [7, 7]
 
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
@@ -95,10 +95,10 @@ nebula_x1:
         []
 
       fabric_mux_cores:
-        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+        [[0, -1], [1, -1], [2, -1]]
 
       dispatch_cores:
-        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+        [[3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       tg_dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
@@ -114,7 +114,7 @@ nebula_x1:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 6]
+        end: [7, 7]
 
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
@@ -124,10 +124,10 @@ nebula_x1:
         []
 
       fabric_mux_cores:
-        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+        [[0, -1], [1, -1], [2, -1]]
 
       dispatch_cores:
-        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+        [[3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       tg_dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
@@ -144,7 +144,7 @@ nebula_x1:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [5, 8]
+        end: [6, 8]
 
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
@@ -154,10 +154,10 @@ nebula_x1:
         []
 
       fabric_mux_cores:
-        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+        [[-1, 0], [-1, 1], [-1, 2]]
 
       dispatch_cores:
-        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+        [[-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
       tg_dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
@@ -173,7 +173,7 @@ nebula_x1:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [5, 8]
+        end: [6, 8]
 
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
@@ -183,10 +183,10 @@ nebula_x1:
         []
 
       fabric_mux_cores:
-        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+        [[-1, 0], [-1, 1], [-1, 2]]
 
       dispatch_cores:
-        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+        [[-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
       tg_dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
@@ -204,16 +204,16 @@ nebula_x2:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 5]
+        end: [7, 6]
 
       storage_cores: # Relative to grid of tensix cores
         []
 
       fabric_mux_cores:
-        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+        [[0, -1], [1, -1], [2, -1]]
 
       dispatch_cores:
-        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+        [[3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -221,16 +221,16 @@ nebula_x2:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [7, 5]
+        end: [7, 6]
 
       storage_cores: # Relative to grid of tensix cores
         []
 
       fabric_mux_cores:
-        [[2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2]]
+        [[0, -1], [1, -1], [2, -1]]
 
       dispatch_cores:
-        [[2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+        [[3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -239,16 +239,16 @@ nebula_x2:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [5, 7]
+        end: [6, 7]
 
       storage_cores: # Relative to grid of tensix cores
         []
 
       fabric_mux_cores:
-        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+        [[-1, 0], [-1, 1], [-1, 2]]
 
       dispatch_cores:
-        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+        [[-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
       dispatch_core_type:
         "tensix"
@@ -256,16 +256,16 @@ nebula_x2:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [5, 7]
+        end: [6, 7]
 
       storage_cores: # Relative to grid of tensix cores
         []
 
       fabric_mux_cores:
-        [[-2, 2], [-2, 3], [-2, 4], [-2, 5], [-2, 6], [-2, 7]]
+        [[-1, 0], [-1, 1], [-1, 2]]
 
       dispatch_cores:
-        [[-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+        [[-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
       dispatch_core_type:
         "tensix"

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2314,7 +2314,7 @@ void ControlPlane::populate_fabric_connection_info(
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& fabric_context = this->get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
-    const bool is_2d_fabric = topology == Topology::Mesh;
+    const bool is_2d_fabric = fabric_context.is_2D_routing_enabled();
     const auto sender_channel = is_2d_fabric ? router_direction : 0;
 
     // Always populate fabric router config for normal workers

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/device_pool.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
+#include "dispatch/kernel_config/relay_mux.hpp"
 #include "tt_align.hpp"
 #include <bit>
 #include <algorithm>
@@ -22,17 +23,60 @@ namespace tt::tt_fabric {
 
 // Helper function to find the maximum number of ethernet channels across all devices
 static size_t find_max_eth_channels(const std::vector<tt_metal::IDevice*>& all_active_devices) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     size_t max_eth_channels = 0;
+    auto device_id = all_active_devices.front()->id();
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    const auto device_has_dispatch_tunnel = [&]() -> bool {
+        auto mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id);
+        // results are inclusive of the mmio_device_id so they will never be zero
+        TT_ASSERT(tunnels_from_mmio.size() > 0);
+        return (tunnels_from_mmio.size() - 1) > 0;
+    }();
 
     for (const auto& device : all_active_devices) {
-        auto dev_id = device->id();
-        auto dev_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
+        std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
+        std::unordered_map<RoutingDirection, FabricNodeId> chip_neighbors;
 
-        // Get all active ethernet channels for this device
-        auto active_channels = control_plane.get_active_fabric_eth_channels(dev_fabric_node_id);
-        max_eth_channels = std::max(max_eth_channels, active_channels.size());
+        auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
+
+        for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
+            auto active_eth_chans =
+                control_plane.get_active_fabric_eth_routing_planes_in_direction(fabric_node_id, direction);
+            if (active_eth_chans.empty()) {
+                continue;
+            }
+            auto neighbors = control_plane.get_chip_neighbors(fabric_node_id, direction);
+            auto intra_mesh_chip_neighbors = neighbors.find(fabric_node_id.mesh_id);
+
+            FabricNodeId neighbor_fabric_node_id = FabricNodeId(neighbors.begin()->first, neighbors.begin()->second[0]);
+            chip_neighbors.emplace(direction, neighbor_fabric_node_id);
+
+            active_fabric_eth_channels.insert({direction, active_eth_chans});
+        }
+
+        std::vector<chan_id_t> non_dispatch_active_channels;
+        for (const auto& [direction, remote_fabric_node_id] : chip_neighbors) {
+            uint32_t dispatch_link_idx =
+                tt_metal::RelayMux::get_dispatch_link_index(fabric_node_id, remote_fabric_node_id, device);
+
+            for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
+                auto link_idx = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);
+
+                if (!(device_has_dispatch_tunnel && link_idx == dispatch_link_idx)) {
+                    non_dispatch_active_channels.push_back(eth_chan);
+                }
+            }
+        }
+
+        max_eth_channels = std::max(max_eth_channels, non_dispatch_active_channels.size());
     }
+
+    log_info(tt::LogTest, "max_eth_channels: {}", max_eth_channels);
 
     return max_eth_channels;
 }
@@ -95,10 +139,10 @@ void FabricTensixDatamoverConfig::initialize_channel_mappings() {
     // Second pass: create per-device channel mappings using real ethernet channel IDs
     for (const auto& device : all_active_devices) {
         auto dev_id = device->id();
-        auto dev_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
+        auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
 
         // Get all active ethernet channels for this device
-        auto active_channels = control_plane.get_active_fabric_eth_channels(dev_fabric_node_id);
+        auto active_channels = control_plane.get_active_fabric_eth_channels(fabric_node_id);
 
         // Initialize per-device mappings
         eth_chan_to_core_index_[dev_id] = std::unordered_map<size_t, size_t>();


### PR DESCRIPTION

### Problem description
We don't have enough coverage in test infra, due to a bug in dispatch that forbids the change of grid sizes during a test run. As a workaround, use the same row/col for dispatch and mux cores. 

Add more tests into test infra.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes