### PR TITLE
#22817 Add SiglipMLP for Siglip/Gemma3

### DIFF
--- a/models/demos/gemma3/tests/test_ci_dispatch.py
+++ b/models/demos/gemma3/tests/test_ci_dispatch.py
@@ -30,6 +30,7 @@ def test_ci_dispatch(model_weights):
     exit_code = pytest.main(
         [
             "models/demos/siglip/tests/test_attention.py",
+            "models/demos/siglip/tests/test_mlp.py",
         ]
         + ["-x"]  # Fail if one of the tests fails
     )

--- a/models/demos/siglip/reference/functional.py
+++ b/models/demos/siglip/reference/functional.py
@@ -70,13 +70,7 @@ def gelu_tanh(x):
     return (
         0.5
         * x
-        * (
-            1
-            + torch.tanh(
-                torch.sqrt(torch.tensor(2.0 / torch.pi, device=x.device))
-                * (x + 0.044715 * torch.pow(x, 3))
-            )
-        )
+        * (1 + torch.tanh(torch.sqrt(torch.tensor(2.0 / torch.pi, device=x.device)) * (x + 0.044715 * torch.pow(x, 3))))
     )
 
 
@@ -90,19 +84,10 @@ def siglip_mlp(
     vision_dim: int = 1152,
     vision_mlp_ratio: float = 4.0,
 ) -> torch.Tensor:
-    
-    hidden_states = F.linear(
-        hidden_states, 
-        state_dict["c_fc"]["weight"], 
-        state_dict["c_fc"].get("bias")
-    )
-    
+    hidden_states = F.linear(hidden_states, state_dict["c_fc"]["weight"], state_dict["c_fc"].get("bias"))
+
     hidden_states = gelu_tanh(hidden_states)
-    
-    hidden_states = F.linear(
-        hidden_states, 
-        state_dict["c_proj"]["weight"], 
-        state_dict["c_proj"].get("bias")
-    )
-    
+
+    hidden_states = F.linear(hidden_states, state_dict["c_proj"]["weight"], state_dict["c_proj"].get("bias"))
+
     return hidden_states

--- a/models/demos/siglip/reference/functional.py
+++ b/models/demos/siglip/reference/functional.py
@@ -64,3 +64,45 @@ def siglip_attention(
     attn_output = F.linear(attn_output, state_dict["wo"]["weight"], state_dict["wo"].get("bias"))
 
     return attn_output, attn_weights
+
+
+def gelu_tanh(x):
+    return (
+        0.5
+        * x
+        * (
+            1
+            + torch.tanh(
+                torch.sqrt(torch.tensor(2.0 / torch.pi, device=x.device))
+                * (x + 0.044715 * torch.pow(x, 3))
+            )
+        )
+    )
+
+
+def siglip_mlp(
+    mesh_device,
+    hidden_states: torch.Tensor,
+    state_dict: Dict,
+    state_dict_prefix: str,
+    weight_cache_path: str,
+    dtype: torch.dtype = torch.bfloat16,
+    vision_dim: int = 1152,
+    vision_mlp_ratio: float = 4.0,
+) -> torch.Tensor:
+    
+    hidden_states = F.linear(
+        hidden_states, 
+        state_dict["c_fc"]["weight"], 
+        state_dict["c_fc"].get("bias")
+    )
+    
+    hidden_states = gelu_tanh(hidden_states)
+    
+    hidden_states = F.linear(
+        hidden_states, 
+        state_dict["c_proj"]["weight"], 
+        state_dict["c_proj"].get("bias")
+    )
+    
+    return hidden_states

--- a/models/demos/siglip/reference/functional.py
+++ b/models/demos/siglip/reference/functional.py
@@ -66,6 +66,7 @@ def siglip_attention(
     return attn_output, attn_weights
 
 
+# https://github.com/google/gemma_pytorch/blob/main/gemma/siglip_vision/siglip_vision_model.py#L93 as function for easier testing
 def gelu_tanh(x):
     return (
         0.5

--- a/models/demos/siglip/tests/common.py
+++ b/models/demos/siglip/tests/common.py
@@ -24,6 +24,9 @@ def convert_state_dict(flat_dict):
         "k_proj": "wk",
         "v_proj": "wv",
         "out_proj": "wo",
+        # MLP weight mappings to TtLlamaImageFeedForward format
+        "fc1": "c_fc",
+        "fc2": "c_proj",
     }
     for m, n in mappings.items():
         flat_dict = {k.replace(m, n): v for k, v in flat_dict.items()}

--- a/models/demos/siglip/tests/test_mlp.py
+++ b/models/demos/siglip/tests/test_mlp.py
@@ -54,9 +54,7 @@ def test_mlp(mesh_device, mlp_func, model_location_generator):
     random_inputs = (
         torch.rand(batch, seq_len, config.hidden_size, dtype=reference_mlp.state_dict()["fc1.weight"].dtype)
         * (expected_max_input_scale - expected_min_input_scale)
-    ) - (
-        (expected_max_input_scale - expected_min_input_scale) / 2
-    )
+) - ((expected_max_input_scale - expected_min_input_scale) / 2)    
 
     reference_output = reference_mlp(hidden_states=random_inputs)
 

--- a/models/demos/siglip/tests/test_mlp.py
+++ b/models/demos/siglip/tests/test_mlp.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+import torch
+from transformers import AutoConfig
+from transformers.models.siglip.modeling_siglip import SiglipMLP
+
+import ttnn
+from models.demos.siglip.compare import comp_pcc
+from models.demos.siglip.reference.functional import siglip_mlp
+from models.demos.siglip.tests.common import convert_state_dict
+from models.demos.siglip.tt.mlp import siglip_mlp_ttnn
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "N150x4": (1, 4),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150": (1, 1),
+            "P300": (1, 2),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mlp_func", [siglip_mlp, siglip_mlp_ttnn])
+def test_mlp(mesh_device, mlp_func, model_location_generator):
+    config = AutoConfig.from_pretrained(
+        model_location_generator(model_version=os.getenv("HF_MODEL"), download_if_ci_v2=True)
+    )
+    assert hasattr(
+        config, "vision_config"
+    ), f"Unexpected model config provided. Expected a vision_config field to be present in: {config}"
+    config = config.vision_config
+
+    reference_mlp = SiglipMLP(config=config)
+
+    batch = 1
+    seq_len = 4096
+    expected_max_input_scale = 15
+    expected_min_input_scale = -15
+
+    random_inputs = (
+        torch.rand(batch, seq_len, config.hidden_size, dtype=reference_mlp.state_dict()["fc1.weight"].dtype)
+        * (expected_max_input_scale - expected_min_input_scale)
+    ) - (
+        (expected_max_input_scale - expected_min_input_scale) / 2
+    )
+
+    reference_output = reference_mlp(hidden_states=random_inputs)
+
+    state_dict = convert_state_dict(reference_mlp.state_dict())
+    result = mlp_func(
+        mesh_device=mesh_device,
+        hidden_states=random_inputs,
+        state_dict=state_dict,
+        state_dict_prefix="",
+        weight_cache_path=None,
+        vision_dim=config.hidden_size,
+        vision_mlp_ratio=config.intermediate_size / config.hidden_size,
+    )
+
+    result, pcc = comp_pcc(reference_output, result)
+
+    if result:
+        print(f"✅ Siglip MLP passes with PCC: {pcc}")
+    else:
+        print(f"❌ Siglip MLP fails with PCC: {pcc}")
+        assert False

--- a/models/demos/siglip/tests/test_mlp.py
+++ b/models/demos/siglip/tests/test_mlp.py
@@ -54,7 +54,7 @@ def test_mlp(mesh_device, mlp_func, model_location_generator):
     random_inputs = (
         torch.rand(batch, seq_len, config.hidden_size, dtype=reference_mlp.state_dict()["fc1.weight"].dtype)
         * (expected_max_input_scale - expected_min_input_scale)
-) - ((expected_max_input_scale - expected_min_input_scale) / 2)    
+    ) - ((expected_max_input_scale - expected_min_input_scale) / 2)
 
     reference_output = reference_mlp(hidden_states=random_inputs)
 

--- a/models/demos/siglip/tests/test_mlp.py
+++ b/models/demos/siglip/tests/test_mlp.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 import torch
+from loguru import logger
 from transformers import AutoConfig
 from transformers.models.siglip.modeling_siglip import SiglipMLP
 
@@ -72,7 +73,7 @@ def test_mlp(mesh_device, mlp_func, model_location_generator):
     result, pcc = comp_pcc(reference_output, result)
 
     if result:
-        print(f"✅ Siglip MLP passes with PCC: {pcc}")
+        logger.info(f"✅ Siglip MLP passes with PCC: {pcc}")
     else:
-        print(f"❌ Siglip MLP fails with PCC: {pcc}")
+        logger.error(f"❌ Siglip MLP fails with PCC: {pcc}")
         assert False

--- a/models/demos/siglip/tt/mlp.py
+++ b/models/demos/siglip/tt/mlp.py
@@ -13,7 +13,6 @@ from models.demos.siglip.tests.common import flatten_state_dict
 from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.common import get_out_subblock_w
 from models.tt_transformers.tt.multimodal.llama_image_mlp import TtLlamaImageFeedForward
-from models.utility_functions import nearest_32
 
 
 def find_largest_divisor(n, max_divisor=8):
@@ -127,7 +126,7 @@ def siglip_mlp_ttnn(
 ) -> torch.Tensor:
     state_dict = flatten_state_dict(state_dict)
     grid = mesh_device.compute_with_storage_grid_size()
