### PR TITLE
#21352: Add int32 support for clamp TSS

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1647,3 +1647,42 @@ def test_unary_square_uint16_ttnn(input_shapes, device):
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
 
     assert torch.equal(golden_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([64, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
+)
+@pytest.mark.parametrize(
+    "min_val, max_val",
+    [
+        (None, None),
+        (-29, None),
+        (None, 18),
+        (-10, 34),
+        (12, 82),
+        (1, -1),
+        (0, 0),
+        (0, 1),
+    ],
+)
+def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device):
+    torch.manual_seed(0)
+    in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    min = min_val
+    max = max_val
+    if min is None and max is None:
+        with pytest.raises(RuntimeError, match="Only one of 'min' or 'max' can be None. Please provide one value"):
+            ttnn.clamp(input_tensor1, min, max)
+    else:
+        output_tensor = ttnn.clamp(input_tensor1, min, max)
+        golden_function = ttnn.get_golden_function(ttnn.clamp)
+        golden_tensor = golden_function(in_data1, min, max)
+        assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -9,15 +9,28 @@
 
 namespace ckernel::sfpu {
 
+enum { Max = true, Min = false };  // Clamp Mode
+
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp(uint param0, uint param1) {
+inline void calculate_clamp(uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        load_value_param_float(param0);
-        calculate_unary_max_min_float_body<true>();
-        load_value_param_float(param1);
-        calculate_unary_max_min_float_body<false>();
+        load_value_param_float(min_val);
+        calculate_unary_max_min_float_body<Max>();
+        load_value_param_float(max_val);
+        calculate_unary_max_min_float_body<Min>();
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_clamp_int32(uint min_val, uint max_val) {
+    for (int d = 0; d < ITERATIONS; d++) {
+        load_value_param_int(min_val);
+        calculate_unary_max_min_int32_body<Max>();
+        load_value_param_int(max_val);
+        calculate_unary_max_min_int32_body<Min>();
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -7,13 +7,13 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 sfpi_inline void load_value_param_float(uint value) {
     TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
 }
+
 template <bool IS_MAX_OP>
 sfpi_inline void calculate_unary_max_min_float_body() {
     // Load input to lreg0
@@ -32,6 +32,36 @@ sfpi_inline void calculate_unary_max_min_float_body() {
     }
 }
 
+// Load value param to lreg2 and cast 2's complement to sign + magnitude format
+sfpi_inline void load_value_param_int(uint value) {
+    _sfpu_load_imm32_(p_sfpu::LREG2, value);
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2);
+    TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+}
+template <bool IS_MAX_OP>
+sfpi_inline void calculate_unary_max_min_int32_body() {
+    // Load input to lreg0
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
+    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2);
+    TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
+
+    // Copy value param to lreg1
+    TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
+    // Swap and store maximum in lreg1, minimum in lreg0
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+    if constexpr (IS_MAX_OP) {
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3);
+        TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
+        TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
+    } else {
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 3);
+        TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
+    }
+}
+
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min(uint value) {
     // Load value param to lreg2
@@ -46,36 +76,13 @@ inline void calculate_unary_max_min(uint value) {
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min_int32(uint value) {
     // Load value param to lreg2 and cast 2's complement to sign + magnitude format
-    _sfpu_load_imm32_(p_sfpu::LREG2, value);
-    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2);
-    TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+    load_value_param_int(value);
 
 #pragma GCC unroll 0
    for (int d = 0; d < ITERATIONS; d++) {
-       // Load input to lreg0
-       TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
-       TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2);
-       TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
-
-       // Copy value param to lreg1
-       TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-
-       // Swap and store maximum in lreg1, minimum in lreg0
-       TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-       if constexpr (IS_MAX_OP) {
-           TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3);
-           TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
-           TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
-       } else {
-           TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 3);
-           TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
-           TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
-       }
-
+       calculate_unary_max_min_int32_body<IS_MAX_OP>();
        sfpi::dst_reg++;
    }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -19,9 +19,16 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
-    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_clamp_int32(
+    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -9,15 +9,29 @@
 
 namespace ckernel::sfpu {
 
+enum { Max = true, Min = false };  // Clamp Mode
+
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp(uint param0, uint param1) {
+inline void calculate_clamp(uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        load_value_param_float(param0);
-        calculate_unary_max_min_float_body<true>();
-        load_value_param_float(param1);
-        calculate_unary_max_min_float_body<false>();
+        load_value_param_float(min_val);
+        calculate_unary_max_min_float_body<Max>();
+        load_value_param_float(max_val);
+        calculate_unary_max_min_float_body<Min>();
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_clamp_int32(uint min_val, uint max_val) {
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        load_value_param_int(min_val);
+        calculate_unary_max_min_int32_body<Max>();
+        load_value_param_int(max_val);
+        calculate_unary_max_min_int32_body<Min>();
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -7,13 +7,13 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 sfpi_inline void load_value_param_float(uint value) {
     TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
 }
+
 template <bool IS_MAX_OP>
 sfpi_inline void calculate_unary_max_min_float_body() {
     // Load input to lreg0
@@ -32,6 +32,35 @@ sfpi_inline void calculate_unary_max_min_float_body() {
     }
 }
 
+
+sfpi_inline void load_value_param_int(uint value) {
+    int scalar = value;
+    if (scalar < 0) {  // To convert from 2's complement to sign+magnitude
+        scalar = -scalar;
+        scalar = 0x80000000 | (scalar & 0x7FFFFFFF);
+    }
+    _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
+}
+
+template <bool IS_MAX_OP>
+sfpi_inline void calculate_unary_max_min_int32_body() {
+    // Load input tensor to lreg0
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+
+    // Copy value param to lreg2 to lreg1
+    TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
+    // Swap and store maximum in lreg1, minimum in lreg0 (sign + magnitude format)
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+    // Store the result
+    if constexpr (IS_MAX_OP) {
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+    }
+}
+
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min(uint value) {
     // Load value param to lreg2
@@ -46,36 +75,12 @@ inline void calculate_unary_max_min(uint value) {
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min_int32(uint value) {
-    int scalar = value;
-    if (scalar < 0) {  // To convert from 2's complement to sign+magnitude
-        scalar = -scalar;
-        int res = 0x80000000 | (scalar & 0x7FFFFFFF);
-        scalar = res;
-    }
-
-    // Load value param to lreg2
-    _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
-
+    load_value_param_int(value);
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        // Load input tensor to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
-
-        // Copy value param to lreg2 to lreg1
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-
-        // Swap and store maximum in lreg1, minimum in lreg0 (sign + magnitude format)
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-        // Store the result
-        if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
-        }
+        calculate_unary_max_min_int32_body<IS_MAX_OP>();
         sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -19,9 +19,16 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
-    uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_clamp_int32(
+    uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/clamp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/clamp.h
@@ -34,6 +34,25 @@ ALWI void clamp_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_clamp<APPROX>(idst, param0, param1)));
 }
 
+// clang-format off
+/**
+ * Performs element-wise clamp operation for int32. The DST
+ * register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
+ * compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The min value for the clamp function                                       | uint32_t |                                                       | True     |
+ * | param1          | The max value for the clamp function                                       | uint32_t |                                                       | True     |
+ */
+// clang-format on
+ALWI void clamp_tile_int32(uint32_t idst, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_clamp_int32<APPROX>(idst, param0, param1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -431,10 +431,21 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         }
         case UnaryOpType::CLAMP_TSS: {
             float param1 = params[1];
-            op_init_and_name = {
-                "clamp_tile_init();",
-                fmt::format(
-                    "clamp_tile({}, {}, {});", idst, std::bit_cast<uint32_t>(param0), std::bit_cast<uint32_t>(param1))};
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {
+                    "clamp_tile_init();",
+                    fmt::format("clamp_tile_int32({}, {}, {});", idst, (uint)param0, (uint)param1)};
+            } else {
+                op_init_and_name = {
+                    "clamp_tile_init();",
+                    fmt::format(
+                        "clamp_tile({}, {}, {});",
+                        idst,
+                        std::bit_cast<uint32_t>(param0),
+                        std::bit_cast<uint32_t>(param1))};
+            }
             break;
         }
         case UnaryOpType::HARDTANH: {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <optional>
+#include <variant>
 
 #include <utility>
 #include <tt-metalium/bfloat16.hpp>
@@ -292,7 +293,13 @@ Tensor ExecuteUnaryCompositeClip::invoke(
     std::optional<float> min,
     std::optional<float> max,
     const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteUnaryCompositeClamp::invoke(a, min, max, output_mem_config);
+    // Convert float optionals to variant optionals
+    std::optional<std::variant<float, int32_t>> min_variant =
+        min ? std::make_optional<std::variant<float, int32_t>>(std::in_place_type<float>, *min) : std::nullopt;
+    std::optional<std::variant<float, int32_t>> max_variant =
+        max ? std::make_optional<std::variant<float, int32_t>>(std::in_place_type<float>, *max) : std::nullopt;
+
+    return ExecuteUnaryCompositeClamp::invoke(a, min_variant, max_variant, output_mem_config);
 }
 
 Tensor ExecuteUnaryCompositeClip::invoke(
@@ -306,29 +313,45 @@ Tensor ExecuteUnaryCompositeClip::invoke(
 // clamp
 Tensor ExecuteUnaryCompositeClamp::invoke(
     const Tensor& input_a,
-    std::optional<float> min,
-    std::optional<float> max,
-    const std::optional<MemoryConfig>& output_mem_config) {
+    std::optional<std::variant<float, int32_t>> min,
+    std::optional<std::variant<float, int32_t>> max,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor) {
     TT_FATAL(
         (max.has_value() || min.has_value()),
         "Either 'min' value or 'max' value can be None. Please provide at least one value");
     Tensor a = input_a;
-    if (input_a.dtype() == DataType::INT32) {
+
+    // Check if we have any int32_t scalars (both will be int32_t or null)
+    bool has_int32_scalar = (min.has_value() && std::holds_alternative<int32_t>(min.value())) ||
+                            (max.has_value() && std::holds_alternative<int32_t>(max.value()));
+
+    // Convert input tensor to float32 only if input is INT32 and scalars are float (not int32)
+    if (input_a.dtype() == DataType::INT32 && !has_int32_scalar) {
         a = ttnn::typecast(a, DataType::FLOAT32, output_mem_config);
     }
 
-    // Handle cases where min or max is not provided (null)
-    float min_val = min.has_value() ? min.value() : std::numeric_limits<float>::lowest();
-    float max_val = max.has_value() ? max.value() : std::numeric_limits<float>::max();
-
-    return ttnn::clamp_tss(a, min_val, max_val, output_mem_config);
+    if (has_int32_scalar) {
+        // All scalars are int32_t (or null)
+        int32_t min_val = min.has_value() ? std::get<int32_t>(min.value()) : -16775716;
+        int32_t max_val =
+            max.has_value() ? std::get<int32_t>(max.value())
+                            : 16775716;  // max_val and min_val will be updated once unary infra supports int32 scalar.
+        return ttnn::clamp_tss(a, min_val, max_val, output_mem_config, output_tensor);
+    } else {
+        // All scalars are float (or null)
+        float min_val = min.has_value() ? std::get<float>(min.value()) : std::numeric_limits<float>::lowest();
+        float max_val = max.has_value() ? std::get<float>(max.value()) : std::numeric_limits<float>::max();
+        return ttnn::clamp_tss(a, min_val, max_val, output_mem_config, output_tensor);
+    }
 }
 
 Tensor ExecuteUnaryCompositeClamp::invoke(
     const Tensor& a,
     std::optional<Tensor> min,
     std::optional<Tensor> max,
-    const std::optional<MemoryConfig>& output_mem_config) {
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<Tensor>& output_tensor) {
     auto output_memory_config = output_mem_config.value_or(a.memory_config());
     TT_FATAL((max.has_value() || min.has_value()), "Only one of 'min' or 'max' can be None. Please provide one value");
     if (!max.has_value()) {
@@ -338,11 +361,11 @@ Tensor ExecuteUnaryCompositeClamp::invoke(
         return ttnn::where(
             ttnn::le(a, max.value(), std::nullopt, output_memory_config), a, max.value(), output_memory_config);
     }
-    Tensor a_max = ttnn::minimum(ttnn::DefaultQueueId, a, max.value(), std::nullopt, output_memory_config);
+    Tensor a_max = ttnn::minimum(a, max.value(), std::nullopt, output_memory_config);
     Tensor temp = ttnn::where(
         ttnn::eq(min.value(), 0.0f, std::nullopt, output_memory_config),
         ttnn::relu(a_max, output_memory_config),
-        ttnn::maximum(ttnn::DefaultQueueId, a_max, min.value(), std::nullopt, output_memory_config),
+        ttnn::maximum(a_max, min.value(), std::nullopt, output_memory_config),
         output_memory_config);
     return ttnn::where(
         ttnn::gt(min.value(), max.value(), std::nullopt, output_memory_config),

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -435,7 +435,6 @@ Tensor Hardtanh::invoke(
 }
 
 Tensor Clamp::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const float min_val,
     const float max_val,
@@ -443,7 +442,26 @@ Tensor Clamp::invoke(
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::CLAMP_TSS;
     return detail::unary_impl(
-        queue_id, input_tensor, {UnaryWithParam{op_type, {min_val, max_val}}}, memory_config, optional_output_tensor);
+        ttnn::DefaultQueueId,
+        input_tensor,
+        {UnaryWithParam{op_type, {min_val, max_val}}},
+        memory_config,
+        optional_output_tensor);
+}
+
+Tensor Clamp::invoke(
+    const Tensor& input_tensor,
+    const int32_t min_val,
+    const int32_t max_val,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::CLAMP_TSS;
+    return detail::unary_impl(
+        ttnn::DefaultQueueId,
+        input_tensor,
+        {UnaryWithParam{op_type, {min_val, max_val}}},
+        memory_config,
+        optional_output_tensor);
 }
 
 Tensor Softshrink::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -331,10 +331,16 @@ struct Tanhshrink {
 
 struct Clamp {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float min_val,
         float max_val,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        int32_t min_val,
+        int32_t max_val,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -55,15 +55,17 @@ struct ExecuteUnaryCompositeOpWithFloats {
 struct ExecuteUnaryCompositeClamp {
     static Tensor invoke(
         const Tensor& input_tensor,
-        std::optional<float> min = std::nullopt,
-        std::optional<float> max = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        std::optional<std::variant<float, int32_t>> min = std::nullopt,
+        std::optional<std::variant<float, int32_t>> max = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output_tensor = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
         std::optional<Tensor> min = std::nullopt,
         std::optional<Tensor> max = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output_tensor = std::nullopt);
 };
 
 struct ExecuteUnaryCompositeClip {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -23,6 +23,86 @@
 namespace ttnn::operations::unary {
 
 namespace {
+template <typename unary_operation_t>
+void bind_unary_clamp(py::module& module, const unary_operation_t& operation) {
+    auto doc = fmt::format(
+        R"doc(
+        Applies {0} to :attr:`input_tensor` element-wise.
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            min (ttnn.Tensor or number): Minimum value. Defaults to `None`.
+            max (ttnn.Tensor or number): Maximum value. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, BFLOAT8_B, INT32, FLOAT32
+                 - TILE
+
+            INT32 is supported only for Tensor-scalar-scalar version.
+
+        Example:
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> min_tensor = ttnn.from_torch(torch.tensor([[0, 2], [0,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> max_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(input_tensor, min_tensor, max_tensor)
+
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(input_tensor, min = 2, max = 9)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name());
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               std::optional<Tensor> parameter_a,
+               std::optional<Tensor> parameter_b,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor) {
+                return self(input_tensor, parameter_a, parameter_b, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg("min") = std::nullopt,
+            py::arg("max") = std::nullopt,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               std::optional<std::variant<float, int32_t>> parameter_a,
+               std::optional<std::variant<float, int32_t>> parameter_b,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor) {
+                return self(input_tensor, parameter_a, parameter_b, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg("min") = std::nullopt,
+            py::arg("max") = std::nullopt,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
+}
 
 template <typename unary_operation_t>
 void bind_unary_composite_optional_floats_with_default(
@@ -2177,16 +2257,7 @@ void py_module(py::module& module) {
         "Maximum value",
         std::nullopt,
         R"doc(Performs clip function on :attr:`input_tensor`, :attr:`min`, :attr:`max`. Only one of 'min' or 'max' value can be None.)doc");
-    bind_unary_composite_optional_floats_with_default(
-        module,
-        ttnn::clamp,
-        "min",
-        "Minimum value",
-        std::nullopt,
-        "max",
-        "Maximum value",
-        std::nullopt,
-        R"doc(Performs clamp function on :attr:`input_tensor`, :attr:`min`, :attr:`max`. Only one of 'min' or 'max' value can be None.)doc");
+    bind_unary_clamp(module, ttnn::clamp);
     bind_unary_composite_floats_with_default(
         module, ttnn::selu, "scale", "Scale value", 1.0507, "alpha", "Alpha value", 1.67326);
     bind_unary_composite_floats_with_default(


### PR DESCRIPTION
### Ticket
Link to Github Issue #21352 

### What's changed

- Added int32 for clamp TSS.
- Added optional output tensor and queue id support clamp op.

### Checklist
- [ ] All post commit
- [ ] Blackhole Post commit