### PR TITLE
#0: update some TT_FATAL messages in normalization

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -21,24 +21,35 @@ void LayerNorm::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     TT_FATAL(
-        input_tensors.size() == 1 and optional_input_tensors.size() <= 4, "Must have between 1 to 4 input tensors");
+        input_tensors.size() == 1 and optional_input_tensors.size() <= 4,
+        "Must have 1 input tensor and up to 4 optional input tensors, got {} input tensors and {} optional input "
+        "tensors",
+        input_tensors.size(),
+        optional_input_tensors.size());
     auto& a = input_tensors.at(0);
     const auto& b = optional_input_tensors.at(0);
     const auto& gamma = optional_input_tensors.at(1);
     const auto& beta = optional_input_tensors.at(2);
     const auto& stats = optional_input_tensors.at(3);
 
-    TT_FATAL(a.layout() == Layout::TILE, "Error");
+    TT_FATAL(a.layout() == Layout::TILE, "Input tensor must have TILE layout, got: {}", a.layout());
     TT_FATAL(
-        a.dtype() == DataType::FLOAT32 or a.dtype() == DataType::BFLOAT16 or a.dtype() == DataType::BFLOAT8_B, "Error");
+        a.dtype() == DataType::FLOAT32 or a.dtype() == DataType::BFLOAT16 or a.dtype() == DataType::BFLOAT8_B,
+        "Input tensor must be FLOAT32, BFLOAT16, or BFLOAT8_B, got: {}",
+        a.dtype());
     TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
 
     if (b.has_value()) {
-        TT_FATAL(b.value().layout() == Layout::TILE, "layot is not tile!");
-        TT_FATAL(a.padded_shape() == b.value().padded_shape(), "shape is not same!");
+        TT_FATAL(
+            b.value().layout() == Layout::TILE, "Residual tensor must have TILE layout, got: {}", b.value().layout());
+        TT_FATAL(
+            a.padded_shape() == b.value().padded_shape(),
+            "Input and residual shapes must match, got input: {} vs residual: {}",
+            a.padded_shape(),
+            b.value().padded_shape());
         TT_FATAL(b.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-        TT_FATAL(a.device() == b.value().device(), "device is not same!");
+        TT_FATAL(a.device() == b.value().device(), "Input and residual tensors must be on same device");
     }
 
     if (gamma.has_value()) {
@@ -50,10 +61,16 @@ void LayerNorm::validate(
                 gamma.value().padded_shape()[-1]);
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == gamma.value().device(), "Error");
-            TT_FATAL(gamma.value().padded_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(a.device() == gamma.value().device(), "Input and gamma tensors must be on same device");
+            TT_FATAL(
+                gamma.value().padded_shape()[-2] == TILE_HEIGHT,
+                "Gamma tensor height must be TILE_HEIGHT (32), got: {}",
+                gamma.value().padded_shape()[-2]);
         } else {
-            TT_FATAL(gamma.value().layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL(
+                gamma.value().layout() == Layout::ROW_MAJOR,
+                "Gamma tensor must have ROW_MAJOR layout, got: {}",
+                gamma.value().layout());
             TT_FATAL(
                 (gamma.value().padded_shape()[-1] == TILE_WIDTH &&
                  gamma.value().physical_volume() / TILE_WIDTH == a.padded_shape()[-1] / TILE_WIDTH),
@@ -67,9 +84,11 @@ void LayerNorm::validate(
                 a.padded_shape());
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == gamma.value().device(), "Error");
+            TT_FATAL(a.device() == gamma.value().device(), "Input and gamma tensors must be on same device");
             TT_FATAL(
-                gamma.value().dtype() == DataType::FLOAT32 or gamma.value().dtype() == DataType::BFLOAT16, "Error");
+                gamma.value().dtype() == DataType::FLOAT32 or gamma.value().dtype() == DataType::BFLOAT16,
+                "Gamma tensor must be FLOAT32 or BFLOAT16, got: {}",
+                gamma.value().dtype());
         }
         if (beta.has_value()) {
             TT_FATAL(gamma.value().layout() == beta.value().layout(), "Gamma and beta must have the same layout!");
@@ -78,21 +97,39 @@ void LayerNorm::validate(
 
     if (beta.has_value()) {
         if (beta.value().layout() == Layout::TILE) {
-            TT_FATAL(a.padded_shape()[-1] == beta.value().padded_shape()[-1], "Error");
+            TT_FATAL(
+                a.padded_shape()[-1] == beta.value().padded_shape()[-1],
+                "Input and beta inner dimensions must match, got input: {} vs beta: {}",
+                a.padded_shape()[-1],
+                beta.value().padded_shape()[-1]);
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == beta.value().device(), "Error");
-            TT_FATAL(beta.value().padded_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(a.device() == beta.value().device(), "Input and beta tensors must be on same device");
+            TT_FATAL(
+                beta.value().padded_shape()[-2] == TILE_HEIGHT,
+                "Beta tensor height must be TILE_HEIGHT (32), got: {}",
+                beta.value().padded_shape()[-2]);
         } else {
-            TT_FATAL(beta.value().layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL(
+                beta.value().layout() == Layout::ROW_MAJOR,
+                "Beta tensor must have ROW_MAJOR layout, got: {}",
+                beta.value().layout());
             TT_FATAL(
                 (beta.value().padded_shape()[-1] == TILE_WIDTH &&
                  beta.value().physical_volume() / TILE_WIDTH == a.padded_shape()[-1] / TILE_WIDTH),
-                "Error");
+                "Beta tensor dimensions must align with input tensor. Got beta padded shape: {}, physical volume: {}, "
+                "input padded shape: {}, TILE_WIDTH: {}",
+                beta.value().padded_shape()[-1],
+                beta.value().physical_volume(),
+                a.padded_shape()[-1],
+                TILE_WIDTH);
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == beta.value().device(), "Error");
-            TT_FATAL(beta.value().dtype() == DataType::FLOAT32 or beta.value().dtype() == DataType::BFLOAT16, "Error");
+            TT_FATAL(a.device() == beta.value().device(), "Input and beta tensors must be on same device");
+            TT_FATAL(
+                beta.value().dtype() == DataType::FLOAT32 or beta.value().dtype() == DataType::BFLOAT16,
+                "Beta tensor must be FLOAT32 or BFLOAT16, got: {}",
+                beta.value().dtype());
         }
     }
     if (a.is_sharded()) {
@@ -141,10 +178,20 @@ void LayerNorm::validate(
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, LayerNormShardedMultiCoreProgramConfig>) {
                 if (program_config.inplace) {
-                    TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+                    TT_FATAL(
+                        this->output_mem_config.is_sharded(),
+                        "Output memory config must be sharded for inplace operation");
                 }
-                TT_FATAL(a.memory_config().buffer_type() == this->output_mem_config.buffer_type(), "Error");
-                TT_FATAL(a.memory_config().memory_layout() == this->output_mem_config.memory_layout(), "Error");
+                TT_FATAL(
+                    a.memory_config().buffer_type() == this->output_mem_config.buffer_type(),
+                    "Input and output buffer types must match, got input: {} vs output: {}",
+                    a.memory_config().buffer_type(),
+                    this->output_mem_config.buffer_type());
+                TT_FATAL(
+                    a.memory_config().memory_layout() == this->output_mem_config.memory_layout(),
+                    "Input and output memory layouts must match, got input: {} vs output: {}",
+                    a.memory_config().memory_layout(),
+                    this->output_mem_config.memory_layout());
 
                 // tensor shape
                 const auto& shape = a.padded_shape();
@@ -161,58 +208,97 @@ void LayerNorm::validate(
                 TT_FATAL(
                     program_config.block_w % program_config.subblock_w == 0,
                     "block_w must be divisible by subblock_w.");
-                TT_FATAL(M % TILE_HEIGHT == 0, "M must be divisible by tile height.");
-                TT_FATAL(K % TILE_WIDTH == 0, "K must be divisible by tile width.");
+                TT_FATAL(M % TILE_HEIGHT == 0, "M ({}) must be divisible by tile height ({})", M, TILE_HEIGHT);
+                TT_FATAL(K % TILE_WIDTH == 0, "K ({}) must be divisible by tile width ({})", K, TILE_WIDTH);
                 const auto bbox = shard_spec.grid.bounding_box();
                 TT_FATAL(
                     bbox.end_coord.x - bbox.start_coord.x < program_config.compute_with_storage_grid_size.x &&
                         bbox.end_coord.y - bbox.start_coord.y < program_config.compute_with_storage_grid_size.y,
-                    "Error");
+                    "Bounding box dimensions must be smaller than compute grid size, got bbox x: {} to {}, y: {} to {} "
+                    "vs grid size x: {}, y: {}",
+                    bbox.start_coord.x,
+                    bbox.end_coord.x,
+                    bbox.start_coord.y,
+                    bbox.end_coord.y,
+                    program_config.compute_with_storage_grid_size.x,
+                    program_config.compute_with_storage_grid_size.y);
 
                 bool mcast_1d = M == block_h;
                 bool row_wise = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
                 if (mcast_1d) {
                     TT_FATAL(
                         tt::div_up(Kt, shard_spec.num_cores()) == program_config.block_w,
-                        "block_w must equal to K / num_cores.");
-                    TT_FATAL(Mt == program_config.block_h, "block_h must equal to M.");
-                    TT_FATAL(a.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+                        "block_w ({}) must equal to K / num_cores ({})",
+                        program_config.block_w,
+                        tt::div_up(Kt, shard_spec.num_cores()));
+                    TT_FATAL(
+                        Mt == program_config.block_h, "block_h ({}) must equal to M ({})", program_config.block_h, Mt);
+                    TT_FATAL(
+                        a.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED,
+                        "Height sharded memory layout is not supported, got: {}",
+                        a.memory_config().memory_layout());
                 } else {
                     if (row_wise) {
                         TT_FATAL(
                             tt::div_up(Kt, (bbox.end_coord.x + 1)) == program_config.block_w,
-                            "block_w must equal to K / num_cores_c.");
+                            "block_w ({}) must equal to K / num_cores_c ({})",
+                            program_config.block_w,
+                            tt::div_up(Kt, (bbox.end_coord.x + 1)));
                         TT_FATAL(
                             Mt / (bbox.end_coord.y + 1) == program_config.block_h,
-                            "block_h must equal to M / num_cores_r.");
+                            "block_h ({}) must equal to M / num_cores_r ({})",
+                            program_config.block_h,
+                            Mt / (bbox.end_coord.y + 1));
                     } else {
                         TT_FATAL(
                             tt::div_up(Kt, (bbox.end_coord.y + 1)) == program_config.block_w,
-                            "block_w must equal to K / num_cores_r.");
+                            "block_w ({}) must equal to K / num_cores_r ({})",
+                            program_config.block_w,
+                            tt::div_up(Kt, (bbox.end_coord.y + 1)));
                         TT_FATAL(
                             Mt / (bbox.end_coord.x + 1) == program_config.block_h,
-                            "block_h must equal to M / num_cores_c.");
+                            "block_h ({}) must equal to M / num_cores_c ({})",
+                            program_config.block_h,
+                            Mt / (bbox.end_coord.x + 1));
                     }
                 }
                 if (b.has_value()) {
-                    TT_FATAL(b.value().is_sharded(), "Error");
-                    TT_FATAL(b.value().shard_spec() == shard_spec, "Error");
+                    TT_FATAL(b.value().is_sharded(), "Residual tensor must be sharded when input is sharded");
+                    TT_FATAL(
+                        b.value().shard_spec() == shard_spec,
+                        "Residual tensor shard spec must match input shard spec, got residual: {} vs input: {}",
+                        b.value().shard_spec(),
+                        shard_spec);
                 }
