### PR TITLE
removing variables from ttnn

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -110,7 +110,7 @@ inline void log_operation(
     log_debug(tt::LogOp, "Program Cache Hit: {}", program_cache_hit);
 
     log_debug(tt::LogOp, "Attributes:");
-    for (const auto& [key, value] : tt::stl::reflection::get_attributes(operation_attributes)) {
+    for ([[maybe_unused]] const auto& [key, value] : tt::stl::reflection::get_attributes(operation_attributes)) {
         log_debug(tt::LogOp, "\t{} = {}", key, value);
     }
 

--- a/ttnn/api/ttnn/graph/graph_operation_queries.hpp
+++ b/ttnn/api/ttnn/graph/graph_operation_queries.hpp
@@ -16,7 +16,7 @@ template <class Callable>
 auto query_trace(Callable&& callable) {
     GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH);
     {
-        auto output = callable();
+        [[maybe_unused]] auto output = callable();
     }
     auto json_trace = GraphProcessor::end_graph_capture();
     return json_trace;

--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
@@ -89,7 +89,6 @@ ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::create_at(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
     log_info(tt::LogAlways, "Creating delay program at mesh coordinate: {}", mesh_coordinate);
-    const auto& mesh_device = *operation_attributes.mesh_device;
     tt::tt_metal::Program program{};
     auto subdevice_cores = corerange_to_cores(operation_attributes.worker_core_range_set);
     auto kernel_id = CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_op.cpp
@@ -253,8 +253,8 @@ tt::tt_metal::operation::ProgramWithCallbacks AllReduceCreateQkvHeads::create_pr
     auto input_tensor_shape = input_tensor.padded_shape();
     auto input_tensor_memory_config = input_tensor.memory_config();
     auto output_tensor_memory_config = output_tensors[0].memory_config();
-    uint32_t input_shard_num_cores = input_tensor_memory_config.shard_spec()->grid.num_cores();
-    uint32_t output_shard_num_cores = output_tensor_memory_config.shard_spec()->grid.num_cores();
+    [[maybe_unused]] uint32_t input_shard_num_cores = input_tensor_memory_config.shard_spec()->grid.num_cores();
+    [[maybe_unused]] uint32_t output_shard_num_cores = output_tensor_memory_config.shard_spec()->grid.num_cores();
 
     log_debug(tt::LogOp, "input_tensor_shape: {}", input_tensor_shape);
     log_debug(tt::LogOp, "input_tensor_memory_config: {}", input_tensor_memory_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -135,8 +135,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
     // End of qkv heads fuse
 
     // TODO: Remove this once we have a way to get the number of cores per link
-    bool is_first_chip = ring_index == 0;
-    bool is_last_chip = ring_index == ring_size - 1;
+    [[maybe_unused]] bool is_first_chip = ring_index == 0;
+    [[maybe_unused]] bool is_last_chip = ring_index == ring_size - 1;
     log_trace(
         tt::LogOp,
         "DEBUG: device: {}, is_first_chip: {}, is_last_chip: {}",
@@ -515,7 +515,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
         reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_x.begin(), input_tensor_cores_x.end());
         reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_y.begin(), input_tensor_cores_y.end());
         log_trace(tt::LogOp, "Reader Runtime Args:");
-        for (const auto& arg : reader_rt_args) {
+        for ([[maybe_unused]] const auto& arg : reader_rt_args) {
             log_trace(tt::LogOp, "\t{}", arg);
         }
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
@@ -570,7 +570,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
         writer_rt_args.insert(writer_rt_args.end(), mcast_end_y.begin(), mcast_end_y.end());
 
         log_trace(tt::LogOp, "Writer Runtime Args:");
-        for (const auto& arg : writer_rt_args) {
+        for ([[maybe_unused]] const auto& arg : writer_rt_args) {
             log_trace(tt::LogOp, "\t{}", arg);
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
@@ -76,7 +76,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_concat_heads_boltz(
     uint32_t src0_cb_index = 0, out_cb_index = 16;
 
     bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM;
 
     tt::tt_metal::KernelHandle reader_kernel_id = 0, writer_kernel_id = 0;
     if (in_sharded) {

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
@@ -95,10 +95,6 @@ IndexFillOperation::MultiCore::cached_program_t IndexFillOperation::MultiCore::c
             .set_page_size(dst_cb_index, rounded_output_unit_size);
     CreateCircularBuffer(program, all_cores, dst_cb_config);
 
-    bool in_is_dram = input.buffer()->is_dram();
-    bool index_is_dram = index.buffer()->is_dram();
-    bool out_is_dram = output.buffer()->is_dram();
-
     // Create Kernels
     // reader
     std::vector<uint32_t> reader_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -148,8 +148,6 @@ operation::ProgramWithCallbacks update_cache_multi_core(
     auto src_buffer = input_tensor.buffer();
     auto dst_buffer = cache_tensor.buffer();
 
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     const uint32_t u_range = std::min(static_cast<uint32_t>(32), Bcache);
     const uint32_t u_count = u_range / granularity;
 

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/receive_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/receive_program_factory.cpp
@@ -54,23 +54,22 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
             num_packet_headers_storable * packet_header_size_bytes * buffering_factor,
             {{packet_header_cb_id, tt::DataFormat::RawUInt32}})
             .set_page_size(packet_header_cb_id, packet_header_size_bytes);
-    auto cb_header_handle = CreateCircularBuffer(program, all_cores, cb_header_config);
+    CreateCircularBuffer(program, all_cores, cb_header_config);
 
     // Scratch CB for loading up pages that are collected into packets
     constexpr auto packet_cb_id = tt::CBIndex::c_1;
     tt::tt_metal::CircularBufferConfig cb_packet_config =
         tt::tt_metal::CircularBufferConfig(packet_size_bytes, {{packet_cb_id, inter_dataformat}})
             .set_page_size(packet_cb_id, packet_size_bytes);
-    tt::tt_metal::CBHandle cb_cb_handle = CreateCircularBuffer(program, all_cores, cb_packet_config);
+    CreateCircularBuffer(program, all_cores, cb_packet_config);
 
     // CB for sender reader->writer kernels
     constexpr auto receiver_cb_id = tt::CBIndex::c_2;
     const uint32_t cb_num_pages = 3 * num_pages_per_packet;
-    tt::DataFormat input_dataformat = tt::tt_metal::datatype_to_dataformat_converter(intermediate_tensor.dtype());
     tt::tt_metal::CircularBufferConfig cb_receiver_config =
         tt::tt_metal::CircularBufferConfig(cb_num_pages * output_page_size_bytes, {{receiver_cb_id, inter_dataformat}})
             .set_page_size(receiver_cb_id, output_page_size_bytes);
-    tt::tt_metal::CBHandle cb_sender_handle = CreateCircularBuffer(program, all_cores, cb_receiver_config);
+    CreateCircularBuffer(program, all_cores, cb_receiver_config);
 
     const auto& topology = operation_attributes.topology;
     auto this_device = mesh_device->get_device(receive_coord);

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
@@ -53,7 +53,7 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
     tt::tt_metal::CircularBufferConfig cb_sender_config =
         tt::tt_metal::CircularBufferConfig(cb_num_pages * aligned_input_page_size_bytes, {{sender_cb_id, input_dataformat}})
             .set_page_size(sender_cb_id, aligned_input_page_size_bytes);
-    tt::tt_metal::CBHandle cb_sender_handle = CreateCircularBuffer(program, all_cores, cb_sender_config);
+    CreateCircularBuffer(program, all_cores, cb_sender_config);
 
     // allocate space for packet headers for payload sempahore
     constexpr auto packet_header_cb_id = tt::CBIndex::c_1;
@@ -65,14 +65,14 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
             num_packet_headers_storable * packet_header_size_bytes * buffering_factor,
             {{packet_header_cb_id, tt::DataFormat::RawUInt32}})
             .set_page_size(packet_header_cb_id, packet_header_size_bytes);
-    auto cb_header_handle = CreateCircularBuffer(program, all_cores, cb_header_config);
+    CreateCircularBuffer(program, all_cores, cb_header_config);
 
     // Scratch CB for coalescing pages into packets
     constexpr auto packet_cb_id = tt::CBIndex::c_2;
     tt::tt_metal::CircularBufferConfig cb_packet_config =
         tt::tt_metal::CircularBufferConfig(packet_size_bytes, {{packet_cb_id, input_dataformat}})
             .set_page_size(packet_cb_id, packet_size_bytes);
-    tt::tt_metal::CBHandle cb_cb_handle = CreateCircularBuffer(program, all_cores, cb_packet_config);
+    CreateCircularBuffer(program, all_cores, cb_packet_config);
 
     // basic reader kernel set up
     std::vector<uint32_t> reader_ct_args;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23444

### Problem description
unused variables cause compile warnings

### What's changed
delete unused variables

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17136601016
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes