### PR TITLE
Max Pool with Indices

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import math
+import pytest
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
+def test_max_pool2d_with_indices(device):
+    in_n = 1
+    in_h = 159
+    in_w = 159
+    in_c = 1
+    kernel_size = [3, 3]
+    stride = [1, 1]
+    padding = [1, 1]
+    dilation = [1, 1]
+    shard_scheme = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    ceil_mode = False
+    ttnn_dtype = ttnn.bfloat16
+    # ttnn_dtype = ttnn.bfloat8_b
+
+    tensor_shape = (in_n, in_c, in_h, in_w)  # NCHW format
+
+    pad_h = padding[0] * 2  # padding is [top/bottom, left/right] but we need total padding
+    pad_w = padding[1] * 2
+    dilation_h = dilation[0]
+    dilation_w = dilation[1]
+    kernel_h = kernel_size[0]
+    kernel_w = kernel_size[1]
+    stride_h = stride[0]
+    stride_w = stride[1]
+
+    if ceil_mode:
+        out_h = math.ceil((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.ceil((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
+        if ((out_h - 1) * stride_h) >= (in_h + padding[0]):
+            ceil_mode_out_shape_adj = True
+            out_h -= 1
+        if ((out_w - 1) * stride_w) >= (in_w + padding[1]):
+            ceil_mode_out_shape_adj = True
+            out_w -= 1
+    else:
+        out_h = math.floor((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.floor((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
+
+    # Create tensor filled with height and width coordinates
+    torch.manual_seed(0)
+    # torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
+
+    # Create tensor where each element equals its HW coordinate (h * in_w + w)
+    torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    # torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
+    # for n in range(in_n):
+    #     for c in range(in_c):
+    #         for h in range(in_h):
+    #             for w in range(in_w):
+    #                 torch_input[n, c, h, w] = 1
+
+    ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
+    torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
+    torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
+    ttnn_layout = ttnn.ROW_MAJOR_LAYOUT
+    if ttnn_dtype == ttnn.bfloat8_b:
+        ttnn_layout = ttnn.TILE_LAYOUT
+    ttnn_input = ttnn.from_torch(torch_input_reshaped, ttnn_dtype, layout=ttnn_layout, device=device)
+
+    ttnn_output, indices = ttnn.max_pool2d(
+        input_tensor=ttnn_input,
+        batch_size=in_n,
+        input_h=in_h,
+        input_w=in_w,
+        channels=in_c,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        applied_shard_scheme=shard_scheme,
+        ceil_mode=ceil_mode,
+        in_place_halo=False,
+        deallocate_input=False,
+        reallocate_halo_output=True,
+        return_indices=True,
+    )
+    ttnn_outputs_exactly_equal = True
+
+    print("\nTTNN max pool results:")
+    print("Output shape:", ttnn.to_torch(ttnn_output).shape)
+    # print("Output:\n", ttnn.to_torch(ttnn_output))
+    print("Indices shape:", ttnn.to_torch(indices).shape)
+    # print("Indices:\n", ttnn.to_torch(indices))
+
+    # Check that ttnn_output_base is exactly equal to ttnn_output
+    ttnn_output_base = ttnn.max_pool2d(
+        input_tensor=ttnn_input,
+        batch_size=in_n,
+        input_h=in_h,
+        input_w=in_w,
+        channels=in_c,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        applied_shard_scheme=shard_scheme,
+        ceil_mode=ceil_mode,
+        in_place_halo=False,
+        deallocate_input=False,
+        reallocate_halo_output=True,
+        return_indices=False,
+    )
+    ttnn_outputs_exactly_equal = torch.equal(ttnn.to_torch(ttnn_output_base), ttnn.to_torch(ttnn_output))
+    print(f"ttnn_output_base exactly equals ttnn_output: {ttnn_outputs_exactly_equal}")
+
+    # Run PyTorch max pool for reference
+    torch_output, torch_indices = torch.nn.functional.max_pool2d(
+        torch_input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=True,
+    )
+
+    # Reshape torch output to match TTNN format (NCHW -> NHWC)
+    torch_output_reshaped = torch_output.permute(0, 2, 3, 1)  # N, H, W, C
+    torch_indices_reshaped = torch_indices.permute(0, 2, 3, 1)  # N, H, W, C
+
+    print("PyTorch max pool results:")
+    print("Output shape:", torch_output_reshaped.shape)
+    # print("Output:\n", torch_output_reshaped)
+    print("Indices shape:", torch_indices_reshaped.shape)
+    # print("Indices:\n", torch_indices_reshaped)
+
+    # Compare outputs using allclose
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+    ttnn_indices_torch = ttnn.to_torch(indices)
+
+    # Reshape TTNN outputs to match PyTorch shape for comparison
+    # TTNN output is in shape (1, 1, out_h*out_w, channels)
+    # Calculate output dimensions using the pooling formula
+    ttnn_output_reshaped = ttnn_output_torch.reshape(in_n, out_h, out_w, in_c)
+    ttnn_indices_reshaped = ttnn_indices_torch.reshape(in_n, out_h, out_w, in_c)
+
+    atol, rtol = torch.testing._comparison.default_tolerances(torch.bfloat16)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        atol = 0.35
+    output_match = torch.allclose(torch_output_reshaped, ttnn_output_reshaped, atol=atol, rtol=rtol)
+    indices_match = torch.equal(torch_indices_reshaped, ttnn_indices_reshaped)
+
+    print(f"Output values match (allclose): {output_match}")
+    print(f"Indices values match (allclose): {indices_match}")
+
+    # Print detailed mismatch information if outputs don't match
+    if not output_match:
+        print("\n=== OUTPUT MISMATCHES ===")
+        diff = torch.abs(torch_output_reshaped - ttnn_output_reshaped)
+        max_diff = torch.max(diff)
+        print(f"Maximum absolute difference: {max_diff}")
+
+        # Find positions where values don't match (with a small tolerance)
+        mismatch_mask = diff > 1e-5
+        mismatch_positions = torch.nonzero(mismatch_mask, as_tuple=False)
+
+        if len(mismatch_positions) > 0:
+            print(f"Number of mismatched elements: {len(mismatch_positions)}")
+            print("All mismatches (n, h, w, c): torch_val vs ttnn_val (diff):")
+            for i, pos in enumerate(mismatch_positions):
+                n, h, w, c = pos
+                torch_val = torch_output_reshaped[n, h, w, c]
+                ttnn_val = ttnn_output_reshaped[n, h, w, c]
+                diff_val = diff[n, h, w, c]
+                print(f"  [{n}, {h}, {w}, {c}]: {torch_val:.6f} vs {ttnn_val:.6f} (diff: {diff_val:.6f})")
+
+    # Count total output elements
+    total_output_elements = torch_output_reshaped.numel()
+    print(f"\nTotal output elements: {total_output_elements}")
+
+    # Analyze indices mismatches
+    tie_breaking_differences = 0
+    value_differences = 0
+    has_actual_errors = False
+
+    if not indices_match:
+        print("\n=== INDICES MISMATCHES ===")
+        torch_indices_float = torch_indices_reshaped.float()
+        ttnn_indices_float = ttnn_indices_reshaped.float()
+        diff = torch.abs(torch_indices_float - ttnn_indices_float)
+        max_diff = torch.max(diff)
+        print(f"Maximum absolute difference: {max_diff}")
+
+        # Find positions where indices don't match
+        mismatch_mask = diff > 1e-5
+        mismatch_positions = torch.nonzero(mismatch_mask, as_tuple=False)
+
+        if len(mismatch_positions) > 0:
+            print(f"Number of mismatched elements: {len(mismatch_positions)}")
+            print("All mismatches (n, h, w, c): torch_idx vs ttnn_idx (diff):")
+            for i, pos in enumerate(mismatch_positions):
+                n, h, w, c = pos
+                torch_idx = torch_indices_float[n, h, w, c]
+                ttnn_idx = ttnn_indices_float[n, h, w, c]
+                diff_val = diff[n, h, w, c]
+
+                # Convert linear indices back to spatial coordinates in the input tensor
+                # PyTorch uses NCHW format for indexing in max_pool2d
+                torch_idx_int = int(torch_idx.item())
+                ttnn_idx_int = int(ttnn_idx.item())
+
+                # Convert linear index to (h, w) coordinates within the pooling window
+                # For PyTorch indices, they are relative to the flattened spatial dimensions (H*W)
+                torch_h = torch_idx_int // in_w
+                torch_w = torch_idx_int % in_w
+                ttnn_h = ttnn_idx_int // in_w
+                ttnn_w = ttnn_idx_int % in_w
+
+                # Get the actual input values at these positions
+                torch_input_val = (
+                    torch_input[n, c, torch_h, torch_w] if torch_h < in_h and torch_w < in_w else float("nan")
+                )
+                ttnn_input_val = torch_input[n, c, ttnn_h, ttnn_w] if ttnn_h < in_h and ttnn_w < in_w else float("nan")
+
+                print(
+                    f"  output [{n}, {h}, {w}, {c}]: torch_idx={torch_idx:.0f} vs ttnn_idx={ttnn_idx:.0f} (diff: {diff_val:.0f})"
+                )
+                print(f"    Torch chose input[{n},{c},{torch_h},{torch_w}] = {torch_input_val:.6f}")
+                print(f"    TTNN chose input[{n},{c},{ttnn_h},{ttnn_w}] = {ttnn_input_val:.6f}")
+
+                # Check if this is a valid tie-breaking difference
+                # Two conditions must be satisfied:
+                # 1. The values must be the same
+                # 2. Both indices must be within the same kernel window
+
+                if ttnn_dtype == ttnn.bfloat8_b:
+                    values_same = math.isclose(torch_input_val, ttnn_input_val, abs_tol=atol, rel_tol=rtol)
+                else:
+                    values_same = torch_input_val == ttnn_input_val
+
+                # Calculate the top-left corner of the kernel window for this output position
+                # Given output position (h, w), the top-left of the kernel window is:
+                kernel_top_left_h = h * stride_h - padding[0]  # padding[0] is top padding
+                kernel_top_left_w = w * stride_w - padding[1]  # padding[1] is left padding
+
+                # Check if both indices are within the same dilated kernel window
+                # With dilation, the kernel doesn't cover a contiguous rectangle but specific positions
+                def is_in_dilated_kernel_window(
+                    input_h, input_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
+                ):
+                    """Check if a position (input_h, input_w) is within the dilated kernel window"""
+                    # Check if the position aligns with the dilated kernel pattern
+                    for kh in range(kernel_h):
+                        for kw in range(kernel_w):
+                            kernel_pos_h = kernel_top_left_h + kh * dilation_h
+                            kernel_pos_w = kernel_top_left_w + kw * dilation_w
+                            if kernel_pos_h == input_h and kernel_pos_w == input_w:
+                                return True
+                    return False
+
+                torch_in_window = is_in_dilated_kernel_window(
+                    torch_h, torch_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
+                )
+                ttnn_in_window = is_in_dilated_kernel_window(
+                    ttnn_h, ttnn_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
+                )
+
+                same_kernel_window = torch_in_window and ttnn_in_window
+
+                print(
+                    f"    Dilated kernel window: top_left=({kernel_top_left_h},{kernel_top_left_w}), kernel_size=({kernel_h},{kernel_w}), dilation=({dilation_h},{dilation_w})"
+                )
+                print(f"    Torch index in window: {torch_in_window}, TTNN index in window: {ttnn_in_window}")
+
+                if values_same and same_kernel_window:
+                    print(f"    -> Same input values AND same kernel window! This is a valid tie-breaking difference.")
+                    tie_breaking_differences += 1
+                elif values_same and not same_kernel_window:
+                    print(f"    -> Same input values but DIFFERENT kernel windows! This is an error.")
+                    value_differences += 1
+                    has_actual_errors = True
+                else:
+                    print(
+                        f"    -> Different input values! Value difference: {abs(torch_input_val - ttnn_input_val):.6f}"
+                    )
+                    value_differences += 1
+                    has_actual_errors = True
+                print()
+
+    print(f"\n=== SUMMARY ===")
+    print(f"Total output elements: {total_output_elements}")
+    print(f"Tie-breaking differences: {tie_breaking_differences}")
+    print(f"Value or window differences(actual errors): {value_differences}")
+
+    # Updated test result logic - only fail if there are actual value differences or output mismatches
+    test_passed = output_match and (not has_actual_errors) and ttnn_outputs_exactly_equal
+
+    if test_passed:
+        print("\n✓ Test PASSED: TTNN and PyTorch outputs match!")
+        if tie_breaking_differences > 0:
+            print(f"  Note: {tie_breaking_differences} tie-breaking differences in indices are acceptable.")
+    else:
+        print("\n✗ Test FAILED:")
+        if not output_match:
+            print("  - Output values do not match")
+        if has_actual_errors:
+            print(f"  - {value_differences} actual value differences found in indices")
+
+    # Ensure the test actually passes/fails based on the results
+    assert test_passed, "Test failed - see output above for details"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -6,3 +6,4 @@
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary_sfpu_init.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
+#include "llk_math_eltwise_binary_sfpu_max_pool_indices.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -244,14 +244,15 @@ template <
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,
     bool narrow_row = false /* unused */,
-    std::uint32_t row_num_datums = TILE_C_DIM /* unused */>
+    std::uint32_t row_num_datums = TILE_C_DIM /* unused */,
+    uint32_t tile_dst_ct_offset = 0>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,
     std::uint32_t output,
     const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t num_faces = 4,
     const std::uint32_t block_c_index = 0,
-    const std::uint32_t tile_dst_offset = 0) {
+    const std::uint32_t tile_dst_rt_offset = 0) {
     static_assert(diagonal == false && "Diagonal packing is not supported for BH!");
     const std::uint32_t output_id = get_output_id(output);
     std::uint32_t pack_tile_addr =
@@ -262,12 +263,12 @@ inline void llk_pack_untilize(
             16;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
-        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
+        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
             pack_tile_addr,
             pack_dst_format[output_id],
             face_r_dim,
             num_faces,
-            block_rt * block_ct_dim + tile_dst_offset);
+            block_rt * block_ct_dim + tile_dst_rt_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "sfpu/ckernel_sfpu_max_pool_indices.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS = 8>
+inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint tile_idx) {
+    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS>(
+        values_tile_idx, indices_tile_idx, tile_idx);
+}
+
+template <bool APPROXIMATION_MODE>
+inline void init_max_pool_with_indices() {
+    _init_max_pool_with_indices_();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_max_pool_indices.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices, APPROXIMATE>(
+        sfpu::init_max_pool_with_indices<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int num_rows>
+inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(
+    uint dst_index, uint32_t idx_index, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows>,
+        dst_index,
+        idx_index,
+        vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -118,5 +118,6 @@ enum SfpuType {
     threshold,
     where,
     softsign,
-    celu
+    celu,
+    max_pool_with_indices,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -6,3 +6,4 @@
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary_sfpu_init.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
+#include "llk_math_eltwise_binary_sfpu_max_pool_indices.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -245,14 +245,15 @@ template <
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,
     bool narrow_row = false,
-    std::uint32_t row_num_datums = TILE_C_DIM>
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    uint32_t tile_dst_ct_offset = 0>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,
     std::uint32_t output,
     const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t num_faces = 4,
     const std::uint32_t block_c_index = 0,
-    const std::uint32_t tile_dst_offset = 0) {
+    const std::uint32_t tile_dst_rt_offset = 0) {
     const std::uint32_t output_id = get_output_id(output);
     std::uint32_t pack_tile_addr =
         get_local_cb_interface(output_id).fifo_wr_ptr - 1 +
@@ -262,12 +263,12 @@ inline void llk_pack_untilize(
             16;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
-        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
+        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
             pack_tile_addr,
             pack_dst_format[output_id],
             face_r_dim,
             num_faces,
-            block_rt * block_ct_dim + tile_dst_offset);
+            block_rt * block_ct_dim + tile_dst_rt_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "sfpu/ckernel_sfpu_max_pool_indices.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS = 8>
+inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint tile_idx) {
+    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS>(
+        values_tile_idx, indices_tile_idx, tile_idx);
+}
+
+template <bool APPROXIMATION_MODE>
+inline void init_max_pool_with_indices() {
+    _init_max_pool_with_indices_();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_max_pool_indices.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices, APPROXIMATE>(
+        sfpu::init_max_pool_with_indices<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int num_rows>
+inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(
+    uint dst_index, uint32_t idx_index, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows>,
+        dst_index,
+        idx_index,
+        vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -120,4 +120,5 @@ enum class SfpuType {
     where,
     softsign,
     celu,
+    max_pool_with_indices,
 };

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -29,6 +29,18 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_hw_configure_disaggregated(icb, icb)));
 }
 
+// no_pack variant to be used with tilize_*_no_pack variants
+ALWI void unary_op_init_common_no_pack(uint32_t icb) {
+    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+
+    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+    // MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
+    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+}
+
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb) { unary_op_init_common(icb, ocb); }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -29,7 +29,13 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_hw_configure_disaggregated(icb, icb)));
 }
 
-// no_pack variant to be used with tilize_*_no_pack variants
+// clang-format off
+/**
+ * no_pack variant of unary_op_init_common, to be used with tilize_*_no_pack variants.
+ *
+ * Note: This function does not configure PACK thread, use with caution.
+ */
+// clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
     UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
@@ -37,7 +43,6 @@ ALWI void unary_op_init_common_no_pack(uint32_t icb) {
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    // MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure_disaggregated(icb, icb)));
 }
 

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -171,19 +171,20 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
  *
  * Return value: None
  *
- * | Param Type | Name           | Description                                                   | Type      | Valid Range     | Required |
- * |------------|----------------|---------------------------------------------------------------|-----------|-----------------|----------|
- * | Template   | block_ct_dim   | Width of a single block in tiles                              | uint32_t  | 1 to max (see note) | False (default = 8) |
- * | Template   | full_ct_dim    | Width of a full input in tiles                                | uint32_t  | Divisible by block_ct_dim | False    |
- * | Template   | diagonal       | Whether to use diagonal packing                               | bool      | true/false      | False    |
- * | Template   | narrow_row     | Whether the provided input is narrow                          | bool      | true/false      | False    |
- * | Template   | row_num_datums | Number of datums per row                                      | uint32_t  | >= 1            | False    |
- * | Function   | ocb            | Output circular buffer identifier                             | uint32_t  | 0 to 31         | True     |
- * | Function   | block_rt_dim   | Height of a single block in tiles                             | uint32_t  | >= 1            | False (default=1) |
- * | Function   | block_c_index  | Block column index (used when full_ct_dim > block_ct_dim)     | uint32_t  | >= 0            | False (default=0) |
- * | Function   | face_r_dim     | Face height in rows                                           | uint32_t  | 1, 8 or 16      | False (default=16) |
- * | Function   | num_faces      | Number of faces                                               | uint32_t  | 1, 2 or 4       | False (default=4) |
- * | Function   | tile_dst_offset | Index of the tile in the dest from which to pack             | uint32_t  | 0 to 7 (0 to 3 if fp32 dest is enabled) | False (default=0) |
+ * | Param Type | Name               | Description                                                                  | Type      | Valid Range                             | Required            |
+ * |------------|--------------------|------------------------------------------------------------------------------|-----------|-----------------------------------------|---------------------|
+ * | Template   | block_ct_dim       | Width of a single block in tiles                                             | uint32_t  | 1 to max (see note)                     | False (default = 8) |
+ * | Template   | full_ct_dim        | Width of a full input in tiles                                               | uint32_t  | Divisible by block_ct_dim               | False               |
+ * | Template   | diagonal           | Whether to use diagonal packing                                              | bool      | true/false                              | False               |
+ * | Template   | narrow_row         | Whether the provided input is narrow                                         | bool      | true/false                              | False               |
+ * | Template   | row_num_datums     | Number of datums per row                                                     | uint32_t  | >= 1                                    | False               |
+ * | Template   | tile_dst_ct_offset | Compile time offset for the index of the tile in the dest from which to pack | uint32_t  | 0 to 7 (0 to 3 if fp32 dest is enabled) | False (default=0)   |
+ * | Function   | ocb                | Output circular buffer identifier                                            | uint32_t  | 0 to 31                                 | True                |
+ * | Function   | block_rt_dim       | Height of a single block in tiles                                            | uint32_t  | >= 1                                    | False (default=1)   |
+ * | Function   | block_c_index      | Block column index (used when full_ct_dim > block_ct_dim)                    | uint32_t  | >= 0                                    | False (default=0)   |
+ * | Function   | face_r_dim         | Face height in rows                                                          | uint32_t  | 1, 8 or 16                              | False (default=16)  |
+ * | Function   | num_faces          | Number of faces                                                              | uint32_t  | 1, 2 or 4                               | False (default=4)   |
+ * | Function   | tile_dst_offset    | Runtime offset for the index of the tile in the dest from which to pack      | uint32_t  | 0 to 7 (0 to 3 if fp32 dest is enabled) | False (default=0)   |
  */
 // clang-format on
 template <
@@ -191,16 +192,17 @@ template <
     uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,
     bool narrow_row = false,
-    std::uint32_t row_num_datums = TILE_C_DIM>
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    uint32_t tile_dst_ct_offset = 0>
 ALWI void pack_untilize_dest(
     uint32_t ocb,
     uint32_t block_rt_dim = 1,
     uint32_t block_c_index = 0 /* used when full_ct_dim > block_ct_dim*/,
     uint32_t face_r_dim = 16,
     uint32_t num_faces = 4,
-    uint32_t tile_dst_offset = 0) {
-    PACK((llk_pack_untilize<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
-        block_rt_dim, ocb, face_r_dim, num_faces, block_c_index, tile_dst_offset)));
+    uint32_t tile_dst_rt_offset = 0) {
+    PACK((llk_pack_untilize<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
+        block_rt_dim, ocb, face_r_dim, num_faces, block_c_index, tile_dst_rt_offset)));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -170,6 +170,8 @@ ALWI void tilize_init_short_with_dt_no_pack(uint32_t old_icb, uint32_t new_icb, 
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
     UNPACK((llk_unpack_tilize_init(new_icb, block)));
 
+// while the *_no_pack variants do not configure the packer, testing has shown that this call is
+// still necessary to ensure the data type is properly updated
 #ifdef ARCH_BLACKHOLE
     PACK((_llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, true>(
         pack_dst_format[new_icb],

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -42,6 +42,31 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb) {
 #endif
 }
 
+// clang-format off
+/**
+ * The same as tilize_init, but skips the packer configuration on blackhole in preparation to leave the
+ * tilized result in DST without packing to an out CB
+ *
+ * Should only be used with *_no_pack variants
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                                   | Type     | Valid Range | Required |
+ * |----------- |--------|-----------------------------------------------|----------|-------------|----------|
+ * | Function   | icb    | Input circular buffer identifier              | uint32_t | 0 to 31     | True     |
+ * | Function   | block  | Size of tile block to work on                 | uint32_t | > 0         | True     |
+ */
+// clang-format on
+ALWI void tilize_init_no_pack(uint32_t icb, uint32_t block) {
+    UNPACK((llk_unpack_tilize_init(icb, block)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          false /*is_int_en*/,
+          true /*tilize en*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+}
+
 #if (defined(REDUCE_OP) and defined(REDUCE_DIM)) or defined(__DOXYGEN__)
 
 // clang-format off
@@ -118,15 +143,57 @@ ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t
 
 // clang-format off
 /**
+ * The same as tilize_init_short_with_dt, but skips part of the packer configuration on blackhole in
+ * preparation to leave the tilized result in DST without packing to an out CB
+ *
+ * Should only be used with *_no_pack variants
+ *
+ * Return value: None
+ *
+ * | Param Type | Name     | Description                              | Type     | Valid Range | Required |
+ * |----------- |----------|------------------------------------------|----------|-------------|----------|
+ * | Function   | old_icb  | Previous input circular buffer identifier| uint32_t | 0 to 31     | True     |
+ * | Function   | new_icb  | New input circular buffer identifier     | uint32_t | 0 to 31     | True     |
+ * | Function   | block    | Size of tile block to work on            | uint32_t | > 0         | True     |
+ */
+// clang-format on
+ALWI void tilize_init_short_with_dt_no_pack(uint32_t old_icb, uint32_t new_icb, uint32_t block) {
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          false /*is_int_en*/,
+          true /*tilize en*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, new_icb)));
+    // This reconfig call checks if old operand has different data format to
+    // new operand idx, otherwise no reconfig call occurs
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
+    UNPACK((llk_unpack_tilize_init(new_icb, block)));
+
+#ifdef ARCH_BLACKHOLE
+    PACK((_llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, true>(
+        pack_dst_format[new_icb],
+        get_output_face_r_dim(new_icb),
+        get_output_tile_c_dim(new_icb),
+        get_output_num_faces(new_icb),
+        get_output_partial_face(new_icb),
+        get_output_narrow_tile(new_icb))));
+#endif
+}
+
+// clang-format off
+/**
  * Performs the tilize operation on a block.
  *
  * Return value: None
  *
- * | Param Type | Name   | Description                              | Type     | Valid Range | Required |
- * |----------- |--------|------------------------------------------|----------|-------------|----------|
- * | Function   | icb    | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
- * | Function   | block  | Size of tile block to work on            | uint32_t | > 0         | True     |
- * | Function   | ocb    | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
+ * | Param Type | Name             | Description                              | Type     | Valid Range | Required |
+ * |----------- |------------------|------------------------------------------|----------|-------------|----------|
+ * | Function   | icb              | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
+ * | Function   | block            | Size of tile block to work on            | uint32_t | > 0         | True     |
+ * | Function   | ocb              | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
+ * | Function   | input_tile_index | Index of the input tile in the icb       | uint32_t | >= 0        | False    |
+ * | Function   | output_tile_index| Index of the output tile in the ocb      | uint32_t | >= 0        | False    |
  */
 // clang-format on
 ALWI void tilize_block(
@@ -146,6 +213,33 @@ ALWI void tilize_block(
         // Release dest
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
         PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+    }
+}
+
+// clang-format off
+/**
+ * The same as tilize_block, but skips the packing step and MATH/PACK synchronization to leave the
+ * tilized result in DST without packing to an out CB
+ *
+ * Should only be used with *_no_pack variants
+ *
+ * Return value: None
+ *
+ * | Param Type | Name             | Description                              | Type     | Valid Range   | Required |
+ * |----------- |------------------|------------------------------------------|----------|---------------|----------|
+ * | Function   | icb              | Input circular buffer identifier         | uint32_t | 0 to 31       | True     |
+ * | Function   | block            | Size of tile block to work on            | uint32_t | > 0           | True     |
+ * | Function   | dst_idx          | Index of the tile in DST to write to     | uint32_t | 0 to DST size | True     |
+ * | Function   | input_tile_index | Index of the input tile in the icb       | uint32_t | >= 0          | False    |
+ */
+// clang-format on
+ALWI void tilize_block_no_pack(uint32_t icb, uint32_t block, uint32_t dst_idx, uint32_t input_tile_index = 0) {
+    UNPACK((llk_unpack_tilize_block(icb, block, input_tile_index)));
+
+    for (uint32_t t = 0; t < block; t++) {
+        // Datacopy
+        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+            dst_idx /*dst index*/)));
     }
 }
 
@@ -210,6 +304,25 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
 
 // clang-format off
 /**
+ * The same as tilize_uninit, but skips the packer configuration on blackhole in preparation to leave
+ * the tilized result in DST without packing to an out CB
+ *
+ * Should only be used with *_no_pack variants
+ *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                              | Type     | Valid Range | Required |
+ * |----------- |--------|------------------------------------------|----------|-------------|----------|
+ * | Function   | icb    | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void tilize_uninit_no_pack(uint32_t icb) { UNPACK((llk_unpack_tilize_uninit(icb))); }
+
+// clang-format off
+/**
  * Uninitializes the tilize operation and reconfigures the unpacker with CB data types.
  *
  * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
@@ -231,6 +344,30 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init(ocb)));
 #endif
+}
+
+// clang-format off
+/**
+ * The same as tilize_uninit_with_dt, but skips the packer configuration on blackhole in preparation to
+ * leave the tilized result in DST without packing to an out CB
+ *
+ * Should only be used with *_no_pack variants
+ *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name     | Description                              | Type     | Valid Range | Required |
+ * |----------- |----------|------------------------------------------|----------|-------------|----------|
+ * | Function   | old_icb  | Previous input circular buffer identifier| uint32_t | 0 to 31     | True     |
+ * | Function   | new_icb  | New input circular buffer identifier     | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void tilize_uninit_with_dt_no_pack(uint32_t old_icb, uint32_t new_icb) {
+    UNPACK((llk_unpack_tilize_uninit(old_icb)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
 }
 
 ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb) {

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -47,7 +47,7 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb) {
  * The same as tilize_init, but skips the packer configuration on blackhole in preparation to leave the
  * tilized result in DST without packing to an out CB
  *
- * Should only be used with *_no_pack variants
+ * Note: Should only be used with *_no_pack variants. Skips Low-Level API layer to enhance perf but limits use case.
  *
  * Return value: None
  *
@@ -146,7 +146,7 @@ ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t
  * The same as tilize_init_short_with_dt, but skips part of the packer configuration on blackhole in
  * preparation to leave the tilized result in DST without packing to an out CB
  *
- * Should only be used with *_no_pack variants
+ * Note: Should only be used with *_no_pack variants. Skips Low-Level API layer to enhance perf but limits use case.
  *
  * Return value: None
  *
@@ -221,7 +221,7 @@ ALWI void tilize_block(
  * The same as tilize_block, but skips the packing step and MATH/PACK synchronization to leave the
  * tilized result in DST without packing to an out CB
  *
- * Should only be used with *_no_pack variants
+ * Note: Should only be used with *_no_pack variants. Skips Low-Level API layer to enhance perf but limits use case.
  *
  * Return value: None
  *
@@ -307,7 +307,7 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
  * The same as tilize_uninit, but skips the packer configuration on blackhole in preparation to leave
  * the tilized result in DST without packing to an out CB
  *
- * Should only be used with *_no_pack variants
+ * Note: Should only be used with *_no_pack variants. Skips Low-Level API layer to enhance perf but limits use case.
  *
  * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
  * as a part of tt-metal#22904.
@@ -351,7 +351,7 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
  * The same as tilize_uninit_with_dt, but skips the packer configuration on blackhole in preparation to
  * leave the tilized result in DST without packing to an out CB
  *
- * Should only be used with *_no_pack variants
+ * Note: Should only be used with *_no_pack variants. Skips Low-Level API layer to enhance perf but limits use case.
  *
  * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
  * as a part of tt-metal#22904.

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -6,6 +6,10 @@
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tilize.h"
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/tile_move_copy.h"
 
 #define DEBUG_PRINT 0
 
@@ -36,16 +40,26 @@ void MAIN {
 
     constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
     constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(8);  // for split reader
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(10);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(11);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(12);
-    constexpr uint32_t num_of_output_pages_to_reserve = get_compile_time_arg_val(13);
+    constexpr uint32_t in_idx_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t in_idx_cb_id_1 = get_compile_time_arg_val(10);  // for split reader
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(11);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(12);
+    constexpr uint32_t tile_tmp_cb_id = get_compile_time_arg_val(13);
+    constexpr uint32_t tile_idx_tmp_cb_id = get_compile_time_arg_val(14);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(15);
+    constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(16);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(17);
+    constexpr bool return_indices = (bool)get_compile_time_arg_val(18);
 
-    constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT ? window_size_hw : FACE_HEIGHT;
+    constexpr uint32_t topk_output_tiles = 1;
+    constexpr uint32_t topk_cb_tile_idx = 0;
+    constexpr uint32_t data_dst_idx = 0;
+    constexpr uint32_t index_dst_idx = 2;
+
+    constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT && !return_indices ? window_size_hw : FACE_HEIGHT;
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0 && in_c % TILE_WIDTH <= FACE_WIDTH;
     constexpr uint32_t num_faces_in_input_tile =
-        (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
+        (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) && !return_indices ? 2 : 4;
     constexpr uint32_t num_faces_in_output_tile = 2;
     constexpr uint32_t num_faces_in_last_output_tile = last_tile_is_partial ? 1 : 2;
     constexpr uint32_t num_out_sticks = 1;
@@ -54,7 +68,7 @@ void MAIN {
     // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
     // otherwise we can reduce 8 tiles at a time.
     constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = (is_avg_pool && is_large_kernel) ? 4 : 8;
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = return_indices ? 1 : (is_avg_pool && is_large_kernel) ? 4 : 8;
     constexpr uint32_t max_tiles_per_iter =
         in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
     constexpr uint32_t partial_iter_output_tiles =
@@ -70,9 +84,24 @@ void MAIN {
     // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
-    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
-        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, out_cb_id, num_faces_in_input_tile, face_r_dim);
-    pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, num_out_sticks, num_faces_in_output_tile);
+    constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
+    if constexpr (!return_indices) {
+        tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
+            in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, out_cb_id, num_faces_in_input_tile, face_r_dim);
+        pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, num_out_sticks, num_faces_in_output_tile);
+    } else {
+        unary_op_init_common(in_cb_id_0, in_cb_id_0);
+        tilize_init_no_pack(in_cb_id_0, topk_output_tiles);
+        if constexpr (!pack_untilize_reinit) {
+            const uint32_t output_faces =
+                last_tile_is_partial ? num_faces_in_last_output_tile : num_faces_in_output_tile;
+            pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
+        }
+
+        // this can be done here because we do not use the SFPU for anything else so it does not get reprogrammed
+        // if you use the sfpu for other operations, you need to call this to reprogram the sfpu
+        max_reduce_with_indices_init();
+    }
 
     constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
     constexpr uint32_t interm_reduction_chunks =
@@ -87,11 +116,9 @@ void MAIN {
         const bool reader0 = !(split_reader && (n & 0x1));
         const uint32_t curr_scalar_cb_id = (!reader0 && !one_scalar_per_core) ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
         const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
+        const uint32_t curr_in_idx_cb_id = !reader0 ? in_idx_cb_id_1 : in_idx_cb_id_0;
         if constexpr (!one_scalar_per_core) {
             cb_wait_front(curr_scalar_cb_id, 1);
-        }
-        if constexpr (num_of_output_pages_to_reserve > 0) {
-            cb_reserve_back(out_cb_id, num_of_output_pages_to_reserve);
         }
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
             const bool last_c_block = c_i == in_nblocks_c - 1;
@@ -99,10 +126,11 @@ void MAIN {
             const uint32_t tiles_to_reduce =
                 tilize_reconfig ? (last_c_block ? partial_iter_output_tiles : max_tiles_per_iter) : max_tiles_per_iter;
             const uint32_t number_of_tiles = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
-            const uint32_t num_faces_to_reserve =
+            const uint32_t output_faces =
                 (last_tile_is_partial && last_c_block)
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
+            cb_reserve_back(out_cb_id, output_faces);
             if constexpr (tilize_reconfig) {
                 if (first_c_block || last_c_block) {
                     UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
@@ -112,27 +140,68 @@ void MAIN {
             tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 cb_wait_front(curr_in_cb_id, 1);
-                unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
-                    curr_in_cb_id,
-                    curr_scalar_cb_id,
-                    tiles_to_reduce,
-                    0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-                    num_faces_in_input_tile,
-                    face_r_dim);
-                for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
-                    reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
+                if constexpr (return_indices) {
+                    cb_wait_front(curr_in_idx_cb_id, 1);
+
+                    tilize_init_short_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id, topk_output_tiles);
+                    tilize_block_no_pack(curr_in_idx_cb_id, topk_output_tiles, index_dst_idx, topk_cb_tile_idx);
+                    tilize_uninit_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id);
+                    tilize_init_short_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id, topk_output_tiles);
+                    tilize_block_no_pack(curr_in_cb_id, topk_output_tiles, data_dst_idx, topk_cb_tile_idx);
+                    tilize_uninit_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id);
+
+                    max_reduce_with_indices<window_size_hw>(data_dst_idx, index_dst_idx);
+
+                    cb_pop_front(curr_in_idx_cb_id, 1);
+                } else {
+                    unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        curr_in_cb_id,
+                        curr_scalar_cb_id,
+                        tiles_to_reduce,
+                        0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
+                        num_faces_in_input_tile,
+                        face_r_dim);
+                    for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
+                        reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
+                    }
                 }
                 cb_pop_front(curr_in_cb_id, 1);
             }
             tile_regs_commit();
             tile_regs_wait();
-            if (last_c_block) {
-                pack_untilize_dest<partial_iter_output_tiles>(
-                    out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+            if constexpr (!return_indices) {
+                // for non-return index version we only have 1 output tensor therefore we can let pack_untilize_dest
+                // overflow by always packing num_faces_in_output_tile even for the last tile which may have less
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(
+                        out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                }
             } else {
-                pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                if constexpr (pack_untilize_reinit) {
+                    tensix_sync();
+                    pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
+                    tensix_sync();
+                }
+
+                pack_reconfig_data_format(out_cb_id);
+                pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, data_dst_idx>(
+                    out_cb_id, 1, 0, num_out_sticks, output_faces);
+                pack_reconfig_data_format(out_idx_cb_id);
+                pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, index_dst_idx>(
+                    out_idx_cb_id, 1, 0, num_out_sticks, output_faces);
+
+                if constexpr (pack_untilize_reinit) {
+                    tensix_sync();
+                    pack_untilize_uninit(out_cb_id);
+                    tensix_sync();
+                }
             }
-            cb_push_back(out_cb_id, num_faces_to_reserve);
+            cb_push_back(out_cb_id, output_faces);
+            if constexpr (return_indices) {
+                cb_push_back(out_idx_cb_id, output_faces);
+            }
             tile_regs_release();
         }
         if constexpr (!one_scalar_per_core) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -66,6 +66,9 @@ ALWI void clear_out_tiles(uint64_t write_addr, uint64_t clear_value_addr) {
 template <
     uint32_t in_nblocks_c,
     uint32_t in_cb_id,
+    uint32_t in_idx_cb_id,
+    uint32_t tile_tmp_cb_id,
+    uint32_t tile_idx_tmp_cb_id,
     uint32_t window_h,
     uint32_t window_w,
     uint32_t in_w_padded,
@@ -81,19 +84,29 @@ template <
     bool is_large_kernel,
     bool last_tile_is_partial,
     uint32_t dilation_h,
-    uint32_t dilation_w>
-ALWI void read_window_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
+    uint32_t dilation_w,
+    bool return_indices>
+ALWI void read_window_with_top_left_index(
+    uint32_t ind, uint32_t in_l1_read_base_addr, uint32_t in_idx_l1_read_base_addr) {
     constexpr uint32_t BYTES_PER_ELEM = 2;
     // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
-    // otherwise we can reduce 8 tiles at a time.
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = (is_avg_pool && is_large_kernel) ? 4 : 8;
+    // return_indices requires 1 tile at a time, otherwise we can reduce 8 tiles at a time.
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = return_indices ? 1 : (is_avg_pool && is_large_kernel) ? 4 : 8;
     constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
     constexpr uint32_t in_ntiles_c = in_c / TILE_WIDTH;
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      (window_h * window_w) <= 16 && !last_tile_is_partial;
-    constexpr uint32_t max_write_inc = wide_reduction ? MAX_BYTES_PER_REDUCTION : in_nbytes_leftover;
-
-    uint32_t in_l1_write_addr_base = get_write_ptr(in_cb_id);
+    uint32_t max_write_inc = wide_reduction ? MAX_BYTES_PER_REDUCTION : in_nbytes_leftover;
+    if constexpr (return_indices) {
+        static_assert(MAX_TILES_PER_REDUCTION == 1, "MAX_TILES_PER_REDUCTION must be 1 for return indices");
+    }
+#ifdef ARCH_BLACKHOLE
+    if constexpr (return_indices) {
+        if (in_c <= FACE_WIDTH) {
+            max_write_inc = FACE_WIDTH * BYTES_PER_ELEM;
+        }
+    }
+#endif
 
     for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
         uint32_t read_bytes = in_nbytes_c;
@@ -102,8 +115,13 @@ ALWI void read_window_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
         }
         uint32_t in_l1_write_addr = get_write_ptr(in_cb_id);
-        uint32_t processed_sticks = 0;
         cb_reserve_back(in_cb_id, 1);
+        uint32_t in_idx_l1_write_addr = 0;
+        if constexpr (return_indices) {
+            in_idx_l1_write_addr = get_write_ptr(in_idx_cb_id);
+            cb_reserve_back(in_idx_cb_id, 1);
+        }
+        uint32_t processed_sticks = 0;
         for (uint32_t h = 0; h < window_h; ++h) {
             auto process_h = [&](uint32_t w_offset, uint32_t w_multiple) __attribute__((always_inline)) {
                 const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
@@ -116,6 +134,17 @@ ALWI void read_window_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                     in_l1_write_addr += read_bytes * w_multiple;
                 } else {
                     in_l1_write_addr += max_write_inc * w_multiple;
+                }
+                if constexpr (return_indices) {
+                    const uint32_t idx_read_offset =
+                        in_idx_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
+                    noc_async_read_one_packet(
+                        get_noc_addr(idx_read_offset), in_idx_l1_write_addr, read_bytes * w_multiple);
+                    if constexpr (tilize_reconfig) {
+                        in_idx_l1_write_addr += read_bytes * w_multiple;
+                    } else {
+                        in_idx_l1_write_addr += max_write_inc * w_multiple;
+                    }
                 }
                 processed_sticks += w_multiple;
                 if constexpr (is_large_kernel) {
@@ -167,6 +196,9 @@ ALWI void read_window_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
         if constexpr (!is_large_kernel) {
             noc_async_read_barrier();
             cb_push_back(in_cb_id, 1);
+            if constexpr (return_indices) {
+                cb_push_back(in_idx_cb_id, 1);
+            }
         }
     }
 }
@@ -234,21 +266,27 @@ void kernel_main() {
 
     constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(16) : get_compile_time_arg_val(15);
     constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
-    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(20);
-    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(21);
-    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(22);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(23);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(24);
-    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(25);
-    constexpr uint32_t in_nbytes_padded_c = get_compile_time_arg_val(26);
-    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(27);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(28);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(29);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(30);
+    constexpr uint32_t in_idx_cb_id = (reader_id == 1) ? get_compile_time_arg_val(19) : get_compile_time_arg_val(18);
+    constexpr uint32_t in_shard_idx_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(21);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(22);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(23);
+    constexpr uint32_t tile_tmp_cb_id = get_compile_time_arg_val(24);
+    constexpr uint32_t tile_idx_tmp_cb_id = get_compile_time_arg_val(25);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(26);
+    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(27);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(28);
+    constexpr uint32_t config_cb_id = get_compile_time_arg_val(29);
+    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(30);
+    constexpr uint32_t in_nbytes_padded_c = get_compile_time_arg_val(31);
+    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(32);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(33);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(34);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(35);
+    constexpr bool return_indices = (bool)get_compile_time_arg_val(36);
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0 && in_c % TILE_WIDTH <= FACE_WIDTH;
 
+    // TODO this should go in the initialization condition below
     if constexpr (last_tile_is_partial) {
         clear_out_tiles<in_cb_id, clear_value_cb_id>();
     }
@@ -262,17 +300,18 @@ void kernel_main() {
     uint32_t scalar_value = 0;
 
     constexpr uint32_t window_size_hw = window_h * window_w;
-    constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT ? window_size_hw : FACE_HEIGHT;
+    constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT && !return_indices ? window_size_hw : FACE_HEIGHT;
     constexpr uint32_t num_faces_in_input_tile =
-        (max_sticks_for_reduction < TILE_WIDTH || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
-    constexpr bool is_large_kernel = (window_h * window_w) > max_sticks_for_reduction;
+        (max_sticks_for_reduction < TILE_WIDTH || window_size_hw <= FACE_HEIGHT) && !return_indices ? 2 : 4;
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
     constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
     constexpr uint32_t interm_reduction_chunks =
         remaining_elems ? window_size_hw / max_sticks_for_reduction + 1 : window_size_hw / max_sticks_for_reduction;
     // we only need to initialize the in_cb if we will not fill each reduction chunk with valid data
-    constexpr bool need_to_initialize_in_cb = remaining_elems && face_r_dim == FACE_HEIGHT &&
-                                              (num_faces_in_input_tile == 4 || last_tile_is_partial) &&
-                                              interm_reduction_chunks <= multi_buffering_factor;
+    constexpr bool need_to_initialize_in_cb =
+        return_indices ||
+        (remaining_elems && face_r_dim == FACE_HEIGHT && (num_faces_in_input_tile == 4 || last_tile_is_partial) &&
+         interm_reduction_chunks <= multi_buffering_factor);
     constexpr uint32_t in_cb_ntiles = in_cb_sz / (TILE_WIDTH * TILE_HEIGHT);  // only use the non-multi buffering size
 
     // fill the clear cb
@@ -285,9 +324,13 @@ void kernel_main() {
             cb_wait_front(clear_value_cb_id, 1);
         }
         // for average pool clear out tiles runs in loop, no need to initialize here
-        if constexpr (!is_avg_pool || !is_large_kernel) {
+        if constexpr (!is_avg_pool || !is_large_kernel || return_indices) {
             clear_out_tiles<in_cb_id, clear_value_cb_id>();
+            if constexpr (return_indices) {
+                clear_out_tiles<in_idx_cb_id, clear_value_cb_id>();
+            }
         }
+        // we don't need to clear the idx CB since the data CB is the one being sorted
     }
 
     // initialize the scalar CB
@@ -297,6 +340,10 @@ void kernel_main() {
     }
 
     const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    uint32_t in_idx_l1_read_base_addr = 0;
+    if constexpr (return_indices) {
+        in_idx_l1_read_base_addr = get_read_ptr(in_shard_idx_cb_id);
+    }
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
@@ -354,6 +401,9 @@ void kernel_main() {
             read_window_with_top_left_index<
                 in_nblocks_c,
                 in_cb_id,
+                in_idx_cb_id,
+                tile_tmp_cb_id,
+                tile_idx_tmp_cb_id,
                 window_h,
                 window_w,
                 in_w_padded,
@@ -369,7 +419,8 @@ void kernel_main() {
                 is_large_kernel,
                 last_tile_is_partial,
                 dilation_h,
-                dilation_w>(ind, in_l1_read_base_addr);
+                dilation_w,
+                return_indices>(ind, in_l1_read_base_addr, in_idx_l1_read_base_addr);
             if (split_reader && ind == end) {
                 first_row_value = false;
             }
@@ -384,6 +435,9 @@ void kernel_main() {
         read_window_with_top_left_index<
             in_nblocks_c,
             in_cb_id,
+            in_idx_cb_id,
+            tile_tmp_cb_id,
+            tile_idx_tmp_cb_id,
             window_h,
             window_w,
             in_w_padded,
@@ -399,6 +453,7 @@ void kernel_main() {
             is_large_kernel,
             last_tile_is_partial,
             dilation_h,
-            dilation_w>(0, in_l1_read_base_addr);
+            dilation_w,
+            return_indices>(0, in_l1_read_base_addr, in_idx_l1_read_base_addr);
     }
 }  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -207,10 +207,10 @@ static Tensor create_scalar_config_tensor(
 
 Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_new(
     Program& program,
-    const Tensor& input,
+    const std::vector<Tensor>& inputs,
     const Tensor& reader_indices,
     uint32_t reader_indices_size,
-    Tensor& output,
+    std::vector<Tensor>& outputs,
     Pool2DType pool_type,
     uint32_t in_n,
     uint32_t in_c,
@@ -229,6 +229,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t ceil_pad_h,
     uint32_t ceil_pad_w,
     bool ceil_mode,
+    bool return_indices,
     bool count_include_pad,
     uint32_t dilation_h,
     uint32_t dilation_w,
@@ -236,25 +237,26 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const MemoryConfig& out_mem_config,
     std::optional<int32_t> divisor_override,
     uint32_t memory_used) {
-    distributed::MeshDevice* device = input.device();
+    distributed::MeshDevice* device = inputs[0].device();
 
     const tt::tt_metal::DeviceStorage& reader_indices_storage = reader_indices.device_storage();
 
     // distributing out_hw across the grid
-    const auto all_cores = input.shard_spec().value().grid;
+    const auto all_cores = inputs[0].shard_spec().value().grid;
     const uint32_t ncores = all_cores.num_cores();
-    const uint32_t out_nhw_per_core = output.shard_spec()->shape[0];
+    const uint32_t out_nhw_per_core = outputs[0].shard_spec()->shape[0];
 
     const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
     const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
-    FactoryParameters params = get_factory_parameters(num_shards_c, input, kernel_h, kernel_w, in_c, pool_type);
+    FactoryParameters params =
+        get_factory_parameters(num_shards_c, inputs[0], kernel_h, kernel_w, in_c, pool_type, return_indices);
     uint32_t pad_h = pad_t + pad_b;
     uint32_t pad_w = pad_l + pad_r;
     const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
-    const auto& input_shape = input.padded_shape();
-    const auto& output_shape = output.padded_shape();
+    const auto& input_shape = inputs[0].padded_shape();
+    const auto& output_shape = outputs[0].padded_shape();
     const uint32_t in_nbytes_c = in_c / num_shards_c * params.nbytes;  // row of input (channels)
     const uint32_t in_nbytes_padded_c = input_shape[3] / num_shards_c * params.nbytes;
 
@@ -298,10 +300,32 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     // incoming data is the input cb instead of raw l1/dram addr
     // this input shard has halo and padding inserted.
-    const uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
+    const uint32_t raw_in_cb_npages = inputs[0].shard_spec().value().shape[0];
     const uint32_t raw_in_cb_pagesize = in_nbytes_c;
     const auto [raw_in_cb_id, raw_in_cb] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, input.buffer());
+        next_cb_index++,
+        program,
+        all_cores,
+        raw_in_cb_pagesize,
+        raw_in_cb_npages,
+        params.data_format,
+        inputs[0].buffer());
+    uint32_t raw_in_idx_cb_id = 32;
+    tt::tt_metal::CBHandle raw_in_idx_cb = 0;
+    if (return_indices) {
+        TT_FATAL(inputs.size() == 2, "Index tensor must be provided if return_indices is true");
+        uint32_t raw_in_idx_cb_npages = raw_in_cb_npages;
+        uint32_t raw_in_idx_cb_pagesize = input_shape[3] / num_shards_c * params.index_nbytes;
+        raw_in_idx_cb_id = next_cb_index++;
+        std::tie(raw_in_idx_cb_id, raw_in_idx_cb) = tt::tt_metal::create_cb(
+            next_cb_index++,
+            program,
+            all_cores,
+            raw_in_idx_cb_pagesize,
+            raw_in_idx_cb_npages,
+            params.index_format,
+            inputs[1].buffer());
+    }
 
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages);
 
@@ -328,11 +352,17 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_reader_indices_cb_npages);
     uint32_t in_cb_sz = 0;
     uint32_t in_nblocks_c = 1;
-    if (params.is_wide_reduction) {
-        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+    if (return_indices) {
+        // for return indices we use 1 whole tile per reduction to simplify logic
+        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
         in_nblocks_c = std::ceil((float)params.in_ntiles_c / params.MAX_TILES_PER_REDUCTION);
     } else {
-        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+        if (params.is_wide_reduction) {
+            in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+            in_nblocks_c = std::ceil((float)params.in_ntiles_c / params.MAX_TILES_PER_REDUCTION);
+        } else {
+            in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+        }
     }
 
     // reader output == input to tilize
@@ -353,20 +383,75 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_1, in_cb_pagesize, in_cb_npages);
     }
 
+    uint32_t in_idx_cb_id_0 = 32;
+    uint32_t in_idx_cb_id_1 = 32;
+    uint32_t tile_tmp_cb_id = 32;
+    uint32_t tile_idx_tmp_cb_id = 32;
+    if (return_indices) {
+        const uint32_t in_idx_cb_pagesize = params.index_nbytes * in_cb_page_padded;
+        const uint32_t in_idx_cb_npages = params.multi_buffering_factor;
+
+        in_idx_cb_id_0 = next_cb_index++;
+        tt::tt_metal::create_cb(
+            in_idx_cb_id_0, program, all_cores, in_idx_cb_pagesize, in_idx_cb_npages, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id_0, in_idx_cb_pagesize, in_idx_cb_npages);
+        if (params.split_reader) {
+            in_idx_cb_id_1 = next_cb_index++;
+            tt::tt_metal::create_cb(
+                in_idx_cb_id_1, program, all_cores, in_idx_cb_pagesize, in_idx_cb_npages, params.index_format);
+            log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id_1, in_idx_cb_pagesize, in_idx_cb_npages);
+        }
+
+        uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+        tile_tmp_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(tile_tmp_cb_id, program, all_cores, params.nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", tile_tmp_cb_id, params.nbytes * tile_elems, 1);
+        tile_idx_tmp_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(
+            tile_idx_tmp_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", tile_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1);
+    }
+
     // output of reduce == writer to write
     // output rows in RM
     // after reduction
     const uint32_t out_cb_pagesize =
-        std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output.shard_spec().value().shape[1]) *
+        std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), outputs[0].shard_spec().value().shape[1]) *
         params.nbytes;  // there is just one row of channels after each reduction (or 1
                         // block of c if its greater than 8 tiles)
-    const uint32_t out_cb_npages = output.shard_spec().value().shape[0] * params.out_ntiles_c;
+    const uint32_t out_cb_npages = outputs[0].shard_spec().value().shape[0] * params.out_ntiles_c;
 
-    const auto [out_cb_id, cb_out] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, params.data_format, output.buffer());
+    const auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, params.data_format, outputs[0].buffer());
+
+    uint32_t out_idx_cb_id = 32;
+    tt::tt_metal::CBHandle out_idx_cb = 0;
+    if (return_indices) {
+        TT_FATAL(
+            outputs.size() == 2,
+            "When return_indices is true, there should be two outputs, but got {}",
+            outputs.size());
+        uint32_t out_idx_cb_npages = out_cb_npages;
+        uint32_t out_idx_cb_pagesize =
+            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), outputs[0].shard_spec().value().shape[1]) *
+            params.index_nbytes;
+        std::tie(out_idx_cb_id, out_idx_cb) = tt::tt_metal::create_cb(
+            next_cb_index++,
+            program,
+            all_cores,
+            out_idx_cb_pagesize,
+            out_idx_cb_npages,
+            params.index_format,
+            outputs[1].buffer());
+    }
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
 
-    TT_FATAL(output.memory_config().is_sharded(), "Output memory config needs to be sharded");
+    for (int i = 0; i < outputs.size(); ++i) {
+        TT_FATAL(
+            outputs[i].memory_config().is_sharded(),
+            "Output memory config needs to be sharded, but got {}",
+            outputs[i].memory_config());
+    }
 
     /**
      * Reader Kernel: input rows -> input cb
@@ -397,13 +482,14 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
             .out_nhw_per_core = out_nhw_per_core,
             .divisor_override = divisor_override};
         config_tensor = create_scalar_config_tensor(
-            avg_pool_config, input.memory_config().memory_layout(), in_n, num_shards_c, ncores);
+            avg_pool_config, inputs[0].memory_config().memory_layout(), in_n, num_shards_c, ncores);
 
         const std::array<uint32_t, 2> shard_shape =
             std::array<uint32_t, 2>({1, static_cast<uint32_t>(config_tensor.logical_shape()[-1])});
-        const tt::tt_metal::ShardOrientation config_tensor_shard_orientation = input.shard_spec().value().orientation;
+        const tt::tt_metal::ShardOrientation config_tensor_shard_orientation =
+            inputs[0].shard_spec().value().orientation;
         const tt::tt_metal::ShardSpec config_shard_spec(
-            input.shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
+            inputs[0].shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
         const MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
         const Tensor config_tensor_device = config_tensor.to_device(device, memory_config);
 
@@ -434,19 +520,25 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_cb_id_0,                     // 15
         in_cb_id_1,                     // 16
         raw_in_cb_id,                   // 17
-        in_reader_indices_cb_id,        // 18
-        in_scalar_cb_id_0,              // 19
-        in_scalar_cb_id_1,              // 20
-        clear_value_cb_id,              // 21
-        (uint32_t)pool_type,            // 22
-        one_scalar_per_core,            // 23
-        config_cb_id,                   // 24
-        in_nbytes_c,                    // 25
-        in_nbytes_padded_c,             // 26
-        params.multi_buffering_factor,  // 27
-        stride_w,                       // 28
-        dilation_h,                     // 29
-        dilation_w};                    // 30
+        in_idx_cb_id_0,                 // 18
+        in_idx_cb_id_1,                 // 19
+        raw_in_idx_cb_id,               // 20
+        in_reader_indices_cb_id,        // 21
+        in_scalar_cb_id_0,              // 22
+        in_scalar_cb_id_1,              // 23
+        tile_tmp_cb_id,                 // 24
+        tile_idx_tmp_cb_id,             // 25
+        clear_value_cb_id,              // 26
+        (uint32_t)pool_type,            // 27
+        one_scalar_per_core,            // 28
+        config_cb_id,                   // 29
+        in_nbytes_c,                    // 30
+        in_nbytes_padded_c,             // 31
+        params.multi_buffering_factor,  // 32
+        stride_w,                       // 33
+        dilation_h,                     // 34
+        dilation_w,                     // 35
+        (uint32_t)return_indices};      // 36
     std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
 
@@ -472,8 +564,6 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
      * output cb
      */
 
-    const uint32_t num_of_pages_to_reserve_back = 0;  // since we do not have a writer
-
     std::vector<uint32_t> compute_ct_args = {
         params.in_ntiles_c,             // 0
         kernel_h * kernel_w,            // 1
@@ -484,11 +574,16 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         params.max_rows_for_reduction,  // 6
         in_cb_id_0,                     // 7
         in_cb_id_1,                     // 8
-        in_scalar_cb_id_0,              // 9
-        in_scalar_cb_id_1,              // 10
-        out_cb_id,                      // 11
-        one_scalar_per_core,
-        num_of_pages_to_reserve_back};  // 12
+        in_idx_cb_id_0,                 // 9
+        in_idx_cb_id_1,                 // 10
+        in_scalar_cb_id_0,              // 11
+        in_scalar_cb_id_1,              // 12
+        tile_tmp_cb_id,                 // 13
+        tile_idx_tmp_cb_id,             // 14
+        out_cb_id,                      // 15
+        out_idx_cb_id,                  // 16
+        one_scalar_per_core,            // 17
+        (uint32_t)return_indices};      // 18
 
     auto compute_config = tt::tt_metal::ComputeConfig{
         .math_fidelity = MathFidelity::HiFi4,
@@ -506,21 +601,22 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     uint32_t temporary_size = program.get_cb_memory_size();
     uint32_t post_allocate_size =
-        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+        inputs[0].device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
     uint32_t l1_usage = calculate_L1_usage(
-        input,
+        inputs[0],
         in_c,
         pad_h,
         pad_w,
         ceil_pad_h,
         ceil_pad_w,
         ceil_mode,
+        return_indices,
         kernel_h,
         kernel_w,
         out_h,
         out_w,
-        input.memory_config(),
-        output.memory_config(),
+        inputs[0].memory_config(),
+        outputs[0].memory_config(),
         pool_type,
         count_include_pad,
         divisor_override);
@@ -572,8 +668,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "split_reader: {}", params.split_reader);
         log_debug(tt::LogOp, "multi_buffering_factor: {}", params.multi_buffering_factor);
         log_debug(tt::LogOp, "is_wide_reduction: {}", params.is_wide_reduction);
-        log_debug(tt::LogOp, "is_in_sharded: {}", input.memory_config().is_sharded());
-        log_debug(tt::LogOp, "is_out_sharded: {}", output.memory_config().is_sharded());
+        log_debug(tt::LogOp, "is_in_sharded: {}", inputs[0].memory_config().is_sharded());
+        log_debug(tt::LogOp, "is_out_sharded: {}", outputs[0].memory_config().is_sharded());
     }
 
     // Capture reader_indices_storage to cache this with the program
@@ -583,20 +679,23 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
          .reader1_kernel = reader1_kernel,
          .compute_kernel = compute_kernel,
          .raw_in_cb = raw_in_cb,
-         .cb_out = cb_out,
+         .raw_in_idx_cb = raw_in_idx_cb,
+         .out_cb = out_cb,
+         .out_idx_cb = out_idx_cb,
          .ncores = ncores,
          .reader_indices_storage = reader_indices_storage,
          .scalar_config_storage = scalar_config_storage}};
 }
 
 Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
-    const operation_attributes_t& op_attr, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
-    const auto& input = tensor_args.input_tensor_;
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {
+    const auto& input = tensor_args.input_tensors_[0];
     const auto& sliding_window_config = op_attr.sliding_window_config_;
     const auto& pool_type = op_attr.pool_type_;
     const auto& out_mem_config = op_attr.memory_config_;
     bool count_include_pad = op_attr.count_include_pad_;
     std::optional<int32_t> divisor_override = op_attr.divisor_override_;
+    bool return_indices = op_attr.return_indices_;
 
     tt::tt_metal::Program program{};
 
@@ -643,10 +742,10 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
 
     return pool2d_multi_core_sharded_with_halo_v2_impl_new(
         program,
-        input,
+        tensor_args.input_tensors_,
         reader_indices_on_device,
         top_left_indices[0].size(),
-        output_tensor,
+        output_tensors,
         pool_type,
         in_n,
         in_c,
@@ -665,6 +764,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         ceil_pad_h,
         ceil_pad_w,
         ceil_mode,
+        return_indices,
         count_include_pad,
         dilation_h,
         dilation_w,
@@ -678,24 +778,39 @@ void Pool2D::MultiCore::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    tensor_return_value_t& output_tensors) {
     auto& program = cached_program.program;
     auto& raw_in_cb = cached_program.shared_variables.raw_in_cb;
-    auto& cb_out = cached_program.shared_variables.cb_out;
+    auto& out_cb = cached_program.shared_variables.out_cb;
 
-    const auto& input_tensor = tensor_args.input_tensor_;
-
+    const auto& input_tensor = tensor_args.input_tensors_[0];
     auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensors[0].buffer();
+
     bool input_sharded = input_tensor.is_sharded();
-
-    auto dst_buffer = output_tensor.buffer();
-    bool out_sharded = output_tensor.is_sharded();
-
     if (input_sharded) {
         UpdateDynamicCircularBufferAddress(program, raw_in_cb, *src_buffer);
     }
+    bool out_sharded = output_tensors[0].is_sharded();
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_out, *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, out_cb, *dst_buffer);
+    }
+
+    if (operation_attributes.return_indices_) {
+        TT_FATAL(tensor_args.input_tensors_.size() == 2, "Index tensor is required when return_indices is true");
+        auto& raw_in_idx_cb = cached_program.shared_variables.raw_in_idx_cb;
+        auto& out_idx_cb = cached_program.shared_variables.out_cb;
+
+        const auto& index_tensor = tensor_args.input_tensors_[1];
+        auto src_idx_buffer = index_tensor.buffer();
+        auto dst_idx_buffer = output_tensors.size() > 1 ? output_tensors[1].buffer() : nullptr;
+
+        if (input_sharded) {
+            UpdateDynamicCircularBufferAddress(program, raw_in_idx_cb, *src_idx_buffer);
+        }
+        if (out_sharded && dst_idx_buffer) {
+            UpdateDynamicCircularBufferAddress(program, out_idx_cb, *dst_idx_buffer);
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -18,17 +18,52 @@ Pool2D::program_factory_t Pool2D::select_program_factory(const operation_attribu
 }
 
 void validate_pool2d(
-    const Tensor& input,
+    const std::vector<Tensor>& input_tensors,
     const Pool2DType pool_type,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     const MemoryConfig& out_mem_config,
-    const std::optional<const int32_t> divisor_override) {
+    const std::optional<const int32_t> divisor_override,
+    const bool return_indices) {
+    // check the input tensor
+    const Tensor& input = input_tensors[0];
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input.buffer() != nullptr, "Operands to reshape need to be allocated in buffers on device!");
     TT_FATAL(input.dtype() == DataType::BFLOAT16, "Only BFLOAT16 supported for now");
     TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR supported for now. Tracked by issue #23338");
-
     TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
+
+    if (return_indices) {
+        // check the index tensor
+        TT_FATAL(input_tensors.size() == 2, "Indices tensor must be provided if return_indices is true");
+        const auto& index = input_tensors[1];
+        TT_FATAL(index.storage_type() == StorageType::DEVICE, "Indices tensor to pool needs to be on device!");
+        TT_FATAL(index.buffer() != nullptr, "Indices tensor to pool needs to be allocated in buffers on device!");
+        TT_FATAL(index.dtype() == DataType::UINT16, "Only UINT16 supported for indices tensor");
+        TT_FATAL(
+            index.layout() == Layout::ROW_MAJOR,
+            "Only ROW_MAJOR supported for indices tensor. Tracked by issue #23338");
+        TT_FATAL(index.memory_config().is_sharded(), "Indices tensor needs to be sharded");
+        TT_FATAL(
+            index.logical_shape() == input.logical_shape() && index.padded_shape() == input.padded_shape(),
+            "Indices tensor shape ({}, {}) must match input tensor shape ({}, {})",
+            index.logical_shape(),
+            index.padded_shape(),
+            input.logical_shape(),
+            input.padded_shape());
+
+        // generality constraints, see https://github.com/tenstorrent/tt-metal/issues/27845
+        auto input_h = sliding_window_config.input_hw.first;
+        auto input_w = sliding_window_config.input_hw.second;
+        TT_FATAL(
+            input_h * input_w <= std::numeric_limits<uint16_t>::max(),
+            "Input HW {} will overflow uint16 indices max {}",
+            input_h * input_w,
+            std::numeric_limits<uint16_t>::max());
+        auto kernel_h = sliding_window_config.window_hw.first;
+        auto kernel_w = sliding_window_config.window_hw.second;
+        TT_FATAL(kernel_h * kernel_w == 9, "only kernel sizes equal to 9 are supported, got {}x{}", kernel_h, kernel_w);
+    }
+
     TT_FATAL(out_mem_config.is_sharded(), "Output memory config needs to be sharded");
 
     const auto& input_shape = input.padded_shape();
@@ -43,29 +78,43 @@ void validate_pool2d(
             input_shape[3],
             num_shards_c);
     }
+
+    // check that the input shape isn't too large for indices in uint16
+    if (return_indices) {
+        auto in_h = sliding_window_config.input_hw.first;
+        auto in_w = sliding_window_config.input_hw.second;
+        TT_FATAL(
+            in_h * in_w <= std::numeric_limits<uint16_t>::max(),
+            "input HW shape ({} * {}) is too large for indices stored in uint16 with a limit of {}",
+            in_h,
+            in_w,
+            std::numeric_limits<uint16_t>::max());
+    }
 }
 
 void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
     return validate_pool2d(
-        tensors.input_tensor_,
+        tensors.input_tensors_,
         op_attr.pool_type_,
         op_attr.sliding_window_config_,
         op_attr.memory_config_,
-        op_attr.divisor_override_);
+        op_attr.divisor_override_,
+        op_attr.return_indices_);
 }
 
 void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
     return validate_pool2d(
-        tensors.input_tensor_,
+        tensors.input_tensors_,
         op_attr.pool_type_,
         op_attr.sliding_window_config_,
         op_attr.memory_config_,
-        op_attr.divisor_override_);
+        op_attr.divisor_override_,
+        op_attr.return_indices_);
 }
 
 Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    auto& input = tensors.input_tensor_;
+    auto& input = tensors.input_tensors_[0];
     auto& sliding_window_config = op_attr.sliding_window_config_;
     auto& out_mem_config = op_attr.memory_config_;
     auto& output_dtype = op_attr.output_dtype_;
@@ -111,27 +160,41 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
 
 Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    auto output_spec = compute_output_specs(op_attr, tensors);
-    return create_device_tensor(output_spec, tensors.input_tensor_.device());
+    auto output_spec_data = compute_output_specs(op_attr, tensors);
+    if (op_attr.return_indices_) {
+        // the index output spec is the same as the input spec just with a different data type
+        tt::tt_metal::TensorLayout output_layout_ind(
+            DataType::UINT16,
+            output_spec_data.page_config(),
+            output_spec_data.memory_config(),
+            output_spec_data.tensor_layout().get_alignment());
+        auto output_spec_ind = TensorSpec(output_spec_data.logical_shape(), output_layout_ind);
+        return {
+            create_device_tensor(output_spec_data, tensors.input_tensors_[0].device()),
+            create_device_tensor(output_spec_ind, tensors.input_tensors_[0].device())};
+    } else {
+        return {create_device_tensor(output_spec_data, tensors.input_tensors_[0].device())};
+    }
 }
 
 tt::stl::hash::hash_t Pool2D::compute_program_hash(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    auto input_mem_config = tensors.input_tensor_.memory_config();
-    auto dtype = tensors.input_tensor_.dtype();
+    auto input_mem_config = tensors.input_tensors_[0].memory_config();
+    auto dtype = tensors.input_tensors_[0].dtype();
     return tt::tt_metal::operation::hash_operation<Pool2D>(
         op_attr.sliding_window_config_.get_hash(),
         op_attr.pool_type_,
         op_attr.memory_config_,
         op_attr.divisor_override_,
         op_attr.count_include_pad_,
+        op_attr.return_indices_,
         input_mem_config,
         dtype);
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
-    const operation_attributes_t& op_attr, const tensor_args_t& inputs, const Tensor& output) {
-    const auto& input = inputs.input_tensor_;
+    const operation_attributes_t& op_attr, const tensor_args_t& inputs, const tensor_return_value_t& outputs) {
+    const auto& input = inputs.input_tensors_[0];
     const auto& input_shape = input.logical_shape();
     auto sliding_window_config = op_attr.sliding_window_config_;
     uint32_t batch_size = sliding_window_config.batch_size;
@@ -162,18 +225,19 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t
     int ideal_dev_clock_cycles = std::ceil((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi));
 
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {input}, {output}, ideal_dev_clock_cycles);
+        {input}, {outputs}, ideal_dev_clock_cycles);
     return result;
 }
 
 std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke(
-    const Tensor& input_tensor,
+    const std::vector<Tensor>& input_tensors,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     Pool2DType pool_type,
     DataType output_dtype,
     MemoryConfig memory_config,
     bool count_include_pad,
     std::optional<int32_t> divisor_override,
+    bool return_indices,
     uint32_t memory_used) {
     return {
         operation_attributes_t{
@@ -183,8 +247,9 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
             .memory_config_ = std::move(memory_config),
             .count_include_pad_ = count_include_pad,
             .divisor_override_ = divisor_override,
+            .return_indices_ = return_indices,
             .memory_used = memory_used},
-        tensor_args_t{input_tensor}};
+        tensor_args_t{input_tensors}};
 }
 
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -41,13 +41,13 @@ struct Pool2D {
 
     struct MultiCore {
         struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader0_kernel;
-            tt::tt_metal::KernelHandle reader1_kernel;
-            tt::tt_metal::KernelHandle compute_kernel;
-            tt::tt_metal::CBHandle raw_in_cb;
-            tt::tt_metal::CBHandle raw_in_idx_cb;
-            tt::tt_metal::CBHandle out_cb;
-            tt::tt_metal::CBHandle out_idx_cb;
+            tt::tt_metal::KernelHandle reader0_kernel{};
+            tt::tt_metal::KernelHandle reader1_kernel{};
+            tt::tt_metal::KernelHandle compute_kernel{};
+            tt::tt_metal::CBHandle raw_in_cb{};
+            tt::tt_metal::CBHandle raw_in_idx_cb{};
+            tt::tt_metal::CBHandle out_cb{};
+            tt::tt_metal::CBHandle out_idx_cb{};
             uint32_t ncores{};
             tt::tt_metal::DeviceStorage reader_indices_storage;
             tt::tt_metal::DeviceStorage scalar_config_storage;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -28,23 +28,26 @@ struct Pool2D {
         MemoryConfig memory_config_;
         bool count_include_pad_;
         std::optional<int32_t> divisor_override_;
+        bool return_indices_;
         uint32_t memory_used;
     };
 
     struct tensor_args_t {
-        const Tensor& input_tensor_;
+        const std::vector<Tensor>& input_tensors_;
     };
 
     using spec_return_value_t = TensorSpec;
-    using tensor_return_value_t = Tensor;
+    using tensor_return_value_t = std::vector<Tensor>;
 
     struct MultiCore {
         struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader0_kernel{};
-            tt::tt_metal::KernelHandle reader1_kernel{};
-            tt::tt_metal::KernelHandle compute_kernel{};
-            tt::tt_metal::CBHandle raw_in_cb{};
-            tt::tt_metal::CBHandle cb_out{};
+            tt::tt_metal::KernelHandle reader0_kernel;
+            tt::tt_metal::KernelHandle reader1_kernel;
+            tt::tt_metal::KernelHandle compute_kernel;
+            tt::tt_metal::CBHandle raw_in_cb;
+            tt::tt_metal::CBHandle raw_in_idx_cb;
+            tt::tt_metal::CBHandle out_cb;
+            tt::tt_metal::CBHandle out_idx_cb;
             uint32_t ncores{};
             tt::tt_metal::DeviceStorage reader_indices_storage;
             tt::tt_metal::DeviceStorage scalar_config_storage;
@@ -69,19 +72,20 @@ struct Pool2D {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static Tensor create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
-        const operation_attributes_t&, const tensor_args_t&, const Tensor&);
+        const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
+        const std::vector<Tensor>& input_tensors,
         const sliding_window::SlidingWindowConfig& sliding_window_config,
         Pool2DType pool_type,
         DataType output_dtype,
         MemoryConfig memory_config,
         bool count_include_pad,
         std::optional<int32_t> divisor_override,
+        bool return_indices,
         uint32_t memory_used);
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -12,6 +12,11 @@
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/operations/data_movement/move/move.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/math.hpp>
 
@@ -21,7 +26,7 @@ namespace operations::pool {
 // Generic invoke function for both max and avg pool operations. Most of the arguments are shared excpet for the
 // dilation which is set to (1,1) for avg pool and count_include_pad and divisor_override which have no effect on
 // maxpool.
-static Tensor pool2d_invoke(
+static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
     QueueId queue_id,
     const Tensor& input_tensor,
     Pool2DType pool_type,
@@ -40,7 +45,8 @@ static Tensor pool2d_invoke(
     const std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
     bool in_place_halo = false,
     bool deallocate_input = false,
-    bool reallocate_halo_output = true) {
+    bool reallocate_halo_output = true,
+    bool return_indices = false) {
     std::array<uint32_t, 4> padding_4d = sliding_window::get_pair_n4_padding(padding);
     bool is_out_tiled = false;  // pool output is row major
     bool is_in_tiled = input_tensor.layout() == ttnn::TILE_LAYOUT;
@@ -107,7 +113,13 @@ static Tensor pool2d_invoke(
         } else {  // auto-sharding
             std::optional<sliding_window::ParallelConfig> sw_parallel_config =
                 pool::determine_pool_config_for_auto_shard(
-                    input_tensor, sliding_window_config, channels, pool_type, count_include_pad, divisor_override);
+                    input_tensor,
+                    sliding_window_config,
+                    channels,
+                    pool_type,
+                    count_include_pad,
+                    divisor_override,
+                    return_indices);
             TT_FATAL(
                 sw_parallel_config.has_value(),
                 "autosharding could not determine valid shard scheme, please check tensor dimensions");
@@ -195,8 +207,45 @@ static Tensor pool2d_invoke(
         .is_avg_pool = pool_type == Pool2DType::AVG_POOL2D,
     };
 
-    // Call the halo uop
-    auto haloed_tensor = ttnn::halo(
+    // create the index tensor if needed
+    Tensor index_tensor_sharded;
+    if (return_indices) {
+        Shape spatial_shape({1, input_h, input_w, 1});
+
+        // Create indices tensor with UINT32 since repeat operation requires it
+        Tensor indices_hw = ttnn::index_all<uint32_t>(
+            spatial_shape,
+            spatial_shape,  // No padding needed for spatial-only shape
+            DataType::UINT32);
+        Shape repeat_shape({batch_size, 1, 1, channels});
+        Tensor index_full = ttnn::repeat(indices_hw.to_device(input_tensor.device()), repeat_shape);
+
+        // Reshape from [batch_size, input_h, input_w, channels] to [1, 1, batch_size * input_h * input_w, channels]
+        uint32_t nhw = batch_size * input_h * input_w;
+        Shape flattened_shape({1, 1, nhw, channels});
+        Tensor index_full_reshaped = ttnn::reshape(index_full, flattened_shape);
+
+        // Convert to TILE layout for typecast operation
+        Tensor index_full_tiled = ttnn::to_layout(index_full_reshaped, ttnn::TILE_LAYOUT);
+
+        // Convert to UINT16
+        Tensor index_full_uint16 = ttnn::typecast(index_full_tiled, DataType::UINT16);
+
+        // Convert back to ROW_MAJOR layout
+        if (!is_in_tiled) {
+            index_full_uint16 = ttnn::to_layout(index_full_uint16, ttnn::ROW_MAJOR_LAYOUT);
+        }
+
+        TT_FATAL(
+            input_tensor_sharded.memory_config().is_sharded(), "Input tensor must be sharded to shard indices tensor.");
+        index_tensor_sharded =
+            ttnn::to_memory_config(index_full_uint16, input_tensor_sharded.memory_config(), std::nullopt);
+    }
+
+    std::vector<Tensor> haloed_tensors;
+
+    // call the halo uop
+    Tensor haloed_tensor = ttnn::halo(
         queue_id,
         input_tensor_sharded,
         sliding_window_config,
@@ -214,29 +263,66 @@ static Tensor pool2d_invoke(
     if (reallocate_halo_output) {
         haloed_tensor = ttnn::move(haloed_tensor);
     }
+    haloed_tensors.push_back(std::move(haloed_tensor));
+
+    if (return_indices) {
+        Tensor haloed_index = ttnn::halo(
+            queue_id,
+            index_tensor_sharded,
+            sliding_window_config,
+            0,  // pad_val - should never be used as padding should never be the max index
+            false,
+            parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+            index_tensor_sharded.memory_config(),
+            is_out_tiled,
+            in_place_halo);
+
+        if (deallocate_input || is_input_tensor_in_dram) {
+            index_tensor_sharded.deallocate(/*force*/ true);
+        }
+
+        if (reallocate_halo_output) {
+            haloed_index = ttnn::move(haloed_index);
+        }
+        haloed_tensors.push_back(std::move(haloed_index));
+    }
 
     const uint32_t pre_allocate_size =
         haloed_tensor.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
 
-    auto output_tensor = ttnn::prim::pool2d(
+    // call the pool2d uop
+    std::vector<Tensor> output_tensors = ttnn::prim::pool2d(
         queue_id,
-        haloed_tensor,
+        haloed_tensors,
         sliding_window_config,
         pool_type,
         DataType::BFLOAT16,  // input_tensor.dtype(), // currently only bfp16 output is supported
         out_memory_config,
         count_include_pad,
         divisor_override,
+        return_indices,
         pre_allocate_size);
 
+    // format and return the result
     if (memory_config.has_value() && memory_config.value() != out_memory_config) {
-        output_tensor = ttnn::to_memory_config(output_tensor, memory_config.value(), std::nullopt);
+        for (int i = 0; i < output_tensors.size(); i++) {
+            output_tensors[i] = ttnn::to_memory_config(output_tensors[i], memory_config.value(), std::nullopt);
+        }
     }
 
-    return output_tensor;
+    if (return_indices) {
+        TT_FATAL(
+            output_tensors.size() == 2,
+            "Expected two output tensors when return_indices is true, but got {}.",
+            output_tensors.size());
+        return MaxPoolWithIndicesResult{std::move(output_tensors[0]), std::move(output_tensors[1])};
+    } else {
+        TT_FATAL(output_tensors.size() == 1, "Expected a single output tensor when return_indices is false.");
+        return std::move(output_tensors[0]);
+    }
 }
 
-Tensor MaxPool2DOp::invoke(
+std::variant<Tensor, MaxPoolWithIndicesResult> MaxPool2DOp::invoke(
     QueueId queue_id,
     const Tensor& input_tensor,
     uint32_t batch_size,
@@ -252,7 +338,8 @@ Tensor MaxPool2DOp::invoke(
     const std::optional<const TensorMemoryLayout> applied_shard_scheme,
     bool in_place_halo,
     bool deallocate_input,
-    bool reallocate_halo_output) {
+    bool reallocate_halo_output,
+    bool return_indices) {
     return pool2d_invoke(
         queue_id,
         input_tensor,
@@ -272,7 +359,8 @@ Tensor MaxPool2DOp::invoke(
         applied_shard_scheme,
         in_place_halo,
         deallocate_input,
-        reallocate_halo_output);
+        reallocate_halo_output,
+        return_indices);
 }
 
 Tensor AvgPool2DOp::invoke(
@@ -293,7 +381,7 @@ Tensor AvgPool2DOp::invoke(
     bool in_place_halo,
     bool deallocate_input,
     bool reallocate_halo_output) {
-    return pool2d_invoke(
+    auto result = pool2d_invoke(
         queue_id,
         input_tensor,
         Pool2DType::AVG_POOL2D,
@@ -312,7 +400,12 @@ Tensor AvgPool2DOp::invoke(
         applied_shard_scheme,
         in_place_halo,
         deallocate_input,
-        reallocate_halo_output);
+        reallocate_halo_output,
+        false  // return_indices
+    );
+
+    // Average pool always returns just the tensor, never indices
+    return std::get<Tensor>(result);
 }
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -14,8 +14,13 @@
 namespace ttnn {
 namespace operations::pool {
 
+struct MaxPoolWithIndicesResult {
+    Tensor output;
+    Tensor indices;
+};
+
 struct MaxPool2DOp {
-    static Tensor invoke(
+    static std::variant<Tensor, MaxPoolWithIndicesResult> invoke(
         QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t batch_size,
@@ -31,7 +36,8 @@ struct MaxPool2DOp {
         std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
         bool in_place_halo = false,
         bool deallocate_input = false,
-        bool reallocate_halo_output = true);
+        bool reallocate_halo_output = true,
+        bool return_indices = false);
 };
 struct AvgPool2DOp {
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -44,10 +44,11 @@ void bind_max_pool2d_operation(py::module& module) {
             in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
+            return_indices (bool, optional): whether to return both values and indices. When True, returns a tuple (values, indices). Defaults to `False`.
             queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
-            ttnn.Tensor: the max pool convolved output tensor.
+            ttnn.Tensor or tuple[ttnn.Tensor, ttnn.Tensor]: the max pool convolved output tensor, or a tuple of (values, indices) if return_indices is True.
 
         Example:
             >>> import ttnn
@@ -101,8 +102,9 @@ void bind_max_pool2d_operation(py::module& module) {
                bool in_place_halo,
                bool deallocate_input,
                bool reallocate_halo_output,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(
+               bool return_indices,
+               QueueId queue_id) -> py::object {
+                auto result = self(
                     queue_id,
                     input_tensor,
                     batch_size,
@@ -118,7 +120,16 @@ void bind_max_pool2d_operation(py::module& module) {
                     applied_shard_scheme,
                     in_place_halo,
                     deallocate_input,
-                    reallocate_halo_output);
+                    reallocate_halo_output,
+                    return_indices);
+
+                // Handle variant return type
+                if (std::holds_alternative<MaxPoolWithIndicesResult>(result)) {
+                    auto mpwi_result = std::get<MaxPoolWithIndicesResult>(result);
+                    return py::make_tuple(mpwi_result.output, mpwi_result.indices);
+                } else {
+                    return py::cast(std::get<ttnn::Tensor>(result));
+                }
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -136,6 +147,7 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("in_place_halo") = false,
             py::arg("deallocate_input") = false,
             py::arg("reallocate_halo_output") = true,
+            py::arg("return_indices") = false,
             py::arg("queue_id") = DefaultQueueId});
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -180,7 +180,6 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                                         // 16: Index Output CB (unused)
             one_scalar_per_core,                                 // 17: Scalar mode
             false,                                               // 18: Return Indices (unused)
-            out_ntiles_c                                         // 19: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_1 = tt::tt_metal::CreateKernel(
@@ -217,7 +216,6 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                                         // 16: Index Output CB (unused)
             one_scalar_per_core,                                 // 17: Scalar mode
             false,                                               // 18: Return Indices (unused)
-            out_ntiles_c                                         // 19: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_2 = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -148,10 +148,10 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const bool split_reader = false;                      // No split reader for grid sample
     const uint32_t channels_per_shard = input_shape[-1];  // All channels in one "shard"
     const uint32_t in_nblocks_c = (uint32_t)std::ceil(
-        (float)in_ntiles_c / MAX_TILES_PER_REDUCTION);    // For now 1, will add wide reduction support later
-    const uint32_t max_rows_for_reduction = 4;            // 4 corner values
-    const bool one_scalar_per_core = false;               // Scalars change during computation
-    const uint32_t dummy_cb_id = 32;                      // Unused CB for split reader
+        (float)in_ntiles_c / MAX_TILES_PER_REDUCTION);  // For now 1, will add wide reduction support later
+    const uint32_t max_rows_for_reduction = 4;          // 4 corner values
+    const bool one_scalar_per_core = false;             // Scalars change during computation
+    const uint32_t dummy_cb_id = 32;                    // Unused CB for split reader
 
     // Create compute kernels for different work loads
     // We'll create kernels for cores with same work amount together
@@ -170,11 +170,17 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             max_rows_for_reduction,                              // 6: Max rows
             input_cb_index,                                      // 7: Input CB
             dummy_cb_id,                                         // 8: Input CB 1 (unused)
-            scalar_cb_index,                                     // 9: Scalar CB
-            dummy_cb_id,                                         // 10: Scalar CB 1 (unused)
-            output_cb_index,                                     // 11: Output CB
-            one_scalar_per_core,                                 // 12: Scalar mode
-            out_ntiles_c                                         // 13: Tiles per channel (for CB space reservation)
+            dummy_cb_id,                                         // 9: Index Input CB (unused)
+            dummy_cb_id,                                         // 10: Index Input CB 1 (unused)
+            scalar_cb_index,                                     // 11: Scalar CB
+            dummy_cb_id,                                         // 12: Scalar CB 1 (unused)
+            dummy_cb_id,                                         // 13: Tile Temp CB (unused)
+            dummy_cb_id,                                         // 14: Index Tile Temp CB (unused)
+            output_cb_index,                                     // 15: Output CB
+            dummy_cb_id,                                         // 16: Index Output CB (unused)
+            one_scalar_per_core,                                 // 17: Scalar mode
+            false,                                               // 18: Return Indices (unused)
+            out_ntiles_c                                         // 19: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_1 = tt::tt_metal::CreateKernel(
@@ -195,17 +201,23 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             in_ntiles_c,                                         // 0: Input tiles per channel
             reduction_size,                                      // 1: Reduction size (4 for bilinear)
             split_reader,                                        // 2: Split reader flag
-            grid_batching_factor * num_sticks_per_core_group_2,  // 3: Total grid interpolations per core for group 2
+            grid_batching_factor * num_sticks_per_core_group_2,  // 3:  Total grid interpolations per core for group 1
             channels_per_shard,                                  // 4: Channels per shard
             in_nblocks_c,                                        // 5: Channel blocks
             max_rows_for_reduction,                              // 6: Max rows
             input_cb_index,                                      // 7: Input CB
             dummy_cb_id,                                         // 8: Input CB 1 (unused)
-            scalar_cb_index,                                     // 9: Scalar CB
-            dummy_cb_id,                                         // 10: Scalar CB 1 (unused)
-            output_cb_index,                                     // 11: Output CB
-            one_scalar_per_core,                                 // 12: Scalar mode
-            out_ntiles_c                                         // 13: Tiles per channel (for CB space reservation)
+            dummy_cb_id,                                         // 9: Index Input CB (unused)
+            dummy_cb_id,                                         // 10: Index Input CB 1 (unused)
+            scalar_cb_index,                                     // 11: Scalar CB
+            dummy_cb_id,                                         // 12: Scalar CB 1 (unused)
+            dummy_cb_id,                                         // 13: Tile Temp CB (unused)
+            dummy_cb_id,                                         // 14: Index Tile Temp CB (unused)
+            output_cb_index,                                     // 15: Output CB
+            dummy_cb_id,                                         // 16: Index Output CB (unused)
+            one_scalar_per_core,                                 // 17: Scalar mode
+            false,                                               // 18: Return Indices (unused)
+            out_ntiles_c                                         // 19: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_2 = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -113,13 +113,16 @@ FactoryParameters get_factory_parameters(
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t in_channels,
-    Pool2DType pool_type) {
+    Pool2DType pool_type,
+    bool return_indices) {
     uint32_t multi_buffering_factor = 2;
     bool split_reader = true;
 
     auto dtype = input.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input.dtype();
     tt::DataFormat data_format = datatype_to_dataformat_converter(dtype);
+    tt::DataFormat index_format = datatype_to_dataformat_converter(DataType::UINT16);
     uint32_t nbytes = datum_size(data_format);
+    uint32_t index_nbytes = datum_size(index_format);
 
     uint32_t kernel_size_hw = kernel_h * kernel_w;  // number of valid rows, to read
     // for medium kernels with sizes 16 < kernel_size_hw < 32 we tilize an entire tile even if some rows are unused,
@@ -137,14 +140,21 @@ FactoryParameters get_factory_parameters(
     const uint32_t max_rows_for_reduction =
         !last_tile_is_partial ? tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT / 2;
     const bool is_large_kernel = kernel_size_hw > max_rows_for_reduction;
-    const uint32_t MAX_TILES_PER_REDUCTION = (is_avg_pool && is_large_kernel) ? 4 : 8;
+    if (return_indices) {
+        TT_FATAL(
+            !is_avg_pool && !is_large_kernel,
+            "Currently only small full width max pool is supported with return_indices");
+    }
+    const uint32_t MAX_TILES_PER_REDUCTION = return_indices ? 1 : (is_avg_pool && is_large_kernel) ? 4 : 8;
     const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
 
     return FactoryParameters{
         .multi_buffering_factor = multi_buffering_factor,
         .split_reader = split_reader,
         .nbytes = nbytes,
+        .index_nbytes = index_nbytes,
         .data_format = data_format,
+        .index_format = index_format,
         .in_ntiles_c = in_ntiles_c,
         .out_ntiles_c = out_ntiles_c,
         .is_avg_pool = is_avg_pool,
@@ -164,6 +174,7 @@ uint32_t calculate_L1_usage(
     uint32_t ceil_pad_h,
     uint32_t ceil_pad_w,
     bool ceil_mode,
+    bool return_indices,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t out_h,
@@ -185,7 +196,8 @@ uint32_t calculate_L1_usage(
         num_shards_c = grid_size.x;
     }
 
-    FactoryParameters params = get_factory_parameters(num_shards_c, input, kernel_h, kernel_w, in_channels, pool_type);
+    FactoryParameters params =
+        get_factory_parameters(num_shards_c, input, kernel_h, kernel_w, in_channels, pool_type, return_indices);
 
     bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
@@ -203,10 +215,14 @@ uint32_t calculate_L1_usage(
     uint32_t clear_value_cb_size = tt::constants::TILE_HW * params.nbytes;
 
     uint32_t in_cb_sz = 0;
-    if (params.is_wide_reduction) {
-        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+    if (return_indices) {
+        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
     } else {
-        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+        if (params.is_wide_reduction) {
+            in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+        } else {
+            in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+        }
     }
 
     uint32_t in_cb_page_padded = tt::round_up(in_cb_sz, tt::constants::TILE_HW);
@@ -219,6 +235,23 @@ uint32_t calculate_L1_usage(
         in_cb_config_1_size = in_cb_npages * in_cb_pagesize;
     }
 
+    uint32_t in_idx_cb_config_0_size = 0;
+    uint32_t in_idx_cb_config_1_size = 0;
+    uint32_t tile_tmp_cb_size = 0;
+    uint32_t tile_idx_tmp_cb_size = 0;
+    if (return_indices) {
+        uint32_t in_idx_cb_pagesize = params.index_nbytes * in_cb_page_padded;
+        in_idx_cb_config_0_size = in_cb_npages * in_idx_cb_pagesize;
+        if (params.split_reader) {
+            in_idx_cb_config_1_size = in_cb_npages * in_idx_cb_pagesize;
+        }
+
+        // Add tile temporary CBs for return_indices
+        uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+        tile_tmp_cb_size = params.nbytes * tile_elems * 1;            // 1 page
+        tile_idx_tmp_cb_size = params.index_nbytes * tile_elems * 1;  // 1 page
+    }
+
     // after reduction
     uint32_t out_cb_pagesize =
         std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
@@ -226,8 +259,17 @@ uint32_t calculate_L1_usage(
     uint32_t out_cb_npages = output_memory.shard_spec().value().shape[0] * params.out_ntiles_c;
     uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
 
+    uint32_t out_idx_cb_config_size = 0;
+    if (return_indices) {
+        uint32_t out_cb_pagesize =
+            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
+            params.index_nbytes;
+        out_idx_cb_config_size = out_cb_npages * out_cb_pagesize;
+    }
+
     return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
-           sliding_window::align_buffer(out_cb_config_size) /* global, involved */;
+           in_idx_cb_config_0_size + in_idx_cb_config_1_size + tile_tmp_cb_size + tile_idx_tmp_cb_size +
+           sliding_window::align_buffer(out_cb_config_size) + sliding_window::align_buffer(out_idx_cb_config_size);
 }
 
 std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
@@ -236,7 +278,8 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     uint32_t channels,
     Pool2DType pool_type,
     bool count_include_pad,
-    std::optional<int32_t> divisor_override) {
+    std::optional<int32_t> divisor_override,
+    bool return_indices) {
     uint32_t batch_size = sliding_window_config.batch_size;
     auto output_shape = sliding_window_config.get_output_shape();
     auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
@@ -281,6 +324,7 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
             sliding_window_config.get_ceil_pad_h(),
             sliding_window_config.get_ceil_pad_w(),
             sliding_window_config.ceil_mode,
+            return_indices,
             sliding_window_config.window_hw.first,
             sliding_window_config.window_hw.second,
             sliding_window_config.get_output_shape()[1],

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -43,7 +43,9 @@ struct FactoryParameters {
     uint32_t multi_buffering_factor;
     bool split_reader;
     uint32_t nbytes;
+    uint32_t index_nbytes;
     tt::DataFormat data_format;
+    tt::DataFormat index_format;
     uint32_t in_ntiles_c;
     uint32_t out_ntiles_c;
     bool is_avg_pool;
@@ -88,7 +90,8 @@ std::optional<sliding_window::ParallelConfig> determine_pool_config_for_auto_sha
     uint32_t channels,
     Pool2DType pool_type,
     bool count_include_pad,
-    std::optional<int32_t> divisor_override);
+    std::optional<int32_t> divisor_override,
+    bool return_indices);
 
 FactoryParameters get_factory_parameters(
     uint32_t num_shards_c,
@@ -96,7 +99,8 @@ FactoryParameters get_factory_parameters(
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t in_channels,
-    Pool2DType pool_type);
+    Pool2DType pool_type,
+    bool return_indices);
 
 uint32_t calculate_L1_usage(
     const Tensor& input,
@@ -106,6 +110,7 @@ uint32_t calculate_L1_usage(
     uint32_t ceil_pad_h,
     uint32_t ceil_pad_w,
     bool ceil_mode,
+    bool return_indices,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t out_h,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12099

### Problem description
Max pool should support the option to return the indexes of the max values.

### What's changed
- A return_indices flag has been added to max pool
- Max pool and sliding window host infrastructure has been updated to generate an index input tensor, and index output tensor, exposing both to kernels via CBs
- The index tensor is passed through Halo just like the data tensor
- The reader kernel has been updated to read index values along side the data values
- The compute kernel has been updated to tilize manually tilize the index and data CBs, copy them to DST, run TopK to reduce the data / indexes simultaneously, and pack the two outputs to their respective output tensors
- A new test has been added to test the index functionality and new checks have been added to clarify when return_indices functionality is supported.
- New DPRINT functions have been added to support common integer formats

### Remaining Limitations
- No support on blackhole for stick sizes larger than 16
- No support for Float32 (Pool2D does not support this even without indices)
- No support for kernel sizes different than 9 elements
- No support for large tensors with input_h * input_w >= 256^2

### Max Pool Compute Perf for the Shield Team Trace:
WH (20 cores BF16):
- Basic Max Pool:            196017
- Max Pool with Indices: 970277
- Ratio:                                  4.9x

BH (20 cores BF16):
- Basic Max Pool:            223294
- Max Pool with Indices: 603522
- Ratio:                                   2.7x

### Checklist
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448443712
failing on main, this PR hits same unrelated error
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448446137
failing on main, this PR hits same unrelated error
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448464804
failing on main, this PR hits same unrelated error
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448461861
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448453234
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448455527
failing on main, this PR hits same unrelated error
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17448458972
failing on main, this PR hits same unrelated error
- [x] New/Existing tests provide coverage for changes