### PR TITLE
Add support for real weights in model test

### DIFF
--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -13,6 +13,7 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Model
 from models.demos.deepseek_v3.tt.mla_1d import MLA1D
 from models.demos.deepseek_v3.tt.model_1d import Model1D
 from models.demos.deepseek_v3.tt.rope import RotarySetup
+from models.demos.deepseek_v3.utils.config_helpers import dequantize_state_dict
 from models.demos.deepseek_v3.utils.reference_forwards import reference_forward_model as reference_forward
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
@@ -21,6 +22,14 @@ from models.demos.deepseek_v3.utils.test_utils import (
     load_state_dict,
 )
 from models.utility_functions import comp_pcc
+
+
+def merge_dicts(parent, child, prefix):
+    for k, v in child.items():
+        if isinstance(v, dict):
+            merge_dicts(parent.setdefault(k, {}), v, prefix + f"{k}.")
+        else:
+            parent[prefix + f"{k}"] = v
 
 
 @pytest.fixture
@@ -60,17 +69,12 @@ def load_reference_model(hf_config):
         # ("prefill", 2048),  # Test chunking # TODO: Uncomment once MLA prefill works
     ],
 )
+@pytest.mark.parametrize(
+    "weights_type",
+    ["random", "real"],
+)
 def test_forward_pass(
-    module_path,
-    mode,
-    seq_len,
-    batch_size,
-    hf_config,
-    tmp_path,
-    mesh_device,
-    model_path,
-    ccl,
-    reset_seeds,
+    module_path, mode, seq_len, batch_size, hf_config, tmp_path, mesh_device, model_path, ccl, reset_seeds, weights_type
 ):
     mesh_device.disable_and_clear_program_cache()
     mesh_shape = list(mesh_device.shape)
@@ -82,14 +86,24 @@ def test_forward_pass(
     ### Set up reference
     ############################
     logger.info("Setting up reference model")
-    if module_path is None:
-        reference_model = load_reference_model(hf_config)
+    reference_model = load_reference_model(hf_config)
+    if weights_type == "random":
         state_dict = add_inv_scale_to_state_dict(
             reference_model.to(torch.bfloat16).state_dict(),
             block_shape=hf_config.quantization_config["weight_block_size"],
         )
     else:
-        state_dict = load_state_dict(model_path, module_path)
+        state_dict = {}
+        state_dict_temp = load_state_dict(model_path, "model.embed_tokens")
+        merge_dicts(state_dict, state_dict_temp, "embed_tokens.")
+        for li in range(hf_config.num_hidden_layers):
+            state_dict_temp = load_state_dict(model_path, f"model.layers.{li}")
+            merge_dicts(state_dict, state_dict_temp, f"layers.{li}.")
+        state_dict_temp = load_state_dict(model_path, "model.norm")
+        merge_dicts(state_dict, state_dict_temp, "norm.")
+
+        dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
+        reference_model.load_state_dict(dequantized_state_dict)
 
     ############################
     ### Torch inputs


### PR DESCRIPTION
### Ticket
None

### What's changed
Create state_dict from real weights for all the layers passed in as config, and load real weights

Test passing with PCC=0.99 for real and random weights

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes