### PR TITLE
#25975: Ported a bunch of misc kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
@@ -12,19 +12,14 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram1 = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_is_dram2 = get_compile_time_arg_val(2) == 1;
+    constexpr auto dst1_args = TensorAccessorArgs<1>();
+    constexpr auto dst2_args = TensorAccessorArgs<dst1_args.next_compile_time_args_offset()>();
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
-
-    const InterleavedAddrGenFast<dst_is_dram1> s1 = {
-        .bank_base_address = dst_addr1, .page_size = tile_bytes, .data_format = data_format};
-
-    const InterleavedAddrGenFast<dst_is_dram2> s2 = {
-        .bank_base_address = dst_addr2, .page_size = tile_bytes, .data_format = data_format};
+    const auto s1 = TensorAccessor(dst1_args, dst_addr1, tile_bytes);
+    const auto s2 = TensorAccessor(dst2_args, dst_addr2, tile_bytes);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
@@ -56,14 +56,11 @@ ExampleMultipleReturnDeviceOperation::SingleCore::create(
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    bool dst_is_dram1 = output_tensor1.has_value()
-                            ? (output_tensor1.value().buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0)
-                            : false;
-    bool dst_is_dram2 = output_tensor2.has_value()
-                            ? (output_tensor2.value().buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0)
-                            : false;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram1, (std::uint32_t)dst_is_dram2};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    tt::tt_metal::TensorAccessorArgs(output_tensor1.has_value() ? output_tensor1.value().buffer() : nullptr)
+        .append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor2.has_value() ? output_tensor2.value().buffer() : nullptr)
+        .append_to(writer_compile_time_args);
 
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "full_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 using namespace tt;
@@ -83,13 +84,14 @@ FullOperation::ProgramFactory::cached_program_t FullOperation::ProgramFactory::c
         }
     }
 
+    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)cb_index};
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+
     auto writer_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp",
         all_cores,
-        {
-            (uint32_t)cb_index,
-        },
+        writer_compile_time_args,
         reader_defines);
 
     // Set runtime arguments

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
@@ -19,8 +19,8 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_value = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t cb_page_size = get_tile_size(cb_value);
-    const auto cb_data_format = get_dataformat(cb_value);
 
     value val;
     val.u = fill_value;
@@ -49,8 +49,7 @@ void kernel_main() {
 #endif
     cb_push_back(cb_value, 1);
 
-    const InterleavedAddrGenFast<true> s = {
-        .bank_base_address = output_addr, .page_size = cb_page_size, .data_format = cb_data_format};
+    const auto s = TensorAccessor(dst_args, output_addr, cb_page_size);
 
     cb_wait_front(cb_value, 1);
 

--- a/ttnn/cpp/ttnn/operations/full_like/device/full_like_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/full_like/device/full_like_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/tensor/types.hpp"
 
 namespace ttnn::operations::full_like {
@@ -93,6 +94,7 @@ FullLikeOperation::ProgramFactory::cached_program_t FullLikeOperation::ProgramFa
     }
 
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)cb_fill_value_id};
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
 
     auto writer_id = CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp
@@ -24,25 +24,25 @@ void kernel_main() {
     uint32_t input_addr = get_arg_val<uint32_t>(0);
     uint32_t index_addr = get_arg_val<uint32_t>(1);
     uint32_t fill_value = get_arg_val<uint32_t>(2);
-    uint32_t input_page_size = get_arg_val<uint32_t>(3);
-    uint32_t index_page_size = get_arg_val<uint32_t>(4);
-    uint32_t start_row_id = get_arg_val<uint32_t>(5);
-    uint32_t num_rows_per_core = get_arg_val<uint32_t>(6);
-    uint32_t num_rows_to_fill_per_index = get_arg_val<uint32_t>(7);
-    uint32_t dim = get_arg_val<uint32_t>(8);
+    uint32_t start_row_id = get_arg_val<uint32_t>(3);
+    uint32_t num_rows_per_core = get_arg_val<uint32_t>(4);
+    uint32_t num_rows_to_fill_per_index = get_arg_val<uint32_t>(5);
+    uint32_t dim = get_arg_val<uint32_t>(6);
 
-    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr bool index_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t index_cb_id = get_compile_time_arg_val(3);
-    constexpr bool is_last_dim = get_compile_time_arg_val(4) == 1;
-    constexpr uint32_t index_size = get_compile_time_arg_val(5);
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t index_cb_id = get_compile_time_arg_val(1);
+    constexpr bool is_last_dim = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t index_size = get_compile_time_arg_val(3);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
+    constexpr uint32_t index_page_size = get_compile_time_arg_val(5);
+    constexpr auto input_args = TensorAccessorArgs<6>();
+    constexpr auto index_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t onetile = 1;
 
-    const InterleavedAddrGen<input_is_dram> s0 = {.bank_base_address = input_addr, .page_size = input_page_size};
+    const auto s0 = TensorAccessor(input_args, input_addr, input_page_size);
 
-    const InterleavedAddrGen<index_is_dram> s1 = {.bank_base_address = index_addr, .page_size = index_page_size};
+    const auto s1 = TensorAccessor(index_args, index_addr, index_page_size);
 
     value val;
     val.u = fill_value;

--- a/ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp
@@ -8,18 +8,15 @@ void kernel_main() {
     uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
     uint32_t num_rows_per_core = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
-    uint32_t output_unit_size = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t dst_cb_id = tt::CBIndex::c_16;
     constexpr uint32_t src_cb_id = tt::CBIndex::c_0;
-    constexpr bool output_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t output_unit_size = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
     constexpr uint32_t onetile = 1;
 
-    const InterleavedAddrGen<output_is_dram> s = {
-        .bank_base_address = output_buffer_address,
-        .page_size = output_unit_size,
-    };
+    const auto s = TensorAccessor(dst_args, output_buffer_address, output_unit_size);
     for (uint32_t i = start_id; i < start_id + num_rows_per_core; i++) {
         cb_wait_front(src_cb_id, onetile);
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -21,10 +21,7 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
-
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -20,19 +20,16 @@ void kernel_main() {
     const uint32_t offset = get_arg_val<uint32_t>(10);
     const uint32_t batch_read_offset = get_arg_val<uint32_t>(11);
 
-    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(4);
-    constexpr uint32_t granularity = get_compile_time_arg_val(5);
-    constexpr uint32_t u_count = get_compile_time_arg_val(6);
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t granularity = get_compile_time_arg_val(4);
+    constexpr uint32_t u_count = get_compile_time_arg_val(5);
+    constexpr auto cache_args = TensorAccessorArgs<6>();
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
-
-    const InterleavedAddrGenFast<cache_is_dram> s0 = {
-        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
+    const auto s0 = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
 
     uint32_t cache_id = cache_start_id;
     uint32_t b = batch_start_id;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -154,21 +154,18 @@ operation::ProgramWithCallbacks update_cache_multi_core(
     const uint32_t u_count = u_range / granularity;
 
     std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)dst_is_dram,
-        (std::uint32_t)src_is_dram,
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)src1_cb_index,
-        (std::uint32_t)granularity,
-        (std::uint32_t)u_count};
+        (std::uint32_t)src0_cb_index, (std::uint32_t)src1_cb_index, (std::uint32_t)granularity, (std::uint32_t)u_count};
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)dst_is_dram,
         (std::uint32_t)output_cb_index,
         (std::uint32_t)interm0_cb_index,
         (std::uint32_t)interm1_cb_index,
         (std::uint32_t)interm2_cb_index,
         (std::uint32_t)granularity,
         (std::uint32_t)u_count};
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> reader_kernel_defines;
     if (shard_spec.has_value()) {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -386,8 +386,8 @@ operation::ProgramWithCallbacks fill_cache_multi_core(
     auto src_buffer = input_tensor.buffer();
     auto dst_buffer = cache_tensor.buffer();
 
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram};
+    std::vector<uint32_t> reader_compile_time_args;
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 
 #include <tt-metalium/fabric.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "point_to_point_device_op.hpp"
 
@@ -73,14 +74,14 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
             .set_page_size(packet_cb_id, packet_size_bytes);
     tt::tt_metal::CBHandle cb_cb_handle = CreateCircularBuffer(program, all_cores, cb_packet_config);
 
-    const bool input_is_dram = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
     // basic reader kernel set up
+    std::vector<uint32_t> reader_ct_args;
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_ct_args);
     tt::tt_metal::KernelHandle send_unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig({input_is_dram}));
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
 
     auto this_device = mesh_device->get_device(send_coord);
     const auto this_fabric_id = get_fabric_node_id_from_physical_chip_id(this_device->id());
@@ -88,10 +89,8 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
     const auto [num_hops, dst_is_forward, next_fabric_id] =
         detail::fabric_1d_routing(mesh_device, send_coord, receive_coord, topology);
 
