### PR TITLE
reordering removed and Clip issues are prevented

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -52,7 +52,7 @@ def run_demo_inference(
     needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
     prompts = prompts + [""] * needed_padding
 
-    guidance_scale = 5.0
+    guidance_scale = 8.0
 
     # 0. Set up default height and width for unet
     height = 1024
@@ -201,16 +201,6 @@ def run_demo_inference(
     profiler.end("encode_prompts")
 
     profiler.start("prepare_latents")
-    # Reorder all_embeds to prepare for splitting across devices
-    items_per_core = len(all_embeds) // batch_size  # this will always be a multiple of batch_size because of padding
-
-    if batch_size > 1:  # If batch_size is 1, no need to reorder
-        reordered = []
-        for i in range(batch_size):
-            for j in range(items_per_core):
-                index = i + j * batch_size
-                reordered.append(all_embeds[index])
-        all_embeds = reordered
 
     prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = zip(*all_embeds)
 

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -40,6 +40,7 @@ def run_demo_inference(
     encoders_on_device,
     evaluation_range,
     capture_trace,
+    guidance_scale,
 ):
     batch_size = ttnn_device.get_num_devices()
 
@@ -51,8 +52,6 @@ def run_demo_inference(
 
     needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
     prompts = prompts + [""] * needed_padding
-
-    guidance_scale = 8.0
 
     # 0. Set up default height and width for unet
     height = 1024
@@ -436,6 +435,10 @@ def run_demo_inference(
     ((50),),
 )
 @pytest.mark.parametrize(
+    "guidance_scale",
+    ((5.0),),
+)
+@pytest.mark.parametrize(
     "vae_on_device",
     [
         (True),
@@ -468,6 +471,7 @@ def test_demo(
     encoders_on_device,
     capture_trace,
     evaluation_range,
+    guidance_scale,
 ):
     return run_demo_inference(
         mesh_device,
@@ -478,4 +482,5 @@ def test_demo(
         encoders_on_device,
         evaluation_range,
         capture_trace,
+        guidance_scale,
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -14,6 +14,7 @@ from models.experimental.stable_diffusion_xl_base.utils.fid_score import calcula
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE, SDXL_TRACE_REGION_SIZE
 import json
 from models.utility_functions import profiler
+from models.experimental.stable_diffusion_xl_base.conftest import get_device_name
 
 test_demo.__test__ = False
 COCO_CAPTIONS_DOWNLOAD_PATH = "https://github.com/mlcommons/inference/raw/4b1d1156c23965172ae56eacdd8372f8897eb771/text_to_image/coco2014/captions/captions_source.tsv"
@@ -25,7 +26,7 @@ OUT_ROOT, RESULTS_FILE_NAME = "test_reports", "sdxl_test_results.json"
 )
 @pytest.mark.parametrize(
     "num_inference_steps",
-    ((50),),
+    ((20),),
 )
 @pytest.mark.parametrize(
     "vae_on_device",
@@ -110,15 +111,18 @@ def test_accuracy_sdxl(
     data = {
         "model": "sdxl",  # For compatibility with current processes
         "metadata": {
-            "device": "N150",
+            "device": get_device_name(),
             "device_vae": vae_on_device,
+            "capture_trace": capture_trace,
+            "encoders_on_device": encoders_on_device,
+            "num_inference_steps": num_inference_steps,
             "start_from": start_from,
             "num_prompts": num_prompts,
             "model_name": "sdxl",
         },
         "benchmarks_summary": [
             {
-                "device": "N150",
+                "device": get_device_name(),
                 "model": "sdxl",
                 "average_denoising_time": profiler.get("denoising_loop"),
                 "average_vae_time": profiler.get("vae_decode"),
@@ -137,11 +141,16 @@ def test_accuracy_sdxl(
     }
 
     os.makedirs(OUT_ROOT, exist_ok=True)
-
-    with open(f"{OUT_ROOT}/{RESULTS_FILE_NAME}", "w") as f:
+    trace_flag = "with_trace" if capture_trace else "no_trace"
+    vae_flag = "device_vae" if vae_on_device else "host_vae"
+    encoders_flag = "device_encoders" if encoders_on_device else "host_encoders"
+    new_file_name = f"sdxl_test_results_{trace_flag}_{vae_flag}_{encoders_flag}_{num_inference_steps}.json"
+    with open(f"{OUT_ROOT}/{new_file_name}", "w") as f:
         json.dump(data, f, indent=4)
 
-    logger.info(f"Test results saved to {OUT_ROOT}/{RESULTS_FILE_NAME}")
+    logger.info(f"Test results saved to {OUT_ROOT}/{new_file_name}")
+
+    check_clip_scores(start_from, num_prompts, prompts, clip_scores)
 
 
 def sdxl_get_prompts(
@@ -172,3 +181,22 @@ def sdxl_get_prompts(
             prompts.append(row[2])
 
     return prompts
+
+
+def check_clip_scores(start_from, num_prompts, prompts, clip_scores):
+    assert len(clip_scores) == num_prompts == len(prompts), f"Expected {num_prompts} CLIP scores and prompts."
+    num_of_very_low_clip_scores = 0
+    for idx, score in enumerate(clip_scores):
+        if clip_scores[idx] < 27:
+            if clip_scores[idx] < 20:
+                logger.error(
+                    f"Very low CLIP score detected for image {start_from + idx + 1}: {score}, prompt: {prompts[idx]},  \
+                        this indicates a fragmented image or noise or prompt mismatch or something else very wrong."
+                )
+                num_of_very_low_clip_scores += 1
+            else:
+                logger.warning(
+                    f"Low CLIP score detected for image {start_from + idx + 1}: {score}, prompt: {prompts[idx]}"
+                )
+
+    assert num_of_very_low_clip_scores == 0, f"Found {num_of_very_low_clip_scores} images with very low CLIP scores"

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -156,6 +156,13 @@ def test_accuracy_sdxl(
 
     logger.info(f"Test results saved to {OUT_ROOT}/{new_file_name}")
 
+    with open(
+        f"{OUT_ROOT}/{RESULTS_FILE_NAME}", "w"
+    ) as f:  # this is for CI and test_sdxl_accuracy_with_reset.py compatibility
+        json.dump(data, f, indent=4)
+
+    logger.info(f"Test results saved to {OUT_ROOT}/{RESULTS_FILE_NAME}")
+
     check_clip_scores(start_from, num_prompts, prompts, clip_scores)
 
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -29,6 +29,10 @@ OUT_ROOT, RESULTS_FILE_NAME = "test_reports", "sdxl_test_results.json"
     ((20),),
 )
 @pytest.mark.parametrize(
+    "guidance_scale",
+    ((8.0),),
+)
+@pytest.mark.parametrize(
     "vae_on_device",
     [
         (True),
@@ -64,6 +68,7 @@ def test_accuracy_sdxl(
     captions_path,
     coco_statistics_path,
     evaluation_range,
+    guidance_scale,
 ):
     start_from, num_prompts = evaluation_range
 
@@ -84,6 +89,7 @@ def test_accuracy_sdxl(
         encoders_on_device,
         capture_trace,
         evaluation_range,
+        guidance_scale,
     )
 
     clip = CLIPEncoder()

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy_with_reset.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy_with_reset.py
@@ -10,7 +10,7 @@ from PIL import Image
 
 from loguru import logger
 from models.experimental.stable_diffusion_xl_base.utils.fid_score import calculate_fid_score
-from models.experimental.stable_diffusion_xl_base.tests.test_sdxl_accuracy import sdxl_get_prompts
+from models.experimental.stable_diffusion_xl_base.tests.test_sdxl_accuracy import sdxl_get_prompts, check_clip_scores
 from models.experimental.stable_diffusion_xl_base.utils.clip_encoder import CLIPEncoder
 from models.experimental.stable_diffusion_xl_base.tests.test_sdxl_accuracy import OUT_ROOT, RESULTS_FILE_NAME
 
@@ -200,18 +200,3 @@ def sdxl_collect_images(start_from, num_prompts):
         img = Image.open(current_filename_path).convert("RGB")
         collected_images.append(img)
     return collected_images
-
-
-def check_clip_scores(start_from, num_prompts, prompts, clip_scores):
-    assert len(clip_scores) == num_prompts == len(prompts), f"Expected {num_prompts} CLIP scores and prompts."
-    for idx, score in enumerate(clip_scores):
-        if clip_scores[idx] < 27:
-            if clip_scores[idx] < 20:
-                logger.error(
-                    f"Very low CLIP score detected for image {start_from + idx + 1}: {score}, prompt: {prompts[idx]},  \
-                        this indicates a fragmented image or noise or prompt mismatch or something else very wrong."
-                )
-            else:
-                logger.warning(
-                    f"Low CLIP score detected for image {start_from + idx + 1}: {score}, prompt: {prompts[idx]}"
-                )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26620)

### Problem description
Reordering now breaks Clip score and Clip Score issues can be detected easily

### What's changed
- Reordering is removed
- sdxl_test_results.json is updated
- added CLIP score check - accuracy test will fail if any Clip score is bellow 20
- changed guidance scale, and default num_inference_steps, negative prompt isn't changed

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17128500708)
- [x] [signle card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17128536981)
- [x] [CI run on N300, 2 test combinations](https://github.com/tenstorrent/tt-shield/actions/runs/17152457150)