### PR TITLE
Provide int32 support for ttnn.rsub

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -37,9 +37,11 @@ import ttnn
         ttnn.add,
         ttnn.sub,
         ttnn.squared_difference,
+        ttnn.rsub,
     ],
 )
-def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, device):
+@pytest.mark.parametrize("use_legacy", [True, False])
+def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
@@ -68,7 +70,7 @@ def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, devic
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, use_legacy=use_legacy)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
@@ -104,6 +106,7 @@ def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, devic
         ttnn.sub,
         ttnn.mul,
         ttnn.squared_difference,
+        ttnn.rsub,
     ],
 )
 def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
@@ -177,7 +180,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ],
 )
 @pytest.mark.parametrize(
-    "ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul", "squared_difference")
+    "ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul", "squared_difference", "rsub")
 )
 def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
     ttnn_op = getattr(ttnn, ttnn_fn)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_rsub_int32(const uint dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        // operand A
+        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        // operand B
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_offset * 64);
+        // Use 6 or LO16 as imod to convert operand A to 2's complement
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, LO16);
+        // LREG_0 -> dest
+        TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -14,13 +14,14 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_rsub_int32(const uint dst_offset) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // operand A
+        // operand A - int32
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
-        // operand B
+        // operand B - int32 (offset by dst_offset * dest tile size)
         TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_offset * 64);
-        // Use 6 or LO16 as imod to convert operand A to 2's complement
-        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, LO16);
-        // LREG_0 -> dest
+        // Reverse subtraction is performed using 2's complement by adding B to the negation of A: LREG1 + (-LREG0)
+        // Use 6 as imod to convert operand A to 2's complement
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 6);
+        // Store result from LREG_0 to dest
         TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_rsub_int32.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_rsub_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_binary_sfpu_rsub_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_rsub_int32<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_rsub_int32(const uint dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        // operand A
+        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        // operand B
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_offset * 64);
+        // Use 6 or LO16 as imod to convert operand A to 2's complement
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, LO16);
+        // LREG_0 -> dest
+        TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -14,13 +14,14 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_rsub_int32(const uint dst_offset) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // operand A
+        // operand A - int32
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
-        // operand B
+        // operand B - int32 (offset by dst_offset * dest tile size)
         TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_offset * 64);
-        // Use 6 or LO16 as imod to convert operand A to 2's complement
-        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, LO16);
-        // LREG_0 -> dest
+        // Reverse subtraction is performed using 2's complement by adding B to the negation of A: LREG1 + (-LREG0)
+        // Use 6 as imod to convert operand A to 2's complement
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 6);
+        // Store result from LREG_0 to dest
         TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_rsub_int32.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_rsub_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_binary_sfpu_rsub_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_rsub_int32<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
@@ -7,6 +7,7 @@
 #include "compute_kernel_api/common_globals.h"
 #ifdef TRISC_MATH
 #include "llk_math_eltwise_binary_sfpu_binop.h"
+#include "llk_math_eltwise_binary_sfpu_rsub_int32.h"
 #define MAIN math_main()
 #define MATH(x) x
 #else
@@ -53,6 +54,10 @@ ALWI void rsub_binary_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::RSUB>(idst0, idst1)));
 }
 
+ALWI void rsub_int32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_rsub_int32<APPROX>(idst0, idst1)));
+}
+
 ALWI void power_binary_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::POW, DST_ACCUM_MODE>(idst0, idst1)));
 }
@@ -71,6 +76,8 @@ ALWI void div_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binop_init
 ALWI void rsub_binary_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::BinaryOp::RSUB>()));
 }
+
+ALWI void rsub_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_rsub_int32_init<APPROX>())); }
 
 ALWI void power_binary_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::BinaryOp::POW>()));

--- a/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
@@ -7,7 +7,6 @@
 #include "compute_kernel_api/common_globals.h"
 #ifdef TRISC_MATH
 #include "llk_math_eltwise_binary_sfpu_binop.h"
-#include "llk_math_eltwise_binary_sfpu_rsub_int32.h"
 #define MAIN math_main()
 #define MATH(x) x
 #else
@@ -54,10 +53,6 @@ ALWI void rsub_binary_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::RSUB>(idst0, idst1)));
 }
 
-ALWI void rsub_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_rsub_int32<APPROX>(idst0, idst1)));
-}
-
 ALWI void power_binary_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::POW, DST_ACCUM_MODE>(idst0, idst1)));
 }
@@ -76,8 +71,6 @@ ALWI void div_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binop_init
 ALWI void rsub_binary_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::BinaryOp::RSUB>()));
 }
-
-ALWI void rsub_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_rsub_int32_init<APPROX>())); }
 
 ALWI void power_binary_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::BinaryOp::POW>()));

--- a/tt_metal/include/compute_kernel_api/sub_int_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/sub_int_sfpu.h
@@ -7,6 +7,7 @@
 #include "compute_kernel_api/common_globals.h"
 #ifdef TRISC_MATH
 #include "llk_math_eltwise_binary_sfpu_sub_int.h"
+#include "llk_math_eltwise_binary_sfpu_rsub_int32.h"
 #define MAIN math_main()
 #define MATH(x) x
 #else
@@ -42,9 +43,15 @@ ALWI void sub_uint16_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::LO16, false>(idst0, idst1)));
 }
 
+ALWI void rsub_int32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_rsub_int32<APPROX>(idst0, idst1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
 ALWI void sub_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_sub_int_init<APPROX>())); }
+
+ALWI void rsub_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_rsub_int32_init<APPROX>())); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -226,8 +226,13 @@ std::map<std::string, std::string> get_defines_fp32(
             }
             break;
         case BinaryOpType::RSUB:
-            new_defines.insert({"BINOP_INIT", fmt::format("rsub_binary_tile_init();")});
-            op_name = "rsub_binary_tile";
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("rsub_int32_tile_init();")});
+                op_name = "rsub_int32_tile";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("rsub_binary_tile_init();")});
+                op_name = "rsub_binary_tile";
+            }
             break;
         case BinaryOpType::POWER:
             new_defines.insert({"BINOP_INIT", fmt::format("power_binary_tile_init();")});
@@ -326,7 +331,7 @@ std::map<std::string, std::string> get_defines_fp32(
             } else {
                 op_name = "sub_binary_tile";
             }
-            new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::BIAS_GELU:
             new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -32,12 +32,12 @@ namespace utils {
             return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
                 || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::DIV:
-        case BinaryOpType::RSUB:
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:
         case BinaryOpType::LDEXP:
         case BinaryOpType::BIAS_GELU: return (a == DataType::FLOAT32 && b == DataType::FLOAT32);
         case BinaryOpType::SQUARED_DIFFERENCE:
+        case BinaryOpType::RSUB:
         case BinaryOpType::GT:
         case BinaryOpType::LT:
         case BinaryOpType::GE:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -26,12 +26,12 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LOGICAL_XOR:
             return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));
         case DIV:
-        case RSUB:
         case LOGADDEXP:
         case LOGADDEXP2:
         case LDEXP:
         case BIAS_GELU: return (a == FLOAT32 && b == FLOAT32);
         case SQUARED_DIFFERENCE:
+        case RSUB:
         case GT:
         case LT:
         case GE:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -356,7 +356,12 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             }
         case DIV: return {"div_binary_tile_init();", "div_binary_tile"};
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
-        case RSUB: return {"rsub_binary_tile_init();", "rsub_binary_tile"};
+        case RSUB:
+            if (dtype == DataType::INT32) {
+                return {"rsub_int32_tile_init();", "rsub_int32_tile"};
+            } else {
+                return {"rsub_binary_tile_init();", "rsub_binary_tile"};
+            }
         case GCD: return {"gcd_tile_init();", "gcd_tile"};
         case LCM: return {"lcm_tile_init();", "lcm_tile"};
         case LEFT_SHIFT:


### PR DESCRIPTION
### Ticket
#26524 

### Problem description
Binary rsub op does not support int32 datatype.

### What's changed
Added kernel implementation for int32 rsub.
(Migration to LLK will be done as part of #22163)

**Perf:**
Device kernel duration for one tile [1, 1, 32, 32]: **2663 ns**

### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/17131205168 - PASSED (latest run: https://github.com/tenstorrent/tt-metal/actions/runs/17165419002)
- [x] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/17131218336 - PASSED
- [x] (Blackhole) Blackhole nightly tests - https://github.com/tenstorrent/tt-metal/actions/runs/17131237634 - PASSED
- [x] New/Existing tests provide coverage for changes