-                TT_FATAL(program_config.block_h * TILE_HEIGHT == shard_spec.shape[0], "Error");
-                TT_FATAL(program_config.block_w * TILE_WIDTH == shard_spec.shape[1], "Error");
+                TT_FATAL(
+                    program_config.block_h * TILE_HEIGHT == shard_spec.shape[0],
+                    "Block height * TILE_HEIGHT must match shard shape[0], got {} vs {}",
+                    program_config.block_h * TILE_HEIGHT,
+                    shard_spec.shape[0]);
+                TT_FATAL(
+                    program_config.block_w * TILE_WIDTH == shard_spec.shape[1],
+                    "Block width * TILE_WIDTH must match shard shape[1], got {} vs {}",
+                    program_config.block_w * TILE_WIDTH,
+                    shard_spec.shape[1]);
                 TT_FATAL(
                     program_config.block_w % program_config.subblock_w == 0,
                     "block_w must be divisible by subblock_w.");
 
                 if (this->distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {
                     const auto stats_shard_spec = stats.value().shard_spec().value();
-                    TT_FATAL(stats_shard_spec.num_cores() == 1, "Stats must be sharded with num_cores = 1");
+                    TT_FATAL(
+                        stats_shard_spec.num_cores() == 1,
+                        "Stats must be sharded with num_cores = 1, got: {}",
+                        stats_shard_spec.num_cores());
 
                     if (this->output_mem_config.shard_spec().has_value()) {
                         const auto output_shard_spec = this->output_mem_config.shard_spec().value();
                         TT_FATAL(
                             output_shard_spec.shape[0] == shard_spec.shape[0],
-                            "Output shard spec must have the same height as input shard spec.");
+                            "Output shard spec must have the same height as input shard spec, got output: {} vs input: "
+                            "{}",
+                            output_shard_spec.shape[0],
+                            shard_spec.shape[0]);
                     }
                 }
             }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -28,23 +28,44 @@ void LayerNormPostAllGather::validate(
     const auto& beta = optional_input_tensors.at(1);
 
     for (const auto& tensor : input_tensors) {
-        TT_FATAL(tensor.layout() == Layout::TILE, "Error");
-        TT_FATAL(tensor.dtype() == DataType::BFLOAT16 || tensor.dtype() == DataType::BFLOAT8_B, "Error");
+        TT_FATAL(tensor.layout() == Layout::TILE, "Input tensor must have TILE layout, got: {}", tensor.layout());
+        TT_FATAL(
+            tensor.dtype() == DataType::BFLOAT16 || tensor.dtype() == DataType::BFLOAT8_B,
+            "Input tensor must be BFLOAT16 or BFLOAT8_B, got: {}",
+            tensor.dtype());
         TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
         TT_FATAL(tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
     }
 
     // stats has 2 or 1 tile columns per device if layernorm or rmsnorm
-    TT_FATAL(stats.padded_shape()[-1] % TILE_WIDTH == 0, "Error");
-    TT_FATAL(stats.padded_shape()[0] == a.padded_shape()[0], "Error");
-    TT_FATAL(stats.padded_shape()[1] == a.padded_shape()[1], "Error");
-    TT_FATAL(stats.padded_shape()[2] == a.padded_shape()[2], "Error");
+    TT_FATAL(
+        stats.padded_shape()[-1] % TILE_WIDTH == 0,
+        "Stats inner dimension must be divisible by TILE_WIDTH (32), got: {}",
+        stats.padded_shape()[-1]);
+    TT_FATAL(
+        stats.padded_shape()[0] == a.padded_shape()[0],
+        "Stats and input batch sizes must match, got stats: {} vs input: {}",
+        stats.padded_shape()[0],
+        a.padded_shape()[0]);
+    TT_FATAL(
+        stats.padded_shape()[1] == a.padded_shape()[1],
+        "Stats and input dim1 must match, got stats: {} vs input: {}",
+        stats.padded_shape()[1],
+        a.padded_shape()[1]);
+    TT_FATAL(
+        stats.padded_shape()[2] == a.padded_shape()[2],
+        "Stats and input dim2 must match, got stats: {} vs input: {}",
+        stats.padded_shape()[2],
+        a.padded_shape()[2]);
     // TODO: How to check if number of tile columns is correct? Would have to know # of devices and is_rmsnorm
 
     if (gamma.has_value()) {
         const auto& gamma_tensor = gamma.value();
 
-        TT_FATAL(gamma_tensor.layout() == Layout::ROW_MAJOR, "Error");  // Only support packed RM right now
+        TT_FATAL(
+            gamma_tensor.layout() == Layout::ROW_MAJOR,
+            "Gamma tensor must have ROW_MAJOR layout (only packed RM supported), got: {}",
+            gamma_tensor.layout());
         if (gamma_tensor.layout() == Layout::TILE) {
             TT_FATAL(
                 a.padded_shape()[-1] == gamma.value().padded_shape()[-1],
@@ -53,45 +74,84 @@ void LayerNormPostAllGather::validate(
                 gamma.value().padded_shape()[-1]);
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == gamma.value().device(), "Error");
-            TT_FATAL(gamma.value().padded_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(a.device() == gamma.value().device(), "Input and gamma tensors must be on same device");
+            TT_FATAL(
+                gamma.value().padded_shape()[-2] == TILE_HEIGHT,
+                "Gamma tensor height must be TILE_HEIGHT (32), got: {}",
+                gamma.value().padded_shape()[-2]);
         } else {
-            TT_FATAL(gamma_tensor.layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL(
+                gamma_tensor.layout() == Layout::ROW_MAJOR,
+                "Gamma tensor must have ROW_MAJOR layout, got: {}",
+                gamma_tensor.layout());
             TT_FATAL(
                 (gamma_tensor.padded_shape()[-1] == TILE_WIDTH &&
                  gamma_tensor.physical_volume() / TILE_WIDTH == a.padded_shape()[-1] / TILE_WIDTH),
-                "Error");
+                "Gamma tensor dimensions must align with input tensor. Got gamma padded shape: {}, physical volume: "
+                "{}, input padded shape: {}, TILE_WIDTH: {}",
+                gamma_tensor.padded_shape()[-1],
+                gamma_tensor.physical_volume(),
+                a.padded_shape()[-1],
+                TILE_WIDTH);
             TT_FATAL(
                 gamma_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == gamma_tensor.device(), "Error");
-            TT_FATAL(gamma_tensor.dtype() == DataType::BFLOAT16, "Error");
+            TT_FATAL(a.device() == gamma_tensor.device(), "Input and gamma tensors must be on same device");
+            TT_FATAL(
+                gamma_tensor.dtype() == DataType::BFLOAT16,
+                "Gamma tensor must be BFLOAT16, got: {}",
+                gamma_tensor.dtype());
         }
         const bool is_layernorm = this->norm_type == LayerNormDistributedType::LAYERNORM;
         const bool has_beta = beta.has_value();
-        TT_FATAL(is_layernorm == has_beta, "Error");  // TODO: Is this a necessary check?
+        TT_FATAL(is_layernorm == has_beta, "Beta tensor must be present if and only if using layernorm (vs rmsnorm)");
 
         if (beta.has_value()) {
             const auto& beta_tensor = beta.value();
-            TT_FATAL(gamma_tensor.layout() == beta_tensor.layout(), "Gamma and beta must have the same layout!");
-            TT_FATAL(beta_tensor.layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL(
+                gamma_tensor.layout() == beta_tensor.layout(),
+                "Gamma and beta must have the same layout, got gamma: {} vs beta: {}",
+                gamma_tensor.layout(),
+                beta_tensor.layout());
+            TT_FATAL(
+                beta_tensor.layout() == Layout::ROW_MAJOR,
+                "Beta tensor must have ROW_MAJOR layout, got: {}",
+                beta_tensor.layout());
             if (beta_tensor.layout() == Layout::TILE) {
-                TT_FATAL(a.padded_shape()[-1] == beta_tensor.padded_shape()[-1], "Error");
+                TT_FATAL(
+                    a.padded_shape()[-1] == beta_tensor.padded_shape()[-1],
+                    "Input and beta inner dimensions must match, got input: {} vs beta: {}",
+                    a.padded_shape()[-1],
+                    beta_tensor.padded_shape()[-1]);
                 TT_FATAL(
                     beta_tensor.buffer() != nullptr,
                     "Operands to layernorm need to be allocated in buffers on device!");
-                TT_FATAL(a.device() == beta_tensor.device(), "Error");
-                TT_FATAL(beta.value().padded_shape()[-2] == TILE_HEIGHT, "Error");
+                TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
+                TT_FATAL(
+                    beta.value().padded_shape()[-2] == TILE_HEIGHT,
+                    "Beta tensor height must be TILE_HEIGHT (32), got: {}",
+                    beta.value().padded_shape()[-2]);
             } else {
-                TT_FATAL(beta_tensor.layout() == Layout::ROW_MAJOR, "Error");
+                TT_FATAL(
+                    beta_tensor.layout() == Layout::ROW_MAJOR,
+                    "Beta tensor must have ROW_MAJOR layout, got: {}",
+                    beta_tensor.layout());
                 TT_FATAL(
                     (beta_tensor.padded_shape()[-1] == TILE_WIDTH &&
                      beta_tensor.physical_volume() / TILE_WIDTH == a.padded_shape()[-1] / TILE_WIDTH),
-                    "Error");
+                    "Beta tensor dimensions must align with input tensor. Got beta padded shape: {}, physical volume: "
+                    "{}, input padded shape: {}, TILE_WIDTH: {}",
+                    beta_tensor.padded_shape()[-1],
+                    beta_tensor.physical_volume(),
+                    a.padded_shape()[-1],
+                    TILE_WIDTH);
                 TT_FATAL(
                     beta_tensor.buffer() != nullptr,
                     "Operands to layernorm need to be allocated in buffers on device!");
-                TT_FATAL(a.device() == beta_tensor.device(), "Error");
-                TT_FATAL(beta_tensor.dtype() == DataType::BFLOAT16, "Error");
+                TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
+                TT_FATAL(
+                    beta_tensor.dtype() == DataType::BFLOAT16,
+                    "Beta tensor must be BFLOAT16, got: {}",
+                    beta_tensor.dtype());
             }
         }
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
It would be good to clean up some TT_FATAL messages.
Useful for AI Hackathon.

### What's changed
Updated messages in normalization via the following prompts. The requests seemed to identify different sets of files and messages, and it took multiple prompts to get good coverage.

Can you please list all of the TT_FATAL calls in files in subdirectories of
ttnn/cpp/ttnn/operations/normalization
that do not print out values that lead to the fatal being triggered?

Please update the listed TT_FATAL calls that only have a message of "Error" to have a more meaningful message. Only print out values in that message when the values are not boolean.

Please list all of the TT_FATAL calls in files in subdirectories of
ttnn/cpp/ttnn/operations/normalization
that check for non-boolean variables and do not print out values that lead to the fatal being triggered?

Got a response:
These TT_FATAL calls should be updated to include the actual values in their error messages to make debugging easier. Would you like me to help update them?

Replied:
Yes. Please update them.

Still did not find all the files. Next prompt:

Please update all of the TT_FATAL calls in files in subdirectories of
ttnn/cpp/ttnn/operations/normalization that only have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL.

Please update the two TT_FATAL calls in ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp that have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL.

Please list all of the TT_FATAL calls in
ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
that check for non-boolean variables and do not print out values that lead to the fatal being triggered.

Got a response:
These TT_FATAL calls should be updated to include the actual values in their error messages to make debugging easier. Would you like me to help update them?

Replied:
Yes. Please update them.

Printing out a device leads to compiler errors. Please update all of the TT_FATAL calls in files in subdirectories of
ttnn/cpp/ttnn/operations/normalization that print out the values of device to not print those values out.



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17099654901
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes