### PR TITLE
[DM] Add tests for multiple cores to read/write to interleaved DRAM

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -16,6 +16,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/interleaved/test_interleaved.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/one_packet/test_one_packet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/multi_interleaved/test_multi_interleaved.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -29,6 +29,7 @@ Some test suites use slow dispatch mode for reliable program execution. These te
 | Conv Hardcoded              | 21-23                | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
 | Interleaved Page Read/Write | 61-69, 71-75         | Reads and writes pages between interleaved buffers and a Tensix core.                   |
 | One Packet Read/Write       | 80-83                | Reads or writes packets between two Tensix cores.                                       |
+| Multi Interleaved           | 110-127              | Reads and writes pages between interleaved DRAM buffers and multiple Tensix cores.      |
 | Core Bidrectional           | 140-148              | Tensix core reads from and writes to another Tensix core simultaneously.                |
 | Deinterleave                | 200-201              | Tests deinterleaving. **(Slow Dispatch)**                                               |
 | All to all                  | 300-308              | Write transactions from multiple cores to multiple cores.                               |

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
@@ -1,0 +1,47 @@
+# Multi Interleaved Data Movement Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between DRAM interleaved buffers and multiple Tensix cores.
+
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+
+## Test Flow
+Runs a reader kernel and/or a writer kernel on a grid of tensix cores.
+
+The reader kernel issues NOC instructions to read data from an interleaved DRAM buffer, initialized with data, into the L1 address of the Tensix cores calling the read_page API. A read barrier is placed after these transactions in order to ensure data validity. If the reader kernel isn't run, this data is initially written directly into L1 memory.
+
+The writer kernel issues NOC instructions to write data from the L1 address of the Tensix cores into an interleaved DRAM buffer. A write barrier is placed after these transactions in order to ensure data validity.
+
+Transactions exceeding 16 pages will consecutively overwrite the same 16 pages so as not to take up excess L1 memory. Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is read from the output interleaved buffer if the writer kernel is run (or directly from L1 memory otherwise), cross-checked with original data, and validated through a pcc check.
+
+Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+The tests use the Mesh Device API with fast dispatch mode:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*MultiInterleaved*"
+```
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| num_of_transactions       | uint32_t              | Number of transactions in test. |
+| num_pages                 | uint32_t              | Number of page read/writes per transaction. |
+| page_size_bytes           | uint32_t              | Size of a page in bytes (max 1 packet - 16kB for BH, 8kB for WH). |
+| l1_data_format            | DataFormat            | Type of data in transaction. |
+| cores                     | CoreRangeSet          | Logical coordinates of Tensix cores running kernels. |
+| read_kernel               | bool                  | True if test runs reader kernel. |
+| write_kernel              | bool                  | True if test runs writer kernel. |
+
+## Test Cases
+Each test case uses bfloat16 as L1 data format.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. Multi Interleaved Sizes: Tests reading and writing with interleaved DRAM buffer over varying number of transactions and transaction sizes over the full grid of Tensix cores.
+2. Multi Interleaved Page Directed Ideal: Tests the most optimal transactions for reading/writing pages by maximizing the number of pages and page size to amortize initialization overhead and saturate the bandwidth over the full grid of Tensix cores.
+3. Read tests: Run only the reader kernel.
+4. Write tests: Run only the writer kernel.
+5. Grid configuration tests: Run kernel(s) on a 2x2 or on a 6x6 grid of Tensix cores.

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+#include "dataflow_api.h"
+#include "tensix_types.h"
+
+// #include "debug/dprint.h"
+// #include "debug/dprint_pages.h"
+
+template <uint32_t num_of_transactions, uint32_t num_pages, uint32_t page_size_bytes, bool is_dram>
+FORCE_INLINE void noc_read_helper(const uint32_t l1_write_addr, const InterleavedAddrGen<is_dram>& s) {
+    for (uint32_t i = 0; i < num_of_transactions; i++) {
+        for (uint32_t p = 0; p < num_pages; p++) {
+            noc_async_read_page(p, s, l1_write_addr + p * page_size_bytes);
+        }
+    }
+    noc_async_read_barrier();
+}
+
+// DRAM to L1 read
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t l1_write_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr bool sync = get_compile_time_arg_val(5) == 1;
+
+    const InterleavedAddrGen<true> s = {.bank_base_address = src_addr, .page_size = page_size_bytes};
+
+    constexpr uint32_t transaction_size_bytes = page_size_bytes;
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    if constexpr (sync) {
+        cb_reserve_back(cb_id_in0, 1);
+    }
+    {
+        DeviceZoneScopedN("RISCV1");
+        noc_read_helper<num_of_transactions, num_pages, page_size_bytes, true>(l1_write_addr, s);
+    }
+    if constexpr (sync) {
+        cb_push_back(cb_id_in0, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
@@ -6,14 +6,16 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "tensix_types.h"
+#include "accessor/tensor_accessor.h"
 
-// #include "debug/dprint.h"
-// #include "debug/dprint_pages.h"
+#include "debug/dprint.h"
+#include "debug/dprint_pages.h"
 
 template <uint32_t num_of_transactions, uint32_t num_pages, uint32_t page_size_bytes, bool is_dram>
 FORCE_INLINE void noc_read_helper(const uint32_t l1_write_addr, const InterleavedAddrGen<is_dram>& s) {
     for (uint32_t i = 0; i < num_of_transactions; i++) {
         for (uint32_t p = 0; p < num_pages; p++) {
+            DPRINT << "Reading page " << p << " of transaction " << i << ENDL();
             noc_async_read_page(p, s, l1_write_addr + p * page_size_bytes);
         }
     }
@@ -22,6 +24,7 @@ FORCE_INLINE void noc_read_helper(const uint32_t l1_write_addr, const Interleave
 
 // DRAM to L1 read
 void kernel_main() {
+    DPRINT << "Kernel start" << ENDL();
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t l1_write_addr = get_arg_val<uint32_t>(1);
 
@@ -33,19 +36,32 @@ void kernel_main() {
     constexpr bool sync = get_compile_time_arg_val(5) == 1;
 
     const InterleavedAddrGen<true> s = {.bank_base_address = src_addr, .page_size = page_size_bytes};
+    // auto args = TensorAccessorArgs<0, 1>();
+    // auto s = TensorAccessor(args, src_addr, page_size_bytes);
 
     constexpr uint32_t transaction_size_bytes = page_size_bytes;
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
 
+    DPRINT << "Before cb reserve" << ENDL();
     if constexpr (sync) {
         cb_reserve_back(cb_id_in0, 1);
     }
+    DPRINT << "Before read" << ENDL();
     {
-        DeviceZoneScopedN("RISCV1");
+        DeviceZoneScopedN("RISCV0");
         noc_read_helper<num_of_transactions, num_pages, page_size_bytes, true>(l1_write_addr, s);
+        // for (uint32_t i = 0; i < num_of_transactions; i++) {
+        //     for (uint32_t p = 0; p < num_pages; p++) {
+        //         // noc_async_read_page(p, s, l1_write_addr + p * page_size_bytes);
+        //         uint64_t noc_addr = s.get_noc_addr(p);
+        //         noc_async_read(noc_addr, l1_write_addr + p * page_size_bytes, page_size_bytes);
+        //     }
+        // }
+        // noc_async_read_barrier();
     }
+    DPRINT << "Before cb push" << ENDL();
     if constexpr (sync) {
         cb_push_back(cb_id_in0, 1);
     }

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
@@ -7,8 +7,8 @@
 #include "dataflow_api.h"
 #include "tensix_types.h"
 
-// #include "debug/dprint.h"
-// #include "debug/dprint_pages.h"
+#include "debug/dprint.h"
+#include "debug/dprint_pages.h"
 
 template <uint32_t num_of_transactions, uint32_t num_pages, uint32_t page_size_bytes, bool is_dram>
 FORCE_INLINE void noc_write_helper(const uint32_t l1_read_addr, const InterleavedAddrGen<is_dram>& s) {
@@ -22,6 +22,7 @@ FORCE_INLINE void noc_write_helper(const uint32_t l1_read_addr, const Interleave
 
 // L1 to DRAM write
 void kernel_main() {
+    DPRINT << "Kernel start" << ENDL();
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t l1_read_addr = get_arg_val<uint32_t>(1);
 
@@ -38,15 +39,16 @@ void kernel_main() {
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
-
+    DPRINT << "Before cb wait" << ENDL();
     if constexpr (sync) {
         cb_wait_front(cb_id_out0, 1);
     }
     {
-        DeviceZoneScopedN("RISCV0");
+        DeviceZoneScopedN("RISCV1");
         noc_write_helper<num_of_transactions, num_pages, page_size_bytes, true>(l1_read_addr, s);
     }
     if constexpr (sync) {
         cb_pop_front(cb_id_out0, 1);
     }
+    DPRINT << "Kernel end" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
@@ -6,23 +6,10 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "tensix_types.h"
-
-#include "debug/dprint.h"
-#include "debug/dprint_pages.h"
-
-template <uint32_t num_of_transactions, uint32_t num_pages, uint32_t page_size_bytes, bool is_dram>
-FORCE_INLINE void noc_write_helper(const uint32_t l1_read_addr, const InterleavedAddrGen<is_dram>& s) {
-    for (uint32_t i = 0; i < num_of_transactions; i++) {
-        for (uint32_t p = 0; p < num_pages; p++) {
-            noc_async_write_page(p, s, l1_read_addr + p * page_size_bytes);
-        }
-    }
-    noc_async_write_barrier();
-}
+#include "accessor/tensor_accessor.h"
 
 // L1 to DRAM write
 void kernel_main() {
-    DPRINT << "Kernel start" << ENDL();
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t l1_read_addr = get_arg_val<uint32_t>(1);
 
@@ -33,22 +20,30 @@ void kernel_main() {
     constexpr uint32_t test_id = get_compile_time_arg_val(4);
     constexpr bool sync = get_compile_time_arg_val(5) == 1;
 
-    const InterleavedAddrGen<true> s = {.bank_base_address = dst_addr, .page_size = page_size_bytes};
+    // Tensor accessor compile time args appended to kernel's compile time args
+    // so the index is offset to start at 6
+    auto args = TensorAccessorArgs<6>();
+    auto s = TensorAccessor(args, dst_addr, page_size_bytes);
 
     constexpr uint32_t transaction_size_bytes = page_size_bytes;
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
-    DPRINT << "Before cb wait" << ENDL();
+
     if constexpr (sync) {
         cb_wait_front(cb_id_out0, 1);
     }
     {
         DeviceZoneScopedN("RISCV1");
-        noc_write_helper<num_of_transactions, num_pages, page_size_bytes, true>(l1_read_addr, s);
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            for (uint32_t p = 0; p < num_pages; p++) {
+                uint64_t noc_addr = s.get_noc_addr(p);
+                noc_async_write(l1_read_addr + p * page_size_bytes, noc_addr, page_size_bytes);
+            }
+        }
+        noc_async_write_barrier();
     }
     if constexpr (sync) {
         cb_pop_front(cb_id_out0, 1);
     }
-    DPRINT << "Kernel end" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+#include "dataflow_api.h"
+#include "tensix_types.h"
+
+// #include "debug/dprint.h"
+// #include "debug/dprint_pages.h"
+
+template <uint32_t num_of_transactions, uint32_t num_pages, uint32_t page_size_bytes, bool is_dram>
+FORCE_INLINE void noc_write_helper(const uint32_t l1_read_addr, const InterleavedAddrGen<is_dram>& s) {
+    for (uint32_t i = 0; i < num_of_transactions; i++) {
+        for (uint32_t p = 0; p < num_pages; p++) {
+            noc_async_write_page(p, s, l1_read_addr + p * page_size_bytes);
+        }
+    }
+    noc_async_write_barrier();
+}
+
+// L1 to DRAM write
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t l1_read_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr bool sync = get_compile_time_arg_val(5) == 1;
+
+    const InterleavedAddrGen<true> s = {.bank_base_address = dst_addr, .page_size = page_size_bytes};
+
+    constexpr uint32_t transaction_size_bytes = page_size_bytes;
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    if constexpr (sync) {
+        cb_wait_front(cb_id_out0, 1);
+    }
+    {
+        DeviceZoneScopedN("RISCV0");
+        noc_write_helper<num_of_transactions, num_pages, page_size_bytes, true>(l1_read_addr, s);
+    }
+    if constexpr (sync) {
+        cb_pop_front(cb_id_out0, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -161,7 +161,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
         MetalContext::instance().get_cluster().l1_barrier(device->id());
     }
 
-    auto mesh_workload = distributed::CreateMeshWorkload();
+    auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -165,7 +165,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -34,7 +34,7 @@ struct MultiInterleavedConfig {
 /// @param mesh_device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const MultiInterleavedConfig& test_config) {
+bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiInterleavedConfig& test_config) {
     log_info(
         tt::LogTest,
         "num transaction {}, num pages: {}, page size bytes: {}",
@@ -204,7 +204,7 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const MultiInterlea
 }
 
 void directed_ideal_test(
-    shared_ptr<distributed::MeshDevice> mesh_device,
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord mst_grid_size,
@@ -240,7 +240,7 @@ void directed_ideal_test(
 }
 
 void packet_sizes_test(
-    shared_ptr<distributed::MeshDevice> mesh_device,
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t test_case_id,
     CoreCoord mst_start_coord,
     CoreCoord mst_grid_size,

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -67,7 +67,7 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const MultiInterlea
 
     // Input
     vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -100.0f, 100.0f, total_size_bytes / bfloat16::SIZEOF, chrono::system_clock::now().time_since_epoch().count());
+        -100.0f, 100.0f, total_size_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
 
     // Golden output
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
@@ -98,7 +98,7 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const MultiInterlea
         CircularBufferConfig l1_cb_config =
             CircularBufferConfig(total_size_bytes, {{l1_cb_index, test_config.l1_data_format}})
                 .set_page_size(l1_cb_index, test_config.page_size_bytes);
-        auto l1_cb = CreateCircularBuffer(program, test_config.cores, l1_cb_config);
+        CreateCircularBuffer(program, test_config.cores, l1_cb_config);
     }
 
     std::vector<uint32_t> l1_addrs;

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace tt::tt_metal {
 
@@ -112,6 +113,7 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const MultiInterlea
 
     // Kernels
     if (test_config.read_kernel) {
+        TensorAccessorArgs(*input_buffer).append_to(reader_compile_args);
         auto reader_kernel = CreateKernel(
             program,
             "tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp",
@@ -128,6 +130,7 @@ bool run_dm(shared_ptr<distributed::MeshDevice> mesh_device, const MultiInterlea
     }
 
     if (test_config.write_kernel) {
+        TensorAccessorArgs(*output_buffer).append_to(writer_compile_args);
         auto writer_kernel = CreateKernel(
             program,
             "tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp",
@@ -291,7 +294,7 @@ void packet_sizes_test(
 
 }  // namespace unit_tests::dm::multi_interleaved
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== Full grid directed ideal ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -303,7 +306,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedDirectedIdeal
         mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== Full grid packet sizes sweep ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedSizes) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -315,7 +318,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedSizes) {
         mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== Full grid read kernel directed ideal ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -327,7 +330,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadDirectedI
         mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== Full grid read kernel packet sizes sweep ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadSizes) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -339,7 +342,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadSizes) {
         mesh_device, test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== Full grid write kernel directed ideal ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -351,7 +354,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteDirected
         mesh_device, test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== Full grid write kernel packet sizes sweep ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteSizes) {
     auto mesh_device = get_mesh_device();
     auto device = mesh_device->get_device(0);
@@ -363,7 +366,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteSizes) {
         mesh_device, test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== 2x2 CORE TESTS ========== */
+
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedDirectedIdeal) {
     uint32_t test_case_id = 116;
     CoreCoord mst_start_coord = {0, 0};
@@ -372,7 +376,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedDirectedId
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedSizes) {
     uint32_t test_case_id = 117;
     CoreCoord mst_start_coord = {0, 0};
@@ -381,7 +384,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedSizes) {
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadDirectedIdeal) {
     uint32_t test_case_id = 118;
     CoreCoord mst_start_coord = {0, 0};
@@ -390,7 +392,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadDirect
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadSizes) {
     uint32_t test_case_id = 119;
     CoreCoord mst_start_coord = {0, 0};
@@ -399,7 +400,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedReadSizes)
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteDirectedIdeal) {
     uint32_t test_case_id = 120;
     CoreCoord mst_start_coord = {0, 0};
@@ -408,7 +408,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteDirec
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteSizes) {
     uint32_t test_case_id = 121;
     CoreCoord mst_start_coord = {0, 0};
@@ -417,7 +416,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement2x2MultiInterleavedWriteSizes
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
+/* ========== 6x6 CORE TESTS ========== */
+
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedDirectedIdeal) {
     uint32_t test_case_id = 122;
     CoreCoord mst_start_coord = {0, 0};
@@ -426,7 +426,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedDirectedId
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedSizes) {
     uint32_t test_case_id = 123;
     CoreCoord mst_start_coord = {0, 0};
@@ -435,7 +434,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedSizes) {
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadDirectedIdeal) {
     uint32_t test_case_id = 124;
     CoreCoord mst_start_coord = {0, 0};
@@ -444,7 +442,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadDirect
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadSizes) {
     uint32_t test_case_id = 125;
     CoreCoord mst_start_coord = {0, 0};
@@ -453,7 +450,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedReadSizes)
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, true, false);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteDirectedIdeal) {
     uint32_t test_case_id = 126;
     CoreCoord mst_start_coord = {0, 0};
@@ -462,7 +458,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteDirec
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
 }
 
-/* ========== Test case for varying number of pages; Test id = 61 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteSizes) {
     uint32_t test_case_id = 127;
     CoreCoord mst_start_coord = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -100,6 +100,90 @@
     riscv_0:
       bandwidth: 61
 
+"Multi Interleaved Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 1
+    riscv_0:
+      bandwidth: 1
+  blackhole:
+    riscv_1:
+      bandwidth: 0.6
+    riscv_0:
+      bandwidth: 0.6
+
+"Multi Interleaved Read Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 1.9
+  blackhole:
+    riscv_0:
+      bandwidth: 1.5
+
+"Multi Interleaved Write Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 1.7
+  blackhole:
+    riscv_1:
+      bandwidth: 1.2
+
+"Multi Interleaved 2x2 Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 7.9
+    riscv_0:
+      bandwidth: 8.1
+  blackhole:
+    riscv_1:
+      bandwidth: 13
+    riscv_0:
+      bandwidth: 13
+
+"Multi Interleaved 2x2 Read Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 13.8
+  blackhole:
+    riscv_0:
+      bandwidth: 26
+
+"Multi Interleaved 2x2 Write Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 16
+  blackhole:
+    riscv_1:
+      bandwidth: 22
+
+"Multi Interleaved 6x6 Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 1.8
+    riscv_0:
+      bandwidth: 1.9
+  blackhole:
+    riscv_1:
+      bandwidth: 1.8
+    riscv_0:
+      bandwidth: 1.8
+
+"Multi Interleaved 6x6 Read Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 3.2
+  blackhole:
+    riscv_0:
+      bandwidth: 4.6
+
+"Multi Interleaved 6x6 Write Directed Ideal":
+  wormhole_b0:
+    riscv_1:
+      bandwidth: 2.9
+  blackhole:
+    riscv_1:
+      bandwidth: 3.5
+
 # OTHER TESTS
 
 "Reshard Hardcoded Small":

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -200,6 +200,60 @@ tests:
   102:
     name: "Multicast Single Scheme"
 
+  110:
+    name: "Multi Interleaved Directed Ideal"
+
+  111:
+    name: "Multi Interleaved Sizes"
+
+  112:
+    name: "Multi Interleaved Read Directed Ideal"
+
+  113:
+    name: "Multi Interleaved Read Sizes"
+
+  114:
+    name: "Multi Interleaved Write Directed Ideal"
+
+  115:
+    name: "Multi Interleaved Write Sizes"
+
+  116:
+    name: "Multi Interleaved 2x2 Directed Ideal"
+
+  117:
+    name: "Multi Interleaved 2x2 Sizes"
+
+  118:
+    name: "Multi Interleaved 2x2 Read Directed Ideal"
+
+  119:
+    name: "Multi Interleaved 2x2 Read Sizes"
+
+  120:
+    name: "Multi Interleaved 2x2 Write Directed Ideal"
+
+  121:
+    name: "Multi Interleaved 2x2 Write Sizes"
+
+  122:
+    name: "Multi Interleaved 6x6 Directed Ideal"
+
+  123:
+    name: "Multi Interleaved 6x6 Sizes"
+
+  124:
+    name: "Multi Interleaved 6x6 Read Directed Ideal"
+
+  125:
+    name: "Multi Interleaved 6x6 Read Sizes"
+
+  126:
+    name: "Multi Interleaved 6x6 Write Directed Ideal"
+
+  127:
+    name: "Multi Interleaved 6x6 Write Sizes"
+
   140:
     name: "Core Bidirectional Directed Ideal Same Kernel"
 


### PR DESCRIPTION
### Ticket
Link to Github Issues:
[1](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=122428137&issue=tenstorrent%7Ctt-metal%7C26097)
[2](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=113685767&issue=tenstorrent%7Ctt-metal%7C22981)

### Problem description
Data movement test suite does not have tests to analyze the performance for transactions where multiple cores want to read from and/or write to interleaved DRAM buffers. Previous tests only used one Tensix core at a time, which is often less realistic in practical applications.

### What's changed
Tests have been added:
- Can run on full grid, 6x6, or 2x2 cores
- Sweep over packet numbers and packet sizes, or perform directed ideal test
- Can test reader and writer kernel independently or together

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes