### PR TITLE
Disable the option to push profiling data to Tracy in the middle of a run when dispatch core profiling or trace-only profiling is active

### DIFF
--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -144,6 +144,14 @@ def main():
     else:
         port = get_available_port()
 
+    if options.mid_run_device_data:
+        if options.device_trace_profiler:
+            logger.error("Cannot use --push-device-data-mid-run and --device-trace-profiler together")
+            sys.exit(1)
+        if options.profile_dispatch_cores:
+            logger.error("Cannot use --push-device-data-mid-run and --profile-dispatch-cores together")
+            sys.exit(1)
+
     opInfoCacheStr = "TT_METAL_PROFILER_NO_CACHE_OP_INFO"
     if options.opInfoCache:
         if opInfoCacheStr in os.environ.keys():


### PR DESCRIPTION
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17107767904)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/17107774555)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17107783130)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17107789333)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17107800149)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17107805894)
- [x] New/Existing tests provide coverage for changes