### PR TITLE
[skip-ci] #0: update some TT_FATAL messages in reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -41,7 +41,10 @@ namespace tt_metal {
 
 void Reduce::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to reduce need to be on device!");
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE,
+        "Operands to reduce need to be on device! Got storage type: {}",
+        input_tensor.storage_type());
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to reduce need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.layout() == Layout::TILE), "Inputs to reduce must be tilized");
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -22,7 +22,7 @@ void Prod::validate(const std::vector<Tensor>& inputs) const {
     const auto& output = inputs.at(1);
 
     auto input_shape = input.padded_shape();
-    TT_FATAL((input_shape.rank() == 4), "rank should be 4");
+    TT_FATAL((input_shape.rank() == 4), "rank should be 4, got rank: {}", input_shape.rank());
     const auto& output_shape = output.padded_shape();
     auto input_shape_wo_padding = input.logical_shape();
 
@@ -32,7 +32,12 @@ void Prod::validate(const std::vector<Tensor>& inputs) const {
     }
 
     for (int i = 0; i < input_shape.rank(); ++i) {
-        TT_FATAL(input_shape[i] == output_shape[i], "Error");
+        TT_FATAL(
+            input_shape[i] == output_shape[i],
+            "Input and output shapes must match at dimension {}, got input: {} vs output: {}",
+            i,
+            input_shape[i],
+            output_shape[i]);
         // TT_FATAL(input_shape_wo_padding[i] == output_shape_wo_padding[i], "Error");
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -19,10 +19,19 @@ namespace primary {
 
 void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
-    TT_FATAL(input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands need to be on device!");
+    TT_FATAL(
+        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        "Operands need to be on device! Got storage type: {}",
+        input_tensor_a.storage_type());
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
-    TT_FATAL((input_tensor_a.layout() == tt::tt_metal::Layout::TILE), "Input Layout must be tilized");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(
+        (input_tensor_a.layout() == tt::tt_metal::Layout::TILE),
+        "Input Layout must be tilized, got layout: {}",
+        input_tensor_a.layout());
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "Memory layout must be INTERLEAVED, got: {}",
+        input_tensor_a.memory_config().memory_layout());
     TT_FATAL(
         input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16,
         "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
It would be good to clean up some TT_FATAL messages.
Useful for AI Hackathon.

### What's changed
Updated messages in reduce via the following prompts:

Can you please list all of the TT_FATAL calls in files in subdirectories of
ttnn/cpp/ttnn/operations/reduction
that do not print out values that lead to the fatal being triggered?

Please update the listed TT_FATAL calls to print out the values. Exclude the one
s that check for dims, size, keepdim, and nullptr.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes