### PR TITLE
Fuse reshape operation with fold for row major tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -83,11 +83,14 @@ Fold::spec_return_value_t Fold::compute_output_specs(
             tt::tt_metal::TensorLayout(
                 input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), mem_config))};
     } else if (op_attr.is_dram_interleaved) {
-        ttnn::Shape output_logical_shape(
-            {input_shape[0],
-             input_shape[1] / op_attr.stride_h,
-             input_shape[2] / op_attr.stride_w,
-             input_shape[3] * op_attr.stride_h * op_attr.stride_w});
+        ttnn::Shape output_logical_shape({input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
+        if (input_tensor.layout() == Layout::ROW_MAJOR) {
+            output_logical_shape = ttnn::Shape(
+                {input_shape[0],
+                 input_shape[1] / op_attr.stride_h,
+                 input_shape[2] / op_attr.stride_w,
+                 input_shape[3] * op_attr.stride_h * op_attr.stride_w});
+        }
         return {TensorSpec(
             output_logical_shape,
             tt::tt_metal::TensorLayout(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -83,7 +83,11 @@ Fold::spec_return_value_t Fold::compute_output_specs(
             tt::tt_metal::TensorLayout(
                 input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), mem_config))};
     } else if (op_attr.is_dram_interleaved) {
-        ttnn::Shape output_logical_shape({input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
+        ttnn::Shape output_logical_shape(
+            {input_shape[0],
+             input_shape[1] / op_attr.stride_h,
+             input_shape[2] / op_attr.stride_w,
+             input_shape[3] * op_attr.stride_h * op_attr.stride_w});
         return {TensorSpec(
             output_logical_shape,
             tt::tt_metal::TensorLayout(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -310,9 +310,21 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
             .set_page_size(cb_src0_index, aligned_stick_nbytes * stride_w * stride_h);
     CreateCircularBuffer(program, all_cores, src_cb_config);
 
+    uint32_t cb_src1_index = tt::CBIndex::c_1;
+    auto src1_cb_config = CircularBufferConfig(stick_nbytes * stride_w * stride_h, {{cb_src1_index, cb_data_format}})
+                              .set_page_size(cb_src1_index, stick_nbytes * stride_w * stride_h);
+    CreateCircularBuffer(program, all_cores, src1_cb_config);
+
     // Create reader kernel
     std::vector<uint32_t> compile_time_args(
-        {stick_nbytes, cb_src0_index, aligned_stick_nbytes, stride_h, stride_w, input_width, patches_per_core});
+        {stick_nbytes,
+         cb_src0_index,
+         aligned_stick_nbytes,
+         stride_h,
+         stride_w,
+         input_width,
+         patches_per_core,
+         cb_src1_index});
     TensorAccessorArgs(*src0_buffer).append_to(compile_time_args);
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -352,7 +364,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
             src_col_offset = out_width * stride_w;
 
             src_idx = src_batch_offset + src_row_offset + src_col_offset;
-            dst_idx = output_offset * patch_size;
+            dst_idx = output_offset;
         }
 
         curr_patches += patches_per_core;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -14,7 +14,7 @@ void kernel_main() {
     constexpr uint32_t stride_w = get_compile_time_arg_val(4);
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
     constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
-    constexpr auto src_args = TensorAccessorArgs<8>();
+    constexpr auto src_args = TensorAccessorArgs<9>();
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     const auto s_in = TensorAccessor(src_args, src_addr, stick_nbytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -14,7 +14,7 @@ void kernel_main() {
     constexpr uint32_t stride_w = get_compile_time_arg_val(4);
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
     constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
-    constexpr auto src_args = TensorAccessorArgs<7>();
+    constexpr auto src_args = TensorAccessorArgs<8>();
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     const auto s_in = TensorAccessor(src_args, src_addr, stick_nbytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -6,22 +6,6 @@
 #include <cstdint>
 #include "dataflow_api.h"
 
-inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
-    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
-    for (uint32_t page = 0; page < npages; ++page) {
-        DPRINT << start + page << ": ";
-        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
-            DPRINT << BF16(*ptr) << " ";
-        }
-        DPRINT << ENDL();
-    }
-}
-
-#define dump(a)                                               \
-    do {                                                      \
-        DPRINT << "Activations: " << #a " = " << a << ENDL(); \
-    } while (false)
-
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
@@ -59,11 +43,8 @@ void kernel_main() {
             // If L1 aligned, write directly from the circular buffer
             noc_async_write(l1_addr, dst_noc_addr, stick_nbytes * patch_size);
         }
-        dump(dst_index);
-        dump(patch_size);
-        print_bf16_pages((uint32_t)patch_data, stick_nbytes / 2, patch_size);
         noc_async_write_barrier();
-        dst_index++;
         cb_pop_front(cb_id_in0, 1);
+        dst_index++;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -31,7 +31,8 @@ void kernel_main() {
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
     constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(7);
-    constexpr auto dst_args = TensorAccessorArgs<8>();
+    constexpr bool is_l1_aligned = get_compile_time_arg_val(8);
+    constexpr auto dst_args = TensorAccessorArgs<9>();
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     constexpr uint32_t patch_size = stride_h * stride_w;
@@ -43,14 +44,21 @@ void kernel_main() {
         uint32_t idx = 0;
         cb_wait_front(cb_id_in0, 1);
         uint32_t l1_addr = get_read_ptr(cb_id_in0);
-        for (uint32_t i = 0; i < patch_size; i++) {
-            for (uint32_t j = 0; j < stick_nbytes; j++) {
-                patch_data[idx++] = *(volatile uint8_t*)(l1_addr + j);
+        if constexpr (!is_l1_aligned) {
+            for (uint32_t i = 0; i < patch_size; i++) {
+                for (uint32_t j = 0; j < stick_nbytes; j++) {
+                    patch_data[idx++] = *(volatile uint8_t*)(l1_addr + j);
+                }
+                l1_addr += aligned_stick_nbytes_dram;
             }
-            l1_addr += aligned_stick_nbytes_dram;
         }
         uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
-        noc_async_write((uint32_t)patch_data, dst_noc_addr, stick_nbytes * patch_size);
+        if constexpr (!is_l1_aligned) {
+            noc_async_write((uint32_t)patch_data, dst_noc_addr, stick_nbytes * patch_size);
+        } else {
+            // If L1 aligned, write directly from the circular buffer
+            noc_async_write(l1_addr, dst_noc_addr, stick_nbytes * patch_size);
+        }
         dump(dst_index);
         dump(patch_size);
         print_bf16_pages((uint32_t)patch_data, stick_nbytes / 2, patch_size);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -6,6 +6,22 @@
 #include <cstdint>
 #include "dataflow_api.h"
 
+inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
+    for (uint32_t page = 0; page < npages; ++page) {
+        DPRINT << start + page << ": ";
+        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
+            DPRINT << BF16(*ptr) << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
+
+#define dump(a)                                               \
+    do {                                                      \
+        DPRINT << "Activations: " << #a " = " << a << ENDL(); \
+    } while (false)
+
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
@@ -14,22 +30,32 @@ void kernel_main() {
     constexpr uint32_t stride_w = get_compile_time_arg_val(4);
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
     constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
-    constexpr auto dst_args = TensorAccessorArgs<7>();
+    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(7);
+    constexpr auto dst_args = TensorAccessorArgs<8>();
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const auto s_out = TensorAccessor(dst_args, dst_addr, stick_nbytes);
-    uint32_t dst_index = get_arg_val<uint32_t>(1);
     constexpr uint32_t patch_size = stride_h * stride_w;
+    const auto s_out = TensorAccessor(dst_args, dst_addr, stick_nbytes * patch_size);
+    uint32_t dst_index = get_arg_val<uint32_t>(1);
+    uint32_t intermed_l1_scratch = get_write_ptr(cb_id_in1);
+    volatile tt_l1_ptr uint8_t* patch_data = (volatile uint8_t*)intermed_l1_scratch;
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
+        uint32_t idx = 0;
         cb_wait_front(cb_id_in0, 1);
         uint32_t l1_addr = get_read_ptr(cb_id_in0);
         for (uint32_t i = 0; i < patch_size; i++) {
-            uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
-            noc_async_write(l1_addr, dst_noc_addr, stick_nbytes);
-            dst_index++;
+            for (uint32_t j = 0; j < stick_nbytes; j++) {
+                patch_data[idx++] = *(volatile uint8_t*)(l1_addr + j);
+            }
             l1_addr += aligned_stick_nbytes_dram;
         }
+        uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
+        noc_async_write((uint32_t)patch_data, dst_noc_addr, stick_nbytes * patch_size);
+        dump(dst_index);
+        dump(patch_size);
+        print_bf16_pages((uint32_t)patch_data, stick_nbytes / 2, patch_size);
         noc_async_write_barrier();
+        dst_index++;
         cb_pop_front(cb_id_in0, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -5,7 +5,9 @@
 #include <stdint.h>
 #include <cstdint>
 #include "dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
+using namespace tt::data_movement::common;
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
@@ -23,15 +25,16 @@ void kernel_main() {
     const auto s_out = TensorAccessor(dst_args, dst_addr, stick_nbytes * patch_size);
     uint32_t dst_index = get_arg_val<uint32_t>(1);
     uint32_t intermed_l1_scratch = get_write_ptr(cb_id_in1);
-    volatile tt_l1_ptr uint8_t* patch_data = (volatile uint8_t*)intermed_l1_scratch;
+    // Datatypes will be multiple of 2 bytes only so it is safe to use uint16_t pointer
+    volatile tt_l1_ptr uint16_t* patch_data = (volatile uint16_t*)intermed_l1_scratch;
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t idx = 0;
         cb_wait_front(cb_id_in0, 1);
         uint32_t l1_addr = get_read_ptr(cb_id_in0);
         if constexpr (!is_l1_aligned) {
             for (uint32_t i = 0; i < patch_size; i++) {
-                for (uint32_t j = 0; j < stick_nbytes; j++) {
-                    patch_data[idx++] = *(volatile uint8_t*)(l1_addr + j);
+                for (uint32_t j = 0; j < (stick_nbytes / 2); j++) {
+                    patch_data[idx++] = *(volatile uint16_t*)(l1_addr + j * 2);
                 }
                 l1_addr += aligned_stick_nbytes_dram;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -330,10 +330,12 @@ Tensor FoldOperation::invoke(
         auto in_channels = input_tensor.logical_shape()[3];
         auto output_tensor =
             ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
-        // return ttnn::reshape(
-        //     output_tensor,
-        //     ttnn::Shape(
-        //         {batch_size, input_height / stride_h, input_width / stride_w, (in_channels)*stride_h * stride_w}));
+        if (input_tensor.layout() == Layout::TILE) {
+            return ttnn::reshape(
+                output_tensor,
+                ttnn::Shape(
+                    {batch_size, input_height / stride_h, input_width / stride_w, (in_channels)*stride_h * stride_w}));
+        }
         return output_tensor;
     }
     return ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -330,10 +330,11 @@ Tensor FoldOperation::invoke(
         auto in_channels = input_tensor.logical_shape()[3];
         auto output_tensor =
             ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
-        return ttnn::reshape(
-            output_tensor,
-            ttnn::Shape(
-                {batch_size, input_height / stride_h, input_width / stride_w, (in_channels)*stride_h * stride_w}));
+        // return ttnn::reshape(
+        //     output_tensor,
+        //     ttnn::Shape(
+        //         {batch_size, input_height / stride_h, input_width / stride_w, (in_channels)*stride_h * stride_w}));
+        return output_tensor;
     }
     return ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
For row major input tensors in fold operation, reshape is taking most time after placement of data at right location using fold device operation.

### What's changed
Fused reshape operation with fold on device for Row Major tensors.
Key Changes:
- Removed unnecessary reshape for RM tensors in `fold.cpp`
- Added L1 memory alignment optimization in writer kernel with conditional scratch buffer usage
- Fixed output shape calculation for RM tensors in device operation
- Enhanced kernel parameters to support both aligned/non-aligned memory scenarios

### Perf gain
Test Configuration: `channels=3, ROW_MAJOR_LAYOUT`

| Test Case | Before: Fold+Reshape (μs) | After: Fold Only (μs) | Improvement |
|-----------|---------------------------|----------------------|-------------|
| **nhw=(1,224,224), stride=(16,16)** | 105 + 566 = 671 | 82 | **87% faster** |
| **nhw=(1,384,512), stride=(16,16)** | 482 + 1,705 = 2,187 | 242 | **89% faster** |
| **nhw=(1,512,672), stride=(16,16)** | 609 + 2,972 = 3,581 | 395 | **89% faster** |
| **nhw=(1,224,224), stride=(32,32)** | 110 + 569 = 679 | 112 | **83% faster** |
| **nhw=(1,384,512), stride=(32,32)** | 450 + 1,718 = 2,168 | 304 | **86% faster** |
| **nhw=(1,512,672), stride=(32,32)** | 858 + 3,427 = 4,285 | 518 | **88% faster** |


### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/17148098316)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/17148104475)
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/17228342840/job/48877520141) same as main