### PR TITLE
Default approx flag in log-related ops to false

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -101,7 +101,7 @@ bool run_test(MeshDevice* device, const ttnn::Shape& shape, float low, float hig
         return ttnn::allclose<bfloat16>(host_output, device_output, args...);
     } else if constexpr (unary_op_type == UnaryOpType::LOG) {
         auto host_output = host_function<::detail::log>(input_tensor);
-        auto device_output = ttnn::log(input_tensor.to_device(device), true).cpu();
+        auto device_output = ttnn::log(input_tensor.to_device(device), /*fast_and_approximate_mode=*/true).cpu();
         return ttnn::allclose<bfloat16>(host_output, device_output, args...);
     } else if constexpr (unary_op_type == UnaryOpType::TANH) {
         auto host_output = host_function<::detail::tanh>(input_tensor);

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -101,7 +101,7 @@ bool run_test(MeshDevice* device, const ttnn::Shape& shape, float low, float hig
         return ttnn::allclose<bfloat16>(host_output, device_output, args...);
     } else if constexpr (unary_op_type == UnaryOpType::LOG) {
         auto host_output = host_function<::detail::log>(input_tensor);
-        auto device_output = ttnn::log(input_tensor.to_device(device)).cpu();
+        auto device_output = ttnn::log(input_tensor.to_device(device), true).cpu();
         return ttnn::allclose<bfloat16>(host_output, device_output, args...);
     } else if constexpr (unary_op_type == UnaryOpType::TANH) {
         auto host_output = host_function<::detail::tanh>(input_tensor);

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
@@ -33,7 +33,7 @@ def test_pow_fractional_composite(device):
     yt = y
     yt_floor = math.floor(yt)
     yt_trunc = yt - yt_floor
-    pow_trunc_log = ttnn.multiply(ttnn.log(xt), yt_trunc)
+    pow_trunc_log = ttnn.multiply(ttnn.log(xt, fast_and_approximate_mode=True), yt_trunc)
     pow_frac = ttnn.exp(pow_trunc_log)
     xtt = ttnn.mul(ttnn.pow(xt, yt_floor), pow_frac)
     assert list(xtt.padded_shape) == [N, C, H, W]

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
@@ -28,7 +28,7 @@ tt::tt_metal::Tensor log_softmax(const tt::tt_metal::Tensor& t, int dim) {
     auto t_sub_max_exp = ttnn::exp(t_sub_max);
     auto t_sum_over_dim = sum_over_dim(t_sub_max_exp, dim);
 
-    auto log_t_sum_over_dim = ttnn::log(t_sum_over_dim);
+    auto log_t_sum_over_dim = ttnn::log(t_sum_over_dim, true);
     return ttnn::subtract(t_sub_max, log_t_sum_over_dim);
 }
 

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
@@ -28,7 +28,7 @@ tt::tt_metal::Tensor log_softmax(const tt::tt_metal::Tensor& t, int dim) {
     auto t_sub_max_exp = ttnn::exp(t_sub_max);
     auto t_sum_over_dim = sum_over_dim(t_sub_max_exp, dim);
 
-    auto log_t_sum_over_dim = ttnn::log(t_sum_over_dim, true);
+    auto log_t_sum_over_dim = ttnn::log(t_sum_over_dim, /*fast_and_approximate_mode=*/true);
     return ttnn::subtract(t_sub_max, log_t_sum_over_dim);
 }
 

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -85,7 +85,7 @@ ALWI void sigmoid_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-template <bool fast_and_approx = true>
+template <bool fast_and_approx = false>
 ALWI void log_tile_init() {
     MATH((llk_math_eltwise_unary_sfpu_log_init<APPROX, fast_and_approx>()));  // TODO(AP): move out init
 }
@@ -104,7 +104,7 @@ ALWI void log_tile_init() {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
  // clang-format on
-template <bool fast_and_approx = true>
+template <bool fast_and_approx = false>
 ALWI void log_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_log<APPROX, fast_and_approx>(idst)));
 }
@@ -112,7 +112,7 @@ ALWI void log_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-template <bool fast_and_approx = true>
+template <bool fast_and_approx = false>
 ALWI void log_with_base_tile_init() {
     MATH((llk_math_eltwise_unary_sfpu_log_with_base_init<APPROX, fast_and_approx>()));  // TODO(AP): move out init
 }
@@ -132,7 +132,7 @@ ALWI void log_with_base_tile_init() {
  * | base_scale      | The log base                                                               | uint32_t | Postive integers                                      | True     |
  */
 // clang-format on
-template <bool fast_and_approx = true>
+template <bool fast_and_approx = false>
 ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
     MATH((llk_math_eltwise_unary_sfpu_log_with_base<APPROX, fast_and_approx>(idst, base_scale)));
 }

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/log1p.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/log1p.h
@@ -14,7 +14,7 @@ namespace ckernel {
 /**
  * Please refer to documentation for any_init.
  */
-template <bool fast_and_approx = true>
+template <bool fast_and_approx = false>
 ALWI void log1p_tile_init() {
     MATH((llk_math_eltwise_unary_sfpu_log1p_init<APPROX, fast_and_approx>()));
 }
@@ -33,7 +33,7 @@ ALWI void log1p_tile_init() {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-template <bool fast_and_approx = true>
+template <bool fast_and_approx = false>
 ALWI void log1p_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_log1p<APPROX, fast_and_approx>(idst)));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -34,8 +34,8 @@ void MAIN {
 
             exp_tile_init<1u>();
             exp_tile<1u>(0);
-            log1p_tile_init();
-            log1p_tile(0);
+            log1p_tile_init<true>();
+            log1p_tile<true>(0);
             tanh_tile_init();
             tanh_tile(0);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -138,24 +138,10 @@ template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::EXP>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::ERF>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::ERFC>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::GELU>;
-
-template <UnaryOpType unary_op_type>
-Tensor ExecuteUnaryWithFastAndApproximateModeTrue<unary_op_type>::invoke(
-    const Tensor& input_tensor,
-    const bool parameter,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    return detail::unary_impl(
-        input_tensor,
-        {UnaryWithParam{unary_op_type, static_cast<float>(parameter)}},
-        memory_config,
-        optional_output_tensor);
-}
-
-template struct ExecuteUnaryWithFastAndApproximateModeTrue<UnaryOpType::LOG>;
-template struct ExecuteUnaryWithFastAndApproximateModeTrue<UnaryOpType::LOG10>;
-template struct ExecuteUnaryWithFastAndApproximateModeTrue<UnaryOpType::LOG2>;
-template struct ExecuteUnaryWithFastAndApproximateModeTrue<UnaryOpType::LOG1P>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG10>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG2>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG1P>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithVectorAndFastAndApproximateMode<unary_op_type>::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -30,15 +30,6 @@ struct ExecuteUnaryWithFastAndApproximateMode {
 };
 
 template <UnaryOpType unary_op_type>
-struct ExecuteUnaryWithFastAndApproximateModeTrue {
-    static Tensor invoke(
-        const Tensor& input_tensor,
-        bool parameter = true,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
-template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithVectorAndFastAndApproximateMode {
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -332,12 +323,6 @@ struct Clamp {
         ttnn::operations::unary::ExecuteUnaryWithFastAndApproximateMode<                        \
             ttnn::operations::unary::UnaryOpType::operation_type>>();
 
-#define REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE_TRUE(operation_name, operation_type) \
-    constexpr auto operation_name = ttnn::register_operation<                                        \
-        "ttnn::" #operation_name,                                                                    \
-        ttnn::operations::unary::ExecuteUnaryWithFastAndApproximateModeTrue<                         \
-            ttnn::operations::unary::UnaryOpType::operation_type>>();
-
 #define REGISTER_UNARY_OPERATION_WITH_VECTOR_AND_FAST_AND_APPROXIMATE_MODE(operation_name, operation_type) \
     constexpr auto operation_name = ttnn::register_operation<                                              \
         "ttnn::" #operation_name,                                                                          \
@@ -424,12 +409,10 @@ REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(exp, EXP);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(erf, ERF);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(erfc, ERFC);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(gelu, GELU);
-
-// Unaries with fast_and_approximate_mode default true
-REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE_TRUE(log, LOG);
-REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE_TRUE(log10, LOG10);
-REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE_TRUE(log2, LOG2);
-REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE_TRUE(log1p, LOG1P);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log, LOG);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log10, LOG10);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log2, LOG2);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log1p, LOG1P);
 
 // Unaries with vector mode and fast and approximate mode
 REGISTER_UNARY_OPERATION_WITH_VECTOR_AND_FAST_AND_APPROXIMATE_MODE(sigmoid, SIGMOID);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -427,7 +427,6 @@ void bind_unary_operation_with_fast_and_approximate_mode(
     const unary_operation_t& operation,
     const std::string& range = "",
     const std::string& supported_dtype = "BFLOAT16",
-    bool fast_approx_mode = false,
     const std::string& info_doc = "") {
     auto doc = fmt::format(
         R"doc(
@@ -471,7 +470,6 @@ void bind_unary_operation_with_fast_and_approximate_mode(
         operation.python_fully_qualified_name(),
         range,
         supported_dtype,
-        fast_approx_mode,
         info_doc);
 
     bind_registered_operation(
@@ -488,7 +486,7 @@ void bind_unary_operation_with_fast_and_approximate_mode(
             },
             py::arg("input_tensor"),
             py::kw_only(),
-            py::arg("fast_and_approximate_mode") = fast_approx_mode,
+            py::arg("fast_and_approximate_mode") = false,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt});
 }
@@ -2111,14 +2109,13 @@ void py_module(py::module& module) {
     bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erf, R"doc(BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erfc, R"doc(BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::gelu, R"doc(BFLOAT16, BFLOAT8_B)doc");
+    bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::log, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_with_fast_and_approximate_mode(
-        module, ttnn::log, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc", true);
+        module, ttnn::log10, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_with_fast_and_approximate_mode(
-        module, ttnn::log10, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc", true);
+        module, ttnn::log2, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_with_fast_and_approximate_mode(
-        module, ttnn::log2, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc", true);
-    bind_unary_operation_with_fast_and_approximate_mode(
-        module, ttnn::log1p, R"doc([Supported range: [-1, 1e7]])doc", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc", true);
+        module, ttnn::log1p, R"doc([Supported range: [-1, 1e7]])doc", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
 
     // Unaries with float parameter
     bind_unary_composite_with_default_float(


### PR DESCRIPTION
### Ticket
#27655

### Problem description
As per https://github.com/tenstorrent/tt-metal/pull/26675#issuecomment-3213907002, set fast and approx flag for log as false by default so that negative inputs return NaN by default (for bf16 it returns inf).

### What's changed
- Changed fast_approx flag to `false` by default.
- Removed `ExecuteUnaryWithFastAndApproximateModeTrue` template since its not being used by any other ops
- Passed fast_approx flag as `true` for failing tests.

### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/17541190299 - PASSED
Latest run: https://github.com/tenstorrent/tt-metal/actions/runs/17787864093 - PASSED
- [x] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/17541194231 - PASSED
Latest run: https://github.com/tenstorrent/tt-metal/actions/runs/17643388671 - same as main
- [x] (Blackhole) Demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/17788045759 - PASSED
- [x] (Blackhole) Blackhole nightly tests - https://github.com/tenstorrent/tt-metal/actions/runs/17787876048 - same as main
- [x] (Single-card) Demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/17201875696 - same as main
Latest run: https://github.com/tenstorrent/tt-metal/actions/runs/17603637367/job/50030806191 - same as main
- [x] (Single-card) Device perf regressions - https://github.com/tenstorrent/tt-metal/actions/runs/17201898990 - PASSED
Latest run: https://github.com/tenstorrent/tt-metal/actions/runs/17679355191 - PASSED
- [x] (Single-card) Frequent model and ttnn tests - https://github.com/tenstorrent/tt-metal/actions/runs/17201923339 - PASSED
- [x] (Single-card) Model perf tests - https://github.com/tenstorrent/tt-metal/actions/runs/17201944949 - PASSED
Latest run: https://github.com/tenstorrent/tt-metal/actions/runs/17603486998 - same as main
- [x] (Single-card) Fast dispatch frequent tests - https://github.com/tenstorrent/tt-metal/actions/runs/17202042933 - PASSED
- [x] T3K - https://github.com/tenstorrent/tt-metal/actions/runs/17541155683 - same as main but for model perf tests
- [x] (T3K) T3000 model perf tests - https://github.com/tenstorrent/tt-metal/actions/runs/17585663474 - same as main
- [x] (Galaxy) Quick - https://github.com/tenstorrent/tt-metal/actions/runs/17788137362 - same as main
- [x] TG - https://github.com/tenstorrent/tt-metal/actions/runs/17202399004 - same as main
- [x] (TG) Demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/17211015786 - same as main

