### PR TITLE
SFPI v6.18.0

### DIFF
--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,13 +1,13 @@
 # set SFPI release version information
 
-sfpi_version=v6.17.0
+sfpi_version=v6.18.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi-\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_aarch64_Linux_txz_md5=15ba323821ed9f2d30807cf965430b5d
-sfpi_aarch64_Linux_deb_md5=71f9532a5dc9e491503b220ce12e00bf
-sfpi_aarch64_Linux_rpm_md5=effd19fed9e1a13e8ed4c346499b832e
-sfpi_x86_64_Linux_txz_md5=fdcd38cb5d1d718904f6ca38043aeef4
-sfpi_x86_64_Linux_deb_md5=e337647c11db17796d0db1b0b985ebaa
-sfpi_x86_64_Linux_rpm_md5=14661bc1f60a10bf992cace08423cbb1
+sfpi_aarch64_Linux_txz_md5=47bf8eb7e72102a8c9b09c3f394a608a
+sfpi_aarch64_Linux_deb_md5=130df3c331c2a8518d9b7d7e1c3dec13
+sfpi_aarch64_Linux_rpm_md5=69ba31658951516a4cc45ba7a03f7317
+sfpi_x86_64_Linux_txz_md5=9fabc29cf5d33b9768b7ef641b1466f6
+sfpi_x86_64_Linux_deb_md5=48cc6b46f02bd039dd07995ebc70fc65
+sfpi_x86_64_Linux_rpm_md5=c40851ce917d790ba41e3269b72d7dcf


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26365
https://github.com/tenstorrent/tt-metal/issues/26049

### Problem description
Compiler failed to predict its future behavior

### What's changed
Fixed compiler

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes