### PR TITLE
Add support for real weights and dequantization in MLA

### DIFF
--- a/models/demos/deepseek_v3/tt/mla_1d.py
+++ b/models/demos/deepseek_v3/tt/mla_1d.py
@@ -23,6 +23,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     ReshardConfig,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
+    dequantize_state_dicts,
     even_int_div,
     get_mesh_coords,
     get_state_dicts,
@@ -88,6 +89,8 @@ class MLA1D(SharedStateAddOn, AbstractModule):
         v_head_dim = hf_config.v_head_dim
         q_lora_rank = hf_config.q_lora_rank
         q_head_dim = qk_nope_head_dim + qk_rope_head_dim
+
+        state_dicts = dequantize_state_dicts(state_dicts, hf_config)
 
         def convert_linear_weight(
             hf_name: str | None,

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -518,7 +518,7 @@ def dequantize_state_dict(state_dict, hf_config, dtype=torch.bfloat16):
 
 
 def dequantize_state_dicts(state_dict_list: list[dict[str, torch.Tensor] | None], hf_config):
-    dequant_state_dicts = [dequantize_state_dict(sd, hf_config) for sd in state_dict_list if sd is not None]
+    dequant_state_dicts = [dequantize_state_dict(sd, hf_config) if sd is not None else None for sd in state_dict_list]
     return dequant_state_dicts
 
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -517,6 +517,11 @@ def dequantize_state_dict(state_dict, hf_config, dtype=torch.bfloat16):
     return dequantized_state_dict
 
 
+def dequantize_state_dicts(state_dict_list: list[dict[str, torch.Tensor] | None], hf_config):
+    dequant_state_dicts = [dequantize_state_dict(sd, hf_config) for sd in state_dict_list if sd is not None]
+    return dequant_state_dicts
+
+
 def get_state_dicts(
     dicts: Sequence[dict[str, torch.Tensor] | None],
     key: Any,


### PR DESCRIPTION
### Ticket
None

### Problem description
MLA module needs to dequantize the weights of inverse scaling key are present in state dict, without
it, PCC and model accuracy woould get affected.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes