### PR TITLE
Add pointer printing support to DPRINT

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -31,11 +31,15 @@ using namespace tt::tt_metal;
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 const std::string golden_output =
-R"(Test Debug Print: ERISC
+    R"(Test Debug Print: ERISC
 Basic Types:
 101-1.618@0.122559
 e5551234569123456789
 -17-343-44444-5123456789
+Pointer:
+123
+456
+789
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
@@ -69,30 +73,18 @@ void RunTest(
         CreateKernel(program, "tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp", core, config);
 
         // Run the program
-        log_info(
-            tt::LogTest,
-            "Running print test on eth core {}:({},{}), {}",
-            device->id(),
-            core.x,
-            core.y,
-            processor
-        );
+        log_info(tt::LogTest, "Running print test on eth core {}:({},{}), {}", device->id(), core.x, core.y, processor);
         fixture->RunProgram(device, program);
 
         // Check the print log against golden output.
-        EXPECT_TRUE(
-            FilesMatchesString(
-                DPrintFixture::dprint_file_name,
-                golden_output
-            )
-        );
+        EXPECT_TRUE(FilesMatchesString(DPrintFixture::dprint_file_name, golden_output));
 
         // Clear the log file for the next core's test
         MetalContext::instance().dprint_server()->clear_log_file();
     }
 }
-}
-}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
 
 TEST_F(DPrintFixture, ActiveEthTestPrint) {
     for (IDevice* device : this->devices_) {
@@ -102,11 +94,8 @@ TEST_F(DPrintFixture, ActiveEthTestPrint) {
             continue;
         }
         this->RunTestOnDevice(
-            [](DPrintFixture *fixture, IDevice* device){
-                CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, device, true);
-            },
-            device
-        );
+            [](DPrintFixture* fixture, IDevice* device) { CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, device, true); },
+            device);
     }
 }
 TEST_F(DPrintFixture, IdleEthTestPrint) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
@@ -39,11 +39,15 @@ using namespace tt::tt_metal;
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 const std::string golden_output =
-R"(Test Debug Print: Data0
+    R"(Test Debug Print: Data0
 Basic Types:
 101-1.618@0.122559
 e5551234569123456789
 -17-343-44444-5123456789
+Pointer:
+123
+456
+789
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
@@ -69,6 +73,10 @@ Basic Types:
 101-1.618@0.122559
 e5551234569123456789
 -17-343-44444-5123456789
+Pointer:
+123
+456
+789
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
@@ -94,6 +102,10 @@ Basic Types:
 101-1.618@0.122559
 e5551234569123456789
 -17-343-44444-5123456789
+Pointer:
+123
+456
+789
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
@@ -112,6 +124,10 @@ Basic Types:
 101-1.618@0.122559
 e5551234569123456789
 -17-343-44444-5123456789
+Pointer:
+123
+456
+789
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
@@ -137,6 +153,10 @@ Basic Types:
 101-1.618@0.122559
 e5551234569123456789
 -17-343-44444-5123456789
+Pointer:
+123
+456
+789
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
@@ -160,22 +180,18 @@ Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b))";
 
 void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program and command queue
-    constexpr CoreCoord core = {0, 0}; // Print on first core only
+    constexpr CoreCoord core = {0, 0};  // Print on first core only
     Program program = Program();
 
     // Create a CB for testing TSLICE, dimensions are 32x32 bfloat16s
-    constexpr uint32_t buffer_size = 32*32*sizeof(bfloat16);
-    CircularBufferConfig cb_src0_config = CircularBufferConfig(
-        buffer_size,
-        {{CBIndex::c_0, tt::DataFormat::Float16_b}}
-    ).set_page_size(CBIndex::c_0, buffer_size);
+    constexpr uint32_t buffer_size = 32 * 32 * sizeof(bfloat16);
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(buffer_size, {{CBIndex::c_0, tt::DataFormat::Float16_b}})
+                                              .set_page_size(CBIndex::c_0, buffer_size);
     tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     // A CB with an unsupported data format
