### PR TITLE
Refactored Transformer Operations to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -323,6 +324,12 @@ operation::ProgramWithCallbacks joint_sdpa(
         padded_Lkt,
         num_cores,
     };
+    TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(joint_tensor_q.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(joint_tensor_k.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(joint_tensor_v.buffer()).append_to(reader_compile_time_args);
 
     // Calculate which K chunks contain the mask boundaries
     // If a tensor does not require masking, set to MAX_UINT32. This avoids a
@@ -355,6 +362,8 @@ operation::ProgramWithCallbacks joint_sdpa(
         mask_chunk_0,
         mask_chunk_1,
     };
+    TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -76,9 +76,9 @@ public:
     }
 };
 
-template <bool is_dram = true, uint32_t tile_bytes>
+template <uint32_t tile_bytes, typename ReaderType>
 void read_chunk_with_padding(
-    const InterleavedAddrGenFast<is_dram>& reader,
+    const ReaderType& reader,
     const uint32_t cb_id,
     uint32_t start_tile_id,
     const uint32_t src_rows,
@@ -134,9 +134,9 @@ void read_chunk_with_padding(
     cb_push_back(cb_id, num_tiles);
 }
 
-template <uint32_t num_heads, uint32_t block_size_t, uint32_t Wt, bool is_dram = true>
+template <uint32_t num_heads, uint32_t block_size_t, uint32_t Wt, typename ReaderType>
 void read_paged_chunk_with_padding(
-    const InterleavedAddrGenFast<is_dram>& reader,
+    const ReaderType& reader,
     const uint32_t cb_id,
     const uint32_t cur_head,
     const uint32_t chunk_start_row,
@@ -475,19 +475,20 @@ void generate_noncausal_padded_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, ui
     cb_push_back(cb_mask_in, mask_size_tiles);
 }
 
+template <typename FirstReaderType, typename SecondReaderType>
 struct CatAddrGenerator {
-    InterleavedAddrGenFast<true> first_reader;
-    InterleavedAddrGenFast<true> second_reader;
+    FirstReaderType first_reader;
+    SecondReaderType second_reader;
     TensorTileShape first_shape;
     TensorTileShape second_shape;
     uint32_t first_seq_padded;
     uint32_t second_seq_padded;
 
     CatAddrGenerator(
-        const InterleavedAddrGenFast<true>& first_reader,
+        const FirstReaderType& first_reader,
         TensorTileShape first_logical_shape,
         uint32_t first_seq_padded,
-        const InterleavedAddrGenFast<true>& second_reader,
+        const SecondReaderType& second_reader,
         TensorTileShape second_logical_shape,
         uint32_t second_seq_padded) :
         first_reader(first_reader),
@@ -544,8 +545,9 @@ struct Slice {
     uint32_t get_d3_size() const { return d3_end - d3_start; }
 };
 
+template <typename CatAddrGeneratorType>
 void read_block(
-    const CatAddrGenerator& cat_addr_generator,
+    const CatAddrGeneratorType& cat_addr_generator,
     const Slice& src_slice,
     const uint32_t cb_id,
     const uint32_t tile_bytes,
@@ -578,8 +580,9 @@ void read_block(
     cb_push_back(cb_id, num_tiles);
 }
 
+template <typename CatAddrGeneratorType>
 void write_block(
-    const CatAddrGenerator& cat_addr_generator,
+    const CatAddrGeneratorType& cat_addr_generator,
     const Slice& dst_slice,
     const uint32_t cb_id,
     const uint32_t tile_bytes,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
@@ -29,6 +29,9 @@ void kernel_main() {
     constexpr uint32_t mask_chunk_0 = get_compile_time_arg_val(18);
     constexpr uint32_t mask_chunk_1 = get_compile_time_arg_val(19);
 
+    constexpr auto out_args = TensorAccessorArgs<20>();
+    constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t joint_out_addr = get_arg_val<uint32_t>(argidx++);
@@ -39,16 +42,12 @@ void kernel_main() {
     const uint32_t local_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t local_q_end = get_arg_val<uint32_t>(argidx++);
 
-    constexpr bool is_dram = true;
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
-    constexpr DataFormat data_format = get_dataformat(cb_out);
 
-    const InterleavedAddrGenFast<is_dram> out_writer = {
-        .bank_base_address = out_addr, .page_size = tile_bytes, .data_format = data_format};
-    const InterleavedAddrGenFast<is_dram> joint_out_writer = {
-        .bank_base_address = joint_out_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto out_writer = TensorAccessor(out_args, out_addr, tile_bytes);
+    const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr, tile_bytes);
 
     const auto output_tile_logical = TensorTileShape(B, NH, valid_Nt, DHt);
     const auto joint_tile_logical = TensorTileShape(B, NH, valid_Lt, DHt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -26,6 +26,13 @@ void kernel_main() {
     constexpr uint32_t global_padded_NK_chunks = get_compile_time_arg_val(15);
     constexpr uint32_t q_num_chunks = get_compile_time_arg_val(16);
 
+    constexpr auto q_args = TensorAccessorArgs<17>();
+    constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
+    constexpr auto joint_q_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
+    constexpr auto joint_k_args = TensorAccessorArgs<joint_q_args.next_compile_time_args_offset()>();
+    constexpr auto joint_v_args = TensorAccessorArgs<joint_k_args.next_compile_time_args_offset()>();
+
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t k_addr = get_arg_val<uint32_t>(argidx++);
@@ -40,33 +47,22 @@ void kernel_main() {
         true, /* wait_for_op_signal */
         argidx);
 
-    constexpr bool is_dram = true;
-
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;
 
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
-    constexpr DataFormat q_data_format = get_dataformat(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
-    constexpr DataFormat k_data_format = get_dataformat(cb_k_in);
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
-    constexpr DataFormat v_data_format = get_dataformat(cb_v_in);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_cores>();
 
-    const InterleavedAddrGenFast<is_dram> q_reader = {
-        .bank_base_address = q_addr, .page_size = q_tile_bytes, .data_format = q_data_format};
-    const InterleavedAddrGenFast<is_dram> k_reader = {
-        .bank_base_address = k_addr, .page_size = k_tile_bytes, .data_format = k_data_format};
-    const InterleavedAddrGenFast<is_dram> v_reader = {
-        .bank_base_address = v_addr, .page_size = v_tile_bytes, .data_format = v_data_format};
-    const InterleavedAddrGenFast<is_dram> joint_q_reader = {
-        .bank_base_address = joint_q_addr, .page_size = q_tile_bytes, .data_format = q_data_format};
-    const InterleavedAddrGenFast<is_dram> joint_k_reader = {
-        .bank_base_address = joint_k_addr, .page_size = k_tile_bytes, .data_format = k_data_format};
-    const InterleavedAddrGenFast<is_dram> joint_v_reader = {
-        .bank_base_address = joint_v_addr, .page_size = v_tile_bytes, .data_format = v_data_format};
+    const auto q_reader = TensorAccessor(q_args, q_addr, q_tile_bytes);
+    const auto k_reader = TensorAccessor(k_args, k_addr, k_tile_bytes);
+    const auto v_reader = TensorAccessor(v_args, v_addr, v_tile_bytes);
+    const auto joint_q_reader = TensorAccessor(joint_q_args, joint_q_addr, q_tile_bytes);
+    const auto joint_k_reader = TensorAccessor(joint_k_args, joint_k_addr, k_tile_bytes);
+    const auto joint_v_reader = TensorAccessor(joint_v_args, joint_v_addr, v_tile_bytes);
 
     const auto q_input_tile_logical = TensorTileShape(B, NH, local_Nt, DHt);
     const auto kv_input_tile_logical = TensorTileShape(B, NH, global_Nt, DHt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -35,6 +35,10 @@ void kernel_main() {
     constexpr uint32_t global_padded_NK_chunks = get_compile_time_arg_val(22);
     constexpr uint32_t q_num_chunks = get_compile_time_arg_val(23);
 
+    constexpr auto out_args = TensorAccessorArgs<24>();
+    constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    constexpr auto lse_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
+
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * DHt;
 
     // Only one iteration of the ring will contain the masked portion of the spatial input.
@@ -53,21 +57,16 @@ void kernel_main() {
         false, /* wait_for_op_signal */
         argidx);
 
-    constexpr bool is_dram = true;
     constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;
     constexpr uint32_t cb_prev_out = tt::CBIndex::c_7;
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
-    constexpr DataFormat data_format = get_dataformat(cb_out);
 
-    const InterleavedAddrGenFast<is_dram> out_writer = {
-        .bank_base_address = out_addr, .page_size = tile_bytes, .data_format = data_format};
-    const InterleavedAddrGenFast<is_dram> joint_out_writer = {
-        .bank_base_address = joint_out_addr, .page_size = tile_bytes, .data_format = data_format};
-    const InterleavedAddrGenFast<is_dram> lse_writer = {
-        .bank_base_address = lse_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto out_writer = TensorAccessor(out_args, out_addr, tile_bytes);
+    const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr, tile_bytes);
+    const auto lse_writer = TensorAccessor(lse_args, lse_addr, tile_bytes);
 
     const auto output_tile_logical = TensorTileShape(B, NH, local_Nt, DHt);
     const auto joint_tile_logical = TensorTileShape(B, NH, logical_Lt, DHt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -28,6 +28,8 @@ void kernel_main() {
     constexpr uint32_t use_padded_mask = get_compile_time_arg_val(17) == 1;
     constexpr uint32_t is_chunked = get_compile_time_arg_val(18) == 1;
 
+    constexpr auto out_args = TensorAccessorArgs<19>();
+
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
     const uint32_t local_batch_start = get_arg_val<uint32_t>(2);
@@ -43,15 +45,12 @@ void kernel_main() {
     constexpr uint32_t mask_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr bool is_dram = true;
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
-    constexpr DataFormat data_format = get_dataformat(cb_out);
 
-    const InterleavedAddrGenFast<is_dram> out_writer = {
-        .bank_base_address = out_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto out_writer = TensorAccessor(out_args, out_addr, tile_bytes);
 
     const auto out_tile_shape = TensorTileShape(B, NQH, valid_Sqt, vDHt);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operation.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::tt_metal;
 
@@ -322,6 +323,13 @@ operation::ProgramWithCallbacks ring_joint_sdpa(
         global_padded_NK_chunks,
         q_num_chunks};
 
+    TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(gathered_input_tensor_k.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(gathered_input_tensor_v.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(joint_tensor_q.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(joint_tensor_k.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(joint_tensor_v.buffer()).append_to(reader_compile_time_args);
+
     // Calculate which K chunks contain the mask boundaries
     // If a tensor does not require masking, set to MAX_UINT32. This avoids a
     // bug in the mask generation code, which would mask a full, valid chunk
@@ -359,6 +367,10 @@ operation::ProgramWithCallbacks ring_joint_sdpa(
         global_logical_NK_chunks,
         global_padded_NK_chunks,
         q_num_chunks};
+
+    TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(lse_output_tensor.buffer()).append_to(writer_compile_time_args);
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -47,7 +47,6 @@ void kernel_main() {
     constexpr bool is_page_table_sharded = get_compile_time_arg_val(28);
     constexpr uint32_t q_page_size_bytes = get_compile_time_arg_val(29);
 
-    // TensorAccessorArgs for all buffers
     constexpr auto k_args = TensorAccessorArgs<30>();
     constexpr auto q_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -94,7 +94,7 @@ void kernel_main() {
                 const auto addrg = TensorAccessor(pos_args, pos_addr, index_stick_size_B);
 
                 // index_tensor has one page to read
-                uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
+                uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
                 noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
                 noc_async_read_barrier();
             }
@@ -243,7 +243,7 @@ void kernel_main() {
         if constexpr (!is_page_table_sharded) {
             page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
             const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr, page_table_page_size);
-            uint64_t page_table_noc_addr = get_noc_addr((cur_batch / q_heads_parallel_factor), page_table_gen);
+            uint64_t page_table_noc_addr = page_table_gen.get_noc_addr((cur_batch / q_heads_parallel_factor));
             noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_page_size);
             noc_async_read_barrier();
             page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -45,6 +45,16 @@ void kernel_main() {
     constexpr uint32_t q_chunk_size_bytes = get_compile_time_arg_val(26);
     constexpr bool is_cur_pos_tensor_sharded = get_compile_time_arg_val(27);
     constexpr bool is_page_table_sharded = get_compile_time_arg_val(28);
+    constexpr uint32_t q_page_size_bytes = get_compile_time_arg_val(29);
+
+    // TensorAccessorArgs for all buffers
+    constexpr auto k_args = TensorAccessorArgs<30>();
+    constexpr auto q_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
+    constexpr auto v_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
+    constexpr auto pos_args = TensorAccessorArgs<mask_args.next_compile_time_args_offset()>();
+    constexpr auto page_table_args = TensorAccessorArgs<pos_args.next_compile_time_args_offset()>();
+    constexpr auto attention_sink_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 
     uint32_t arg_idx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(arg_idx++);
@@ -81,7 +91,7 @@ void kernel_main() {
             uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
 
             if constexpr (!is_cur_pos_tensor_sharded) {
-                const InterleavedAddrGen<true> addrg = {.bank_base_address = pos_addr, .page_size = index_stick_size_B};
+                const auto addrg = TensorAccessor(pos_args, pos_addr, index_stick_size_B);
 
                 // index_tensor has one page to read
                 uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
@@ -134,15 +144,10 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
-    constexpr DataFormat q_data_format = get_dataformat(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
-    constexpr DataFormat k_data_format = get_dataformat(cb_k_in);
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
-    constexpr DataFormat v_data_format = get_dataformat(cb_v_in);
     constexpr uint32_t mask_tile_bytes = get_tile_size(cb_mask_in);
-    constexpr DataFormat mask_data_format = get_dataformat(cb_mask_in);
     constexpr uint32_t attention_sink_tile_bytes = get_tile_size(cb_attention_sink);
-    constexpr DataFormat attention_sink_data_format = get_dataformat(cb_attention_sink);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_cores>();
     uint32_t barrier_count = 0;
@@ -183,13 +188,13 @@ void kernel_main() {
             cb_push_back(cb_q_in, q_chunk_tiles);
         }
     } else {
-        const InterleavedAddrGenFast<is_dram> q_reader = {
-            .bank_base_address = q_addr, .page_size = q_tile_bytes, .data_format = q_data_format};
+        const auto q_reader = TensorAccessor(q_args, q_addr, q_page_size_bytes);
         uint32_t q_tile_id = q_batch_offset;
         cb_reserve_back(cb_q_in, q_chunk_tiles);
         uint32_t q_write_ptr = get_write_ptr(cb_q_in);
         for (uint32_t tile = 0; tile < q_chunk_tiles; ++tile) {
-            noc_async_read_tile(q_tile_id, q_reader, q_write_ptr);
+            uint64_t q_read_addr = q_reader.get_noc_addr(q_tile_id);
+            noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
             q_tile_id += 1;
             q_write_ptr += q_tile_bytes;
             if (++barrier_count == barrier_threshold) {
@@ -202,18 +207,14 @@ void kernel_main() {
     }
 
     // Read the rest
-    const InterleavedAddrGenFast<is_dram> k_reader = {
-        .bank_base_address = k_addr, .page_size = k_tile_bytes, .data_format = k_data_format};
+    const auto k_reader = TensorAccessor(k_args, k_addr, k_tile_bytes);
 
-    const InterleavedAddrGenFast<is_dram> v_reader = {
-        .bank_base_address = v_addr, .page_size = v_tile_bytes, .data_format = v_data_format};
+    const auto v_reader = TensorAccessor(v_args, v_addr, v_tile_bytes);
 
-    const InterleavedAddrGenFast<is_dram> mask_reader = {
-        .bank_base_address = mask_addr, .page_size = mask_tile_bytes, .data_format = mask_data_format};
+    const auto mask_reader = TensorAccessor(mask_args, mask_addr, mask_tile_bytes);
 
     // Read attention sink
     if constexpr (use_attention_sink) {
-        constexpr auto attention_sink_args = TensorAccessorArgs<29>();
         const auto attention_sink_reader =
             TensorAccessor(attention_sink_args, attention_sink_addr, attention_sink_tile_bytes);
 
@@ -241,8 +242,7 @@ void kernel_main() {
         // Read page table from DRAM
         if constexpr (!is_page_table_sharded) {
             page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
-            const InterleavedAddrGen<is_paged_attention> page_table_gen = {
-                .bank_base_address = page_table_addr, .page_size = page_table_page_size};
+            const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr, page_table_page_size);
             uint64_t page_table_noc_addr = get_noc_addr((cur_batch / q_heads_parallel_factor), page_table_gen);
             noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_page_size);
             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -133,8 +133,6 @@ void kernel_main() {
     uint32_t v_chunk_tiles = Sk_chunk_t_dynamic * vDHt;
     uint32_t mask_chunk_tiles = PNHt * Sk_chunk_t_dynamic;
 
-    constexpr bool is_dram = true;
-
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_q_rm = tt::CBIndex::c_10;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -110,7 +110,6 @@ void kernel_main() {
     }
     uint32_t num_tiles_to_wait = (out_chunk_tiles + 2 * PNHt) * num_cores_to_wait;
 
-    constexpr bool is_dram = true;
     constexpr uint32_t cb_out = tt::CBIndex::c_20;
     constexpr uint32_t cb_intermed_out =
         tt::CBIndex::c_19;  // this cb holds the output intermediates from other worker cores

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -36,6 +36,8 @@ void kernel_main() {
     constexpr bool is_causal = get_compile_time_arg_val(22) == 1;
     constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(23);
     constexpr uint32_t q_heads_parallel_factor = get_compile_time_arg_val(24);
+    // TensorAccessorArgs for output buffer
+    constexpr auto out_args = TensorAccessorArgs<25>();
 
     uint32_t arg_idx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(arg_idx++);
@@ -143,10 +145,8 @@ void kernel_main() {
     // *** Reducer Compute Below ***
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t tile_bytes_intermed = get_tile_size(cb_intermed_out);
-    constexpr DataFormat data_format = get_dataformat(cb_out);
 
-    const InterleavedAddrGenFast<is_dram> out_writer = {
-        .bank_base_address = out_addr, .page_size = tile_bytes, .data_format = data_format};
+    const auto out_writer = TensorAccessor(out_args, out_addr, tile_bytes);
 
     uint64_t intermed_l1_read_addr = get_noc_addr(get_read_ptr(cb_intermed_out));
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -36,7 +36,7 @@ void kernel_main() {
     constexpr bool is_causal = get_compile_time_arg_val(22) == 1;
     constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(23);
     constexpr uint32_t q_heads_parallel_factor = get_compile_time_arg_val(24);
-    // TensorAccessorArgs for output buffer
+
     constexpr auto out_args = TensorAccessorArgs<25>();
 
     uint32_t arg_idx = 0;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -741,7 +741,16 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         q_chunk_size_bytes,
         is_cur_pos_tensor_sharded,
         is_page_table_sharded,
+        full_tile.get_tile_size(q_df),
     };
+    tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(attn_mask ? attn_mask->buffer() : nullptr).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(cur_pos_tensor ? cur_pos_tensor->buffer() : nullptr)
+        .append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(page_table_tensor ? page_table_tensor->buffer() : nullptr)
+        .append_to(reader_compile_time_args_common);
 
     if (use_attention_sink) {
         tt_metal::TensorAccessorArgs(*attention_sink->buffer()).append_to(reader_compile_time_args_common);
@@ -776,6 +785,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         max_dynamic_chunk_size,
         q_heads_parallel_factor,
     };
+    tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args_common);
 
     std::vector<uint32_t> compute_compile_time_args_common = {
         St,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.
### What's changed
Refactored the transformer/sdpa_decode program_factory, reader kernel, and writer kernel to use TensorAccessor.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17220602563) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17220630804) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes