### PR TITLE
Tensor pages iterator

### DIFF
--- a/tech_reports/tensor_accessor/tensor_accessor.md
+++ b/tech_reports/tensor_accessor/tensor_accessor.md
@@ -199,7 +199,7 @@ Or this sharded tensor copy, which should be more efficient, since it uses an it
 ```c++
 for (uint32_t i = 0; i < num_shards; ++i) {
     uint32_t shard_id = first_shard_id + i * num_cores;
-    auto shard_pages_src = tensor_accessor_src.shard_pages(shard_id);
+    auto shard_pages_src = tensor_accessor_src.shard_pages(shard_id, /*start_page_offset=*/0);
     auto shard_pages_dst = tensor_accessor_dst.shard_pages(shard_id);
     auto page_dst = shard_pages_dst.begin();
     for (const auto& page_src : shard_pages_src) {
@@ -207,6 +207,23 @@ for (uint32_t i = 0; i < num_shards; ++i) {
         noc_async_writes_flushed();
         ++page_dst;
     }
+}
+
+```
+
+**Pages iterator**
+
+Similar to *Shard pages iterator*, but iterates over all pages in the tensor. Also, it works only for sharded tensor right now.
+
+Similar example of using the page iterator
+```c++
+auto pages_src = tensor_accessor_src.pages(/*start_page_id=*/0);
+auto pages_dst = tensor_accessor_dst.pages();
+auto page_dst = shard_pages_dst.begin();
+for (const auto& page_src : shard_pages_src) {
+    noc_async_read(page_src.get_noc_addr(), page_dst->get_noc_addr(), page_size);
+    noc_async_writes_flushed();
+    ++page_dst;
 }
 
 ```

--- a/tests/ttnn/benchmark/python/test_accessor_benchmarks.py
+++ b/tests/ttnn/benchmark/python/test_accessor_benchmarks.py
@@ -48,8 +48,16 @@ ARGS_CONFIGS = [
     "1111101",  # Everything dynamic
 ]
 
+# For benchmarks that only support all-static configuration
+STATIC_ONLY_ARGS_CONFIGS = [
+    "0000001",  # Everything static
+]
 
-def impl_test(gtest_filter, res_dir):
+
+def impl_test(gtest_filter, res_dir, args_configs=None):
+    if args_configs is None:
+        args_configs = ARGS_CONFIGS
+
     ENV = os.environ.copy()
     ENV["TT_METAL_DEVICE_PROFILER"] = "1"
     BASE = Path(ENV["TT_METAL_HOME"])
@@ -60,7 +68,7 @@ def impl_test(gtest_filter, res_dir):
     setup = device_post_proc_config.default_setup()
     zone_names = []
     timerAnalysis = {}
