### PR TITLE
Add --build-packages option to build_metal.sh

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -31,6 +31,7 @@ show_help() {
     echo "  --build-umd-tests                Build umd Testcases."
     echo "  --build-programming-examples     Build programming examples."
     echo "  --build-tt-train                 Build tt-train."
+    echo "  --build-packages                 Build installation packages (.deb)"
     echo "  --build-all                      Build all optional components."
     echo "  --release                        Set the build type as Release."
     echo "  --development                    Set the build type as RelWithDebInfo."
@@ -77,6 +78,7 @@ build_tt_train="OFF"
 build_static_libs="OFF"
 unity_builds="ON"
 light_metal_trace="ON"
+build_packages="OFF"
 build_all="OFF"
 cxx_compiler_path=""
 cpm_source_cache=""
@@ -115,6 +117,7 @@ build-metal-tests
 build-umd-tests
 build-programming-examples
 build-tt-train
+build-packages
 build-static-libs
 disable-unity-builds
 disable-light-metal-trace
@@ -182,6 +185,8 @@ while true; do
             build_programming_examples="ON";;
         --build-tt-train)
             build_tt_train="ON";;
+        --build-packages)
+            build_packages="ON";;
         --build-static-libs)
             build_static_libs="ON";;
         --build-all)
@@ -403,8 +408,14 @@ echo "INFO: Configuring Project"
 echo "INFO: Running: cmake "${cmake_args[@]}""
 cmake "${cmake_args[@]}"
 
+if [ "$build_packages" == "ON" ];  then
+  target="package"
+else
+  target="install"
+fi
+
 # Build libraries and cpp tests
 if [ "$configure_only" = "OFF" ]; then
     echo "INFO: Building Project"
-    cmake --build $build_dir --target install
+    cmake --build $build_dir --target $target
 fi


### PR DESCRIPTION
### Ticket

New `build_metal.sh` option as described in #27096.

### Problem description

Building .deb packages is working but requires to be manually called. Option `--build-packages` allows to skip additional step and run everything in one command.

### What's changed

New option in `build_metal.sh` script.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes