### PR TITLE
Add missing include files to tt-nn-dev.deb.

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -415,8 +415,11 @@ set_target_properties(
             "default" # FIXME: Export the symbols we want, and use hidden visibility instead of default
         ADDITIONAL_CLEAN_FILES
             "${PROJECT_SOURCE_DIR}/ttnn/ttnn/_'${LIBRARY_NAME}'.so;${PROJECT_SOURCE_DIR}/ttnn/'${LIBRARY_NAME}'.egg-info" # FIXME: Confirm this is a relic of the past and can be deleted; No generated files should land in the source tree!
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
 )
 
+file(GLOB_RECURSE ttnn_kernels cpp/ttnn/operations/copy/typecast/device/kernels/*)
 file(GLOB_RECURSE api api/*)
 target_sources(
     ttnncpp
@@ -424,7 +427,16 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/cpp
-        FILES ${api} cpp/ttnn/operations/creation.hpp cpp/ttnn/operations/functions.hpp
+        FILES
+            ${api}
+            cpp/ttnn/operations/copy/typecast/typecast.hpp
+            cpp/ttnn/operations/creation.hpp
+            cpp/ttnn/operations/functions.hpp
+            cpp/ttnn/operations/compute_throttle_utils.hpp
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${ttnn_kernels}
     PRIVATE
         # FIXME: Move these out to appropriate sub targets
         cpp/ttnn/operations/compute_throttle_utils.cpp
@@ -524,8 +536,6 @@ target_link_libraries(
         TTNN::Ops::Rand
 )
 if(TT_INSTALL)
-    install(TARGETS ttnncpp LIBRARY COMPONENT ttnn-runtime)
-
     install(
         TARGETS
             ttnncpp
@@ -533,7 +543,20 @@ if(TT_INSTALL)
             DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT tar
     )
-    install(TARGETS ttnncpp EXPORT TT-NN LIBRARY COMPONENT ttnn-runtime FILE_SET api COMPONENT ttnn-dev)
+    install(
+        TARGETS
+            ttnncpp
+        EXPORT TT-NN
+        FILE_SET
+        api
+            COMPONENT ttnn-dev
+        FILE_SET
+        kernels
+            DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn
+            COMPONENT ttnn-runtime
+        LIBRARY
+            COMPONENT ttnn-runtime
+    )
 endif()
 
 if(WITH_PYTHON_BINDINGS)

--- a/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
@@ -19,6 +19,10 @@ file(
 target_sources(
     ttnn_op_ccl
     PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ccl_op_fusion.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -76,6 +80,9 @@ target_link_libraries(
 install(
     TARGETS
         ttnn_op_ccl
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
     FILE_SET
     kernels
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/ccl

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -13,11 +13,19 @@ set_target_properties(
 # Globbing non-build files is acceptable for now because devs don't generate packages.
 file(
     GLOB_RECURSE kernels
+    bcast/device/kernels/*
+    concat/device/kernels/*
     common/kernels/*
+    copy/device/kernels/*
     move/device/kernels/*
     permute/device/kernels/*
+    repeat/device/device/*
+    reshape_view/device/device/*
     sharded/device/kernels/*
+    slice/device/kernels/*
+    tilize_with_val_padding/device/kernels/*
     transpose/device/kernels/*
+    untilize/device/kernels/*
 )
 target_sources(
     ttnn_op_data_movement
@@ -26,12 +34,23 @@ target_sources(
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
         FILES
-            sharded/reshard/device/reshard_op.hpp
-            sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
-            sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
+            bcast/bcast.hpp
+            bcast/bcast_types.hpp
+            concat/concat.hpp
             copy/device/copy_device_operation.hpp
+            permute/permute.hpp
+            repeat/repeat.hpp
             reshape_view/reshape.hpp
             reshape_view/reshape_common.hpp
+            sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+            sharded/reshard/device/reshard_op.hpp
+            sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
+            slice/slice.hpp
+            tilize_with_val_padding/tilize_with_val_padding.hpp
+            tilize_with_val_padding/tilize_with_val_padding_common.hpp
+            tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
+            transpose/transpose.hpp
+            untilize/untilize.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/CMakeLists.txt
@@ -18,7 +18,13 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
-        FILES binary.hpp common/binary_op_types.hpp
+        FILES
+            binary.hpp
+            binary_composite.hpp
+            common/binary_op_types.hpp
+            common/binary_op_utils.hpp
+            device/binary_composite_op.hpp
+            device/binary_device_operation.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/CMakeLists.txt
@@ -3,9 +3,26 @@ add_library(TTNN::Ops::Eltwise::Ternary ALIAS ttnn_op_eltwise_ternary)
 
 target_precompile_headers(ttnn_op_eltwise_ternary REUSE_FROM TT::CommonPCH)
 TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_ternary)
+set_target_properties(
+    ttnn_op_eltwise_ternary
+    PROPERTIES
+        VERIFY_INTERFACE_HEADER_SETS
+            FALSE
+)
 
+# Globbing non-build files is acceptable for now because devs don't generate packages.
+file(GLOB_RECURSE kernels where/device/kernels/*)
 target_sources(
     ttnn_op_eltwise_ternary
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES where/where.hpp
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
     PRIVATE
         ternary_composite_op.cpp
         where/where.cpp
@@ -20,6 +37,18 @@ target_link_libraries(
     PRIVATE
         TT::Metalium
         TTNN::Core
+)
+
+install(
+    TARGETS
+        ttnn_op_eltwise_ternary
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
+    FILE_SET
+    kernels
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/eltwise/ternary
+        COMPONENT ttnn-runtime
 )
 
 install(TARGETS ttnn_op_eltwise_ternary LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
-        FILES unary.hpp common/unary_op_types.hpp
+        FILES common/unary_op_types.hpp device/unary_composite_op.hpp unary.hpp unary_composite.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/CMakeLists.txt
@@ -3,9 +3,26 @@ add_library(TTNN::Ops::Experimental::Transformer ALIAS ttnn_op_experimental_tran
 
 target_precompile_headers(ttnn_op_experimental_transformer REUSE_FROM TT::CommonPCH)
 TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_transformer)
+set_target_properties(
+    ttnn_op_experimental_transformer
+    PROPERTIES
+        VERIFY_INTERFACE_HEADER_SETS
+            FALSE
+)
 
+# Globbing non-build files is acceptable for now because devs don't generate packages.
+file(GLOB_RECURSE nlp_kv_cache_load_slice/device/kernels/*)
 target_sources(
     ttnn_op_experimental_transformer
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.hpp
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
     PRIVATE
         all_reduce_create_qkv_heads/all_reduce_create_qkv_heads.cpp
         all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_op.cpp
@@ -68,6 +85,18 @@ target_link_libraries(
     PRIVATE
         TT::Metalium
         TTNN::Core
+)
+
+install(
+    TARGETS
+        ttnn_op_experimental_transformer
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
+    FILE_SET
+    kernels
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/transformer
+        COMPONENT ttnn-runtime
 )
 
 install(TARGETS ttnn_op_experimental_transformer LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/kv_cache/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/kv_cache/CMakeLists.txt
@@ -3,9 +3,26 @@ add_library(TTNN::Ops::KvCache ALIAS ttnn_op_kv_cache)
 
 target_precompile_headers(ttnn_op_kv_cache REUSE_FROM TT::CommonPCH)
 TT_ENABLE_UNITY_BUILD(ttnn_op_kv_cache)
+set_target_properties(
+    ttnn_op_kv_cache
+    PROPERTIES
+        VERIFY_INTERFACE_HEADER_SETS
+            FALSE
+)
 
+# Globbing non-build files is acceptable for now because devs don't generate packages.
+file(GLOB_RECURSE kernels device/kernels/*)
 target_sources(
     ttnn_op_kv_cache
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES kv_cache.hpp
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
     PRIVATE
         device/update_cache_op.cpp
         device/update_cache_op_multi_core.cpp
@@ -18,6 +35,18 @@ target_link_libraries(
     PRIVATE
         TT::Metalium
         TTNN::Core
+)
+
+install(
+    TARGETS
+        ttnn_op_kv_cache
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
+    FILE_SET
+    kernels
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/kv_cache
+        COMPONENT ttnn-runtime
 )
 
 install(TARGETS ttnn_op_kv_cache LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/matmul/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/matmul/CMakeLists.txt
@@ -14,6 +14,10 @@ file(GLOB_RECURSE kernels device/kernels/*)
 target_sources(
     ttnn_op_matmul
     PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES matmul.hpp device/matmul_op.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -40,6 +44,9 @@ target_link_libraries(
 install(
     TARGETS
         ttnn_op_matmul
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
     FILE_SET
     kernels
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/matmul

--- a/ttnn/cpp/ttnn/operations/moreh/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/moreh/CMakeLists.txt
@@ -16,10 +16,16 @@ file(
     moreh_dot/device/kernels/*
     moreh_getitem/device/moreh_getitem_kernels/*
     moreh_getitem/device/moreh_getitem_tilized_kernels/*
+    moreh_group_norm/device/kernels/*
+    moreh_matmul/device/kernels/*
 )
 target_sources(
     ttnn_op_moreh
     PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES moreh_group_norm/moreh_group_norm.hpp moreh_matmul/moreh_matmul.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -168,6 +174,9 @@ target_link_libraries(
 install(
     TARGETS
         ttnn_op_moreh
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
     FILE_SET
     kernels
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/moreh

--- a/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
@@ -11,10 +11,24 @@ set_target_properties(
 )
 
 # Globbing non-build files is acceptable for now because devs don't generate packages.
-file(GLOB_RECURSE kernels softmax/device/kernels/*)
+file(
+    GLOB_RECURSE kernels
+    layernorm/device/kernels/*
+    softmax/device/kernels/*
+)
 target_sources(
     ttnn_op_normalization
     PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES
+            layernorm/layernorm.hpp
+            layernorm/device/layernorm_types.hpp
+            rmsnorm/rmsnorm.hpp
+            softmax/device/softmax_op.hpp
+            softmax/device/softmax_types.hpp
+            softmax/softmax.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -52,6 +66,9 @@ target_link_libraries(
 install(
     TARGETS
         ttnn_op_normalization
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
     FILE_SET
     kernels
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/normalization

--- a/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
@@ -11,10 +11,18 @@ set_target_properties(
 )
 
 # Globbing non-build files is acceptable for now because devs don't generate packages.
-file(GLOB_RECURSE kernels argmax/device/kernels/*)
+file(
+    GLOB_RECURSE kernels
+    argmax/device/kernels/*
+    generic/device/kernels/*
+)
 target_sources(
     ttnn_op_reduction
     PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES generic/generic_reductions.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -62,6 +70,9 @@ target_link_libraries(
 install(
     TARGETS
         ttnn_op_reduction
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
     FILE_SET
     kernels
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/reduction


### PR DESCRIPTION
### Ticket

Issue: https://github.com/tenstorrent/tt-metal/issues/27371

### Problem description

Trying to build llama.cpp from https://github.com/marty1885/llama.cpp with files installed from tt-nn-dev .deb package results in errors due to missing header files for operations used in ggml Metalium backend. 

### What's changed

This PR contains changes in cmake files causing cpack to include missing files.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes