### PR TITLE
Refactor AG Llama Case Detection

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -14,6 +14,86 @@
 
 namespace ttnn::operations::experimental::ccl {
 
+bool use_all_gather_async_llama_sharded(const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    auto input_tensor_shape = input_tensor.padded_shape();
+    auto input_tensor_page_layout = input_tensor.layout();
+    auto input_tensor_memory_config = input_tensor.memory_config();
+    bool input_is_sharded = input_tensor_memory_config.shard_spec().has_value();
+    bool output_is_sharded = output_mem_config.shard_spec().has_value();
+
+    log_trace(tt::LogOp, "[select_version] input_tensor_shape: {}", input_tensor_shape);
+    log_trace(tt::LogOp, "[select_version] input_tensor_memory_config: {}", input_tensor_memory_config);
+    log_trace(tt::LogOp, "[select_version] output_mem_config: {}", output_mem_config);
+
+    log_trace(tt::LogOp, "[select_version] input_is_sharded: {}", input_is_sharded);
+    log_trace(tt::LogOp, "[select_version] output_is_sharded: {}", output_is_sharded);
+
+    // Check for minimal sharded case
+    if (input_is_sharded && output_is_sharded) {
+        uint32_t input_shard_num_cores = input_tensor_memory_config.shard_spec()->grid.num_cores();
+        uint32_t output_shard_num_cores = output_mem_config.shard_spec()->grid.num_cores();
+
+        log_trace(tt::LogOp, "[select_version] input_shard_num_cores: {}", input_shard_num_cores);
+        log_trace(tt::LogOp, "[select_version] output_shard_num_cores: {}", output_shard_num_cores);
+
+        log_trace(
+            tt::LogOp,
+            "[select_version] input_tensor_memory_config.shard_spec()->shape: {}",
+            input_tensor_memory_config.shard_spec()->shape);
+        log_trace(
+            tt::LogOp,
+            "[select_version] output_mem_config.shard_spec()->shape: {}",
+            output_mem_config.shard_spec()->shape);
+
+        // Check for llama post binary mult+silu case
+        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
+            input_tensor_shape[3] == 960 && input_tensor_memory_config.buffer_type() == BufferType::L1 &&
+            output_mem_config.buffer_type() == BufferType::L1 &&
+            input_tensor_memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+            output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+            input_tensor_memory_config.shard_spec()->shape[0] == 32 &&
+            input_tensor_memory_config.shard_spec()->shape[1] == 32 && output_mem_config.shard_spec()->shape[0] == 32 &&
+            output_mem_config.shard_spec()->shape[1] == 160 && input_shard_num_cores == 30 &&
+            output_shard_num_cores == 24) {
+            log_trace(
+                tt::LogOp,
+                "Matching conditions for Llama post binary mult+silu, using LLAMA_MINIMAL_SHARDED implementation");
+            return true;
+        }
+
+        // Check for llama post SDPA case
+        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 8 && input_tensor_shape[2] == 32 &&
+            input_tensor_shape[3] == 128 && input_tensor_memory_config.buffer_type() == BufferType::L1 &&
+            output_mem_config.buffer_type() == BufferType::L1 &&
+            input_tensor_memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+            output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+            input_tensor_memory_config.shard_spec()->shape[0] == 32 &&
+            input_tensor_memory_config.shard_spec()->shape[1] == 128 &&
+            output_mem_config.shard_spec()->shape[0] == 32 && output_mem_config.shard_spec()->shape[1] == 128 &&
+            input_shard_num_cores == 8 && output_shard_num_cores == 32) {
+            log_trace(tt::LogOp, "Matching conditions for Llama post SDPA, using LLAMA_MINIMAL_SHARDED implementation");
+            return true;
+        }
+
+        // Check for llama rms norm case
+        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
+            input_tensor_shape[3] == 32 && input_tensor_memory_config.buffer_type() == BufferType::L1 &&
+            output_mem_config.buffer_type() == BufferType::L1 &&
+            input_tensor_memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+            output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+            input_tensor_memory_config.shard_spec()->shape[0] == 32 &&
+            input_tensor_memory_config.shard_spec()->shape[1] == 32 && output_mem_config.shard_spec()->shape[0] == 32 &&
+            output_mem_config.shard_spec()->shape[1] == 128 && input_shard_num_cores == 1 &&
+            output_shard_num_cores == 1) {
+            log_trace(
+                tt::LogOp, "Matching conditions for Llama rms norm case, using LLAMA_MINIMAL_SHARDED implementation");
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool use_composite_all_gather(
     const ttnn::Tensor& input_tensor,
     const int32_t dim,
@@ -139,7 +219,10 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size(), memory_config)) {
+    bool composite_all_gather_case = (input_tensor, dim, multi_device_global_semaphore.size(), memory_config);
+    bool all_gather_async_llama_sharded_case =
+        use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
+    if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
         return composite_all_gather(
             input_tensor,
             dim,
@@ -156,6 +239,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
             memory_config,
             topology,
             subdevice_id,
+            all_gather_async_llama_sharded_case,
             use_optimal_ccl_for_llama,
             barrier_semaphore);
     }
@@ -176,7 +260,10 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
-    if (use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size(), memory_config)) {
+    bool composite_all_gather_case = use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size(), memory_config);
+    bool all_gather_async_llama_sharded_case =
+        use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
+    if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
         return composite_all_gather(input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
         return ttnn::operations::experimental::ccl::all_gather_async(
@@ -189,6 +276,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
             topology,
             subdevice_id,
             cluster_axis,
+            all_gather_async_llama_sharded_case,
             use_optimal_ccl_for_llama,
             barrier_semaphore,
             chunks_per_sync,
@@ -207,7 +295,10 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensors[0], dim, multi_device_global_semaphore.size(), memory_config)) {
+    bool composite_all_gather_case = use_composite_all_gather(input_tensors[0], dim, multi_device_global_semaphore.size(), memory_config);
+    bool all_gather_async_llama_sharded_case =
+        use_all_gather_async_llama_sharded(input_tensors[0], memory_config.value_or(input_tensors[0].memory_config()));
+    if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
         return composite_all_gather(
             input_tensors,
             dim,
@@ -224,6 +315,7 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
             memory_config,
             topology,
             subdevice_id,
+            all_gather_async_llama_sharded_case,
             use_optimal_ccl_for_llama,
             barrier_semaphore);
     }
@@ -242,7 +334,10 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size(), memory_config)) {
+    bool composite_all_gather_case = use_composite_all_gather(input_tensor, dim, multi_device_global_semaphore.size(), memory_config);
+    bool all_gather_async_llama_sharded_case =
+        use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
+    if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
         return composite_all_gather(
             input_tensor, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
@@ -257,6 +352,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
             memory_config,
             num_preferred_links,
             subdevice_id,
+            all_gather_async_llama_sharded_case,
             use_optimal_ccl_for_llama,
             barrier_semaphore);
     }
@@ -275,7 +371,10 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
-    if (use_composite_all_gather(input_tensors[0], dim, multi_device_global_semaphore.size(), memory_config)) {
+    bool composite_all_gather_case = use_composite_all_gather(input_tensors[0], dim, multi_device_global_semaphore.size(), memory_config);
+    bool all_gather_async_llama_sharded_case =
+        use_all_gather_async_llama_sharded(input_tensors[0], memory_config.value_or(input_tensors[0].memory_config()));
+    if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
         return composite_all_gather(
             input_tensors, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
@@ -290,6 +389,7 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
             memory_config,
             num_preferred_links,
             subdevice_id,
+            all_gather_async_llama_sharded_case,
             use_optimal_ccl_for_llama,
             barrier_semaphore);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -146,89 +146,13 @@ std::vector<Tensor> AllGatherAsync::create_output_tensors(
 }
 
 AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor) const {
-    auto input_tensor_shape = input_tensor.padded_shape();
-    auto input_tensor_page_layout = input_tensor.layout();
-    auto input_tensor_memory_config = input_tensor.memory_config();
-    bool input_is_sharded = input_tensor_memory_config.shard_spec().has_value();
-    bool output_is_sharded = output_mem_config.shard_spec().has_value();
-    uint32_t input_shard_num_cores = 0;
-    uint32_t output_shard_num_cores = 0;
-    if (input_is_sharded) {
-        input_shard_num_cores = input_tensor_memory_config.shard_spec()->grid.num_cores();
-        log_trace(
-            tt::LogOp,
-            "[select_version] input_tensor_memory_config.shard_spec()->shape: {}",
-            input_tensor_memory_config.shard_spec()->shape);
-    }
-    if (output_is_sharded) {
-        output_shard_num_cores = output_mem_config.shard_spec()->grid.num_cores();
-        log_trace(
-            tt::LogOp,
-            "[select_version] output_mem_config.shard_spec()->shape: {}",
-            output_mem_config.shard_spec()->shape);
-    }
-
-    log_trace(tt::LogOp, "[select_version] input_tensor_shape: {}", input_tensor_shape);
-    log_trace(tt::LogOp, "[select_version] input_tensor_memory_config: {}", input_tensor_memory_config);
-    log_trace(tt::LogOp, "[select_version] output_mem_config: {}", output_mem_config);
-    log_trace(tt::LogOp, "[select_version] input_shard_num_cores: {}", input_shard_num_cores);
-    log_trace(tt::LogOp, "[select_version] output_shard_num_cores: {}", output_shard_num_cores);
-
-    log_trace(tt::LogOp, "[select_version] input_is_sharded: {}", input_is_sharded);
-    log_trace(tt::LogOp, "[select_version] output_is_sharded: {}", output_is_sharded);
-
     // Check for minimal sharded case
-    if (input_is_sharded && output_is_sharded) {
-        // Check for llama post binary mult+silu case
-        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
-            input_tensor_shape[3] == 960 && input_tensor_memory_config.buffer_type() == BufferType::L1 &&
-            output_mem_config.buffer_type() == BufferType::L1 &&
-            input_tensor_memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
-            output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
-            input_tensor_memory_config.shard_spec()->shape[0] == 32 &&
-            input_tensor_memory_config.shard_spec()->shape[1] == 32 && output_mem_config.shard_spec()->shape[0] == 32 &&
-            output_mem_config.shard_spec()->shape[1] == 160 && input_shard_num_cores == 30 &&
-            output_shard_num_cores == 24) {
-            log_trace(
-                tt::LogOp,
-                "Matching conditions for Llama post binary mult+silu, using LLAMA_MINIMAL_SHARDED implementation");
-            return AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED;
-        }
-
-        // Check for llama post SDPA case
-        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 8 && input_tensor_shape[2] == 32 &&
-            input_tensor_shape[3] == 128 && input_tensor_memory_config.buffer_type() == BufferType::L1 &&
-            output_mem_config.buffer_type() == BufferType::L1 &&
-            input_tensor_memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
-            output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
-            input_tensor_memory_config.shard_spec()->shape[0] == 32 &&
-            input_tensor_memory_config.shard_spec()->shape[1] == 128 &&
-            output_mem_config.shard_spec()->shape[0] == 32 && output_mem_config.shard_spec()->shape[1] == 128 &&
-            input_shard_num_cores == 8 && output_shard_num_cores == 32) {
-            log_trace(tt::LogOp, "Matching conditions for Llama post SDPA, using LLAMA_MINIMAL_SHARDED implementation");
-            return AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED;
-        }
-
-        // Check for llama rms norm case
-        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
-            input_tensor_shape[3] == 32 && input_tensor_memory_config.buffer_type() == BufferType::L1 &&
-            output_mem_config.buffer_type() == BufferType::L1 &&
-            input_tensor_memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
-            output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
-            input_tensor_memory_config.shard_spec()->shape[0] == 32 &&
-            input_tensor_memory_config.shard_spec()->shape[1] == 32 && output_mem_config.shard_spec()->shape[0] == 32 &&
-            output_mem_config.shard_spec()->shape[1] == 128 && input_shard_num_cores == 1 &&
-            output_shard_num_cores == 1) {
-            log_trace(
-                tt::LogOp, "Matching conditions for Llama rms norm case, using LLAMA_MINIMAL_SHARDED implementation");
-            return AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED;
-        }
+    if (this->use_all_gather_async_llama_sharded) {
+        return AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED;
     }
 
     // Check for default minimal case
-    // Note: Since default minimal implementation also supports sharding,
-    // should check for the special llama sharding case first before falling back to this implementation
-    if (input_tensor_page_layout == tt::tt_metal::Layout::TILE && semaphore.size() == 2) {
+    if (input_tensor.layout() == tt::tt_metal::Layout::TILE && semaphore.size() == 2) {
         return AllGatherAsyncVersion::MINIMAL_DEFAULT;
     }
 
@@ -397,6 +321,7 @@ Tensor all_gather_async_impl(
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
     const std::vector<IDevice*>& devices,
+    bool use_all_gather_async_llama_sharded,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
     TT_FATAL(
@@ -429,6 +354,7 @@ Tensor all_gather_async_impl(
                    multi_device_global_semaphore,
                    sub_device_id,
                    /*cluster_axis=*/std::nullopt,
+                   use_all_gather_async_llama_sharded,
                    use_optimal_ccl_for_llama,
                    barrier_semaphore,
                    using_persistent_buffers,
@@ -450,6 +376,7 @@ Tensor all_gather_async_impl(
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
     const std::vector<IDevice*>& devices,
     const std::optional<uint32_t>& cluster_axis,
+    bool use_all_gather_async_llama_sharded,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     const std::optional<uint32_t>& chunks_per_sync,
@@ -491,6 +418,7 @@ Tensor all_gather_async_impl(
                    multi_device_global_semaphore,
                    sub_device_id,
                    cluster_axis,
+                   use_all_gather_async_llama_sharded,
                    use_optimal_ccl_for_llama,
                    barrier_semaphore,
                    using_persistent_buffers,
@@ -514,6 +442,7 @@ Tensor all_gather_async_impl(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool use_all_gather_async_llama_sharded,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
     const auto& mesh_view = mesh_device.get_view();
@@ -550,6 +479,7 @@ Tensor all_gather_async_impl(
                    multi_device_global_semaphore,
                    sub_device_id,
                    cluster_axis,
+                   use_all_gather_async_llama_sharded,
                    use_optimal_ccl_for_llama,
                    barrier_semaphore,
                    using_persistent_buffers,
@@ -572,6 +502,7 @@ Tensor all_gather_async(
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
     bool use_optimal_ccl_for_llama,
+    bool use_all_gather_async_llama_sharded,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
     std::vector<IDevice*> devices;
     return all_gather_async_impl(
@@ -583,6 +514,7 @@ Tensor all_gather_async(
         topology,
         sub_device_id,
         ttnn::ccl::get_active_physical_devices(input_tensor),
+        use_all_gather_async_llama_sharded,
         use_optimal_ccl_for_llama,
         barrier_semaphore);
 }
@@ -598,6 +530,7 @@ Tensor all_gather_async(
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
     std::optional<uint32_t> cluster_axis,
     bool use_optimal_ccl_for_llama,
+    bool use_all_gather_async_llama_sharded,
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     std::optional<uint32_t> chunks_per_sync,
     std::optional<uint32_t> num_workers_per_link,
@@ -615,6 +548,7 @@ Tensor all_gather_async(
         sub_device_id,
         devices,
         cluster_axis,
+        use_all_gather_async_llama_sharded,
         use_optimal_ccl_for_llama,
         barrier_semaphore,
         chunks_per_sync,
@@ -630,6 +564,7 @@ std::vector<Tensor> all_gather_async(
     const std::optional<MemoryConfig>& memory_config,
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool use_all_gather_async_llama_sharded,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
     std::vector<GlobalSemaphore> semaphore;
@@ -649,6 +584,7 @@ std::vector<Tensor> all_gather_async(
             topology,
             sub_device_id,
             ttnn::ccl::get_active_physical_devices(input_tensors),
+            use_all_gather_async_llama_sharded,
             use_optimal_ccl_for_llama,
             barrier_semaphore));
     }
@@ -666,6 +602,7 @@ Tensor all_gather_async(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool use_all_gather_async_llama_sharded,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
     return all_gather_async_impl(
@@ -679,6 +616,7 @@ Tensor all_gather_async(
         memory_config,
         num_preferred_links,
         sub_device_id,
+        use_all_gather_async_llama_sharded,
         use_optimal_ccl_for_llama,
         barrier_semaphore);
 }
@@ -694,6 +632,7 @@ std::vector<Tensor> all_gather_async(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool use_all_gather_async_llama_sharded,
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore) {
     std::vector<Tensor> output_tensors;
@@ -715,6 +654,7 @@ std::vector<Tensor> all_gather_async(
             memory_config,
             num_preferred_links,
             sub_device_id,
+            use_all_gather_async_llama_sharded,
             use_optimal_ccl_for_llama,
             barrier_semaphore));
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -301,6 +301,8 @@ tt::tt_metal::operation::Hash AllGatherAsync::compute_program_hash(const std::ve
         this->chunks_per_sync,
         this->num_workers_per_link,
         this->num_buffers_per_channel,
+        this->use_all_gather_async_llama_sharded,
+        this->use_optimal_ccl_for_llama,
         input_shape,
         input_memory_layout,
         input_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -41,6 +41,7 @@ struct AllGatherAsync {
     const std::vector<GlobalSemaphore> semaphore;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
     std::optional<uint32_t> cluster_axis;
+    bool use_all_gather_async_llama_sharded;
     bool use_optimal_ccl_for_llama;
     const std::optional<GlobalSemaphore>& barrier_semaphore;
     bool using_persistent_buffers;
@@ -58,6 +59,7 @@ struct AllGatherAsync {
         std::vector<GlobalSemaphore> semaphore,
         std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
         std::optional<uint32_t> cluster_axis,
+        bool use_all_gather_async_llama_sharded,
         bool use_optimal_ccl_for_llama,
         const std::optional<GlobalSemaphore>& barrier_semaphore,
         bool using_persistent_buffers,
@@ -73,6 +75,7 @@ struct AllGatherAsync {
         semaphore(semaphore),
         sub_device_id(sub_device_id),
         cluster_axis(cluster_axis),
+        use_all_gather_async_llama_sharded(use_all_gather_async_llama_sharded),
         use_optimal_ccl_for_llama(use_optimal_ccl_for_llama),
         barrier_semaphore(barrier_semaphore),
         using_persistent_buffers(using_persistent_buffers),
@@ -93,6 +96,7 @@ struct AllGatherAsync {
         attrs.emplace_back("barrier_semaphore", barrier_semaphore);
         attrs.emplace_back("using_persistent_buffers", using_persistent_buffers);
         attrs.emplace_back("cluster_axis", cluster_axis);
+        attrs.emplace_back("use_all_gather_async_llama_sharded", use_all_gather_async_llama_sharded);
         attrs.emplace_back("use_optimal_ccl_for_llama", use_optimal_ccl_for_llama);
         attrs.emplace_back("semaphore", semaphore);
         attrs.emplace_back("chunks_per_sync", chunks_per_sync);
@@ -206,6 +210,7 @@ Tensor all_gather_async(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    bool use_all_gather_async_llama_sharded = false,
     bool use_optimal_ccl_for_llama = false,
     const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
@@ -219,6 +224,7 @@ Tensor all_gather_async(
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
     std::optional<uint32_t> cluster_axis = std::nullopt,
+    bool use_all_gather_async_llama_sharded = false,
     bool use_optimal_ccl_for_llama = false,
     const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt,
     std::optional<uint32_t> chunks_per_sync = std::nullopt,
@@ -233,6 +239,7 @@ std::vector<Tensor> all_gather_async(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    bool use_all_gather_async_llama_sharded = false,
     bool use_optimal_ccl_for_llama = false,
     const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
@@ -247,6 +254,7 @@ Tensor all_gather_async(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<size_t> num_preferred_links = std::nullopt,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    bool use_all_gather_async_llama_sharded = false,
     bool use_optimal_ccl_for_llama = false,
     const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
@@ -261,6 +269,7 @@ std::vector<Tensor> all_gather_async(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<size_t> num_preferred_links = std::nullopt,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    bool use_all_gather_async_llama_sharded = false,
     bool use_optimal_ccl_for_llama = false,
     const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_op.cpp
@@ -268,6 +268,7 @@ std::vector<ttnn::Tensor> all_gather_matmul_async(
         sub_device_id,
         /*cluster_axis=*/std::nullopt,
         false,
+        false,
         barrier_semaphore,
         using_persistent_buffers,
         chunks_per_sync,


### PR DESCRIPTION
### Problem description
We're using the composite-AG implementation for more use cases, and need to make sure we don't multiplex into it for a configuration that is meant for the llama AG special case

### What's changed
Move the llama AG case detection up a level to where we check if we should use the composite AG implementation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17074183010
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17074185617
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17084288473
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/17084283687
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/17081128972
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/17081131601
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
- [ ] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17075075434