-    const bool output_is_dram = output_tensors.at(0).buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
-    const std::vector<uint32_t> writer_ct_args = {
-        sender_cb_id, packet_header_cb_id, packet_cb_id, output_is_dram, l1_alignment};
+    std::vector<uint32_t> writer_ct_args = {sender_cb_id, packet_header_cb_id, packet_cb_id, l1_alignment};
+    tt::tt_metal::TensorAccessorArgs(output_tensors.at(0).buffer()).append_to(writer_ct_args);
 
     tt::tt_metal::KernelHandle send_unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp
@@ -11,14 +11,14 @@ void kernel_main() {
     const uint32_t num_tiles = get_arg_val<uint32_t>(1);
     const uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
     constexpr uint32_t cb_id_in0 = 0;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
 
     const uint32_t page_bytes = get_arg_val<uint32_t>(3);
-    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = page_bytes};
+    const auto s = TensorAccessor(src_args, src_addr, page_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t end_id = start_id + num_tiles;

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp
@@ -10,13 +10,13 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
 
     const uint32_t page_bytes = get_arg_val<uint32_t>(3);
-    const InterleavedAddrGen<dst_is_dram> s = {.bank_base_address = dst_addr, .page_size = page_bytes};
+    const auto s = TensorAccessor(dst_args, dst_addr, page_bytes);
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
@@ -10,15 +10,14 @@ using namespace tt;
 void kernel_main() {
     constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(1);
-    constexpr bool output_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<2>();
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t start_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
     uint32_t end_id = start_id + num_tiles;
 
-    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
-        .bank_base_address = dst_addr, .page_size = get_tile_size(dst_cb_id), .data_format = get_dataformat(dst_cb_id)};
+    const auto output_addrg = TensorAccessor(dst_args, dst_addr, get_tile_size(dst_cb_id));
 
     cb_reserve_back(dst_cb_id, 1);
     uint32_t dst_cb_write_ptr = get_write_ptr(dst_cb_id);

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "rand_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::rand {
 
@@ -56,8 +57,8 @@ RandDeviceOperation::ProgramFactory::cached_program_t RandDeviceOperation::Progr
     tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/rand/device/kernels/";
-    const uint32_t output_is_dram = output.buffer()->buffer_type() == BufferType::DRAM ? 1 : 0;
-    const std::vector<uint32_t> writer_compile_time_args{intermed_cb_id, dst_cb_id, output_is_dram};
+    std::vector<uint32_t> writer_compile_time_args{intermed_cb_id, dst_cb_id};
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
     const std::string writer_file_path = kernels_dir_path + "writer_uniform.cpp";
     const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
     const std::string compute_file_path = kernels_dir_path + "compute_uniform.cpp";

--- a/ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp
@@ -10,15 +10,14 @@ using namespace tt;
 void kernel_main() {
     constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(1);
-    constexpr bool output_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<2>();
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t start_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
     uint32_t end_id = start_id + num_tiles;
 
-    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
-        .bank_base_address = dst_addr, .page_size = get_tile_size(dst_cb_id), .data_format = get_dataformat(dst_cb_id)};
+    const auto output_addrg = TensorAccessor(dst_args, dst_addr, get_tile_size(dst_cb_id));
 
     cb_reserve_back(dst_cb_id, 1);
     uint32_t dst_cb_write_ptr = get_write_ptr(dst_cb_id);

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "uniform_device_operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::uniform {
 
@@ -57,8 +58,8 @@ UniformDeviceOperation::ProgramFactory::cached_program_t UniformDeviceOperation:
     tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/uniform/device/kernels/";
-    const uint32_t output_is_dram = output.buffer()->buffer_type() == BufferType::DRAM ? 1 : 0;
-    const std::vector<uint32_t> writer_compile_time_args{intermed_cb_id, dst_cb_id, output_is_dram};
+    std::vector<uint32_t> writer_compile_time_args{intermed_cb_id, dst_cb_id};
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
     const std::string writer_file_path = kernels_dir_path + "writer_uniform.cpp";
     const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
     const std::string compute_file_path = kernels_dir_path + "compute_uniform.cpp";


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
Refactored all of the kernels for the following OPs to use TensorAccessor:
- full
- full_like
- index_fill
- rand
- unform
- kv_cache
- point_to_point
- example_multiple_return

This PR was generated by AI: Cursor + GPT 5 Max using this updated [prompt](https://gist.github.com/sminakov-tt/0ee29006457ccee6aa9bdb534663cc46).

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17090210736)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/17088776430)
- [x] [T3000 unit tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17088802380)
- [x] New/Existing tests provide coverage for changes