### PR TITLE
Enable int32_t permute test cases (Issue 22298 fixed in llk)

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -10,7 +10,7 @@ import ttnn
 import itertools
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
-from models.utility_functions import is_blackhole, skip_for_wormhole_b0
+from models.utility_functions import is_blackhole
 
 
 def random_torch_tensor(dtype, shape):
@@ -83,10 +83,7 @@ def test_permute_on_4D_tensor_with_smaller_tuple_size(device, h, w, dtype):
     "dtype",
     [
         ttnn.bfloat16,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_on_less_than_4D(device, perm, dtype):
@@ -243,10 +240,7 @@ def test_permute_5d_width(device, shape, perm, memory_config, dtype):
     [
         ttnn.bfloat16,
         ttnn.float32,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_5d_blocked(device, shape, perm, memory_config, dtype):
@@ -301,10 +295,7 @@ def test_permute_squeeze(device, dtype):
     [
         ttnn.bfloat16,
         ttnn.float32,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_3D(device, shape, perm, layout, memory_config, dtype):
@@ -393,10 +384,7 @@ def test_permute_4d_wh(device, shape, dtype):
     "dtype",
     [
         ttnn.bfloat16,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_4d_cnwh(device, shape, dtype):
@@ -415,10 +403,7 @@ def test_permute_4d_cnwh(device, shape, dtype):
     "dtype",
     [
         ttnn.bfloat16,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_8d_swapped(device, shape, dims, dtype):
@@ -554,10 +539,7 @@ def test_permute_5d_yw_padded(device, shape, perm, dtype, pad_value):
     [
         ttnn.bfloat16,
         ttnn.float32,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_5d_yw_permutations(device, shape, perm, dtype):
@@ -581,10 +563,7 @@ def test_permute_5d_yw_permutations(device, shape, perm, dtype):
     "dtype",
     [
         ttnn.bfloat16,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_4d_yw_permutations(device, shape, perm, dtype):
@@ -603,10 +582,7 @@ def test_permute_4d_yw_permutations(device, shape, perm, dtype):
     "dtype",
     [
         ttnn.bfloat16,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_4d_whyx_permutations(device, shape, perm, dtype):
@@ -625,10 +601,7 @@ def test_permute_4d_whyx_permutations(device, shape, perm, dtype):
     "dtype",
     [
         ttnn.bfloat16,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_4d_other_permutations(device, shape, perm, dtype):
@@ -648,10 +621,7 @@ def test_permute_4d_other_permutations(device, shape, perm, dtype):
     [
         ttnn.bfloat16,
         ttnn.float32,
-        pytest.param(
-            ttnn.int32,
-            marks=skip_for_wormhole_b0("possible race condition: https://github.com/tenstorrent/tt-metal/issues/22298"),
-        ),
+        ttnn.int32,
     ],
 )
 def test_permute_5d_wyh(device, shape, perm, dtype):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22298)

### Problem description
Int32_t permute tests were failing due to a race condition, that has been fixed in the LLK. 


### What's changed
This PR picks up that change (https://github.com/tenstorrent/tt-llk/pull/602) and re enables the relevant test cases. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17116367494) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17116358416) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes