### PR TITLE
#0: update some TT_FATAL messages in matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1061,7 +1061,7 @@ MatmulProgramConfig get_matmul_program_config(
         uint32_t batch_size_a = get_batch_size(input_tensor_a.padded_shape());
         uint32_t batch_size_b = get_batch_size(input_tensor_b.padded_shape());
         bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-        TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported");
+        TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
 
         if (input_tensor_b.is_sharded()) {
             TT_FATAL(
@@ -2320,7 +2320,7 @@ void Matmul::validate(
                 uint32_t batch_size_a = get_batch_size(input_tensor_a.padded_shape());
                 uint32_t batch_size_b = get_batch_size(input_tensor_b.padded_shape());
                 bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-                TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported");
+                TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
 
                 if (input_tensor_b.is_sharded()) {
                     TT_FATAL(per_core_M % M == 0, "per_core_M must be a multiple of M if input b is sharded!");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -722,7 +722,8 @@ MatmulProgramConfig create_matmul_program_config(
         } else if (a_is_sharded) {
             TT_FATAL(
                 a_layout != TensorMemoryLayout::WIDTH_SHARDED,
-                "MatmulMultiCoreReuseProgramConfig: Cannot be width sharded");
+                "MatmulMultiCoreReuseProgramConfig: Input A cannot be width sharded, got layout: {}",
+                a_layout);
             auto shard_shape = input_tensor_a_memory_config.shard_spec().value().shape;
             uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
             m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
@@ -731,7 +732,8 @@ MatmulProgramConfig create_matmul_program_config(
         } else {
             TT_FATAL(
                 input_tensor_b_memory_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                "MatmulMultiCoreReuseProgramConfig: Cannot be width sharded");
+                "MatmulMultiCoreReuseProgramConfig: Input B cannot be width sharded, got layout: {}",
+                input_tensor_b_memory_config.memory_layout());
             auto shard_shape = input_tensor_b_memory_config.shard_spec().value().shape;
             m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
             n_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
@@ -847,7 +849,7 @@ MatmulProgramConfig get_matmul_program_config(
     const std::optional<const CoreCoord> user_core_coord,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const tt::tt_metal::DataType output_dtype) {
-    TT_FATAL(input_tensor_a.is_sharded(), "Error");
+    TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded");
     bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
     // TODO: allow overwriting of grid size by user_core_coord after allowing
     // support of arbitrary compute grid and more generic sharded output tensor
@@ -859,16 +861,30 @@ MatmulProgramConfig get_matmul_program_config(
 
     // MCAST matmuls only support input_b in INTERLEAVED
     if (matmul) {
-        TT_FATAL(input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor B must have INTERLEAVED memory layout, got: {}",
+            input_tensor_b.memory_config().memory_layout());
         if ((input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED or
              input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) and
             (grid_size.x > 1 or grid_size.y > 1)) {
-            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                "Input tensor A must have ROW_MAJOR shard orientation, got: {}",
+                input_tensor_a.shard_spec().value().orientation);
 
             bool per_core_N_equals_subblock_w_constraint = false;
             if (output_mem_config.is_sharded()) {
-                TT_FATAL(input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(), "Error");
-                TT_FATAL(input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(), "Error");
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    output_mem_config.memory_layout());
                 per_core_N_equals_subblock_w_constraint = true;
             }
 
@@ -935,8 +951,16 @@ MatmulProgramConfig get_matmul_program_config(
 
             bool per_core_N_equals_subblock_w_constraint = false;
             if (output_mem_config.is_sharded()) {
-                TT_FATAL(input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(), "Error");
-                TT_FATAL(input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(), "Error");
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    output_mem_config.memory_layout());
                 per_core_N_equals_subblock_w_constraint = true;
             }
 
@@ -951,10 +975,16 @@ MatmulProgramConfig get_matmul_program_config(
             bool cores_along_y_match_grid_size = virtual_y == (M / (shard_shape[0] / in0_tile_shape[0]));
             TT_FATAL(
                 cores_along_y_match_grid_size || virtual_y == div_up(M, (shard_shape[0] / in0_tile_shape[0])),
-                "Num cores along y must match provided grid size!");
+                "Num cores along y ({}) must match provided grid size ({}) or divided up size ({})",
+                virtual_y,
+                M / (shard_shape[0] / in0_tile_shape[0]),
+                div_up(M, (shard_shape[0] / in0_tile_shape[0])));
             TT_FATAL(
                 cores_along_x_match_grid_size || virtual_x == div_up(K, (shard_shape[1] / in0_tile_shape[1])),
-                "Num cores along x must match provided grid size!");
+                "Num cores along x ({}) must match provided grid size ({}) or divided up size ({})",
+                virtual_x,
+                K / (shard_shape[1] / in0_tile_shape[1]),
+                div_up(K, (shard_shape[1] / in0_tile_shape[1])));
 
             uint32_t per_core_M = div_up(M, virtual_y);
             uint32_t per_core_N = div_up(N, virtual_x);
@@ -993,12 +1023,23 @@ MatmulProgramConfig get_matmul_program_config(
     } else {
         // TODO: Need a better criteria for BMMs and
         // MatmulMultiCoreReuseProgramConfig
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "Input A memory layout must not be WIDTH_SHARDED, got: {}",
+            input_tensor_a.memory_config().memory_layout());
 
         bool per_core_N_equals_subblock_w_constraint = false;
         if (output_mem_config.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(), "Error");
-            TT_FATAL(input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(), "Error");
+            TT_FATAL(
+                input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
+                "Input A and output buffer types must match, got input: {} vs output: {}",
+                input_tensor_a.memory_config().buffer_type(),
+                output_mem_config.buffer_type());
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == output_mem_config.memory_layout(),
+                "Input A and output memory layouts must match, got input: {} vs output: {}",
+                input_tensor_a.memory_config().memory_layout(),
+                output_mem_config.memory_layout());
             per_core_N_equals_subblock_w_constraint = true;
         }
 
@@ -1020,15 +1061,22 @@ MatmulProgramConfig get_matmul_program_config(
         uint32_t batch_size_a = get_batch_size(input_tensor_a.padded_shape());
         uint32_t batch_size_b = get_batch_size(input_tensor_b.padded_shape());
         bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-        TT_FATAL(!broadcast_batch, "Error");
+        TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported");
 
         if (input_tensor_b.is_sharded()) {
             TT_FATAL(
-                input_tensor_a.memory_config().buffer_type() == input_tensor_b.memory_config().buffer_type(), "Error");
+                input_tensor_a.memory_config().buffer_type() == input_tensor_b.memory_config().buffer_type(),
+                "Input A and B buffer types must match, got A: {} vs B: {}",
+                input_tensor_a.memory_config().buffer_type(),
+                input_tensor_b.memory_config().buffer_type());
             TT_FATAL(
                 input_tensor_a.memory_config().memory_layout() == input_tensor_b.memory_config().memory_layout(),
-                "Error");
-            TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid, "Error");
+                "Input A and B memory layouts must match, got A: {} vs B: {}",
+                input_tensor_a.memory_config().memory_layout(),
+                input_tensor_b.memory_config().memory_layout());
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
+                "Input A and B shard grids must match");
             TT_FATAL(
                 input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation,
                 "Orientation mismatch a {} vs b {}.",
@@ -1570,7 +1618,10 @@ void Matmul::validate(
     const bool is_optional_output_tensor =
         !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
 
-    TT_FATAL(optional_input_tensors.size() == 1, "Error");
+    TT_FATAL(
+        optional_input_tensors.size() == 1,
+        "Must have exactly 1 optional input tensor, got: {}",
+        optional_input_tensors.size());
 
     const auto output_tensor_spec = this->compute_output_specs(input_tensors, {}, optional_input_tensors).at(0);
     if (is_optional_output_tensor) {
@@ -1624,7 +1675,9 @@ void Matmul::validate(
         // same condition as above, different message
         TT_FATAL(
             a_shape.rank() == b_shape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank",
-            "Error");
+            "Input tensors must have the same rank, got a_shape rank: {} vs b_shape rank: {}",
+            a_shape.rank(),
+            b_shape.rank());
         for (auto i = 0; i < a_shape.rank() - 2; i++) {
             TT_FATAL(
                 a_shape[i] == b_shape[i],
@@ -1681,7 +1734,7 @@ void Matmul::validate(
                 input_tensors[i].dtype());
         }
     } else {
-        TT_FATAL(input_tensors.size() == 2, "Error");
+        TT_FATAL(input_tensors.size() == 2, "Must have exactly 2 input tensors, got: {}", input_tensors.size());
     }
 
     if (optional_bias.has_value()) {
@@ -1719,7 +1772,7 @@ void Matmul::validate(
     }
 
     if (this->untilize_out) {
-        TT_FATAL(this->output_dtype.has_value(), "Error");
+        TT_FATAL(this->output_dtype.has_value(), "Output dtype must be specified when untilize_out is true");
         TT_FATAL(
             (this->output_dtype.value() == DataType::BFLOAT16) || (this->output_dtype.value() == DataType::FLOAT32),
             "Unsupported data type: {}",
@@ -1978,14 +2031,28 @@ void Matmul::validate(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
-                TT_FATAL(input_tensor_a.is_sharded(), "Error");
-                TT_FATAL(this->output_mem_config.is_sharded(), "Error");
-                TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED, "Error");
+                TT_FATAL(input_tensor_a.is_sharded(), "Input tensor A must be sharded for DRAM sharded program config");
                 TT_FATAL(
-                    input_tensor_a.memory_config().buffer_type() == this->output_mem_config.buffer_type(), "Error");
+                    this->output_mem_config.is_sharded(),
+                    "Output memory config must be sharded for DRAM sharded program config");
                 TT_FATAL(
-                    input_tensor_a.memory_config().memory_layout() == this->output_mem_config.memory_layout(), "Error");
-                TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
+                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                    "Input A memory layout must be WIDTH_SHARDED, got: {}",
+                    input_tensor_a.memory_config().memory_layout());
+                TT_FATAL(
+                    input_tensor_a.memory_config().buffer_type() == this->output_mem_config.buffer_type(),
+                    "Input A and output buffer types must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().buffer_type(),
+                    this->output_mem_config.buffer_type());
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == this->output_mem_config.memory_layout(),
+                    "Input A and output memory layouts must match, got input: {} vs output: {}",
+                    input_tensor_a.memory_config().memory_layout(),
+                    this->output_mem_config.memory_layout());
+                TT_FATAL(
+                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                    "Input A shard orientation must be ROW_MAJOR, got: {}",
+                    input_tensor_a.shard_spec().value().orientation);
                 uint32_t M = input_tensor_a.physical_volume() / input_tensor_a.padded_shape()[-1] / in0_tile_shape[0];
                 uint32_t N = input_tensor_b.padded_shape()[-1] / in1_tile_shape[1];
                 uint32_t K = input_tensor_a.padded_shape()[-1] / in0_tile_shape[1];
@@ -1994,14 +2061,29 @@ void Matmul::validate(
                 auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
                 // No padding
-                TT_FATAL(M == per_core_M, "Error");
+                TT_FATAL(M == per_core_M, "M ({}) must equal per_core_M ({})", M, per_core_M);
                 TT_FATAL(M == 1, "currently only support in0 tensor height of tile height");
-                TT_FATAL(per_core_M == (shard_shape[0] / in0_tile_shape[0]), "Error");
-                TT_FATAL(K % program_config.in0_block_w == 0, "Error");
-                TT_FATAL((shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0, "Error");
+                TT_FATAL(
+                    per_core_M == (shard_shape[0] / in0_tile_shape[0]),
+                    "per_core_M ({}) must equal shard_shape[0] / in0_tile_shape[0] ({})",
+                    per_core_M,
+                    (shard_shape[0] / in0_tile_shape[0]));
+                TT_FATAL(
+                    K % program_config.in0_block_w == 0,
+                    "K ({}) must be divisible by in0_block_w ({})",
+                    K,
+                    program_config.in0_block_w);
+                TT_FATAL(
+                    (shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0,
+                    "shard_shape[1] / in0_tile_shape[1] ({}) must be divisible by in0_block_w ({})",
+                    (shard_shape[1] / in0_tile_shape[1]),
+                    program_config.in0_block_w);
 
                 // tensor in1
-                TT_FATAL(input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED, "Error");
+                TT_FATAL(
+                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                    "Input B memory layout must be WIDTH_SHARDED, got: {}",
+                    input_tensor_b.memory_config().memory_layout());
             } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 check_tensor_in_grid(input_tensor_a, program_config.compute_with_storage_grid_size);
                 check_tensor_in_grid(input_tensor_b, program_config.compute_with_storage_grid_size);
@@ -2026,7 +2108,7 @@ void Matmul::validate(
                     program_config.out_block_w,
                     program_config.out_subblock_w);
                 if (input_tensor_a.memory_config().is_sharded()) {
-                    TT_FATAL(program_config.fuse_batch, "Error");
+                    TT_FATAL(program_config.fuse_batch, "Batch fusion is required when input A is sharded");
                     auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
                     uint32_t M =
                         input_tensor_a.physical_volume() / input_tensor_a.padded_shape()[-1] / in0_tile_shape[0];
@@ -2045,40 +2127,69 @@ void Matmul::validate(
                         if (program_config.transpose_mcast) {
                             TT_FATAL(
                                 input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR,
-                                "Error");
+                                "Input tensor A must have COL_MAJOR shard orientation for transpose MCAST, got: {}",
+                                input_tensor_a.shard_spec().value().orientation);
                         } else {
                             TT_FATAL(
                                 input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
-                                "Error");
+                                "Input tensor A must have ROW_MAJOR shard orientation for non-transpose MCAST, got: {}",
+                                input_tensor_a.shard_spec().value().orientation);
                         }
                         if (this->output_mem_config.is_sharded()) {
                             TT_FATAL(
                                 input_tensor_a.memory_config().buffer_type() == this->output_mem_config.buffer_type(),
-                                "Error");
+                                "Input tensor A and output buffer types must match, got input: {} vs output: {}",
+                                input_tensor_a.memory_config().buffer_type(),
+                                this->output_mem_config.buffer_type());
                             TT_FATAL(
                                 input_tensor_a.memory_config().memory_layout() ==
                                     this->output_mem_config.memory_layout(),
-                                "Error");
+                                "Input tensor A and output memory layouts must match, got input: {} vs output: {}",
+                                input_tensor_a.memory_config().memory_layout(),
+                                this->output_mem_config.memory_layout());
                         }
 
                     } else if (tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-                        TT_FATAL(!program_config.transpose_mcast, "Error");
-                        TT_FATAL(K == program_config.in0_block_w, "Error");
-                        TT_FATAL(program_config.in0_block_w == (shard_shape[1] / in0_tile_shape[1]), "Error");
+                        TT_FATAL(
+                            !program_config.transpose_mcast,
+                            "Transpose MCAST not supported with HEIGHT_SHARDED layout");
+                        TT_FATAL(
+                            K == program_config.in0_block_w,
+                            "K ({}) must equal in0_block_w ({})",
+                            K,
+                            program_config.in0_block_w);
+                        TT_FATAL(
+                            program_config.in0_block_w == (shard_shape[1] / in0_tile_shape[1]),
+                            "in0_block_w ({}) must equal shard_shape[1] / in0_tile_shape[1] ({})",
+                            program_config.in0_block_w,
+                            (shard_shape[1] / in0_tile_shape[1]));
                         TT_FATAL(
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
                                 input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x,
-                            "Error");
+                            "Grid bounding box x coordinates must match, got start: {} vs end: {}",
+                            input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x,
+                            input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
                     }
 
-                    TT_FATAL(per_core_M == (shard_shape[0] / in0_tile_shape[0]), "Error");
-                    TT_FATAL((shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0, "Error");
+                    TT_FATAL(
+                        per_core_M == (shard_shape[0] / in0_tile_shape[0]),
+                        "per_core_M ({}) must equal shard_shape[0] / in0_tile_shape[0] ({})",
+                        per_core_M,
+                        (shard_shape[0] / in0_tile_shape[0]));
+                    TT_FATAL(
+                        (shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0,
+                        "shard_shape[1] / in0_tile_shape[1] ({}) must be divisible by in0_block_w ({})",
+                        (shard_shape[1] / in0_tile_shape[1]),
+                        program_config.in0_block_w);
                 }
 
                 if (input_tensor_b.memory_config().is_sharded()) {
-                    TT_FATAL(!program_config.transpose_mcast, "Error");
+                    TT_FATAL(!program_config.transpose_mcast, "Transpose MCAST not supported when input B is sharded");
                     auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout();
-                    TT_FATAL(tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
+                    TT_FATAL(
+                        tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+                        "Input B memory layout must be WIDTH_SHARDED, got: {}",
+                        tensor_b_memory_layout);
                     if (input_tensor_b.buffer()->buffer_type() != tt_metal::BufferType::DRAM) {
                         const auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout();
                         TT_FATAL(
@@ -2091,16 +2202,24 @@ void Matmul::validate(
                         TT_FATAL(
                             program_config.per_core_N ==
                                 (input_tensor_b.shard_spec().value().shape[1] / in1_tile_shape[1]),
-                            "Error");
+                            "per_core_N ({}) must equal input tensor B shard shape[1] / tile shape[1] ({})",
+                            program_config.per_core_N,
+                            (input_tensor_b.shard_spec().value().shape[1] / in1_tile_shape[1]));
                     }
                     TT_FATAL(
                         input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y ==
                             input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y,
-                        "Error");
+                        "Input tensor B grid bounding box must have equal start and end y coordinates, got start: {} "
+                        "vs end: {}",
+                        input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y,
+                        input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
                 }
 
                 if (this->output_mem_config.is_sharded()) {
-                    TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED, "Error");
+                    TT_FATAL(
+                        this->output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
+                        "Output memory layout must be BLOCK_SHARDED, got: {}",
+                        this->output_mem_config.memory_layout());
                     uint32_t M =
                         input_tensor_a.physical_volume() / input_tensor_a.padded_shape()[-1] / in0_tile_shape[0];
                     uint32_t N = input_tensor_b.padded_shape()[-1] / in1_tile_shape[1];
@@ -2165,52 +2284,92 @@ void Matmul::validate(
                         TT_FATAL(
                             input_tensor_a.memory_config().buffer_type() ==
                                 input_tensor_b.memory_config().buffer_type(),
-                            "Error");
+                            "Input tensors A and B must have matching buffer types, got A: {} vs B: {}",
+                            input_tensor_a.memory_config().buffer_type(),
+                            input_tensor_b.memory_config().buffer_type());
                         TT_FATAL(
                             input_tensor_a.memory_config().memory_layout() ==
                                 input_tensor_b.memory_config().memory_layout(),
-                            "Error");
+                            "Input tensors A and B must have matching memory layouts, got A: {} vs B: {}",
+                            input_tensor_a.memory_config().memory_layout(),
+                            input_tensor_b.memory_config().memory_layout());
                         TT_FATAL(
                             input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
-                            "Error");
+                            "Input tensors A and B must have matching shard spec grids");
                         TT_FATAL(
                             input_tensor_a.shard_spec().value().orientation ==
                                 input_tensor_b.shard_spec().value().orientation,
-                            "Error");
+                            "Input tensors A and B must have matching shard orientations, got A: {} vs B: {}",
+                            input_tensor_a.shard_spec().value().orientation,
+                            input_tensor_b.shard_spec().value().orientation);
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(
                             input_tensor_a.memory_config().buffer_type() == this->output_mem_config.buffer_type(),
-                            "Error");
+                            "Input tensor A and output buffer types must match, got input: {} vs output: {}",
+                            input_tensor_a.memory_config().buffer_type(),
+                            this->output_mem_config.buffer_type());
                         TT_FATAL(
                             input_tensor_a.memory_config().memory_layout() == this->output_mem_config.memory_layout(),
-                            "Error");
+                            "Input tensor A and output memory layouts must match, got input: {} vs output: {}",
+                            input_tensor_a.memory_config().memory_layout(),
+                            this->output_mem_config.memory_layout());
                     }
                 }
 
                 uint32_t batch_size_a = get_batch_size(input_tensor_a.padded_shape());
                 uint32_t batch_size_b = get_batch_size(input_tensor_b.padded_shape());
                 bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-                TT_FATAL(!broadcast_batch, "Error");
+                TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported");
 
                 if (input_tensor_b.is_sharded()) {
                     TT_FATAL(per_core_M % M == 0, "per_core_M must be a multiple of M if input b is sharded!");
                     TT_FATAL(
-                        input_tensor_b.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+                        input_tensor_b.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                        "Input B memory layout must not be WIDTH_SHARDED, got: {}",
+                        input_tensor_b.memory_config().memory_layout());
                     auto in1_shard_shape = input_tensor_b.shard_spec().value().shape;
-                    TT_FATAL(in1_shard_shape[1] == input_tensor_b.padded_shape()[-1], "Error");
-                    TT_FATAL(per_core_N * in1_tile_shape[1] == in1_shard_shape[1], "Error");
-                    TT_FATAL(in1_shard_shape[0] % K == 0, "Error");
+                    TT_FATAL(
+                        in1_shard_shape[1] == input_tensor_b.padded_shape()[-1],
+                        "Input B shard shape[1] ({}) must equal padded shape[-1] ({})",
+                        in1_shard_shape[1],
+                        input_tensor_b.padded_shape()[-1]);
+                    TT_FATAL(
+                        per_core_N * in1_tile_shape[1] == in1_shard_shape[1],
+                        "per_core_N * in1_tile_shape[1] ({}) must equal shard shape[1] ({})",
+                        per_core_N * in1_tile_shape[1],
+                        in1_shard_shape[1]);
+                    TT_FATAL(
+                        in1_shard_shape[0] % K == 0,
+                        "Input B shard shape[0] ({}) must be divisible by K ({})",
+                        in1_shard_shape[0],
+                        K);
                 }
                 if (this->output_mem_config.is_sharded()) {
-                    TT_FATAL(this->output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
                     TT_FATAL(
-                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
+                        this->output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                        "Output memory layout must not be WIDTH_SHARDED, got: {}",
+                        this->output_mem_config.memory_layout());
+                    TT_FATAL(
+                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+                        "Either out_subblock_w ({}) must equal per_core_N ({}) or out_subblock_h ({}) must be 1",
+                        program_config.out_subblock_w,
+                        per_core_N,
+                        program_config.out_subblock_h);
                 }
             } else {
-                TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-                TT_FATAL(input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-                TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+                TT_FATAL(
+                    input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Input A memory layout must be INTERLEAVED, got: {}",
+                    input_tensor_a.memory_config().memory_layout());
+                TT_FATAL(
+                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Input B memory layout must be INTERLEAVED, got: {}",
+                    input_tensor_b.memory_config().memory_layout());
+                TT_FATAL(
+                    this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                    "Output memory layout must be INTERLEAVED, got: {}",
+                    this->output_mem_config.memory_layout());
             }
             if constexpr (
                 std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig> ||

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2572,22 +2572,22 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
     TT_FATAL(
         ashape[-2] % in0_tile_shape[0] == 0,
-        "Input A inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
         ashape[-2],
         in0_tile_shape[0]);
     TT_FATAL(
         ashape[-1] % in0_tile_shape[1] == 0,
-        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
         ashape[-1],
         in0_tile_shape[1]);
     TT_FATAL(
         bshape[-2] % in1_tile_shape[0] == 0,
-        "Input B inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
         bshape[-2],
         in1_tile_shape[0]);
     TT_FATAL(
         bshape[-1] % in1_tile_shape[1] == 0,
-        "Input B inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
         bshape[-1],
         in1_tile_shape[1]);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2538,7 +2538,10 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -2553,16 +2556,40 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
+    TT_FATAL(
+        in0_buffer->size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_buffer->size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_buffer->size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_buffer->size(),
+        in1_single_tile_size);
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % in0_tile_shape[0] == 0, "Error");
-    TT_FATAL(ashape[-1] % in0_tile_shape[1] == 0, "Error");
-    TT_FATAL(bshape[-2] % in1_tile_shape[0] == 0, "Error");
-    TT_FATAL(bshape[-1] % in1_tile_shape[1] == 0, "Error");
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "Input A inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "Input B inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "Input B inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -2581,7 +2608,7 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
         Mt = B * Mt;
         B = 1;
     }
