### PR TITLE
Port experimental OPs to TensorAccessor, part 1 (attempt #2)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_col_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_col_bcast_to.cpp
@@ -22,14 +22,12 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_src = get_compile_time_arg_val(1);
+    constexpr auto cb_id_src = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_no_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_no_bcast_to.cpp
@@ -22,14 +22,12 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_src = get_compile_time_arg_val(1);
+    constexpr auto cb_id_src = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_row_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_row_bcast_to.cpp
@@ -22,14 +22,12 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_src = get_compile_time_arg_val(1);
+    constexpr auto cb_id_src = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_scalar_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_scalar_bcast_to.cpp
@@ -22,14 +22,12 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(arg_index++);
     uint32_t Wt = get_arg_val<uint32_t>(arg_index++);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_src = get_compile_time_arg_val(1);
+    constexpr auto cb_id_src = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+    const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
     // this is the INPUT tile offset

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_col_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_col_bcast_to.cpp
@@ -25,13 +25,10 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
+    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_no_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_no_bcast_to.cpp
@@ -25,14 +25,11 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_dst = get_compile_time_arg_val(2);
+    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_row_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_row_bcast_to.cpp
@@ -25,13 +25,10 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
+    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_scalar_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_scalar_bcast_to.cpp
@@ -25,13 +25,10 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
+    constexpr auto cb_id_dst = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
-
-    const InterleavedAddrGenFast<dst_is_dram> dst = {
-        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+    const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     uint32_t HtWt = Ht * Wt;
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::dropout::program {
 namespace {
@@ -209,15 +210,12 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     // 3) Create reader/writer kernels
     // -------------------------------------------------------------------------
     auto src_buffer = input.buffer();
-    bool src_is_dram = (src_buffer->buffer_type() == BufferType::DRAM);
-
-    std::vector<uint32_t> reader_compile_args = {static_cast<uint32_t>(src_is_dram)};
+    std::vector<uint32_t> reader_compile_args = {static_cast<uint32_t>(kSrc0CbIndex)};
+    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_args);
 
     auto dst_buffer = output.buffer();
-    bool dst_is_dram = (dst_buffer->buffer_type() == BufferType::DRAM);
-
-    std::vector<uint32_t> writer_compile_args = {
-        static_cast<uint32_t>(kOutputCbIndex), static_cast<uint32_t>(dst_is_dram)};
+    std::vector<uint32_t> writer_compile_args = {static_cast<uint32_t>(kOutputCbIndex)};
+    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_args);
 
     DropoutKernels kernels{};
     kernels.reader = create_reader_kernel(program, all_cores, reader_compile_args, kReaderKernelPath);

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
@@ -10,17 +10,13 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-
-    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
-
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
 #ifdef OUT_SHARDED
     cb_wait_front(cb_id_out, num_tiles);
@@ -19,10 +19,7 @@ void kernel_main() {
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -23,11 +23,11 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t misalignment = get_compile_time_arg_val(1);
+    constexpr uint32_t misalignment = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
+    const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
 
     constexpr uint32_t cb_id_in0 = 0;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -19,14 +19,13 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-
     constexpr uint32_t cb_id_in0 = 0;
 
     uint32_t src_stick_id = start_id;
     uint32_t tiles_read = 0;
     const uint32_t tile_size = get_tile_size(cb_id_in0);
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = tile_size};
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(src_args, src_addr, tile_size);
 
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", num_dims: " << num_dims << ", start_id: " << start_id

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <vector>
@@ -278,7 +279,8 @@ static operation::ProgramWithCallbacks padded_slice_rm_multi_core(
 
     std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index};
 
-    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram, misalignment};
+    std::vector<uint32_t> reader_compile_time_args_vec = {misalignment};
+    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args_vec);
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/"
@@ -759,7 +761,8 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
         input_padded_shape.rank() /* == 4*/,
         output.element_size()};
 
-    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram, misalignment};
+    std::vector<uint32_t> reader_compile_time_args_vec = {};
+    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args_vec);
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -15,9 +15,9 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto src_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
+    const auto s0 = TensorAccessor(src_args, src_addr, stick_size);
 
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -40,9 +40,9 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
-    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = output_stick_size};
+    const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
     const uint32_t noc_write_size = std::min(output_stick_size, input_stick_size);
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
@@ -13,8 +13,7 @@ void kernel_main() {
     uint32_t input_num_blocks_h = get_arg_val<uint32_t>(3);
     uint32_t input_total_blocks_w = get_arg_val<uint32_t>(4);
 
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+    constexpr uint32_t scaler = get_compile_time_arg_val(0);
 
     constexpr uint32_t cb_id_in2 = 2;
     generate_reduce_scaler(cb_id_in2, scaler);
@@ -24,10 +23,8 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
-
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto src_args = TensorAccessorArgs<1>();
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
@@ -20,14 +20,11 @@ void kernel_main() {
     constexpr uint32_t intermed_cb_id1 = get_compile_time_arg_val(0);
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(2);
-    constexpr bool output_is_dram = get_compile_time_arg_val(3) == 1;
 
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(output_cb_id);
-    const DataFormat data_format = get_dataformat(output_cb_id);
-
-    const InterleavedAddrGenFast<output_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     const uint32_t end_id = start_id + num_output_blocks_w_per_core;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "prefix_scan_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::tt_metal;
 
@@ -98,6 +99,10 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
 
     std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id, cb_h_in_id};
     std::vector<uint32_t> writer_compile_time_args = {cb_out_id, cb_h_acc_id, cb_h_in_id};
+    tt::tt_metal::TensorAccessorArgs(a_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(bx_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(h_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_compile_time_args = {
         cb_a_in_id,
         cb_bx_in_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
@@ -18,20 +18,16 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_in1_transposed = get_compile_time_arg_val(2);
     constexpr uint32_t cb_in1_bcast_row = get_compile_time_arg_val(3);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(4) == 1;
-    constexpr bool src1_is_dram = get_compile_time_arg_val(5) == 1;
 
     uint32_t l1_write_addr_in0;
     uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
-    DataFormat src0_data_format = get_dataformat(cb_id_in0);
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr, .page_size = src0_tile_bytes, .data_format = src0_data_format};
+    constexpr auto src0_args = TensorAccessorArgs<4>();
+    const auto s0 = TensorAccessor(src0_args, src0_addr, src0_tile_bytes);
 
     uint32_t l1_write_addr_in1;
     uint32_t src1_tile_bytes = get_tile_size(cb_id_in1);
-    DataFormat src1_data_format = get_dataformat(cb_id_in1);
-    const InterleavedAddrGenFast<src1_is_dram> s1 = {
-        .bank_base_address = src1_addr, .page_size = src1_tile_bytes, .data_format = src1_data_format};
+    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+    const auto s1 = TensorAccessor(src1_args, src1_addr, src1_tile_bytes);
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_face = 16;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
@@ -12,15 +12,12 @@ void kernel_main() {
     uint32_t out_total_blocks_w = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
-
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     for (uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++) {
         uint32_t end_id = start_id + out_num_blocks_w_per_core;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::ssm::detail {
 
@@ -106,21 +107,18 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed3_config);
 
     // Compile time args
-    bool in0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool in1_is_dram = src1_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool out_is_dram = out_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)cb_intermed1_index,
         (std::uint32_t)cb_intermed2_index,
-        (std::uint32_t)in0_is_dram,
-        (std::uint32_t)in1_is_dram,
     };
+    tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(src1_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)output_cb_index,
-        (std::uint32_t)out_is_dram,
     };
+    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_args = {
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp
@@ -13,31 +13,27 @@ void kernel_main() {
     auto args = make_runtime_struct_from_args<ElemwiseReaderKernelArgs>();
     constexpr auto c_args = make_compile_time_struct_from_args<CompileTimeReaderKernelArgs>();
 
-    const InterleavedAddrGenFast<c_args.is_cond_tensor_in_dram> condition_tensor_addr_gen = {
-        .bank_base_address = args.condition_tensor_base_addr,
-        .page_size = get_tile_size(c_args.condition_cb),
-        .data_format = get_dataformat(c_args.condition_cb)};
+    constexpr auto condition_args = TensorAccessorArgs<3>();
+    constexpr auto true_args = TensorAccessorArgs<condition_args.next_compile_time_args_offset()>();
+    constexpr auto false_args = TensorAccessorArgs<true_args.next_compile_time_args_offset()>();
 
-    const InterleavedAddrGenFast<c_args.is_true_tensor_in_dram> true_tensor_addr_gen = {
-        .bank_base_address = args.true_tensor_base_addr,
-        .page_size = get_tile_size(c_args.true_tensor_cb),
-        .data_format = get_dataformat(c_args.true_tensor_cb)};
-
-    const InterleavedAddrGenFast<c_args.is_false_tensor_in_dram> false_tensor_addr_gen = {
-        .bank_base_address = args.false_tensor_base_addr,
-        .page_size = get_tile_size(c_args.false_tensor_cb),
-        .data_format = get_dataformat(c_args.false_tensor_cb)};
+    const auto condition_tensor =
+        TensorAccessor(condition_args, args.condition_tensor_base_addr, get_tile_size(c_args.condition_cb));
+    const auto true_tensor =
+        TensorAccessor(true_args, args.true_tensor_base_addr, get_tile_size(c_args.true_tensor_cb));
+    const auto false_tensor =
+        TensorAccessor(false_args, args.false_tensor_base_addr, get_tile_size(c_args.false_tensor_cb));
 
     constexpr uint32_t tile_cnt = 1;
     for (uint32_t tile_id = args.tile_ofs; tile_id < args.tile_ofs + args.num_tiles; tile_id++) {
         cb_reserve_back(c_args.condition_cb, tile_cnt);
-        noc_async_read_tile(tile_id, condition_tensor_addr_gen, get_write_ptr(c_args.condition_cb));
+        noc_async_read_tile(tile_id, condition_tensor, get_write_ptr(c_args.condition_cb));
 
         cb_reserve_back(c_args.true_tensor_cb, tile_cnt);
-        noc_async_read_tile(tile_id, true_tensor_addr_gen, get_write_ptr(c_args.true_tensor_cb));
+        noc_async_read_tile(tile_id, true_tensor, get_write_ptr(c_args.true_tensor_cb));
 
         cb_reserve_back(c_args.false_tensor_cb, tile_cnt);
-        noc_async_read_tile(tile_id, false_tensor_addr_gen, get_write_ptr(c_args.false_tensor_cb));
+        noc_async_read_tile(tile_id, false_tensor, get_write_ptr(c_args.false_tensor_cb));
 
         noc_async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel_args.hpp
@@ -21,9 +21,6 @@ struct CompileTimeReaderKernelArgs {
     uint32_t condition_cb;
     uint32_t true_tensor_cb;
     uint32_t false_tensor_cb;
-    bool is_cond_tensor_in_dram;
-    bool is_true_tensor_in_dram;
-    bool is_false_tensor_in_dram;
 };
 
 static_assert(ttnn::kernel_utils::SerializableKernelArgs<ElemwiseReaderKernelArgs>);

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel.cpp
@@ -12,17 +12,15 @@ void kernel_main() {
     auto args = make_runtime_struct_from_args<ElemwiseWriterKernelArgs>();
     constexpr auto c_args = make_compile_time_struct_from_args<CompileTimeWriterKernelArgs>();
 
-    const InterleavedAddrGenFast<c_args.is_dst_dram> dst_tensor_addr_gen = {
-        .bank_base_address = args.dst_base_addr,
-        .page_size = get_tile_size(c_args.cb_dst),
-        .data_format = get_dataformat(c_args.cb_dst)};
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+    const auto dst_tensor = TensorAccessor(dst_args, args.dst_base_addr, get_tile_size(c_args.cb_dst));
 
     constexpr uint32_t onetile = 1;
     uint32_t end_id = args.tile_ofs + args.num_tiles;
     for (uint32_t i = args.tile_ofs; i < end_id; ++i) {
         cb_wait_front(c_args.cb_dst, onetile);
         uint32_t l1_read_addr = get_read_ptr(c_args.cb_dst);
-        noc_async_write_tile(i, dst_tensor_addr_gen, l1_read_addr);
+        noc_async_write_tile(i, dst_tensor, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(c_args.cb_dst, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel_args.hpp
@@ -17,7 +17,6 @@ struct ElemwiseWriterKernelArgs {
 
 struct CompileTimeWriterKernelArgs {
     uint32_t cb_dst;
-    bool is_dst_dram;
 };
 
 static_assert(ttnn::kernel_utils::SerializableKernelArgs<ElemwiseWriterKernelArgs>);

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/element_wise_multi_core_where_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/element_wise_multi_core_where_program.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
@@ -73,31 +74,31 @@ ElementWiseMultiCoreWhereProgram::cached_program_t ElementWiseMultiCoreWhereProg
     CBHandle cb_output = createCircularBuffer(output_cb_index, single_tile_size, num_output_tiles);
 
     CompileTimeReaderKernelArgs reader_compile_time_args = {
-        .condition_cb = condition_cb,
-        .true_tensor_cb = true_values_cb,
-        .false_tensor_cb = false_values_cb,
-        .is_cond_tensor_in_dram = args.condition_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
-        .is_true_tensor_in_dram = args.true_value_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM,
-        .is_false_tensor_in_dram = args.false_value_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM};
+        .condition_cb = condition_cb, .true_tensor_cb = true_values_cb, .false_tensor_cb = false_values_cb};
 
     /* Specify data movement kernels for reading/writing data to/from DRAM */
     std::map<std::string, std::string> reader_defines;
+    std::vector<uint32_t> reader_compile_time_vec = ttnn::kernel_utils::to_vector(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(args.condition_tensor.buffer()).append_to(reader_compile_time_vec);
+    tt::tt_metal::TensorAccessorArgs(args.true_value_tensor.buffer()).append_to(reader_compile_time_vec);
+    tt::tt_metal::TensorAccessorArgs(args.false_value_tensor.buffer()).append_to(reader_compile_time_vec);
     KernelHandle reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp",
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig(ttnn::kernel_utils::to_vector(reader_compile_time_args), reader_defines));
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_vec, reader_defines));
 
     tt_metal::Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-    CompileTimeWriterKernelArgs writer_compile_time_args = {
-        .cb_dst = output_cb_index, .is_dst_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM};
+    CompileTimeWriterKernelArgs writer_compile_time_args = {.cb_dst = output_cb_index};
     std::map<std::string, std::string> writer_defines;
+    std::vector<uint32_t> writer_compile_time_vec = ttnn::kernel_utils::to_vector(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_vec);
     KernelHandle writer_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_writer_kernel.cpp",
         all_device_cores,
-        tt_metal::WriterDataMovementConfig(ttnn::kernel_utils::to_vector(writer_compile_time_args), writer_defines));
+        tt_metal::WriterDataMovementConfig(writer_compile_time_vec, writer_defines));
 
     /* Use the add_tiles operation in the compute kernel */
     KernelHandle compute_kernel_id = CreateKernel(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
This is the second attempt of the previously reverted PR https://github.com/tenstorrent/tt-metal/pull/27145.
The only difference is that I removed the changes to paged_cache OP which were causing failures. It will be ported separately in a future PR.

Refactored all of the kernels for the following experimental OPs to use TensorAccessor:
- bcast_to
- dropout
- padded_slice
- slice_write
- ssm
- where

This PR was generated by AI: Cursor + GPT 5 Max using this updated [prompt](https://gist.github.com/sminakov-tt/0ee29006457ccee6aa9bdb534663cc46).

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17108765423)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/17108770593)
- [x] [Blackhole nightly tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17109434156)
- [x] [Nightly L2 conv and pool tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17109441516)
- [x] [TG demo all-post-commit tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17166127549)
- [x] [Galaxy Quick CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17166131662)
- [x] New/Existing tests provide coverage for changes