### PR TITLE
Fix kernel bug in SDPA decode

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -726,6 +726,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     };
     if (use_attention_sink) {
         tt_metal::TensorAccessorArgs(*attention_sink->buffer()).append_to(reader_compile_time_args_common);
+    } else {
+        reader_compile_time_args_common.push_back(0);
     }
 
     std::vector<uint32_t> writer_compile_time_args_common = {


### PR DESCRIPTION
### Problem description
[APC](https://github.com/tenstorrent/tt-metal/actions/runs/17081433236/job/48437005063) is broken due to recent changes to SDPA decode that use the new TensorAccessor.

### What's changed
- Push empty compile time arg when not using TensorAccessor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17083469743) CI passes