### PR TITLE
Max Pool Fixes for Dilation with Ceil Mode on WH+BH and In Place Halo with Small Stick Sizes on BH

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -276,7 +276,10 @@ def run_max_pool(
 )
 @pytest.mark.parametrize(
     "dilation",
-    ((1, 1), (3, 4)),
+    (
+        (1, 1),
+        (3, 4),
+    ),
 )
 @pytest.mark.parametrize(
     "dtype",

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -278,7 +278,7 @@ def run_max_pool(
     "dilation",
     (
         (1, 1),
-        (3, 4),
+        (2, 2),
     ),
 )
 @pytest.mark.parametrize(
@@ -347,7 +347,7 @@ def test_run_max_pool_height_shard(
     "dilation",
     (
         (1, 1),
-        (2, 2),
+        (3, 1),
     ),
 )
 @pytest.mark.parametrize(
@@ -422,7 +422,7 @@ def test_run_max_pool_width_shard(
     "dilation",
     (
         (1, 1),
-        (1, 3),
+        (4, 3),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -89,6 +89,8 @@ def run_max_pool(
         if ceil_mode:
             if kernel_size == (3, 3) or kernel_size == (9, 9):
                 pytest.skip("Skip for kernel size (3, 3) and (9, 9) for ceil mode!")
+        if dilation != (1, 1) and stride != (1, 1):
+            pytest.skip("Skip for dilation with stride != (1, 1), also skips ceil mode for dilation!")
 
     if pad_t > kernel_h / 2 or pad_b > kernel_h / 2 or pad_l > kernel_w / 2 or pad_r > kernel_w / 2:
         pytest.skip("padding is too large for the kernel size")
@@ -274,7 +276,7 @@ def run_max_pool(
 )
 @pytest.mark.parametrize(
     "dilation",
-    ((1, 1),),
+    ((1, 1), (3, 4)),
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -341,8 +343,8 @@ def test_run_max_pool_height_shard(
 @pytest.mark.parametrize(
     "dilation",
     (
-        (1, 1),  # default - no dilation
-        (2, 2),  # symmetric dilation for width shard
+        (1, 1),
+        (2, 2),
     ),
 )
 @pytest.mark.parametrize(
@@ -416,8 +418,8 @@ def test_run_max_pool_width_shard(
 @pytest.mark.parametrize(
     "dilation",
     (
-        (1, 1),  # default - no dilation
-        (1, 3),  # asymmetric dilation for block shard
+        (1, 1),
+        (1, 3),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -115,13 +115,13 @@ def run_max_pool(
         out_w = math.floor((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
 
     torch.manual_seed(0)
-    # torch_input = randomize_torch_tensor(tensor_map, input_shape)
-    torch_input = torch.zeros(input_shape, dtype=torch.bfloat16)
-    for n in range(input_shape[0]):
-        for c in range(input_shape[1]):
-            for h in range(input_shape[2]):
-                for w in range(input_shape[3]):
-                    torch_input[n, c, h, w] = h * in_w + w
+    torch_input = randomize_torch_tensor(tensor_map, input_shape)
+    # act = torch.zeros(input_shape, dtype=torch.bfloat16)
+    # for n in range(input_shape[0]):
+    #     for c in range(input_shape[1]):
+    #         for h in range(input_shape[2]):
+    #             for w in range(input_shape[3]):
+    #                 act[n, c, h, w] = h * in_w + w
     ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
     torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
@@ -208,27 +208,6 @@ def run_max_pool(
     if dtype == ttnn.bfloat8_b:
         pcc_thresh = 0.997
         atol = 0.35
-
-    # Print mismatch coordinates if there are differences
-    diff_mask = ~torch.isclose(ttnn_output, torch_output, atol=atol, rtol=rtol)
-    if diff_mask.any():
-        mismatch_coords = torch.nonzero(diff_mask, as_tuple=False)
-        print(f"\nFound {mismatch_coords.shape[0]} mismatches:")
-        print(f"Output shape: {ttnn_output.shape} (N, C, H, W)")
-
-        # Print first 20 mismatches to avoid overwhelming output
-        max_print = min(20, mismatch_coords.shape[0])
-        for i in range(max_print):
-            coord = mismatch_coords[i]
-            n, c, h, w = coord[0].item(), coord[1].item(), coord[2].item(), coord[3].item()
-            ttnn_val = ttnn_output[n, c, h, w].item()
-            torch_val = torch_output[n, c, h, w].item()
-            diff = abs(ttnn_val - torch_val)
-            print(f"  [{n:2d}, {c:3d}, {h:3d}, {w:3d}]: ttnn={ttnn_val:8.4f}, torch={torch_val:8.4f}, diff={diff:8.4f}")
-
-        if mismatch_coords.shape[0] > max_print:
-            print(f"  ... and {mismatch_coords.shape[0] - max_print} more mismatches")
-
     assert_with_pcc(ttnn_output, torch_output, pcc_thresh)
     allclose = torch.allclose(ttnn_output, torch_output, atol=atol, rtol=rtol)
     isequal = torch.equal(ttnn_output, torch_output)

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -16,9 +16,8 @@ parameters = {
             [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
             [1, 16, 25, 23, 2, 2, 2, 2, 0, 0, 1, 1, False],  # C=16
             [1, 480, 28, 28, 3, 3, 2, 2, 1, 1, 1, 1, True],
-            # Dilation test cases for height shard
-            [1, 32, 24, 24, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Basic dilation=2
-            [1, 64, 32, 32, 3, 3, 1, 1, 1, 1, 2, 2, False],  # Dilation=2 with padding
+            [1, 7, 24, 24, 3, 3, 1, 1, 0, 0, 2, 2, False],  # dilation, C = 7
+            [1, 1, 59, 59, 3, 5, 4, 2, 1, 1, 5, 4, True],  # dilation with ceil mode, C = 1
             [1, 64, 400, 544, 3, 3, 2, 2, 1, 1, 1, 1, False],  # massive NHW
             [1, 832, 14, 14, 4, 4, 2, 2, 0, 0, 1, 1, True],  # > 800 channels, 16 kernel
             [1, 160, 30, 30, 15, 15, 1, 1, 7, 5, 1, 1, False],  # 15x15 kernel, uneven padding
@@ -42,8 +41,6 @@ parameters = {
             [1, 32768, 6, 6, 2, 2, 1, 1, 0, 0, 1, 1, False],  # wide in place untilize
             [1, 16384, 8, 8, 2, 2, 1, 1, 0, 0, 1, 1, False],  # normal in place untilize
             [1, 6144, 20, 20, 11, 11, 1, 1, 5, 5, 1, 1, False],  # 11x11 kernel
-            # Dilation test cases for width shard
-            [1, 8192, 16, 16, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Wide dilation=2
         ],
     },
     "block_shard_tests": {
@@ -52,9 +49,6 @@ parameters = {
         "input_specs": [
             [1, 4096, 16, 16, 2, 2, 1, 1, 0, 0, 1, 1, False],  # wide in place untilize
             [1, 2048, 16, 16, 2, 2, 1, 1, 0, 0, 1, 1, False],  # normal in place untilize
-            # Dilation test cases for block shard
-            [1, 1024, 20, 20, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Block shard dilation=2
-            [1, 2048, 16, 16, 3, 3, 1, 1, 1, 1, 1, 2, False],  # Block shard asymmetric dilation (1,2)
             # requires reversed local reads on some cores, and forward reads on others, wide in place untilize, large kernel
             [1, 4096, 16, 16, 5, 5, 2, 2, 2, 2, 1, 1, True],
             # requires reversed local reads on some cores, and forward reads on others, normal in place untilize, large kernel
@@ -66,8 +60,6 @@ parameters = {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_specs": [
             [1, 32, 224, 224, 3, 3, 2, 2, 1, 1, 1, 1, False],
-            # Dilation test case for memory config
-            [1, 64, 64, 64, 3, 3, 1, 1, 0, 0, 2, 2, False],  # Memory config dilation=2
         ],
     },
 }

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -9,34 +9,29 @@ from tests.ttnn.nightly.unit_tests.operations.pool.test_maxpool2d import run_max
 parameters = {
     "height_shard_tests": {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "in_place": [True],
+        "in_place": [True, False],
         "input_specs": [
             # Contains following parameters
             # [in_n, in_c, in_h, in_w, kernel_h, kernel_w, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
-            # [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
-            # [1, 16, 25, 23, 2, 2, 2, 2, 0, 0, 1, 1, False],  # C=16
-            # [1, 480, 28, 28, 3, 3, 2, 2, 1, 1, 1, 1, True],
-            [1, 1, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
-            [1, 4, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
-            [1, 7, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
-            [1, 8, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
-            [1, 16, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
-            [1, 32, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
-            # [1, 1, 59, 59, 3, 5, 4, 2, 1, 1, 5, 4, True],  # dilation with ceil mode, C = 1
-            # [1, 64, 400, 544, 3, 3, 2, 2, 1, 1, 1, 1, False],  # massive NHW
-            # [1, 832, 14, 14, 4, 4, 2, 2, 0, 0, 1, 1, True],  # > 800 channels, 16 kernel
-            # [1, 160, 30, 30, 15, 15, 1, 1, 7, 5, 1, 1, False],  # 15x15 kernel, uneven padding
-            # [1, 224, 20, 20, 8, 8, 6, 6, 2, 4, 1, 1, False],  # 8x8 kernel, uneven padding
-            # [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # massive kernel, wide
-            # [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW
-            # [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, True],  # massive kernel, wide, ceil mode
-            # [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, True],  # non-tile multiple NHW, ceil mode
-            # [1, 32, 6, 6, 3, 3, 1, 1, 1, 1, 1, 1, False],  # partial grid on WH to use noop cores
-            # [1, 32, 13, 8, 4, 3, 6, 5, 2, 1, 1, 1, True],  # ceil mode output shape adjustment edge case
-            # # requires reversed local reads on some cores, and forward reads on others
-            # [8, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, True],
-            # # requires reversed local reads on some cores, and forward reads on others, large kernel
-            # [32, 32, 264, 40, 5, 5, 2, 2, 2, 2, 1, 1, True],
+            [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
+            [1, 16, 25, 23, 2, 2, 2, 2, 0, 0, 1, 1, False],  # C=16
+            [1, 480, 28, 28, 3, 3, 2, 2, 1, 1, 1, 1, True],
+            [1, 7, 24, 24, 3, 3, 1, 1, 0, 0, 2, 2, False],  # dilation, C = 7
+            [1, 1, 59, 59, 3, 5, 4, 2, 1, 1, 5, 4, True],  # dilation with ceil mode, C = 1
+            [1, 64, 400, 544, 3, 3, 2, 2, 1, 1, 1, 1, False],  # massive NHW
+            [1, 832, 14, 14, 4, 4, 2, 2, 0, 0, 1, 1, True],  # > 800 channels, 16 kernel
+            [1, 160, 30, 30, 15, 15, 1, 1, 7, 5, 1, 1, False],  # 15x15 kernel, uneven padding
+            [1, 224, 20, 20, 8, 8, 6, 6, 2, 4, 1, 1, False],  # 8x8 kernel, uneven padding
+            [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # massive kernel, wide
+            [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW
+            [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, True],  # massive kernel, wide, ceil mode
+            [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, True],  # non-tile multiple NHW, ceil mode
+            [1, 32, 6, 6, 3, 3, 1, 1, 1, 1, 1, 1, False],  # partial grid on WH to use noop cores
+            [1, 32, 13, 8, 4, 3, 6, 5, 2, 1, 1, 1, True],  # ceil mode output shape adjustment edge case
+            # requires reversed local reads on some cores, and forward reads on others
+            [8, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, True],
+            # requires reversed local reads on some cores, and forward reads on others, large kernel
+            [32, 32, 264, 40, 5, 5, 2, 2, 2, 2, 1, 1, True],
         ],
     },
     "width_shard_tests": {
@@ -110,7 +105,7 @@ def test_max_pool2d_height_shard(device, dtype, in_place, input_spec):
     )
 
 
-""" @pytest.mark.parametrize("input_spec", parameters["width_shard_tests"]["input_specs"])
+@pytest.mark.parametrize("input_spec", parameters["width_shard_tests"]["input_specs"])
 @pytest.mark.parametrize("dtype", parameters["width_shard_tests"]["dtype"])
 @pytest.mark.parametrize("in_place", parameters["width_shard_tests"]["in_place"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
@@ -222,4 +217,4 @@ def test_max_pool2d_mem_config(device, dtype, input_spec, memory_config):
         ceil_mode=ceil_mode,
         in_place=False,
         nightly_skips=False,
-    ) """
+    )

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -9,29 +9,34 @@ from tests.ttnn.nightly.unit_tests.operations.pool.test_maxpool2d import run_max
 parameters = {
     "height_shard_tests": {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "in_place": [True, False],
+        "in_place": [True],
         "input_specs": [
             # Contains following parameters
             # [in_n, in_c, in_h, in_w, kernel_h, kernel_w, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
-            [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
-            [1, 16, 25, 23, 2, 2, 2, 2, 0, 0, 1, 1, False],  # C=16
-            [1, 480, 28, 28, 3, 3, 2, 2, 1, 1, 1, 1, True],
-            [1, 7, 24, 24, 3, 3, 1, 1, 0, 0, 2, 2, False],  # dilation, C = 7
-            [1, 1, 59, 59, 3, 5, 4, 2, 1, 1, 5, 4, True],  # dilation with ceil mode, C = 1
-            [1, 64, 400, 544, 3, 3, 2, 2, 1, 1, 1, 1, False],  # massive NHW
-            [1, 832, 14, 14, 4, 4, 2, 2, 0, 0, 1, 1, True],  # > 800 channels, 16 kernel
-            [1, 160, 30, 30, 15, 15, 1, 1, 7, 5, 1, 1, False],  # 15x15 kernel, uneven padding
-            [1, 224, 20, 20, 8, 8, 6, 6, 2, 4, 1, 1, False],  # 8x8 kernel, uneven padding
-            [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # massive kernel, wide
-            [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW
-            [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, True],  # massive kernel, wide, ceil mode
-            [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, True],  # non-tile multiple NHW, ceil mode
-            [1, 32, 6, 6, 3, 3, 1, 1, 1, 1, 1, 1, False],  # partial grid on WH to use noop cores
-            [1, 32, 13, 8, 4, 3, 6, 5, 2, 1, 1, 1, True],  # ceil mode output shape adjustment edge case
-            # requires reversed local reads on some cores, and forward reads on others
-            [8, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, True],
-            # requires reversed local reads on some cores, and forward reads on others, large kernel
-            [32, 32, 264, 40, 5, 5, 2, 2, 2, 2, 1, 1, True],
+            # [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
+            # [1, 16, 25, 23, 2, 2, 2, 2, 0, 0, 1, 1, False],  # C=16
+            # [1, 480, 28, 28, 3, 3, 2, 2, 1, 1, 1, 1, True],
+            [1, 1, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
+            [1, 4, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
+            [1, 7, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
+            [1, 8, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
+            [1, 16, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
+            [1, 32, 11, 11, 2, 2, 1, 1, 0, 0, 1, 1, False],  # dilation, C = 7
+            # [1, 1, 59, 59, 3, 5, 4, 2, 1, 1, 5, 4, True],  # dilation with ceil mode, C = 1
+            # [1, 64, 400, 544, 3, 3, 2, 2, 1, 1, 1, 1, False],  # massive NHW
+            # [1, 832, 14, 14, 4, 4, 2, 2, 0, 0, 1, 1, True],  # > 800 channels, 16 kernel
+            # [1, 160, 30, 30, 15, 15, 1, 1, 7, 5, 1, 1, False],  # 15x15 kernel, uneven padding
+            # [1, 224, 20, 20, 8, 8, 6, 6, 2, 4, 1, 1, False],  # 8x8 kernel, uneven padding
+            # [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # massive kernel, wide
+            # [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW
+            # [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, True],  # massive kernel, wide, ceil mode
+            # [1, 290, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, True],  # non-tile multiple NHW, ceil mode
+            # [1, 32, 6, 6, 3, 3, 1, 1, 1, 1, 1, 1, False],  # partial grid on WH to use noop cores
+            # [1, 32, 13, 8, 4, 3, 6, 5, 2, 1, 1, 1, True],  # ceil mode output shape adjustment edge case
+            # # requires reversed local reads on some cores, and forward reads on others
+            # [8, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, True],
+            # # requires reversed local reads on some cores, and forward reads on others, large kernel
+            # [32, 32, 264, 40, 5, 5, 2, 2, 2, 2, 1, 1, True],
         ],
     },
     "width_shard_tests": {
@@ -105,7 +110,7 @@ def test_max_pool2d_height_shard(device, dtype, in_place, input_spec):
     )
 
 
-@pytest.mark.parametrize("input_spec", parameters["width_shard_tests"]["input_specs"])
+""" @pytest.mark.parametrize("input_spec", parameters["width_shard_tests"]["input_specs"])
 @pytest.mark.parametrize("dtype", parameters["width_shard_tests"]["dtype"])
 @pytest.mark.parametrize("in_place", parameters["width_shard_tests"]["in_place"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
@@ -217,4 +222,4 @@ def test_max_pool2d_mem_config(device, dtype, input_spec, memory_config):
         ceil_mode=ceil_mode,
         in_place=False,
         nightly_skips=False,
-    )
+    ) """

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/assert.hpp>
 
 #include "tt-metalium/constants.hpp"
-#include "tt-metalium/hal.hpp"
 
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 namespace ttnn::operations::pool {
@@ -225,14 +224,8 @@ uint32_t calculate_L1_usage(
     uint32_t out_cb_npages = output_memory.shard_spec().value().shape[0] * params.out_ntiles_c;
     uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
 
-    uint32_t alignment_bytes = tt::tt_metal::hal::get_dram_alignment();
-    auto align = [alignment_bytes](uint32_t size) {
-        uint32_t factor = (size + alignment_bytes - 1) / alignment_bytes;
-        return factor * alignment_bytes;
-    };
-
     return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
-           align(out_cb_config_size) /* global, involved */;
+           sliding_window::align_buffer(out_cb_config_size) /* global, involved */;
 }
 
 std::optional<ParallelConfig> determine_pool_config_for_auto_shard(

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -117,6 +117,8 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         const uint32_t output_shard_width = output_tensor.memory_config().shard_spec()->shape[1];
         const uint32_t input_width_bytes = input_shard_width * nbytes;
         const uint32_t output_width_bytes = output_shard_width * nbytes;
+        // for small stick sizes alignment can cause the shards to be larger than the number of sticks, thus
+        // we must account for alignment when computing the size delta between input and output shards
         uint32_t aligned_delta_size =
             align_buffer(this->max_out_nsticks_per_core_ * output_width_bytes) / output_width_bytes -
             align_buffer(this->in_nsticks_per_core_ * input_width_bytes) / input_width_bytes;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -109,7 +109,8 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
     Program program = CreateProgram();
 
     if (this->in_place_) {
-        const DataType dtype = input_tensor.dtype();
+        // after untilize bfloat8 is converted to bfloat16
+        const DataType dtype = input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.dtype();
         const tt::DataFormat data_format = datatype_to_dataformat_converter(dtype);
         const uint32_t nbytes = datum_size(data_format);
         const uint32_t channels_padded = input_tensor.padded_shape()[3];

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -103,7 +103,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
     auto pad_metadata = sliding_window::generate_pad_metadata(config_);
     auto op_trace_metadata = sliding_window::generate_op_trace_metadata(config_);
     auto shard_boundaries = sliding_window::generate_shard_boundaries(config_, op_trace_metadata);
-    uint32_t input_shard_height = input_tensor.memory_config().shard_spec()->shape[0];
+    const uint32_t input_shard_height = input_tensor.memory_config().shard_spec()->shape[0];
     auto tensor_metadata = sliding_window::generate_tensor_metadata(pad_metadata, config_, input_shard_height);
 
     Program program = CreateProgram();
@@ -113,11 +113,13 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         const DataType dtype = input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.dtype();
         const tt::DataFormat data_format = datatype_to_dataformat_converter(dtype);
         const uint32_t nbytes = datum_size(data_format);
-        const uint32_t channels_padded = input_tensor.padded_shape()[3];
-        const uint32_t num_shards_c = this->config_.num_cores_c;
-        const uint32_t stick_size = channels_padded / num_shards_c * nbytes;
-        uint32_t aligned_delta_size = align_buffer(this->max_out_nsticks_per_core_ * stick_size) / stick_size -
-                                      align_buffer(this->in_nsticks_per_core_ * stick_size) / stick_size;
+        const uint32_t input_shard_width = input_tensor.memory_config().shard_spec()->shape[1];
+        const uint32_t output_shard_width = output_tensor.memory_config().shard_spec()->shape[1];
+        const uint32_t input_width_bytes = input_shard_width * nbytes;
+        const uint32_t output_width_bytes = output_shard_width * nbytes;
+        uint32_t aligned_delta_size =
+            align_buffer(this->max_out_nsticks_per_core_ * output_width_bytes) / output_width_bytes -
+            align_buffer(this->in_nsticks_per_core_ * input_width_bytes) / input_width_bytes;
         int32_t in_out_shard_size_delta = (this->in_place_ && is_in_tiled)
                                               ? 0
                                               : aligned_delta_size;  // for in place with tilized data we untilize

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "compile_time_args.h"
+#include "c_tensix_core.h"
 #include "dataflow_api.h"
 
 #define ENABLE_DEBUG 0
@@ -168,6 +169,7 @@ void copy_sticks_async_local(
             const uint16_t src_local_idx = config_data[i + j + 0];
             const uint16_t dst_local_idx = config_data[i + j + 1];
             const uint16_t nsticks = config_data[i + j + 2];
+
             const uint32_t size = nsticks * stick_nbytes;
             const uint32_t dst_offset = dst_local_idx * stick_nbytes;
             const uint32_t src_offset = src_local_idx * input_aligned_page_size;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -7,7 +7,6 @@
 #include <cstdint>
 
 #include "compile_time_args.h"
-#include "c_tensix_core.h"
 #include "dataflow_api.h"
 
 #define ENABLE_DEBUG 0
@@ -169,7 +168,6 @@ void copy_sticks_async_local(
             const uint16_t src_local_idx = config_data[i + j + 0];
             const uint16_t dst_local_idx = config_data[i + j + 1];
             const uint16_t nsticks = config_data[i + j + 2];
-
             const uint32_t size = nsticks * stick_nbytes;
             const uint32_t dst_offset = dst_local_idx * stick_nbytes;
             const uint32_t src_offset = src_local_idx * input_aligned_page_size;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -344,6 +344,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     const uint32_t ncores_c,
     const uint32_t max_out_nsticks_per_core,
     const uint32_t max_ref_size,
+    const uint32_t in_out_shard_size_delta,
     const Tensor& padding_config,
     const Tensor& local_config,
     const Tensor& remote_config,
@@ -490,10 +491,6 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
-    int32_t in_out_buffer_start_delta = max_out_nsticks_per_core - input_npages;
-    if (!skip_untilize) {
-        in_out_buffer_start_delta = 0;
-    }
     const auto delta = output_tensor.buffer()->aligned_size_per_bank() - input_tensor.buffer()->aligned_size_per_bank();
     TT_ASSERT(
         src_buffer->address() == dst_buffer->address() + delta,
@@ -596,7 +593,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
         rectangular_y,
         last_active_x,
         semaphore_id,
-        in_out_buffer_start_delta,
+        in_out_shard_size_delta,
         temp_cb_id,
         ntiles_per_block,
         input_nblocks_per_core,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
@@ -35,6 +35,7 @@ tt::tt_metal::operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_c
     uint32_t ncores_c,
     uint32_t max_out_nsticks_per_core,
     uint32_t max_ref_size,
+    uint32_t in_out_shard_size_delta,
     const Tensor& padding_config,
     const Tensor& local_config,
     const Tensor& remote_config,

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1012,7 +1012,6 @@ std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_inplac
 
         std::vector<std::vector<std::vector<uint16_t>>> flattened_config(2);
         int max_ref_size = 0;  // track the max remote ref size for sizing the remote temp tensor
-        int core = 0;
         for (const auto& core_config : config) {
             std::vector<std::vector<uint16_t>> flat_data(2, std::vector<uint16_t>(max_len, 0));
             uint32_t idx1 = 0, idx2 = 0;
@@ -1050,7 +1049,6 @@ std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_inplac
                 idx2 = flat_data[1][len_idx2] ? idx2 : idx2 - 3;
             }
 
-            core++;
             flattened_config[0].emplace_back(std::move(flat_data[0]));
             flattened_config[1].emplace_back(std::move(flat_data[1]));
             max_ref_size = std::max(max_ref_size, ref_size);

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -128,8 +128,12 @@ uint32_t SlidingWindowConfig::get_ceil_pad_h() const {
             (float)(input_hw.first + get_pad_h() - dilation_hw.first * (window_hw.first - 1) - 1) / stride_hw.first;
         uint32_t output_h = std::ceil(output_h_float) + 1;
 
+        // Calculate effective kernel size with dilation
+        uint32_t effective_kernel_h = dilation_hw.first * (window_hw.first - 1) + 1;
+
         // extra_padding = ceil size - non ceil size
-        ceil_padding_h = stride_hw.first * (output_h - 1) + window_hw.first - input_hw.first - get_pad_h();
+        int32_t padding_calc = stride_hw.first * (output_h - 1) + effective_kernel_h - input_hw.first - get_pad_h();
+        ceil_padding_h = (padding_calc > 0) ? static_cast<uint32_t>(padding_calc) : 0;
     }
 
     return ceil_padding_h;
@@ -143,8 +147,12 @@ uint32_t SlidingWindowConfig::get_ceil_pad_w() const {
             (float)(input_hw.second + get_pad_w() - dilation_hw.second * (window_hw.second - 1) - 1) / stride_hw.second;
         uint32_t output_w = std::ceil(output_w_float) + 1;
 
+        // Calculate effective kernel size with dilation
+        uint32_t effective_kernel_w = dilation_hw.second * (window_hw.second - 1) + 1;
+
         // extra_padding = ceil size - non ceil size
-        ceil_padding_w = stride_hw.second * (output_w - 1) + window_hw.second - input_hw.second - get_pad_w();
+        int32_t padding_calc = stride_hw.second * (output_w - 1) + effective_kernel_w - input_hw.second - get_pad_w();
+        ceil_padding_w = (padding_calc > 0) ? static_cast<uint32_t>(padding_calc) : 0;
     }
 
     return ceil_padding_w;

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -9,6 +9,7 @@
 #include <fmt/core.h>
 
 #include "ttnn/tensor/host_buffer/functions.hpp"
+#include "tt-metalium/hal.hpp"
 
 namespace ttnn::operations::sliding_window {
 
@@ -131,7 +132,8 @@ std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_inplac
     tt::tt_metal::IDevice* device,
     uint32_t max_out_nsticks_per_core = INT_MAX,
     uint32_t in_nsticks_per_core = 0,
-    bool in_place = false);
+    bool in_place = false,
+    uint32_t in_out_shard_size_delta = 0);
 
 struct HaloGatherKernelConfig {
     std::vector<std::vector<uint16_t>> pad_config0;
@@ -178,6 +180,8 @@ Tensor move_config_tensor_to_device(
     const ParallelConfig& p_config,
     bool is_block_sharded,
     tt::tt_metal::distributed::MeshDevice* device);
+
+uint32_t align_buffer(uint32_t size);
 
 }  // namespace ttnn::operations::sliding_window
 


### PR DESCRIPTION
### Ticket
No issue for the bugs, but also took care of https://github.com/tenstorrent/tt-metal/issues/27316 while I was at it.

### Problem description
There are two bugs in the version of Max Pool on main:
- Non (1, 1) dilation causes a seg fault when ceiling mode was enabled
- In Place Halo can give incorrect results for small stick sizes on blackhole

### What's changed
- The `get_ceil_pad_h/w` functions have been updated to use the effective kernel width in the calculation fixing the seg fault
- The `in_out_shard_size_delta` calculation for in-place halo has been updated to account for blackhole's different alignment in the case of small stick sizes.
- Test coverage for dilation has been increased in the nightly test and the test cases in the unit test have been made more challenging

Nightly Blackhole runtime is around 30 min
Unit Blackhole runtime is around 4 min

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17215323701
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17215326131
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17215331743
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17215335740
- [x] New/Existing tests provide coverage for changes