### PR TITLE
Shortening time for Galaxy fabric unit tests in TG Nightly Test Pipeline

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         test-group: [
           { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: ULMEPM2MA}, # Sean Nijjar
-          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 180, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
+          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           {
             name: "Llama Galaxy Accuracy Test",
             arch: wormhole_b0,


### PR DESCRIPTION
### Problem description
Average times for Galaxy Fabric Unit tests are approximately 35 mins as can be seen in the most recent jobs:
- [~27 mins](https://github.com/tenstorrent/tt-metal/actions/runs/17012861051/job/48231329953)
- [~39 mins](https://github.com/tenstorrent/tt-metal/actions/runs/17052434446/job/48343825564)
- [~26 mins](https://github.com/tenstorrent/tt-metal/actions/runs/17025823628/job/48261190825)

### What's changed
We have reduced the timeout so it went from 180 minutes to 60 minutes

### Checklist
- [ ] [TG nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17108818511)