### PR TITLE
Refactored the Pooling Upsample Kernels to use TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_unary_stick_layout_interleaved_start_id.cpp
@@ -11,13 +11,10 @@ void kernel_main() {
     uint32_t start_page_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr bool src_page_size_is_pow2 = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(4);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
 
-    const auto s0 =
-        get_interleaved_addr_gen<src0_is_dram, src_page_size_is_pow2>(src_addr, page_size, src_log_base_2_of_page_size);
+    constexpr auto src_args = TensorAccessorArgs<2>();
+    const auto s0 = TensorAccessor(src_args, src_addr, page_size);
 
     const uint32_t end_id = start_page_id + num_pages;
 
@@ -25,7 +22,7 @@ void kernel_main() {
     for (uint32_t i = start_page_id; i < end_id; ++i) {
         cb_reserve_back(cb_id_in0, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint64_t src_noc_addr = get_noc_addr(i, s0);
+        uint64_t src_noc_addr = s0.get_noc_addr(i);
 
         noc_async_read(src_noc_addr, l1_write_addr, page_size);
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_interleaved.cpp
@@ -18,19 +18,16 @@ void kernel_main() {
     uint32_t start_block_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(2);
-    constexpr bool dst_page_size_is_pow2 = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(4);
-    constexpr uint32_t scale_h = get_compile_time_arg_val(5);
-    constexpr uint32_t scale_w = get_compile_time_arg_val(6);
-    constexpr uint32_t height = get_compile_time_arg_val(7);
-    constexpr uint32_t width = get_compile_time_arg_val(8);
-    constexpr uint32_t block_height = get_compile_time_arg_val(9);
-    constexpr uint32_t num_tiles_per_block_row = get_compile_time_arg_val(10);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t scale_h = get_compile_time_arg_val(2);
+    constexpr uint32_t scale_w = get_compile_time_arg_val(3);
+    constexpr uint32_t height = get_compile_time_arg_val(4);
+    constexpr uint32_t width = get_compile_time_arg_val(5);
+    constexpr uint32_t block_height = get_compile_time_arg_val(6);
+    constexpr uint32_t num_tiles_per_block_row = get_compile_time_arg_val(7);
 
-    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_page_size_is_pow2>(
-        dst_addr, output_page_size, dst_log_base_2_of_page_size);
+    constexpr auto dst_args = TensorAccessorArgs<8>();
+    const auto s0 = TensorAccessor(dst_args, dst_addr, output_page_size);
 
     constexpr uint32_t in_width = width / scale_w;
     constexpr uint32_t in_height = height / scale_h;
@@ -62,7 +59,7 @@ void kernel_main() {
                 for (uint32_t k = 0; k < scale_w; k++) {
                     uint64_t offset = j * width + k;
 
-                    uint64_t dst_noc_addr_1 = get_noc_addr((start_index + offset), s0);
+                    uint64_t dst_noc_addr_1 = s0.get_noc_addr(start_index + offset);
                     noc_async_write(read_addr, dst_noc_addr_1, output_page_size);
                 }
             }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed

Refactored the pool/upscale, reader kernel, and writer kernel to use TensorAccessor.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17222244175) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17222256240) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes
- [x] [Blackhole Nightly Tests](https://github.com/tenstorrent/tt-metal/actions/runs/17248656299) CI with demo tests passes (if applicable)