-    
+
     mlp_config = MLPConfig(
         num_devices=mesh_device.get_num_devices() if mesh_device else 0,
         vision_dim=vision_dim,
@@ -145,7 +144,7 @@ def siglip_mlp_ttnn(
         weight_cache_path=weight_cache_path,
         dtype=dtype,
     )
-    
+
     if isinstance(hidden_states, torch.Tensor):
         hidden_states = ttnn.from_torch(
             hidden_states,
@@ -160,5 +159,5 @@ def siglip_mlp_ttnn(
         output = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[0]
     else:
         output = ttnn_mlp(hidden_states)
-    
+
     return output

--- a/models/demos/siglip/tt/mlp.py
+++ b/models/demos/siglip/tt/mlp.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from typing import Dict, Optional, Tuple
+
+import torch
+from pydantic import BaseModel, Field
+
+import ttnn
+from models.demos.siglip.tests.common import flatten_state_dict
+from models.tt_transformers.tt.ccl import TT_CCL
+from models.tt_transformers.tt.common import get_out_subblock_w
+from models.tt_transformers.tt.multimodal.llama_image_mlp import TtLlamaImageFeedForward
+from models.utility_functions import nearest_32
+
+
+def find_largest_divisor(n, max_divisor=8):
+    for i in range(max_divisor, 0, -1):
+        if n % i == 0:
+            return i
+    return 1
+
+
+def matmul_config(
+    tile_size,
+    m: int,
+    k: int,
+    n: int,
+    grid_size: Tuple[int, int],
+    in0_block_w: int = None,
+    fuse_batch: bool = False,
+    fused_activation=None,
+    per_core_M=None,
+    per_core_N=None,
+):
+    if per_core_M is None:
+        per_core_M = math.ceil(m / (tile_size * grid_size[1]))
+    if per_core_N is None:
+        per_core_N = math.ceil(n / (tile_size * grid_size[0]))
+
+    out_subblock_h = 1
+    out_subblock_w = get_out_subblock_w(per_core_N, out_subblock_h)
+
+    if in0_block_w is None:
+        assert k % (tile_size * grid_size[1]) == 0, f"Input width must be divisible by tile size times grid size"
+        in0_block_w = find_largest_divisor(k // (tile_size * grid_size[1]))
+
+    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=fused_activation,
+        fuse_batch=fuse_batch,
+    )
+
+
+class MLPConfig(BaseModel):
+    model_config = {
+        "arbitrary_types_allowed": True,
+    }
+    tile_size: Optional[int] = 32
+    num_devices: int
+    vision_dim: int
+    vision_mlp_ratio: float = 4.0
+    max_grid_size: ttnn.CoreGrid
+    compute_kernel_config_hifi2: ttnn.WormholeComputeKernelConfig = Field(
+        default_factory=lambda: ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+    )
+    compute_kernel_config_hifi4: ttnn.WormholeComputeKernelConfig = Field(
+        default_factory=lambda: ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+    )
+    dummy_weights: bool = False
+    VISION_MAX_MM_SEQ: int = 32
+
+    @property
+    def vision_mlp_dim(self):
+        return int(self.vision_dim * self.vision_mlp_ratio)
+
+    def get_model_config(self):
+        return {
+            "IMAGE_MLP_FC_PROGCFG": lambda seq_len, max_seq: matmul_config(
+                tile_size=self.tile_size,
+                m=min(seq_len, max_seq),
+                k=self.vision_dim,
+                n=self.vision_mlp_dim // self.num_devices,
+                grid_size=(8, 8),
+                in0_block_w=1,
+                fuse_batch=seq_len <= max_seq,
+            ),
+            "IMAGE_MLP_PROJ_PROGCFG": lambda seq_len, max_seq: matmul_config(
+                tile_size=self.tile_size,
+                m=min(seq_len, max_seq),
+                k=self.vision_mlp_dim // self.num_devices,
+                n=self.vision_dim,
+                grid_size=(8, 8),
+                in0_block_w=1,
+                fuse_batch=seq_len <= max_seq,
+            ),
+        }
+
+
+def siglip_mlp_ttnn(
+    mesh_device,
+    hidden_states: torch.Tensor,
+    state_dict: Dict,
+    state_dict_prefix: str,
+    weight_cache_path: str,
+    dtype=ttnn.bfloat16,
+    vision_dim: int = 1152,
+    vision_mlp_ratio: float = 4.0,
+) -> torch.Tensor:
+    state_dict = flatten_state_dict(state_dict)
+    grid = mesh_device.compute_with_storage_grid_size()
+    
+    mlp_config = MLPConfig(
+        num_devices=mesh_device.get_num_devices() if mesh_device else 0,
+        vision_dim=vision_dim,
+        vision_mlp_ratio=vision_mlp_ratio,
+        max_grid_size=ttnn.CoreGrid(x=grid.x, y=grid.y),
+        dummy_weights=(weight_cache_path is None),
+    )
+
+    ttnn_mlp = TtLlamaImageFeedForward(
+        mesh_device=mesh_device,
+        tt_ccl=TT_CCL(mesh_device),
+        args=mlp_config,
+        state_dict=state_dict,
+        state_dict_prefix=state_dict_prefix,
+        weight_cache_path=weight_cache_path,
+        dtype=dtype,
+    )
+    
+    if isinstance(hidden_states, torch.Tensor):
+        hidden_states = ttnn.from_torch(
+            hidden_states,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=dtype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+        output = ttnn_mlp(hidden_states)
+        output = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[0]
+    else:
+        output = ttnn_mlp(hidden_states)
+    
+    return output


### PR DESCRIPTION
### Ticket
#26817 

### Problem description
MLP for siglip requires gelu_tanh activation

### What's changed
Adds MLP on device for siglip encoder with gelu_tanh activation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes