### PR TITLE
#0: Fix distributed host buffer allocations

### DIFF
--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -730,14 +730,19 @@ Tensor allocate_tensor_on_device(const TensorSpec& tensor_spec, distributed::Mes
 }
 
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* device) {
-    auto distributed_host_buffer = DistributedHostBuffer::create(device->shape());
+    auto distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
+
+    std::vector<distributed::MeshCoordinate> coords;
+    coords.reserve(device->shape().mesh_size());
     for (const auto& coord : distributed::MeshCoordinateRange(device->shape())) {
-        distributed_host_buffer.emplace_shard(coord, []() { return HostBuffer(); });
+        coords.push_back(coord);
     }
 
-    distributed_host_buffer = distributed_host_buffer.transform(
-        [&](const HostBuffer&) { return tensor_impl::allocate_host_buffer(tensor_spec); },
+    distributed_host_buffer.emplace_shards(
+        coords,
+        [&](const auto&) { return tensor_impl::allocate_host_buffer(tensor_spec); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+
     // TODO (#25340): Implement correct logic and add test for this
     return Tensor(HostStorage(std::move(distributed_host_buffer)), tensor_spec, ReplicateTensor{}, TensorTopology{});
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -534,7 +534,7 @@ Tensor to_host(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
     distributed::MeshCommandQueue& mesh_cq = device->mesh_command_queue(*cq_id);
 
     // For performance, perform all allocations via DistributedHostBuffer::transform, run from multiple threads.
-    auto distributed_host_buffer = DistributedHostBuffer::create(device->shape());
+    auto distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
 
     distributed_host_buffer.emplace_shards(
         storage.coords,
@@ -698,7 +698,7 @@ void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blockin
         shards.push_back({device_coord, distributed_host_buffer.get_shard(device_coord)});
     }
 
-    DistributedHostBuffer dst_distributed_host_buffer = DistributedHostBuffer::create(device->shape());
+    DistributedHostBuffer dst_distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
     const size_t expected_size_bytes = device_tensor.tensor_spec().compute_packed_buffer_size_bytes();
     for (const auto& [device_coord, host_buffer] : shards) {
         dst_distributed_host_buffer.emplace_shard(device_coord, [&]() {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
https://github.com/tenstorrent/tt-metal/commit/196f240c45283b47a8f0b853da8fc5728ab1dbe6#diff-34de76e6a46483e94eb0ee1d3c41fb97539596ec5df778a48c8b2032dc6dc74c introduced an optimization to avoid re-processing of replicated data shards. It broke allocation code, as it relied on 2 step process to create empty shards, and then allocate them to non-empty buffers in parallel.

### What's changed
Fix the problematic code.

### Checklist
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/17158054923)
- [X] New/Existing tests provide coverage for changes - tested locally that the regression is gone
