### PR TITLE
Falcon40B: Save benchmark results for Superset

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -91,7 +91,7 @@ jobs:
             ${{ matrix.test-group.cmd }}
 
       - name: Save environment data
-        if: ${{ (matrix.test-group.name == 't3k_falcon7b_tests' || matrix.test-group.name == 't3k_mixtral_tests' || matrix.test-group.name == 't3k_qwen25_tests' || matrix.test-group.name == 't3k_qwen3_tests' || matrix.test-group.name == 't3k_llama3_tests' || matrix.test-group.name == 't3k_llama3_70b_tests' || matrix.test-group.name == 't3k_llama3_vision_tests') && !cancelled() }}
+        if: ${{ (matrix.test-group.name == 't3k_falcon7b_tests' || matrix.test-group.name == 't3k_falcon40b_tests' || matrix.test-group.name == 't3k_mixtral_tests' || matrix.test-group.name == 't3k_qwen25_tests' || matrix.test-group.name == 't3k_qwen3_tests' || matrix.test-group.name == 't3k_llama3_tests' || matrix.test-group.name == 't3k_llama3_70b_tests' || matrix.test-group.name == 't3k_llama3_vision_tests') && !cancelled() }}
         uses: ./.github/actions/docker-run
         env:
           LOGURU_LEVEL: INFO
@@ -107,7 +107,7 @@ jobs:
           run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
 
       - name: Upload benchmark data
-        if: ${{ (matrix.test-group.name == 't3k_falcon7b_tests' || matrix.test-group.name == 't3k_mixtral_tests' || matrix.test-group.name == 't3k_qwen25_tests' || matrix.test-group.name == 't3k_qwen3_tests' || matrix.test-group.name == 't3k_llama3_tests' || matrix.test-group.name == 't3k_llama3_70b_tests' || matrix.test-group.name == 't3k_llama3_vision_tests') && !cancelled() }}
+        if: ${{ (matrix.test-group.name == 't3k_falcon7b_tests' || matrix.test-group.name == 't3k_falcon40b_tests' || matrix.test-group.name == 't3k_mixtral_tests' || matrix.test-group.name == 't3k_qwen25_tests' || matrix.test-group.name == 't3k_qwen3_tests' || matrix.test-group.name == 't3k_llama3_tests' || matrix.test-group.name == 't3k_llama3_70b_tests' || matrix.test-group.name == 't3k_llama3_vision_tests') && !cancelled() }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -187,13 +187,18 @@ def run_falcon_demo_kv(
     profiler = BenchmarkProfiler()
     profiler.start("run")
 
+    # Set up warmup iterations and targets dicts for saving benchmark data
+    N_warmup_iter = {}
+    perf_targets = {}
     if perf_mode:
         logger.info("Running in performance measurement mode (invalid outputs)!")
 
-        # Set up warmup iterations and targets dicts for saving benchmark data
         N_warmup_iter = {"inference_prefill": 5, "inference_decode": 5}
-    else:
-        N_warmup_iter = {}
+        perf_targets = {
+            "prefill_t/s": None,
+            "decode_t/s": 11.9 * batch_size,
+            "decode_t/s/u": 11.9,
+        }
 
     configuration = FalconConfig(**model_config_entries)
 
@@ -592,7 +597,7 @@ def run_falcon_demo_kv(
     )
 
     # Save benchmark data (will only save if running in CI environment)
-    benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, targets={})
+    benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, targets=perf_targets)
     run_type = f"demo_{'perf' if perf_mode else 'generate'}_{mesh_device.get_num_devices()}chip"
     benchmark_data.save_partial_run_json(
         profiler,

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -571,6 +571,7 @@ def run_falcon_demo_kv(
     logger.info(f"prefill inference time: {round(measurements['inference_prefill'], 5)} s")
     logger.info(f"decode inference time: {round(measurements['inference_decode'], 5)} s")
     logger.info(f"total inference time: {round(measurements['inference_total'], 5)} s")
+    logger.info(f"time to first token (prefill, 1st user): {round(measurements['prefill_time_to_token'], 5)} s")
     if not prefill_on_host:
         logger.info(
             f"inference throughput prefill: {round(measurements['inference_user_throughput_prefill'], 5)} users/s"
@@ -580,6 +581,9 @@ def run_falcon_demo_kv(
         )
     logger.info(f"inference throughput decode: {round(measurements['decode_t/s'], 5)} tok/s")
     logger.info(f"inference throughput decode (per user): {round(measurements['decode_t/s/u'], 5)} tok/s/user")
+    logger.info(
+        f"inference throughput prefill+decode (per user): {round(measurements['prefill_decode_t/s/u'], 5)} tok/s/user"
+    )
 
     # Save benchmark data (will only save if running in CI environment)
     benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, targets={})

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -196,8 +196,8 @@ def run_falcon_demo_kv(
         N_warmup_iter = {"inference_prefill": 5, "inference_decode": 5}
         perf_targets = {
             "prefill_t/s": None,
-            "decode_t/s": 11.9 * batch_size,
-            "decode_t/s/u": 11.9,
+            "decode_t/s": 36 * batch_size,
+            "decode_t/s/u": 36,
         }
 
     configuration = FalconConfig(**model_config_entries)

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -19,7 +19,9 @@ from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconConf
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.falcon_common import PytorchFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model_config_entries
-from models.utility_functions import enable_persistent_kernel_cache, nearest_32, profiler
+from models.demos.utils.llm_demo_utils import create_benchmark_data
+from models.perf.benchmarking_utils import BenchmarkProfiler
+from models.utility_functions import enable_persistent_kernel_cache, nearest_32
 
 END_OF_TEXT = 11
 SPACE = 204
@@ -106,7 +108,7 @@ def initialize_and_fill_kv_cache(
 
     kv_cache = ()
     for i in range(num_layers):
-        logger.info(f"Putting kv cache on devices for layer: {i+1}")
+        logger.info(f"Putting kv cache on devices for layer: {i + 1}")
         k_cache_repeat_interleaved, v_cache_repeat_interleaved = pytorch_layer_present[i]
         k_cache = k_cache_repeat_interleaved[:, ::q_heads_per_kv_heads, ...]
         v_cache = v_cache_repeat_interleaved[:, ::q_heads_per_kv_heads, ...]
@@ -182,23 +184,30 @@ def run_falcon_demo_kv(
     greedy_sampling=False,
 ):
     torch.manual_seed(0)
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
 
     if perf_mode:
         logger.info("Running in performance measurement mode (invalid outputs)!")
 
+        # Set up warmup iterations and targets dicts for saving benchmark data
+        N_warmup_iter = {"inference_prefill": 5, "inference_decode": 5}
+    else:
+        N_warmup_iter = {}
+
     configuration = FalconConfig(**model_config_entries)
 
-    profiler.start(f"loading_inputs")
+    profiler.start("loading_inputs")
     if len(user_input) == 1:
         input_prompts = user_input
     else:
         input_prompts = load_inputs(user_input, batch_size)
 
-    profiler.end(f"loading_inputs")
+    profiler.end("loading_inputs")
 
     # State dict is needed for embeddings
     logger.info("Loading weights...")
-    profiler.start(f"loading_weights")
+    profiler.start("loading_weights")
 
     model_name = model_location_generator(model_version, model_subdir="Falcon")
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
@@ -206,17 +215,17 @@ def run_falcon_demo_kv(
     state_dict = hugging_face_reference_model.state_dict()
 
     logger.info("Loading weights finished!")
-    profiler.end(f"loading_weights")
+    profiler.end("loading_weights")
 
     ttnn.synchronize_device(mesh_device)
 
     logger.info("Tokenizing inputs...")
-    profiler.start(f"tokenizing_inputs")
+    profiler.start("tokenizing_inputs")
     tokenizer = AutoTokenizer.from_pretrained(model_version)
     prefill_ids, num_users, num_input_tokens = preprocess_and_validate_inputs(
         input_prompts, tokenizer, max_seq_len, perf_mode
     )
-    profiler.end(f"tokenizing_inputs")
+    profiler.end("tokenizing_inputs")
 
     # Update model_config for prefill
     model_config = get_model_config(
@@ -251,12 +260,12 @@ def run_falcon_demo_kv(
 
     ### First prefill run with compile ###
     use_cache = True
-    time_prefill_compile = 0
+    profiler.start("compile_prefill")
     if not prefill_on_host:
         logger.info("Running 1st run prefill stage with compile...")
+
         N = num_users if not perf_mode else 1
         for user_id in tqdm(range(N), desc="Filling kv caches for each user"):
-            time_prefill_compile_start = time.time()
             (
                 tt_prefill_inputs,
                 tt_prefill_attention_mask,
@@ -280,8 +289,7 @@ def run_falcon_demo_kv(
             del tt_prefill_attention_mask
             del tt_logits
 
-            time_prefill_compile += time.time() - time_prefill_compile_start
-
+    profiler.end("compile_prefill")
     ttnn.synchronize_device(mesh_device)
     logger.info("Finished 1st run prefill stage with compile!")
 
@@ -295,9 +303,8 @@ def run_falcon_demo_kv(
     logger.info("Running 1st run decode stage with compile...")
     decode_ids = torch.randint(low=0, high=configuration.vocab_size - 1, size=(batch_size, 1), dtype=torch.int64)
 
-    time_decode_compile = 0
+    profiler.start("compile_decode")
     for kv_cache_len in tqdm(range(num_input_tokens, max_seq_len, 32)):
-        time_decode_compile_start = time.time()
         (
             tt_decode_inputs,
             tt_decode_attention_mask,
@@ -321,8 +328,7 @@ def run_falcon_demo_kv(
             del tt_decode_attention_mask
         del tt_logits
 
-        time_decode_compile += time.time() - time_decode_compile_start
-
+    profiler.end("compile_decode")
     logger.info("Finished 1st run decode stage with compile!")
     ttnn.synchronize_device(mesh_device)
 
@@ -336,7 +342,7 @@ def run_falcon_demo_kv(
     )
 
     logger.info("Moving weights (all layers) to device; might take some time...")
-    profiler.start(f"moving_to_device")
+    profiler.start("moving_to_device")
     tt_FalconCausalLM = TtFalconCausalLM(
         mesh_device,
         state_dict,
@@ -349,11 +355,11 @@ def run_falcon_demo_kv(
         use_global_cos_sin_cache,
     )
     logger.info("Moved weights (all layers) to device!")
-    profiler.end(f"moving_to_device")
+    profiler.end("moving_to_device")
 
-    profiler.start(f"initializing_KV_cache")
+    profiler.start("initializing_KV_cache")
     kv_cache = tt_FalconCausalLM.initialize_kv_cache()  # Initialized kv cache for all layers
-    profiler.end(f"initializing_KV_cache")
+    profiler.end("initializing_KV_cache")
 
     ### Second prefill run without compile ###
     enable_persistent_kernel_cache()
@@ -365,7 +371,7 @@ def run_falcon_demo_kv(
     if prefill_on_host:
         pytorch_FalconCausalLM = PytorchFalconCausalLM(hugging_face_reference_model, num_layers)
         logger.info("Initializing and filling KV cache")
-        profiler.start(f"initializing_KV_cache_on_host")
+        profiler.start("initializing_KV_cache_on_host")
         pt_logits, kv_cache = initialize_and_fill_kv_cache(
             pytorch_FalconCausalLM,
             model_config,
@@ -376,7 +382,7 @@ def run_falcon_demo_kv(
             max_seq_len,
             mesh_device,
         )
-        profiler.end(f"initializing_KV_cache_on_host")
+        profiler.end("initializing_KV_cache_on_host")
 
         output_ids = torch.zeros(num_users, 1, dtype=torch.int64)
         for user_id in range(num_users):
@@ -388,7 +394,7 @@ def run_falcon_demo_kv(
             N_warmup = 0
         else:
             N = 15
-            N_warmup = 5
+            N_warmup = N_warmup_iter["inference_prefill"]
         for i in tqdm(range(N), desc="Filling kv caches for each user"):
             user_id = i if not perf_mode else 0
             time_prefill_inference_start = time.time()
@@ -431,6 +437,7 @@ def run_falcon_demo_kv(
 
     logger.info("Finished inference prefill stage!")
     num_users_generated_prefill = num_users if not perf_mode else (N - N_warmup)
+    prefill_time_to_token_per_user = time_prefill_inference / num_users_generated_prefill
 
     generated_ids = torch.concat((prefill_ids[..., :num_input_tokens], output_ids), dim=1)
 
@@ -456,7 +463,7 @@ def run_falcon_demo_kv(
         N_warmup = 0
     else:
         N = 15
-        N_warmup = 5
+        N_warmup = N_warmup_iter["inference_decode"]
     for output_token_index in range(N):
         time_decode_inference_start = time.time()
         (
@@ -516,6 +523,7 @@ def run_falcon_demo_kv(
 
     logger.info("Finished inference decode stage!")
     num_tokens_generated_decode = batch_size * (output_token_index - N_warmup + 1)
+    decode_time_to_token_per_user = time_decode_inference / (output_token_index - N_warmup + 1)
     logger.info(f"Total number of tokens generated in decode: {num_tokens_generated_decode}")
 
     if not perf_mode:
@@ -525,23 +533,31 @@ def run_falcon_demo_kv(
 
     generated_text = tokenizer.batch_decode(generated_ids.tolist())
 
+    profiler.end("run")
+    time_prefill_compile = profiler.get_duration("compile_prefill")
+    time_decode_compile = profiler.get_duration("compile_decode")
+
     measurements = {
-        "preprocessing": profiler.get("tokenizing_inputs"),
-        "loading_weights": profiler.get("loading_weights"),
-        "moving_to_device": profiler.get("moving_to_device"),
-        "initializing_KV_cache": profiler.get("initializing_KV_cache"),
+        "total_demo_time": profiler.get_duration("run"),
+        "preprocessing": profiler.get_duration("tokenizing_inputs"),
+        "loading_weights": profiler.get_duration("loading_weights"),
+        "moving_to_device": profiler.get_duration("moving_to_device"),
+        "initializing_KV_cache": profiler.get_duration("initializing_KV_cache"),
         "compile_prefill": time_prefill_compile if not prefill_on_host else None,
         "compile_decode": time_decode_compile,
         "compile_total": time_prefill_compile + time_decode_compile,
         "inference_prefill": time_prefill_inference,
         "inference_decode": time_decode_inference,
         "inference_total": time_prefill_inference + time_decode_inference,
-        "inference_throughput_prefill": (
-            num_users_generated_prefill / time_prefill_inference if not prefill_on_host else None
-        ),
-        "inference_throughput_decode": num_tokens_generated_decode / time_decode_inference,
+        "prefill_time_to_token": prefill_time_to_token_per_user,  # time to first output token (1 user)
+        "inference_user_throughput_prefill": num_users_generated_prefill / time_prefill_inference,  # users/s
+        "prefill_t/s": num_users_generated_prefill / time_prefill_inference * prefill_ids.shape[1],  # tokens/s
+        "decode_t/s": num_tokens_generated_decode / time_decode_inference,  # tokens/s
+        "decode_t/s/u": num_tokens_generated_decode / time_decode_inference / batch_size,  # tokens/s/user
+        "prefill_decode_t/s/u": 1.0 / (prefill_time_to_token_per_user + decode_time_to_token_per_user),  # tokens/s/user
     }
 
+    logger.info(f"total demo duration: {round(measurements['total_demo_time'], 5)} s")
     logger.info(f"pre processing: {round(measurements['preprocessing'], 5)} s")
     logger.info(f"loading weights (+downloading if not on machine): {round(measurements['loading_weights'], 5)} s")
     logger.info(
@@ -549,20 +565,36 @@ def run_falcon_demo_kv(
     )
     logger.info(f"initializing KV cache: {round(measurements['initializing_KV_cache'], 5)} s")
     if not prefill_on_host:
-        logger.info(f"prefill compile time: {round(measurements['compile_prefill'],5)} s")
+        logger.info(f"prefill compile time: {round(measurements['compile_prefill'], 5)} s")
     logger.info(f"decode compile time: {round(measurements['compile_decode'], 5)} s")
     logger.info(f"total compile time: {round(measurements['compile_total'], 5)} s")
     logger.info(f"prefill inference time: {round(measurements['inference_prefill'], 5)} s")
     logger.info(f"decode inference time: {round(measurements['inference_decode'], 5)} s")
     logger.info(f"total inference time: {round(measurements['inference_total'], 5)} s")
     if not prefill_on_host:
-        logger.info(f"inference throughput prefill: {round(measurements['inference_throughput_prefill'], 5)} users/s")
         logger.info(
-            f"inference throughput prefill | seq_len={prefill_ids.shape[1]}: {round(measurements['inference_throughput_prefill']*prefill_ids.shape[1], 5)} tok/s"
+            f"inference throughput prefill: {round(measurements['inference_user_throughput_prefill'], 5)} users/s"
         )
-    logger.info(f"inference throughput decode: {round(measurements['inference_throughput_decode'], 5)} tok/s")
-    logger.info(
-        f"inference throughput decode (per user): {round(measurements['inference_throughput_decode']/batch_size, 5)} tok/s/user"
+        logger.info(
+            f"inference throughput prefill | seq_len={prefill_ids.shape[1]}: {round(measurements['prefill_t/s'], 5)} tok/s"
+        )
+    logger.info(f"inference throughput decode: {round(measurements['decode_t/s'], 5)} tok/s")
+    logger.info(f"inference throughput decode (per user): {round(measurements['decode_t/s/u'], 5)} tok/s/user")
+
+    # Save benchmark data (will only save if running in CI environment)
+    benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, targets={})
+    run_type = f"demo_{'perf' if perf_mode else 'generate'}_{mesh_device.get_num_devices()}chip"
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type=run_type,
+        ml_model_name=model_version,
+        ml_model_type="llm",
+        num_layers=num_layers,
+        batch_size=batch_size,
+        config_params=configuration.to_dict(),
+        precision=f"prefill[{model_config_str_for_prefill}]_decode[{model_config_str_for_decode}]",
+        input_sequence_length=num_input_tokens,
+        output_sequence_length=1 if perf_mode else output_token_index + 1,
     )
 
     return generated_text, measurements

--- a/models/demos/t3000/falcon40b/tests/test_demo.py
+++ b/models/demos/t3000/falcon40b/tests/test_demo.py
@@ -44,11 +44,13 @@ def test_demo_generate_reference_output(
 
 @pytest.mark.parametrize("max_seq_len", (128,))
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("perf_mode", (True, False))
 def test_demo(
     max_seq_len,
     model_location_generator,
     get_tt_cache_path,
     t3k_mesh_device,
+    perf_mode,
 ):
     input_file = "models/demos/t3000/falcon40b/demo/input_data.json"
 
@@ -64,11 +66,12 @@ def test_demo(
         get_tt_cache_path=get_tt_cache_path,
         mesh_device=t3k_mesh_device,
         prefill_on_host=False,
-        perf_mode=False,
+        perf_mode=perf_mode,
         greedy_sampling=True,
     )
 
-    # Validate generated_text against expected output
-    with open("models/demos/t3000/falcon40b/demo/expected_output_data.json", "r") as f:
-        expected_output_data = json.load(f)
-        assert expected_output_data == generated_text
+    if not perf_mode:
+        # Validate generated_text against expected output
+        with open("models/demos/t3000/falcon40b/demo/expected_output_data.json", "r") as f:
+            expected_output_data = json.load(f)
+            assert expected_output_data == generated_text


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26533

### Problem description
We should be pushing Falcon40B performance metrics into a Superset dashboard ([link](https://superset.tenstorrent.com/superset/dashboard/5/?native_filters_key=3t0bDxa_IV0)) so we can easily triage regressions and track performance.

### What's changed
Added saving benchmark data in Falcon40B's demo script, similarly to those of Mamba and Falcon7B models. Whenever the demo is run in CI environment, it saves a PKL file with all measurements, to be used in Superset.
Followed some of the changes from a closed PR https://github.com/tenstorrent/tt-metal/pull/11548



### Checklist
- [x] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes for Falcon40B with the two newly enabled steps
    https://github.com/tenstorrent/tt-metal/actions/runs/17273277670/job/49024523277
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes