### PR TITLE
ci(draft): bh 20 cores: simplify runner selection logic and use harbor image

### DIFF
--- a/.github/workflows/blackhole-20-cores-tests.yaml
+++ b/.github/workflows/blackhole-20-cores-tests.yaml
@@ -22,7 +22,7 @@ on:
         description: 'Runner label'
         required: false
         type: string
-        default: "BH"
+        default: "P150b"
 
 jobs:
   blackhole-20-cores-unit-tests:
@@ -33,13 +33,9 @@ jobs:
           - name: "test_sharding_on_bh_20_cores_test1"
             cmd:  tests/ttnn/unit_tests/test_bh_20_cores_sharding.py::test_sharding_on_bh_20_cores
     name: ${{ matrix.test-group.name }}
-    runs-on: >-
-      ${{
-        (github.event.pull_request.head.repo.fork == true || contains('P150b', inputs.runner-label)) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
-      }}
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner-label) }}
     container:
-      image: ${{ inputs.docker-image }}
+      image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
         ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -48,8 +48,6 @@ on:
   # Pause this since not enough runners to support every commit to main
   # push:
   #  branches: ["main"]
-  push:
-    branches: ["jlakis/bh-20cores-image"]
 
 run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 
@@ -124,7 +122,6 @@ jobs:
       version: "22.04"
       build-umd-tests: true
   build-artifact-profiler:
-    if: ${{ false }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -136,7 +133,6 @@ jobs:
       version: "22.04"
       build-umd-tests: true
   run-profiler-regression:
-    if: ${{ false }}
     needs: [build-artifact-profiler, generate-matrix]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
@@ -152,7 +148,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   umd-unit-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml
@@ -166,7 +161,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   sd-unit-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     secrets: inherit
@@ -182,7 +176,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   fd-unit-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     secrets: inherit
@@ -199,7 +192,6 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
   # FD C++ Unit Tests
   cpp-unit-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/cpp-post-commit.yaml
@@ -215,7 +207,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   models-unit-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/models-post-commit.yaml
@@ -231,7 +222,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   blackhole-demo-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
@@ -246,7 +236,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   ttnn-unit-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
@@ -289,7 +278,6 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-metalium
   ttnn-smoke-tests:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     strategy:
       fail-fast: false
@@ -303,7 +291,6 @@ jobs:
       product: tt-nn
 
   test-ttnn-tutorials:
-    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
@@ -386,7 +373,6 @@ jobs:
 
   # Multi-card post-commit tests
   blackhole-multi-card-post-commit-tests:
-    if: ${{ false }}
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -48,6 +48,8 @@ on:
   # Pause this since not enough runners to support every commit to main
   # push:
   #  branches: ["main"]
+  push:
+    branches: ["jlakis/bh-20cores-image"]
 
 run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 
@@ -122,6 +124,7 @@ jobs:
       version: "22.04"
       build-umd-tests: true
   build-artifact-profiler:
+    if: ${{ false }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -133,6 +136,7 @@ jobs:
       version: "22.04"
       build-umd-tests: true
   run-profiler-regression:
+    if: ${{ false }}
     needs: [build-artifact-profiler, generate-matrix]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
@@ -148,6 +152,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   umd-unit-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml
@@ -161,6 +166,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   sd-unit-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     secrets: inherit
@@ -176,6 +182,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   fd-unit-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     secrets: inherit
@@ -192,6 +199,7 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
   # FD C++ Unit Tests
   cpp-unit-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/cpp-post-commit.yaml
@@ -207,6 +215,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   models-unit-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/models-post-commit.yaml
@@ -222,6 +231,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   blackhole-demo-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
@@ -236,6 +246,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   ttnn-unit-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
@@ -278,6 +289,7 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-metalium
   ttnn-smoke-tests:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     strategy:
       fail-fast: false
@@ -291,6 +303,7 @@ jobs:
       product: tt-nn
 
   test-ttnn-tutorials:
+    if: ${{ false }}
     needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
@@ -373,6 +386,7 @@ jobs:
 
   # Multi-card post-commit tests
   blackhole-multi-card-post-commit-tests:
+    if: ${{ false }}
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26828

**DO NOT MERGE YET**: This removes the CI version selection logic, TO BE CONFIRMED are we going to keep the V1 runners for the p100 case.

### Problem description
* Harbor image isn't used in the BH 20 cores test
* BH 20 cores test uses redundant(?) logic of fork and runner selection

### What's changed
* Added harbor prefix
* Simplified logic to use CI v2 only and no forks considered.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes