### PR TITLE
Revert "#25975: Ported kernels in experimental OPs to TensorAccessor,…

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -101,76 +101,76 @@ jobs:
         run: |
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
-  check-interleaved-addr-gen-usage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for git diff comparison
-      - name: Check for new InterleavedAddrGen usages in changed files
-        run: |
-          set -euo pipefail
-          # Get the base branch for comparison
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
-          else
-            BASE_REF="HEAD^"
-          fi
+  # check-interleaved-addr-gen-usage:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0  # Fetch all history for git diff comparison
+  #     - name: Check for new InterleavedAddrGen usages in changed files
+  #       run: |
+  #         set -euo pipefail
+  #         # Get the base branch for comparison
+  #         if [ "${{ github.event_name }}" = "pull_request" ]; then
+  #           BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+  #         else
+  #           BASE_REF="HEAD^"
+  #         fi
 
-          declare -A OLD_FOR_NEW
-          CHANGED=()
+  #         declare -A OLD_FOR_NEW
+  #         CHANGED=()
 
-          # Collect changed C/C++ files and map renames (old -> new)
-          while IFS=$'\t' read -r status path1 path2; do
-            case "$status" in
-              A|M)
-                if [[ "$path1" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
-                  CHANGED+=("$path1")
-                fi
-                ;;
-              R*)
-                if [[ "$path2" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
-                  CHANGED+=("$path2")
-                  OLD_FOR_NEW["$path2"]="$path1"
-                fi
-                ;;
-            esac
-          done < <(git diff --name-status -M "$BASE_REF" HEAD)
+  #         # Collect changed C/C++ files and map renames (old -> new)
+  #         while IFS=$'\t' read -r status path1 path2; do
+  #           case "$status" in
+  #             A|M)
+  #               if [[ "$path1" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
+  #                 CHANGED+=("$path1")
+  #               fi
+  #               ;;
+  #             R*)
+  #               if [[ "$path2" =~ \.(c|cc|cxx|cpp|h|hh|hpp)$ ]]; then
+  #                 CHANGED+=("$path2")
+  #                 OLD_FOR_NEW["$path2"]="$path1"
+  #               fi
+  #               ;;
+  #           esac
+  #         done < <(git diff --name-status -M "$BASE_REF" HEAD)
 
-          if (( ${#CHANGED[@]} == 0 )); then
-            echo "No C/C++ files changed in this PR."
-            exit 0
-          fi
+  #         if (( ${#CHANGED[@]} == 0 )); then
+  #           echo "No C/C++ files changed in this PR."
+  #           exit 0
+  #         fi
 
-          NEW_USAGE_FOUND=0
-          regex='(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)'
+  #         NEW_USAGE_FOUND=0
+  #         regex='(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)'
 
-          for file in "${CHANGED[@]}"; do
-            old_path="${OLD_FOR_NEW[$file]:-$file}"
+  #         for file in "${CHANGED[@]}"; do
+  #           old_path="${OLD_FOR_NEW[$file]:-$file}"
 
-            base_count=$(git show "$BASE_REF:$old_path" 2>/dev/null | grep -E -o "$regex" | wc -l || true)
-            if [ -f "$file" ]; then
-              head_count=$(grep -E -o "$regex" "$file" 2>/dev/null | wc -l || true)
-            else
-              head_count=0
-            fi
+  #           base_count=$(git show "$BASE_REF:$old_path" 2>/dev/null | grep -E -o "$regex" | wc -l || true)
+  #           if [ -f "$file" ]; then
+  #             head_count=$(grep -E -o "$regex" "$file" 2>/dev/null | wc -l || true)
+  #           else
+  #             head_count=0
+  #           fi
 
-            if [ "$head_count" -gt "$base_count" ]; then
-              echo "❌ Increased InterleavedAddrGen usage in: $file (base=$base_count → head=$head_count)"
-              echo "Added matching lines:"
-              git diff "$BASE_REF" HEAD -- "$file" | grep -E '^\+[^+].*(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)' || true
-              NEW_USAGE_FOUND=1
-            fi
-          done
+  #           if [ "$head_count" -gt "$base_count" ]; then
+  #             echo "❌ Increased InterleavedAddrGen usage in: $file (base=$base_count → head=$head_count)"
+  #             echo "Added matching lines:"
+  #             git diff "$BASE_REF" HEAD -- "$file" | grep -E '^\+[^+].*(Interleaved[^[:space:]]*AddrGen|get_interleaved_addr_gen)' || true
+  #             NEW_USAGE_FOUND=1
+  #           fi
+  #         done
 
-          if [ "$NEW_USAGE_FOUND" -eq 1 ]; then
-            echo ""
-            echo "❌ New InterleavedAddrGen usages detected!"
-            echo "Please use TensorAccessor instead."
-            exit 1
-          else
-            echo "✅ No increase in InterleavedAddrGen usages found in changed files."
-          fi
+  #         if [ "$NEW_USAGE_FOUND" -eq 1 ]; then
+  #           echo ""
+  #           echo "❌ New InterleavedAddrGen usages detected!"
+  #           echo "Please use TensorAccessor instead."
+  #           exit 1
+  #         else
+  #           echo "✅ No increase in InterleavedAddrGen usages found in changed files."
+  #         fi
   check-sweeps-workflow:
     runs-on: ubuntu-latest
     steps:

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_program_factory.cpp
@@ -18,7 +18,6 @@
 
 #include "bcast_to_device_operation.hpp"
 #include "bcast_to_utils.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace ttnn::operations::experimental::broadcast_to;
 
@@ -162,27 +161,24 @@ BcastToOperation::BcastToTileFactory::cached_program_t BcastToOperation::BcastTo
 
     create_cb(tt::CBIndex::c_1, program, all_device_cores, input_single_tile_size, num_tiles_per_cb, input_data_format);
 
+    const auto src_is_dram = static_cast<const uint32_t>(input.buffer()->is_dram());
+    const auto dst_is_dram = static_cast<const uint32_t>(output.buffer()->is_dram());
+
     auto kernel_config = BcastToKernelConfig(operation_attributes.subtile_broadcast_type);
 
     // READER KERNEL
-    std::vector<uint32_t> reader_compile_time_args{(uint32_t)tt::CBIndex::c_0};
-    tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
     auto reader_id = tt::tt_metal::CreateKernel(
         program,
         get_kernel_file_path(kernel_config.reader_kernel),
         all_device_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig({src_is_dram, (uint32_t)tt::CBIndex::c_0}));
 
     // WRITER KERNEL
-    uint32_t writer_cb_id = (kernel_config.writer_kernel == KernelName::WriterNoBcast) ? (uint32_t)tt::CBIndex::c_0
-                                                                                       : (uint32_t)tt::CBIndex::c_1;
-    std::vector<uint32_t> writer_compile_time_args{writer_cb_id};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
     auto writer_id = tt::tt_metal::CreateKernel(
         program,
         get_kernel_file_path(kernel_config.writer_kernel),
         all_device_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig({dst_is_dram, (uint32_t)tt::CBIndex::c_1, (uint32_t)tt::CBIndex::c_0}));
 
     // COMPUTE KERNEL
     auto compute_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_col_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_col_bcast_to.cpp
@@ -22,12 +22,14 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr auto cb_id_src = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_src = get_compile_time_arg_val(1);
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
     uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_no_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_no_bcast_to.cpp
@@ -22,12 +22,14 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr auto cb_id_src = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_src = get_compile_time_arg_val(1);
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
     uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_row_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_row_bcast_to.cpp
@@ -22,12 +22,14 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr auto cb_id_src = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_src = get_compile_time_arg_val(1);
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
     uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_scalar_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_scalar_bcast_to.cpp
@@ -22,12 +22,14 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr auto cb_id_src = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_src = get_compile_time_arg_val(1);
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
     uint32_t HtWt = Ht * Wt;
     // this is the INPUT tile offset

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_col_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_col_bcast_to.cpp
@@ -25,10 +25,13 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_no_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_no_bcast_to.cpp
@@ -25,11 +25,14 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_dst = get_compile_time_arg_val(2);
 
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_row_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_row_bcast_to.cpp
@@ -25,10 +25,13 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_scalar_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_scalar_bcast_to.cpp
@@ -25,10 +25,13 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::dropout::program {
 namespace {
@@ -210,12 +209,15 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     // 3) Create reader/writer kernels
     // -------------------------------------------------------------------------
     auto src_buffer = input.buffer();
-    std::vector<uint32_t> reader_compile_args = {static_cast<uint32_t>(kSrc0CbIndex)};
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_args);
+    bool src_is_dram = (src_buffer->buffer_type() == BufferType::DRAM);
+
+    std::vector<uint32_t> reader_compile_args = {static_cast<uint32_t>(src_is_dram)};
 
     auto dst_buffer = output.buffer();
-    std::vector<uint32_t> writer_compile_args = {static_cast<uint32_t>(kOutputCbIndex)};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_args);
+    bool dst_is_dram = (dst_buffer->buffer_type() == BufferType::DRAM);
+
+    std::vector<uint32_t> writer_compile_args = {
+        static_cast<uint32_t>(kOutputCbIndex), static_cast<uint32_t>(dst_is_dram)};
 
     DropoutKernels kernels{};
     kernels.reader = create_reader_kernel(program, all_cores, reader_compile_args, kReaderKernelPath);

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
@@ -10,13 +10,17 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr uint32_t cb_id_in0 = 0;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
 #ifdef OUT_SHARDED
     cb_wait_front(cb_id_out, num_tiles);
@@ -19,7 +19,10 @@ void kernel_main() {
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -23,11 +23,11 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
-    constexpr uint32_t misalignment = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t misalignment = get_compile_time_arg_val(1);
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
+    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
 
     constexpr uint32_t cb_id_in0 = 0;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -19,13 +19,14 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
+    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+
     constexpr uint32_t cb_id_in0 = 0;
 
     uint32_t src_stick_id = start_id;
     uint32_t tiles_read = 0;
     const uint32_t tile_size = get_tile_size(cb_id_in0);
-    constexpr auto src_args = TensorAccessorArgs<0>();
-    const auto s0 = TensorAccessor(src_args, src_addr, tile_size);
+    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = tile_size};
 
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", num_dims: " << num_dims << ", start_id: " << start_id

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <vector>
@@ -270,8 +269,7 @@ static operation::ProgramWithCallbacks padded_slice_rm_multi_core(
 
     std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index};
 
-    std::vector<uint32_t> reader_compile_time_args_vec = {misalignment};
-    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args_vec);
+    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram, misalignment};
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/"
@@ -731,8 +729,7 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
     std::vector<uint32_t> writer_compile_time_args_vec = {
         cb_untilized_index, cb_output_index, input_padded_shape.rank() /* == 4*/};
 
-    std::vector<uint32_t> reader_compile_time_args_vec = {};
-    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args_vec);
+    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram, misalignment};
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
@@ -10,12 +10,15 @@ void kernel_main() {
     const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
     const uint32_t num_rows = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t Wt = get_compile_time_arg_val(1);
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt = get_compile_time_arg_val(2);
 
     const uint32_t tile_bytes = get_tile_size(cb_id_in);
-    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(cb_id_in);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     // uint32_t end_id = start_id + num_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
@@ -27,24 +27,29 @@ void kernel_main() {
         input_cb_id = input2_cb_id;
     }
 
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(2);
-    constexpr bool use_index_tensor = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t cb_index_id = get_compile_time_arg_val(4);
-    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt = get_compile_time_arg_val(6);
-    const uint32_t index_stick_size_B = get_compile_time_arg_val(7);
+    constexpr bool cache_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(3);
+    constexpr bool use_index_tensor = get_compile_time_arg_val(4) == 1;
+    constexpr bool index_is_dram = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t cb_index_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t Wt = get_compile_time_arg_val(8);
+    const uint32_t log_base_2_of_page_size = get_compile_time_arg_val(9);
+    const uint32_t index_stick_size_B = get_compile_time_arg_val(10);
 
     // paged_cache args
-    constexpr bool is_paged_cache = get_compile_time_arg_val(8) == 1;
-    constexpr uint32_t num_heads = get_compile_time_arg_val(9);
-    constexpr uint32_t block_size = get_compile_time_arg_val(10);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(11);
-    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(12);
-    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(13);
-    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(14);
+    constexpr bool is_paged_cache = get_compile_time_arg_val(11) == 1;
+    constexpr uint32_t num_heads = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size = get_compile_time_arg_val(13);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(14);
+    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(15);
+    constexpr uint32_t log2_page_table_stick_size = get_compile_time_arg_val(16);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(17);
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(18) == 1;
+    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(19);
 
-    const uint32_t St = get_compile_time_arg_val(15);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
+    const uint32_t St = get_compile_time_arg_val(20);
+    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));  // semaphore for receiver
 
     constexpr uint32_t head_offset_t = Wt * St;
 
@@ -53,19 +58,20 @@ void kernel_main() {
     cb_push_back(input_cb_id, Wt);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
 
     constexpr uint32_t TILE_HEIGHT = 32;
 
     uint32_t cache_id = cache_start_id;
 
-    constexpr auto cache_args = TensorAccessorArgs<17>();
-    const auto s0 = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
 
     bool skip_update = false;
 
     if constexpr (use_index_tensor) {
-        constexpr auto index_args = TensorAccessorArgs<cache_args.next_compile_time_args_offset()>();
-        const auto addrg = TensorAccessor(index_args, index_tensor_addr, index_stick_size_B);
+        const InterleavedAddrGen<index_is_dram> addrg = {
+            .bank_base_address = index_tensor_addr, .page_size = index_stick_size_B};
 
         cb_reserve_back(cb_index_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
@@ -82,9 +88,8 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                constexpr auto pagetable_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
-                const auto page_table_gen =
-                    TensorAccessor(pagetable_args, page_table_tensor_addr, page_table_stick_size);
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
                 cb_reserve_back(page_table_cb_id, 1);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
                 uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -27,24 +27,29 @@ void kernel_main() {
         input_cb_id = input2_cb_id;
     }
 
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(2);
-    constexpr bool use_index_tensor = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t cb_index_id = get_compile_time_arg_val(4);
-    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(5);
-    constexpr uint32_t Wt = get_compile_time_arg_val(6);
-    const uint32_t index_stick_size_B = get_compile_time_arg_val(7);
+    constexpr bool cache_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(3);
+    constexpr bool use_index_tensor = get_compile_time_arg_val(4) == 1;
+    constexpr bool index_is_dram = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t cb_index_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t Wt = get_compile_time_arg_val(8);
+    const uint32_t log_base_2_of_page_size = get_compile_time_arg_val(9);
+    const uint32_t index_stick_size_B = get_compile_time_arg_val(10);
 
     // paged_cache args
-    constexpr bool is_paged_cache = get_compile_time_arg_val(8) == 1;
-    constexpr uint32_t num_heads = get_compile_time_arg_val(9);
-    constexpr uint32_t block_size = get_compile_time_arg_val(10);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(11);
-    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(12);
-    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(13);
-    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(14);
+    constexpr bool is_paged_cache = get_compile_time_arg_val(11) == 1;
+    constexpr uint32_t num_heads = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size = get_compile_time_arg_val(13);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(14);
+    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(15);
+    constexpr uint32_t log2_page_table_stick_size = get_compile_time_arg_val(16);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(17);
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(18) == 1;
+    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(19);
 
-    const uint32_t St = get_compile_time_arg_val(15);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
+    const uint32_t St = get_compile_time_arg_val(20);
+    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));  // semaphore for receiver
 
     constexpr uint32_t head_offset_t = Wt * St;
 
@@ -53,19 +58,20 @@ void kernel_main() {
     cb_push_back(input_cb_id, 1);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
 
     constexpr uint32_t TILE_HEIGHT = 32;
 
     uint32_t cache_id = cache_start_id;
 
-    constexpr auto cache_args = TensorAccessorArgs<17>();
-    const auto s0 = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
 
     bool skip_update = false;
 
     if constexpr (use_index_tensor) {
-        constexpr auto index_args = TensorAccessorArgs<cache_args.next_compile_time_args_offset()>();
-        const auto addrg = TensorAccessor(index_args, index_tensor_addr, index_stick_size_B);
+        const InterleavedAddrGen<index_is_dram> addrg = {
+            .bank_base_address = index_tensor_addr, .page_size = index_stick_size_B};
 
         cb_reserve_back(cb_index_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
@@ -82,9 +88,8 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                constexpr auto pagetable_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
-                const auto page_table_gen =
-                    TensorAccessor(pagetable_args, page_table_tensor_addr, page_table_stick_size);
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
                 cb_reserve_back(page_table_cb_id, 1);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
                 uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -13,25 +13,30 @@ void kernel_main() {
     const uint32_t page_table_tensor_addr = get_arg_val<uint32_t>(4);
     const bool wait_to_start_signal = get_arg_val<uint32_t>(5) == 1;
 
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t input_cb_id = get_compile_time_arg_val(1);
-    constexpr bool use_index_tensor = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t cb_index_id = get_compile_time_arg_val(3);
-    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt = get_compile_time_arg_val(5);
-    const uint32_t index_stick_size_B = get_compile_time_arg_val(6);
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(2);
+    constexpr bool use_index_tensor = get_compile_time_arg_val(3) == 1;
+    constexpr bool index_is_dram = get_compile_time_arg_val(4) == 1;
+    constexpr uint32_t cb_index_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    const uint32_t log_base_2_of_page_size = get_compile_time_arg_val(8);
+    const uint32_t index_stick_size_B = get_compile_time_arg_val(9);
 
     // paged_cache args
-    constexpr bool is_paged_cache = get_compile_time_arg_val(7) == 1;
-    constexpr uint32_t num_heads = get_compile_time_arg_val(8);
-    constexpr uint32_t block_size = get_compile_time_arg_val(9);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(10);
-    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(11);
-    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(12);
-    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(13);
+    constexpr bool is_paged_cache = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t num_heads = get_compile_time_arg_val(11);
+    constexpr uint32_t block_size = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(13);
+    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(14);
+    constexpr uint32_t log2_page_table_stick_size = get_compile_time_arg_val(15);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(16);
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(17) == 1;
+    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(18);
 
-    const uint32_t St = get_compile_time_arg_val(14);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(15));  // semaphore for receiver
+    const uint32_t St = get_compile_time_arg_val(19);
+    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(20));  // semaphore for receiver
 
     constexpr uint32_t head_offset_t = Wt * St;
 
@@ -40,19 +45,20 @@ void kernel_main() {
     cb_push_back(input_cb_id, Wt);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
 
     constexpr uint32_t TILE_HEIGHT = 32;
 
     uint32_t cache_id = cache_start_id;
 
-    constexpr auto cache_args = TensorAccessorArgs<16>();
-    const auto s0 = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
 
     bool skip_update = false;
 
     if constexpr (use_index_tensor) {
-        constexpr auto index_args = TensorAccessorArgs<cache_args.next_compile_time_args_offset()>();
-        const auto addrg = TensorAccessor(index_args, index_tensor_addr, index_stick_size_B);
+        const InterleavedAddrGen<index_is_dram> addrg = {
+            .bank_base_address = index_tensor_addr, .page_size = index_stick_size_B};
 
         cb_reserve_back(cb_index_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
@@ -69,9 +75,8 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                constexpr auto pagetable_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
-                const auto page_table_gen =
-                    TensorAccessor(pagetable_args, page_table_tensor_addr, page_table_stick_size);
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
                 cb_reserve_back(page_table_cb_id, 1);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
                 uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -36,27 +36,30 @@ void kernel_main() {
     // Arg 4 is either batch_idx_tensor_addr or batch_idx_fallback scalar
     uint32_t batch_arg = get_arg_val<uint32_t>(4);
 
-    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_page_table = get_compile_time_arg_val(1);
-    constexpr uint32_t num_heads = get_compile_time_arg_val(2);
-    constexpr uint32_t num_blocks_of_work_per_head = get_compile_time_arg_val(3);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt = get_compile_time_arg_val(5);
-    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(6);
+    constexpr bool out_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool page_table_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_page_table = get_compile_time_arg_val(3);
+    constexpr uint32_t num_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t num_blocks_of_work_per_head = get_compile_time_arg_val(5);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    constexpr uint32_t log2_page_table_stick_size = get_compile_time_arg_val(8);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(9);
 
     // New compile-time args for optional batch_idx_tensor
-    constexpr bool use_batch_idx_tensor = get_compile_time_arg_val(7) == 1;
-    constexpr uint32_t cb_id_batch_idx = get_compile_time_arg_val(8);       // CB for reading from batch_idx_tensor
-    constexpr uint32_t batch_idx_stick_size = get_compile_time_arg_val(9);  // Expected to be small (e.g., 4 for uint32)
-
-    constexpr auto out_args = TensorAccessorArgs<10>();
-    constexpr auto page_table_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
-    constexpr auto batch_idx_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
+    constexpr bool use_batch_idx_tensor = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t cb_id_batch_idx = get_compile_time_arg_val(11);  // CB for reading from batch_idx_tensor
+    constexpr bool batch_idx_tensor_is_dram = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t batch_idx_stick_size =
+        get_compile_time_arg_val(13);  // Expected to be small (e.g., 4 for uint32)
 
     uint32_t batch_idx;
     if constexpr (use_batch_idx_tensor) {
         uint32_t batch_idx_tensor_addr = batch_arg;  // Arg 4 is the address
-        const auto batch_idx_gen = TensorAccessor(batch_idx_args, batch_idx_tensor_addr, batch_idx_stick_size);
+
+        const InterleavedAddrGen<batch_idx_tensor_is_dram> batch_idx_gen = {
+            .bank_base_address = batch_idx_tensor_addr, .page_size = batch_idx_stick_size};
         cb_reserve_back(cb_id_batch_idx, 1);  // Expecting 1 element (the batch_idx)
         uint32_t batch_idx_cb_wr_ptr = get_write_ptr(cb_id_batch_idx);
         uint64_t batch_idx_noc_addr = get_noc_addr(0, batch_idx_gen);
@@ -70,9 +73,13 @@ void kernel_main() {
     }
 
     const uint32_t tile_bytes = get_tile_size(cb_id_in);
-    const auto out_gen = TensorAccessor(out_args, dst_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(cb_id_in);
 
-    const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr, page_table_stick_size);
+    const InterleavedAddrGenFast<out_is_dram> out_gen = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+        .bank_base_address = page_table_addr, .page_size = page_table_stick_size};
     cb_reserve_back(cb_id_page_table, 1);
     uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
     uint64_t page_table_noc_addr = get_noc_addr(batch_idx, page_table_gen);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -20,7 +20,8 @@ void kernel_main() {
     const uint32_t send_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t send_core_y = get_arg_val<uint32_t>(rt_args_idx++);
 
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
     constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(4);
@@ -43,11 +44,12 @@ void kernel_main() {
     constexpr uint32_t head_offset_t = Wt * St;
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
 
     constexpr uint32_t TILE_HEIGHT = 32;
 
-    constexpr auto cache_args = TensorAccessorArgs<18>();
-    const auto s0 = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
 
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -21,7 +21,8 @@ void kernel_main() {
     const uint32_t send_core_y = get_arg_val<uint32_t>(rt_args_idx++);
     const bool is_input1 = get_arg_val<uint32_t>(rt_args_idx++);
 
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
     constexpr uint32_t untilized_input1_cb_id = get_compile_time_arg_val(4);
@@ -50,11 +51,12 @@ void kernel_main() {
     constexpr uint32_t head_offset_t = Wt * St;
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
 
     constexpr uint32_t TILE_HEIGHT = 32;
 
-    constexpr auto cache_args = TensorAccessorArgs<19>();
-    const auto s0 = TensorAccessor(cache_args, cache_addr, cache_tile_bytes);
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
 
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -14,34 +14,36 @@ void kernel_main() {
     const uint32_t send_core_x = get_arg_val<uint32_t>(5);
     const uint32_t send_core_y = get_arg_val<uint32_t>(6);
 
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(3);
-    constexpr bool use_index_tensor = get_compile_time_arg_val(4) == 1;
-    constexpr uint32_t cb_index_id = get_compile_time_arg_val(5);
-    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t Wt = get_compile_time_arg_val(7);
-    constexpr uint32_t Wbytes = get_compile_time_arg_val(8);
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(4);
+    constexpr bool use_index_tensor = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t cb_index_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t Wt = get_compile_time_arg_val(8);
+    constexpr uint32_t Wbytes = get_compile_time_arg_val(9);
 
     // paged_cache args
-    constexpr bool is_paged_cache = get_compile_time_arg_val(9) == 1;
-    constexpr uint32_t num_heads = get_compile_time_arg_val(10);
-    constexpr uint32_t block_size = get_compile_time_arg_val(11);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(12);
-    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(13);
-    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(14);
+    constexpr bool is_paged_cache = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t num_heads = get_compile_time_arg_val(11);
+    constexpr uint32_t block_size = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(13);
+    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(14);
+    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(15);
 
-    constexpr uint32_t St = get_compile_time_arg_val(15);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
+    constexpr uint32_t St = get_compile_time_arg_val(16);
+    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
     constexpr uint32_t head_offset_t = Wt * St;
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
 
     constexpr uint32_t TILE_HEIGHT = 32;
 
-    constexpr auto dst_args = TensorAccessorArgs<17>();
-    const auto s0 = TensorAccessor(dst_args, cache_addr, cache_tile_bytes);
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
 
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
@@ -8,7 +8,6 @@
 #include "ttnn/operations/cb_utils.hpp"
 #include "paged_cache_operation.hpp"
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.hpp"
 
 using namespace tt::tt_metal;
@@ -223,15 +222,20 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
 
     auto dst2_buffer = cache_tensor2.buffer();
 
+    bool dst_is_dram = dst1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)src2_cb_index,
+        (std::uint32_t)dst_is_dram,
         (std::uint32_t)cache_cb_index,
         // Index tensor args
         (std::uint32_t)use_index_tensor,
+        (std::uint32_t)index_is_dram,
         cb_index_id,
         cache_batch_num_tiles,
         Wt,
+        log2_page_size,
         index_stick_size,
         // page_table args
         (std::uint32_t)is_paged_cache,
@@ -239,28 +243,27 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
         (std::uint32_t)block_size,
         (std::uint32_t)block_size_t,
         (std::uint32_t)max_blocks_per_seq,
+        log2_page_table_stick_size,
         page_table_stick_size,
+        (std::uint32_t)page_table_is_dram,
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
     };
-    tt::tt_metal::TensorAccessorArgs(dst1_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(use_index_tensor ? update_idxs_tensor.value().buffer() : nullptr)
-        .append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(is_paged_cache ? page_table.value().buffer() : nullptr)
-        .append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t)dst_is_dram,
         (std::uint32_t)output_cb_index,
-        (std::uint32_t)0,
         (std::uint32_t)intermed0_cb_index,
         (std::uint32_t)intermed1_cb_index,
         (std::uint32_t)intermed2_cb_index,
+        // Index tensor args
         (std::uint32_t)use_index_tensor,
         cb_index_id,
         cache_batch_num_tiles,
         Wt,
         Wbytes,
+        // page_table args
         (std::uint32_t)is_paged_cache,
         (std::uint32_t)num_heads,
         (std::uint32_t)block_size,
@@ -270,7 +273,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
         St,
         in0_sequential_mode_semaphore_id,
     };
-    tt::tt_metal::TensorAccessorArgs(dst1_buffer).append_to(writer_compile_time_args);
 
     std::vector<uint32_t> compute_kernel_args = {
         src1_cb_index,

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
@@ -12,11 +12,12 @@ void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t stick_size = get_compile_time_arg_val(1);
-    constexpr uint32_t W = get_compile_time_arg_val(2);
-    constexpr uint32_t H = get_compile_time_arg_val(3);
-    constexpr auto src_args = TensorAccessorArgs<4>();
-    const auto s0 = TensorAccessor(src_args, src_addr, stick_size);
+    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(1);
+    constexpr uint32_t stick_size = get_compile_time_arg_val(2);
+    constexpr uint32_t W = get_compile_time_arg_val(3);
+    constexpr uint32_t H = get_compile_time_arg_val(4);
+
+    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
 
     // Use cb as L1 scratch memory
     uint32_t cb_addr = get_write_ptr(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operation.hpp"
 
 namespace ttnn::operations::experimental::detail {
@@ -48,14 +47,15 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     auto src_buffer = input.buffer();
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     std::vector<uint32_t> reader_compile_time_args = {
         src0_cb_index,
+        src_is_dram,
         aligned_input_unit_size,
         W,
         H,
     };
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     std::map<std::string, std::string> kernel_defines;
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -15,9 +15,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
 
-    const auto s0 = TensorAccessor(src_args, src_addr, stick_size);
+    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
 
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -40,9 +40,9 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
 
-    const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
+    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = output_stick_size};
     const uint32_t noc_write_size = std::min(output_stick_size, input_stick_size);
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "slice_write_op.hpp"
 #include "tt-metalium/math.hpp"
@@ -422,8 +421,7 @@ static operation::ProgramWithCallbacks slice_write_rm_sharded_input_multi_core(
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args_vec);
+    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
 
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -737,8 +735,7 @@ static operation::ProgramWithCallbacks slice_write_tiled_sharded_input_multi_cor
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args_vec);
+    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
     std::map<std::string, std::string> writer_defines;
     if (num_tiles_channel_per_core * TILE_WIDTH * num_cores_channels > output_shape[-1]) {
         writer_defines["UNPAD_INPUT_WIDTH"] = "1";
@@ -867,10 +864,8 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
             .set_page_size(src0_cb_index, cb_page_size);
     tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
-    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index};
-    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args_vec);
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args_vec);
+    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_cb_index, src0_is_dram};
+    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
 
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
@@ -6,7 +6,6 @@
 
 #include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::ssm::detail {
 
@@ -21,9 +20,11 @@ operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto* input_buffer = a.buffer();
+    const bool input_is_dram = input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     tt::tt_metal::Buffer* out_buffer = output.buffer();
     TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    const bool output_is_dram = out_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     const auto& ashape = a.padded_shape();
     auto num_output_blocks_total = a.padded_shape()[-1] / (TILE_WIDTH * TILE_WIDTH);
@@ -80,14 +81,13 @@ operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(
 
     const bfloat16 bfloat_scaler_value = bfloat16(1.0f);
     const uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
-    tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> reader_compile_time_args = {input_is_dram, packed_scaler_value};
     std::vector<uint32_t> writer_compile_time_args = {
         intermed_cb_id1,
         intermed_cb_id2,
         output_cb_id,
+        output_is_dram,
     };
-    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_compile_time_args = {
         input_cb_id,
         scalar_cb_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
@@ -13,7 +13,8 @@ void kernel_main() {
     uint32_t input_num_blocks_h = get_arg_val<uint32_t>(3);
     uint32_t input_total_blocks_w = get_arg_val<uint32_t>(4);
 
-    constexpr uint32_t scaler = get_compile_time_arg_val(0);
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t scaler = get_compile_time_arg_val(1);
 
     constexpr uint32_t cb_id_in2 = 2;
     generate_reduce_scaler(cb_id_in2, scaler);
@@ -23,8 +24,10 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
-    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
@@ -20,11 +20,14 @@ void kernel_main() {
     constexpr uint32_t intermed_cb_id1 = get_compile_time_arg_val(0);
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(2);
+    constexpr bool output_is_dram = get_compile_time_arg_val(3) == 1;
 
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(output_cb_id);
-    constexpr auto dst_args = TensorAccessorArgs<3>();
-    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(output_cb_id);
+
+    const InterleavedAddrGenFast<output_is_dram> s = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
 
     const uint32_t end_id = start_id + num_output_blocks_w_per_core;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -5,7 +5,6 @@
 #include "prefix_scan_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::tt_metal;
 
@@ -99,10 +98,6 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
 
     std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id, cb_h_in_id};
     std::vector<uint32_t> writer_compile_time_args = {cb_out_id, cb_h_acc_id, cb_h_in_id};
-    tt::tt_metal::TensorAccessorArgs(a_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(bx_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(h_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_compile_time_args = {
         cb_a_in_id,
         cb_bx_in_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
@@ -18,16 +18,20 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_in1_transposed = get_compile_time_arg_val(2);
     constexpr uint32_t cb_in1_bcast_row = get_compile_time_arg_val(3);
+    constexpr bool src0_is_dram = get_compile_time_arg_val(4) == 1;
+    constexpr bool src1_is_dram = get_compile_time_arg_val(5) == 1;
 
     uint32_t l1_write_addr_in0;
     uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
-    constexpr auto src0_args = TensorAccessorArgs<4>();
-    const auto s0 = TensorAccessor(src0_args, src0_addr, src0_tile_bytes);
+    DataFormat src0_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<src0_is_dram> s0 = {
+        .bank_base_address = src0_addr, .page_size = src0_tile_bytes, .data_format = src0_data_format};
 
     uint32_t l1_write_addr_in1;
     uint32_t src1_tile_bytes = get_tile_size(cb_id_in1);
-    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
-    const auto s1 = TensorAccessor(src1_args, src1_addr, src1_tile_bytes);
+    DataFormat src1_data_format = get_dataformat(cb_id_in1);
+    const InterleavedAddrGenFast<src1_is_dram> s1 = {
+        .bank_base_address = src1_addr, .page_size = src1_tile_bytes, .data_format = src1_data_format};
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_face = 16;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
@@ -12,12 +12,15 @@ void kernel_main() {
     uint32_t out_total_blocks_w = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
-    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
 
     for (uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++) {
         uint32_t end_id = start_id + out_num_blocks_w_per_core;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -8,7 +8,6 @@
 
 #include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::ssm::detail {
 
@@ -107,18 +106,21 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed3_config);
 
     // Compile time args
+    bool in0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool in1_is_dram = src1_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool out_is_dram = out_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)cb_intermed1_index,
         (std::uint32_t)cb_intermed2_index,
+        (std::uint32_t)in0_is_dram,
+        (std::uint32_t)in1_is_dram,
     };
-    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(src1_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)output_cb_index,
+        (std::uint32_t)out_is_dram,
     };
-    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_args = {
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp
@@ -13,27 +13,31 @@ void kernel_main() {
     auto args = make_runtime_struct_from_args<ElemwiseReaderKernelArgs>();
     constexpr auto c_args = make_compile_time_struct_from_args<CompileTimeReaderKernelArgs>();
 
-    constexpr auto condition_args = TensorAccessorArgs<3>();
-    constexpr auto true_args = TensorAccessorArgs<condition_args.next_compile_time_args_offset()>();
-    constexpr auto false_args = TensorAccessorArgs<true_args.next_compile_time_args_offset()>();
+    const InterleavedAddrGenFast<c_args.is_cond_tensor_in_dram> condition_tensor_addr_gen = {
+        .bank_base_address = args.condition_tensor_base_addr,
+        .page_size = get_tile_size(c_args.condition_cb),
+        .data_format = get_dataformat(c_args.condition_cb)};
 
-    const auto condition_tensor =
-        TensorAccessor(condition_args, args.condition_tensor_base_addr, get_tile_size(c_args.condition_cb));
-    const auto true_tensor =
-        TensorAccessor(true_args, args.true_tensor_base_addr, get_tile_size(c_args.true_tensor_cb));
-    const auto false_tensor =
-        TensorAccessor(false_args, args.false_tensor_base_addr, get_tile_size(c_args.false_tensor_cb));
+    const InterleavedAddrGenFast<c_args.is_true_tensor_in_dram> true_tensor_addr_gen = {
+        .bank_base_address = args.true_tensor_base_addr,
+        .page_size = get_tile_size(c_args.true_tensor_cb),
+        .data_format = get_dataformat(c_args.true_tensor_cb)};
+
+    const InterleavedAddrGenFast<c_args.is_false_tensor_in_dram> false_tensor_addr_gen = {
+        .bank_base_address = args.false_tensor_base_addr,
+        .page_size = get_tile_size(c_args.false_tensor_cb),
+        .data_format = get_dataformat(c_args.false_tensor_cb)};
 
     constexpr uint32_t tile_cnt = 1;
     for (uint32_t tile_id = args.tile_ofs; tile_id < args.tile_ofs + args.num_tiles; tile_id++) {
         cb_reserve_back(c_args.condition_cb, tile_cnt);
-        noc_async_read_tile(tile_id, condition_tensor, get_write_ptr(c_args.condition_cb));
+        noc_async_read_tile(tile_id, condition_tensor_addr_gen, get_write_ptr(c_args.condition_cb));
 
         cb_reserve_back(c_args.true_tensor_cb, tile_cnt);
-        noc_async_read_tile(tile_id, true_tensor, get_write_ptr(c_args.true_tensor_cb));
+        noc_async_read_tile(tile_id, true_tensor_addr_gen, get_write_ptr(c_args.true_tensor_cb));
 
         cb_reserve_back(c_args.false_tensor_cb, tile_cnt);
-        noc_async_read_tile(tile_id, false_tensor, get_write_ptr(c_args.false_tensor_cb));
+        noc_async_read_tile(tile_id, false_tensor_addr_gen, get_write_ptr(c_args.false_tensor_cb));
 
         noc_async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel_args.hpp
@@ -21,6 +21,9 @@ struct CompileTimeReaderKernelArgs {
     uint32_t condition_cb;
     uint32_t true_tensor_cb;
     uint32_t false_tensor_cb;
+    bool is_cond_tensor_in_dram;
+    bool is_true_tensor_in_dram;
+    bool is_false_tensor_in_dram;
 };
 
 static_assert(ttnn::kernel_utils::SerializableKernelArgs<ElemwiseReaderKernelArgs>);

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel.cpp
@@ -12,15 +12,17 @@ void kernel_main() {
     auto args = make_runtime_struct_from_args<ElemwiseWriterKernelArgs>();
     constexpr auto c_args = make_compile_time_struct_from_args<CompileTimeWriterKernelArgs>();
 
-    constexpr auto dst_args = TensorAccessorArgs<1>();
-    const auto dst_tensor = TensorAccessor(dst_args, args.dst_base_addr, get_tile_size(c_args.cb_dst));
+    const InterleavedAddrGenFast<c_args.is_dst_dram> dst_tensor_addr_gen = {
+        .bank_base_address = args.dst_base_addr,
+        .page_size = get_tile_size(c_args.cb_dst),
+        .data_format = get_dataformat(c_args.cb_dst)};
 
     constexpr uint32_t onetile = 1;
     uint32_t end_id = args.tile_ofs + args.num_tiles;
     for (uint32_t i = args.tile_ofs; i < end_id; ++i) {
         cb_wait_front(c_args.cb_dst, onetile);
         uint32_t l1_read_addr = get_read_ptr(c_args.cb_dst);
-        noc_async_write_tile(i, dst_tensor, l1_read_addr);
+        noc_async_write_tile(i, dst_tensor_addr_gen, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(c_args.cb_dst, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel_args.hpp
@@ -17,6 +17,7 @@ struct ElemwiseWriterKernelArgs {
 
 struct CompileTimeWriterKernelArgs {
     uint32_t cb_dst;
+    bool is_dst_dram;
 };
 
 static_assert(ttnn::kernel_utils::SerializableKernelArgs<ElemwiseWriterKernelArgs>);

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/element_wise_multi_core_where_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/element_wise_multi_core_where_program.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
@@ -74,31 +73,31 @@ ElementWiseMultiCoreWhereProgram::cached_program_t ElementWiseMultiCoreWhereProg
     CBHandle cb_output = createCircularBuffer(output_cb_index, single_tile_size, num_output_tiles);
 
     CompileTimeReaderKernelArgs reader_compile_time_args = {
-        .condition_cb = condition_cb, .true_tensor_cb = true_values_cb, .false_tensor_cb = false_values_cb};
+        .condition_cb = condition_cb,
+        .true_tensor_cb = true_values_cb,
+        .false_tensor_cb = false_values_cb,
+        .is_cond_tensor_in_dram = args.condition_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
+        .is_true_tensor_in_dram = args.true_value_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
+        .is_false_tensor_in_dram = args.false_value_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM};
 
     /* Specify data movement kernels for reading/writing data to/from DRAM */
     std::map<std::string, std::string> reader_defines;
-    std::vector<uint32_t> reader_compile_time_vec = ttnn::kernel_utils::to_vector(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(args.condition_tensor.buffer()).append_to(reader_compile_time_vec);
-    tt::tt_metal::TensorAccessorArgs(args.true_value_tensor.buffer()).append_to(reader_compile_time_vec);
-    tt::tt_metal::TensorAccessorArgs(args.false_value_tensor.buffer()).append_to(reader_compile_time_vec);
     KernelHandle reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp",
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_vec, reader_defines));
+        tt_metal::ReaderDataMovementConfig(ttnn::kernel_utils::to_vector(reader_compile_time_args), reader_defines));
 
     tt_metal::Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-    CompileTimeWriterKernelArgs writer_compile_time_args = {.cb_dst = output_cb_index};
+    CompileTimeWriterKernelArgs writer_compile_time_args = {
+        .cb_dst = output_cb_index, .is_dst_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM};
     std::map<std::string, std::string> writer_defines;
-    std::vector<uint32_t> writer_compile_time_vec = ttnn::kernel_utils::to_vector(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_vec);
     KernelHandle writer_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel.cpp",
         all_device_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_vec, writer_defines));
+        tt_metal::WriterDataMovementConfig(ttnn::kernel_utils::to_vector(writer_compile_time_args), writer_defines));
 
     /* Use the add_tiles operation in the compute kernel */
     KernelHandle compute_kernel_id = CreateKernel(


### PR DESCRIPTION
This reverts commit f91811c228f030895cfd124a1c36cb27f5971e72.

### Problem description
Both [TG apc](https://github.com/tenstorrent/tt-metal/actions/runs/17123888843) and [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/17112547843) are failing after this commit

Revert [TG apc](https://github.com/tenstorrent/tt-metal/actions/runs/17124555590)
Revert [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/17123616793)