### PR TITLE
Check arch type in a separate process for profiler integration

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler_gs_no_reset.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler_gs_no_reset.py
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-
-# SPDX-License-Identifier: Apache-2.0
-
-from tests.tt_metal.tools.profiler import test_device_profiler
-
-
-def test_multi_op_gs_no_reset():
-    test_device_profiler.test_multi_op()


### PR DESCRIPTION
### Ticket
#25388 

### Problem description
Profiler pytest integration tests are double opening the device.

### What's changed
Avoid double opening by checking arch type in a separate process.

### Checklist
- [ ] [All post commit profiler only]
- [ ] [T3K profiler]
- [ ] [BH post commit]