### PR TITLE
#0: Simplify `core.py`: remove unnecessary validation, remove unused feature

### DIFF
--- a/tests/ttnn/unit_tests/test_as_tensor.py
+++ b/tests/ttnn/unit_tests/test_as_tensor.py
@@ -35,20 +35,6 @@ def test_allocate_large_tensor(device, height, width):
     )
 
 
-@pytest.mark.parametrize("height", [32])
-@pytest.mark.parametrize("width", [32])
-def test_as_tensor_with_device_tilizer(device, height, width):
-    torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
-
-    memory_config = ttnn.L1_MEMORY_CONFIG
-    tensor = ttnn.as_tensor(
-        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config, use_device_tilizer=True
-    )
-
-    torch_output_tensor = ttnn.to_torch(tensor)
-    assert torch.allclose(torch_input_tensor, torch_output_tensor)
-
-
 @pytest.mark.parametrize("height", [7])
 @pytest.mark.parametrize("width", [3])
 def test_as_tensor_with_cache(tmp_path, device, height, width):

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -296,19 +296,9 @@ def from_torch(
         memory_config = spec.memory_config
         tile = spec.tile
 
-    if layout is None:
-        layout = ttnn.ROW_MAJOR_LAYOUT
-
     if memory_config is not None and memory_config.is_sharded():
         if memory_config.shard_spec is None and memory_config.nd_shard_spec is None:
             raise RuntimeError("ttnn.from_torch: Shard spec must not be None for sharded tensors")
-
-    if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
-        if layout != ttnn.TILE_LAYOUT:
-            raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
-
-    if memory_config is not None and device is None:
-        raise RuntimeError("ttnn.from_torch: device must be specified when memory_config is specified")
 
     return ttnn.Tensor(
         tensor=tensor,
@@ -594,7 +584,6 @@ def as_tensor(
     cache_file_name: Optional[Union[str, pathlib.Path]] = None,
     preprocess: Optional[Callable[[ttnn.Tensor], ttnn.Tensor]] = None,
     mesh_mapper: Optional[ttnn.CppTensorToMesh | ttnn.ReplicateTensorToMeshWrapper] = None,
-    use_device_tilizer: bool = False,
     enable_multihost_format: bool = False,
 ) -> ttnn.Tensor:
     """
@@ -611,7 +600,6 @@ def as_tensor(
         cache_file_name (str | pathlib.Path, optional): The cache file name. Defaults to `None`.
         preprocess (Callable[[ttnn.Tensor], ttnn.Tensor], optional): The function to preprocess the tensor before serializing/converting to ttnn. Defaults to `None`.
         mesh_mapper (ttnn.CppTensorToMesh, optional): The TensorToMesh to define the mapping from torch to multi-device. Defaults to `None`.
-        use_device_tilizer (bool, optional): The flag that toggles whether to use host vs. device tilizer. Defaults to `False`.
         enable_multihost_format (bool, optional): Whether to use the multi-host format for the cache file. Defaults to `False`.
 
             - For Grayskull, the on-device tilizer will truncate mantissa bits for bfp* formats.
@@ -634,14 +622,6 @@ def as_tensor(
     if ttnn.using_distributed_env():
         enable_multihost_format = True
 
-    if use_device_tilizer:
-        if device is None:
-            raise RuntimeError("device must be specified when use_device_tilizer is True")
-        if memory_config is None:
-            raise RuntimeError("memory_config must be specified when use_device_tilizer is True")
-        if layout != ttnn.TILE_LAYOUT:
-            raise RuntimeError("layout must be TILE_LAYOUT when use_device_tilizer is True")
-
     if device is not None and memory_config is None:
         raise RuntimeError("memory_config must be specified when device is specified")
 
@@ -655,25 +635,14 @@ def as_tensor(
     ):
         if preprocess:
             tensor = preprocess(tensor)
-        if use_device_tilizer:
-            tensor = ttnn.from_torch(
-                tensor,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=mesh_mapper,
-                device=device,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
-            tensor = ttnn.to_layout(tensor, layout, dtype=dtype, memory_config=memory_config)
-        else:
-            tensor = ttnn.from_torch(
-                tensor,
-                dtype=dtype,
-                layout=layout,
-                mesh_mapper=mesh_mapper,
-                memory_config=memory_config,
-                device=device,
-            )
-        return tensor
+        return ttnn.from_torch(
+            tensor,
+            dtype=dtype,
+            layout=layout,
+            mesh_mapper=mesh_mapper,
+            memory_config=memory_config,
+            device=device,
+        )
 
     if cache_file_name is None:
         return torch_to_ttnn(tensor, dtype, layout, device, memory_config, mesh_mapper)
@@ -687,7 +656,16 @@ def as_tensor(
             mesh_mapper: Optional[ttnn.CppTensorToMesh | ttnn.ReplicateTensorToMeshWrapper],
             enable_multihost_format: bool,
         ):
-            tensor = torch_to_ttnn(tensor, dtype, layout, device, memory_config, mesh_mapper)
+            # Generate the tensor on host, and dump it to the cache file.
+            tensor = torch_to_ttnn(
+                tensor=tensor,
+                dtype=dtype,
+                layout=layout,
+                device=None,
+                memory_config=memory_config,
+                mesh_mapper=mesh_mapper,
+            )
+            assert tensor.storage_type() == ttnn.StorageType.HOST, "tensor should be on host"
             logger.debug(
                 f"Generating cache for {cache_file_name} of shape {tensor.shape}, dtype {dtype_name}, layout {layout_name}"
             )
@@ -696,6 +674,8 @@ def as_tensor(
                 ttnn._ttnn.tensor.dump_tensor_flatbuffer(cache_file_name, tensor)
             else:
                 ttnn._ttnn.tensor.dump_tensor(cache_file_name, tensor)
+            if device is not None:
+                tensor = tensor.to_device(device, memory_config)
             return tensor
 
         if enable_multihost_format:

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -675,7 +675,7 @@ def as_tensor(
             else:
                 ttnn._ttnn.tensor.dump_tensor(cache_file_name, tensor)
             if device is not None:
-                tensor = tensor.to_device(device, memory_config)
+                tensor = tensor.to(device, memory_config)
             return tensor
 
         if enable_multihost_format:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
See inline comments for explanation.

Some of these items currently prevent us from migrating tensor caches to the new format:
1. Sometimes we rely on fully replicated tensor caches and re-use the same weights for different mesh devices (e.g. falcon7b).
2. In the new format, we track tensor topology shape. If the shape is 1x1, it can be replicated across mesh of any shape. Otherwise, it has to match mesh device shape.
3. `core.py` code currently messes up "fully replicated" tensors by unnecessarily uploading them to device, and reading them back.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17081238669)