-    CircularBufferConfig cb_src1_config = CircularBufferConfig(
-        buffer_size,
-        {{CBIndex::c_1, tt::DataFormat::Bfp2_b}}
-    ).set_page_size(CBIndex::c_1, buffer_size);
+    CircularBufferConfig cb_src1_config = CircularBufferConfig(buffer_size, {{CBIndex::c_1, tt::DataFormat::Bfp2_b}})
+                                              .set_page_size(CBIndex::c_1, buffer_size);
     tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     // Three different kernels to mirror typical usage and some previously
@@ -203,15 +219,10 @@ void RunTest(DPrintFixture* fixture, IDevice* device) {
     fixture->RunProgram(device, program);
 
     // Check that the expected print messages are in the log file
-    EXPECT_TRUE(
-        FilesMatchesString(
-            DPrintFixture::dprint_file_name,
-            golden_output
-        )
-    );
+    EXPECT_TRUE(FilesMatchesString(DPrintFixture::dprint_file_name, golden_output));
 }
-}
-}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
 
 TEST_F(DPrintFixture, TensixTestPrintFromAllHarts) {
     for (IDevice* device : this->devices_) {

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -25,6 +25,7 @@
  */
 
 #include <cstdint>
+#include <type_traits>
 #if defined(COMPILE_FOR_NCRISC) | defined(COMPILE_FOR_BRISC)
 // TODO(AP): this ifdef doesn't seem to make sense given we include risc_common.h
 // The issue is some files included inside risc_common.h only apply to NC/BRISCS
@@ -467,6 +468,15 @@ template DebugPrinter operator<< <SETPRECISION>(DebugPrinter, SETPRECISION val);
 template DebugPrinter operator<< <BF16>(DebugPrinter, BF16 val);
 template DebugPrinter operator<< <F32>(DebugPrinter, F32 val);
 template DebugPrinter operator<< <U32>(DebugPrinter, U32 val);
+
+// This allows printing of any (non char) pointer types as uint32_t
+template <typename T, typename = std::enable_if_t<!std::is_same_v<std::remove_cv_t<T>, char>>>
+DebugPrinter operator<<(DebugPrinter dp, T* val) {
+    using KernelPointerType = uint32_t;
+    static_assert(sizeof(KernelPointerType) == sizeof(T*));
+
+    return dp << reinterpret_cast<KernelPointerType>(val);
+}
 
 // Tile printing only supported in kernels
 #if defined(KERNEL_BUILD)

--- a/tt_metal/hw/inc/debug/dprint_test_common.h
+++ b/tt_metal/hw/inc/debug/dprint_test_common.h
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <cstdint>
 #include "debug/dprint.h"
 
 // A helper function to exercise print features.
@@ -15,10 +16,14 @@ inline void print_test_data() {
     int32_t my_int32 = -44444;
     int64_t my_int64 = -5123456789;
     float my_float = 3.14159f;
+    int* my_int_ptr = reinterpret_cast<int*>(123);
+    float* my_float_ptr = reinterpret_cast<float*>(456);
+    uint16_t* my_uint16_ptr = reinterpret_cast<uint16_t*>(789);
     DPRINT << DEFAULTFLOAT() << DEC() << SETPRECISION(6);  // Restore defaults
     DPRINT << "Basic Types:\n" << 101 << -1.6180034f << '@' << BF16(0x3dfb) << ENDL();
     DPRINT << my_uint8 << my_uint16 << my_uint32 << my_uint64 << ENDL();
     DPRINT << my_int8 << my_int16 << my_int32 << my_int64 << ENDL();
+    DPRINT << "Pointer:\n" << my_int_ptr << "\n" << my_float_ptr << "\n" << my_uint16_ptr << ENDL();
     DPRINT << "SETPRECISION/FIXED/DEFAULTFLOAT:\n";
     DPRINT << SETPRECISION(5) << my_float << ENDL();
     DPRINT << SETPRECISION(9) << my_float << ENDL();


### PR DESCRIPTION
### Ticket
#26255

### Problem description
Currently DPRINT cannot print a pointer directly.

### What's changed
Add support for pointer printing, any pointer will be casted to a uint32_t and print the address they're pointing at.

### Checklist
- [x] [All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/17081000892) 