### PR TITLE
Dependency issues with tt-nn-dev and tt-metalium-dev .deb -- fixes

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -45,6 +45,9 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS TRUE)
 # jit-build is cross compiling; shlibdeps does not find dependencies on the host; it should be self-contained anyway.
 set(CPACK_DEBIAN_METALIUM-JIT_PACKAGE_SHLIBDEPS FALSE)
 
+set(CPACK_DEBIAN_METALIUM-DEV_PACKAGE_DEPENDS "nlohmann-json3-dev (>= 3.10)")
+set(CPACK_DEBIAN_NN-DEV_PACKAGE_DEPENDS "libxtensor-dev (>= 0.23.10)")
+
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     ${PROJECT_BINARY_DIR}/tt-metalium-config-version.cmake
@@ -92,6 +95,7 @@ list(
     msgpack-cxx
     Headers
     Library
+    json-dev
     Unspecified # TODO: audit if there's anything we need to ship here
 )
 
@@ -108,7 +112,6 @@ cpack_add_component(tracy GROUP metalium)
 cpack_add_component_group(metalium-dev)
 cpack_add_component(metalium-dev DEPENDS metalium GROUP metalium-dev DESCRIPTION "TT-Metalium SDK")
 cpack_add_component(fmt-core GROUP metalium-dev)
-cpack_add_component(json-dev GROUP metalium-dev)
 cpack_add_component(enchantum GROUP metalium-dev)
 cpack_add_component(umd-dev GROUP metalium-dev)
 cpack_add_component(spdlog-dev GROUP metalium-dev)

--- a/cmake/packaging.d/tt-nn-config.cmake.in
+++ b/cmake/packaging.d/tt-nn-config.cmake.in
@@ -4,6 +4,7 @@ include(CMakeFindDependencyMacro)
 
 # Find all required dependencies
 find_dependency(TT-Metalium REQUIRED)
+find_dependency(xtensor REQUIRED)
 
 # Set package as found
 set(TT-NN_FOUND TRUE)


### PR DESCRIPTION
### Ticket

See #27323.

### Problem description

Adding tt-nn cmake package from tt-nn-dev (find_package(TT-NN REQUIRED) results in dependency error as xtensor library is missing. But trying to install libxtensor-dev .deb results in a conflict as it depends on nlohmann-json3-dev and tt-metalium-dev contains the same files, so there is conflict.

### What's changed

Package `tt-metalium-dev` now adds `nlohman-json3-dev` dependency instead of embedding json-dev files. Package `tt-nn-dev` adds `libxtensor-dev` dependency and in `tt-nn-config.cmake` there is reference to xtensor cmake package.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes