### PR TITLE
#4483: Update rdiv for inf cases

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -513,11 +513,15 @@ def test_unary_logit(input_shapes, param, device):
 
 @pytest.mark.parametrize(
     "param",
-    {-1.5, 1.7},
+    {-1.5, 1.7, 0.0},
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_inf_check(param, round_mode, device):
-    in_data = torch.zeros(torch.Size([1, 1, 32, 32]), dtype=torch.bfloat16)
+def test_unary_rdiv_inf_nan_check(param, round_mode, device):
+    dtype = torch.bfloat16
+    if dtype == torch.bfloat16 and param == 0.0:
+        pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
+
+    in_data = torch.zeros(torch.Size([1, 1, 32, 32]), dtype=dtype)
     input_tensor = ttnn.from_torch(
         in_data,
         dtype=ttnn.bfloat16,
@@ -530,7 +534,6 @@ def test_unary_rdiv_inf_check(param, round_mode, device):
     golden_function = ttnn.get_golden_function(ttnn.rdiv)
     golden_tensor = golden_function(in_data, param, round_mode=round_mode)
 
-    print(output_tensor, golden_tensor)
     comp_pass = compare_equal([output_tensor], [golden_tensor])
     assert comp_pass
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -541,7 +541,7 @@ Tensor ExecuteRdiv::invoke(
         result = ttnn::floor(result);
     }
     return ttnn::where(
-        ttnn::eqz(queue_id, input_tensor, memory_config), t_inf, result, memory_config, optional_output_tensor);
+        ttnn::eqz(queue_id, input_tensor, memory_config), t_inf * value, result, memory_config, optional_output_tensor);
 }
 
 // logit(input, eps)=log(input / 1 - input)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -733,7 +733,7 @@ void bind_unary_rdiv(
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
-            {2} (int): {3}.
+            {2} (float): {3}.
 
         Keyword Args:
             {4} (string): {5}. Can be  None, "trunc", "floor". Defaults to `None`.
@@ -2277,7 +2277,7 @@ void py_module(py::module& module) {
         module,
         ttnn::rdiv,
         "value",
-        "denominator value which is actually calculated as numerator float value >= 0",
+        "denominator that is considered as numerator, which should be a non-zero float value",
         "round_mode",
         "rounding_mode value",
         "None",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/4483

### Problem description
To handle inf cases in Rdiv. Need to handle for cases where the parameter passed is a non-zero value.

### What's changed
Handled inf cases in rdiv
<img width="852" height="686" alt="Screenshot 2025-08-21 at 8 58 15 AM" src="https://github.com/user-attachments/assets/c7a576e2-9301-4ee7-8732-f3d0b66b3097" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17128361528) PASSED
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17128364130) PASSED
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes