### PR TITLE
[skip ci] Use default timeout for BHPC cpp unit tests

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -202,7 +202,6 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}
-      timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Test times out on P100 and reaches close to the 20m timeout on P150, remove line and default back to 35min specified in the workflow
https://github.com/tenstorrent/tt-metal/actions/runs/17148558321/job/48675149803

### What's changed
Remove timeout input (default: 35min)

### Checklist
- [ ] New/Existing tests provide coverage for changes