### PR TITLE
Add support for unstructured sparsity in SparseMatmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -10,6 +10,7 @@ import random
 import torch
 import ttnn
 
+from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -97,6 +98,7 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, ti
 @pytest.mark.parametrize("tile_h", [16])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
+@skip_for_blackhole("Semaphores used to broadcast sparsity is not propagating on BH, Issue #27979")
 def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype):
     # torch.manual_seed(0)
     m, k, n = mkn

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -13,7 +13,7 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("mkn", [(32, 128, 512)])
+@pytest.mark.parametrize("mkn", [(16, 128, 512)])
 @pytest.mark.parametrize("num_experts", [8])
 @pytest.mark.parametrize("num_tokens", [(1, 4)])
 @pytest.mark.parametrize("tile_h", [16])
@@ -77,7 +77,6 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, ti
     )
 
     output_tensor = ttnn.to_torch(output_t)
-    logger.info(output_tensor.shape)
 
     # Compute matmul using torch for each batch and concatenate the results
     for b, s, e in itertools.product(range(b), range(s), range(num_experts)):
@@ -121,7 +120,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_tokens, tile_h,
 
     in0_t = ttnn.from_torch(
         in0,
-        tile=ttnn.Tile((tile_h, 32)),
+        tile=ttnn.Tile((tile_h, tile_w)),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -35,7 +35,7 @@ def test_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 
-    sparsity = sparsity.to(dtype=torch.float32)
+    sparsity = sparsity.to(dtype=torch.bfloat16)
 
     nnz = int((sparsity != 0).sum().item())
     logger.info(f"nnz: {nnz}")
@@ -60,7 +60,7 @@ def test_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1
 
     sparsity_t = ttnn.from_torch(
         sparsity,
-        dtype=ttnn.float32,
+        dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -19,7 +19,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("tile_h", [16])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
-def test_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype):
+def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype):
     torch.manual_seed(0)
     m, k, n = mkn
     b, s = num_tokens
@@ -72,6 +72,84 @@ def test_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1
         in1_t,
         sparsity=sparsity_t,
         nnz=nnz,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_tile=output_tile,
+    )
+
+    output_tensor = ttnn.to_torch(output_t)
+    logger.info(output_tensor.shape)
+
+    # Compute matmul using torch for each batch and concatenate the results
+    for b, s, e in itertools.product(range(b), range(s), range(num_experts)):
+        if sparsity[0, b, s, e] == 0.0:
+            continue
+        in0_batch = in0[b, s, :, :]
+        in1_batch = in1[0, e, :, :]
+        pt_out = torch.matmul(in0_batch, in1_batch)
+
+        # Compare with output tensor
+        expected_pcc = 0.999
+        assert_with_pcc(pt_out, output_tensor[b, s, 0, e, :, :], expected_pcc)
+
+
+@pytest.mark.parametrize("mkn", [(32, 128, 512)])
+@pytest.mark.parametrize("num_experts", [8])
+@pytest.mark.parametrize("num_tokens", [(1, 4)])
+@pytest.mark.parametrize("tile_h", [16])
+@pytest.mark.parametrize("tile_w", [32])
+@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
+def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype):
+    # torch.manual_seed(0)
+    m, k, n = mkn
+    b, s = num_tokens
+    in0 = torch.randn((b, s, m, k), dtype=torch.bfloat16)
+    in1 = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
+
+    sparsity_shape = (1, b, s, num_experts)
+    sparsity = torch.rand(sparsity_shape)
+
+    # Mark some as 0 to test the sparsity
+    sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
+    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
+    sparsity.view(-1)[zero_indices] = 0.0
+
+    sparsity = sparsity.to(dtype=torch.bfloat16)
+
+    nnz = int((sparsity != 0).sum().item())
+    logger.info(f"nnz: {nnz}")
+
+    in0_t = ttnn.from_torch(
+        in0,
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    in1_t = ttnn.from_torch(
+        in1,
+        tile=ttnn.Tile((32, tile_w)),
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    sparsity_t = ttnn.from_torch(
+        sparsity,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tile = ttnn.Tile([tile_h, tile_w])
+    output_t = ttnn.sparse_matmul(
+        in0_t,
+        in1_t,
+        sparsity=sparsity_t,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         output_tile=output_tile,
     )

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -24,6 +24,10 @@ void kernel_main() {
     uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     // batch args
     constexpr uint32_t batch = get_compile_time_arg_val(6);
+    // sparsity args
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(7);
+    constexpr uint32_t nnz_cb_id = tt::CBIndex::c_25;
+    constexpr uint32_t IGNORE_BATCH = 0x2;
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -34,6 +38,28 @@ void kernel_main() {
         get_noc_addr(in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, in0_mcast_sender_semaphore_addr);
 
     for (uint32_t b = 0; b < batch; ++b) {
+        if constexpr (get_batch_from_reader) {
+            // Set in0 semaphore value to INVALID
+            noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+            // Atomic increment source core counter
+            noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+            // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+            noc_semaphore_wait_min(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+
+            const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
+            // We need to pass the value to compute UNPACK regardless of the value of is_batch_valid
+            cb_reserve_back(nnz_cb_id, 1);
+            auto nnz_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(nnz_cb_id));
+            // Pass chunk_count to compute UNPACK
+            nnz_ptr[0] = is_batch_valid;
+            cb_push_back(nnz_cb_id, 1);
+
+            // If value is 0x2, then we ignore the batch
+            if (!is_batch_valid) {
+                continue;
+            }
+        }
+
         for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                 for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -140,7 +140,7 @@ void kernel_main() {
 
         for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
             if constexpr (batchB > 0) {
-                if (reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr_sparsity)[bB] == 0) {
+                if (reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity)[bB] == 0) {
                     continue;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -55,9 +55,13 @@ void kernel_main() {
     constexpr uint32_t batch = get_compile_time_arg_val(19);
 
     // sparsity args
+
     constexpr uint32_t batchB = get_compile_time_arg_val(20);
     constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(21);
+    // Boolean that is set when input A is sparse. If set, both input A and B are assumed to be sparse.
+    // Based on the sparsity tensor, the corresponding batch in input A and B are skipped.
     constexpr bool bcast_A = (bool)get_compile_time_arg_val(22);
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
     constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(23);
 
     constexpr bool fuse_op = (bool)get_compile_time_arg_val(24);
@@ -65,7 +69,12 @@ void kernel_main() {
     constexpr auto in0_args = TensorAccessorArgs<25>();
     constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
 
+    // Reader will use this CB to pass the number of non-zero (nnz) entries in the sparsity tensor.
     constexpr uint32_t nnz_cb_id = tt::CBIndex::c_25;
+
+    // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
+    // 0x1 is used to specify "VALID" state, i.e. when the batch is valid.
+    // 0x2 is used to specify "IGNORE_BATCH" state, i.e. when the batch is not valid.
     constexpr uint32_t IGNORE_BATCH = 0x2;
 
     // When sparsity is disabled, we just loop once

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -224,7 +224,7 @@ void kernel_main() {
 
         for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
             if constexpr (batchB > 0) {
-                if (reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr_sparsity)[bB] == 0) {
+                if (reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity)[bB] == 0) {
                     out_tensor_start_tile_id += MtNt;
                     in1_batch_tile_id += KtNt;
                     continue;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -2836,7 +2836,7 @@ void SparseMatmul::validate(
         in1_tile_shape[1],
         bshape,
         in1_tile_shape);
-    TT_FATAL(this->nnz > 0, "nnz must be greater than 0");
+    TT_FATAL(this->nnz.value_or(1) > 0, "nnz ({}) must be greater than 0", this->nnz.value());
 
     // Check that nnz is less than or equal to the length of all batch dimensions
     uint32_t batch_length = 1;
@@ -2850,17 +2850,18 @@ void SparseMatmul::validate(
             batch_length *= bshape[i];
         }
     }
-    TT_FATAL(
-        this->nnz <= batch_length,
-        "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
-        this->nnz,
-        batch_length);
 
     // Check that sparsity has enough entries
     TT_FATAL(
         sparsity.logical_volume() == batch_length,
         "sparsity.logical_volume() ({}) must be equal to the product of all batch dimensions ({})",
         sparsity.logical_volume(),
+        batch_length);
+
+    TT_FATAL(
+        this->nnz.value_or(1) <= batch_length,
+        "nnz ({}) must be less than or equal to the length of all batch dimensions ({})",
+        this->nnz,
         batch_length);
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -158,7 +158,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
-    uint32_t nnz,
+    const std::optional<uint32_t> nnz,
     bool is_input_a_sparse,
     Tensor& output_tensor,
     CoreCoord compute_with_storage_grid_size,
@@ -281,7 +281,7 @@ Matmul create_matmul_struct(
     const std::vector<std::optional<Tensor>>& optional_output_tensors = {std::nullopt});
 
 struct SparseMatmul {
-    uint32_t nnz;
+    const std::optional<uint32_t> nnz;
     bool is_input_a_sparse;
     const std::optional<const MatmulProgramConfig> program_config = std::nullopt;
     const MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -64,7 +64,8 @@ ttnn::Shape compute_matmul_output_shape(const Tensor& input_tensor_a, const Tens
  * @param input_tensor_b Second input tensor
  * @return Shape of the resulting tensor after sparse matmul
  */
-ttnn::Shape compute_sparse_matmul_output_shape(const Tensor& input_tensor_a, const Tensor& input_tensor_b);
+ttnn::Shape compute_sparse_matmul_output_shape(
+    const Tensor& input_tensor_a, const Tensor& input_tensor_b, bool is_input_a_sparse);
 
 /*
  * GENERAL MATMUL AND BMM
@@ -158,6 +159,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
     uint32_t nnz,
+    bool is_input_a_sparse,
     Tensor& output_tensor,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -280,6 +282,7 @@ Matmul create_matmul_struct(
 
 struct SparseMatmul {
     uint32_t nnz;
+    bool is_input_a_sparse;
     const std::optional<const MatmulProgramConfig> program_config = std::nullopt;
     const MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
     const std::optional<DataType> output_dtype = std::nullopt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -158,7 +158,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
-    const std::optional<uint32_t> nnz,
+    std::optional<uint32_t> nnz,
     bool is_input_a_sparse,
     Tensor& output_tensor,
     CoreCoord compute_with_storage_grid_size,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2935,6 +2935,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     const Tensor& b,
     const Tensor& sparsity,
     uint32_t nnz,
+    bool is_input_a_sparse,
     Tensor& output_tensor,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -341,17 +341,10 @@ process_mcast_in0_program_and_create_override_variables(
             (std::uint32_t)M * K,  // MtKt
             (std::uint32_t)B,      // batch
             // sparsity args
-<<<<<<< HEAD
-            (std::uint32_t)0,   // batchB
-            (std::uint32_t)0,   // sparsity_pagesize (placeholder since sparsity not used in this case)
-            (std::uint32_t)true // bcast_A
-=======
-            (std::uint32_t)0,      // batchB
-            (std::uint32_t)false,  // sparsity_is_dram
-            (std::uint32_t)0,      // sparsity_log2_of_pagesize
-            (std::uint32_t)true,   // bcast_A
-            (std::uint32_t)false   // get_batch_from_reader
->>>>>>> db0b8b6f2b (SparseMatmul: Add option for not providing nnz and reading it on the fly)
+            (std::uint32_t)0,     // batchB
+            (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,  // bcast_A
+            (std::uint32_t)false  // get_batch_from_reader
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
@@ -3161,17 +3154,10 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         (std::uint32_t)Mt * Kt,  // MtKt
         (std::uint32_t)B_A,      // batchA
         // sparsity args
-<<<<<<< HEAD
         (std::uint32_t)B_B,                               // batchB
         (std::uint32_t)B_B * (uint32_t)sizeof(uint32_t),  // sparsity_pagesize
         (std::uint32_t)!is_input_a_sparse,                // bcast_A
-=======
-        (std::uint32_t)B_B,  // batchB
-        (std::uint32_t)sparsity_is_dram,
-        (std::uint32_t)std::log2(B_B * (uint32_t)sizeof(uint32_t)),  // log2 of page size
-        (std::uint32_t)!is_input_a_sparse,                           // bcast_A
-        (std::uint32_t)!nnz.has_value(),                             // get_batch_from_reader
->>>>>>> db0b8b6f2b (SparseMatmul: Add option for not providing nnz and reading it on the fly)
+        (std::uint32_t)!nnz.has_value(),                  // get_batch_from_reader
         // fuse op args
         (std::uint32_t)false,  // fuse_op
     };
@@ -3409,7 +3395,8 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     auto cb_sparsity1 = tt_metal::CreateCircularBuffer(program, all_cores, sparsity_cb_config1);
 
     if (!nnz.has_value()) {
-        // Create circular buffers
+        // When nnz is not provided, we need to infer this at runtime based on the sparsity tensor.
+        // We create a circular buffer to pass this value to the compute kernel from the reader.
         uint32_t nnz_cb_index = tt::CBIndex::c_25;
         const auto nnz_data_format = tt::DataFormat::UInt32;
         const auto nnz_cb_size = sparsity.logical_volume() * tt::datum_size(nnz_data_format);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -388,8 +388,9 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             (std::uint32_t)B,      // batch
 
             // sparsity args
-            (std::uint32_t)0,  // batchB
-            (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)0,   // batchB
+            (std::uint32_t)0,   // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true // bcast_A
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -388,9 +388,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             (std::uint32_t)B,      // batch
 
             // sparsity args
-            (std::uint32_t)0,   // batchB
-            (std::uint32_t)0,   // sparsity_pagesize (placeholder since sparsity not used in this case)
-            (std::uint32_t)true // bcast_A
+            (std::uint32_t)0,     // batchB
+            (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
+            (std::uint32_t)true,  // bcast_A
+            (std::uint32_t)false, // get_batch_from_reader
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
@@ -472,7 +473,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         (std::uint32_t)in0_mcast_sender_semaphore_id,
         (std::uint32_t)in0_mcast_receiver_semaphore_id,
         // batch args
-        (std::uint32_t)B  // batch
+        (std::uint32_t)B,     // batch
+        (std::uint32_t)false  // get_batch_from_reader
     };
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
         // READER
@@ -720,7 +722,9 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         B,                       // batch,
         out_block_tiles,         // out_block_num_tiles
 
-        untilize_out};
+        untilize_out,  // untilize_out
+        false          // get_batch_from_reader
+    };
 
     // Create compute kernel
     // bool fp32_dest_acc_en = true;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -434,7 +434,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
         B,                       // batch
         out_block_tiles,         // out_block_num_tiles
 
-        untilize_out  // untilize_out
+        untilize_out,  // untilize_out
+        false          // get_batch_from_reader
     };
 
     // Create compute kernel

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -214,7 +214,9 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
         num_blocks_per_core_group_1,  // batch
         out_block_tiles,
 
-        untilize_out};
+        untilize_out,  // untilize_out
+        false          // get_batch_from_reader
+    };
 
     std::map<std::string, std::string> mm_kernel_defines;
     if (packer_l1_acc_en) {
@@ -264,7 +266,9 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
             num_blocks_per_core_group_2,  // batch
             out_block_tiles,
 
-            untilize_out};
+            untilize_out,  // untilize_out
+            false          // get_batch_from_reader
+        };
         auto mm_kernel_group_2_id = tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -404,6 +404,7 @@ Tensor SparseMatmulOperation::invoke(
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
     uint32_t nnz,
+    bool is_input_a_sparse,
     const std::optional<const MemoryConfig>& memory_config,
     const std::optional<const DataType> dtype,
     const std::optional<const MatmulProgramConfig>& program_config,
@@ -421,6 +422,7 @@ Tensor SparseMatmulOperation::invoke(
         sparsity,
         SparseMatmul{
             nnz,
+            is_input_a_sparse,
             program_config,
             memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
             dtype,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -403,7 +403,7 @@ Tensor SparseMatmulOperation::invoke(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
-    uint32_t nnz,
+    const std::optional<uint32_t> nnz,
     bool is_input_a_sparse,
     const std::optional<const MemoryConfig>& memory_config,
     const std::optional<const DataType> dtype,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -116,6 +116,7 @@ struct SparseMatmulOperation {
         const Tensor& input_tensor_b,
         const Tensor& sparsity,
         uint32_t nnz,
+        bool is_input_a_sparse = false,
         const std::optional<const MemoryConfig>& memory_config = std::nullopt,
         std::optional<const DataType> dtype = std::nullopt,
         const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -115,7 +115,7 @@ struct SparseMatmulOperation {
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const Tensor& sparsity,
-        uint32_t nnz,
+        const std::optional<uint32_t> nnz,
         bool is_input_a_sparse = false,
         const std::optional<const MemoryConfig>& memory_config = std::nullopt,
         std::optional<const DataType> dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -115,7 +115,7 @@ struct SparseMatmulOperation {
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const Tensor& sparsity,
-        const std::optional<uint32_t> nnz,
+        std::optional<uint32_t> nnz,
         bool is_input_a_sparse = false,
         const std::optional<const MemoryConfig>& memory_config = std::nullopt,
         std::optional<const DataType> dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -645,7 +645,7 @@ void py_module(py::module& module) {
             input_tensor_b (ttnn.Tensor): the second tensor to be multiplied, containing the tokens to be processed. Needs to be on the device.
         Keyword Args:
             sparsity (ttnn.Tensor): the sparsity tensor containing the scale factor for each token for each expert. Needs to be on the device.
-            nnz (int): the number of non-zero values in the sparsity tensor.
+            nnz (int, optional): the number of non-zero values in the sparsity tensor. If not provided, it will be inferred from the sparsity tensor at runtime.
             is_input_a_sparse (bool): boolean indicating whether input_tensor_a is sparse. If true, corresponding inputs in both input_tensor_a and input_tensor_b are skipped according to sparsity tensor. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
@@ -681,7 +681,7 @@ void py_module(py::module& module) {
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
                const ttnn::Tensor& sparsity,
-               uint32_t nnz,
+               const std::optional<uint32_t> nnz,
                const bool is_input_a_sparse,
                const std::optional<const ttnn::MemoryConfig>& memory_config,
                const std::optional<const DataType> dtype,
@@ -712,7 +712,7 @@ void py_module(py::module& module) {
             py::arg("input_tensor_b"),
             py::kw_only(),
             py::arg("sparsity"),
-            py::arg("nnz"),
+            py::arg("nnz") = std::nullopt,
             py::arg("is_input_a_sparse") = false,
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -646,6 +646,7 @@ void py_module(py::module& module) {
         Keyword Args:
             sparsity (ttnn.Tensor): the sparsity tensor containing the scale factor for each token for each expert. Needs to be on the device.
             nnz (int): the number of non-zero values in the sparsity tensor.
+            is_input_a_sparse (bool): boolean indicating whether input_tensor_a is sparse. If true, corresponding inputs in both input_tensor_a and input_tensor_b are skipped according to sparsity tensor. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
@@ -681,6 +682,7 @@ void py_module(py::module& module) {
                const ttnn::Tensor& input_tensor_b,
                const ttnn::Tensor& sparsity,
                uint32_t nnz,
+               const bool is_input_a_sparse,
                const std::optional<const ttnn::MemoryConfig>& memory_config,
                const std::optional<const DataType> dtype,
                const std::optional<const MatmulProgramConfig>& program_config,
@@ -695,6 +697,7 @@ void py_module(py::module& module) {
                     input_tensor_b,
                     sparsity,
                     nnz,
+                    is_input_a_sparse,
                     memory_config,
                     dtype,
                     program_config,
@@ -710,6 +713,7 @@ void py_module(py::module& module) {
             py::kw_only(),
             py::arg("sparsity"),
             py::arg("nnz"),
+            py::arg("is_input_a_sparse") = false,
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("program_config") = std::nullopt,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25457

### Problem description
Previously, `SparseMatmul` op relied on `nnz` parameter to know how many tiles in inputs are valid. This integer parameter was fed at compile time for the kernel. At runtime, the exact locations of these tiles could vary, but the number of valid tiles always summed up to `nnz`. This is a common case when experts are replicated across all devices and when tokens are replicated OR sharded across devices.

When experts are sharded over devices, there is no fixed `nnz` that can be supplied at compile time. Depending on the token and the placement of experts, `nnz` for a given device and token can vary from [0-num_experts] (both inclusive).

### What's changed
This PR addresses this by adding a mode where `nnz` is not required at compile time. Rather, it allows the tiles to be operated or skipped dynamically at runtime. The reader kernel broadcasts the validity of each tile to (a) compute kernel and (b) reader kernels in other tensix cores of the device via broadcast.

It also adds support for input A to be sparse. When it is so, the sparsity vector is used to skip the invalid tiles in input A and the corresponding tiles in input B. This is different from the current mode where only input B is assumed to be sparse.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17479122469
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17479127142/job/49646269614 (1 known failure, also in main)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes