### PR TITLE
[POOL] Dilation support for maxpool2d

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -149,8 +149,8 @@ def run_avg_pool2d(
 
     ceil_mode_out_shape_adj = False
     if ceil_mode:
-        out_h = math.ceil((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
-        out_w = math.ceil((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
+        out_h = math.ceil((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.ceil((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
         if ((out_h - 1) * stride_h) >= (in_h + pad_t):
             ceil_mode_out_shape_adj = True
             out_h -= 1
@@ -158,8 +158,8 @@ def run_avg_pool2d(
             ceil_mode_out_shape_adj = True
             out_w -= 1
     else:
-        out_h = math.floor((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
-        out_w = math.floor((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
+        out_h = math.floor((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.floor((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
 
     # using non-zero seed to avoid random spike in floating point error on single element of the
     # 1x256x56x56 tensor with divisor_override=5 and 5x5 kernel resulting in rtol=0.015 for that element

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -119,8 +119,8 @@ def run_max_pool(
     out_c = in_c
     ceil_mode_out_shape_adj = False
     if ceil_mode:
-        out_h = math.ceil((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
-        out_w = math.ceil((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
+        out_h = math.ceil((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.ceil((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
         if ((out_h - 1) * stride_h) >= (in_h + pad_t):
             ceil_mode_out_shape_adj = True
             out_h -= 1
@@ -128,8 +128,8 @@ def run_max_pool(
             ceil_mode_out_shape_adj = True
             out_w -= 1
     else:
-        out_h = math.floor((in_h + pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
-        out_w = math.floor((in_w + pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
+        out_h = math.floor((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.floor((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
 
     torch.manual_seed(0)
     torch_input = randomize_torch_tensor(tensor_map, input_shape)

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -291,11 +291,7 @@ def run_max_pool(
 )
 @pytest.mark.parametrize(
     "dilation",
-    (
-        (1, 1),  # default - no dilation
-        (2, 2),  # symmetric dilation
-        (2, 1),  # asymmetric dilation
-    ),
+    ((1, 1),),
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -363,7 +359,7 @@ def test_run_max_pool_height_shard(
     "dilation",
     (
         (1, 1),  # default - no dilation
-        (2, 2),  # symmetric dilation for wide tests
+        (2, 2),  # symmetric dilation for width shard
     ),
 )
 @pytest.mark.parametrize(
@@ -438,7 +434,6 @@ def test_run_max_pool_width_shard(
     "dilation",
     (
         (1, 1),  # default - no dilation
-        (2, 2),  # symmetric dilation for block shard
         (1, 3),  # asymmetric dilation for block shard
     ),
 )
@@ -536,10 +531,7 @@ def test_run_max_pool_mem_config(
 )
 @pytest.mark.parametrize(
     "dilation",
-    (
-        (1, 1),  # default - no dilation
-        (2, 2),  # symmetric dilation for model tests
-    ),
+    ((1, 1),),
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_run_max_pool_yolov4(
@@ -571,10 +563,7 @@ def test_run_max_pool_yolov4(
 @pytest.mark.parametrize("stride", ((2, 2),))
 @pytest.mark.parametrize(
     "dilation",
-    (
-        (1, 1),  # default - no dilation
-        (2, 2),  # symmetric dilation for model tests
-    ),
+    ((1, 1),),
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("ceil_mode", [False, True])

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -16,6 +16,9 @@ parameters = {
             [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
             [1, 16, 25, 23, 2, 2, 2, 2, 0, 0, 1, 1, False],  # C=16
             [1, 480, 28, 28, 3, 3, 2, 2, 1, 1, 1, 1, True],
+            # Dilation test cases for height shard
+            [1, 32, 24, 24, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Basic dilation=2
+            [1, 64, 32, 32, 3, 3, 1, 1, 1, 1, 2, 2, False],  # Dilation=2 with padding
             [1, 64, 400, 544, 3, 3, 2, 2, 1, 1, 1, 1, False],  # massive NHW
             [1, 832, 14, 14, 4, 4, 2, 2, 0, 0, 1, 1, True],  # > 800 channels, 16 kernel
             [1, 160, 30, 30, 15, 15, 1, 1, 7, 5, 1, 1, False],  # 15x15 kernel, uneven padding
@@ -39,6 +42,8 @@ parameters = {
             [1, 32768, 6, 6, 2, 2, 1, 1, 0, 0, 1, 1, False],  # wide in place untilize
             [1, 16384, 8, 8, 2, 2, 1, 1, 0, 0, 1, 1, False],  # normal in place untilize
             [1, 6144, 20, 20, 11, 11, 1, 1, 5, 5, 1, 1, False],  # 11x11 kernel
+            # Dilation test cases for width shard
+            [1, 8192, 16, 16, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Wide dilation=2
         ],
     },
     "block_shard_tests": {
@@ -47,6 +52,9 @@ parameters = {
         "input_specs": [
             [1, 4096, 16, 16, 2, 2, 1, 1, 0, 0, 1, 1, False],  # wide in place untilize
             [1, 2048, 16, 16, 2, 2, 1, 1, 0, 0, 1, 1, False],  # normal in place untilize
+            # Dilation test cases for block shard
+            [1, 1024, 20, 20, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Block shard dilation=2
+            [1, 2048, 16, 16, 3, 3, 1, 1, 1, 1, 1, 2, False],  # Block shard asymmetric dilation (1,2)
             # requires reversed local reads on some cores, and forward reads on others, wide in place untilize, large kernel
             [1, 4096, 16, 16, 5, 5, 2, 2, 2, 2, 1, 1, True],
             # requires reversed local reads on some cores, and forward reads on others, normal in place untilize, large kernel
@@ -58,6 +66,8 @@ parameters = {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_specs": [
             [1, 32, 224, 224, 3, 3, 2, 2, 1, 1, 1, 1, False],
+            # Dilation test case for memory config
+            [1, 64, 64, 64, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Memory config dilation=2
         ],
     },
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -271,8 +271,6 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
                   params.nbytes
             : tt::round_up(input_shape[3] / num_shards_c, tt::constants::TILE_WIDTH) * params.nbytes;
 
-    TT_FATAL(dilation_h == 1 && dilation_w == 1, "Dilation is not yet supported by the maxpool reader");
-
     uint32_t next_cb_index = tt::CBIndex::c_0;
     const uint32_t in_scalar_cb_id_0 = next_cb_index++;
     const uint32_t in_scalar_cb_pagesize = tile_size(params.data_format);
@@ -445,7 +443,9 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_nbytes_c,                    // 25
         in_nbytes_padded_c,             // 26
         params.multi_buffering_factor,  // 27
-        stride_w};                      // 28
+        stride_w,                       // 28
+        dilation_h,                     // 29
+        dilation_w};                    // 30
     std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
 


### PR DESCRIPTION
### Ticket
[25845](https://github.com/tenstorrent/tt-metal/issues/25845)

### Problem description
Dilation was not supported in pool 2d operations. By pytorch documentation dilation is relevant for maxpool2d only and non-existent for avgpool2d. 

### What's changed
Added dilation support in pool2d reader kernels.
Added test for different dilations to maxpool2d unit and nightly tests.
Added skips for invalid dilation, stride, padding and kernel values combinations.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17156297977)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17156304287)
- [x]  [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17156307291)