### PR TITLE
Build docker images if basic-ttnn-runtime doesn't exist

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -162,7 +162,7 @@ jobs:
   build-docker-image:
     name: "🐳️ Build images"
     needs: check-docker-images
-    if: needs.check-docker-images.outputs.dev-exists != 'true' || needs.check-docker-images.outputs.basic-dev-exists != 'true' || needs.check-docker-images.outputs.manylinux-exists != 'true'
+    if: needs.check-docker-images.outputs.dev-exists != 'true' || needs.check-docker-images.outputs.basic-dev-exists != 'true' || needs.check-docker-images.outputs.basic-ttnn-runtime-exists != 'true' || needs.check-docker-images.outputs.manylinux-exists != 'true'
     timeout-minutes: 90
     runs-on: tt-ubuntu-2204-large-stable
     steps:


### PR DESCRIPTION
### Ticket
In the APC pipeline, if the basic-ttnn-runtime Docker image isn’t found, the image-creation job isn’t triggered, which causes downstream failures. [Link](https://github.com/tenstorrent/tt-metal/actions/runs/17166642019/job/48708400680)

```
Run if docker manifest inspect ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:1f372bff01436b6c6f677d6bd3c568e25ab3690d > /dev/null 2>&1; then
ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:1f372bff01436b6c6f677d6bd3c568e25ab3690d exists
ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:358fadfe72089bc3e37dada913e19d22befab578 exists
ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-ttnn-runtime-amd64:591151031a338e9f857f00936fb8443884245ede does not exist
ghcr.io/tenstorrent/tt-metal/tt-metalium/manylinux-amd64:0f48acd041a10dd5ac344885962eb631ad59e446 exists
```

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. [Result](https://github.com/tenstorrent/tt-metal/actions/runs/17172666806)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes