### PR TITLE
Don't run model tests in parallel

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -74,13 +74,13 @@ run_python_model_tests_wormhole_b0() {
 
     # Run all Llama3 tests for 8B, 1B, and 3B weights - dummy weights with tight PCC check
     for llama_dir in  "$llama1b" "$llama3b" "$llama8b" "$llama11b"; do
-        LLAMA_DIR=$llama_dir pytest -n auto models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
+        LLAMA_DIR=$llama_dir pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
         echo "LOG_METAL: Llama3 tests for $llama_dir completed"
     done
 
     # Mistral-7B-v0.3
     mistral_weights=mistralai/Mistral-7B-Instruct-v0.3
-    HF_MODEL=$mistral_weights pytest -n auto models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
+    HF_MODEL=$mistral_weights pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
 }
 
 run_python_model_tests_slow_runtime_mode_wormhole_b0() {
@@ -101,7 +101,7 @@ run_python_model_tests_blackhole() {
     llama8b=/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/
     # Run all Llama3 tests for 8B - dummy weights with tight PCC check
     for llama_dir in "$llama8b"; do
-        LLAMA_DIR=$llama_dir pytest -n auto models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
+        LLAMA_DIR=$llama_dir pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
         echo "LOG_METAL: Llama3 tests for $llama_dir completed"
     done
 


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-umd/issues/1132
Related to https://github.com/tenstorrent/tt-metal/issues/22754

### Problem description
The "-n auto" switch makes pytest initialize multiple processes for running test. Each process will call pytest_addoption in conftest.py, which does import ttnn and calls ttnn.get_arch_name(). These calls initialize MetalContext. Multiple initializations of metal context means that driver is being opened for the same device multiple times.

### What's changed
- Remove -n auto flag for all pytest commands in model test script

### Checklist
All runs on brosko/model_tests_serial :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/17097418938
This is a test change, so only all post-commit is affected by this change

TBD: Spawn a run with chip lock enabled to verify the issue went away