### PR TITLE
[skip ci] Update softmax_pybind.cpp, formatting changes for consistency

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -39,12 +39,12 @@ void bind_normalization_softmax_operation(py::module& module) {
                 \sigma(z_i) = \frac{e^{z_{i}}}{\sum_{j=1}^K e^{z_{j}}} \ \ \ for\ i=1,2,\dots,K
 
             Args:
-                * :attr:`input_tensor`: the input tensor
-                * :attr:`dim`: the dimension along which to compute softmax.
+                input_tensor (ttnn.Tensor): The input tensor.
+                dim (int): The dimension along which to compute softmax.
 
             Keyword Args:
-                * :attr:`memory_config`: the memory configuration for the output tensor. If not provided, the memory configuration of the input tensor is used.
-                * :attr:`compute_kernel_config`: the compute kernel configuration for the op. If not provided, the default configuration of the op is used.
+                memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. If not provided, the memory configuration of the input tensor is used.
+                compute_kernel_config (ttnn.ComputeKernelConfig, optional): the compute kernel configuration for the op. If not provided, the default configuration of the op is used.
 
             Note:
               Supported data types and layouts by tensor:


### PR DESCRIPTION
### Ticket
[25066](https://github.com/tenstorrent/tt-metal/issues/25066)
### Problem description
Formatting is different from other API descriptions.

### What's changed
Changed Args and Keyword Args formatting to match other APIs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes