### PR TITLE
Don't set HF_HOME for single card model demos

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -221,7 +221,6 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e ARCH_NAME=${{ inputs.arch }}
-            ${{ !matrix.test-group.civ2-compatible && '-e HF_HOME=/mnt/MLPerf/huggingface' || '' }}
             ${{ matrix.test-group.civ2-compatible && '-e TT_GH_CI_INFRA=1' || '' }}
             -v /mnt/MLPerf:/mnt/MLPerf:ro
             --cap-add=ALL

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -221,7 +221,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e ARCH_NAME=${{ inputs.arch }}
-            -e HF_HOME=/mnt/MLPerf/huggingface
+            ${{ !matrix.test-group.civ2-compatible && '-e HF_HOME=/mnt/MLPerf/huggingface' || '' }}
             ${{ matrix.test-group.civ2-compatible && '-e TT_GH_CI_INFRA=1' || '' }}
             -v /mnt/MLPerf:/mnt/MLPerf:ro
             --cap-add=ALL


### PR DESCRIPTION
### Ticket
None

### Problem description
Single card demos broken due to addition of `HF_HOME` env var set to `/mnt/MLPerf/huggingface` (from https://github.com/tenstorrent/tt-metal/commit/6d136d4ea9a1bcfbcc1309ae47299d05ba21c94f)

### What's changed
Do not set `HF_HOME` in single card demos

### Checklist
- [x] Single card demos: https://github.com/tenstorrent/tt-metal/actions/runs/17219066204