### PR TITLE
Fix broken fabric sanity smoke tests

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(
             ${kernels}
             perf_microbenchmark/common/kernel_utils.hpp
             perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen.hpp
+            ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_fabric/common/utils.hpp
 )
 
 install(

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -8,12 +8,12 @@ target_link_libraries(
     tt-metalium-validation-smoke
     PRIVATE
         TT::SystemHealth::Smoke
-        TT::Metalium::Test::Fabric::Smoke
         TT::Metalium::Test::API
         TT::Metalium::Test::Device::Smoke
         TT::Metalium::Test::Dispatch::Smoke
         TT::Metalium::Test::SFPI
         TT::Metalium::Test::STL::Smoke
+        TT::Metalium::Test::Fabric::Smoke
 )
 
 install(TARGETS tt-metalium-validation-smoke RUNTIME COMPONENT metalium-validation)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The previous implementation of fabric smoke tests hangs randomly

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes