### PR TITLE
Migrating transformer sdpa_decode kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -131,13 +131,18 @@ void fill_tile_partial(uint32_t cb_id, uint32_t tile_id, uint32_t cur_pos_in_til
 /******************************************************************************
  *                   Attention Mask Functions                                 *
  ******************************************************************************/
-template <uint32_t cb_mask_in, uint32_t mask_tile_bytes, uint32_t barrier_threshold, uint32_t PNHt>
+template <
+    uint32_t cb_mask_in,
+    uint32_t mask_tile_bytes,
+    uint32_t barrier_threshold,
+    uint32_t PNHt,
+    typename MaskReaderType>
 uint32_t read_mask_chunk(
     uint32_t PSt,
     uint32_t Sk_chunk_t,
     uint32_t mask_chunk_tiles,
     uint32_t mask_start_tile_id,
-    const InterleavedAddrGenFast<true> mask_reader) {
+    const MaskReaderType& mask_reader) {
     // Read mask chunk
     cb_reserve_back(cb_mask_in, mask_chunk_tiles);
     uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
@@ -298,9 +303,8 @@ void worker_compute(
     cb_pop_front(cb_out_l, PNHt);
 }
 
-template <uint32_t cb_out, uint32_t out_chunk_tiles, uint32_t barrier_threshold>
-uint32_t write_tiles_to_memory(
-    uint32_t& out_tile_id, const InterleavedAddrGenFast<true>& out_writer, uint32_t& barrier_count) {
+template <uint32_t cb_out, uint32_t out_chunk_tiles, uint32_t barrier_threshold, typename WriterType>
+uint32_t write_tiles_to_memory(uint32_t& out_tile_id, const WriterType& out_writer, uint32_t& barrier_count) {
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     uint32_t l1_read_addr = get_read_ptr(cb_out);
     for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
@@ -315,10 +319,10 @@ uint32_t write_tiles_to_memory(
     return barrier_count;
 }
 
-template <uint32_t cb_out, uint32_t ELEMENT_SIZE, uint32_t barrier_threshold>
+template <uint32_t cb_out, uint32_t ELEMENT_SIZE, uint32_t barrier_threshold, typename WriterType>
 uint32_t write_partial_tiles_to_memory(
     uint32_t& out_tile_id,
-    const InterleavedAddrGenFast<true>& out_writer,
+    const WriterType& out_writer,
     uint32_t& barrier_count,
     uint32_t cur_head,
     uint32_t num_heads_to_write,
@@ -376,8 +380,10 @@ template <
     uint32_t cb_k_in,
     uint32_t cb_v_in,
     uint32_t cb_mask_in,
-    bool reuse_k  // If enabled, read V from K, instead of from DRAM
-    >
+    bool reuse_k,  // If enabled, read V from K, instead of from DRAM
+    typename KReaderType,
+    typename VReaderType,
+    typename MaskReaderType>
 void read_kv_mask_chunks(
     uint32_t k_chunk_start,
     uint32_t k_chunk_end,
@@ -387,9 +393,9 @@ void read_kv_mask_chunks(
     uint32_t k_chunk_tiles,
     uint32_t v_chunk_tiles,
     uint32_t mask_chunk_tiles,
-    const InterleavedAddrGenFast<true>& k_reader,
-    const InterleavedAddrGenFast<true>& v_reader,
-    const InterleavedAddrGenFast<true>& mask_reader,
+    const KReaderType& k_reader,
+    const VReaderType& v_reader,
+    const MaskReaderType& mask_reader,
     uint32_t k_tile_bytes,
     uint32_t v_tile_bytes,
     uint32_t PSt) {
@@ -416,7 +422,7 @@ void read_kv_mask_chunks(
         cb_push_back(cb_k_in, k_chunk_tiles);
 
         if constexpr (use_attention_mask) {
-            mask_start_tile_id = read_mask_chunk<cb_mask_in, mask_tile_bytes, barrier_threshold, PNHt>(
+            mask_start_tile_id = read_mask_chunk<cb_mask_in, mask_tile_bytes, barrier_threshold, PNHt, MaskReaderType>(
                 PSt, Sk_chunk_t, mask_chunk_tiles, mask_start_tile_id, mask_reader);
         }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -37,6 +37,9 @@ void kernel_main() {
     constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(23);
     constexpr uint32_t q_heads_parallel_factor = get_compile_time_arg_val(24);
 
+    // TensorAccessorArgs for output buffer
+    constexpr auto out_args = TensorAccessorArgs<25>();
+
     uint32_t arg_idx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t worker_id_for_reduce = get_arg_val<uint32_t>(arg_idx++);
@@ -107,8 +110,6 @@ void kernel_main() {
         num_cores_to_wait = k_num_chunks - 1;
     }
     uint32_t num_tiles_to_wait = (out_chunk_tiles + 2 * PNHt) * num_cores_to_wait;
-
-    constexpr bool is_dram = true;
     constexpr uint32_t cb_out = tt::CBIndex::c_20;
     constexpr uint32_t cb_intermed_out =
         tt::CBIndex::c_19;  // this cb holds the output intermediates from other worker cores
@@ -143,10 +144,8 @@ void kernel_main() {
     // *** Reducer Compute Below ***
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t tile_bytes_intermed = get_tile_size(cb_intermed_out);
-    constexpr DataFormat data_format = get_dataformat(cb_out);
 
-    const InterleavedAddrGenFast<is_dram> out_writer = {
-        .bank_base_address = out_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto out_writer = TensorAccessor(out_args, out_addr, tile_bytes);
 
     uint64_t intermed_l1_read_addr = get_noc_addr(get_read_ptr(cb_intermed_out));
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -724,6 +724,15 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         use_half_tile,
         q_chunk_size_bytes,
     };
+    // Add TensorAccessorArgs for all buffers in the order expected by the kernel
+    tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(attn_mask ? attn_mask->buffer() : nullptr).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(cur_pos_tensor ? cur_pos_tensor->buffer() : nullptr)
+        .append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(page_table_tensor ? page_table_tensor->buffer() : nullptr)
+        .append_to(reader_compile_time_args_common);
     if (use_attention_sink) {
         tt_metal::TensorAccessorArgs(*attention_sink->buffer()).append_to(reader_compile_time_args_common);
     } else {
@@ -757,6 +766,9 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         max_dynamic_chunk_size,
         q_heads_parallel_factor,
     };
+
+    // Add TensorAccessorArgs for output buffer
+    tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args_common);
 
     std::vector<uint32_t> compute_compile_time_args_common = {
         St,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs
### What's changed
Describe the approach used to solve the problem.
Refactored the transformer/sdpa_decode program_factory, reader kernel, and writer kernel to use TensorAccessor.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17138207757) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17138224561) CI with demo tests passes (if applicable)
- [ ] New/Existing tests provide coverage for changes