-    TT_FATAL(Kt % in0_block_w == 0, "Error");
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1412,7 +1412,10 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -1427,16 +1430,40 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
+    TT_FATAL(
+        in0_buffer->size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_buffer->size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_buffer->size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_buffer->size(),
+        in1_single_tile_size);
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % in0_tile_shape[0] == 0, "Error");
-    TT_FATAL(ashape[-1] % in0_tile_shape[1] == 0, "Error");
-    TT_FATAL(bshape[-2] % in1_tile_shape[0] == 0, "Error");
-    TT_FATAL(bshape[-1] % in1_tile_shape[1] == 0, "Error");
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "Input A inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "Input B inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "Input B inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -1454,7 +1481,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
         Mt = B * Mt;
         B = 1;
     }
-    TT_FATAL(Kt % in0_block_w == 0, "Error");
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1443,25 +1443,27 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
-        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
     TT_FATAL(
         ashape[-2] % in0_tile_shape[0] == 0,
-        "Input A inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
         ashape[-2],
         in0_tile_shape[0]);
     TT_FATAL(
         ashape[-1] % in0_tile_shape[1] == 0,
-        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
         ashape[-1],
         in0_tile_shape[1]);
     TT_FATAL(
         bshape[-2] % in1_tile_shape[0] == 0,
-        "Input B inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
         bshape[-2],
         in1_tile_shape[0]);
     TT_FATAL(
         bshape[-1] % in1_tile_shape[1] == 0,
-        "Input B inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
         bshape[-1],
         in1_tile_shape[1]);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -988,25 +988,27 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
-        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
     TT_FATAL(
         ashape[-2] % in0_tile_shape[0] == 0,
-        "Input A inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
         ashape[-2],
         in0_tile_shape[0]);
     TT_FATAL(
         ashape[-1] % in0_tile_shape[1] == 0,
-        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
         ashape[-1],
         in0_tile_shape[1]);
     TT_FATAL(
         bshape[-2] % in1_tile_shape[0] == 0,
-        "Input B inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
         bshape[-2],
         in1_tile_shape[0]);
     TT_FATAL(
         bshape[-1] % in1_tile_shape[1] == 0,
-        "Input B inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
         bshape[-1],
         in1_tile_shape[1]);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -952,7 +952,10 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -963,7 +966,8 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
 
     tt::tt_metal::IDevice* device = a.mesh_device()->get_device(mesh_coord);
 
-    TT_FATAL(a.shard_spec().has_value() && output.shard_spec().has_value(), "Error");
+    TT_FATAL(
+        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
     CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
     CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
 
@@ -971,16 +975,40 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
+    TT_FATAL(
+        in0_buffer->size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_buffer->size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_buffer->size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_buffer->size(),
+        in1_single_tile_size);
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % in0_tile_shape[0] == 0, "Error");
-    TT_FATAL(ashape[-1] % in0_tile_shape[1] == 0, "Error");
-    TT_FATAL(bshape[-2] % in1_tile_shape[0] == 0, "Error");
-    TT_FATAL(bshape[-1] % in1_tile_shape[1] == 0, "Error");
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "Input A inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "Input B inner dimension 1 ({}) must be divisible by tile shape 0 ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "Input B inner dimension 2 ({}) must be divisible by tile shape 1 ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -996,7 +1024,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     uint32_t Nt = bshape[-1] / in1_tile_shape[1];
     uint32_t in0_last_ktile_w = a.logical_shape()[-1] % in0_tile_shape[1];
 
-    TT_FATAL(Kt % in0_block_w == 0, "Error");
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -272,9 +272,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse(
     uint32_t per_core_M = 16;
     uint32_t per_core_N = 16;
 
-    TT_FATAL(Mt % per_core_M == 0, "Error");
-    TT_FATAL(Nt % per_core_N == 0, "Error");
-    TT_FATAL(Kt % in0_block_w == 0, "Error");
+    TT_FATAL(Mt % per_core_M == 0, "Mt ({}) must be divisible by per_core_M ({})", Mt, per_core_M);
+    TT_FATAL(Nt % per_core_N == 0, "Nt ({}) must be divisible by per_core_N ({})", Nt, per_core_N);
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     // This should allocate a DRAM buffer on the device
     tt_metal::IDevice* device = a.device();
@@ -283,7 +283,11 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     uint32_t num_blocks_total = (Mt / per_core_M) * (Nt / per_core_N);
-    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y, "Error");
+    TT_FATAL(
+        num_blocks_total <= num_cores_x * num_cores_y,
+        "Total number of blocks ({}) must not exceed available cores ({})",
+        num_blocks_total,
+        num_cores_x * num_cores_y);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
It would be good to clean up some TT_FATAL messages.
Useful for AI Hackathon.

### What's changed
Updated messages in matmul via the following prompts. The requests seemed to identify different sets of files and messages, and it took multiple prompts to get good coverage. Also, the AI had problems finding the right locations because of bad usage of grep. Had to be provided with a specific grep command and results with line numbers to proceed.

Please update all of the TT_FATAL calls in files in subdirectories of
ttnn/cpp/ttnn/operations/matmul that only have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL, except when those values are of a device (via the device() method). Printing out the values of device leads to a compiler error.

Please update all of the TT_FATAL calls in files in ttnn/cpp/ttnn/operations/matmul/device that only have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL. Exclude the values when the TT_FATAL checks only for dtype having a value or a tensor being sharded.

Please update the TT_FATAL calls in ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp on lines 1725 and 1984 to have meaningful error messages. Do not include the value checked by TT_FATAL in the error message.

Please update the TT_FATAL call in ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp on line 1985 to have meaningful error messages. Do not include the value checked by TT_FATAL in the error message.


Please update all of the TT_FATAL calls in files in ttnn/cpp/ttnn/operations/matmul/device that only have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL.

Please update the TT_FATAL calls in ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp that only have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL. Note that the "Error" messages are on different lines than the TT_FATAL because of formatting.

Please list all of the TT_FATAL calls in ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp that only have "Error" as an error message.

Follow up prompt since the previous one was a complete failure:
Please just grep for "Error" (e.g. grep '"Error"') to identify these TT_FATALs.

Follow up prompt since the previous one was a complete failure:
Please just grep for '"Error"'  to identify these TT_FATALs.

Had to be stopped.

Follow up prompt since the previous one was a complete failure:
I used a grep command to identify the line numbers of the error messages. The command and output is shown below.
grep -n '"Error"' ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
1632:            "Error");
2057:                                "Error");
2061:                                "Error");
2066:                                "Error");
2070:                                "Error");
2105:                            "Error");
2110:                        "Error");
2179:                            "Error");
2183:                            "Error");
2186:                            "Error");
2190:                            "Error");
2195:                            "Error");
2198:                            "Error");

Please update these TT_FATAL calls in ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp that only have "Error" as an error message to have meaningful error messages that include the values that are checked by TT_FATAL.

Additional prompts for reviewer feedback (note: some very simple text was updated manually since that was faster than trying to create a prompt).

For the changes made to TT_FATAL messages, which were saved in commit b4a97ba7cc please identify the changes where the check is done for a negative number and t
he message shows a positive number. The following lines are an example:
TT_FATAL(
        ashape[-1] % in0_tile_shape[1] == 0,
        "Input A inner dimension 2 ({}) must be divisible by tile shape 1 ({})",

AI went into a bad state. I had to start a new chat.

Please identify the TT_FATALs in cpp files in the directory
ttnn/cpp/ttnn/operations/matmul/device/
that check for shape values at index -1 or -2.

Please update these TT_FATALs to all print out the values used for the check and to retain the -1 or -2 in the text of the message instead of using text that provides a positive inner dimension.

Please put back the text Dimension K in the changes that you just made.

Please identify all of the lines with "inner dimension" in the cpp files in the directory
ttnn/cpp/ttnn/operations/matmul/device/

Please update the messages on these lines to refer to the approriate negative di
mension that is checked in the TT_FATALs.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17102667408
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes