### PR TITLE
Remove redundant read of TT_METAL_HOME in core_descriptor

### DIFF
--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -40,12 +40,7 @@ inline YAML::Node string_to_yaml_node(const std::string& input) {
 inline std::string get_core_descriptor_file(
     const tt::ARCH& arch, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
-    std::string core_desc_dir;
-    if (getenv("TT_METAL_HOME")) {
-        core_desc_dir = getenv("TT_METAL_HOME");
-    } else {
-        core_desc_dir = "./";
-    }
+    std::string core_desc_dir = tt_metal::MetalContext::instance().rtoptions().get_root_dir();
     if (core_desc_dir.back() != '/') {
         core_desc_dir += "/";
     }


### PR DESCRIPTION
### Ticket
#13726 

### Problem description
To begin removing TT_METAL_HOME we need to first minimize the number of places where it is read.
Getting the root_dir from rtoptions is the idiomatic way to centralize access to environment variables in this code base.

### What's changed
Use MetalContext and rtoptions to get the resolved value of TT_METAL_HOME without the environment variable access.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17209799138) CI passes
- [x] New/Existing tests provide coverage for changes