### PR TITLE
[skip ci] Change CODEOWNERS for tt_umd

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,7 +95,7 @@ tt_metal/**/profiler/**/CMakeLists.txt @mo-tenstorrent @tenstorrent/metalium-dev
 tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
 
 tt_metal/third_party/tt_llk @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT
-tt_metal/third_party/tt_umd @broskoTT @pjanevskiTT
+tt_metal/third_party/umd @broskoTT @pjanevskiTT
 
 # metal tests
 tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,7 +94,8 @@ tt_metal/tt_metal.cpp @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @pgkeller @ali
 tt_metal/**/profiler/**/CMakeLists.txt @mo-tenstorrent @tenstorrent/metalium-developers-infra
 tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
 
-tt_metal/third_party/tt_llk @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT #does this actually do anything?
+tt_metal/third_party/tt_llk @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT
+tt_metal/third_party/tt_umd @broskoTT @pjanevskiTT
 
 # metal tests
 tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt


### PR DESCRIPTION
### Ticket
No ticket

### Problem description
We've been the main contributors for a while 

### What's changed
- Set @pjanevskiTT and me as codeowners of tt_umd submodule in tt_metal

### Checklist
No CI checks