### PR TITLE
Enable saving more intermediate compilation artifacts

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -377,6 +377,10 @@ void JitBuildState::compile_one(
     string cmd{"cd " + out_dir + " && " + env_.gpp_};
     string defines = this->defines_;
 
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_build_map_enabled()) {
+        cmd += "-save-temps=obj -fdump-tree-all -fdump-rtl-all ";
+    }
+
     if (settings) {
         // Append user args
         if (process_defines_at_compile_) {
@@ -440,7 +444,7 @@ void JitBuildState::link(const string& log_file, const string& out_dir, const Ji
     string lflags = this->lflags_;
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_build_map_enabled()) {
         lflags += "-Wl,-Map=" + out_dir + this->target_name_ + ".map ";
-        lflags += "-save-temps -fdump-tree-all -fdump-rtl-all ";
+        lflags += "-save-temps=obj -fdump-tree-all -fdump-rtl-all ";
     }
 
     // Append user args


### PR DESCRIPTION
### Ticket
NA

### Problem description
We don't provide a way of saving intermediate compilation artifacts (only intermediate linking artifacts).  This means the preprocessed source is unavailable when debugging compiler issues.

### What's changed
* Add similar dump options on compilation (`-c`) from linking.  Continue to (ab)use the map saving environment variable.
* specify `save-temps=obj` to be clear about where the intermediates are being saved.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes