### PR TITLE
#27233: SDXL wrapper class

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -7,27 +7,15 @@ import pytest
 import torch
 from diffusers import DiffusionPipeline
 from loguru import logger
-from conftest import is_galaxy
-import ttnn
-from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
-from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
-from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from transformers import CLIPTextModelWithProjection, CLIPTextModel
 from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
-    batch_encode_prompt_on_device,
-    create_tt_clip_text_encoders,
-    retrieve_timesteps,
-    run_tt_image_gen,
-    prepare_input_tensors,
-    allocate_input_tensors,
-    create_user_tensors,
-    warmup_tt_text_encoders,
 )
 import os
 from models.utility_functions import profiler
+
+from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
 
 
 @torch.no_grad()
@@ -71,135 +59,37 @@ def run_demo_inference(
         pipeline.text_encoder_2, CLIPTextModelWithProjection
     ), "pipeline.text_encoder_2 is not a CLIPTextModelWithProjection"
 
-    # Have to throttle matmuls due to di/dt
-    if is_galaxy():
-        logger.info("Setting TT_MM_THROTTLE_PERF for Galaxy")
-        os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    profiler.start("load_tt_componenets")
-    with ttnn.distribute(ttnn.ReplicateTensorToMesh(ttnn_device)):
-        # 2. Load tt_unet, tt_vae and tt_scheduler
-        tt_model_config = ModelOptimisations()
-        tt_unet = TtUNet2DConditionModel(
-            ttnn_device,
-            pipeline.unet.state_dict(),
-            "unet",
-            model_config=tt_model_config,
-        )
-        tt_vae = (
-            TtAutoencoderKL(ttnn_device, pipeline.vae.state_dict(), tt_model_config, batch_size)
-            if vae_on_device
-            else None
-        )
-        tt_scheduler = TtEulerDiscreteScheduler(
-            ttnn_device,
-            pipeline.scheduler.config.num_train_timesteps,
-            pipeline.scheduler.config.beta_start,
-            pipeline.scheduler.config.beta_end,
-            pipeline.scheduler.config.beta_schedule,
-            pipeline.scheduler.config.trained_betas,
-            pipeline.scheduler.config.prediction_type,
-            pipeline.scheduler.config.interpolation_type,
-            pipeline.scheduler.config.use_karras_sigmas,
-            pipeline.scheduler.config.use_exponential_sigmas,
-            pipeline.scheduler.config.use_beta_sigmas,
-            pipeline.scheduler.config.sigma_min,
-            pipeline.scheduler.config.sigma_max,
-            pipeline.scheduler.config.timestep_spacing,
-            pipeline.scheduler.config.timestep_type,
-            pipeline.scheduler.config.steps_offset,
-            pipeline.scheduler.config.rescale_betas_zero_snr,
-            pipeline.scheduler.config.final_sigmas_type,
-        )
-    pipeline.scheduler = tt_scheduler
-    ttnn.synchronize_device(ttnn_device)
-    profiler.end("load_tt_componenets")
+    tt_sdxl = TtSDXLPipeline(
+        ttnn_device=ttnn_device,
+        torch_pipeline=pipeline,
+        pipeline_config=TtSDXLPipelineConfig(
+            capture_trace=capture_trace,
+            vae_on_device=vae_on_device,
+            encoders_on_device=encoders_on_device,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+        ),
+    )
 
     cpu_device = "cpu"
 
     if encoders_on_device:
-        logger.info("Encoding prompts on device...")
-        # TT text encoder setup
-        tt_text_encoder, tt_text_encoder_2 = create_tt_clip_text_encoders(pipeline, ttnn_device)
-
-        # program cache for text encoders
-        warmup_tt_text_encoders(
-            tt_text_encoder, tt_text_encoder_2, pipeline.tokenizer, pipeline.tokenizer_2, ttnn_device, batch_size
+        tt_sdxl.compile_text_encoding(
+            prompts,
+            batch_size,
+            cpu_device,
         )
+    all_embeds = tt_sdxl.encode_prompt(prompts)
 
-        all_embeds = []
-        profiler.start("encode_prompts")
-        for i in range(0, len(prompts), batch_size):
-            batch_prompts = prompts[i : i + batch_size]
-            batch_embeds = batch_encode_prompt_on_device(
-                pipeline,
-                tt_text_encoder,
-                tt_text_encoder_2,
-                ttnn_device,
-                prompt=batch_prompts,  # Pass the entire batch
-                prompt_2=None,
-                device=cpu_device,
-                num_images_per_prompt=1,
-                do_classifier_free_guidance=True,
-                negative_prompt=None,
-                negative_prompt_2=None,
-                prompt_embeds=None,
-                negative_prompt_embeds=None,
-                pooled_prompt_embeds=None,
-                negative_pooled_prompt_embeds=None,
-                lora_scale=None,
-                clip_skip=None,
-            )
-            # batch_encode_prompt_on_device returns a single tuple of 4 tensors,
-            # but we need individual tuples for each prompt
-            prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = batch_embeds
-            # Split the tensors by batch dimension and create individual tuples
-            for j in range(len(batch_prompts)):
-                all_embeds.append(
-                    (
-                        prompt_embeds[j : j + 1],  # Keep batch dimension
-                        negative_prompt_embeds[j : j + 1] if negative_prompt_embeds is not None else None,
-                        pooled_prompt_embeds[j : j + 1],
-                        negative_pooled_prompt_embeds[j : j + 1] if negative_pooled_prompt_embeds is not None else None,
-                    )
-                )
-    else:
-        logger.info("Encoding prompts on host...")
-        # batched impl of host encoding
-        profiler.start("encode_prompts")
-        all_embeds = pipeline.encode_prompt(
-            prompt=prompts,  # Pass the entire list at once
-            prompt_2=None,
-            device=cpu_device,
-            num_images_per_prompt=1,
-            do_classifier_free_guidance=True,
-            negative_prompt=None,
-            negative_prompt_2=None,
-            prompt_embeds=None,
-            negative_prompt_embeds=None,
-            pooled_prompt_embeds=None,
-            negative_pooled_prompt_embeds=None,
-            lora_scale=None,
-            clip_skip=None,
-        )
-        (
-            prompt_embeds_batch,
-            negative_prompt_embeds_batch,
-            pooled_prompt_embeds_batch,
-            negative_pooled_prompt_embeds_batch,
-        ) = all_embeds
-        all_embeds = list(
-            zip(
-                torch.split(prompt_embeds_batch, 1, dim=0),
-                torch.split(negative_prompt_embeds_batch, 1, dim=0),
-                torch.split(pooled_prompt_embeds_batch, 1, dim=0),
-                torch.split(negative_pooled_prompt_embeds_batch, 1, dim=0),
-            )
-        )
+    items_per_core = len(all_embeds) // batch_size  # this will always be a multiple of batch_size because of padding
 
-    profiler.end("encode_prompts")
-
-    profiler.start("prepare_latents")
+    if batch_size > 1:  # If batch_size is 1, no need to reorder
+        reordered = []
+        for i in range(batch_size):
+            for j in range(items_per_core):
+                index = i + j * batch_size
+                reordered.append(all_embeds[index])
+        all_embeds = reordered
 
     prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = zip(*all_embeds)
 
@@ -210,142 +100,24 @@ def run_demo_inference(
         torch.cat(negative_pooled_prompt_embeds, dim=0), batch_size, dim=0
     )
 
-    # Prepare timesteps
-    ttnn_timesteps, num_inference_steps = retrieve_timesteps(
-        pipeline.scheduler, num_inference_steps, cpu_device, None, None
+    tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
+        prompt_embeds,
+        prompt_embeds_torch,
+        negative_prompt_embeds_torch,
+        pooled_prompt_embeds,
+        pooled_prompt_embeds_torch,
+        negative_pooled_prompt_embeds_torch,
     )
 
-    num_channels_latents = pipeline.unet.config.in_channels
-    assert num_channels_latents == 4, f"num_channels_latents is {num_channels_latents}, but it should be 4"
-
-    latents = pipeline.prepare_latents(
-        1,
-        num_channels_latents,
-        height,
-        width,
-        prompt_embeds[0].dtype,
-        cpu_device,
-        None,
-        None,
-    )
-
-    extra_step_kwargs = pipeline.prepare_extra_step_kwargs(None, 0.0)
-    add_text_embeds = pooled_prompt_embeds
-    text_encoder_projection_dim = pipeline.text_encoder_2.config.projection_dim
-    assert (
-        text_encoder_projection_dim == 1280
-    ), f"text_encoder_projection_dim is {text_encoder_projection_dim}, but it should be 1280"
-
-    original_size = (height, width)
-    target_size = (height, width)
-    crops_coords_top_left = (0, 0)
-    add_time_ids = pipeline._get_add_time_ids(
-        original_size,
-        crops_coords_top_left,
-        target_size,
-        dtype=prompt_embeds[0].dtype,
-        text_encoder_projection_dim=text_encoder_projection_dim,
-    )
-    negative_add_time_ids = add_time_ids
-
-    scaling_factor = ttnn.from_torch(
-        torch.Tensor([pipeline.vae.config.scaling_factor]),
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
-    )
-
-    B, C, H, W = latents.shape
-
-    # All device code will work with channel last tensors
-    tt_latents = torch.permute(latents, (0, 2, 3, 1))
-    tt_latents = tt_latents.reshape(1, 1, B * H * W, C)
-    tt_latents, tt_prompt_embeds, tt_add_text_embeds = create_user_tensors(
-        ttnn_device=ttnn_device,
-        latents=tt_latents,
-        negative_prompt_embeds=negative_prompt_embeds_torch,
-        prompt_embeds=prompt_embeds_torch,
-        negative_pooled_prompt_embeds=negative_pooled_prompt_embeds_torch,
-        add_text_embeds=pooled_prompt_embeds_torch,
-    )
-
-    tt_latents_device, tt_prompt_embeds_device, tt_text_embeds_device, tt_time_ids_device = allocate_input_tensors(
-        ttnn_device=ttnn_device,
-        tt_latents=tt_latents,
-        tt_prompt_embeds=tt_prompt_embeds,
-        tt_text_embeds=tt_add_text_embeds,
-        tt_time_ids=[negative_add_time_ids, add_time_ids],
-    )
-    ttnn.synchronize_device(ttnn_device)
-    profiler.end("prepare_latents")
-
-    profiler.start("warmup_run")
-    logger.info("Performing warmup run on denoising, to make use of program caching in actual inference...")
-    prepare_input_tensors(
+    tt_sdxl.prepare_input_tensors(
         [
             tt_latents,
             *tt_prompt_embeds[0],
             tt_add_text_embeds[0][0],
             tt_add_text_embeds[0][1],
-        ],
-        [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
+        ]
     )
-    _, _, _, output_shape, _ = run_tt_image_gen(
-        ttnn_device,
-        tt_unet,
-        tt_scheduler,
-        tt_latents_device,
-        tt_prompt_embeds_device,
-        tt_time_ids_device,
-        tt_text_embeds_device,
-        [ttnn_timesteps[0]],
-        extra_step_kwargs,
-        guidance_scale,
-        scaling_factor,
-        [B, C, H, W],
-        tt_vae if vae_on_device else pipeline.vae,
-        batch_size,
-        capture_trace=False,
-    )
-    ttnn.synchronize_device(ttnn_device)
-    profiler.end("warmup_run")
-
-    tid = None
-    output_device = None
-    tid_vae = None
-    if capture_trace:
-        logger.info("Capturing model trace...")
-        profiler.start("capture_model_trace")
-        prepare_input_tensors(
-            [
-                tt_latents,
-                *tt_prompt_embeds[0],
-                tt_add_text_embeds[0][0],
-                tt_add_text_embeds[0][1],
-            ],
-            [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
-        )
-        _, tid, output_device, output_shape, tid_vae = run_tt_image_gen(
-            ttnn_device,
-            tt_unet,
-            tt_scheduler,
-            tt_latents_device,
-            tt_prompt_embeds_device,
-            tt_time_ids_device,
-            tt_text_embeds_device,
-            [ttnn_timesteps[0]],
-            extra_step_kwargs,
-            guidance_scale,
-            scaling_factor,
-            [B, C, H, W],
-            tt_vae if vae_on_device else pipeline.vae,
-            batch_size,
-            capture_trace=True,
-        )
-        ttnn.synchronize_device(ttnn_device)
-        profiler.end("capture_model_trace")
+    tt_sdxl.compile_image_processing()
 
     logger.info("=" * 80)
     for key, data in profiler.times.items():
@@ -363,35 +135,16 @@ def run_demo_inference(
         logger.info(
             f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
         )
-        prepare_input_tensors(
+
+        tt_sdxl.prepare_input_tensors(
             [
                 tt_latents,
                 *tt_prompt_embeds[iter],
                 tt_add_text_embeds[iter][0],
                 tt_add_text_embeds[iter][1],
-            ],
-            [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
+            ]
         )
-        imgs, tid, output_device, output_shape, tid_vae = run_tt_image_gen(
-            ttnn_device,
-            tt_unet,
-            tt_scheduler,
-            tt_latents_device,
-            tt_prompt_embeds_device,
-            tt_time_ids_device,
-            tt_text_embeds_device,
-            ttnn_timesteps,
-            extra_step_kwargs,
-            guidance_scale,
-            scaling_factor,
-            [B, C, H, W],
-            tt_vae if vae_on_device else pipeline.vae,
-            batch_size,
-            tid=tid,
-            output_device=output_device,
-            output_shape=output_shape,
-            tid_vae=tid_vae,
-        )
+        imgs = tt_sdxl.generate_images()
 
         logger.info(
             f"Prepare input tensors for {batch_size} prompts completed in {profiler.times['prepare_input_tensors'][-1]:.2f} seconds"
@@ -416,10 +169,7 @@ def run_demo_inference(
             else:
                 img.save(f"output/output{len(images) + start_from}.png")
                 logger.info(f"Image saved to output/output{len(images) + start_from}.png")
-    if capture_trace:
-        ttnn.release_trace(ttnn_device, tid)
-        if vae_on_device:
-            ttnn.release_trace(ttnn_device, tid_vae)
+
     return images
 
 

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -79,7 +79,7 @@ def run_demo_inference(
             batch_size,
             cpu_device,
         )
-    all_embeds = tt_sdxl.encode_prompt(prompts)
+    all_embeds = tt_sdxl.encode_prompts(prompts)
 
     items_per_core = len(all_embeds) // batch_size  # this will always be a multiple of batch_size because of padding
 

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -41,10 +41,6 @@ def run_demo_inference(
     needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
     prompts = prompts + [""] * needed_padding
 
-    # 0. Set up default height and width for unet
-    height = 1024
-    width = 1024
-
     # 1. Load components
     profiler.start("diffusion_pipeline_from_pretrained")
     pipeline = DiffusionPipeline.from_pretrained(
@@ -71,14 +67,8 @@ def run_demo_inference(
         ),
     )
 
-    cpu_device = "cpu"
-
     if encoders_on_device:
-        tt_sdxl.compile_text_encoding(
-            prompts,
-            batch_size,
-            cpu_device,
-        )
+        tt_sdxl.compile_text_encoding()
     (
         prompt_embeds_torch,
         negative_prompt_embeds_torch,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
@@ -100,22 +100,26 @@ class TtEulerDiscreteScheduler(nn.Module):
                     layout=ttnn.TILE_LAYOUT,
                 ),
             )
-        sigma_step = self.tt_sigmas[0]
-        self.tt_sigma_step = ttnn.allocate_tensor_on_device(
-            sigma_step.shape,
-            sigma_step.dtype,
-            sigma_step.layout,
-            self.device,
-            ttnn.DRAM_MEMORY_CONFIG,
-        )
-        sigma_next_step = self.tt_sigmas[1]
-        self.tt_sigma_next_step = ttnn.allocate_tensor_on_device(
-            sigma_next_step.shape,
-            sigma_next_step.dtype,
-            sigma_next_step.layout,
-            self.device,
-            ttnn.DRAM_MEMORY_CONFIG,
-        )
+        if not hasattr(self, "tt_sigma_step"):
+            sigma_step = self.tt_sigmas[0]
+
+            self.tt_sigma_step = ttnn.allocate_tensor_on_device(
+                sigma_step.shape,
+                sigma_step.dtype,
+                sigma_step.layout,
+                self.device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            )
+        if not hasattr(self, "tt_sigma_next_step"):
+            sigma_next_step = self.tt_sigmas[1]
+
+            self.tt_sigma_next_step = ttnn.allocate_tensor_on_device(
+                sigma_next_step.shape,
+                sigma_next_step.dtype,
+                sigma_next_step.layout,
+                self.device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            )
 
     def update_device_sigmas(self):
         ttnn.copy_host_to_device_tensor(self.tt_sigmas[self.step_index], self.tt_sigma_step)
@@ -131,14 +135,17 @@ class TtEulerDiscreteScheduler(nn.Module):
                     layout=ttnn.TILE_LAYOUT,
                 ),
             )
-        tt_timestep_step = self.timesteps[0]
-        self.tt_timestep = ttnn.allocate_tensor_on_device(
-            tt_timestep_step.shape,
-            tt_timestep_step.dtype,
-            tt_timestep_step.layout,
-            self.device,
-            ttnn.DRAM_MEMORY_CONFIG,
-        )
+
+        if not hasattr(self, "tt_timestep"):
+            tt_timestep_step = self.timesteps[0]
+
+            self.tt_timestep = ttnn.allocate_tensor_on_device(
+                tt_timestep_step.shape,
+                tt_timestep_step.dtype,
+                tt_timestep_step.layout,
+                self.device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            )
 
     def update_device_timestep(self):
         ttnn.copy_host_to_device_tensor(self.timesteps[self.step_index], self.tt_timestep)
@@ -153,14 +160,17 @@ class TtEulerDiscreteScheduler(nn.Module):
                     layout=ttnn.TILE_LAYOUT,
                 ),
             )
-        tt_val_step = self.variance_normalization_factor[0]
-        self.tt_norm_factor = ttnn.allocate_tensor_on_device(
-            tt_val_step.shape,
-            tt_val_step.dtype,
-            tt_val_step.layout,
-            self.device,
-            ttnn.DRAM_MEMORY_CONFIG,
-        )
+
+        if not hasattr(self, "tt_norm_factor"):
+            tt_val_step = self.variance_normalization_factor[0]
+
+            self.tt_norm_factor = ttnn.allocate_tensor_on_device(
+                tt_val_step.shape,
+                tt_val_step.dtype,
+                tt_val_step.layout,
+                self.device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            )
 
     def update_device_norm_factor(self):
         ttnn.copy_host_to_device_tensor(self.variance_normalization_factor[self.step_index], self.tt_norm_factor)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -4,7 +4,6 @@
 
 import os
 import torch
-import torch.nn as nn
 from dataclasses import dataclass
 
 from diffusers import StableDiffusionXLPipeline
@@ -12,6 +11,7 @@ from loguru import logger
 from conftest import is_galaxy
 import ttnn
 
+from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
@@ -36,7 +36,7 @@ class TtSDXLPipelineConfig:
     encoders_on_device: bool = True
 
 
-class TtSDXLPipeline(nn.Module):
+class TtSDXLPipeline(LightweightModule):
     # TtSDXLPipeline is a wrapper class for the Stable Diffusion XL pipeline.
     # Class contains encoder, scheduler, unet and vae decoder modules.
     # Additionally, methods for text encoding, image generation, and input preparation are provided.
@@ -620,6 +620,9 @@ class TtSDXLPipeline(nn.Module):
         if self.pipeline_config.vae_on_device and hasattr(self, "tid_vae") and self.tid_vae is not None:
             ttnn.release_trace(self.ttnn_device, self.tid_vae)
             delattr(self, "tid_vae")
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError("Use individual methods for text encoding and image generation.")
 
     def __del__(self):
         self.__release_trace()

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -1,0 +1,590 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import torch
+import torch.nn as nn
+from dataclasses import dataclass
+
+from diffusers import StableDiffusionXLPipeline
+from loguru import logger
+from conftest import is_galaxy
+import ttnn
+
+from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
+from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from transformers import CLIPTextModelWithProjection, CLIPTextModel
+from models.experimental.stable_diffusion_xl_base.tests.test_common import (
+    create_tt_clip_text_encoders,
+    warmup_tt_text_encoders,
+    batch_encode_prompt_on_device,
+    retrieve_timesteps,
+    run_tt_image_gen,
+)
+from models.utility_functions import profiler
+
+
+@dataclass
+class TtSDXLPipelineConfig:
+    capture_trace: bool
+    vae_on_device: bool
+    encoders_on_device: bool
+    num_inference_steps: int
+    guidance_scale: float
+
+
+class TtSDXLPipeline(nn.Module):
+    # TtSDXLPipeline is a wrapper class for the Stable Diffusion XL pipeline.
+    # Class contains encoder, scheduler, unet and vae decoder modules.
+    # Additionally, methods for text encoding, image generation, and input preparation are provided.
+    # Compile and trace methods are also included for model optimization.
+    # The class will fallback on the CPU implementetion for the non critical components.
+
+    def __init__(self, ttnn_device, torch_pipeline, pipeline_config: TtSDXLPipelineConfig):
+        super().__init__()
+
+        assert isinstance(
+            torch_pipeline, StableDiffusionXLPipeline
+        ), "torch_pipeline must be an instance of StableDiffusionXLPipeline"
+        assert isinstance(torch_pipeline.text_encoder, CLIPTextModel), "pipeline.text_encoder is not a CLIPTextModel"
+        assert isinstance(
+            torch_pipeline.text_encoder_2, CLIPTextModelWithProjection
+        ), "pipeline.text_encoder_2 is not a CLIPTextModelWithProjection"
+
+        self.ttnn_device = ttnn_device
+        self.cpu_device = "cpu"
+        self.batch_size = ttnn_device.get_num_devices()
+        self.torch_pipeline = torch_pipeline
+        self.pipeline_config = pipeline_config
+
+        self.encoders_compiled = False
+        self.image_processing_compiled = False
+
+        if is_galaxy():
+            logger.info("Setting TT_MM_THROTTLE_PERF for Galaxy")
+            os.environ["TT_MM_THROTTLE_PERF"] = "5"
+
+        logger.info("Loading TT components...")
+        self.__load_tt_components(pipeline_config)
+        logger.info("TT components loaded")
+
+        self.scaling_factor = ttnn.from_torch(
+            torch.Tensor([self.torch_pipeline.vae.config.scaling_factor]),
+            dtype=ttnn.bfloat16,
+            device=self.ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
+        )
+
+        self.guidance_scale = ttnn.from_torch(
+            torch.Tensor([self.pipeline_config.guidance_scale]),
+            dtype=ttnn.bfloat16,
+            device=self.ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
+        )
+
+        # Hardcoded input tensor parameters
+
+        # Tensor shapes
+        B, C, H, W = 1, 4, 128, 128
+        self.tt_latents_shape = (1, 1, B * H * W, C)
+        self.tt_prompt_embeds_shape = (1, 77, 2048)
+        self.tt_text_embeds_shape = (1, 1280)
+        self.tt_time_ids_shape = (1, 6)
+
+        # Tensor dtypes
+        self.tt_latents_dtype = ttnn.bfloat16
+        self.tt_prompt_embeds_dtype = ttnn.bfloat16
+        self.tt_text_embeds_dtype = ttnn.bfloat16
+        self.tt_time_ids_dtype = ttnn.bfloat16
+
+        # Tensor layouts
+        self.tt_latents_layout = ttnn.TILE_LAYOUT
+        self.tt_prompt_embeds_layout = ttnn.TILE_LAYOUT
+        self.tt_text_embeds_layout = ttnn.ROW_MAJOR_LAYOUT
+        self.tt_time_ids_layout = ttnn.TILE_LAYOUT
+
+    def set_guidance_scale(self, guidance_scale: float):
+        self.pipeline_config.guidance_scale = guidance_scale
+        host_guidance_scale = ttnn.from_torch(
+            torch.Tensor([self.pipeline_config.guidance_scale]),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
+        )
+        ttnn.copy_host_to_device_tensor(host_guidance_scale, self.guidance_scale)
+
+    def compile_text_encoding(self):
+        # Compilation of text encoders on the device.
+
+        assert self.pipeline_config.encoders_on_device, "Host text encoders are used; compile is not needed"
+        assert self.tt_text_encoder is not None, "Text encoder is not loaded on the device"
+
+        warmup_tt_text_encoders(
+            self.tt_text_encoder,
+            self.tt_text_encoder_2,
+            self.torch_pipeline.tokenizer,
+            self.torch_pipeline.tokenizer_2,
+            self.ttnn_device,
+            self.batch_size,
+        )
+
+    def compile_image_processing(self):
+        # Compile/trace run for denoising loop and vae decoder.
+
+        profiler.start("warmup_run")
+        logger.info("Performing warmup run on denoising, to make use of program caching in actual inference...")
+
+        _, _, _, self.output_shape, _ = run_tt_image_gen(
+            self.ttnn_device,
+            self.tt_unet,
+            self.tt_scheduler,
+            self.tt_latents_device,
+            self.tt_prompt_embeds_device,
+            self.tt_time_ids_device,
+            self.tt_text_embeds_device,
+            [self.ttnn_timesteps[0]],
+            self.extra_step_kwargs,
+            self.guidance_scale,
+            self.scaling_factor,
+            [1, 4, 128, 128],
+            self.tt_vae if self.pipeline_config.vae_on_device else self.torch_pipeline.vae,
+            self.batch_size,
+            capture_trace=False,
+        )
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("warmup_run")
+
+        if self.pipeline_config.capture_trace:
+            self.__trace_image_processing()
+
+    def encode_prompt(self, prompts):
+        # Encode prompts using the text encoders.
+
+        if self.pipeline_config.encoders_on_device:
+            # Prompt encode on device
+            assert self.encoders_compiled, "Text encoders are not compiled"
+            logger.info("Encoding prompts on device...")
+            profiler.start("encode_prompts")
+
+            all_embeds = []
+            for i in range(0, len(prompts), self.batch_size):
+                batch_prompts = prompts[i : i + self.batch_size]
+                batch_embeds = batch_encode_prompt_on_device(
+                    self.torch_pipeline,
+                    self.tt_text_encoder,
+                    self.tt_text_encoder_2,
+                    self.ttnn_device,
+                    prompt=batch_prompts,  # Pass the entire batch
+                    prompt_2=None,
+                    device=self.cpu_device,
+                    num_images_per_prompt=1,
+                    do_classifier_free_guidance=True,
+                    negative_prompt=None,
+                    negative_prompt_2=None,
+                    prompt_embeds=None,
+                    negative_prompt_embeds=None,
+                    pooled_prompt_embeds=None,
+                    negative_pooled_prompt_embeds=None,
+                    lora_scale=None,
+                    clip_skip=None,
+                )
+                # batch_encode_prompt_on_device returns a single tuple of 4 tensors,
+                # but we need individual tuples for each prompt
+                (
+                    prompt_embeds,
+                    negative_prompt_embeds,
+                    pooled_prompt_embeds,
+                    negative_pooled_prompt_embeds,
+                ) = batch_embeds
+                # Split the tensors by batch dimension and create individual tuples
+                for j in range(len(batch_prompts)):
+                    all_embeds.append(
+                        (
+                            prompt_embeds[j : j + 1],  # Keep batch dimension
+                            negative_prompt_embeds[j : j + 1] if negative_prompt_embeds is not None else None,
+                            pooled_prompt_embeds[j : j + 1],
+                            negative_pooled_prompt_embeds[j : j + 1]
+                            if negative_pooled_prompt_embeds is not None
+                            else None,
+                        )
+                    )
+        else:
+            # Prompt encode on host
+            logger.info("Encoding prompts on host...")
+
+            # batched impl of host encoding
+            profiler.start("encode_prompts")
+            all_embeds = self.torch_pipeline.encode_prompt(
+                prompt=prompts,  # Pass the entire list at once
+                prompt_2=None,
+                device=self.cpu_device,
+                num_images_per_prompt=1,
+                do_classifier_free_guidance=True,
+                negative_prompt=None,
+                negative_prompt_2=None,
+                prompt_embeds=None,
+                negative_prompt_embeds=None,
+                pooled_prompt_embeds=None,
+                negative_pooled_prompt_embeds=None,
+                lora_scale=None,
+                clip_skip=None,
+            )
+            (
+                prompt_embeds_batch,
+                negative_prompt_embeds_batch,
+                pooled_prompt_embeds_batch,
+                negative_pooled_prompt_embeds_batch,
+            ) = all_embeds
+            all_embeds = list(
+                zip(
+                    torch.split(prompt_embeds_batch, 1, dim=0),
+                    torch.split(negative_prompt_embeds_batch, 1, dim=0),
+                    torch.split(pooled_prompt_embeds_batch, 1, dim=0),
+                    torch.split(negative_pooled_prompt_embeds_batch, 1, dim=0),
+                )
+            )
+
+        profiler.end("encode_prompts")
+        logger.info(f"Encoded prompts")
+        return all_embeds
+
+    def generate_input_tensors(
+        self,
+        prompt_embeds,
+        prompt_embeds_torch,
+        negative_prompt_embeds_torch,
+        pooled_prompt_embeds,
+        pooled_prompt_embeds_torch,
+        negative_pooled_prompt_embeds_torch,
+    ):
+        # Generate user input tensors for the TT model.
+
+        logger.info("Generating input tensors...")
+        profiler.start("prepare_latents")
+        self.__prepare_timesteps()
+
+        num_channels_latents = self.torch_pipeline.unet.config.in_channels
+        height = width = 1024
+        assert num_channels_latents == 4, f"num_channels_latents is {num_channels_latents}, but it should be 4"
+
+        latents = self.torch_pipeline.prepare_latents(
+            1,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds[0].dtype,
+            self.cpu_device,
+            None,
+            None,
+        )
+
+        self.extra_step_kwargs = self.torch_pipeline.prepare_extra_step_kwargs(None, 0.0)
+        add_text_embeds = pooled_prompt_embeds
+        text_encoder_projection_dim = self.torch_pipeline.text_encoder_2.config.projection_dim
+        assert (
+            text_encoder_projection_dim == 1280
+        ), f"text_encoder_projection_dim is {text_encoder_projection_dim}, but it should be 1280"
+
+        original_size = (height, width)
+        target_size = (height, width)
+        crops_coords_top_left = (0, 0)
+        add_time_ids = self.torch_pipeline._get_add_time_ids(
+            original_size,
+            crops_coords_top_left,
+            target_size,
+            dtype=prompt_embeds[0].dtype,
+            text_encoder_projection_dim=text_encoder_projection_dim,
+        )
+        negative_add_time_ids = add_time_ids
+
+        B, C, H, W = latents.shape
+
+        # All device code will work with channel last tensors
+        tt_latents = torch.permute(latents, (0, 2, 3, 1))
+        tt_latents = tt_latents.reshape(1, 1, B * H * W, C)
+        tt_latents, tt_prompt_embeds, tt_add_text_embeds = self.__create_user_tensors(
+            latents=tt_latents,
+            negative_prompt_embeds=negative_prompt_embeds_torch,
+            prompt_embeds=prompt_embeds_torch,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds_torch,
+            add_text_embeds=pooled_prompt_embeds_torch,
+        )
+
+        self.__allocate_input_tensors(
+            tt_latents=tt_latents,
+            tt_prompt_embeds=tt_prompt_embeds,
+            tt_text_embeds=tt_add_text_embeds,
+            tt_time_ids=[negative_add_time_ids, add_time_ids],
+        )
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("prepare_latents")
+        logger.info("Input tensors generated")
+        return tt_latents, tt_prompt_embeds, tt_add_text_embeds
+
+    def prepare_input_tensors(self, host_tensors):
+        # Tensor device transfer for the current users.
+
+        logger.info("Preparing input tensors for TT model...")
+        profiler.start("prepare_input_tensors")
+        device_tensors = [self.tt_latents_device, *self.tt_prompt_embeds_device, *self.tt_text_embeds_device]
+
+        for host_tensor, device_tensor in zip(host_tensors, device_tensors):
+            ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
+
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("prepare_input_tensors")
+
+    def generate_images(self):
+        # SDXL inference run.
+
+        logger.info("Generating images...")
+        imgs, self.tid, self.output_device, self.output_shape, self.tid_vae = run_tt_image_gen(
+            self.ttnn_device,
+            self.tt_unet,
+            self.tt_scheduler,
+            self.tt_latents_device,
+            self.tt_prompt_embeds_device,
+            self.tt_time_ids_device,
+            self.tt_text_embeds_device,
+            self.ttnn_timesteps,
+            self.extra_step_kwargs,
+            self.guidance_scale,
+            self.scaling_factor,
+            [1, 4, 128, 128],
+            self.tt_vae if self.pipeline_config.vae_on_device else self.torch_pipeline.vae,
+            self.batch_size,
+            tid=self.tid,
+            output_device=self.output_device,
+            output_shape=self.output_shape,
+            tid_vae=self.tid_vae,
+        )
+        return imgs
+
+    def __load_tt_components(self, pipeline_config):
+        # Method for instantiating TT components based on the torch pipeline.
+        # Included components are TtUNet2DConditionModel, TtAutoencoderKL, and TtEulerDiscreteScheduler.
+        # TODO: move encoder here
+
+        profiler.start("load_tt_componenets")
+        with ttnn.distribute(ttnn.ReplicateTensorToMesh(self.ttnn_device)):
+            # 2. Load tt_unet, tt_vae and tt_scheduler
+            self.tt_model_config = ModelOptimisations()
+            self.tt_unet = TtUNet2DConditionModel(
+                self.ttnn_device,
+                self.torch_pipeline.unet.state_dict(),
+                "unet",
+                model_config=self.tt_model_config,
+            )
+            self.tt_vae = (
+                TtAutoencoderKL(self.ttnn_device, self.torch_pipeline.vae.state_dict(), self.tt_model_config)
+                if pipeline_config.vae_on_device
+                else None
+            )
+            self.tt_scheduler = TtEulerDiscreteScheduler(
+                self.ttnn_device,
+                self.torch_pipeline.scheduler.config.num_train_timesteps,
+                self.torch_pipeline.scheduler.config.beta_start,
+                self.torch_pipeline.scheduler.config.beta_end,
+                self.torch_pipeline.scheduler.config.beta_schedule,
+                self.torch_pipeline.scheduler.config.trained_betas,
+                self.torch_pipeline.scheduler.config.prediction_type,
+                self.torch_pipeline.scheduler.config.interpolation_type,
+                self.torch_pipeline.scheduler.config.use_karras_sigmas,
+                self.torch_pipeline.scheduler.config.use_exponential_sigmas,
+                self.torch_pipeline.scheduler.config.use_beta_sigmas,
+                self.torch_pipeline.scheduler.config.sigma_min,
+                self.torch_pipeline.scheduler.config.sigma_max,
+                self.torch_pipeline.scheduler.config.timestep_spacing,
+                self.torch_pipeline.scheduler.config.timestep_type,
+                self.torch_pipeline.scheduler.config.steps_offset,
+                self.torch_pipeline.scheduler.config.rescale_betas_zero_snr,
+                self.torch_pipeline.scheduler.config.final_sigmas_type,
+            )
+        self.torch_pipeline.scheduler = self.tt_scheduler
+
+        if pipeline_config.encoders_on_device:
+            self.tt_text_encoder, self.tt_text_encoder_2 = create_tt_clip_text_encoders(
+                self.torch_pipeline, self.ttnn_device
+            )
+        else:
+            self.tt_text_encoder, self.tt_text_encoder_2 = None, None
+
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("load_tt_componenets")
+
+    def __allocate_input_tensors(self, tt_latents, tt_prompt_embeds, tt_text_embeds, tt_time_ids):
+        # Allocation of device tensors for the input data.
+
+        profiler.start("allocate_input_tensors")
+
+        is_mesh_device = isinstance(self.ttnn_device, ttnn._ttnn.multi_device.MeshDevice)
+        self.tt_latents_device = ttnn.allocate_tensor_on_device(
+            tt_latents.shape,
+            tt_latents.dtype,
+            tt_latents.layout,
+            self.ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        self.tt_prompt_embeds_device = [
+            ttnn.allocate_tensor_on_device(
+                tt_prompt_embeds[0][0].shape,
+                tt_prompt_embeds[0][0].dtype,
+                tt_prompt_embeds[0][0].layout,
+                self.ttnn_device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            ),
+            ttnn.allocate_tensor_on_device(
+                tt_prompt_embeds[0][1].shape,
+                tt_prompt_embeds[0][1].dtype,
+                tt_prompt_embeds[0][1].layout,
+                self.ttnn_device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        ]
+
+        self.tt_text_embeds_device = [
+            ttnn.allocate_tensor_on_device(
+                tt_text_embeds[0][0].shape,
+                tt_text_embeds[0][0].dtype,
+                tt_text_embeds[0][0].layout,
+                self.ttnn_device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            ),
+            ttnn.allocate_tensor_on_device(
+                tt_text_embeds[0][1].shape,
+                tt_text_embeds[0][1].dtype,
+                tt_text_embeds[0][1].layout,
+                self.ttnn_device,
+                ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        ]
+
+        self.tt_time_ids_device = [
+            ttnn.from_torch(
+                tt_time_ids[0].squeeze(0),
+                dtype=ttnn.bfloat16,
+                device=self.ttnn_device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device) if is_mesh_device else None,
+            ),
+            ttnn.from_torch(
+                tt_time_ids[1].squeeze(0),
+                dtype=ttnn.bfloat16,
+                device=self.ttnn_device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device) if is_mesh_device else None,
+            ),
+        ]
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("prepare_input_tensors")
+
+    def __create_user_tensors(
+        self, latents, negative_prompt_embeds, prompt_embeds, negative_pooled_prompt_embeds, add_text_embeds
+    ):
+        # Instantiation of user host input tensors for the TT model.
+
+        profiler.start("create_user_tensors")
+        is_mesh_device = isinstance(self.ttnn_device, ttnn._ttnn.multi_device.MeshDevice)
+        tt_latents = ttnn.from_torch(
+            latents,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device) if is_mesh_device else None,
+        )
+
+        tt_prompt_embeds = [
+            [
+                ttnn.from_torch(
+                    negative_prompt_embed,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                    mesh_mapper=ttnn.ShardTensorToMesh(self.ttnn_device, dim=0) if is_mesh_device else None,
+                ),
+                ttnn.from_torch(
+                    prompt_embed,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                    mesh_mapper=ttnn.ShardTensorToMesh(self.ttnn_device, dim=0) if is_mesh_device else None,
+                ),
+            ]
+            for negative_prompt_embed, prompt_embed in zip(negative_prompt_embeds, prompt_embeds)
+        ]
+
+        tt_add_text_embeds = [
+            [
+                ttnn.from_torch(
+                    negative_pooled_prompt_embed,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=ttnn.ShardTensorToMesh(self.ttnn_device, dim=0) if is_mesh_device else None,
+                ),
+                ttnn.from_torch(
+                    add_text_embed,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=ttnn.ShardTensorToMesh(self.ttnn_device, dim=0) if is_mesh_device else None,
+                ),
+            ]
+            for negative_pooled_prompt_embed, add_text_embed in zip(negative_pooled_prompt_embeds, add_text_embeds)
+        ]
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("create_user_tensors")
+        return tt_latents, tt_prompt_embeds, tt_add_text_embeds
+
+    def __prepare_timesteps(self):
+        # Helper method for timestep preparation.
+
+        self.ttnn_timesteps, self.pipeline_config.num_inference_steps = retrieve_timesteps(
+            self.torch_pipeline.scheduler, self.pipeline_config.num_inference_steps, self.cpu_device, None, None
+        )
+
+    def __trace_image_processing(self):
+        # Helper method for image processing trace capture.
+
+        self.__release_trace()
+
+        logger.info("Capturing model trace...")
+        profiler.start("capture_model_trace")
+
+        _, self.tid, self.output_device, self.output_shape, self.tid_vae = run_tt_image_gen(
+            self.ttnn_device,
+            self.tt_unet,
+            self.tt_scheduler,
+            self.tt_latents_device,
+            self.tt_prompt_embeds_device,
+            self.tt_time_ids_device,
+            self.tt_text_embeds_device,
+            [self.ttnn_timesteps[0]],
+            self.extra_step_kwargs,
+            self.guidance_scale,
+            self.scaling_factor,
+            [1, 4, 128, 128],
+            self.tt_vae if self.pipeline_config.vae_on_device else self.torch_pipeline.vae,
+            self.batch_size,
+            capture_trace=True,
+        )
+        ttnn.synchronize_device(self.ttnn_device)
+        profiler.end("capture_model_trace")
+
+    def __release_trace(self):
+        # Helper method for trace release.
+        if self.pipeline_config.capture_trace and hasattr(self, "tid"):
+            ttnn.release_trace(self.ttnn_device, self.tid)
+            delattr(self, "tid")
+
+        if self.pipeline_config.vae_on_device and hasattr(self, "tid_vae"):
+            ttnn.release_trace(self.ttnn_device, self.tid_vae)
+            delattr(self, "tid_vae")
+
+    def __del__(self):
+        self.__release_trace()

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -29,11 +29,11 @@ from models.utility_functions import profiler
 
 @dataclass
 class TtSDXLPipelineConfig:
-    capture_trace: bool
-    vae_on_device: bool
-    encoders_on_device: bool
     num_inference_steps: int
     guidance_scale: float
+    capture_trace: bool = True
+    vae_on_device: bool = True
+    encoders_on_device: bool = True
 
 
 class TtSDXLPipeline(nn.Module):
@@ -613,11 +613,11 @@ class TtSDXLPipeline(nn.Module):
 
     def __release_trace(self):
         # Helper method for trace release.
-        if self.pipeline_config.capture_trace and hasattr(self, "tid"):
+        if self.pipeline_config.capture_trace and hasattr(self, "tid") and self.tid is not None:
             ttnn.release_trace(self.ttnn_device, self.tid)
             delattr(self, "tid")
 
-        if self.pipeline_config.vae_on_device and hasattr(self, "tid_vae"):
+        if self.pipeline_config.vae_on_device and hasattr(self, "tid_vae") and self.tid_vae is not None:
             ttnn.release_trace(self.ttnn_device, self.tid_vae)
             delattr(self, "tid_vae")
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
@@ -9,7 +9,12 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtAutoencoderKL(nn.Module):
-    def __init__(self, device, state_dict, model_config, batch_size=1):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        model_config,
+    ):
         super().__init__()
 
         self.device = device
@@ -20,7 +25,11 @@ class TtAutoencoderKL(nn.Module):
         self.dilation = (1, 1)
         self.groups = 1
 
-        self.decoder = TtDecoder(device, state_dict, model_config, batch_size=batch_size)
+        self.decoder = TtDecoder(
+            device,
+            state_dict,
+            model_config,
+        )
 
         post_quant_conv_weights = state_dict[f"post_quant_conv.weight"].squeeze()
         post_quant_conv_bias = state_dict[f"post_quant_conv.bias"]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -16,11 +16,10 @@ from loguru import logger
 
 
 class TtDecoder(nn.Module):
-    def __init__(self, device, state_dict, model_config, batch_size=1):
+    def __init__(self, device, state_dict, model_config):
         super().__init__()
 
         self.device = device
-        self.batch_size = batch_size
 
         self.norm_groups = 32
         self.norm_eps = 1e-5


### PR DESCRIPTION
### Ticket
#27233 

### What's changed

- Implemented `TtSDXLPipeline`. 
- Adapted `demo.py` to use this class (this is an example of how inference server should instantiate and use SDXL model). 
- Adapted `TtEulerDiscreteScheduler` for `num_inference_steps` change. 
- Additionally, removed `batch_size` arg from `TtAutoencoderKL` and `TtDecoder` as it is unused.

Demo tested locally

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17126303164) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17126308632) CI passes