### PR TITLE
Remove redundant TT_METAL_HOME access in profiler_paths

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -437,7 +437,8 @@ void dump_eth_link_stats(
         return;  // link stats not populated for BH yet!
     }
 
-    std::filesystem::path output_dir = std::filesystem::path(tt::tt_metal::get_profiler_logs_dir());
+    std::filesystem::path output_dir =
+        std::filesystem::path(::tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_logs_dir());
     std::filesystem::path log_path = output_dir / "eth_link_stats.csv";
     std::ofstream log_file;
     if (write_header) {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -46,6 +46,11 @@ namespace tt {
 
 namespace tt_metal {
 
+static std::string PROFILER_ZONE_SRC_LOCATIONS_LOG =
+    MetalContext::instance().rtoptions().get_profiler_logs_dir() + PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
+static std::string NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG =
+    MetalContext::instance().rtoptions().get_profiler_logs_dir() + NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
+
 static kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
     return static_cast<kernel_profiler::PacketTypes>((timer_id >> 16) & 0x7);
 }
@@ -105,7 +110,7 @@ std::unordered_map<uint16_t, ZoneDetails> generateZoneSourceLocationsHashes() {
 
     // Load existing zones from previous runs
     populateZoneSrcLocations(
-        tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG, "", false, hash_to_zone_src_locations, zone_src_locations);
+        PROFILER_ZONE_SRC_LOCATIONS_LOG, "", false, hash_to_zone_src_locations, zone_src_locations);
 
     // Load new zones from the current run
     populateZoneSrcLocations(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1503,7 +1503,7 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs) {
     this->device_arch = device->arch();
     this->device_core_frequency =
         tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(this->device_id);
-    this->output_dir = std::filesystem::path(get_profiler_logs_dir());
+    this->output_dir = std::filesystem::path(MetalContext::instance().rtoptions().get_profiler_logs_dir());
     std::filesystem::create_directories(this->output_dir);
     std::filesystem::path log_path = this->output_dir / DEVICE_SIDE_LOG;
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -46,11 +46,6 @@ namespace tt {
 
 namespace tt_metal {
 
-static std::string PROFILER_ZONE_SRC_LOCATIONS_LOG =
-    MetalContext::instance().rtoptions().get_profiler_logs_dir() + PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
-static std::string NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG =
-    MetalContext::instance().rtoptions().get_profiler_logs_dir() + NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
-
 static kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
     return static_cast<kernel_profiler::PacketTypes>((timer_id >> 16) & 0x7);
 }
@@ -108,14 +103,19 @@ std::unordered_map<uint16_t, ZoneDetails> generateZoneSourceLocationsHashes() {
     std::unordered_map<uint16_t, ZoneDetails> hash_to_zone_src_locations;
     std::unordered_set<std::string> zone_src_locations;
 
+    static const std::string PROFILER_ZONE_SRC_LOCATIONS_LOG =
+        MetalContext::instance().rtoptions().get_profiler_logs_dir() + PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
+    static const std::string NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG =
+        MetalContext::instance().rtoptions().get_profiler_logs_dir() + NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
+
     // Load existing zones from previous runs
     populateZoneSrcLocations(
         PROFILER_ZONE_SRC_LOCATIONS_LOG, "", false, hash_to_zone_src_locations, zone_src_locations);
 
     // Load new zones from the current run
     populateZoneSrcLocations(
-        tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG,
-        tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG,
+        NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG,
+        PROFILER_ZONE_SRC_LOCATIONS_LOG,
         true,
         hash_to_zone_src_locations,
         zone_src_locations);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -24,7 +24,6 @@
 #include "hostdevcommon/profiler_common.h"
 #include "profiler_optional_metadata.hpp"
 #include "profiler_types.hpp"
-#include "profiler_paths.hpp"
 #include "tt-metalium/program.hpp"
 #include "tracy/TracyTTDevice.hpp"
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -27,7 +27,6 @@
 #include "tt-metalium/program.hpp"
 #include "tracy/TracyTTDevice.hpp"
 
-#define HOST_SIDE_LOG "profile_log_host.csv"
 #define DEVICE_SIDE_LOG "profile_log_device.csv"
 
 namespace tt {

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -24,8 +24,12 @@
 #include "hostdevcommon/profiler_common.h"
 #include "profiler_optional_metadata.hpp"
 #include "profiler_types.hpp"
+#include "profiler_paths.hpp"
 #include "tt-metalium/program.hpp"
 #include "tracy/TracyTTDevice.hpp"
+
+#define HOST_SIDE_LOG "profile_log_host.csv"
+#define DEVICE_SIDE_LOG "profile_log_device.csv"
 
 namespace tt {
 enum class ARCH;

--- a/tt_metal/impl/profiler/profiler_paths.hpp
+++ b/tt_metal/impl/profiler/profiler_paths.hpp
@@ -4,36 +4,13 @@
 
 #pragma once
 
-#define HOST_SIDE_LOG "profile_log_host.csv"
-#define DEVICE_SIDE_LOG "profile_log_device.csv"
-
 namespace tt {
 
 namespace tt_metal {
 
-constexpr std::string_view PROFILER_RUNTIME_ROOT_DIR = "generated/profiler/";
-constexpr std::string_view PROFILER_LOGS_DIR_NAME = ".logs/";
+constexpr auto PROFILER_ZONE_SRC_LOCATIONS_LOG_FN = "zone_src_locations.log";
+constexpr auto NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG_FN = "new_zone_src_locations.log";
 
-inline std::string get_profiler_artifacts_dir() {
-    std::string artifacts_dir;
-    if (std::getenv("TT_METAL_PROFILER_DIR")) {
-        artifacts_dir = std::string(std::getenv("TT_METAL_PROFILER_DIR")) + "/";
-    } else {
-        std::string prefix;
-        if (std::getenv("TT_METAL_HOME")) {
-            prefix = std::string(std::getenv("TT_METAL_HOME")) + "/";
-        }
-        artifacts_dir = prefix + std::string(PROFILER_RUNTIME_ROOT_DIR);
-    }
-    return artifacts_dir;
-}
-
-inline std::string get_profiler_logs_dir() {
-    return get_profiler_artifacts_dir() + std::string(PROFILER_LOGS_DIR_NAME);
-}
-
-inline std::string PROFILER_ZONE_SRC_LOCATIONS_LOG = get_profiler_logs_dir() + "zone_src_locations.log";
-inline std::string NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG = get_profiler_logs_dir() + "new_zone_src_locations.log";
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -128,7 +128,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     tt_metal::detail::LaunchProgram(
         device, sync_program, false /* wait_until_cores_done */, /* force_slow_dispatch */ true);
 
-    std::filesystem::path output_dir = std::filesystem::path(get_profiler_logs_dir());
+    std::filesystem::path output_dir =
+        std::filesystem::path(::tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_logs_dir());
     std::filesystem::path log_path = output_dir / "sync_device_info.csv";
     std::ofstream log_file;
 
@@ -289,7 +290,8 @@ void setShift(int device_id, int64_t shift, double scale, const SyncInfo& root_s
         device_profiler_it->second.shift = shift;
         device_profiler_it->second.setSyncInfo(root_sync_info);
 
-        std::filesystem::path output_dir = std::filesystem::path(get_profiler_logs_dir());
+        std::filesystem::path output_dir =
+            std::filesystem::path(::tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_logs_dir());
         std::filesystem::path log_path = output_dir / "sync_device_info.csv";
         std::ofstream log_file;
         log_file.open(log_path, std::ios_base::app);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -489,18 +489,20 @@ void JitBuildState::extract_zone_src_locations(const string& log_file) const {
     // ZoneScoped;
     static std::atomic<bool> new_log = true;
     if (tt::tt_metal::getDeviceProfilerState()) {
-        if (new_log.exchange(false) && std::filesystem::exists(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
-            std::remove(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG.c_str());
+        const std::string new_profiler_zone_src_locations_log_path =
+            MetalContext::instance().rtoptions().get_profiler_logs_dir() + NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG_FN;
+        if (new_log.exchange(false) && std::filesystem::exists(new_profiler_zone_src_locations_log_path)) {
+            std::remove(new_profiler_zone_src_locations_log_path.c_str());
         }
 
-        if (!std::filesystem::exists(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
-            tt::utils::create_file(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG);
+        if (!std::filesystem::exists(new_profiler_zone_src_locations_log_path)) {
+            tt::utils::create_file(new_profiler_zone_src_locations_log_path);
         }
 
         // Only interested in log entries with KERNEL_PROFILER inside them as device code
         // tags source location info with it using pragma messages
         string cmd = "cat " + log_file + " | grep KERNEL_PROFILER";
-        tt::utils::run_command(cmd, tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, false);
+        tt::utils::run_command(cmd, new_profiler_zone_src_locations_log_path, false);
     }
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
+#include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -271,7 +272,9 @@ const std::string& RunTimeOptions::get_root_dir() const {
 }
 
 const std::string& RunTimeOptions::get_profiler_logs_dir() const {
-    TT_FATAL(is_profiler_logs_dir_specified(), "Cannot determine PROFILER logs directory.");
+    if (!is_profiler_logs_dir_specified()) {
+        log_warning(tt::LogType::LogAlways, "Cannot determine PROFILER logs directory.");
+    }
 
     return profiler_logs_dir_;
 }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -11,7 +11,6 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
-#include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -273,7 +272,7 @@ const std::string& RunTimeOptions::get_root_dir() const {
 
 const std::string& RunTimeOptions::get_profiler_logs_dir() const {
     if (!is_profiler_logs_dir_specified()) {
-        log_warning(tt::LogType::LogAlways, "Cannot determine PROFILER logs directory.");
+        TT_THROW("Cannot determine PROFILER logs directory.");
     }
 
     return profiler_logs_dir_;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -254,8 +254,10 @@ RunTimeOptions::RunTimeOptions() {
         auto* env = std::getenv("TT_METAL_PROFILER_DIR");
         if (env) {
             profiler_logs_dir_ = std::string(env) + "/";
-        } else {
-            profiler_logs_dir_ = get_root_dir() + "/generated/profiler/.logs/";
+            is_profiler_logs_dir_specified_ = true;
+        } else if (is_root_dir_specified()) {
+            profiler_logs_dir_ = root_dir + "/generated/profiler/.logs/";
+            is_profiler_logs_dir_specified_ = true;
         }
     }
 }
@@ -266,6 +268,12 @@ const std::string& RunTimeOptions::get_root_dir() const {
     }
 
     return root_dir;
+}
+
+const std::string& RunTimeOptions::get_profiler_logs_dir() const {
+    TT_FATAL(is_profiler_logs_dir_specified(), "Cannot determine PROFILER logs directory.");
+
+    return profiler_logs_dir_;
 }
 
 const std::string& RunTimeOptions::get_cache_dir() const {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -249,6 +249,15 @@ RunTimeOptions::RunTimeOptions() {
     if (getenv("TT_METAL_LOG_KERNELS_COMPILE_COMMANDS")) {
         this->log_kernels_compilation_commands = true;
     }
+
+    {
+        auto* env = std::getenv("TT_METAL_PROFILER_DIR");
+        if (env) {
+            profiler_logs_dir_ = std::string(env) + "/";
+        } else {
+            profiler_logs_dir_ = get_root_dir() + "/generated/profiler/.logs/";
+        }
+    }
 }
 
 const std::string& RunTimeOptions::get_root_dir() const {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -132,6 +132,7 @@ class RunTimeOptions {
     bool profiler_buffer_usage_enabled = false;
     bool profiler_noc_events_enabled = false;
     std::string profiler_noc_events_report_path;
+    std::string profiler_logs_dir_ = "";
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -386,6 +387,7 @@ public:
     bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
     bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
+    const std::string& get_profiler_logs_dir() const { return profiler_logs_dir_; }
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -132,8 +132,6 @@ class RunTimeOptions {
     bool profiler_buffer_usage_enabled = false;
     bool profiler_noc_events_enabled = false;
     std::string profiler_noc_events_report_path;
-    std::string profiler_logs_dir_ = "";
-    bool is_profiler_logs_dir_specified_ = false;
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -211,7 +209,7 @@ public:
     RunTimeOptions& operator=(const RunTimeOptions&) = delete;
 
     bool is_root_dir_specified() const { return this->is_root_dir_env_var_set; }
-    bool is_profiler_logs_dir_specified() const { return this->is_profiler_logs_dir_specified_; }
+    bool is_profiler_logs_dir_specified() const;
     const std::string& get_root_dir() const;
 
     bool is_cache_dir_specified() const { return this->is_cache_dir_env_var_set; }
@@ -389,7 +387,7 @@ public:
     bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
     bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
-    const std::string& get_profiler_logs_dir() const;
+    std::string get_profiler_logs_dir() const;
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -133,6 +133,7 @@ class RunTimeOptions {
     bool profiler_noc_events_enabled = false;
     std::string profiler_noc_events_report_path;
     std::string profiler_logs_dir_ = "";
+    bool is_profiler_logs_dir_specified_ = false;
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -210,6 +211,7 @@ public:
     RunTimeOptions& operator=(const RunTimeOptions&) = delete;
 
     bool is_root_dir_specified() const { return this->is_root_dir_env_var_set; }
+    bool is_profiler_logs_dir_specified() const { return this->is_profiler_logs_dir_specified_; }
     const std::string& get_root_dir() const;
 
     bool is_cache_dir_specified() const { return this->is_cache_dir_env_var_set; }
@@ -387,7 +389,7 @@ public:
     bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
     bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
-    const std::string& get_profiler_logs_dir() const { return profiler_logs_dir_; }
+    const std::string& get_profiler_logs_dir() const;
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }


### PR DESCRIPTION
### Ticket
#13726 

### Problem description
To remove TT_METAL_HOME we must first centralize access to it.

### What's changed
Make profiler depend on rtoptions to get its required log path.

This required moving get_profiler_logs_dir from being a free function, to being a class method of rtoptions.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17251770583) CI passes
- [x] New/Existing tests provide coverage for changes