### PR TITLE
Add prefetch command to read in prefetch_h

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -64,7 +64,7 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 5 -spre -sdis" # Packed Read Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 8 -i 5 -spre -sdis"  # Ringbuffer Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 9 -i 5 -spre" # Raw Copy Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 10 -i 5 -spre -sdis" # Raw Copy Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 9 -i 5 -spre -sdis" # Raw Copy Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -rb -spre -sdis"  # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -rb -spre -sdis"  # Random Test
 

--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -63,6 +63,8 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -spre -sdis" # Host Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 5 -spre -sdis" # Packed Read Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 8 -i 5 -spre -sdis"  # Ringbuffer Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 9 -i 5 -spre" # Raw Copy Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 10 -i 5 -spre -sdis" # Raw Copy Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -rb -spre -sdis"  # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -rb -spre -sdis"  # Random Test
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1594,6 +1594,83 @@ void gen_smoke_test(
     // gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 32, 64, 128);
 }
 
+void gen_relay_linear_h_test(
+    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
+    static constexpr uint32_t min_read_size = 128;
+    static constexpr uint32_t max_read_size = 4096;  // Keep reasonable size for test
+
+    bool done = false;
+    while (!done) {
+        // Generate random read size, ensure it's aligned
+        auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+        uint32_t length = tt::align(std::max(min_read_size, std::rand() % max_read_size), dram_alignment);
+
+        if (device_data.size() * sizeof(uint32_t) + length > DEVICE_DATA_SIZE) {
+            // Close to the end, finish up
+            done = true;
+        } else {
+            // Generate the dispatcher write command first
+            vector<uint32_t> dispatch_cmds;
+            gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, first_worker_g, device_data, length);
+
+            // Add the CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH with the dispatch command as payload
+            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
+
+            // Now generate the CQ_PREFETCH_CMD_RELAY_LINEAR_H command to fetch data from NOC
+            auto prior_end = prefetch_cmds.size();
+
+            // Create the relay linear H command
+            CQPrefetchCmd cmd{};
+            cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR_H;
+
+            // Set up the source NOC address - we'll read from DRAM where data is initialized
+            // Use DRAM bank 0 for simplicity
+            const uint32_t dram_bank_id = 0;
+            auto dram_channel = device->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+            CoreCoord dram_logical_core = device->logical_core_from_dram_channel(dram_channel);
+            CoreCoord dram_physical_core = tt::tt_metal::MetalContext::instance()
+                                               .get_cluster()
+                                               .get_soc_desc(device->id())
+                                               .get_preferred_worker_core_for_dram_view(dram_channel, NOC::NOC_0);
+            cmd.relay_linear_h.noc_xy_addr = device->get_noc_unicast_encoding(NOC::NOC_0, dram_physical_core);
+
+            [[maybe_unused]] auto offset = device->allocator()->get_bank_offset(BufferType::DRAM, dram_bank_id);
+            // Read from DRAM result data address where data is stored
+            // DeviceData uses the logical coordinates as keys
+            cmd.relay_linear_h.addr = DRAM_DATA_BASE_ADDR + offset;
+            cmd.relay_linear_h.length = length;
+
+            // Add the command
+            update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() { add_bare_prefetcher_cmd(prefetch_cmds, cmd, true); });
+
+            // Update device data to simulate the data that would be written
+            // For relay linear H, we're reading from DRAM which should already be populated.
+            // We need to simulate writing that DRAM data to the target worker core.
+            uint32_t length_words = length / sizeof(uint32_t);
+
+            // Ensure DRAM data exists
+            TT_FATAL(
+                device_data.core_and_bank_present(dram_logical_core, dram_bank_id),
+                "DRAM core {} bank {} not present in device data",
+                dram_logical_core.str(),
+                dram_bank_id);
+            TT_FATAL(
+                length_words <= device_data.size_at(dram_logical_core, dram_bank_id),
+                "Requested length {} words exceeds available DRAM data {} words at core {} bank {}",
+                length_words,
+                device_data.size_at(dram_logical_core, dram_bank_id),
+                dram_logical_core.str(),
+                dram_bank_id);
+
+            for (uint32_t i = 0; i < length_words; i++) {
+                // Get the actual data from DRAM - it must exist
+                uint32_t data_value = device_data.at(dram_logical_core, dram_bank_id, i);
+                device_data.push_one(first_worker_g, data_value);
+            }
+        }
+    }
+}
+
 void gen_prefetcher_cmds(
     IDevice* device,
     vector<uint32_t>& prefetch_cmds,
@@ -1616,6 +1693,7 @@ void gen_prefetcher_cmds(
         case 6: gen_host_test(device, prefetch_cmds, cmd_sizes, device_data); break;
         case 7: gen_packed_read_test(device, prefetch_cmds, cmd_sizes, device_data); break;
         case 8: gen_ringbuffer_read_test(device, prefetch_cmds, cmd_sizes, device_data); break;
+        case 9: gen_relay_linear_h_test(device, prefetch_cmds, cmd_sizes, device_data); break;
         default:
             log_fatal(tt::LogTest, "Unknown test: {}", test_type_g);
             exit(0);
@@ -2050,7 +2128,7 @@ void configure_for_single_chip(
         prefetch_defines["DOWNSTREAM_CB_SEM_ID"] = std::to_string(prefetch_d_upstream_cb_sem);
         prefetch_defines["CMDDAT_Q_BASE"] = std::to_string(cmddat_q_base);
         prefetch_defines["CMDDAT_Q_SIZE"] = std::to_string(cmddat_q_size_g);
-        prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(0);
+        prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
         CoreCoord phys_prefetch_h_downstream_core = phys_prefetch_d_core;
         configure_kernel_variant<false, true>(
             program,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1596,8 +1596,10 @@ void gen_smoke_test(
 
 void gen_relay_linear_h_test(
     IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    static constexpr uint32_t min_read_size = 128;
-    static constexpr uint32_t max_read_size = 4096;  // Keep reasonable size for test
+    static constexpr uint32_t min_read_size = 32;
+    const uint32_t max_read_size =
+        std::min(scratch_db_size_g, prefetch_q_entries_g * (uint32_t)sizeof(DispatchSettings::prefetch_q_entry_type)) -
+        64;
 
     bool done = false;
     while (!done) {

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -16,20 +16,22 @@ constexpr uint32_t CQ_DISPATCH_CMD_SIZE = 16;  // for L1 alignment
 
 // Prefetcher CMD ID enums
 enum CQPrefetchCmdId : uint8_t {
-    CQ_PREFETCH_CMD_ILLEGAL = 0,               // common error value
-    CQ_PREFETCH_CMD_RELAY_LINEAR = 1,          // relay banked/paged data from src_noc to dispatcher
-    CQ_PREFETCH_CMD_RELAY_PAGED = 2,           // relay banked/paged data from src_noc to dispatcher
-    CQ_PREFETCH_CMD_RELAY_PAGED_PACKED = 3,    // relay banked/paged data from multiple srcs to dispacher
-    CQ_PREFETCH_CMD_RELAY_INLINE = 4,          // relay (inline) data from CmdDatQ to dispatcher
-    CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH = 5,  // same as above, but doesn't flush the page to dispatcher
-    CQ_PREFETCH_CMD_EXEC_BUF = 6,              // execute commands from a buffer
-    CQ_PREFETCH_CMD_EXEC_BUF_END = 7,  // finish executing commands from a buffer (return), payload like relay_inline
-    CQ_PREFETCH_CMD_STALL = 8,         // drain pipe through dispatcher
-    CQ_PREFETCH_CMD_DEBUG = 9,         // log waypoint data to watcher, checksum
-    CQ_PREFETCH_CMD_TERMINATE = 10,    // quit
-    CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER = 11,    // Copy paged data to the ringbuffer
-    CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET = 12,  // Set an offset in the ringbuffer for later reads.
-    CQ_PREFETCH_CMD_RELAY_RINGBUFFER = 13,       // Relay data from the ringbuffer to the dispatcher
+    CQ_PREFETCH_CMD_ILLEGAL = 0,       // common error value
+    CQ_PREFETCH_CMD_RELAY_LINEAR = 1,  // relay banked/paged data from src_noc to dispatcher
+    CQ_PREFETCH_CMD_RELAY_LINEAR_H =
+        2,  // relay linear from src_noc on prefetch_h chip to dispatcher. Must be only command in fetchq entry.
+    CQ_PREFETCH_CMD_RELAY_PAGED = 3,           // relay banked/paged data from src_noc to dispatcher
+    CQ_PREFETCH_CMD_RELAY_PAGED_PACKED = 4,    // relay banked/paged data from multiple srcs to dispacher
+    CQ_PREFETCH_CMD_RELAY_INLINE = 5,          // relay (inline) data from CmdDatQ to dispatcher
+    CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH = 6,  // same as above, but doesn't flush the page to dispatcher
+    CQ_PREFETCH_CMD_EXEC_BUF = 7,              // execute commands from a buffer
+    CQ_PREFETCH_CMD_EXEC_BUF_END = 8,  // finish executing commands from a buffer (return), payload like relay_inline
+    CQ_PREFETCH_CMD_STALL = 9,         // drain pipe through dispatcher
+    CQ_PREFETCH_CMD_DEBUG = 10,        // log waypoint data to watcher, checksum
+    CQ_PREFETCH_CMD_TERMINATE = 11,    // quit
+    CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER = 12,    // Copy paged data to the ringbuffer
+    CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET = 13,  // Set an offset in the ringbuffer for later reads.
+    CQ_PREFETCH_CMD_RELAY_RINGBUFFER = 14,       // Relay data from the ringbuffer to the dispatcher
     CQ_PREFETCH_CMD_MAX_COUNT,                   // for checking legal IDs
 };
 
@@ -83,6 +85,7 @@ struct CQPrefetchBaseCmd {
     enum CQPrefetchCmdId cmd_id;
 } __attribute__((packed));
 
+// Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH)
 struct CQPrefetchRelayLinearCmd {
     uint8_t pad1;
     uint16_t pad2;
@@ -90,7 +93,15 @@ struct CQPrefetchRelayLinearCmd {
     uint32_t addr;
     uint32_t length;
 } __attribute__((packed));
-;
+
+// Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH)
+struct CQPrefetchRelayLinearHCmd {
+    uint8_t pad1;
+    uint16_t pad2;
+    uint32_t noc_xy_addr;
+    uint32_t addr;
+    uint32_t length;  // Length must be <= min(scratch_db_size, max command size) - sizeof(CQPrefetchHToPrefetchDHeader)
+} __attribute__((packed));
 
 constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK = 0xff;
 constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT = 15;
@@ -173,6 +184,7 @@ struct CQPrefetchCmd {
     CQPrefetchBaseCmd base;
     union {
         CQPrefetchRelayLinearCmd relay_linear;
+        CQPrefetchRelayLinearHCmd relay_linear_h;
         CQPrefetchRelayPagedCmd relay_paged;
         CQPrefetchRelayPagedPackedCmd relay_paged_packed;
         CQPrefetchRelayInlineCmd relay_inline;

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -94,7 +94,8 @@ struct CQPrefetchRelayLinearCmd {
     uint32_t length;
 } __attribute__((packed));
 
-// Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH)
+// Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH). Must be only
+// command in fetchq entry.
 struct CQPrefetchRelayLinearHCmd {
     uint8_t pad1;
     uint16_t pad2;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1697,7 +1697,7 @@ inline void relay_raw_data_to_downstream(
 
         // Release pages consumed by this chunk; include extra_pages on final chunk
         uint32_t pages_to_release = npages;
-        if (is_final_chunk && extra_pages != 0) {
+        if (is_final_chunk) {
             pages_to_release += extra_pages;
         }
         if (pages_to_release != 0) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -27,6 +27,8 @@
 constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC PCIe alignemnt
 struct CQPrefetchHToPrefetchDHeader_s {
     uint32_t length;
+    uint8_t raw_copy;     // If true, copy the data directly to the downstream.
+    uint8_t extra_pages;  // Number of extra pages to flush at the end (if doing raw copy)
 };
 union CQPrefetchHToPrefetchDHeader {
     CQPrefetchHToPrefetchDHeader_s header;
@@ -1513,6 +1515,76 @@ bool process_cmd(
     return done;
 }
 
+// Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
+uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr) {
+    // This ensures that a previous cmd using the scratch buf has finished
+    noc_async_writes_flushed();
+
+    volatile CQPrefetchCmd tt_l1_ptr* cmd =
+        (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    uint32_t noc_xy_addr = cmd->relay_linear_h.noc_xy_addr;
+    uint32_t read_addr = cmd->relay_linear_h.addr;
+    uint32_t length = cmd->relay_linear_h.length;
+
+    uint32_t total_length = length + CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+    ASSERT(total_length <= scratch_db_size);
+
+    // DPRINT << "relay_linear_h: " << ((uint32_t)cmd_ptr) << " " << static_cast<uint32_t>(cmd->base.cmd_id) << " " <<
+    // length << " " << read_addr << " " << noc_xy_addr << " dest " << scratch_db_top[0] << ENDL();
+
+    uint32_t data_ptr = scratch_db_top[0];
+    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
+        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_db_top[0];
+    dptr->header.length = total_length;
+    dptr->header.raw_copy = true;
+    dptr->header.extra_pages = 1;
+
+    uint32_t payload_ptr = data_ptr + sizeof(CQPrefetchHToPrefetchDHeader);
+    uint64_t noc_addr = get_noc_addr_helper(noc_xy_addr, read_addr);
+
+    noc_async_read(noc_addr, payload_ptr, length);
+    noc_async_read_barrier();
+
+    uint32_t npages = (total_length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
+    // Assume the dispatch buffer is big relative to cmddat command size that we can
+    // grab what we need in one chunk
+    cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(npages, my_downstream_cb_sem_additional_count);
+
+    // Write sizes below may exceed NOC_MAX_BURST_SIZE so we use the any_len version
+    // Amount to write depends on how much free space
+    uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
+    if (downstream_pages_left >= npages) {
+        // WAIT is not needed here because previous writes have already been flushed. Prefetch H only uses this
+        // function and this function always flushes before returning
+        relay_client
+            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, false, NCRISC_WR_CMD_BUF>(
+                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), total_length, npages);
+        downstream_data_ptr += npages * downstream_cb_page_size;
+    } else {
+        uint32_t tail_pages = npages - downstream_pages_left;
+        uint32_t available = downstream_pages_left * downstream_cb_page_size;
+        if (available > 0) {
+            relay_client.write_any_len<my_noc_index, false, NCRISC_WR_CMD_BUF, true>(
+                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
+            data_ptr += available;
+            total_length -= available;
+        }
+
+        // Remainder
+        // WAIT is needed here because previously "if (available > 0)" then it used the write buf which may still be
+        // busy at this point
+        relay_client
+            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
+                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), total_length, npages);
+
+        downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
+    }
+
+    noc_async_writes_flushed();
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE + sizeof(CQPrefetchHToPrefetchDHeader);
+}
+
 // This function is only valid when called on the H variant
 // It expects the NoC async write state to be initialized to point to the downstream
 static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool is_exec_buf) {
@@ -1521,6 +1593,7 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
     // This packet header just contains the length
     volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr = (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
     dptr->header.length = length;
+    dptr->header.raw_copy = false;
 
     uint32_t npages = (length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
 
@@ -1572,40 +1645,74 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
     return fence;
 }
 
+// Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
+template <typename RelayInlineState>
+inline void relay_raw_data_to_downstream(
+    uint32_t& data_ptr, uint32_t length, uint32_t& local_downstream_data_ptr, uint8_t extra_pages) {
+    // DPRINT << "relay_raw_data_to_downstream: " << data_ptr << " " << length << " " << local_downstream_data_ptr << "
+    // " << static_cast<uint32_t>(extra_pages) << ENDL();
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    if (length > remaining) {
+        uint32_t npages = write_pages_to_dispatcher<0, false>(local_downstream_data_ptr, data_ptr, remaining);
+        data_ptr = cmddat_q_base;
+        length -= remaining;
+        remaining = cmddat_q_end - data_ptr;
+    }
+    uint32_t npages = write_pages_to_dispatcher<1, true>(local_downstream_data_ptr, data_ptr, length);
+    local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
+    cb_release_pages<my_noc_index, RelayInlineState::downstream_noc_encoding, RelayInlineState::downstream_cb_sem>(
+        npages + extra_pages);
+    noc_async_writes_flushed();
+    data_ptr += length;
+    data_ptr = round_up_pow2(data_ptr, cmddat_q_page_size);
+}
+
 // Gets cmds from upstream prefetch_h
 // Note the prefetch_h uses the HostQ and grabs whole commands
 // Shared command processor assumes whole commands are present, really
 // just matters for the inline command which could be re-implemented
 // This grabs whole (possibly sets of if multiple in a page) commands
-inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr) {
-    // DPRINT << "get_commands: " << data_ptr << " " << fence << " " << cmddat_q_base << " " << cmddat_q_end << ENDL();
-    if (data_ptr == fence) {
-        get_cb_page<cmddat_q_base, cmddat_q_blocks, cmddat_q_log_page_size, my_upstream_cb_sem_id>(
-            data_ptr, fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
+inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr, uint32_t& downstream_data_ptr) {
+    while (true) {
+        // DPRINT << "get_commands: " << data_ptr << " " << fence << " " << cmddat_q_base << " " << cmddat_q_end <<
+        // ENDL();
+        if (data_ptr == fence) {
+            get_cb_page<cmddat_q_base, cmddat_q_blocks, cmddat_q_log_page_size, my_upstream_cb_sem_id>(
+                data_ptr, fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
+        }
+
+        volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* cmd_ptr =
+            (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
+        uint32_t length = cmd_ptr->header.length;
+
+        uint32_t pages_ready = (fence - data_ptr) >> cmddat_q_log_page_size;
+        uint32_t pages_needed = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+        int32_t pages_pending = pages_needed - pages_ready;
+        int32_t npages = 0;
+
+        // TODO
+        // Ugly: get_cb_page was written to process 1 page at a time, we need multiple
+        // If it wraps, it resets the data_ptr to the top of the buffer, hand it a dummy for now
+        uint32_t dummy_data_ptr = data_ptr;
+        while (npages < pages_pending) {
+            npages += get_cb_page<cmddat_q_base, cmddat_q_blocks, cmddat_q_log_page_size, my_upstream_cb_sem_id>(
+                dummy_data_ptr, fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
+            IDLE_ERISC_RETURN(length - sizeof(CQPrefetchHToPrefetchDHeader));
+        }
+
+        data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
+        if (cmd_ptr->header.raw_copy) {
+            relay_raw_data_to_downstream<DispatchRelayInlineState>(
+                data_ptr,
+                length - sizeof(CQPrefetchHToPrefetchDHeader),
+                downstream_data_ptr,
+                cmd_ptr->header.extra_pages);
+            uint32_t pages_to_free = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+            relay_client.release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
+        } else {
+            return length - sizeof(CQPrefetchHToPrefetchDHeader);
+        }
     }
-
-    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* cmd_ptr =
-        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
-    uint32_t length = cmd_ptr->header.length;
-
-    uint32_t pages_ready = (fence - data_ptr) >> cmddat_q_log_page_size;
-    uint32_t pages_needed = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
-    int32_t pages_pending = pages_needed - pages_ready;
-    int32_t npages = 0;
-
-    // TODO
-    // Ugly: get_cb_page was written to process 1 page at a time, we need multiple
-    // If it wraps, it resets the data_ptr to the top of the buffer, hand it a dummy for now
-    uint32_t dummy_data_ptr = data_ptr;
-    while (npages < pages_pending) {
-        npages += get_cb_page<cmddat_q_base, cmddat_q_blocks, cmddat_q_log_page_size, my_upstream_cb_sem_id>(
-            dummy_data_ptr, fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
-        IDLE_ERISC_RETURN(length - sizeof(CQPrefetchHToPrefetchDHeader));
-    }
-
-    data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
-
-    return length - sizeof(CQPrefetchHToPrefetchDHeader);
 }
 
 void kernel_main_h() {
@@ -1649,7 +1756,11 @@ void kernel_main_h() {
         uint32_t cmd_id = cmd->base.cmd_id;
         // Infer that an exec_buf command is to be executed based on the stall state.
         bool is_exec_buf = (stall_state == STALLED);
-        cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
+        if (cmd_id == CQ_PREFETCH_CMD_RELAY_LINEAR_H) {
+            cmd_ptr += process_relay_linear_h_cmd(cmd_ptr);
+        } else {
+            cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
+        }
 
         // Note: one fetch_q entry can contain multiple commands
         // The code below assumes these commands arrive individually, packing them would require parsing all cmds
@@ -1711,7 +1822,7 @@ void kernel_main_d() {
     while (!done) {
         // cmds come in packed batches based on HostQ reads in prefetch_h
         // once a packed batch ends, we need to jump to the next page
-        uint32_t length = relay_cb_get_cmds(fence, cmd_ptr);
+        uint32_t length = relay_cb_get_cmds(fence, cmd_ptr, downstream_data_ptr);
 
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1648,14 +1648,11 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
 }
 
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
-// Since the size of the data is less that the size of the cmddat_q, we let the caller return pages to the upstream all at once.
+// Since the size of the data is less that the size of the cmddat_q, we let the caller return pages to the upstream all
+// at once.
 template <typename RelayInlineState>
 inline void relay_raw_data_to_downstream(
-    uint32_t& fence,
-    uint32_t& data_ptr,
-    uint32_t length,
-    uint32_t& local_downstream_data_ptr,
-    uint8_t extra_pages) {
+    uint32_t& fence, uint32_t& data_ptr, uint32_t length, uint32_t& local_downstream_data_ptr, uint8_t extra_pages) {
     ASSERT(length < (cmddat_q_end - cmddat_q_base));
     // Stream data to downstream as it arrives. Acquire upstream pages incrementally.
     uint32_t remaining = length;


### PR DESCRIPTION
### Ticket
#25673 

### Problem description
We want to be able to read from PCIe memory (outside the hugepage) in the prefetcher. This is currently possible with CQ_PREFETCH_CMD_RELAY_LINEAR on mmio devices, but not possible on remote devices.

### What's changed
Add a new CQ_PREFETCH_CMD_RELAY_LINEAR_H command that runs on the prefetch h core, and tunnels the data through to prefetch_d, where it's written directly to the dispatcher (instead of being processed).

Also add a test to test_prefetcher for this code.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes