### PR TITLE
#27136 Binary_ng row col mixed subtile broadcast using LLK with bloat16

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2104,7 +2104,8 @@ def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     [
-        [[1, 1, 320, 1], [1, 1, 1, 320]],
+        [[1, 1, 9600, 1], [1, 1, 1, 9600]],
+        [[1, 1, 1, 9600], [1, 1, 9600, 1]],
         # a col, b row
         [[1, 1, 320, 1], [1, 4, 1, 320]],
         [[1, 1, 320, 1], [4, 1, 1, 320]],
@@ -2133,9 +2134,11 @@ def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
     torch_input_tensor_b, input_tensor_b = rand_bf16_gen(b_shape, device)
 
-    torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
-
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
+    torch_output_tensor = torch_input_tensor_a - torch_input_tensor_b
+    # add is non associative, so we use subtract to test the bcast because it is associative
+    output_tensor = ttnn.subtract(
+        input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None
+    )
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -323,6 +323,8 @@ def test_sub_opt_output_typecast_inputs(input_shapes, device):
         (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
         (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
         (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+        (torch.Size([5, 1, 1, 128]), torch.Size([1, 3, 64, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([1, 3, 64, 128]), torch.Size([5, 1, 1, 128]), torch.Size([5, 3, 64, 128])),
     ),
 )
 # Typecast on output

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -465,19 +465,33 @@ void overwrite_compute_kernel_name_and_defines(
     KernelName& kernel_name,
     const SubtileBroadcastType subtile_broadcast_type,
     std::map<std::string, std::string>& compute_defines) {
-    compute_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
-    compute_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
-    kernel_name = KernelName::ComputeRowBcastNg;
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        compute_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
+        compute_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
+        kernel_name = KernelName::ComputeRowBcastNg;
+    } else if (
+        subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A) {
+        kernel_name = KernelName::ComputeRowColBcastNg;
+    }
 }
 
 bool is_llk_bcast(const SubtileBroadcastType subtile_broadcast_type, const DataType a_dtype, const DataType b_dtype) {
-    if (not(subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
-            subtile_broadcast_type == SubtileBroadcastType::ROW_B)) {
-        return false;
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
+            return true;
+        }
     }
-    if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
-        return true;
+
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A) {
+        if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
+            return true;
+        }
     }
+
     return false;
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -630,10 +644,12 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             tt::CBIndex::c_4, program, all_device_cores, b_intermediate_single_tile_size, 1, b_intermediate_format);
     }
 
-    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A) {
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B) {
         create_cb(tt::CBIndex::c_5, program, all_device_cores, a_single_tile_size, 2, a_data_format);
     }
-    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+    if (operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_B ||
+        operation_attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A) {
         create_cb(tt::CBIndex::c_6, program, all_device_cores, b_single_tile_size, 2, b_data_format);
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -477,17 +477,21 @@ void overwrite_compute_kernel_name_and_defines(
     }
 }
 
-bool is_llk_bcast(const SubtileBroadcastType subtile_broadcast_type, const DataType a_dtype, const DataType b_dtype) {
+bool is_llk_bcast(
+    const SubtileBroadcastType subtile_broadcast_type,
+    const DataType a_dtype,
+    const DataType b_dtype,
+    const DataType c_dtype) {
     if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
         subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
-        if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
+        if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16 && c_dtype == DataType::BFLOAT16) {
             return true;
         }
     }
 
     if (subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B ||
         subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A) {
-        if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
+        if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16 && c_dtype == DataType::BFLOAT16) {
             return true;
         }
     }
@@ -730,7 +734,7 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
 
     const uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
-    if (CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(operation_attributes.subtile_broadcast_type, a_dtype, b_dtype)) {
+    if (CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(operation_attributes.subtile_broadcast_type, a_dtype, b_dtype, c_dtype)) {
         CMAKE_UNIQUE_NAMESPACE::overwrite_compute_kernel_name_and_defines(
             compute_kernel, operation_attributes.subtile_broadcast_type, compute_kernel_defines);
         reader_defines["BCAST_LLK"] = "1";

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -139,6 +139,11 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu) {
         case KernelName::ComputeRowBcastNg:
             return fmt::format(
                 compute, root_ng, is_sfpu ? "eltwise_binary_sfpu_row_bcast.cpp" : "eltwise_binary_row_bcast.cpp");
+        case KernelName::ComputeRowColBcastNg:
+            return fmt::format(
+                compute,
+                root_ng,
+                is_sfpu ? "eltwise_binary_sfpu_row_col_bcast.cpp" : "eltwise_binary_row_col_bcast.cpp");
         default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -33,6 +33,7 @@ enum class KernelName {
     ReaderRowBColABcastNg,
     ReaderScalarBcastNg,
     ComputeRowBcastNg,
+    ComputeRowColBcastNg,
 };
 
 struct BinaryNgKernelConfig {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/trigonometry.h"
+#include "compute_kernel_api/bcast.h"
+
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+namespace NAMESPACE {
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+#if BCAST_INPUT  // ROW_A_COL_B
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+    constexpr auto cb_llk_post = tt::CBIndex::c_5;
+    constexpr auto cb_left = tt::CBIndex::c_5;
+    auto cb_right = cb_post_rhs;
+#else  // ROW_B_COL_A
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+    constexpr auto cb_llk_post = tt::CBIndex::c_6;
+    auto cb_left = cb_post_lhs;
+    constexpr auto cb_right = tt::CBIndex::c_6;
+#endif
+
+    binary_op_init_common(cb_left, cb_right, cb_out);
+    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
+    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
+        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
+        cb_reserve_back(cb_llk_post, 1);
+        unary_bcast_init<BroadcastType::ROW>(CB_POST_OTHER, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(CB_POST_OTHER, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        cb_push_back(cb_llk_post, 1);
+        tile_regs_release();
+
+        cb_pop_front(CB_POST_OTHER, 1);
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_left, cb_right);
+
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_llk_post, 1);
+        tile_regs_acquire();
+        BINARY_OP(cb_left, cb_right, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_llk_post, num_tiles_per_cycle);
+    }
+    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
+}
+
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs = HAS_ACTIVATIONS(LHS) ? tt::CBIndex::c_3 : cb_pre_lhs;
+    constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_pre_rhs;
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start, num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -112,7 +112,9 @@ void kernel_main() {
                             noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
                             noc_async_read_barrier();
 #endif
+#if !BCAST_LLK
                             FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+#endif
 #if !SRC_SHARDED_B
                             cb_push_back(cb_id_src_b, onetile);
 #endif
@@ -124,7 +126,9 @@ void kernel_main() {
                             noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
                             noc_async_read_barrier();
 #endif
+#if !BCAST_LLK
                             FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+#endif
 #if !SRC_SHARDED_B
                             cb_push_back(cb_id_src, onetile);
 #endif


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27136)

### Problem description
row_a_col_b and row_b_col_a subtile broadcast case performance is low due to using software broadcast

### What's changed
Similar with row broadcast only case that is simpler, with this it has covered all row related. Note col broadcast is still done by software. It is on purpose, because it achieve the good balance of using both reader and compute kernel. Profiling data shows row col mixed handling like this is the same gain of 4x as row only.

Note currently it only support bf16 because of LLK's limitation.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes