### PR TITLE
One-to-Many Sockets

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -48,16 +48,22 @@ static inline uint32_t align_up_local(uint32_t value, uint32_t alignment) {
 static ParsedSenderPage parse_sender_page(
     const uint8_t* page_base, uint32_t l1_alignment, uint32_t max_num_downstreams) {
     ParsedSenderPage parsed;
+    // copy the static md
     std::memcpy(&parsed.md, page_base, sizeof(sender_socket_md));
+
     const uint32_t md_size_aligned = align_up_local(sizeof(sender_socket_md), l1_alignment);
     const uint32_t ack_stride = align_up_local(sizeof(uint32_t), l1_alignment);
     const uint32_t ack_base = md_size_aligned;
+
+    // copy each of the acked bytes
     parsed.bytes_acked.resize(parsed.md.num_downstreams);
     for (uint32_t i = 0; i < parsed.md.num_downstreams; ++i) {
         uint32_t v = 0;
         std::memcpy(&v, page_base + ack_base + i * ack_stride, sizeof(uint32_t));
         parsed.bytes_acked[i] = v;
     }
+
+    // copy each of the encodings
     const uint32_t enc_stride = align_up_local(sizeof(sender_downstream_encoding), l1_alignment);
     const uint32_t enc_base = ack_base + max_num_downstreams * ack_stride;
     parsed.encodings.resize(parsed.md.num_downstreams);

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -261,11 +261,12 @@ void test_single_connection_single_device_socket(
     MeshCoordinateRange devices(md0->shape());
 
     AddProgramToMeshWorkload(mesh_workload, std::move(send_recv_program), devices);
-
+    log_info(LogTest, "Enqueuing workload");
     EnqueueMeshWorkload(md0->mesh_command_queue(), mesh_workload, false);
-
+    log_info(LogTest, "Workload enqueued");
     std::vector<uint32_t> recv_data_readback;
     ReadShard(md0->mesh_command_queue(), recv_data_readback, recv_data_buffer, MeshCoordinate(0, 0));
+    log_info(LogTest, "Readback complete");
     EXPECT_EQ(src_vec, recv_data_readback);
 }
 

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <algorithm>
+#include <chrono>
 #include <random>
 #include "gmock/gmock.h"
 #include <tt-metalium/fabric.hpp>
@@ -841,7 +842,7 @@ void test_single_connection_multi_device_socket_with_workers(
     auto output_buffer = MeshBuffer::create(buffer_config, output_device_local_config, md1.get());
 
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
-    std::iota(src_vec.begin(), src_vec.end(), 0);
+    std::iota(src_vec.begin(), src_vec.end(), std::chrono::system_clock::now().time_since_epoch().count());
 
     WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
 

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -139,13 +139,6 @@ void test_single_connection_single_device_socket(
     bool use_cbs) {
     auto sender_logical_coord = CoreCoord(0, 0);
     auto recv_logical_coord = CoreCoord(0, 1);
-    log_info(LogTest, "chip device id: {}", md0->get_devices()[0]->id());
-    auto sender_virtual_coord = md0->worker_core_from_logical_core(sender_logical_coord);
-    log_info(LogTest, "Sender virtual coord: {} {}", sender_virtual_coord.x, sender_virtual_coord.y);
-    auto recv_virtual_coord = md0->worker_core_from_logical_core(recv_logical_coord);
-    log_info(LogTest, "Receiver virtual coord: {} {}", recv_virtual_coord.x, recv_virtual_coord.y);
-
-    auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     SocketConnection socket_connection = {
         .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -130,34 +130,6 @@ void verify_socket_configs(
     EXPECT_EQ(recv_config.upstream_bytes_acked_addr % l1_alignment, 0);
 }
 
-void test_broadcast_single_device_socket(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
-    std::size_t socket_fifo_size,
-    std::size_t page_size,
-    std::size_t data_size,
-    bool use_cbs) {
-    auto sender_logical_coord = CoreCoord(0, 0);
-    auto recv_logical_coord_0 = CoreCoord(0, 1);
-    auto recv_logical_coord_1 = CoreCoord(0, 2);
-
-    auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    SocketConnection socket_connection = {
-        .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},
-        .receiver_core = {MeshCoordinate(0, 0), recv_logical_coord},
-    };
-
-    SocketMemoryConfig socket_mem_config = {
-        .socket_storage_type = BufferType::L1,
-        .fifo_size = socket_fifo_size,
-    };
-
-    SocketConfig socket_config = {
-        .socket_connection_config = {socket_connection},
-        .socket_mem_config = socket_mem_config,
-    };
-}
-
 void test_single_connection_single_device_socket(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
     std::size_t socket_fifo_size,

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -264,14 +264,10 @@ void test_single_connection_single_device_socket(
     MeshCoordinateRange devices(md0->shape());
 
     AddProgramToMeshWorkload(mesh_workload, std::move(send_recv_program), devices);
-    log_info(LogTest, "Enqueuing workload");
     EnqueueMeshWorkload(md0->mesh_command_queue(), mesh_workload, false);
-    log_info(LogTest, "Workload enqueued");
     std::vector<uint32_t> recv_data_readback;
     Finish(md0->mesh_command_queue());
-    log_info(LogTest, "Workload finished");
     ReadShard(md0->mesh_command_queue(), recv_data_readback, recv_data_buffer, MeshCoordinate(0, 0));
-    log_info(LogTest, "Readback complete");
     EXPECT_EQ(src_vec, recv_data_readback);
 }
 

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -130,6 +130,34 @@ void verify_socket_configs(
     EXPECT_EQ(recv_config.upstream_bytes_acked_addr % l1_alignment, 0);
 }
 
+void test_broadcast_single_device_socket(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
+    std::size_t socket_fifo_size,
+    std::size_t page_size,
+    std::size_t data_size,
+    bool use_cbs) {
+    auto sender_logical_coord = CoreCoord(0, 0);
+    auto recv_logical_coord_0 = CoreCoord(0, 1);
+    auto recv_logical_coord_1 = CoreCoord(0, 2);
+
+    auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+    SocketConnection socket_connection = {
+        .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},
+        .receiver_core = {MeshCoordinate(0, 0), recv_logical_coord},
+    };
+
+    SocketMemoryConfig socket_mem_config = {
+        .socket_storage_type = BufferType::L1,
+        .fifo_size = socket_fifo_size,
+    };
+
+    SocketConfig socket_config = {
+        .socket_connection_config = {socket_connection},
+        .socket_mem_config = socket_mem_config,
+    };
+}
+
 void test_single_connection_single_device_socket(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
     std::size_t socket_fifo_size,

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -2131,7 +2131,7 @@ TEST_F(MeshSocketTest2DFabric, SocketsOnSubDevice) {
     md1->clear_loaded_sub_device_manager();
 }
 
-TEST_F(MeshSocketTest, AssertOnDuplicateCores) {
+TEST_F(MeshSocketTest, AssertOnDuplicateRecvCores) {
     auto [coord0, coord1] = get_random_mesh_coordinates(mesh_device_->shape());
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), coord0);
     auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), coord1);
@@ -2168,7 +2168,7 @@ TEST_F(MeshSocketTest, AssertOnDuplicateCores) {
     SocketConfig socket_config_2 = {
         .socket_connection_config = {socket_connection}, .socket_mem_config = socket_mem_config};
 
-    EXPECT_THROW(MeshSocket::create_socket_pair(md0, md1, socket_config_0), std::exception);
+    EXPECT_NO_THROW(MeshSocket::create_socket_pair(md0, md1, socket_config_0));
     EXPECT_THROW(MeshSocket::create_socket_pair(md0, md1, socket_config_1), std::exception);
     // Having the sender and receiver on the same core is valid. Ensure that this doesn't fail.
     EXPECT_NO_THROW(MeshSocket::create_socket_pair(md0, md0, socket_config_2));

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml
@@ -15,7 +15,6 @@ tests:
     pattern_expansions:
       - type: "all_to_all_devices"
         core_coord: [0, 0]
-  # Test Infra will be changed to enable patterns and make this more readable in subsequent PR
   - name: "all_device_broadcast_pattern_test"
     num_iterations: 2
     memory_config:

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml
@@ -15,3 +15,14 @@ tests:
     pattern_expansions:
       - type: "all_to_all_devices"
         core_coord: [0, 0]
+  # Test Infra will be changed to enable patterns and make this more readable in subsequent PR
+  - name: "all_device_broadcast_pattern_test"
+    num_iterations: 2
+    memory_config:
+      fifo_size: 2048
+      page_size: 512
+      data_size: 4096
+      num_transactions: 15
+    pattern_expansions:
+      - type: "all_device_broadcast"
+        core_coord: [0, 0]

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml
@@ -13,10 +13,10 @@ tests:
       data_size: 8192
       num_transactions: 20
     pattern_expansions:
-      - type: "all_to_all_devices"
+      - type: "all_to_all_device_unicast"
         core_coord: [0, 0]
   - name: "all_device_broadcast_pattern_test"
-    num_iterations: 2
+    num_iterations: 5
     memory_config:
       fifo_size: 2048
       page_size: 512

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -24,7 +24,7 @@ tests:
       - type: "all_to_all_devices"
         core_coord: [0, 0]
   - name: "all_device_broadcast_pattern_test"
-    num_iterations: 20
+    num_iterations: 5
     memory_config:
       fifo_size: 2048
       page_size: 512

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -13,13 +13,37 @@ fabric_config:
 
 # Test definitions (required)
 tests:
-  - name: "all_to_all_test"
+  # - name: "all_to_all_test"
+  #   num_iterations: 1
+  #   memory_config:
+  #     fifo_size: [1024, 2048]
+  #     page_size: [256, 512]
+  #     data_size: 4096
+  #     num_transactions: 15
+  #   pattern_expansions:
+  #     - type: "all_to_all_devices"
+  #       core_coord: [0, 0]
+  - name: "broadcast_test"
     num_iterations: 1
     memory_config:
       fifo_size: [1024, 2048]
       page_size: [256, 512]
       data_size: 4096
       num_transactions: 15
-    pattern_expansions:
-      - type: "all_to_all_devices"
-        core_coord: [0, 0]
+    sockets:
+      - sender_rank: 0
+        receiver_rank: 1
+        connections:
+          - sender:
+              mesh_coord: [0, 0]
+              core_coord: [0, 0]
+            receiver:
+              mesh_coord: [0, 0]
+              core_coord: [1, 1]
+          - sender:
+              mesh_coord: [0, 0]
+              core_coord: [0, 0]
+            receiver:
+              mesh_coord: [1, 0]
+              core_coord: [1, 1]
+        

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -21,7 +21,7 @@ tests:
       data_size: 4096
       num_transactions: 15
     pattern_expansions:
-      - type: "all_to_all_devices"
+      - type: "all_to_all_device_unicast"
         core_coord: [0, 0]
   - name: "all_device_broadcast_pattern_test"
     num_iterations: 20

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -13,18 +13,18 @@ fabric_config:
 
 # Test definitions (required)
 tests:
-  # - name: "all_to_all_test"
-  #   num_iterations: 1
-  #   memory_config:
-  #     fifo_size: [1024, 2048]
-  #     page_size: [256, 512]
-  #     data_size: 4096
-  #     num_transactions: 15
-  #   pattern_expansions:
-  #     - type: "all_to_all_devices"
-  #       core_coord: [0, 0]
+  - name: "all_to_all_test"
+    num_iterations: 1
+    memory_config:
+      fifo_size: [1024, 2048]
+      page_size: [256, 512]
+      data_size: 4096
+      num_transactions: 15
+    pattern_expansions:
+      - type: "all_to_all_devices"
+        core_coord: [0, 0]
   - name: "all_device_broadcast_pattern_test"
-    num_iterations: 2
+    num_iterations: 20
     memory_config:
       fifo_size: 2048
       page_size: 512

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -24,7 +24,7 @@ tests:
       - type: "all_to_all_devices"
         core_coord: [0, 0]
   - name: "all_device_broadcast_pattern_test"
-    num_iterations: 5
+    num_iterations: 20
     memory_config:
       fifo_size: 2048
       page_size: 512

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -13,16 +13,16 @@ fabric_config:
 
 # Test definitions (required)
 tests:
-  - name: "all_to_all_test"
-    num_iterations: 1
-    memory_config:
-      fifo_size: [1024, 2048]
-      page_size: [256, 512]
-      data_size: 4096
-      num_transactions: 15
-    pattern_expansions:
-      - type: "all_to_all_devices"
-        core_coord: [0, 0]
+  # - name: "all_to_all_test"
+  #   num_iterations: 1
+  #   memory_config:
+  #     fifo_size: [1024, 2048]
+  #     page_size: [256, 512]
+  #     data_size: 4096
+  #     num_transactions: 15
+  #   pattern_expansions:
+  #     - type: "all_to_all_devices"
+  #       core_coord: [0, 0]
   - name: "all_device_broadcast_pattern_test"
     num_iterations: 2
     memory_config:

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml
@@ -13,37 +13,23 @@ fabric_config:
 
 # Test definitions (required)
 tests:
-  # - name: "all_to_all_test"
-  #   num_iterations: 1
-  #   memory_config:
-  #     fifo_size: [1024, 2048]
-  #     page_size: [256, 512]
-  #     data_size: 4096
-  #     num_transactions: 15
-  #   pattern_expansions:
-  #     - type: "all_to_all_devices"
-  #       core_coord: [0, 0]
-  - name: "broadcast_test"
+  - name: "all_to_all_test"
     num_iterations: 1
     memory_config:
       fifo_size: [1024, 2048]
       page_size: [256, 512]
       data_size: 4096
       num_transactions: 15
-    sockets:
-      - sender_rank: 0
-        receiver_rank: 1
-        connections:
-          - sender:
-              mesh_coord: [0, 0]
-              core_coord: [0, 0]
-            receiver:
-              mesh_coord: [0, 0]
-              core_coord: [1, 1]
-          - sender:
-              mesh_coord: [0, 0]
-              core_coord: [0, 0]
-            receiver:
-              mesh_coord: [1, 0]
-              core_coord: [1, 1]
-        
+    pattern_expansions:
+      - type: "all_to_all_devices"
+        core_coord: [0, 0]
+  - name: "all_device_broadcast_pattern_test"
+    num_iterations: 2
+    memory_config:
+      fifo_size: 2048
+      page_size: 512
+      data_size: 4096
+      num_transactions: 15
+    pattern_expansions:
+      - type: "all_device_broadcast"
+        core_coord: [0, 0]

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_config_example.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_config_example.yaml
@@ -129,9 +129,9 @@ tests:
       data_size: 2048
       num_transactions: 10
     pattern_expansions:
-      - type: "all_to_all_devices"
+      - type: "all_to_all_device_unicast"
         core_coord: [0, 0]
-      - type: "all_to_all_devices"
+      - type: "all_to_all_device_unicast"
         core_coord: [0, 1]
   - name: "all_hosts_random_sockets_pattern_test"
     num_iterations: 3

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_config_example.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_config_example.yaml
@@ -144,3 +144,13 @@ tests:
       - type: "all_hosts_random_sockets"
         core_coord: [0, 0]
         num_sockets: 4
+  - name: "all_device_broadcast_pattern_test"
+    num_iterations: 2
+    memory_config:
+      fifo_size: 2048
+      page_size: 512
+      data_size: 4096
+      num_transactions: 15
+    pattern_expansions:
+      - type: "all_device_broadcast"
+        core_coord: [0, 0]

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
@@ -219,7 +219,7 @@ std::vector<TestSocketConfig> MeshSocketYamlParser::expand_all_to_all_devices_pa
         }
     }
 
-    log_info(tt::LogTest, "Generated {} sockets for all_to_all_devices pattern", sockets.size());
+    log_info(tt::LogTest, "Generated {} sockets for all_to_all_device_unicast pattern", sockets.size());
     return sockets;
 }
 
@@ -525,7 +525,7 @@ CoreCoord MeshSocketYamlParser::parse_core_coordinate(const YAML::Node& node) {
 }
 
 PatternType MeshSocketYamlParser::parse_pattern_type(const std::string& pattern_string) {
-    if (pattern_string == "all_to_all_devices") {
+    if (pattern_string == "all_to_all_device_unicast") {
         return PatternType::AllToAllDevices;
     } else if (pattern_string == "all_hosts_random_sockets") {
         return PatternType::AllHostsRandomSockets;
@@ -533,7 +533,7 @@ PatternType MeshSocketYamlParser::parse_pattern_type(const std::string& pattern_
         return PatternType::AllDeviceBroadcast;
     } else {
         TT_THROW(
-            "Invalid pattern type: '{}'. Valid types are: all_to_all_devices, all_hosts_random_sockets, "
+            "Invalid pattern type: '{}'. Valid types are: all_to_all_device_unicast, all_hosts_random_sockets, "
             "all_device_broadcast",
             pattern_string);
     }
@@ -757,7 +757,7 @@ void MeshSocketYamlParser::print_test_configuration(const MeshSocketTestConfigur
 
                 // switch if we add more patterns
                 switch (pattern.type) {
-                    case PatternType::AllToAllDevices: pattern_type = "all_to_all_devices"; break;
+                    case PatternType::AllToAllDevices: pattern_type = "all_to_all_device_unicast"; break;
                     case PatternType::AllHostsRandomSockets: pattern_type = "all_hosts_random_sockets"; break;
                     case PatternType::AllDeviceBroadcast: pattern_type = "all_device_broadcast"; break;
                     default: TT_THROW("Invalid pattern type: {}", static_cast<int>(pattern.type));

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
@@ -590,8 +590,8 @@ void MeshSocketYamlParser::validate_socket_config(
 
         // Check for duplicate sender endpoints
         auto sender_insert_result = sender_endpoints.insert(sender_mesh_coord);
-        TT_FATAL(
-            sender_insert_result.second, "Duplicate sender endpoint found at mesh coordinate {}", sender_mesh_coord);
+        // TT_FATAL(
+        //     sender_insert_result.second, "Duplicate sender endpoint found at mesh coordinate {}", sender_mesh_coord);
 
         // Check for duplicate receiver endpoints
         auto receiver_insert_result = receiver_endpoints.insert(receiver_mesh_coord);

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
@@ -179,6 +179,7 @@ std::vector<TestSocketConfig> MeshSocketYamlParser::expand_pattern(
     switch (pattern.type) {
         case PatternType::AllToAllDevices: return expand_all_to_all_devices_pattern(pattern, test_context);
         case PatternType::AllHostsRandomSockets: return expand_all_hosts_random_sockets_pattern(pattern, test_context);
+        case PatternType::AllDeviceBroadcast: return expand_all_device_broadcast_pattern(pattern, test_context);
         default: TT_THROW("Unknown pattern type");
     }
 }
@@ -266,6 +267,53 @@ std::vector<TestSocketConfig> MeshSocketYamlParser::expand_all_hosts_random_sock
     }
 
     log_info(tt::LogTest, "Generated {} sockets for all_hosts_random_sockets pattern", sockets.size());
+    return sockets;
+}
+
+/* Create broadcast sockets where each device on every host acts as a sender to all devices on other hosts.
+ * For each device coordinate on each rank, create sockets to all other ranks where the sender is that
+ * specific device and the receivers are all devices on the target rank.
+ */
+std::vector<TestSocketConfig> MeshSocketYamlParser::expand_all_device_broadcast_pattern(
+    const PatternExpansionConfig& pattern, const MeshSocketTestContext& test_context) {
+    std::vector<TestSocketConfig> sockets;
+
+    const auto& mesh_graph = test_context.get_mesh_graph();
+    const auto& rank_to_mesh_id = test_context.get_rank_to_mesh_mapping();
+    const CoreCoord& core_coord = pattern.core_coord;
+
+    for (const auto& [sender_rank, sender_mesh_id] : rank_to_mesh_id) {
+        auto sender_coord_range = mesh_graph.get_coord_range(sender_mesh_id);
+        for (const auto& sender_coord : sender_coord_range) {
+            for (const auto& [receiver_rank, recv_mesh_id] : rank_to_mesh_id) {
+                if (sender_rank == receiver_rank) {
+                    continue;  // Skip self-connections
+                }
+                auto recv_coord_range = mesh_graph.get_coord_range(recv_mesh_id);
+                std::vector<SocketConnectionConfig> connections;
+
+                for (const auto& recv_coord : recv_coord_range) {
+                    connections.push_back(SocketConnectionConfig{
+                        .sender = EndpointConfig(sender_coord, core_coord),
+                        .receiver = EndpointConfig(recv_coord, core_coord)});
+                }
+
+                sockets.push_back(TestSocketConfig{
+                    .connections = connections,
+                    .sender_rank = Rank{*sender_rank},
+                    .receiver_rank = Rank{*receiver_rank}});
+                log_info(
+                    tt::LogTest,
+                    "Generated broadcast socket: device {} on rank {} -> all {} devices on rank {}",
+                    sender_coord,
+                    *sender_rank,
+                    connections.size(),
+                    *receiver_rank);
+            }
+        }
+    }
+
+    log_info(tt::LogTest, "Generated {} sockets for all_device_broadcast pattern", sockets.size());
     return sockets;
 }
 
@@ -481,9 +529,12 @@ PatternType MeshSocketYamlParser::parse_pattern_type(const std::string& pattern_
         return PatternType::AllToAllDevices;
     } else if (pattern_string == "all_hosts_random_sockets") {
         return PatternType::AllHostsRandomSockets;
+    } else if (pattern_string == "all_device_broadcast") {
+        return PatternType::AllDeviceBroadcast;
     } else {
         TT_THROW(
-            "Invalid pattern type: '{}'. Valid types are: all_to_all_devices, all_hosts_random_sockets",
+            "Invalid pattern type: '{}'. Valid types are: all_to_all_devices, all_hosts_random_sockets, "
+            "all_device_broadcast",
             pattern_string);
     }
 }
@@ -590,8 +641,6 @@ void MeshSocketYamlParser::validate_socket_config(
 
         // Check for duplicate sender endpoints
         auto sender_insert_result = sender_endpoints.insert(sender_mesh_coord);
-        // TT_FATAL(
-        //     sender_insert_result.second, "Duplicate sender endpoint found at mesh coordinate {}", sender_mesh_coord);
 
         // Check for duplicate receiver endpoints
         auto receiver_insert_result = receiver_endpoints.insert(receiver_mesh_coord);
@@ -710,6 +759,7 @@ void MeshSocketYamlParser::print_test_configuration(const MeshSocketTestConfigur
                 switch (pattern.type) {
                     case PatternType::AllToAllDevices: pattern_type = "all_to_all_devices"; break;
                     case PatternType::AllHostsRandomSockets: pattern_type = "all_hosts_random_sockets"; break;
+                    case PatternType::AllDeviceBroadcast: pattern_type = "all_device_broadcast"; break;
                     default: TT_THROW("Invalid pattern type: {}", static_cast<int>(pattern.type));
                 }
                 if (pattern.num_sockets.has_value()) {

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
@@ -640,7 +640,7 @@ void MeshSocketYamlParser::validate_socket_config(
             *receiver_mesh_id);
 
         // Check for duplicate sender endpoints
-        auto sender_insert_result = sender_endpoints.insert(sender_mesh_coord);
+        sender_endpoints.insert(sender_mesh_coord);
 
         // Check for duplicate receiver endpoints
         auto receiver_insert_result = receiver_endpoints.insert(receiver_mesh_coord);

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
@@ -38,6 +38,7 @@ enum class RoutingType : uint32_t {
 enum class PatternType : uint32_t {
     AllToAllDevices = 0,
     AllHostsRandomSockets = 1,
+    AllDeviceBroadcast = 2,
 };
 
 // Data structures for parsed YAML configuration
@@ -162,6 +163,8 @@ private:
     static std::vector<TestSocketConfig> expand_all_to_all_devices_pattern(
         const PatternExpansionConfig& pattern, const MeshSocketTestContext& test_context);
     static std::vector<TestSocketConfig> expand_all_hosts_random_sockets_pattern(
+        const PatternExpansionConfig& pattern, const MeshSocketTestContext& test_context);
+    static std::vector<TestSocketConfig> expand_all_device_broadcast_pattern(
         const PatternExpansionConfig& pattern, const MeshSocketTestContext& test_context);
 
     // Memory config expansion methods

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
@@ -86,7 +86,7 @@ struct TestSocketConfig {
 };
 
 struct PatternExpansionConfig {
-    PatternType type{};    // "all_to_all_devices" or "all_hosts_random_sockets"
+    PatternType type{};
     CoreCoord core_coord;  // Core coordinate to use for connections
     std::optional<uint32_t> num_sockets;  // Optional number of random sockets to generate
 };

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -105,16 +105,8 @@ bool test_socket_send_recv(
     }
     const auto reserved_packet_header_CB_index = tt::CB::c_in0;
 
-    log_info(tt::LogTest, "Starting socket send/recv test with {} transactions, data_size={}, page_size={}", 
-             num_txns, data_size, page_size);
-    log_info(tt::LogTest, "Socket has {} connections, sender_rank={}, recv_rank={}", 
-             socket.get_config().socket_connection_config.size(), *sender_rank, *recv_rank);
-
     for (int i = 0; i < num_txns; i++) {
-        log_debug(tt::LogTest, "Starting transaction {}/{}", i + 1, num_txns);
         if (distributed_context->rank() == sender_rank) {
-            log_info(tt::LogTest, "Found sender id={}", mesh_device_->get_devices()[0]->id());
-            log_info(tt::LogTest, "Rank {} acting as sender for transaction {}", *distributed_context->rank(), i + 1);
             auto sender_data_shard_params = ShardSpecBuffer(
                 sender_core_range, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {sender_core_range_set.num_cores(), 1});
 
@@ -128,13 +120,12 @@ bool test_socket_send_recv(
             auto sender_data_buffer = MeshBuffer::create(buffer_config, sender_device_local_config, mesh_device_.get());
             auto sender_mesh_workload = CreateMeshWorkload();
             std::unordered_set<MeshCoreCoord> mesh_core_coords;
-            log_info(tt::LogTest, "Processing {} socket connections for sender", socket.get_config().socket_connection_config.size());
-            
+
             for (const auto& connection : socket.get_config().socket_connection_config) {
                 if (mesh_core_coords.find(connection.sender_core) != mesh_core_coords.end()) {
                     continue;
                 }
-                mesh_core_coords.insert(connection.sender_core);    
+                mesh_core_coords.insert(connection.sender_core);
                 auto sender_core = connection.sender_core.core_coord;
                 WriteShard(
                     mesh_device_->mesh_command_queue(),
@@ -180,12 +171,9 @@ bool test_socket_send_recv(
                     MeshCoordinateRange(connection.sender_core.device_coord));
             }
             // Run workload performing Data Movement over the socket
-            log_info(tt::LogTest, "Enqueueing sender mesh workload with {} unique sender cores", mesh_core_coords.size());
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), sender_mesh_workload, false);
             Finish(mesh_device_->mesh_command_queue());
-            log_info(tt::LogTest, "Sender workload completed for transaction {}", i + 1);
         } else if (distributed_context->rank() == recv_rank) {
-            log_info(tt::LogTest, "Rank {} acting as receiver for transaction {}", *distributed_context->rank(), i + 1);
             auto recv_data_shard_params = ShardSpecBuffer(
                 recv_core_range, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {recv_core_range_set.num_cores(), 1});
 
@@ -199,12 +187,8 @@ bool test_socket_send_recv(
             auto recv_data_buffer = MeshBuffer::create(buffer_config, recv_device_local_config, mesh_device_.get());
 
             auto recv_mesh_workload = CreateMeshWorkload();
-            log_info(tt::LogTest, "Creating {} receiver kernels", socket.get_config().socket_connection_config.size());
-            
+
             for (const auto& connection : socket.get_config().socket_connection_config) {
-                log_debug(tt::LogTest, "Creating receiver kernel for core [{},{}] coord ({},{})", 
-                         connection.receiver_core.device_coord.row, connection.receiver_core.device_coord.col,
-                         connection.receiver_core.core_coord.x, connection.receiver_core.core_coord.y);
                 auto recv_core = connection.receiver_core.core_coord;
                 auto sender_fabric_node_id =
                     socket.get_fabric_node_id(SocketEndpoint::SENDER, connection.sender_core.device_coord);
@@ -214,7 +198,7 @@ bool test_socket_send_recv(
 
                 auto recv_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
                 auto output_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
-                
+
                 KernelHandle recv_kernel = CreateKernel(
                     recv_program,
                     "tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_receiver_worker.cpp",
@@ -240,10 +224,8 @@ bool test_socket_send_recv(
                     MeshCoordinateRange(connection.receiver_core.device_coord));
             }
             // Run receiver workload using the created socket
-            log_info(tt::LogTest, "Enqueueing receiver mesh workload");
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), recv_mesh_workload, false);
             auto& core_to_core_id = recv_data_buffer->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
-            log_info(tt::LogTest, "Receiver workload completed, starting data validation");
             for (const auto& connection : socket.get_config().socket_connection_config) {
                 std::vector<uint32_t> recv_data_readback;
                 ReadShard(
@@ -258,7 +240,6 @@ bool test_socket_send_recv(
                 is_data_match &= (src_vec_per_core == recv_data_readback_per_core);
                 EXPECT_TRUE(is_data_match);
             }
-            log_info(tt::LogTest, "Data validation completed for transaction {}, match={}", i + 1, is_data_match);
         }
         // Increment the source vector for the next iteration
         // This is to ensure that the data is different for each transaction

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -237,7 +237,7 @@ bool test_socket_send_recv(
                     recv_data_readback.begin() + idx * data_size / sizeof(uint32_t),
                     recv_data_readback.begin() + (idx + 1) * data_size / sizeof(uint32_t));
                 is_data_match &= (src_vec_per_core == recv_data_readback_per_core);
-                EXPECT_TRUE(is_data_match);
+                EXPECT_EQ(src_vec_per_core, recv_data_readback_per_core);
             }
         }
         // Increment the source vector for the next iteration

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -196,7 +196,6 @@ bool test_socket_send_recv(
                 auto recv_program = CreateProgram();
 
                 auto recv_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
-                auto output_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
 
                 KernelHandle recv_kernel = CreateKernel(
                     recv_program,

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -187,7 +187,6 @@ bool test_socket_send_recv(
             auto recv_data_buffer = MeshBuffer::create(buffer_config, recv_device_local_config, mesh_device_.get());
 
             auto recv_mesh_workload = CreateMeshWorkload();
-
             for (const auto& connection : socket.get_config().socket_connection_config) {
                 auto recv_core = connection.receiver_core.core_coord;
                 auto sender_fabric_node_id =

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
@@ -38,8 +38,7 @@ void kernel_main() {
         uint32_t data_addr = get_read_ptr(out_cb_id);
 
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
-            sender_downstream_encoding* downstream_enc = reinterpret_cast<sender_downstream_encoding*>(
-                sender_socket.downstream_enc_addr + i * align_up(sizeof(sender_downstream_encoding)));
+            sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, i);
             uint64_t receiver_noc_coord_addr =
                 get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0);
             fabric_set_unicast_route(data_packet_header_addr, *downstream_enc);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
@@ -26,8 +26,6 @@ void kernel_main() {
     SocketSenderInterface sender_socket = create_sender_socket_interface(socket_config_addr);
     set_sender_socket_page_size(sender_socket, page_size);
 
-    uint64_t receiver_noc_coord_addr = get_noc_addr(sender_socket.downstream_noc_x, sender_socket.downstream_noc_y, 0);
-
     sender_fabric_connection.open_finish();
 
     // Reads one page at a time and sends ack to sender, can be optimized to notify
@@ -38,13 +36,20 @@ void kernel_main() {
         socket_reserve_pages(sender_socket, 1);
         // Write Data over Fabric
         uint32_t data_addr = get_read_ptr(out_cb_id);
-        fabric_set_unicast_route(data_packet_header_addr, sender_socket);
-        data_packet_header_addr->to_noc_unicast_write(
-            NocUnicastCommandHeader{receiver_noc_coord_addr | sender_socket.write_ptr}, page_size);
-        sender_fabric_connection.wait_for_empty_write_slot();
-        sender_fabric_connection.send_payload_without_header_non_blocking_from_address(data_addr, page_size);
-        sender_fabric_connection.send_payload_blocking_from_address(
-            (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+
+        for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
+            sender_downstream_encoding* downstream_enc = reinterpret_cast<sender_downstream_encoding*>(
+                sender_socket.downstream_enc_addr + i * align_up(sizeof(sender_downstream_encoding)));
+            uint64_t receiver_noc_coord_addr =
+                get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0);
+            fabric_set_unicast_route(data_packet_header_addr, *downstream_enc);
+            data_packet_header_addr->to_noc_unicast_write(
+                NocUnicastCommandHeader{receiver_noc_coord_addr | sender_socket.write_ptr}, page_size);
+            sender_fabric_connection.wait_for_empty_write_slot();
+            sender_fabric_connection.send_payload_without_header_non_blocking_from_address(data_addr, page_size);
+            sender_fabric_connection.send_payload_blocking_from_address(
+                (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+        }
         socket_push_pages(sender_socket, 1);
         fabric_socket_notify_receiver(sender_socket, sender_fabric_connection, socket_packet_header_addr);
         noc_async_writes_flushed();

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
@@ -38,10 +38,10 @@ void kernel_main() {
         uint32_t data_addr = get_read_ptr(out_cb_id);
 
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
-            sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, i);
+            sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
             uint64_t receiver_noc_coord_addr =
-                get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0);
-            fabric_set_unicast_route(data_packet_header_addr, *downstream_enc);
+                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, 0);
+            fabric_set_unicast_route(data_packet_header_addr, downstream_enc);
             data_packet_header_addr->to_noc_unicast_write(
                 NocUnicastCommandHeader{receiver_noc_coord_addr | sender_socket.write_ptr}, page_size);
             sender_fabric_connection.wait_for_empty_write_slot();

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
@@ -40,10 +40,9 @@ void kernel_main() {
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
             sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
             uint64_t receiver_noc_coord_addr =
-                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, 0);
+                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, sender_socket.write_ptr);
             fabric_set_unicast_route(data_packet_header_addr, downstream_enc);
-            data_packet_header_addr->to_noc_unicast_write(
-                NocUnicastCommandHeader{receiver_noc_coord_addr | sender_socket.write_ptr}, page_size);
+            data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{receiver_noc_coord_addr}, page_size);
             sender_fabric_connection.wait_for_empty_write_slot();
             sender_fabric_connection.send_payload_without_header_non_blocking_from_address(data_addr, page_size);
             sender_fabric_connection.send_payload_blocking_from_address(

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
@@ -65,12 +65,12 @@ void kernel_main() {
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
             sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
             uint64_t receiver_noc_coord_addr =
-                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, 0);
+                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, sender_socket.write_ptr);
             fabric_write_any_len(
                 data_packet_header_addr,
                 fabric_connection,
                 data_addr,
-                receiver_noc_coord_addr | sender_socket.write_ptr,
+                receiver_noc_coord_addr,
                 page_size,
                 downstream_enc);
         }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
@@ -37,9 +37,7 @@ void kernel_main() {
     constexpr uint32_t local_l1_buffer_addr = get_compile_time_arg_val(1);
     constexpr uint32_t page_size = get_compile_time_arg_val(2);
     constexpr uint32_t data_size = get_compile_time_arg_val(3);
-    
-    DPRINT << "fabric_sender: Starting kernel with socket_config_addr=" << socket_config_addr 
-           << ", data_size=" << data_size << ", page_size=" << page_size << ENDL();
+
     // Setup Fabric Headers and Connections
     size_t rt_args_idx = 0;
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
@@ -56,31 +54,19 @@ void kernel_main() {
     // Create Socket Interface
     SocketSenderInterface sender_socket = create_sender_socket_interface(socket_config_addr);
     set_sender_socket_page_size(sender_socket, page_size);
-    
-    DPRINT << "fabric_sender: Socket interface created, num_downstreams=" << sender_socket.num_downstreams << ENDL();
 
     uint32_t data_addr = local_l1_buffer_addr;
 
     uint32_t outstanding_data_size = data_size;
     uint32_t pages_sent = 0;
 
-    DPRINT << "fabric_sender: Starting data transfer, total_pages=" << (data_size / page_size) << ENDL();
-
     // Sends 1 page at a time and does handshake with receiver, can be optimized
     // to notify receiver after writing larger chunks
     while (outstanding_data_size) {
         pages_sent++;
-        DPRINT << "fabric_sender: Sending page " << pages_sent << ", outstanding_data=" << outstanding_data_size << ENDL();
         socket_reserve_pages(sender_socket, 1);
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
-            sender_downstream_encoding* downstream_enc = reinterpret_cast<sender_downstream_encoding*>(
-                sender_socket.downstream_enc_addr + i * align_up(sizeof(sender_downstream_encoding)));
-            
-            DPRINT << "fabric_sender: Broadcasting to downstream " << i << " at node id ("
-                   << downstream_enc->downstream_mesh_id << "," << downstream_enc->downstream_chip_id << ")"
-                   << " at noc(" 
-                   << downstream_enc->downstream_noc_x << "," << downstream_enc->downstream_noc_y << ")" << ENDL();
-            
+            sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, i);
             // Write Data over Fabric
             uint64_t receiver_noc_coord_addr =
                 get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0);
@@ -98,14 +84,9 @@ void kernel_main() {
 
         fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
     }
-    
-    DPRINT << "fabric_sender: All pages sent (" << pages_sent << "), waiting for barrier" << ENDL();
     socket_barrier(sender_socket);
-    
-    DPRINT << "fabric_sender: Barrier complete, updating socket config and closing connection" << ENDL();
+
     // Write updated socket configs to the L1 config buffer (were cached on stack during kernel execution)
     update_socket_config(sender_socket);
     fabric_connection.close();
-    
-    DPRINT << "fabric_sender: Kernel completed successfully" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
@@ -12,8 +12,8 @@ void fabric_write_any_len(
     uint32_t src_addr,
     uint64_t dst_addr,
     uint32_t xfer_size,
-    SocketSenderInterface& sender_socket) {
-    fabric_set_unicast_route(data_packet_header_addr, sender_socket);
+    sender_downstream_encoding& downstream_enc) {
+    fabric_set_unicast_route(data_packet_header_addr, downstream_enc);
     while (xfer_size > FABRIC_MAX_PACKET_SIZE) {
         data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, FABRIC_MAX_PACKET_SIZE);
         fabric_connection.wait_for_empty_write_slot();
@@ -55,7 +55,6 @@ void kernel_main() {
     set_sender_socket_page_size(sender_socket, page_size);
 
     uint32_t data_addr = local_l1_buffer_addr;
-    uint64_t receiver_noc_coord_addr = get_noc_addr(sender_socket.downstream_noc_x, sender_socket.downstream_noc_y, 0);
 
     uint32_t outstanding_data_size = data_size;
 
@@ -63,14 +62,20 @@ void kernel_main() {
     // to notify receiver after writing larger chunks
     while (outstanding_data_size) {
         socket_reserve_pages(sender_socket, 1);
-        // Write Data over Fabric
-        fabric_write_any_len(
-            data_packet_header_addr,
-            fabric_connection,
-            data_addr,
-            receiver_noc_coord_addr | sender_socket.write_ptr,
-            page_size,
-            sender_socket);
+        for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
+            sender_downstream_encoding* downstream_enc = reinterpret_cast<sender_downstream_encoding*>(
+                sender_socket.downstream_enc_addr + i * align_up(sizeof(sender_downstream_encoding)));
+            // Write Data over Fabric
+            uint64_t receiver_noc_coord_addr =
+                get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0);
+            fabric_write_any_len(
+                data_packet_header_addr,
+                fabric_connection,
+                data_addr,
+                receiver_noc_coord_addr | sender_socket.write_ptr,
+                page_size,
+                *downstream_enc);
+        }
         data_addr += page_size;
         outstanding_data_size -= page_size;
         socket_push_pages(sender_socket, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
@@ -63,16 +63,16 @@ void kernel_main() {
     while (outstanding_data_size) {
         socket_reserve_pages(sender_socket, 1);
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
-            sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, i);
+            sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
             uint64_t receiver_noc_coord_addr =
-                get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0);
+                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, 0);
             fabric_write_any_len(
                 data_packet_header_addr,
                 fabric_connection,
                 data_addr,
                 receiver_noc_coord_addr | sender_socket.write_ptr,
                 page_size,
-                *downstream_enc);
+                downstream_enc);
         }
         data_addr += page_size;
         outstanding_data_size -= page_size;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
@@ -18,8 +18,6 @@ void kernel_main() {
     set_sender_socket_page_size(sender_socket, page_size);
 
     uint32_t data_addr = local_l1_buffer_addr;
-    uint64_t receiver_noc_coord_addr = get_noc_addr(sender_socket.downstream_noc_x, sender_socket.downstream_noc_y, 0);
-
     // Sends 1 page at a time and does handshake with receiver, can be optimized
     // to notify receiver after writing larger chunks
     while (outstanding_data_size) {
@@ -29,7 +27,7 @@ void kernel_main() {
         // Issuing the write requires the wptr from the socket itself
         // The user can get the wptr directly from the sender_socket, or
         // we can add wrappers issue the write itself
-        noc_async_write(data_addr, receiver_noc_coord_addr | sender_socket.write_ptr, page_size);
+        socket_async_write(sender_socket, data_addr, page_size);
         data_addr += page_size;
         outstanding_data_size -= page_size;
         socket_push_pages(sender_socket, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
@@ -28,10 +28,10 @@ void kernel_main() {
         // The user can get the wptr directly from the sender_socket, or
         // we can add wrappers issue the write itself
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
-            sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, i);
+            sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
             noc_async_write(
                 data_addr,
-                get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0) |
+                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, 0) |
                     sender_socket.write_ptr,
                 page_size);
         }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "socket_api.h"
+#include "debug/dprint.h"
 
 void kernel_main() {
     // Get this value from MeshSocket struct on host

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
@@ -27,7 +27,6 @@ void kernel_main() {
         // Issuing the write requires the wptr from the socket itself
         // The user can get the wptr directly from the sender_socket, or
         // we can add wrappers issue the write itself
-
         for (uint32_t i = 0; i < sender_socket.num_downstreams; i++) {
             sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, i);
             noc_async_write(

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender.cpp
@@ -31,8 +31,7 @@ void kernel_main() {
             sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, i);
             noc_async_write(
                 data_addr,
-                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, 0) |
-                    sender_socket.write_ptr,
+                get_noc_addr(downstream_enc.downstream_noc_x, downstream_enc.downstream_noc_y, sender_socket.write_ptr),
                 page_size);
         }
         data_addr += page_size;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender_multi_data.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/sender_multi_data.cpp
@@ -27,8 +27,6 @@ void kernel_main() {
     uint32_t outstanding_data_size = data_size;
     set_sender_socket_page_size(sender_socket, page_size);
 
-    uint64_t receiver_noc_coord_addr = get_noc_addr(sender_socket.downstream_noc_x, sender_socket.downstream_noc_y, 0);
-
     uint64_t src_noc_addr = get_noc_addr(src_core_x, src_core_y, src_buffer_addr);
 
     uint32_t local_write_addr = get_write_ptr(scratch_cb_index);

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -110,7 +110,12 @@ private:
 }  // namespace tt::tt_metal::distributed
 
 namespace std {
-
+template <>
+struct hash<tt::tt_metal::distributed::MeshCoreCoord> {
+    size_t operator()(const tt::tt_metal::distributed::MeshCoreCoord& coord) const noexcept {
+        return tt::stl::hash::hash_objects_with_default_seed(coord.device_coord, coord.core_coord);
+    }
+};
 template <>
 struct hash<tt::tt_metal::distributed::SocketConfig> {
     size_t operator()(const tt::tt_metal::distributed::SocketConfig& config) const noexcept;

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -26,6 +26,10 @@ struct MeshCoreCoord {
 struct SocketConnection {
     MeshCoreCoord sender_core;
     MeshCoreCoord receiver_core;
+
+    bool operator==(const SocketConnection& other) const {
+        return sender_core == other.sender_core && receiver_core == other.receiver_core;
+    }
 };
 
 // Specifies how memory is allocated for this socket.
@@ -114,6 +118,12 @@ template <>
 struct hash<tt::tt_metal::distributed::MeshCoreCoord> {
     size_t operator()(const tt::tt_metal::distributed::MeshCoreCoord& coord) const noexcept {
         return tt::stl::hash::hash_objects_with_default_seed(coord.device_coord, coord.core_coord);
+    }
+};
+template <>
+struct hash<tt::tt_metal::distributed::SocketConnection> {
+    size_t operator()(const tt::tt_metal::distributed::SocketConnection& conn) const noexcept {
+        return tt::stl::hash::hash_objects_with_default_seed(conn.sender_core, conn.receiver_core);
     }
 };
 template <>

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -116,15 +116,11 @@ private:
 namespace std {
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoreCoord> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoreCoord& coord) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(coord.device_coord, coord.core_coord);
-    }
+    size_t operator()(const tt::tt_metal::distributed::MeshCoreCoord& coord) const noexcept;
 };
 template <>
 struct hash<tt::tt_metal::distributed::SocketConnection> {
-    size_t operator()(const tt::tt_metal::distributed::SocketConnection& conn) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(conn.sender_core, conn.receiver_core);
-    }
+    size_t operator()(const tt::tt_metal::distributed::SocketConnection& conn) const noexcept;
 };
 template <>
 struct hash<tt::tt_metal::distributed::SocketConfig> {

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -135,6 +135,16 @@ tt::tt_fabric::FabricNodeId MeshSocket::get_fabric_node_id(SocketEndpoint endpoi
 
 namespace std {
 
+std::size_t hash<tt::tt_metal::distributed::SocketConnection>::operator()(
+    const tt::tt_metal::distributed::SocketConnection& conn) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(conn.sender_core, conn.receiver_core);
+}
+
+std::size_t hash<tt::tt_metal::distributed::MeshCoreCoord>::operator()(
+    const tt::tt_metal::distributed::MeshCoreCoord& coord) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(coord.device_coord, coord.core_coord);
+}
+
 std::size_t hash<tt::tt_metal::distributed::SocketConfig>::operator()(
     const tt::tt_metal::distributed::SocketConfig& config) const noexcept {
     std::optional<tt::tt_metal::distributed::multihost::Rank> distributed_context_rank = std::nullopt;

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -108,7 +108,12 @@ std::pair<MeshSocket, MeshSocket> MeshSocket::create_socket_pair(
     auto recv_peer_descriptor = generate_local_endpoint_descriptor(receiver_socket);
 
     write_socket_configs(sender_config_buffer, send_peer_descriptor, recv_peer_descriptor, SocketEndpoint::SENDER);
-    write_socket_configs(recv_config_buffer, recv_peer_descriptor, send_peer_descriptor, SocketEndpoint::RECEIVER);
+    write_socket_configs(
+        recv_config_buffer,
+        recv_peer_descriptor,
+        send_peer_descriptor,
+        SocketEndpoint::RECEIVER,
+        0 /* downstream_num */);
 
     auto fabric_node_id_map = generate_fabric_node_id_map(config, send_peer_descriptor, recv_peer_descriptor);
 

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -108,12 +108,7 @@ std::pair<MeshSocket, MeshSocket> MeshSocket::create_socket_pair(
     auto recv_peer_descriptor = generate_local_endpoint_descriptor(receiver_socket);
 
     write_socket_configs(sender_config_buffer, send_peer_descriptor, recv_peer_descriptor, SocketEndpoint::SENDER);
-    write_socket_configs(
-        recv_config_buffer,
-        recv_peer_descriptor,
-        send_peer_descriptor,
-        SocketEndpoint::RECEIVER,
-        0 /* downstream_num */);
+    write_socket_configs(recv_config_buffer, recv_peer_descriptor, send_peer_descriptor, SocketEndpoint::RECEIVER);
 
     auto fabric_node_id_map = generate_fabric_node_id_map(config, send_peer_descriptor, recv_peer_descriptor);
 

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -274,7 +274,7 @@ void write_socket_configs(
         uint32_t ack_size_bytes = align_up(sizeof(uint32_t)) * num_downstreams;
         uint32_t enc_size_bytes = align_up(sizeof(sender_downstream_encoding)) * num_downstreams;
         uint32_t sender_total_size_bytes = md_size_bytes + ack_size_bytes + enc_size_bytes;
-        std::vector<uint32_t> config_data(sender_total_size_bytes / sizeof(uint32_t), 0);
+        std::vector<uint32_t> config_data(config_buffer->size() / sizeof(uint32_t), 0);
         for (const auto& [device_coord, indexed_connections] : grouped_connections) {
             for (const auto& [conn_idx, connection] : indexed_connections) {
                 const auto& [sender_core, recv_core] = connection;

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include "impl/context/metal_context.hpp"
-#include <cstring>
 
 #include "tt_metal/hw/inc/socket.h"
 
@@ -279,10 +278,10 @@ void write_socket_configs(
     auto& core_to_core_id = config_buffer->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
     bool is_sender = socket_endpoint == SocketEndpoint::SENDER;
     const auto& config = peer_descriptor.config;
+    auto grouped_connections = group_socket_connections(config, socket_endpoint);
     auto peer_config_buf_addr = peer_descriptor.config_buffer_address;
     const SocketSenderSize sender_size;
     tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-    const auto grouped_connections = group_socket_connections(config, socket_endpoint);
     const auto receiver_ids_per_sender = get_receiver_ids_per_sender(config);
     if (is_sender) {
         const auto max_num_downstreams = get_max_num_downstreams_per_core(config);

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -302,10 +302,11 @@ void write_socket_configs(
                 uint32_t enc_offset = idx * sender_total_size_bytes / sizeof(uint32_t) +
                                       md_size_bytes / sizeof(uint32_t) + ack_size_bytes / sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_downstreams_per_core.at(sender_core); ++i) {
-                    config_data[enc_offset++] = *downstream_mesh_id;  // downstream_mesh_id
-                    config_data[enc_offset++] = downstream_chip_id;   // downstream_chip_id
-                    config_data[enc_offset++] = recv_virtual_core.y;  // downstream_noc_y
-                    config_data[enc_offset++] = recv_virtual_core.x;  // downstream_noc_x
+                    config_data[enc_offset] = *downstream_mesh_id;      // downstream_mesh_id
+                    config_data[enc_offset + 1] = downstream_chip_id;   // downstream_chip_id
+                    config_data[enc_offset + 2] = recv_virtual_core.y;  // downstream_noc_y
+                    config_data[enc_offset + 3] = recv_virtual_core.x;  // downstream_noc_x
+                    enc_offset += l1_alignment / sizeof(uint32_t);
                 }
             }
             distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -35,10 +35,8 @@ group_socket_connections(const SocketConfig& config, SocketEndpoint socket_endpo
             grouped_connections;
     uint32_t conn_idx = 0;
     for (const auto& connection : config.socket_connection_config) {
-        auto& device_map = grouped_connections
-            [is_sender ? connection.sender_core.device_coord : connection.receiver_core.device_coord];
-        device_map[is_sender ? connection.sender_core.core_coord : connection.receiver_core.core_coord].push_back(
-            std::make_pair(conn_idx++, connection));
+        auto& core = is_sender ? connection.sender_core : connection.receiver_core;
+        grouped_connections[core.device_coord][core.core_coord].push_back(std::make_pair(conn_idx++, connection));
     }
     return grouped_connections;
 }

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include "impl/context/metal_context.hpp"
-
+#include <tt-metalium/tt_align.hpp>
 #include "tt_metal/hw/inc/socket.h"
 
 using namespace tt::tt_metal::distributed::multihost;
@@ -19,13 +19,12 @@ namespace {
 
 struct SocketSenderSize {
     const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    const uint32_t md_size_bytes = ((sizeof(sender_socket_md) + l1_alignment - 1) / l1_alignment) * l1_alignment;
-    const uint32_t ack_size_bytes = ((sizeof(uint32_t) + l1_alignment - 1) / l1_alignment) * l1_alignment;
-    const uint32_t enc_size_bytes =
-        ((sizeof(sender_downstream_encoding) + l1_alignment - 1) / l1_alignment) * l1_alignment;
+    const uint32_t md_size_bytes = tt::align(sizeof(sender_socket_md), l1_alignment);
+    const uint32_t ack_size_bytes = tt::align(sizeof(uint32_t), l1_alignment);
+    const uint32_t enc_size_bytes = tt::align(sizeof(sender_downstream_encoding), l1_alignment);
 };
 
-// need to index the connections to properly read the FabricNodeId from peer descriptor.
+// Need to index the connections to properly read the FabricNodeId from peer descriptor.
 // This will get cleaned up with the improved socket APIs. See Issue #27207
 std::unordered_map<MeshCoordinate, std::unordered_map<CoreCoord, std::vector<std::pair<uint32_t, SocketConnection>>>>
 group_socket_connections(const SocketConfig& config, SocketEndpoint socket_endpoint) {

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -318,12 +318,10 @@ void write_socket_configs(
                 // Write one encoding per receiver, ordered by receiver ID
                 for (const auto& [conn_idx, connection] : connections) {
                     uint32_t receiver_id = receiver_ids_per_sender.at(connection);
-                    auto mesh_id = tt::tt_fabric::MeshId{peer_descriptor.mesh_ids[conn_idx]};
-                    auto chip_id = MetalContext::instance().get_control_plane().get_mesh_graph().coordinate_to_chip(
-                        mesh_id, connection.receiver_core.device_coord);
                     auto [downstream_mesh_id, downstream_chip_id] = get_sender_receiver_chip_fabric_encoding(
                         mesh_device->get_fabric_node_id(sender_core.device_coord),
-                        tt_fabric::FabricNodeId(mesh_id, chip_id),
+                        tt_fabric::FabricNodeId(
+                            tt_fabric::MeshId{peer_descriptor.mesh_ids[conn_idx]}, peer_descriptor.chip_ids[conn_idx]),
                         fabric_config,
                         SocketEndpoint::SENDER);
                     auto recv_virtual_core = mesh_device->worker_core_from_logical_core(connection.receiver_core.core_coord);

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -41,7 +41,8 @@ void write_socket_configs(
     const std::shared_ptr<MeshBuffer>& config_buffer,
     const SocketPeerDescriptor& local_descriptor,
     const SocketPeerDescriptor& peer_descriptor,
-    SocketEndpoint socket_endpoint);
+    SocketEndpoint socket_endpoint,
+    uint32_t downstream_num = 0);
 
 SocketPeerDescriptor generate_local_endpoint_descriptor(
     const MeshSocket& socket_endpoint, std::optional<multihost::DistributedContextId> context_id = std::nullopt);

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -41,8 +41,7 @@ void write_socket_configs(
     const std::shared_ptr<MeshBuffer>& config_buffer,
     const SocketPeerDescriptor& local_descriptor,
     const SocketPeerDescriptor& peer_descriptor,
-    SocketEndpoint socket_endpoint,
-    uint32_t downstream_num = 0);
+    SocketEndpoint socket_endpoint);
 
 SocketPeerDescriptor generate_local_endpoint_descriptor(
     const MeshSocket& socket_endpoint, std::optional<multihost::DistributedContextId> context_id = std::nullopt);

--- a/tt_metal/hw/inc/socket.h
+++ b/tt_metal/hw/inc/socket.h
@@ -53,18 +53,14 @@ struct SocketSenderInterface {
     uint32_t config_addr;
     uint32_t write_ptr;
     uint32_t bytes_sent;
-    uint32_t bytes_acked_addr;
+    uint32_t bytes_acked_base_addr;
     uint32_t page_size;
-
-    // Downstream Socket Metadata
-    uint32_t downstream_mesh_id;
-    uint32_t downstream_chip_id;
-    uint32_t downstream_noc_y;
-    uint32_t downstream_noc_x;
+    uint32_t num_downstreams;
     uint32_t downstream_bytes_sent_addr;
     uint32_t downstream_fifo_addr;
     uint32_t downstream_fifo_total_size;
     uint32_t downstream_fifo_curr_size;
+    uint32_t downstream_enc_addr;
 };
 
 struct SocketReceiverInterface {

--- a/tt_metal/hw/inc/socket.h
+++ b/tt_metal/hw/inc/socket.h
@@ -26,7 +26,7 @@ struct sender_socket_md {
 
     uint32_t is_sender = 0;
 };
-
+// After the metadata, the buffer contains the following arrays:
 // uint32_t bytes_acked_array[num_downstreams]
 // sender_downstream_encoding[num_downstreams]
 

--- a/tt_metal/hw/inc/socket.h
+++ b/tt_metal/hw/inc/socket.h
@@ -60,7 +60,7 @@ struct SocketSenderInterface {
     uint32_t downstream_fifo_addr;
     uint32_t downstream_fifo_total_size;
     uint32_t downstream_fifo_curr_size;
-    uint32_t downstream_enc_addr;
+    uint32_t downstream_enc_base_addr;
 };
 
 struct SocketReceiverInterface {

--- a/tt_metal/hw/inc/socket.h
+++ b/tt_metal/hw/inc/socket.h
@@ -6,24 +6,29 @@
 
 #include <cstdint>
 
-// Config Buffer on Sender Core will be populated as follows
-struct sender_socket_md {
-    // Standard Config Entries
-    uint32_t bytes_acked = 0;
-    uint32_t write_ptr = 0;
-    uint32_t bytes_sent = 0;
-
-    // Downstream Socket Metadata
+struct sender_downstream_encoding {
     uint32_t downstream_mesh_id = 0;
     uint32_t downstream_chip_id = 0;
     uint32_t downstream_noc_y = 0;
     uint32_t downstream_noc_x = 0;
+};
+
+// Config Buffer on Sender Core will be populated as follows. Metadata size based on number of downstream receivers.
+struct sender_socket_md {
+    // Standard Config Entries
+    uint32_t num_downstreams = 0;
+    uint32_t write_ptr = 0;
+    uint32_t bytes_sent = 0;
+
     uint32_t downstream_bytes_sent_addr = 0;
     uint32_t downstream_fifo_addr = 0;
     uint32_t downstream_fifo_total_size = 0;
 
     uint32_t is_sender = 0;
 };
+
+// uint32_t bytes_acked_array[num_downstreams]
+// sender_downstream_encoding[num_downstreams]
 
 // Config Buffer on Receiver Cores will be populated as follows
 struct receiver_socket_md {

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -72,11 +72,11 @@ sender_downstream_encoding get_downstream_encoding(const SocketSenderInterface& 
         socket.downstream_enc_base_addr + downstream_id * downstream_encoding_size_bytes);
     // Write to risc from L1
     sender_downstream_encoding downstream_enc_interface;
-    downstream_enc.downstream_mesh_id = downstream_enc->downstream_mesh_id;
-    downstream_enc.downstream_chip_id = downstream_enc->downstream_chip_id;
-    downstream_enc.downstream_noc_y = downstream_enc->downstream_noc_y;
-    downstream_enc.downstream_noc_x = downstream_enc->downstream_noc_x;
-    return downstream_enc;
+    downstream_enc_interface.downstream_mesh_id = downstream_enc->downstream_mesh_id;
+    downstream_enc_interface.downstream_chip_id = downstream_enc->downstream_chip_id;
+    downstream_enc_interface.downstream_noc_y = downstream_enc->downstream_noc_y;
+    downstream_enc_interface.downstream_noc_x = downstream_enc->downstream_noc_x;
+    return downstream_enc_interface;
 }
 
 void set_sender_socket_page_size(SocketSenderInterface& socket, uint32_t page_size) {

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -60,7 +60,7 @@ SocketSenderInterface create_sender_socket_interface(uint32_t config_addr) {
     socket.downstream_fifo_addr = socket_config->downstream_fifo_addr;
     socket.downstream_bytes_sent_addr = socket_config->downstream_bytes_sent_addr;
     socket.downstream_fifo_total_size = socket_config->downstream_fifo_total_size;
-    socket.downstream_enc_addr =
+    socket.downstream_enc_base_addr =
         config_addr + sender_socket_md_size_bytes + socket_config->num_downstreams * bytes_acked_size_bytes;
 
     return socket;
@@ -68,7 +68,7 @@ SocketSenderInterface create_sender_socket_interface(uint32_t config_addr) {
 
 sender_downstream_encoding* get_downstream_encoding(const SocketSenderInterface& socket, uint32_t downstream_id) {
     return reinterpret_cast<sender_downstream_encoding*>(
-        socket.downstream_enc_addr + downstream_id * downstream_encoding_size_bytes);
+        socket.downstream_enc_base_addr + downstream_id * downstream_encoding_size_bytes);
 }
 
 void set_sender_socket_page_size(SocketSenderInterface& socket, uint32_t page_size) {

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -161,9 +161,9 @@ void socket_barrier(const SocketSenderInterface& socket) {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(socket.bytes_acked_base_addr);
     while (reinterpret_cast<uint32_t>(bytes_acked_ptr) <
            socket.bytes_acked_base_addr + socket.num_downstreams * bytes_acked_size_bytes) {
-        while (socket.bytes_sent != *bytes_acked_ptr) {
+        do {
             invalidate_l1_cache();
-        }
+        } while (socket.bytes_sent != *bytes_acked_ptr);
         bytes_acked_ptr += bytes_acked_size_bytes;
     }
 }

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -20,7 +20,6 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 
 static_assert(offsetof(receiver_socket_md, bytes_sent) % L1_ALIGNMENT == 0);
-static_assert(offsetof(sender_socket_md, num_downstreams) % L1_ALIGNMENT == 0);
 
 template <typename T>
 constexpr bool always_false = false;

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -11,6 +11,7 @@
 #include "risc_attribs.h"
 #include "socket.h"
 #include "utils/utils.h"
+
 #ifndef COMPILE_FOR_TRISC
 #include <type_traits>
 #include "dataflow_api.h"
@@ -258,7 +259,6 @@ void assign_local_cb_to_socket(const SocketReceiverInterface& socket, uint32_t c
 }
 
 #ifndef COMPILE_FOR_TRISC
-
 void socket_notify_sender(const SocketReceiverInterface& socket) {
     // TODO: Store noc encoding in struct?
     auto upstream_bytes_acked_noc_addr =

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -11,7 +11,7 @@
 #include "risc_attribs.h"
 #include "socket.h"
 #include "utils/utils.h"
-#include "debug/deprint.h"
+#include "debug/dprint.h"
 #ifndef COMPILE_FOR_TRISC
 #include <type_traits>
 #include "dataflow_api.h"
@@ -110,17 +110,6 @@ void socket_push_pages(SocketSenderInterface& socket, uint32_t num_pages) {
     } else {
         socket.write_ptr += num_bytes;
         socket.bytes_sent += num_bytes;
-    }
-}
-
-void socket_async_write(SocketSenderInterface& socket, uint32_t data_addr, uint32_t data_size) {
-    for (uint32_t i = 0; i < socket.num_downstreams; i++) {
-        sender_downstream_encoding* downstream_enc = reinterpret_cast<sender_downstream_encoding*>(
-            socket.downstream_enc_addr + i * align_up(sizeof(sender_downstream_encoding)));
-        noc_async_write(
-            data_addr,
-            get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0) | socket.write_ptr,
-            data_size);
     }
 }
 
@@ -265,6 +254,17 @@ void assign_local_cb_to_socket(const SocketReceiverInterface& socket, uint32_t c
 }
 
 #ifndef COMPILE_FOR_TRISC
+void socket_async_write(SocketSenderInterface& socket, uint32_t data_addr, uint32_t data_size) {
+    for (uint32_t i = 0; i < socket.num_downstreams; i++) {
+        sender_downstream_encoding* downstream_enc = reinterpret_cast<sender_downstream_encoding*>(
+            socket.downstream_enc_addr + i * align_up(sizeof(sender_downstream_encoding)));
+        noc_async_write(
+            data_addr,
+            get_noc_addr(downstream_enc->downstream_noc_x, downstream_enc->downstream_noc_y, 0) | socket.write_ptr,
+            data_size);
+    }
+}
+
 void socket_notify_sender(const SocketReceiverInterface& socket) {
     // TODO: Store noc encoding in struct?
     auto upstream_bytes_acked_noc_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
@@ -67,7 +67,9 @@ void kernel_main() {
     SocketSenderInterface sender_socket = create_sender_socket_interface(socket_config_addr);
     set_sender_socket_page_size(sender_socket, socket_block_size);
 
-    fabric_set_unicast_route(data_packet_header_addr, sender_socket);
+    // Only one downstream in this test
+    sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, 0);
+    fabric_set_unicast_route(data_packet_header_addr, *downstream_enc);
 
     uint64_t receiver_noc_coord_addr = get_noc_addr_from_bank_id<is_dram>(bank_id, 0, edm_fabric_write_noc_index);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
@@ -68,8 +68,8 @@ void kernel_main() {
     set_sender_socket_page_size(sender_socket, socket_block_size);
 
     // Only one downstream in this test
-    sender_downstream_encoding* downstream_enc = get_downstream_encoding(sender_socket, 0);
-    fabric_set_unicast_route(data_packet_header_addr, *downstream_enc);
+    sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, 0);
+    fabric_set_unicast_route(data_packet_header_addr, downstream_enc);
 
     uint64_t receiver_noc_coord_addr = get_noc_addr_from_bank_id<is_dram>(bank_id, 0, edm_fabric_write_noc_index);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
@@ -67,7 +67,7 @@ void kernel_main() {
     SocketSenderInterface sender_socket = create_sender_socket_interface(socket_config_addr);
     set_sender_socket_page_size(sender_socket, socket_block_size);
 
-    // Only one downstream in this test
+    // Only one downstream in this op
     sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, 0);
     fabric_set_unicast_route(data_packet_header_addr, downstream_enc);
 


### PR DESCRIPTION
### Ticket
No Ticket

### Problem description
MeshSockets currently only support one sender to one receiver sockets. This PR implements one-to-many sockets, as long as receivers are on the same host. A one-to-many socket has a single sender with a single write pointer with multiple receivers. Control flow happens in lockstep across recievers.

### What's changed
Kernel Side Socket Interface is now

```
struct SocketSenderInterface {
    uint32_t config_addr;
    uint32_t write_ptr;
    uint32_t bytes_sent;
    uint32_t bytes_acked_base_addr;
    uint32_t page_size;
    uint32_t num_downstreams;
    uint32_t downstream_bytes_sent_addr;
    uint32_t downstream_fifo_addr;
    uint32_t downstream_fifo_total_size;
    uint32_t downstream_fifo_curr_size;
    uint32_t downstream_enc_base_addr;
};

struct sender_downstream_encoding {
    uint32_t downstream_mesh_id = 0;
    uint32_t downstream_chip_id = 0;
    uint32_t downstream_noc_y = 0;
    uint32_t downstream_noc_x = 0;
};
```
Downstream encodings get now be retrieved using the API:
```
sender_downstream_encoding* get_downstream_encoding(const SocketSenderInterface& socket, uint32_t downstream_id)
```

Host side outward APIs remain the same, with internals modified to support one-to-many sockets. HostSide APIs will be changed in a later PR (see #27207 ).

Mesh Socket test infra contains. a new pattern, `all_device_broadcast`, where every device broadcasts to every other host.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17112478091) CI passes
- [ ] [t3k unit](https://github.com/tenstorrent/tt-metal/actions/runs/17217029078)
- [ ] [Physical Multi-Host]()