### PR TITLE
Add SrcOrder tag to compute_kernel_hw_startup (#22219, part 1)

### DIFF
--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -15,6 +15,28 @@ namespace ckernel {
 
 // clang-format off
 /**
+ * Describes how the two input circular buffers map onto the source registers (SrcA/SrcB) of the
+ * compute engine. This matters because compute_kernel_hw_startup() programs per-source-register
+ * state (data formats, tile/face dimensions, tile sizes) and that state must match the operand
+ * ordering of the operation that follows.
+ *
+ *  - SrcOrder::Regular : icb0 -> SrcA, icb1 -> SrcB. This is the natural ordering used by virtually
+ *                        every operation (e.g. eltwise binary, where in0 -> SrcA and in1 -> SrcB).
+ *  - SrcOrder::Reverse : icb0 -> SrcB, icb1 -> SrcA. The operands are mapped onto the source registers
+ *                        in reverse. Matmul is the operation that needs this today: in0 (the "A" /
+ *                        activations operand) is loaded into SrcB, while in1 (the "B" / weights operand)
+ *                        is loaded into SrcA. Passing this tag lets the kernel keep calling startup with
+ *                        the natural (in0, in1) argument order while startup programs the source
+ *                        registers in the reversed order such an operation requires.
+ */
+// clang-format on
+enum class SrcOrder : uint8_t {
+    Regular = 0,  // icb0 -> SrcA, icb1 -> SrcB
+    Reverse = 1,  // icb0 -> SrcB, icb1 -> SrcA
+};
+
+// clang-format off
+/**
  * Performs the required hardware initialization for all subsequent operations in the compute kernel. This function should be
  * called exactly once at the very beginning of the kernel, before any operation-specific initialization functions (such as
  * reduce_init, tilize_init, etc.). The circular buffer (CB) IDs provided to this function must match those used in the next
@@ -22,6 +44,12 @@ namespace ckernel {
  * what was configured here, you must call one of the reconfig_data_format functions before proceeding with the next
  * initialization. Similarly, if the next operation requires different properties (such as tile or face dimensions), you must
  * ensure that the same CB IDs are used as in this function.
+ *
+ * The src_order template parameter selects how (icb0, icb1) map onto SrcA/SrcB; this is the single piece of
+ * operation-specific knowledge startup needs, because the per-source-register state it programs (formats, tile/face
+ * dimensions, tile sizes) depends on that mapping. Use SrcOrder::Regular for all operations except matmul, which must use
+ * SrcOrder::Reverse (see the SrcOrder documentation). The (icb0, icb1) arguments are always passed in natural operand order
+ * (in0, in1) regardless of the tag.
  *
  * NOTE: This function performs MMIO writes, which are slow and almost exclusively require the idle state of the execution
  * units that should be configured (PACK, MATH, UNPACK, CFG, etc.). This is why it is unsafe to call this function in the
@@ -31,30 +59,40 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Param Type | Name  | Description                                                     | Type     | Valid Range | Required |
- * |------------|-------|-----------------------------------------------------------------|----------|-------------|----------|
- * | Function   | icb0  | The identifier of the circular buffer (CB) containing operand A | uint32_t | 0 to 31     | True     |
- * | Function   | icb1  | The identifier of the circular buffer (CB) containing operand B | uint32_t | 0 to 31     | True     |
- * | Function   | ocb   | The identifier of the output circular buffer (CB)               | uint32_t | 0 to 31     | True     |
+ * | Param Type | Name      | Description                                                     | Type     | Valid Range | Required |
+ * |------------|-----------|-----------------------------------------------------------------|----------|-------------|----------|
+ * | Template   | src_order | How icb0/icb1 map onto SrcA/SrcB (Regular or Reverse)          | SrcOrder | N/A         | False    |
+ * | Function   | icb0      | The identifier of the circular buffer (CB) containing operand A | uint32_t | 0 to 31     | True     |
+ * | Function   | icb1      | The identifier of the circular buffer (CB) containing operand B | uint32_t | 0 to 31     | True     |
+ * | Function   | ocb       | The identifier of the output circular buffer (CB)               | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
+template <SrcOrder src_order = SrcOrder::Regular>
 ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
+    // Map the operands onto the physical source registers. For SrcOrder::Reverse (matmul) in0 (icb0)
+    // lands in SrcB and in1 (icb1) lands in SrcA, so the per-source state below is programmed with the
+    // operands swapped. src_order is a template parameter, so reverse (and the selection below) is
+    // resolved at compile time. Both UNPACK and MATH hw_configure are programmed with the same
+    // (src_a_cb, src_b_cb) ordering so the unpacker tile descriptors and the math ALU format registers agree.
+    constexpr bool reverse = (src_order == SrcOrder::Reverse);
+    const uint32_t src_a_cb = reverse ? icb1 : icb0;
+    const uint32_t src_b_cb = reverse ? icb0 : icb1;
 #ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(src_a_cb, src_b_cb)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(src_a_cb, src_b_cb)));
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init<PackMode::Default>(ocb)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
 
-    ComputeKernelSentinel::instance().set_srca(icb0).set_srcb(icb1).set_pack(ocb);
+    ComputeKernelSentinel::instance().set_srca(src_a_cb).set_srcb(src_b_cb).set_pack(ocb);
 #else
-    UNPACK((llk_unpack_hw_configure(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure(src_a_cb, src_b_cb)));
 
     MATH((llk_math_pack_sync_init()));
-    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(src_a_cb, src_b_cb)));
 
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));


### PR DESCRIPTION
### PR Category
Feature

### Summary
First step of the matmul compute API cleanup (#22219). This PR only adds the `SrcOrder` tag to `compute_kernel_hw_startup`; the matmul API that uses it, and the kernel migration, follow in a separate PR so this one stays small and easy to review.

The end goal of #22219 is the same simple model for every op: call `compute_kernel_hw_startup` once at the start of the kernel, then call one `<op>_init` before the op. Matmul is the awkward case because it consumes its operands in the opposite order from every other op: in0 goes to SrcB and in1 goes to SrcA. `compute_kernel_hw_startup` programs the source registers (formats, tile and face sizes), so it has to know that order.

To handle it cleanly without leaking the swap into every kernel, this adds a small template tag:

- `SrcOrder::Regular` (the default) keeps the existing mapping (icb0 to SrcA, icb1 to SrcB), so **every current call site is unchanged**.
- `SrcOrder::Reverse` maps icb0 to SrcB and icb1 to SrcA, which is what matmul needs.

```cpp
compute_kernel_hw_startup<SrcOrder::Reverse>(in0, in1, out);  // matmul
matmul_init(in0, in1);
```

The tag is a template parameter, so the mapping is resolved at compile time, and both UNPACK and MATH `hw_configure` are programmed with the same ordering.

### Notes for reviewers
- One file: `compute_kernel_hw_startup.h`.
- Default is `SrcOrder::Regular`, so this is a no-op for all existing callers; nothing else in the tree needs to change for this PR.
- The matmul API (`matmul_init`, `matmul_block_init`), the deprecation of the old `mm_*` inits, and the migration of all matmul kernels to the new API will come in a follow-up PR (kept separate so the deprecation warnings land together with the kernel changes that remove them).