-    for args_config in ARGS_CONFIGS:
+    for args_config in args_configs:
         zone_name = f"SHARDED_ACCESSOR_{args_config}"
         timerAnalysis[zone_name] = {
             "across": "core",
@@ -87,6 +95,11 @@ def impl_test(gtest_filter, res_dir):
             logger.info(f"Zone: {zone_name}: Average: {st['Average']} (cycles)")
 
 
+def impl_test_static_only(gtest_filter, res_dir):
+    """Implementation for tests that only run with all-static configuration."""
+    impl_test(gtest_filter, res_dir, STATIC_ONLY_ARGS_CONFIGS)
+
+
 def test_get_noc_addr_page_id():
     impl_test("AccessorTests/AccessorBenchmarks.GetNocAddr/*", res_dir="accessor_get_noc_addr_benchmarks")
 
@@ -99,3 +112,15 @@ def test_get_noc_addr_page_coord():
 
 def test_constructor():
     impl_test("AccessorTests/AccessorBenchmarks.Constructor/*", res_dir="accessor_constructor_benchmarks")
+
+
+def test_manual_pages_iteration():
+    impl_test_static_only(
+        "AccessorTests/AccessorBenchmarks.ManualPagesIteration/*", res_dir="accessor_manual_pages_iteration_benchmarks"
+    )
+
+
+def test_pages_iterator():
+    impl_test_static_only(
+        "AccessorTests/AccessorBenchmarks.PagesIterator/*", res_dir="accessor_pages_iterator_benchmarks"
+    )

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_manual_pages_iteration_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_manual_pages_iteration_benchmark.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "accessor/tensor_accessor.h"
+
+void kernel_main() {
+    constexpr uint32_t base_idx_cta = 0;
+    constexpr uint32_t base_idx_crta = 0;
+
+    auto args = TensorAccessorArgs<base_idx_cta, base_idx_crta>();
+    auto tensor_accessor = TensorAccessor(args, 0, 1024);
+
+    auto tensor_volume = tensor_accessor.dspec().tensor_volume();
+
+    constexpr size_t benchmark_iterations = 125;
+    for (size_t iteration = 0; iteration < benchmark_iterations; ++iteration) {
+        {
+            DeviceZoneScopedN(ACCESSOR_CONFIG_NAME);
+            // Manual iteration over all pages
+            for (uint32_t page_id = 0; page_id < tensor_volume; ++page_id) {
+                volatile auto _ = tensor_accessor.get_noc_addr(page_id);
+            }
+        }
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_pages_iterator_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_pages_iterator_benchmark.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "accessor/tensor_accessor.h"
+
+void kernel_main() {
+    constexpr uint32_t base_idx_cta = 0;
+    constexpr uint32_t base_idx_crta = 0;
+
+    auto args = TensorAccessorArgs<base_idx_cta, base_idx_crta>();
+    auto tensor_accessor = TensorAccessor(args, 0, 1024);
+
+    // Use PagesAddressIterator - this benchmark only runs with all-static configuration
+    auto pages = tensor_accessor.pages();
+
+    constexpr size_t benchmark_iterations = 125;
+    for (size_t iteration = 0; iteration < benchmark_iterations; ++iteration) {
+        {
+            DeviceZoneScopedN(ACCESSOR_CONFIG_NAME);
+            // Iterator-based iteration over all pages
+            for (const auto& page : pages) {
+                volatile auto _ = page.get_noc_addr();
+            }
+        }
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_copy_all_pages.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_copy_all_pages.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+This reader kernel reads all pages from a tensor and pushes them to a circular buffer.
+This kernel is expected to be executed on only one core (RISCV_0).
+*/
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "accessor/tensor_accessor.h"
+
+void kernel_main() {
+    auto args_src = TensorAccessorArgs<0, 0>();
+    uint32_t cb_id = get_compile_time_arg_val(args_src.next_compile_time_args_offset());
+    uint32_t page_size = get_compile_time_arg_val(args_src.next_compile_time_args_offset() + 1);
+    uint32_t input_base_address = get_common_arg_val<uint32_t>(0);
+
+    auto tensor_accessor_src = TensorAccessor(args_src, input_base_address, page_size);
+
+    // Iterate over all pages in the tensor and read them to CB
+    auto all_pages = tensor_accessor_src.pages();
+    for (const auto& page : all_pages) {
+        cb_reserve_back(cb_id, 1);
+        uint32_t l1_write_addr = get_write_ptr(cb_id);
+
+        noc_async_read(page.get_noc_addr(), l1_write_addr, page_size);
+        noc_async_read_barrier();
+
+        cb_push_back(cb_id, 1);
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_copy_all_pages.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_copy_all_pages.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+This writer kernel pops pages from a circular buffer and writes them to a tensor.
+This kernel is expected to be executed on only one core (RISCV_1).
+*/
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "accessor/tensor_accessor.h"
+
+void kernel_main() {
+    auto args_dst = TensorAccessorArgs<0, 0>();
+    uint32_t cb_id = get_compile_time_arg_val(args_dst.next_compile_time_args_offset());
+    uint32_t page_size = get_compile_time_arg_val(args_dst.next_compile_time_args_offset() + 1);
+    uint32_t output_base_address = get_common_arg_val<uint32_t>(0);
+
+    auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address, page_size);
+
+    // Iterate over all pages in the tensor and write them from CB
+    auto all_pages = tensor_accessor_dst.pages();
+    for (const auto& page : all_pages) {
+        cb_wait_front(cb_id, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id);
+
+        noc_async_write(l1_read_addr, page.get_noc_addr(), page_size);
+        noc_async_write_barrier();
+
+        cb_pop_front(cb_id, 1);
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -70,11 +70,20 @@ using namespace tt::tt_metal;
 
 class AccessorBenchmarks : public GenericMeshDeviceFixture, public ::testing::WithParamInterface<InputBufferParams> {};
 
-void benchmark_all_args_combinations_single_core(
+std::vector<tensor_accessor::ArgsConfig> get_all_static_args_config() {
+    // Return only the all-static configuration (0000001 = only Sharded bit set)
+    using tensor_accessor::ArgConfig;
+    using tensor_accessor::ArgsConfig;
+    ArgsConfig static_config{ArgConfig::Sharded};
+    return {static_config};
+}
+
+void benchmark_args_combinations_single_core(
     const InputBufferParams& params,
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_,
     const std::string& res_path,
-    const std::string& kernel_path) {
+    const std::string& kernel_path,
+    const std::vector<tensor_accessor::ArgsConfig>& args_combinations) {
     // Create input and output replicated mesh buffers across generic mesh device; tests will only use first device
     const auto input_mesh_buffer = create_replicated_input_mesh_buffer_from_inputs(params, mesh_device_.get());
 
@@ -85,8 +94,7 @@ void benchmark_all_args_combinations_single_core(
 
     tt::tt_metal::detail::SetDeviceProfilerDir(res_path + "/" + params.test_name);
     tt::tt_metal::detail::FreshProfilerDeviceLog();
-    auto all_args_combinations = get_all_sharded_args_configs();
-    for (const auto& arg_config : all_args_combinations) {
+    for (const auto& arg_config : args_combinations) {
         auto args_bitmask = arg_config.raw();
 
         std::string crta_config_str = fmt::format("\"SHARDED_ACCESSOR_{:07b}\"", args_bitmask);
@@ -130,6 +138,15 @@ void benchmark_all_args_combinations_single_core(
     tt::tt_metal::detail::ReadDeviceProfilerResults(local_device);
 }
 
+void benchmark_all_args_combinations_single_core(
+    const InputBufferParams& params,
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_,
+    const std::string& res_path,
+    const std::string& kernel_path) {
+    auto all_args_combinations = get_all_sharded_args_configs();
+    benchmark_args_combinations_single_core(params, mesh_device_, res_path, kernel_path, all_args_combinations);
+}
+
 TEST_P(AccessorBenchmarks, GetNocAddr) {
     benchmark_all_args_combinations_single_core(
         GetParam(),
@@ -152,6 +169,26 @@ TEST_P(AccessorBenchmarks, Constructor) {
         mesh_device_,
         "accessor_constructor_benchmarks",
         "tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_constructor_benchmark.cpp");
+}
+
+TEST_P(AccessorBenchmarks, ManualPagesIteration) {
+    auto static_args_combinations = get_all_static_args_config();
+    benchmark_args_combinations_single_core(
+        GetParam(),
+        mesh_device_,
+        "accessor_manual_pages_iteration_benchmarks",
+        "tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_manual_pages_iteration_benchmark.cpp",
+        static_args_combinations);
+}
+
+TEST_P(AccessorBenchmarks, PagesIterator) {
+    auto static_args_combinations = get_all_static_args_config();
+    benchmark_args_combinations_single_core(
+        GetParam(),
+        mesh_device_,
+        "accessor_pages_iterator_benchmarks",
+        "tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_pages_iterator_benchmark.cpp",
+        static_args_combinations);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -202,6 +202,84 @@ static void test_multi_core_copy(
     EXPECT_EQ(output_vec, src);
 }
 
+template <typename T>
+static void test_single_core_copy(const CopyParams& params, tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    MemoryConfig input_mem_config = MemoryConfig(params.buffer_type, params.input_shard_spec);
+    TensorSpec input_spec(params.tensor_shape, TensorLayout(params.dtype, PageConfig(params.layout), input_mem_config));
+
+    const auto src = tt::test_utils::generate_uniform_random_vector<T>(0, UINT8_MAX, params.tensor_shape.volume());
+
+    auto input_tensor = Tensor::from_vector(src, input_spec, mesh_device);
+    auto output_tensor = Tensor::from_vector(std::vector<T>(params.tensor_shape.volume()), input_spec, mesh_device);
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+    auto aligned_page_size = input_buffer->aligned_page_size();
+    if (output_buffer->aligned_page_size() != aligned_page_size) {
+        GTEST_SKIP() << "Input and output buffers must have the same aligned page size!";
+    }
+
+    auto program = CreateProgram();
+
+    constexpr CoreCoord grid = {0, 0};
+    const auto data_format = datatype_to_dataformat_converter(params.dtype);
+
+    constexpr auto num_tiles = 2;
+    CBHandle cb_in0_idx = tt::CBIndex::c_0;
+    auto c_in0_config = CircularBufferConfig(aligned_page_size * num_tiles, {{cb_in0_idx, data_format}})
+                            .set_page_size(cb_in0_idx, aligned_page_size);
+    CreateCircularBuffer(program, grid, c_in0_config);
+
+    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
+    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+
+    std::vector<uint32_t> input_compile_time_args = input_accessor_args.get_compile_time_args();
+    input_compile_time_args.push_back(cb_in0_idx);
+    input_compile_time_args.push_back(aligned_page_size);
+
+    std::vector<uint32_t> output_compile_time_args = output_accessor_args.get_compile_time_args();
+    output_compile_time_args.push_back(cb_in0_idx);
+    output_compile_time_args.push_back(aligned_page_size);
+
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        "tests/ttnn/unit_tests/gtests/accessor/kernels/reader_copy_all_pages.cpp",
+        grid,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = input_compile_time_args,
+        });
+
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        "tests/ttnn/unit_tests/gtests/accessor/kernels/writer_copy_all_pages.cpp",
+        grid,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = output_compile_time_args,
+        });
+
+    std::vector<uint32_t> input_runtime_args{input_buffer->address()};
+    SetCommonRuntimeArgs(program, reader_kernel_id, input_runtime_args);
+
+    std::vector<uint32_t> output_runtime_args{output_buffer->address()};
+    SetCommonRuntimeArgs(program, writer_kernel_id, output_runtime_args);
+
+    auto mesh_workload = tt::tt_metal::distributed::CreateMeshWorkload();
+    mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
+    EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, true);
+
+    auto output_tensor_cpu = output_tensor.cpu(true);
+
+    // Data should be only in the first shard
+    Tensor output_tensor_shard0 = ttnn::distributed::get_device_tensors(output_tensor_cpu).front();
+    auto output_vec = output_tensor_shard0.to_vector<T>();
+
+    EXPECT_EQ(output_vec, src);
+}
+
 }  // namespace tensor_accessor_device_tests
 
 using namespace tensor_accessor_device_tests;
@@ -442,6 +520,7 @@ TEST_P(ShardedAccessorTestsCopyOnDevice, MultiCoreCopyLocal) {
     switch (params.dtype) {
         case DataType::UINT8: test_multi_core_copy<uint8_t>(params, mesh_device_.get(), kernel_path); break;
         case DataType::UINT16: test_multi_core_copy<uint16_t>(params, mesh_device_.get(), kernel_path); break;
+        case DataType::BFLOAT16: test_multi_core_copy<bfloat16>(params, mesh_device_.get(), kernel_path); break;
         default: TT_THROW("Unsupported data type");
     }
 }
@@ -453,6 +532,18 @@ TEST_P(ShardedAccessorTestsCopyOnDevice, MultiCoreCopyLocalShardIterator) {
     switch (params.dtype) {
         case DataType::UINT8: test_multi_core_copy<uint8_t>(params, mesh_device_.get(), kernel_path); break;
         case DataType::UINT16: test_multi_core_copy<uint16_t>(params, mesh_device_.get(), kernel_path); break;
+        case DataType::BFLOAT16: test_multi_core_copy<bfloat16>(params, mesh_device_.get(), kernel_path); break;
+        default: TT_THROW("Unsupported data type");
+    }
+}
+
+TEST_P(ShardedAccessorTestsCopyOnDevice, SingleCoreCopyAllPages) {
+    const auto& params = GetParam();
+
+    switch (params.dtype) {
+        case DataType::UINT8: test_single_core_copy<uint8_t>(params, mesh_device_.get()); break;
+        case DataType::UINT16: test_single_core_copy<uint16_t>(params, mesh_device_.get()); break;
+        case DataType::BFLOAT16: test_single_core_copy<bfloat16>(params, mesh_device_.get()); break;
         default: TT_THROW("Unsupported data type");
     }
 }
@@ -460,70 +551,193 @@ TEST_P(ShardedAccessorTestsCopyOnDevice, MultiCoreCopyLocalShardIterator) {
 INSTANTIATE_TEST_SUITE_P(
     ShardedAccessorTests,
     ShardedAccessorTestsCopyOnDevice,
-    testing::ValuesIn(
-        {CopyParams{
-             .tensor_shape = tt::tt_metal::Shape{4, 64, 96},
-             .layout = Layout::TILE,
-             .dtype = DataType::UINT16,
-             .buffer_type = BufferType::L1,
+    testing::ValuesIn({// 2D cases at the beginning
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{64, 128},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::UINT8,
+                           .buffer_type = BufferType::L1,
 
-             .input_shard_spec =
-                 NdShardSpec{
-                     .shard_shape = tt::tt_metal::Shape{1, 32, 64},
-                     .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
-                     .orientation = ShardOrientation::ROW_MAJOR,
-                 },
-         },
-         CopyParams{
-             .tensor_shape = tt::tt_metal::Shape{18, 128, 64},
-             .layout = Layout::TILE,
-             .dtype = DataType::UINT8,
-             .buffer_type = BufferType::L1,
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{32, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{96, 64},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::UINT16,
+                           .buffer_type = BufferType::L1,
 
-             .input_shard_spec =
-                 NdShardSpec{
-                     .shard_shape = tt::tt_metal::Shape{1, 64, 96},
-                     .grid = CoreRangeSet(CoreRange({0, 0}, {3, 4})),
-                     .orientation = ShardOrientation::ROW_MAJOR,
-                 },
-         },
-         CopyParams{
-             .tensor_shape = tt::tt_metal::Shape{2, 3, 256},
-             .layout = Layout::ROW_MAJOR,
-             .dtype = DataType::UINT8,
-             .buffer_type = BufferType::L1,
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{24, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                                   .orientation = ShardOrientation::COL_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{128, 96},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
 
-             .input_shard_spec =
-                 NdShardSpec{
-                     .shard_shape = tt::tt_metal::Shape{2, 4, 16},
-                     .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
-                     .orientation = ShardOrientation::ROW_MAJOR,
-                 },
-         },
-         CopyParams{
-             .tensor_shape = tt::tt_metal::Shape{3, 2, 2, 3, 4},
-             .layout = Layout::ROW_MAJOR,
-             .dtype = DataType::UINT8,
-             .buffer_type = BufferType::L1,
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{32, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {2, 2})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
 
-             .input_shard_spec =
-                 NdShardSpec{
-                     .shard_shape = tt::tt_metal::Shape{1, 1, 2, 2, 4},
-                     .grid = CoreRangeSet(CoreRange({0, 0}, {1, 4})),
-                     .orientation = ShardOrientation::COL_MAJOR,
-                 },
-         },
-         CopyParams{
-             .tensor_shape = tt::tt_metal::Shape{5, 2, 2, 64, 96},
-             .layout = Layout::TILE,
-             .dtype = DataType::UINT16,
-             .buffer_type = BufferType::L1,
+                       // 3D cases
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{4, 64, 96},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::UINT16,
+                           .buffer_type = BufferType::L1,
 
-             .input_shard_spec =
-                 NdShardSpec{
-                     .shard_shape = tt::tt_metal::Shape{1, 1, 2, 64, 64},
-                     .grid = CoreRangeSet(
-                         tt::stl::Span<const CoreRange>({CoreRange({0, 0}, {2, 0}), CoreRange({0, 1}, {1, 1})})),
-                     .orientation = ShardOrientation::COL_MAJOR,
-                 },
-         }}));
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{1, 32, 64},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{18, 128, 64},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::UINT8,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{1, 64, 96},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {3, 4})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{2, 3, 256},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::UINT8,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{2, 4, 16},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+
+                       // More L1->L1 cases
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{32, 192},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::UINT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{32, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 2})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{8, 64, 64},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{2, 32, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{12, 96, 32},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::UINT8,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{3, 32, 16},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                                   .orientation = ShardOrientation::COL_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{4, 6, 128},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{2, 3, 64},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 0})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{256, 64},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::UINT8,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{64, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                                   .orientation = ShardOrientation::COL_MAJOR,
+                               },
+                       },
+
+                       // More BFLOAT16 cases
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{6, 64, 128},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{2, 32, 64},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {2, 1})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{3, 2, 2, 3, 4},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{1, 1, 2, 2, 4},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {1, 4})),
+                                   .orientation = ShardOrientation::COL_MAJOR,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{5, 2, 2, 64, 96},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::UINT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{1, 1, 2, 64, 64},
+                                   .grid = CoreRangeSet(tt::stl::Span<const CoreRange>(
+                                       {CoreRange({0, 0}, {2, 0}), CoreRange({0, 1}, {1, 1})})),
+                                   .orientation = ShardOrientation::COL_MAJOR,
+                               },
+                       }}));

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -302,6 +302,8 @@ target_sources(
             inc/accessor/tensor_accessor.h
             inc/accessor/tensor_accessor_args.h
             inc/accessor/shard_pages_address_iterator.h
+            inc/accessor/pages_address_iterator.h
+            inc/accessor/page.h
             inc/atomic_rwptr.h
             inc/bit_utils.h
             inc/blackhole/c_tensix_core.h

--- a/tt_metal/hw/inc/accessor/page.h
+++ b/tt_metal/hw/inc/accessor/page.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tensor_accessor {
+
+/**
+ * @brief Represents a page in a tensor with its NOC address and identifiers.
+ */
+class Page {
+public:
+    Page(uint64_t noc_addr, uint32_t global_page_id, uint32_t shard_id) :
+        noc_addr_(noc_addr), global_page_id_(global_page_id), shard_id_(shard_id) {}
+
+    uint64_t get_noc_addr() const { return noc_addr_; }
+    uint32_t page_id() const { return global_page_id_; }
+    uint32_t shard_id() const { return shard_id_; }
+
+private:
+    uint64_t noc_addr_;
+    uint32_t global_page_id_;
+    uint32_t shard_id_;
+};
+
+}  // namespace tensor_accessor

--- a/tt_metal/hw/inc/accessor/pages_address_iterator.h
+++ b/tt_metal/hw/inc/accessor/pages_address_iterator.h
@@ -15,8 +15,8 @@ namespace tensor_accessor {
 /**
  * Iterator over all pages in a tensor.
  * The iterator is initialized with a start_page_id and can be incremented by one page at a time,
- * or by a given number of pages. It efficiently computes NOC addresses by minimizing bank lookups
- * and reusing address computations when possible.
+ * or by a given number of pages. It efficiently computes NOC addresses by maintaining page
+ * coordinates and minimizing divisions through incremental updates.
  */
 template <typename Accessor>
 class PagesAddressIterator {
@@ -31,9 +31,8 @@ public:
     PagesAddressIterator(const Accessor& accessor, uint32_t start_page_id = 0, uint8_t noc = noc_index) :
         accessor(accessor), current_page_id(start_page_id), noc(noc) {
         if (current_page_id < accessor.dspec().tensor_volume()) {
-            current_page_mapping = accessor.get_bank_and_offset(current_page_id);
-            current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
-            current_shard_id = compute_shard_id(current_page_id);
+            // Initialize coordinates and state from page_id
+            initialize_from_page_id(start_page_id);
             update_current_page();
         }
     }
@@ -56,16 +55,8 @@ public:
             return *this;
         }
 
-        // Efficient address computation: check if we're moving to the next page in the same bank
-        if (can_use_incremental_update()) {
-            current_noc_addr += accessor.page_size;
-        } else {
-            // Need to recompute bank mapping and NOC address
-            current_page_mapping = accessor.get_bank_and_offset(current_page_id);
-            current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
-            current_shard_id = compute_shard_id(current_page_id);
-        }
-
+        // Efficiently update coordinates and address without divisions
+        increment_page_coordinate();
         update_current_page();
         return *this;
     }
@@ -88,10 +79,8 @@ public:
             return *this;
         }
 
-        // For large steps, it's more efficient to recompute from scratch
-        current_page_mapping = accessor.get_bank_and_offset(current_page_id);
-        current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
-        current_shard_id = compute_shard_id(current_page_id);
+        // For large steps or when crossing many boundaries, reinitialize from page_id
+        initialize_from_page_id(current_page_id);
         update_current_page();
         return *this;
     }
@@ -123,36 +112,145 @@ public:
 
 private:
     const Accessor& accessor;
-    uint32_t current_page_id = 0;
-    uint64_t current_noc_addr = 0;
+    uint32_t current_page_id = 0;   // current page id
+    uint64_t current_noc_addr = 0;  // current NOC address for this page
     uint8_t noc = noc_index;
-    uint32_t current_shard_id = 0;
+    uint32_t current_shard_id = 0;  // Which shard this page belongs to
 
-    typename Accessor::PageMapping current_page_mapping{0, 0};
+    // State for efficient incremental updates
+    typename Accessor::PageMapping current_page_mapping{0, 0};  // {bank_id, bank_page_offset}
     mutable Page current_page{0, 0, 0};
 
-    void update_current_page() {
-        if (current_page_id < accessor.dspec().tensor_volume()) {
-            current_page = Page(current_noc_addr, current_page_id, current_shard_id);
+    // Coordinates and derived state for avoiding divisions
+    [[no_unique_address]] mutable tensor_accessor::detail::
+        ConditionalField<!Accessor::DSpec::has_static_rank, uint32_t[tensor_accessor::MAX_RANK]> _page_coord_buf;
+    typename Accessor::DSpec::Shape page_coord;  // Current page coordinates [dim0, dim1, ...]
+    uint32_t page_offset_within_shard = 0;       // Offset of this page within its shard
+    uint32_t flattened_shard_id = 0;             // Linear shard id in the shard grid
+    uint32_t bank_shard_id = 0;                  // Which shard within the bank this page belongs to
+
+    void update_current_page() { current_page = Page(current_noc_addr, current_page_id, current_shard_id); }
+
+    // Initialize all state from a page_id (used in constructor and operator+=)
+    void initialize_from_page_id(uint32_t page_id) {
+        // Initialize page coordinate buffer if needed
+        if constexpr (!Accessor::DSpec::has_static_rank) {
+            page_coord = typename Accessor::DSpec::Shape(_page_coord_buf.value, accessor.dspec().rank());
+        }
+
+        // Convert page_id to coordinates (this is the only place we do divisions)
+        uint32_t temp_page_id = page_id;
+        for (int i = accessor.dspec().rank() - 1; i >= 0; --i) {
+            page_coord[i] = temp_page_id % accessor.dspec().tensor_shape()[i];
+            temp_page_id /= accessor.dspec().tensor_shape()[i];
+        }
+
+        // Calculate shard information
+        flattened_shard_id = 0;
+        page_offset_within_shard = 0;
+        for (size_t i = 0; i < accessor.dspec().rank(); ++i) {
+            flattened_shard_id +=
+                (page_coord[i] / accessor.dspec().shard_shape()[i]) * accessor.dspec().shard_grid_strides()[i];
+            page_offset_within_shard +=
+                (page_coord[i] % accessor.dspec().shard_shape()[i]) * accessor.dspec().shard_strides()[i];
+        }
+
+        // Calculate bank mapping
+        current_page_mapping.bank_id = flattened_shard_id % accessor.dspec().num_banks();
+        bank_shard_id = flattened_shard_id / accessor.dspec().num_banks();
+        current_page_mapping.bank_page_offset =
+            bank_shard_id * accessor.dspec().shard_volume() + page_offset_within_shard;
+
+        // Calculate NOC address and shard ID
+        current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
+        current_shard_id = current_page_mapping.bank_id + bank_shard_id * accessor.dspec().num_banks();
+    }
+
+    // Efficiently increment page coordinate and update derived state
+    void increment_page_coordinate() {
+        const auto& dspec = accessor.dspec();
+
+        // Simple approach: just increment and recalculate when we can't use simple increment
+        // This is more reliable than complex incremental logic
+
+        // Try simple increment first (consecutive pages in same bank)
+        if (can_use_simple_increment()) {
+            apply_simple_increment();
+            return;
+        }
+
+        // Need to update coordinates and recalculate (shard boundary crossed)
+        increment_coordinates();
+        recalculate_mapping_from_coordinates();
+    }
+
+    // Check if we can just increment the address (consecutive pages in same bank)
+    bool can_use_simple_increment() const {
+        const auto& dspec = accessor.dspec();
+
+        // Check if incrementing rightmost coordinate would stay in same row
+        uint32_t next_coord = page_coord[dspec.rank() - 1] + 1;
+        if (next_coord >= dspec.tensor_shape()[dspec.rank() - 1]) {
+            return false;  // Would overflow tensor bounds
+        }
+
+        // Check if still in same shard
+        uint32_t current_shard_coord = page_coord[dspec.rank() - 1] / dspec.shard_shape()[dspec.rank() - 1];
+        uint32_t next_shard_coord = next_coord / dspec.shard_shape()[dspec.rank() - 1];
+
+        if (current_shard_coord != next_shard_coord) {
+            return false;  // Would cross shard boundary
+        }
+
+        return true;  // Safe to increment
+    }
+
+    // Apply the simple increment (called after can_use_simple_increment returns true)
+    void apply_simple_increment() {
+        const auto& dspec = accessor.dspec();
+
+        // Update coordinate tracking
+        page_coord[dspec.rank() - 1]++;
+        page_offset_within_shard += dspec.shard_strides()[dspec.rank() - 1];
+
+        // Update NOC address and bank offset
+        current_noc_addr += accessor.page_size;
+        current_page_mapping.bank_page_offset++;
+    }
+
+    // Increment coordinates like a multi-dimensional counter
+    void increment_coordinates() {
+        const auto& dspec = accessor.dspec();
+
+        for (int i = dspec.rank() - 1; i >= 0; --i) {
+            page_coord[i]++;
+            if (page_coord[i] < dspec.tensor_shape()[i]) {
+                return;  // No carry needed
+            }
+            page_coord[i] = 0;  // Carry over
         }
     }
 
-    // Check if we can use incremental address update (same bank, consecutive pages in bank)
-    bool can_use_incremental_update() const {
-        auto next_page_mapping = accessor.get_bank_and_offset(current_page_id);
+    // Recalculate all mapping info from current coordinates
+    void recalculate_mapping_from_coordinates() {
+        const auto& dspec = accessor.dspec();
 
-        // Same bank and consecutive pages within that bank
-        return (next_page_mapping.bank_id == current_page_mapping.bank_id) &&
-               (next_page_mapping.bank_page_offset == current_page_mapping.bank_page_offset + 1);
-    }
+        // Recalculate shard information from coordinates
+        flattened_shard_id = 0;
+        page_offset_within_shard = 0;
+        for (size_t i = 0; i < dspec.rank(); ++i) {
+            flattened_shard_id += (page_coord[i] / dspec.shard_shape()[i]) * dspec.shard_grid_strides()[i];
+            page_offset_within_shard += (page_coord[i] % dspec.shard_shape()[i]) * dspec.shard_strides()[i];
+        }
 
-    // Compute which shard a page belongs to
-    uint32_t compute_shard_id(uint32_t page_id) const {
-        auto page_mapping = accessor.get_bank_and_offset(page_id);
+        // Recalculate bank mapping
+        current_page_mapping.bank_id = flattened_shard_id % dspec.num_banks();
+        bank_shard_id = flattened_shard_id / dspec.num_banks();
+        current_page_mapping.bank_page_offset = bank_shard_id * dspec.shard_volume() + page_offset_within_shard;
 
-        // Shard ID is determined by the bank and the position within the bank
-        uint32_t bank_shard_id = page_mapping.bank_page_offset / accessor.dspec().shard_volume();
-        return page_mapping.bank_id + bank_shard_id * accessor.dspec().num_banks();
+        // Recalculate NOC address and shard ID
+        current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
+        current_shard_id = current_page_mapping.bank_id + bank_shard_id * dspec.num_banks();
     }
 };
 

--- a/tt_metal/hw/inc/accessor/pages_address_iterator.h
+++ b/tt_metal/hw/inc/accessor/pages_address_iterator.h
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include "page.h"
+#include "helpers.h"
+
+namespace tensor_accessor {
+
+/**
+ * Iterator over all pages in a tensor.
+ * The iterator is initialized with a start_page_id and can be incremented by one page at a time,
+ * or by a given number of pages. It efficiently computes NOC addresses by minimizing bank lookups
+ * and reusing address computations when possible.
+ */
+template <typename Accessor>
+class PagesAddressIterator {
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Page;
+    using difference_type = std::ptrdiff_t;
+    using reference = const Page&;
+    using pointer = const Page*;
+
+    // Constructor that initializes the iterator at a starting position
+    PagesAddressIterator(const Accessor& accessor, uint32_t start_page_id = 0, uint8_t noc = noc_index) :
+        accessor(accessor), current_page_id(start_page_id), noc(noc) {
+        if (current_page_id < accessor.dspec().tensor_volume()) {
+            current_page_mapping = accessor.get_bank_and_offset(current_page_id);
+            current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
+            current_shard_id = compute_shard_id(current_page_id);
+            update_current_page();
+        }
+    }
+
+    // Getters
+    uint32_t page_id() const { return current_page_id; }
+
+    reference operator*() const { return current_page; }
+    pointer operator->() const { return &current_page; }
+
+    // Arithmetic operators
+    PagesAddressIterator& operator++() {
+        if (current_page_id >= accessor.dspec().tensor_volume()) {
+            return *this;  // End iterator
+        }
+
+        current_page_id++;
+        if (current_page_id >= accessor.dspec().tensor_volume()) {
+            current_page_id = accessor.dspec().tensor_volume();
+            return *this;
+        }
+
+        // Efficient address computation: check if we're moving to the next page in the same bank
+        if (can_use_incremental_update()) {
+            current_noc_addr += accessor.page_size;
+        } else {
+            // Need to recompute bank mapping and NOC address
+            current_page_mapping = accessor.get_bank_and_offset(current_page_id);
+            current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
+            current_shard_id = compute_shard_id(current_page_id);
+        }
+
+        update_current_page();
+        return *this;
+    }
+
+    PagesAddressIterator operator++(int) {
+        PagesAddressIterator tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    PagesAddressIterator& operator+=(difference_type steps) {
+        ASSERT(steps >= 0);
+        if (current_page_id >= accessor.dspec().tensor_volume()) {
+            return *this;  // End iterator
+        }
+
+        current_page_id += steps;
+        if (current_page_id >= accessor.dspec().tensor_volume()) {
+            current_page_id = accessor.dspec().tensor_volume();
+            return *this;
+        }
+
+        // For large steps, it's more efficient to recompute from scratch
+        current_page_mapping = accessor.get_bank_and_offset(current_page_id);
+        current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
+        current_shard_id = compute_shard_id(current_page_id);
+        update_current_page();
+        return *this;
+    }
+
+    PagesAddressIterator operator+(difference_type steps) const {
+        PagesAddressIterator tmp = *this;
+        tmp += steps;
+        return tmp;
+    }
+
+    const Page& operator[](difference_type n) const {
+        auto temp = *this;
+        temp += n;
+        return *temp;
+    }
+
+    // Comparison operators
+    bool operator==(const PagesAddressIterator& other) const { return current_page_id == other.current_page_id; }
+
+    bool operator!=(const PagesAddressIterator& other) const { return !(*this == other); }
+
+    bool operator<(const PagesAddressIterator& other) const { return current_page_id < other.current_page_id; }
+
+    bool operator>(const PagesAddressIterator& other) const { return other < *this; }
+
+    bool operator<=(const PagesAddressIterator& other) const { return *this < other || *this == other; }
+
+    bool operator>=(const PagesAddressIterator& other) const { return !(*this < other); }
+
+private:
+    const Accessor& accessor;
+    uint32_t current_page_id = 0;
+    uint64_t current_noc_addr = 0;
+    uint8_t noc = noc_index;
+    uint32_t current_shard_id = 0;
+
+    typename Accessor::PageMapping current_page_mapping{0, 0};
+    mutable Page current_page{0, 0, 0};
+
+    void update_current_page() {
+        if (current_page_id < accessor.dspec().tensor_volume()) {
+            current_page = Page(current_noc_addr, current_page_id, current_shard_id);
+        }
+    }
+
+    // Check if we can use incremental address update (same bank, consecutive pages in bank)
+    bool can_use_incremental_update() const {
+        auto next_page_mapping = accessor.get_bank_and_offset(current_page_id);
+
+        // Same bank and consecutive pages within that bank
+        return (next_page_mapping.bank_id == current_page_mapping.bank_id) &&
+               (next_page_mapping.bank_page_offset == current_page_mapping.bank_page_offset + 1);
+    }
+
+    // Compute which shard a page belongs to
+    uint32_t compute_shard_id(uint32_t page_id) const {
+        auto page_mapping = accessor.get_bank_and_offset(page_id);
+
+        // Shard ID is determined by the bank and the position within the bank
+        uint32_t bank_shard_id = page_mapping.bank_page_offset / accessor.dspec().shard_volume();
+        return page_mapping.bank_id + bank_shard_id * accessor.dspec().num_banks();
+    }
+};
+
+/**
+ * Proxy for PagesAddressIterator, to enable range-based for loop over all pages in a tensor.
+ */
+template <typename Accessor>
+class Pages {
+public:
+    using iterator = PagesAddressIterator<Accessor>;
+    using const_iterator = PagesAddressIterator<Accessor>;
+
+    Pages(const Accessor& accessor, uint32_t start_page_id = 0, uint8_t noc = noc_index) :
+        accessor_(accessor), start_page_id_(start_page_id), noc_(noc) {}
+
+    iterator begin() const { return PagesAddressIterator<Accessor>(accessor_, start_page_id_, noc_); }
+
+    iterator end() const { return PagesAddressIterator<Accessor>(accessor_, accessor_.dspec().tensor_volume(), noc_); }
+
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+private:
+    const Accessor& accessor_;
+    uint32_t start_page_id_;
+    uint8_t noc_;
+};
+
+}  // namespace tensor_accessor

--- a/tt_metal/hw/inc/accessor/shard_pages_address_iterator.h
+++ b/tt_metal/hw/inc/accessor/shard_pages_address_iterator.h
@@ -7,22 +7,9 @@
 #include <array>
 #include <cstddef>
 #include <iterator>
+#include "page.h"
 
 namespace tensor_accessor {
-class Page {
-public:
-    Page(uint64_t noc_addr, uint32_t global_page_id, uint32_t shard_id) :
-        noc_addr_(noc_addr), global_page_id_(global_page_id), shard_id_(shard_id) {}
-
-    uint64_t get_noc_addr() const { return noc_addr_; }
-    uint32_t page_id() const { return global_page_id_; }
-    uint32_t shard_id() const { return shard_id_; }
-
-private:
-    uint64_t noc_addr_;
-    uint32_t global_page_id_;
-    uint32_t shard_id_;
-};
 
 /**
  * Iterator over pages in a shard.

--- a/tt_metal/hw/inc/accessor/tensor_accessor.h
+++ b/tt_metal/hw/inc/accessor/tensor_accessor.h
@@ -10,6 +10,7 @@
 #include "dspec.h"
 #include "helpers.h"
 #include "shard_pages_address_iterator.h"
+#include "pages_address_iterator.h"
 #include "compile_time_args.h"
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
@@ -222,6 +223,11 @@ public:
         return tensor_accessor::ShardPages<TensorAccessor>(*this, shard_id, start_page_offset, noc);
     }
 
+    // Returns a proxy for pages iterator (iterates over all pages in the tensor)
+    tensor_accessor::Pages<TensorAccessor> pages(uint32_t start_page_id = 0, uint8_t noc = noc_index) const {
+        return tensor_accessor::Pages<TensorAccessor>(*this, start_page_id, noc);
+    }
+
 private:
     // NOC APIs
     FORCE_INLINE
@@ -267,6 +273,7 @@ public:
     const uint32_t page_size = 0;
 
     friend class tensor_accessor::ShardPagesAddressIterator<TensorAccessor>;
+    friend class tensor_accessor::PagesAddressIterator<TensorAccessor>;
 };
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
@@ -331,6 +338,14 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
         static_assert(
             tensor_accessor::detail::always_false_v<TensorAccessor>,
             "TensorAccessor::shard_pages is not supported by the interleaved tensor accessor");
+        return {};
+    }
+
+    // Returns a proxy for pages iterator (iterates over all pages in the tensor)
+    tensor_accessor::Pages<TensorAccessor> pages(uint32_t start_page_id = 0, uint8_t noc = noc_index) const {
+        static_assert(
+            tensor_accessor::detail::always_false_v<TensorAccessor>,
+            "TensorAccessor::pages is not supported by the interleaved tensor accessor");
         return {};
     }
 };


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24288

### Problem description
Some accessing patterns can be optimized

### What's changed
- Add PagesAddressIterator that allows to iterate over all pages of tensor quicker, then manually recalculate address for each page. Interface is the same as in ShardPagesAddressIterator
- Add test for PagesAddressIterator
  - Also, increase number of parameters tested for this and other tests
- Add  benchmark for PagesAddressIterator
- Add a small example in tensor accessor doc

Benchmark -- single core iterating over addresses of all pages. "Copy Manual" - recalculate page address with tensor accessor at each iteration, "Copy Iterator" - Use page address iterator instead.  

| Tensor Shape            | Shard Shape             | Copy Manual (K cycles) | Copy Iterator (K cycles) | Speed Up |
| ----------------------- | ----------------------- | ---------------------- | ------------------------ | -------- |
| {320, 320}              | {96, 96}                | 6.4K                   | 4.6K                     | 1.4x      |
| {5, 160, 320}           | {3, 96, 96}             | 37.9K                  | 20.9K                    | 1.8x      |
| {5, 5, 160, 160}        | {3, 3, 96, 96}          | 130.9K                 | 60.4K                    | 2.2x      |
| {5, 5, 5, 160, 160}     | {3, 3, 3, 96, 96}       | 833.4K                 | 334.5K                   | 2.5x      |
| {3, 3, 3, 3, 160, 160}  | {2, 2, 2, 2, 96, 96}    | 606.0K                 | 242.0K                   | 2.5x      |
| {3, 3, 3, 3, 3, 64, 64} | {2, 2, 2, 2, 2, 96, 96} | 335.8K                 | 148.1K                   | 2.3x      |

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes -- https://github.com/tenstorrent/tt-metal/actions/runs/17211243447
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) -- https://github.com/tenstorrent/tt-metal/actions/runs/17261258290 
- [X] New/Existing tests provide coverage for changes
