### PR TITLE
[skip ci] Allow user to choose to tag image as latest in release container wrapper

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -267,7 +267,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      tag-latest:  ${{ needs.get-params.outputs.is-release-candidate !='true' }}
+      tag-latest:  ${{ needs.get-params.outputs.is-release-candidate != 'true' }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   release-docs:
     needs: [

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -267,7 +267,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' }}
+      tag-latest:  ${{ needs.get-params.outputs.is-release-candidate !='true' }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   release-docs:
     needs: [

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -2,6 +2,12 @@ name: "Create and Publish Release Docker Image"
 
 on:
   workflow_dispatch:
+    inputs:
+      tag-latest:
+        description: 'Tag the image as latest (WARNING: Affects production!)'
+        required: true
+        type: boolean
+        default: false
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
@@ -32,5 +38,5 @@ jobs:
     secrets: inherit
     with:
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}
-      is_major_version: false
+      tag-latest: ${{ inputs.tag-latest }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -6,7 +6,7 @@ on:
       version:
         required: true
         type: string
-      is_major_version:
+      tag-latest:
         required: true
         type: boolean
         default: false
@@ -138,7 +138,7 @@ jobs:
         run: |
           set -eu # basic shell hygiene
           LATEST_TAG=latest
-          if [ "${{  inputs.is_major_version }}" = "true" ]; then
+          if [ "${{ inputs.tag-latest }}" = "true" ]; then
             LATEST_TAG=latest
           else
             LATEST_TAG=latest-rc


### PR DESCRIPTION
Currently the publish-release-image-wrapper script allows devs to upload latest-rc tagged Docker images (specifically release and release-models), while only major new Metal releases push to latest. This is in line with desired behavior, but in certain cases where the containers need a quick update (such as when we introduced release-models), it may be beneficial to bypass this process and push the built images directly to latest. This PR introduces that option.