### PR TITLE
#22794: Update fmod to handle when input_b=0

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
+
+
+def test_fmod(device):
+    torch_input_a = torch.tensor([1.0, 0.0, -1.0], dtype=torch.float32)
+    torch_input_b = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)
+
+    golden_function = ttnn.get_golden_function(ttnn.fmod)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.fmod(tt_in_a, tt_in_b)
+    output_tensor = ttnn.to_torch(tt_result)
+
+    assert torch.equal(torch.isnan(golden), torch.isnan(output_tensor))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
@@ -8,7 +8,7 @@ import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 
 
-def test_fmod(device):
+def test_fmod_nan(device):
     torch_input_a = torch.tensor([1.0, 0.0, -1.0], dtype=torch.float32)
     torch_input_b = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -484,7 +484,8 @@ Tensor run_fmod(
         ttnn::multiply(division_result, input_b, std::nullopt, output_mem_config),
         std::nullopt,
         output_mem_config);
-    return ttnn::where(ttnn::eq(input_a, input_b, std::nullopt, output_mem_config), 0.0f, result);
+    result = ttnn::where(ttnn::eq(input_a, input_b, std::nullopt, output_mem_config), 0.0f, result);
+    return ttnn::where(ttnn::eqz(input_b, output_mem_config), std::nanf(""), result);
 }
 
 // FMOD result = input − (other * trunc(input/other))


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22794

### Problem description
FMOD doesn't handle input_b=0 correctly. It is expected to give nan.

### What's changed
Implementation fixed to return nan

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17112225272) PASSED
- [x] [Blackhole Post commit](t/tt-metal/actions/runs/17112231047) PASSED
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes