### PR TITLE
#0: Update fmod test

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
@@ -8,16 +8,25 @@ import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 
 
-def test_fmod_nan(device):
-    torch_input_a = torch.tensor([1.0, 0.0, -1.0], dtype=torch.float32)
-    torch_input_b = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)
+@pytest.mark.parametrize(
+    "testing_dtype",
+    ["bfloat16", "float32"],
+)
+def test_fmod_nan(testing_dtype, device):
+    torch_dtype = getattr(torch, testing_dtype)
+    ttnn_dtype = getattr(ttnn, testing_dtype)
+    if testing_dtype == "bfloat16":
+        pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
+
+    torch_input_a = torch.tensor([1.0, 0.0, -1.0], dtype=torch_dtype)
+    torch_input_b = torch.tensor([0.0, 0.0, 0.0], dtype=torch_dtype)
 
     golden_function = ttnn.get_golden_function(ttnn.fmod)
     golden = golden_function(torch_input_a, torch_input_b, device=device)
 
     tt_in_a = ttnn.from_torch(
         torch_input_a,
-        dtype=ttnn.float32,
+        dtype=ttnn_dtype,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -25,7 +34,7 @@ def test_fmod_nan(device):
 
     tt_in_b = ttnn.from_torch(
         torch_input_b,
-        dtype=ttnn.float32,
+        dtype=ttnn_dtype,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,


### PR DESCRIPTION
### Ticket
-

### Problem description
Add nan test for fmod

### What's changed
Update FMOD Test for bf16 dtype

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17146661926) PASSES
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17146663189) PASSES
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes