### PR TITLE
fix fabric tensix gtest to skip galaxy

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -128,7 +128,8 @@ private:
 protected:
     static void SetUpTestSuite() {
         if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() ==
-            tt::tt_metal::ClusterType::GALAXY) {
+                tt::tt_metal::ClusterType::GALAXY ||
+            tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
             should_skip_ = true;
             return;
         }

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -122,12 +122,30 @@ protected:
 };
 
 class Fabric1DTensixFixture : public BaseFabricFixture {
+private:
+    inline static bool should_skip_ = false;
+
 protected:
     static void SetUpTestSuite() {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() ==
+            tt::tt_metal::ClusterType::GALAXY) {
+            should_skip_ = true;
+            return;
+        }
         BaseFabricFixture::DoSetUpTestSuite(
             tt::tt_fabric::FabricConfig::FABRIC_1D, std::nullopt, tt::tt_fabric::FabricTensixConfig::MUX);
     }
-    static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
+    static void TearDownTestSuite() {
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+        }
+    }
+    void SetUp() override {
+        if (should_skip_) {
+            GTEST_SKIP() << "Fabric1DTensixFixture tests are not supported on Galaxy systems";
+        }
+        BaseFabricFixture::SetUp();
+    }
 };
 
 class NightlyFabric1DFixture : public BaseFabricFixture {


### PR DESCRIPTION
### Problem description
Current health check pipeline is failing for 6U, should skip the added test since it is not supported.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes