### PR TITLE
#0: removed visualize_mesh_device tests using old signature

### DIFF
--- a/tests/ttnn/distributed/test_multidevice_TG.py
+++ b/tests/ttnn/distributed/test_multidevice_TG.py
@@ -1474,28 +1474,7 @@ def test_device_line_all_gather_8x4_data(mesh_device, cluster_axis: int, dim: in
     # )
 
 
-@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_visualize_mesh_device_with_tensor_row_major(mesh_device):
-    rows, cols, tile_size = 4, 4, 32
-    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
-
-    ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
-    )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
-    ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
-
-
-@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_visualize_mesh_device_with_tensor_col_major(mesh_device):
-    rows, cols, tile_size = 8, 2, 32
-    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
-
-    ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
-    )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
-    ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
+# TODO #11406 - Add unit tests for visualize_tensor API
 
 
 def rms_norm(x, gamma, eps):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[#11406: basic sharded tensor visualization across mesh](https://github.com/tenstorrent/tt-metal/pull/26413) changed the `visualize_mesh_device` signature by removing the `tensor` argument. The unit tests that were testing this functionality were not updated/removed, which caused frequent TG tests to [throw](https://github.com/tenstorrent/tt-metal/actions/runs/17149708107/job/48653430362#step:5:481).

### What's changed
Removed the unit tests. Unit tests for the new functionality will be pushed in a separate PR.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/17163310761))
- [x] [TG Frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/17163913234)
