### PR TITLE
Hackathon AI finds

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -216,7 +216,7 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
             auto src_dram_buffer = input_tensors.at(0).buffer();
 
             auto dst_0_dram_buffer = output_tensors.at(0).buffer();
-            auto dst_1_dram_buffer = output_tensors.at(0).buffer();
+            auto dst_1_dram_buffer = output_tensors.at(1).buffer();
 
             for (int core_idx_y = 0; core_idx_y < num_cores_c; core_idx_y++) {
                 for (int core_idx_x = 0; core_idx_x < num_cores_r; core_idx_x++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -33,7 +33,7 @@ uint32_t get_pf_type(bool output_is_sharded, const Tensor& tensor) {
     uint32_t num_tiles_per_col = tensor_height / tile_height;
 
     // If the input is interleaved and an entire row of tiles can't fit in a CB at once
-    if (!output_is_sharded && num_tiles_per_row > max_tiles_per_cb) {
+    if (!tensor.is_sharded() && num_tiles_per_row > max_tiles_per_cb) {
         // If the output is also interleaved and the tensor is only a single tile high, we can
         // parellize the work column wise. Otherwise we have to resort to the single core implementation,
         // as the current default multi core implementation processes an entire row of tiles at once.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -13,6 +13,39 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
+uint32_t get_pf_type(bool output_is_sharded, const Tensor& tensor) {
+    auto device = tensor.device();
+    uint32_t max_l1_size =
+        device->l1_size_per_core() / 2 - device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    // Determine the max number of tiles that can be in any CB at a given time (1 input CB + 1 output CB = 2 total CBs)
+    uint32_t max_tiles_per_cb = max_l1_size / (2 * single_tile_size);
+
+    // TODO : currently multi_core parallelization on column only works for single tile height tensors.
+    // Need to debug this to work on wide tensors that are higher than a single tile
+    const auto& tile_shape = tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tensor_width = tensor.padded_shape()[-1];
+    uint32_t tensor_height = tensor.physical_volume() / tensor_width;
+    uint32_t tile_height = tile_shape[0];
+    uint32_t tile_width = tile_shape[1];
+    uint32_t num_tiles_per_row = tensor_width / tile_width;
+    uint32_t num_tiles_per_col = tensor_height / tile_height;
+
+    // If the input is interleaved and an entire row of tiles can't fit in a CB at once
+    if (!output_is_sharded && num_tiles_per_row > max_tiles_per_cb) {
+        // If the output is also interleaved and the tensor is only a single tile high, we can
+        // parellize the work column wise. Otherwise we have to resort to the single core implementation,
+        // as the current default multi core implementation processes an entire row of tiles at once.
+        if (!output_is_sharded && num_tiles_per_col == 1) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+    return 2;
+}
+
 void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
     const auto& input_tensor_a = input_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -25,6 +25,7 @@ struct Untilize {
     const std::optional<CoreRangeSet> sub_core_grids;
     const bool enough_space_width;
     const bool enough_space_height;
+    const uint32_t pf_type;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -11,6 +11,8 @@
 
 namespace ttnn::operations::data_movement {
 
+uint32_t get_pf_type(bool output_is_sharded, const Tensor& tensor);
+
 namespace untilize_helpers {
 
 uint32_t get_num_cores(CoreCoord grid_size, uint32_t nblocks);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ttnn/operation.hpp"
+#include "untilize_op.hpp"
 
 namespace ttnn::operations::data_movement::detail {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -67,7 +67,10 @@ ttnn::Tensor ExecuteUntilize::invoke(
                 fp32_dest_acc_en,
                 sub_core_grids,
                 enough_space_width,
-                enough_space_height},
+                enough_space_height,
+                ttnn::operations::data_movement::get_pf_type(
+                    memory_config.has_value() ? memory_config.value().is_sharded() : input_tensor.is_sharded(),
+                    input_tensor)},
             {input_tensor},
             {},
             {},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.cpp
@@ -139,7 +139,8 @@ tt::tt_metal::operation::Hash AllBroadcastAsync::compute_program_hash(const std:
         this->cluster_axis,
         this->sub_device_id.has_value(),
         this->sub_device_id.has_value()
-            ? input_tensors[0].device()->worker_cores(HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
             : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         input_shape,
         input_memory_layout,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_op.cpp
@@ -137,6 +137,10 @@ tt::tt_metal::operation::Hash AllBroadcastAsync::compute_program_hash(const std:
         this->output_mem_config,
         this->topology,
         this->cluster_axis,
+        this->sub_device_id.has_value(),
+        this->sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         input_shape,
         input_memory_layout,
         input_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -285,6 +285,11 @@ tt::tt_metal::operation::Hash AllGatherAsync::compute_program_hash(const std::ve
             this->output_mem_config,
             this->topology,
             this->cluster_axis,
+            this->sub_device_id.has_value(),
+            this->sub_device_id.has_value()
+                ? input_tensors[0].device()->worker_cores(
+                      tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+                : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
             input_shape,
             input_memory_layout,
             input_dtype,
@@ -298,6 +303,11 @@ tt::tt_metal::operation::Hash AllGatherAsync::compute_program_hash(const std::ve
         this->output_mem_config,
         this->topology,
         this->cluster_axis,
+        this->sub_device_id.has_value(),
+        this->sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         this->barrier_semaphore.has_value(),
         this->using_persistent_buffers,
         this->chunks_per_sync,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_op.cpp
@@ -197,7 +197,11 @@ tt::tt_metal::operation::Hash AllGatherMatmulAsync::compute_program_hash(
         this->all_gather_async_struct.ring_size,
         this->all_gather_async_struct.output_mem_config,
         this->all_gather_async_struct.topology,
-        this->all_gather_async_struct.sub_device_id,
+        this->all_gather_async_struct.sub_device_id.has_value(),
+        this->all_gather_async_struct.sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  shard_builder::HalProgrammableCoreType::TENSIX, this->all_gather_async_struct.sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         this->all_gather_async_struct.cluster_axis,
         this->all_gather_async_struct.barrier_semaphore.has_value(),
         this->all_gather_async_struct.using_persistent_buffers,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
@@ -165,6 +165,11 @@ tt::tt_metal::operation::Hash AllReduceAsync::compute_program_hash(const std::ve
         this->output_mem_config,
         this->topology,
         this->cluster_axis,
+        this->sub_device_id.has_value(),
+        this->sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         input_shape,
         input_memory_layout,
         input_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_op.cpp
@@ -177,7 +177,12 @@ tt::tt_metal::operation::Hash MatmulReduceScatterAsync::compute_program_hash(
         this->reduce_scatter_minimal_async_struct.output_mem_config,
         this->reduce_scatter_minimal_async_struct.intermediate_mem_config,
         this->reduce_scatter_minimal_async_struct.topology,
-        this->reduce_scatter_minimal_async_struct.sub_device_id,
+        this->reduce_scatter_minimal_async_struct.sub_device_id.has_value(),
+        this->reduce_scatter_minimal_async_struct.sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX,
+                  this->reduce_scatter_minimal_async_struct.sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         this->reduce_scatter_minimal_async_struct.cluster_axis,
         this->reduce_scatter_minimal_async_struct.barrier_semaphore.has_value(),
         this->reduce_scatter_minimal_async_struct.using_persistent_buffers,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -234,6 +234,11 @@ operation::Hash ReduceScatterAsync::compute_program_hash(const std::vector<Tenso
         this->ring_size,
         this->topology,
         this->cluster_axis,
+        this->sub_device_id.has_value(),
+        this->sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         input_shape,
         input_memory_layout,
         input_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -289,7 +289,11 @@ tt::tt_metal::operation::Hash ReduceScatterMinimalAsync::compute_program_hash(
         this->topology,
         this->barrier_semaphore.has_value(),
         this->using_persistent_buffers,
-        this->sub_device_id,
+        this->sub_device_id.has_value(),
+        this->sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         this->cluster_axis,
         this->chunks_per_sync,
         this->num_workers_per_link,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
@@ -186,7 +186,11 @@ tt::tt_metal::operation::Hash RingAttentionAllGatherAsync::compute_program_hash(
         this->output_mem_config,
         this->topology,
         this->cluster_axis,
-        this->sub_device_id,
+        this->sub_device_id.has_value(),
+        this->sub_device_id.has_value()
+            ? input_tensors[0].device()->worker_cores(
+                  tt::tt_metal::HalProgrammableCoreType::TENSIX, this->sub_device_id.value())
+            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
         input_shape,
         input_memory_layout,
         input_dtype,


### PR DESCRIPTION
### Ticket
These are the hackathon bug fixes from team Program Ca$h 3000
It includes 11 OP fixes in the program cache where we used AI to point out the issues but we resolved them manually.

This is the combined work of @nardoTT @grechsteinerTT @sjameelTT @ntarafdar and @jvegaTT 

Issue to add testing is
https://github.com/tenstorrent/tt-metal/issues/27421

Prompts were:

Prompts:
1- Write a code for untilize_single_core in untilize_program_factory.py that: 1- Create two empty sets: one for reader and
  one for writer. 2- For reader and writer RT args (reader_run_time_args, writer_run_time_args), if the arguments being
  added has (address()) in it, then add its index of that arg in the corresponding set. 3- Pass these sets to the
  override_runtime_args_callback function. 4- Make sure every index in each set is getting updated, otherwise Fatal
2- We want to do something similar for this program factory: rms_allgather_pf.cpp. On top of the address logic shared earlier, we want to also account for the allocated addresses of CBs. So for
  example if in the program factory, we have set_globally_allocated_address for a circular buffer, we want to make sure that this is getting updated in the override_runtime_arguments_callback
  through this function: UpdateDynamicCircularBufferAddress if the control logic is the same. You might need to store circular buffer names for that (cb_in1). To check if logic match, look into
  create_program_at in this file ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp to compare names of tensors
3- if you look at the control logic in ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp, the buffer addresses that get updated differ depending on input arguments (look at lines 1263 - 1278)
4- I think you are appending the set for addresses indices from tehe hardcoded valeus coming form the program factory not from the ones getting updated, so the two will always match even if the rt indices that are getting updated are different
5- the expected cbs and indices should be passed from the program factory not hardcoded in override
6- you are trying to fix the code: you are using the indices passed from program factory to update the rts in override. What you need to do is keep the logic as is, and detect whether the code is doing the indexing wrong or missing some
7- using a similar logic for validating the addresses and CB updates in the override function, add validation to all program factories of all ops in ttnn/cpp/ttnn/operations
8- note that the files may have multiple program factories, so apply the logic for all of them
9- you are only accounting for the addresses/buffers that are getting updated in the override function, for example in this function pad_rm_reader_writer in pad_program_factory.cpp, the program cache is adding 2 addresses for reader and writer rts (source addr and dst addr), however you are just adding the index of the first one in the expected set. Change the ops to account for that
10- We just want to highlight the differences between the program cache updated and the expected updates not fix them
11- you haven't changed all program factories in the ops (example concat), please apply the changes in all of them
12- you are still missing some program factories: exmaple s2s_tiled_concat_two_tensors_height_multi_core
13- I noticed your note for concat program factory: NOTE: This function uses UpdateDynamicCircularBufferAddress for sharded tensors
          // Validation is different from runtime args - we ensure circular buffer addresses are updated
          // which is the expected pattern for sharded concat operations with globally allocated buffers
          // The output buffer is not explicitly updated here as it may be handled differently       Can you error out for these cases? (check rms_allgather_pf.cpp for cb update validation
  logic)
14- You are still missing some program factories, update ALL of them
15- let us target one file at a time, can you start with transpose_program_factory.cpp, cover all program factories/override functions
16- could you add this comment "/look into this file" to the top of every file ending with program_factory.cpp
17- could you look into every file that has this comment at the top "//look into this file" , and apply the validation logic of override to it
18- Can you apply this validation to all files having the comment "// look into this file" at the top?
19 - Did you find any bugs?
20- For the ccl operations, the program hashing use compute_program_hash API (check the ccl files ending with _op.cpp). Make sure this function does not hash on sub_device_id. Return the operations that hashes on it
21- Look for any attribute called sub_device_id in compute_hash_function from any class
22- program cache might be buggy if we have a hit for an op that does not hash on sub core grids, and its program factory has non globally allocated CBs, semaphores or multicasting. Could you find the ops that have that
23- All the ops above do hash on subcore grids, another infra for hashing is operation::run(OP{hashing_args})
For CCL ops, if an op is using subdevice id but not hashing on it, program cache might also be buggy, can you point the ops that are doing that?
Could you look into these csaes and report them?
24- what else might go wrong in program cache for single device ops and ccl ops?
25- Can you elaborate more on this point and give exmaples for op that do so?
	3. Runtime Buffer Allocation Details
                 - Problem: Some operations allocate resources based on runtime memory availability                                                                                                   │
		- Issue: Memory constraints at program creation time aren't hashed                                                                                                                   │
		- Risk: Cache hits with incompatible memory layouts
26- can you please point to the ops that hash semaphore addresses (not global semaphore) because these might also add program cache bugs


https://github.com/tenstorrent/tt-metal/actions/runs/17109888253
https://github.com/tenstorrent/tt-metal/actions/runs/17110578326
https://github.com/tenstorrent/tt-metal/actions/runs/17110572094