### PR TITLE
Loosen Torch version reqs in smoke-test-docker-image

### DIFF
--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Run frequent regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-            pip install 'torch==2.2.1+cpu' 'numpy>=1.24.4,<2' pytest
+            pip install 'torch>=2.7.1+cpu' 'numpy>=1.24.4,<2' pytest
             ${{ matrix.test_group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26890

### Problem description
smoke-test-docker-image fails because the Torch version it requests is old. We should use a newer version and ask for a ">=" requirement to avoid this problem in the future.

Note that this change only affects tests to bring them in line with our current version of Torch.