### PR TITLE
#25975: Port all tt-train OPs to TensorAccessor

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/reader_cross_entropy_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/reader_cross_entropy_bw_interleaved_start_id.cpp
@@ -13,9 +13,10 @@
 #include "debug/dprint_pages.h"
 #include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
 
+template <typename AddrGen>
 void read_block_tiles(
     const uint32_t cb_input_idx,
-    const InterleavedAddrGenFast<true>& input_address_generator,
+    const AddrGen& input_address_generator,
     const uint32_t Wt,
     const uint32_t block_size,
     const uint32_t tile_bytes,
@@ -77,13 +78,10 @@ void kernel_main() {
     generate_matmul_row_reduce_tile(cb_matmul_reduce);  // generate tile for matmul row reduce
 
     const uint32_t tile_bytes = get_tile_size(cb_input_idx);
-    const DataFormat data_format = get_dataformat(cb_input_idx);
-
-    const InterleavedAddrGenFast</* is_dram */ true> input_address_generator = {
-        .bank_base_address = input_address, .page_size = tile_bytes, .data_format = data_format};
-
-    const InterleavedAddrGen</* is_dram */ true> target_indexes_address_generator = {
-        .bank_base_address = target_address, .page_size = target_indexes_page_size};
+    constexpr auto input_args = TensorAccessorArgs<6>();
+    constexpr auto target_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    const auto input_address_generator = TensorAccessor(input_args, input_address, tile_bytes);
+    const auto target_indexes_address_generator = TensorAccessor(target_args, target_address, target_indexes_page_size);
 
     for (uint32_t i = 0; i < num_rows_to_process; ++i) {
         // calculate the address of the first tile in the row

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/writer_cross_entropy_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/writer_cross_entropy_bw_interleaved_start_id.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
 
     const float scaler = uint32_to_float(scaler_bits);
     const uint32_t tile_bytes = get_tile_size(cb_output_idx);
-    constexpr auto output_args = TensorAccessorArgs<4>();
+    constexpr auto output_args = TensorAccessorArgs<3>();
     const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/writer_cross_entropy_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/writer_cross_entropy_bw_interleaved_start_id.cpp
@@ -26,10 +26,8 @@ void kernel_main() {
 
     const float scaler = uint32_to_float(scaler_bits);
     const uint32_t tile_bytes = get_tile_size(cb_output_idx);
-    const DataFormat data_format = get_dataformat(cb_output_idx);
-
-    const InterleavedAddrGenFast</* is dram */ true> output_addr_generator = {
-        .bank_base_address = output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto output_args = TensorAccessorArgs<4>();
+    const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;
 

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
@@ -4,11 +4,11 @@
 
 #include "cross_entropy_fw_program_factory.hpp"
 
-#include <enchantum/enchantum.hpp>
-
 #include <bit>
 #include <cstdint>
+#include <enchantum/enchantum.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "cross_entropy_fw_device_operation_types.hpp"
 #include "metal/ops/common/program_utils.hpp"
@@ -310,16 +310,15 @@ CrossEntropyForwardProgramFactory::cached_program_t CrossEntropyForwardProgramFa
     defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
 
     CrossEntropyForwardKernels kernels;
-    kernels.reader = create_reader_kernel(
-        program,
-        all_cores,
-        /* reader_compile_args */
-        {block_size, Wt, mask_w, target_indexes_inner_dim_size, Ht, uint32_read_page_size},
-        defines,
-        kReaderKernelPath);
+    std::vector<uint32_t> reader_compile_time_args{
+        block_size, Wt, mask_w, target_indexes_inner_dim_size, Ht, uint32_read_page_size};
+    tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(target_buffer).append_to(reader_compile_time_args);
+    kernels.reader = create_reader_kernel(program, all_cores, reader_compile_time_args, defines, kReaderKernelPath);
 
-    kernels.writer = create_writer_kernel(
-        program, all_cores, /* writer_compile_args */ {block_size, Wt}, defines, kWriterKernelPath);
+    std::vector<uint32_t> writer_compile_time_args{block_size, Wt};
+    tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_compile_time_args);
+    kernels.writer = create_writer_kernel(program, all_cores, writer_compile_time_args, defines, kWriterKernelPath);
 
     // -------------------------------------------------------------------------
     // 4) Create compute kernels for cross_entropy_fw

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
@@ -76,13 +76,10 @@ void kernel_main() {
     cb_push_back(cb_scaler_idx, onetile);
 
     const uint32_t tile_bytes = get_tile_size(cb_input_idx);
-    const DataFormat data_format = get_dataformat(cb_input_idx);
-
-    const InterleavedAddrGenFast</* is_dram */ true> input_address_generator = {
-        .bank_base_address = input_address, .page_size = tile_bytes, .data_format = data_format};
-
-    const InterleavedAddrGen</* is_dram */ true> target_indexes_address_generator = {
-        .bank_base_address = target_address, .page_size = target_indexes_page_size};
+    constexpr auto input_args = TensorAccessorArgs<6>();
+    constexpr auto target_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    const auto input_address_generator = TensorAccessor(input_args, input_address, tile_bytes);
+    const auto target_indexes_address_generator = TensorAccessor(target_args, target_address, target_indexes_page_size);
 
     for (uint32_t i = 0; i < num_rows_to_process; ++i) {
         // calculate the address of the first tile in the row

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/writer_cross_entropy_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/writer_cross_entropy_fw_interleaved_start_id.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1U;
 
     const uint32_t tile_bytes = get_tile_size(cb_output_idx);
-    constexpr auto output_args = TensorAccessorArgs<3>();
+    constexpr auto output_args = TensorAccessorArgs<2>();
     const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/writer_cross_entropy_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/writer_cross_entropy_fw_interleaved_start_id.cpp
@@ -18,10 +18,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1U;
 
     const uint32_t tile_bytes = get_tile_size(cb_output_idx);
-    const DataFormat data_format = get_dataformat(cb_output_idx);
-
-    const InterleavedAddrGenFast</* is dram */ true> output_addr_generator = {
-        .bank_base_address = output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto output_args = TensorAccessorArgs<3>();
+    const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;
 

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/kernels/dataflow/reader_profiler_no_op_interleaved_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/kernels/dataflow/reader_profiler_no_op_interleaved_id.cpp
@@ -24,7 +24,6 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
 
     const uint32_t tile_bytes = get_tile_size(cb_dataflow_idx);
-    const DataFormat data_format = get_dataformat(cb_dataflow_idx);
 
     for (uint32_t i = 0; i < num_rows_to_process; ++i) {
         for (uint32_t j = 0; j < Wt; j += block_size) {

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/kernels/dataflow/writer_profiler_no_op_interleaved_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/kernels/dataflow/writer_profiler_no_op_interleaved_id.cpp
@@ -22,10 +22,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1U;
 
     const uint32_t tile_bytes = get_tile_size(cb_dataflow_idx);
-    const DataFormat data_format = get_dataformat(cb_dataflow_idx);
-
-    const InterleavedAddrGenFast</* is dram */ true> output_addr_generator = {
-        .bank_base_address = output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto output_args = TensorAccessorArgs<2>();
+    const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;
 

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/dataflow/reader_rmsnorm_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/dataflow/reader_rmsnorm_fw_interleaved_start_id.cpp
@@ -69,13 +69,10 @@ void kernel_main() {
     generate_tile_with_value(cb_eps_idx, packed_eps);
 
     const uint32_t tile_bytes = get_tile_size(cb_input_idx);
-    const DataFormat data_format = get_dataformat(cb_input_idx);
-
-    const InterleavedAddrGenFast</* is_dram */ true> input_address_generator = {
-        .bank_base_address = input_address, .page_size = tile_bytes, .data_format = data_format};
-
-    const InterleavedAddrGenFast</* is_dram */ true> gamma_address_generator = {
-        .bank_base_address = gamma_address, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto input_args = TensorAccessorArgs<5>();
+    constexpr auto gamma_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    const auto input_address_generator = TensorAccessor(input_args, input_address, tile_bytes);
+    const auto gamma_address_generator = TensorAccessor(gamma_args, gamma_address, tile_bytes);
 
     const uint32_t max_block_size = 4;
 

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/dataflow/writer_rmsnorm_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/dataflow/writer_rmsnorm_fw_interleaved_start_id.cpp
@@ -20,14 +20,12 @@ void kernel_main() {
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_output_idx);
-    const DataFormat data_format = get_dataformat(cb_output_idx);
-
-    const InterleavedAddrGenFast</* is dram */ true> output_addr_generator = {
-        .bank_base_address = output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto output_args = TensorAccessorArgs<2>();
+    const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
 #ifdef RETURN_RMS
-    const InterleavedAddrGenFast</* is dram */ true> rms_output_addr_generator = {
-        .bank_base_address = rms_output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto rms_output_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
+    const auto rms_output_addr_generator = TensorAccessor(rms_output_args, rms_output_addr, tile_bytes);
 #endif
 
     uint32_t end_row = start_row + num_rows_to_process;

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/kernels/dataflow/writer_silu_bw_interleaved_start_id.cpp
@@ -22,9 +22,10 @@ constexpr uint32_t cb_times_sigmoid_idx = tt::CBIndex::c_6;
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
 
+template <typename AddrGen>
 inline void write_cb_block_to_dram(
     uint32_t cb_idx,
-    const InterleavedAddrGenFast</* is dram */ true>& addr_gen,
+    const AddrGen& addr_gen,
     uint32_t start_idx,
     uint32_t block_size,
     uint32_t current_block_size,
@@ -46,10 +47,8 @@ void kernel_main() {
     uint32_t start_row = get_arg_val<uint32_t>(runtime_args_counter++);
 
     const uint32_t tile_bytes = get_tile_size(cb_dL_da_idx);
-    const DataFormat data_format = get_dataformat(cb_dL_da_idx);
-
-    const InterleavedAddrGenFast</* is dram */ true> da_output_addr_generator = {
-        .bank_base_address = da_output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto da_args = TensorAccessorArgs<2>();
+    const auto da_output_addr_generator = TensorAccessor(da_args, da_output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;
     for (uint32_t r = start_row; r < end_row; ++r) {

--- a/tt-train/sources/ttml/metal/ops/softmax/device/kernels/dataflow/writer_softmax_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/kernels/dataflow/writer_softmax_interleaved_start_id.cpp
@@ -22,10 +22,8 @@ void kernel_main() {
     constexpr uint32_t onetile = 1U;
 
     const uint32_t tile_bytes = get_tile_size(cb_output_idx);
-    const DataFormat data_format = get_dataformat(cb_output_idx);
-
-    const InterleavedAddrGenFast</* is dram */ true> output_addr_generator = {
-        .bank_base_address = output_addr, .page_size = tile_bytes, .data_format = data_format};
+    constexpr auto output_args = TensorAccessorArgs<2>();
+    const auto output_addr_generator = TensorAccessor(output_args, output_addr, tile_bytes);
 
     uint32_t end_row = start_row + num_rows_to_process;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
Ported all kernels within tt-train to use TensorAccessor

This PR was generated by AI: Cursor + GPT 5 Max using this updated [prompt](https://gist.github.com/sminakov-tt/0ee29006457ccee6aa9bdb534663cc46).

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17222683074)
- [x] New/Existing tests provide coverage for changes