### PR TITLE
enable fabric receiver channel to alternate nocs when issuing noc writes out of the receiver channel

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -225,7 +225,8 @@ struct FabricEriscDatamoverConfig {
     static constexpr uint32_t DEFAULT_NOC_VC = 2;
     static constexpr uint32_t NUM_EDM_NOC_VCS = 2;
 
-    static constexpr uint32_t DEFAULT_RECEIVER_FORWARDING_NOC = 1;
+    static constexpr uint32_t DEFAULT_RECEIVER_FORWARDING_NOC_WHEN_NOT_NOC_SWITCHING = 1;
+    static constexpr uint32_t DEFAULT_RECEIVER_FORWARDING_NOC_WHEN_NOC_SWITCHING = 0;
     static constexpr uint32_t DEFAULT_RECEIVER_LOCAL_WRITE_NOC = 1;
     static constexpr uint32_t DEFAULT_SENDER_ACK_NOC = 0;
 
@@ -390,6 +391,8 @@ struct FabricEriscDatamoverConfig {
     std::size_t edm_noc_vc = 0;
 
 private:
+    void initialize_noc_command_buffer_assignments(Topology topology);
+
     void configure_buffer_slots_helper(
         Topology topology,
         const FabricEriscDatamoverOptions& options,

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
@@ -23,6 +23,7 @@ FORCE_INLINE void send_chunk_from_address_with_trid(
     uint32_t remote_l1_write_addr_l,
     uint8_t trid,
     uint8_t noc,
+    uint8_t vc,
     uint8_t cmd_buf) {
     if constexpr (stateful_api) {
         noc_async_write_one_packet_with_trid_with_state<false, true>(
@@ -34,7 +35,8 @@ FORCE_INLINE void send_chunk_from_address_with_trid(
             page_size * num_pages,
             trid,
             cmd_buf,
-            noc);
+            noc,
+            vc);
     }
     // TODO: this barrier will no longer be functional since we are not incrementing noc counters, remove
     if constexpr (blocking_mode == EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING) {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -428,6 +428,11 @@ constexpr bool enable_trid_flush_check_on_noc_txn = false;
 
 constexpr bool is_persistent_fabric = true;
 
+// TODO: get from CT args
+constexpr bool ENABLE_NOC_SWAPPING_ON_RECEIVER_CHANNEL_WRITES = is_2d_fabric;
+// NoC Programming Constants
+constexpr bool ENABLE_FORWARD_WRITE_STATEFUL_API_USE = !is_2d_fabric && !ENABLE_NOC_SWAPPING_ON_RECEIVER_CHANNEL_WRITES;
+
 namespace tt::tt_fabric {
 static_assert(
     receiver_channel_local_write_noc_ids[0] == edm_to_local_chip_noc,

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1784,7 +1784,12 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 // clang-format on
 template <InlineWriteDst dst_type = InlineWriteDst::DEFAULT, bool posted = false>
 FORCE_INLINE void noc_inline_dw_write(
-    uint64_t addr, uint32_t val, uint8_t be = 0xF, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    uint64_t addr,
+    uint32_t val,
+    uint8_t be = 0xF,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_UNICAST_WRITE_VC,
+    uint8_t cmd_buf = write_at_cmd_buf) {
     WAYPOINT("NWIW");
     DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
     DEBUG_SANITIZE_NO_DRAM_ADDR(noc, addr, 4);
@@ -1797,7 +1802,7 @@ FORCE_INLINE void noc_inline_dw_write(
 
     noc_fast_write_dw_inline<noc_mode, dst_type>(
         noc,
-        write_at_cmd_buf,
+        cmd_buf,
         val,
         addr,
         be,  // byte-enable


### PR DESCRIPTION
this change optimizes the fabric router by working around noc command buffer buffering limitations: each command buffer is only a single entry deep and the noc can only service one command buffer at a time. The consequence of this is that if multiple writes are to be queued up, the second, third, fourth, etc. noc writes will block the issuing risc core until (roughly) the previous write is completed. 

In the case of a 4096 B noc write, this means a second write to the same noc and command buffer would stall for atleast 128 cycles, in the best case. This is more than half of the entire instruction budget per processed packet in fabric to serve 4k packets at 20 GB/s; worse for fabric-level-multicasts with mcast factors greater than 2. Note: this value is obtained by dividing the message size by the ideal noc bandwidth (4096 B / 32 B/c = 128 cycles).

The changes in this PR adopt a simple initial scheme of alternating nocs between subsequent writes out of the receiver  channel. In practice, this means stall time for noc command buf readiness can but cut roughly in half, in the worst case. This change does not apply the ideal noc assignment scheme for each channel - the ideal assignment is the one which minimizes noc congestion. That change is left as future work.

However, despite this change only including the simplest optimization of blindly alternating the noc, the performance improvement is still notable:

Issue: https://github.com/tenstorrent/tt-metal/issues/27039


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes