### PR TITLE
Fix test case for conv1d prepare conv weights.

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -354,7 +354,10 @@ def test_squeezebert_conv1d(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_length, kernel_size, stride, padding, groups",
-    ((1, 32, 32, 1024, 3, 1, 1, 1),),
+    (
+        (1, 32, 32, 1024, 3, 1, 1, 1),
+        (2, 512, 512, 1024, 7, 1, 3, 512),
+    ),
 )
 @pytest.mark.parametrize("prepare_weights", [True, False])
 def test_with_prepare_weights(
@@ -400,11 +403,11 @@ def test_with_prepare_weights(
             input_height=input_length,
             input_width=1,
             kernel_size=(kernel_size, 1),
-            stride=(1, 1),
-            padding=(1, 0),
+            stride=(stride, 1),
+            padding=(padding, 0),
             dilation=(1, 1),
             has_bias=False,
-            groups=1,
+            groups=groups,
             device=device,
             input_dtype=ttnn.bfloat16,
         )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27161

### Problem description
`prepare_weights` path in `test_with_prepare_weights` does not consider input argument's passed `stride`, `padding` and `groups` and sets them as 1.

### What's changed
Use user passed `stride`, `padding` and `groups` for `prepare_weights` path

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/17119848669)
- [ ] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/17119859082)