### PR TITLE
Update YoloV4/YoloV7/YoloV8x performance tests to use TT-CNN

### DIFF
--- a/models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py
@@ -71,11 +71,10 @@ def run_mobilenetv2_e2e(
     )
 
     iterations = 32
-    pipe.compile(host_input_tensor)
     host_inputs = [host_input_tensor] * iterations
 
     pipe.preallocate_output_tensors_on_host(
-        iterations, [batch_size_per_device, torch_output_tensor.shape[-1]], ttnn.bfloat16, ttnn.TILE_LAYOUT
+        len(host_inputs),
     )
 
     start = time.time()

--- a/models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py
@@ -73,9 +73,8 @@ def run_mobilenetv2_e2e(
     iterations = 32
     host_inputs = [host_input_tensor] * iterations
 
-    pipe.preallocate_output_tensors_on_host(
-        len(host_inputs),
-    )
+    pipe.compile(host_input_tensor)
+    pipe.preallocate_output_tensors_on_host(len(host_inputs))
 
     start = time.time()
     outputs = pipe.enqueue(host_inputs).pop_all()

--- a/models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py
@@ -54,6 +54,7 @@ def _run_model_pipeline(
         l1_input_memory_config=input_mem_config,
     )
 
+    logger.info(f"Running model warmup with input shape {list(tt_inputs_host.shape)}")
     profiler.start("compile")
     pipeline.compile(tt_inputs_host)
     profiler.end("compile")
@@ -68,6 +69,9 @@ def _run_model_pipeline(
         ttnn.ROW_MAJOR_LAYOUT,
     )
 
+    logger.info(
+        f"Starting performance pipline for {num_measurement_iterations} iterations with batch_size={test_infra.batch_size} and num_devices={test_infra.num_devices}"
+    )
     if use_signpost:
         signpost(header="start")
     profiler.start(f"run")

--- a/models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py
@@ -61,6 +61,13 @@ def _run_model_pipeline(
 
     host_inputs = [tt_inputs_host] * num_measurement_iterations
 
+    pipeline.preallocate_output_tensors_on_host(
+        num_measurement_iterations,
+        [test_infra.batch_size * test_infra.num_devices, 1, 1, 1000],
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+    )
+
     if use_signpost:
         signpost(header="start")
     profiler.start(f"run")

--- a/models/demos/yolov4/demo.py
+++ b/models/demos/yolov4/demo.py
@@ -16,6 +16,7 @@ from models.demos.utils.common_demo_utils import LoadImages, get_mesh_mappers, l
 from models.demos.yolov4.common import YOLOV4_L1_SMALL_SIZE, get_model_result
 from models.demos.yolov4.post_processing import plot_boxes_cv2, post_processing
 from models.demos.yolov4.runner.performant_runner_infra import YOLOv4PerformanceRunnerInfra
+from models.demos.yolov4.runner.pipeline_runner import YoloV4PipelineRunner
 from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
 from models.utility_functions import disable_persistent_kernel_cache, run_for_wormhole_b0
 
@@ -60,19 +61,11 @@ def run_yolov4(
         device, mesh_mapper=inputs_mesh_mapper, mesh_composer=output_mesh_composer
     )
 
-    # Create a model wrapper that handles the input tensor properly
-    def model_wrapper(l1_input_tensor):
-        # Set up the input tensor for the model
-        test_infra.input_tensor = l1_input_tensor
-        test_infra.run()
-        # Return the output tensor tuple (boxes, confs)
-        return test_infra.output_tensor
-
     # Create pipeline configuration
     config = PipelineConfig(use_trace=True, num_command_queues=2, all_transfers_on_separate_command_queue=False)
     pipeline = create_pipeline_from_config(
         config,
-        model_wrapper,
+        YoloV4PipelineRunner(test_infra),
         device,
         dram_input_memory_config=sharded_mem_config_DRAM,
         l1_input_memory_config=input_mem_config,
@@ -163,19 +156,11 @@ def run_yolov4_coco(
         device, mesh_mapper=inputs_mesh_mapper, mesh_composer=output_mesh_composer
     )
 
-    # Create a model wrapper that handles the input tensor properly
-    def model_wrapper(l1_input_tensor):
-        # Set up the input tensor for the model
-        test_infra.input_tensor = l1_input_tensor
-        test_infra.run()
-        # Return the output tensor tuple (boxes, confs)
-        return test_infra.output_tensor
-
     # Create pipeline configuration
     config = PipelineConfig(use_trace=True, num_command_queues=2, all_transfers_on_separate_command_queue=False)
     pipeline = create_pipeline_from_config(
         config,
-        model_wrapper,
+        YoloV4PipelineRunner(test_infra),
         device,
         dram_input_memory_config=sharded_mem_config_DRAM,
         l1_input_memory_config=input_mem_config,

--- a/models/demos/yolov4/demo.py
+++ b/models/demos/yolov4/demo.py
@@ -13,9 +13,10 @@ from loguru import logger
 
 import ttnn
 from models.demos.utils.common_demo_utils import LoadImages, get_mesh_mappers, load_coco_class_names
-from models.demos.yolov4.common import YOLOV4_L1_SMALL_SIZE
+from models.demos.yolov4.common import YOLOV4_L1_SMALL_SIZE, get_model_result
 from models.demos.yolov4.post_processing import plot_boxes_cv2, post_processing
-from models.demos.yolov4.runner.performant_runner import YOLOv4PerformantRunner
+from models.demos.yolov4.runner.performant_runner_infra import YOLOv4PerformanceRunnerInfra
+from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
 from models.utility_functions import disable_persistent_kernel_cache, run_for_wormhole_b0
 
 
@@ -41,17 +42,46 @@ def run_yolov4(
     logger.info(f"Running with batch_size={batch_size} across {device.get_num_devices()} devices")
 
     inputs_mesh_mapper, _, output_mesh_composer = get_mesh_mappers(device)
-    runner = YOLOv4PerformantRunner(
+
+    # Create the performance runner infrastructure
+    test_infra = YOLOv4PerformanceRunnerInfra(
         device,
         batch_size_per_device,
         act_dtype,
         weight_dtype,
-        resolution=resolution,
         model_location_generator=model_location_generator,
+        resolution=resolution,
         mesh_mapper=inputs_mesh_mapper,
         mesh_composer=output_mesh_composer,
     )
 
+    # Get memory configs from the infrastructure
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(
+        device, mesh_mapper=inputs_mesh_mapper, mesh_composer=output_mesh_composer
+    )
+
+    # Create a model wrapper that handles the input tensor properly
+    def model_wrapper(l1_input_tensor):
+        # Set up the input tensor for the model
+        test_infra.input_tensor = l1_input_tensor
+        test_infra.run()
+        # Return the output tensor tuple (boxes, confs)
+        return test_infra.output_tensor
+
+    # Create pipeline configuration
+    config = PipelineConfig(use_trace=True, num_command_queues=2, all_transfers_on_separate_command_queue=False)
+    pipeline = create_pipeline_from_config(
+        config,
+        model_wrapper,
+        device,
+        dram_input_memory_config=sharded_mem_config_DRAM,
+        l1_input_memory_config=input_mem_config,
+    )
+
+    # Compile pipeline
+    pipeline.compile(tt_inputs_host)
+
+    # Load and preprocess images
     image_files = [
         os.path.join(input_loc, f) for f in os.listdir(input_loc) if f.lower().endswith((".png", ".jpg", ".jpeg"))
     ]
@@ -73,11 +103,20 @@ def run_yolov4(
         torch_images.append(tensor.unsqueeze(0))
 
     torch_input_tensor = torch.cat(torch_images, dim=0)
-    tt_output = runner.run(torch_input_tensor)
+
+    # Convert input to TTNN format using the infrastructure's method
+    tt_inputs_host, _ = test_infra._setup_l1_sharded_input(device, torch_input_tensor)
+
+    # Run inference
+    outputs = pipeline.enqueue([tt_inputs_host]).pop_all()
+    tt_output = outputs[0]
+
+    # Convert TTNN output to PyTorch tensors using get_model_result
+    result_boxes, result_confs = get_model_result(tt_output, resolution, mesh_composer=output_mesh_composer)
 
     conf_thresh = 0.3
     nms_thresh = 0.4
-    boxes = post_processing(torch_images, conf_thresh, nms_thresh, tt_output)
+    boxes = post_processing(torch_images, conf_thresh, nms_thresh, [result_boxes, result_confs])
 
     class_names = load_coco_class_names()
     output_dir = "yolov4_predictions"
@@ -89,7 +128,7 @@ def run_yolov4(
         output_path = os.path.join(output_dir, output_filename)
         plot_boxes_cv2(orig_images[i], boxes[i], output_path, class_names)
 
-    runner.release()
+    pipeline.cleanup()
 
 
 def run_yolov4_coco(
@@ -106,16 +145,44 @@ def run_yolov4_coco(
     logger.info(f"Running with batch_size={batch_size} across {device.get_num_devices()} devices")
 
     inputs_mesh_mapper, _, output_mesh_composer = get_mesh_mappers(device)
-    runner = YOLOv4PerformantRunner(
+
+    # Create the performance runner infrastructure
+    test_infra = YOLOv4PerformanceRunnerInfra(
         device,
         batch_size_per_device,
         act_dtype,
         weight_dtype,
-        resolution=resolution,
         model_location_generator=model_location_generator,
+        resolution=resolution,
         mesh_mapper=inputs_mesh_mapper,
         mesh_composer=output_mesh_composer,
     )
+
+    # Get memory configs from the infrastructure
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(
+        device, mesh_mapper=inputs_mesh_mapper, mesh_composer=output_mesh_composer
+    )
+
+    # Create a model wrapper that handles the input tensor properly
+    def model_wrapper(l1_input_tensor):
+        # Set up the input tensor for the model
+        test_infra.input_tensor = l1_input_tensor
+        test_infra.run()
+        # Return the output tensor tuple (boxes, confs)
+        return test_infra.output_tensor
+
+    # Create pipeline configuration
+    config = PipelineConfig(use_trace=True, num_command_queues=2, all_transfers_on_separate_command_queue=False)
+    pipeline = create_pipeline_from_config(
+        config,
+        model_wrapper,
+        device,
+        dram_input_memory_config=sharded_mem_config_DRAM,
+        l1_input_memory_config=input_mem_config,
+    )
+
+    # Compile pipeline
+    pipeline.compile(tt_inputs_host)
 
     dataset = fiftyone.zoo.load_zoo_dataset("coco-2017", split="validation", max_samples=batch_size)
     data_set = LoadImages([sample["filepath"] for sample in dataset])
@@ -138,14 +205,22 @@ def run_yolov4_coco(
             break
 
     torch_input_tensor = torch.cat(torch_images, dim=0)
-    tt_output = runner.run(torch_input_tensor)
+
+    # Convert input to TTNN format using the infrastructure's method
+    tt_inputs_host, _ = test_infra._setup_l1_sharded_input(device, torch_input_tensor)
+
+    # Run inference
+    outputs = pipeline.enqueue([tt_inputs_host]).pop_all()
+    tt_output = outputs[0]
+
+    # Convert TTNN output to PyTorch tensors using get_model_result
+    result_boxes, result_confs = get_model_result(tt_output, resolution, mesh_composer=output_mesh_composer)
 
     conf_thresh = 0.3
     nms_thresh = 0.4
-    boxes = post_processing(torch_images, conf_thresh, nms_thresh, tt_output)
+    boxes = post_processing(torch_images, conf_thresh, nms_thresh, [result_boxes, result_confs])
 
-    namesfile = "models/demos/yolov4/resources/coco.names"
-    class_names = load_coco_class_names(namesfile)
+    class_names = load_coco_class_names()
     output_dir = "yolov4_predictions"
     os.makedirs(output_dir, exist_ok=True)
     for i in range(batch_size):
@@ -154,7 +229,7 @@ def run_yolov4_coco(
         output_path = os.path.join(output_dir, output_filename)
         plot_boxes_cv2(orig_images[i], boxes[i], output_path, class_names)
 
-    runner.release()
+    pipeline.cleanup()
 
 
 @run_for_wormhole_b0()

--- a/models/demos/yolov4/runner/pipeline_runner.py
+++ b/models/demos/yolov4/runner/pipeline_runner.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+class YoloV4PipelineRunner:
+    def __init__(self, test_infra):
+        self._test_infra = test_infra
+
+    def __call__(self, l1_input_tensor):
+        self._test_infra.input_tensor = l1_input_tensor
+        self._test_infra.run()
+        return self._test_infra.output_tensor

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -105,15 +105,14 @@ def run_perf_e2e_yolov4(
         device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations
     )
 
-    first_iter_time = profiler.get("compile")
+    compile_time = profiler.get("compile")
     inference_time_avg = profiler.get(f"run_model_pipeline_2cqs") / num_measurement_iterations
-    compile_time = first_iter_time - 2 * inference_time_avg
     expected_inference_time = batch_size / expected_inference_throughput
 
     prep_perf_report(
         model_name=f"ttnn_yolov4_trace_2cqs_batch_size{batch_size}",
         batch_size=batch_size,
-        inference_and_compile_time=first_iter_time,
+        inference_and_compile_time=compile_time,
         inference_time=inference_time_avg,
         expected_compile_time=1,
         expected_inference_time=expected_inference_time,

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -11,6 +11,7 @@ import ttnn
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.yolov4.common import YOLOV4_L1_SMALL_SIZE
 from models.demos.yolov4.runner.performant_runner_infra import YOLOv4PerformanceRunnerInfra
+from models.demos.yolov4.runner.pipeline_runner import YoloV4PipelineRunner
 from models.perf.perf_utils import prep_perf_report
 from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
 from models.utility_functions import profiler, run_for_wormhole_b0
@@ -21,16 +22,11 @@ def _run_model_pipeline(
 ):
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
 
-    def model_wrapper(l1_input_tensor):
-        test_infra.input_tensor = l1_input_tensor
-        test_infra.run()
-        return test_infra.output_tensor
-
     pipeline = create_pipeline_from_config(
         config=PipelineConfig(
             use_trace=trace, num_command_queues=num_command_queues, all_transfers_on_separate_command_queue=False
         ),
-        model=model_wrapper,
+        model=YoloV4PipelineRunner(test_infra),
         device=device,
         dram_input_memory_config=sharded_mem_config_DRAM,
         l1_input_memory_config=input_mem_config,

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import time
 
 import pytest
 import torch
@@ -11,9 +10,103 @@ from loguru import logger
 import ttnn
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.yolov4.common import YOLOV4_L1_SMALL_SIZE
-from models.demos.yolov4.runner.performant_runner import YOLOv4PerformantRunner
+from models.demos.yolov4.runner.performant_runner_infra import YOLOv4PerformanceRunnerInfra
 from models.perf.perf_utils import prep_perf_report
-from models.utility_functions import run_for_wormhole_b0
+from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
+from models.utility_functions import profiler, run_for_wormhole_b0
+
+
+def _run_model_pipeline(
+    device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations, num_command_queues, trace
+):
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
+
+    def model_wrapper(l1_input_tensor):
+        test_infra.input_tensor = l1_input_tensor
+        test_infra.run()
+        return test_infra.output_tensor
+
+    pipeline = create_pipeline_from_config(
+        config=PipelineConfig(
+            use_trace=trace, num_command_queues=num_command_queues, all_transfers_on_separate_command_queue=False
+        ),
+        model=model_wrapper,
+        device=device,
+        dram_input_memory_config=sharded_mem_config_DRAM,
+        l1_input_memory_config=input_mem_config,
+    )
+
+    logger.info(f"Running model warmup with input shape {list(tt_inputs_host.shape)}")
+    profiler.start("compile")
+    pipeline.compile(tt_inputs_host)
+    profiler.end("compile")
+
+    host_inputs = [tt_inputs_host] * num_measurement_iterations
+
+    pipeline.preallocate_output_tensors_on_host(
+        num_measurement_iterations,
+    )
+
+    logger.info(
+        f"Starting performance pipeline for {num_measurement_iterations} iterations with batch_size={test_infra.batch_size} and num_devices={test_infra.num_devices}"
+    )
+    profiler.start(f"run_model_pipeline_{num_command_queues}cqs")
+    outputs = pipeline.enqueue(host_inputs).pop_all()
+    profiler.end(f"run_model_pipeline_{num_command_queues}cqs")
+
+    for i, output in enumerate(outputs):
+        test_infra.validate(output)
+        logger.info(f"Output {i} validation passed")
+
+    pipeline.cleanup()
+
+
+def run_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=1,
+        trace=False,
+    )
+
+
+def run_trace_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=1,
+        trace=True,
+    )
+
+
+def run_2cq_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=2,
+        trace=False,
+    )
+
+
+def run_trace_2cq_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=2,
+        trace=True,
+    )
 
 
 def run_perf_e2e_yolov4(
@@ -24,16 +117,19 @@ def run_perf_e2e_yolov4(
     model_location_generator,
     resolution,
     expected_inference_throughput,
+    model_version="yolov4_trace_2cqs",
 ):
+    profiler.clear()
+
     inputs_mesh_mapper, _, output_mesh_composer = get_mesh_mappers(device)
 
-    performant_runner = YOLOv4PerformantRunner(
+    test_infra = YOLOv4PerformanceRunnerInfra(
         device,
         batch_size_per_device,
         act_dtype,
         weight_dtype,
-        resolution=resolution,
         model_location_generator=model_location_generator,
+        resolution=resolution,
         mesh_mapper=inputs_mesh_mapper,
         mesh_composer=output_mesh_composer,
     )
@@ -46,30 +142,48 @@ def run_perf_e2e_yolov4(
 
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper)
 
-    inference_times = []
-    for _ in range(10):
-        t0 = time.time()
-        _ = performant_runner.run(torch_input_tensor)
-        t1 = time.time()
-        inference_times.append(t1 - t0)
+    num_warmup_iterations = 5
+    num_measurement_iterations = 15
 
-    performant_runner.release()
-    inference_time_avg = sum(inference_times) / len(inference_times)
-    logger.info(
-        f"Model: ttnn_yolov4 - batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {(batch_size * num_devices)/inference_time_avg}"
-    )
+    if "yolov4_trace_2cqs" in model_version:
+        run_trace_2cq_model_pipeline(
+            device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations
+        )
+    elif "yolov4_trace" in model_version:
+        run_trace_model_pipeline(
+            device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations
+        )
+    elif "yolov4_2cqs" in model_version:
+        run_2cq_model_pipeline(device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations)
+    elif "yolov4" in model_version:
+        run_model_pipeline(device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations)
+    else:
+        assert False, f"Model version to run {model_version} not found"
 
+    first_iter_time = profiler.get("compile")
+
+    # ensuring inference time fluctuations is not noise
+    num_cqs = 2 if "2cqs" in model_version else 1
+    inference_time_avg = profiler.get(f"run_model_pipeline_{num_cqs}cqs") / num_measurement_iterations
+
+    compile_time = first_iter_time - 2 * inference_time_avg
     expected_inference_time = batch_size / expected_inference_throughput
+
     prep_perf_report(
-        model_name="yolov4",
+        model_name=f"ttnn_{model_version}_batch_size{batch_size}",
         batch_size=batch_size,
-        inference_and_compile_time=inference_time_avg,
+        inference_and_compile_time=first_iter_time,
         inference_time=inference_time_avg,
         expected_compile_time=1,
         expected_inference_time=expected_inference_time,
-        comments="",
+        comments=f"{resolution[0]}x{resolution[1]}_batchsize{batch_size}",
         inference_time_cpu=0.0,
     )
+
+    logger.info(
+        f"YoloV4 {resolution[0]}x{resolution[1]} batch_size{batch_size} inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
+    )
+    logger.info(f"YoloV4 compile time: {compile_time}")
 
 
 @run_for_wormhole_b0()
@@ -104,6 +218,7 @@ def test_e2e_performant(
         model_location_generator,
         resolution,
         expected_inference_throughput,
+        model_version="yolov4_trace_2cqs",
     )
 
 
@@ -139,4 +254,5 @@ def test_e2e_performant_dp(
         model_location_generator,
         resolution,
         expected_inference_throughput,
+        model_version="yolov4_trace_2cqs",
     )

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -38,16 +38,13 @@ def _run_model_pipeline(
     profiler.end("compile")
 
     host_inputs = [tt_inputs_host] * num_measurement_iterations
-
-    pipeline.preallocate_output_tensors_on_host(
-        num_measurement_iterations,
-    )
-
     logger.info(
         f"Starting performance pipeline for {num_measurement_iterations} iterations with batch_size={test_infra.batch_size} and num_devices={test_infra.num_devices}"
     )
+    outputs = []
     profiler.start(f"run_model_pipeline_{num_command_queues}cqs")
-    outputs = pipeline.enqueue(host_inputs).pop_all()
+    for host_input in host_inputs:
+        outputs.append(*pipeline.enqueue([host_input]).pop_all())
     profiler.end(f"run_model_pipeline_{num_command_queues}cqs")
 
     for i, output in enumerate(outputs):
@@ -148,7 +145,7 @@ def run_perf_e2e_yolov4(
 )
 @pytest.mark.parametrize(
     "resolution, expected_inference_throughput",
-    [((320, 320), 103), ((640, 640), 46)],
+    [((320, 320), 130), ((640, 640), 65)],
 )
 def test_e2e_performant(
     device,
@@ -183,7 +180,7 @@ def test_e2e_performant(
 )
 @pytest.mark.parametrize(
     "resolution, expected_inference_throughput",
-    [((320, 320), 103), ((640, 640), 46)],
+    [((320, 320), 235), ((640, 640), 120)],
 )
 def test_e2e_performant_dp(
     mesh_device,

--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -2,79 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-
 import pytest
-import torch
-from loguru import logger
 
-import ttnn
-from models.demos.yolov4.common import YOLOV4_L1_SMALL_SIZE
-from models.demos.yolov4.runner.performant_runner import YOLOv4PerformantRunner
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
-from models.perf.perf_utils import prep_perf_report
-from models.utility_functions import run_for_wormhole_b0
-
-
-@run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize(
-    "device_params",
-    [{"l1_small_size": YOLOV4_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype",
-    ((1, ttnn.bfloat16, ttnn.bfloat16),),
-)
-@pytest.mark.parametrize(
-    "resolution, expected_inference_throughput",
-    [
-        ((320, 320), 103),
-        ((640, 640), 47),
-    ],
-)
-def test_perf_e2e_yolov4(device, batch_size, act_dtype, weight_dtype, resolution, expected_inference_throughput):
-    performant_runner = YOLOv4PerformantRunner(
-        device,
-        batch_size,
-        act_dtype,
-        weight_dtype,
-        resolution=resolution,
-        model_location_generator=None,
-    )
-
-    input_shape = (1, 3, *resolution)
-    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-
-    iterations = 32
-    t0 = time.time()
-    for _ in range(iterations):
-        _ = performant_runner.run(torch_input_tensor)
-    ttnn.synchronize_device(device)
-    t1 = time.time()
-
-    performant_runner.release()
-
-    inference_time_avg = round((t1 - t0) / iterations, 4)
-    throughput_avg = round(batch_size / inference_time_avg, 2)
-    logger.info(f"average inference time: {inference_time_avg * 1000} ms, average throughput: {throughput_avg} fps")
-
-    expected_inference_time = batch_size / expected_inference_throughput
-    prep_perf_report(
-        model_name="yolov4",
-        batch_size=batch_size,
-        inference_and_compile_time=inference_time_avg,
-        inference_time=inference_time_avg,
-        expected_compile_time=1,
-        expected_inference_time=expected_inference_time,
-        comments="",
-        inference_time_cpu=0.0,
-    )
-
-    assert (
-        throughput_avg >= expected_inference_throughput
-    ), f"Expected end-to-end performance to exceed {expected_inference_throughput} fps but was {throughput_avg} fps"
 
 
 @pytest.mark.parametrize(

--- a/models/demos/yolov7/runner/performant_runner_infra.py
+++ b/models/demos/yolov7/runner/performant_runner_infra.py
@@ -44,7 +44,7 @@ class YOLOv7PerformanceRunnerInfra:
         self.outputs_mesh_composer = outputs_mesh_composer
 
         self.torch_model = load_torch_model(self.model_location_generator)
-        self.torch_input_tensor = torch.randn((self.batch_size * self.num_devices, 3, 640, 640), dtype=torch.float32)
+        self.torch_input_tensor = torch.randn((self.batch_size, 3, 640, 640), dtype=torch.float32)
         self.parameters = custom_preprocessor(model=self.torch_model, mesh_mapper=self.weights_mesh_mapper)
         nx_ny = [80, 40, 20]
         grid_tensors = []
@@ -107,12 +107,9 @@ class YOLOv7PerformanceRunnerInfra:
 
     def validate(self, output_tensor=None, torch_output_tensor=None):
         if output_tensor is None:
-            # Use self.output_tensor (original behavior)
             output_tensor = self.output_tensor
         else:
-            # Handle output from pipeline (which might be a list or multi-device tensor)
             if isinstance(output_tensor, (list, tuple)):
-                # Extract the first element from the list
                 output_tensor = output_tensor[0]
 
         torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor

--- a/models/demos/yolov7/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov7/tests/perf/test_e2e_performant.py
@@ -97,15 +97,14 @@ def run_perf_e2e_yolov7(
     num_measurement_iterations = 32
     run_model_pipeline(device, test_infra, num_measurement_iterations)
 
-    first_iter_time = profiler.get("compile")
+    compile_time = profiler.get("compile")
     inference_time_avg = profiler.get(f"run_model_pipeline_2cqs") / num_measurement_iterations
-    compile_time = first_iter_time - 2 * inference_time_avg
     expected_inference_time = batch_size / expected_inference_throughput
 
     prep_perf_report(
         model_name=f"ttnn_yolov7_trace_2cqs_batch_size{batch_size}",
         batch_size=batch_size,
-        inference_and_compile_time=first_iter_time,
+        inference_and_compile_time=compile_time,
         inference_time=inference_time_avg,
         expected_compile_time=240,
         expected_inference_time=expected_inference_time,

--- a/models/demos/yolov7/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov7/tests/perf/test_e2e_performant.py
@@ -2,8 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+
 import sys
-import time
 
 import pytest
 import torch
@@ -14,56 +14,133 @@ import models.demos.yolov7.reference.yolov7_utils as yolov7_utils
 import ttnn
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.yolov7.common import YOLOV7_L1_SMALL_SIZE
-from models.demos.yolov7.runner.performant_runner import YOLOv7PerformantRunner
-from models.utility_functions import run_for_wormhole_b0
+from models.demos.yolov7.runner.performant_runner_infra import YOLOv7PerformanceRunnerInfra
+from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
+from models.utility_functions import profiler, run_for_wormhole_b0
 
 sys.modules["models.common"] = yolov7_utils
 sys.modules["models.yolo"] = yolov7_model
 
 
-def run_yolov7_trace_2cqs_inference(
-    model_location_generator,
+def _run_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    """Run the model using TT-CNN Pipeline and Executor APIs."""
+
+    # Get memory configs from the infrastructure
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(
+        device, mesh_mapper=test_infra.inputs_mesh_mapper, mesh_composer=test_infra.outputs_mesh_composer
+    )
+
+    # Create pipeline configuration
+    pipeline_config = PipelineConfig(
+        use_trace=True,
+        num_command_queues=2,
+        all_transfers_on_separate_command_queue=False,
+    )
+
+    # Create a model wrapper that handles the input tensor properly
+    def model_wrapper(l1_input_tensor):
+        # Set up the input tensor for the model
+        test_infra.input_tensor = l1_input_tensor
+        test_infra.run()
+        return test_infra.output_tensor
+
+    # Create pipeline from config
+    pipeline = create_pipeline_from_config(
+        device=device,
+        model=model_wrapper,
+        config=pipeline_config,
+        dram_input_memory_config=sharded_mem_config_DRAM,
+        l1_input_memory_config=input_mem_config,
+    )
+
+    # Compile the pipeline
+    logger.info(f"Running model warmup with input shape {list(tt_inputs_host.shape)}")
+    profiler.start("compile")
+    pipeline.compile(tt_inputs_host)
+    profiler.end("compile")
+
+    # Prepare inputs for measurement
+    host_inputs = [tt_inputs_host] * num_measurement_iterations
+
+    # Preallocate output tensors
+    pipeline.preallocate_output_tensors_on_host(num_measurement_iterations)
+
+    # Run measurement iterations
+    logger.info(
+        f"Starting performance pipeline for {num_measurement_iterations} iterations with batch_size={test_infra.batch_size} and num_devices={test_infra.num_devices}"
+    )
+
+    profiler.start("run_model_pipeline_2cqs")
+    outputs = pipeline.enqueue(host_inputs).pop_all()
+    profiler.end("run_model_pipeline_2cqs")
+
+    # Validate outputs
+    for i, output in enumerate(outputs):
+        test_infra.validate(output)
+        logger.info(f"Output {i} validation passed")
+
+    pipeline.cleanup()
+
+    return outputs
+
+
+def run_perf_e2e_yolov7(
     device,
     batch_size_per_device,
     act_dtype,
     weight_dtype,
+    model_location_generator,
     resolution,
+    expected_inference_throughput,
+    model_version="yolov7_trace_2cqs",
 ):
-    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+    profiler.clear()
+
+    inputs_mesh_mapper, _, output_mesh_composer = get_mesh_mappers(device)
+
+    test_infra = YOLOv7PerformanceRunnerInfra(
+        device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        model_location_generator=model_location_generator,
+        resolution=resolution,
+        inputs_mesh_mapper=inputs_mesh_mapper,
+        outputs_mesh_composer=output_mesh_composer,
+    )
 
     num_devices = device.get_num_devices()
     batch_size = batch_size_per_device * num_devices
 
-    performant_runner = YOLOv7PerformantRunner(
-        device,
-        batch_size,
-        act_dtype,
-        weight_dtype,
-        resolution=resolution,
-        model_location_generator=model_location_generator,
-        inputs_mesh_mapper=inputs_mesh_mapper,
-        weights_mesh_mapper=weights_mesh_mapper,
-        outputs_mesh_composer=outputs_mesh_composer,
-    )
-
-    input_shape = (batch_size, 3, *resolution)
+    input_shape = (batch_size_per_device * num_devices, 3, *resolution)
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
 
-    t0 = time.time()
-    for _ in range(10):
-        _ = performant_runner.run(torch_input_tensor)
-    ttnn.synchronize_device(device)
-    t1 = time.time()
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper)
 
-    performant_runner.release()
+    num_warmup_iterations = 5
+    num_measurement_iterations = 15
 
-    inference_time_avg = round((t1 - t0) / 10, 6)
+    if "yolov7_trace_2cqs" in model_version:
+        _run_model_pipeline(device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations)
+    else:
+        assert False, f"Model version to run {model_version} not found"
+
+    first_iter_time = profiler.get("compile")
+
+    # ensuring inference time fluctuations is not noise
+    num_cqs = 2 if "2cqs" in model_version else 1
+    inference_time_avg = profiler.get(f"run_model_pipeline_{num_cqs}cqs") / num_measurement_iterations
+
+    compile_time = first_iter_time
+
     logger.info(
-        f"ttnn_yolov7_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size / inference_time_avg)}"
+        f"YoloV7 {resolution[0]}x{resolution[1]} batch_size{batch_size} inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
     )
+    logger.info(f"YoloV7 compile time: {compile_time}")
 
 
 @run_for_wormhole_b0()
+@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV7_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
@@ -74,31 +151,32 @@ def run_yolov7_trace_2cqs_inference(
     ((1, ttnn.bfloat16, ttnn.bfloat16),),
 )
 @pytest.mark.parametrize(
-    "resolution",
-    [
-        (640, 640),
-    ],
+    "resolution, expected_inference_throughput",
+    [((640, 640), 46)],
 )
-@pytest.mark.models_performance_bare_metal
 def test_e2e_performant(
-    model_location_generator,
     device,
     batch_size_per_device,
     act_dtype,
     weight_dtype,
+    model_location_generator,
     resolution,
+    expected_inference_throughput,
 ):
-    run_yolov7_trace_2cqs_inference(
-        model_location_generator,
+    run_perf_e2e_yolov7(
         device,
         batch_size_per_device,
         act_dtype,
         weight_dtype,
+        model_location_generator,
         resolution,
+        expected_inference_throughput,
+        model_version="yolov7_trace_2cqs",
     )
 
 
 @run_for_wormhole_b0()
+@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV7_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
@@ -109,26 +187,25 @@ def test_e2e_performant(
     ((1, ttnn.bfloat16, ttnn.bfloat16),),
 )
 @pytest.mark.parametrize(
-    "resolution",
-    [
-        (640, 640),
-    ],
+    "resolution, expected_inference_throughput",
+    [((640, 640), 46)],
 )
-@pytest.mark.models_performance_bare_metal
-@pytest.mark.models_performance_virtual_machine
 def test_e2e_performant_dp(
-    model_location_generator,
     mesh_device,
     batch_size_per_device,
     act_dtype,
     weight_dtype,
+    model_location_generator,
     resolution,
+    expected_inference_throughput,
 ):
-    run_yolov7_trace_2cqs_inference(
-        model_location_generator,
+    run_perf_e2e_yolov7(
         mesh_device,
         batch_size_per_device,
         act_dtype,
         weight_dtype,
+        model_location_generator,
         resolution,
+        expected_inference_throughput,
+        model_version="yolov7_trace_2cqs",
     )

--- a/models/demos/yolov7/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov7/tests/perf/test_e2e_performant.py
@@ -2,11 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-
 import sys
 
 import pytest
-import torch
 from loguru import logger
 
 import models.demos.yolov7.reference.yolov7_model as yolov7_model
@@ -15,6 +13,7 @@ import ttnn
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.yolov7.common import YOLOV7_L1_SMALL_SIZE
 from models.demos.yolov7.runner.performant_runner_infra import YOLOv7PerformanceRunnerInfra
+from models.perf.perf_utils import prep_perf_report
 from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
 from models.utility_functions import profiler, run_for_wormhole_b0
 
@@ -22,59 +21,43 @@ sys.modules["models.common"] = yolov7_utils
 sys.modules["models.yolo"] = yolov7_model
 
 
-def _run_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
-    """Run the model using TT-CNN Pipeline and Executor APIs."""
-
-    # Get memory configs from the infrastructure
+def run_model_pipeline(device, test_infra, num_measurement_iterations):
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(
         device, mesh_mapper=test_infra.inputs_mesh_mapper, mesh_composer=test_infra.outputs_mesh_composer
     )
 
-    # Create pipeline configuration
-    pipeline_config = PipelineConfig(
-        use_trace=True,
-        num_command_queues=2,
-        all_transfers_on_separate_command_queue=False,
-    )
-
-    # Create a model wrapper that handles the input tensor properly
     def model_wrapper(l1_input_tensor):
-        # Set up the input tensor for the model
         test_infra.input_tensor = l1_input_tensor
         test_infra.run()
         return test_infra.output_tensor
 
-    # Create pipeline from config
     pipeline = create_pipeline_from_config(
         device=device,
         model=model_wrapper,
-        config=pipeline_config,
+        config=PipelineConfig(
+            use_trace=True,
+            num_command_queues=2,
+            all_transfers_on_separate_command_queue=False,
+        ),
         dram_input_memory_config=sharded_mem_config_DRAM,
         l1_input_memory_config=input_mem_config,
     )
 
-    # Compile the pipeline
     logger.info(f"Running model warmup with input shape {list(tt_inputs_host.shape)}")
     profiler.start("compile")
     pipeline.compile(tt_inputs_host)
     profiler.end("compile")
 
-    # Prepare inputs for measurement
     host_inputs = [tt_inputs_host] * num_measurement_iterations
-
-    # Preallocate output tensors
     pipeline.preallocate_output_tensors_on_host(num_measurement_iterations)
 
-    # Run measurement iterations
     logger.info(
         f"Starting performance pipeline for {num_measurement_iterations} iterations with batch_size={test_infra.batch_size} and num_devices={test_infra.num_devices}"
     )
-
     profiler.start("run_model_pipeline_2cqs")
     outputs = pipeline.enqueue(host_inputs).pop_all()
     profiler.end("run_model_pipeline_2cqs")
 
-    # Validate outputs
     for i, output in enumerate(outputs):
         test_infra.validate(output)
         logger.info(f"Output {i} validation passed")
@@ -92,15 +75,17 @@ def run_perf_e2e_yolov7(
     model_location_generator,
     resolution,
     expected_inference_throughput,
-    model_version="yolov7_trace_2cqs",
 ):
     profiler.clear()
 
     inputs_mesh_mapper, _, output_mesh_composer = get_mesh_mappers(device)
 
+    num_devices = device.get_num_devices()
+    batch_size = batch_size_per_device * num_devices
+
     test_infra = YOLOv7PerformanceRunnerInfra(
         device,
-        batch_size_per_device,
+        batch_size,
         act_dtype,
         weight_dtype,
         model_location_generator=model_location_generator,
@@ -109,34 +94,29 @@ def run_perf_e2e_yolov7(
         outputs_mesh_composer=output_mesh_composer,
     )
 
-    num_devices = device.get_num_devices()
-    batch_size = batch_size_per_device * num_devices
-
-    input_shape = (batch_size_per_device * num_devices, 3, *resolution)
-    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-
-    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper)
-
-    num_warmup_iterations = 5
-    num_measurement_iterations = 15
-
-    if "yolov7_trace_2cqs" in model_version:
-        _run_model_pipeline(device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations)
-    else:
-        assert False, f"Model version to run {model_version} not found"
+    num_measurement_iterations = 32
+    run_model_pipeline(device, test_infra, num_measurement_iterations)
 
     first_iter_time = profiler.get("compile")
+    inference_time_avg = profiler.get(f"run_model_pipeline_2cqs") / num_measurement_iterations
+    compile_time = first_iter_time - 2 * inference_time_avg
+    expected_inference_time = batch_size / expected_inference_throughput
 
-    # ensuring inference time fluctuations is not noise
-    num_cqs = 2 if "2cqs" in model_version else 1
-    inference_time_avg = profiler.get(f"run_model_pipeline_{num_cqs}cqs") / num_measurement_iterations
-
-    compile_time = first_iter_time
+    prep_perf_report(
+        model_name=f"ttnn_yolov7_trace_2cqs_batch_size{batch_size}",
+        batch_size=batch_size,
+        inference_and_compile_time=first_iter_time,
+        inference_time=inference_time_avg,
+        expected_compile_time=240,
+        expected_inference_time=expected_inference_time,
+        comments=f"{resolution[0]}x{resolution[1]}_batchsize{batch_size}",
+        inference_time_cpu=0.0,
+    )
 
     logger.info(
-        f"YoloV7 {resolution[0]}x{resolution[1]} batch_size{batch_size} inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
+        f"YoloV7 {resolution[0]}x{resolution[1]} batch_size: {batch_size}, inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
     )
-    logger.info(f"YoloV7 compile time: {compile_time}")
+    logger.info(f"YoloV7 compile time: {compile_time} s")
 
 
 @run_for_wormhole_b0()
@@ -152,7 +132,7 @@ def run_perf_e2e_yolov7(
 )
 @pytest.mark.parametrize(
     "resolution, expected_inference_throughput",
-    [((640, 640), 46)],
+    [((640, 640), 62.5)],
 )
 def test_e2e_performant(
     device,
@@ -171,7 +151,6 @@ def test_e2e_performant(
         model_location_generator,
         resolution,
         expected_inference_throughput,
-        model_version="yolov7_trace_2cqs",
     )
 
 
@@ -188,7 +167,7 @@ def test_e2e_performant(
 )
 @pytest.mark.parametrize(
     "resolution, expected_inference_throughput",
-    [((640, 640), 46)],
+    [((640, 640), 125)],
 )
 def test_e2e_performant_dp(
     mesh_device,
@@ -207,5 +186,4 @@ def test_e2e_performant_dp(
         model_location_generator,
         resolution,
         expected_inference_throughput,
-        model_version="yolov7_trace_2cqs",
     )

--- a/models/demos/yolov8x/runner/performant_runner_infra.py
+++ b/models/demos/yolov8x/runner/performant_runner_infra.py
@@ -46,8 +46,7 @@ class YOLOv8xPerformanceRunnerInfra:
         self.ttnn_yolov8_model = load_ttnn_model(
             device=self.device, torch_model=torch_model, weights_mesh_mapper=self.weights_mesh_mapper
         )
-
-        input_shape = (self.batch_size * self.num_devices, 3, 640, 640)
+        input_shape = (self.batch_size, 3, 640, 640)
         self.torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
         self.tt_input_tensor = ttnn.from_torch(
             self.torch_input_tensor, ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper
@@ -79,7 +78,6 @@ class YOLOv8xPerformanceRunnerInfra:
         )
 
         assert torch_input_tensor.ndim == 4, "Expected input tensor to have shape (BS, C, H, W)"
-
         tt_inputs_host = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper)
 
         return tt_inputs_host, input_mem_config

--- a/models/demos/yolov8x/runner/performant_runner_infra.py
+++ b/models/demos/yolov8x/runner/performant_runner_infra.py
@@ -46,11 +46,16 @@ class YOLOv8xPerformanceRunnerInfra:
         self.ttnn_yolov8_model = load_ttnn_model(
             device=self.device, torch_model=torch_model, weights_mesh_mapper=self.weights_mesh_mapper
         )
-        input_shape = (batch_size, 3, 640, 640)
+
+        # For multi-device scenarios, we use batch_size_per_device=1
+        # and replicate the same input across devices
+        batch_size_per_device = 1
+        input_shape = (batch_size_per_device, 3, 640, 640)
         self.torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
         self.tt_input_tensor = ttnn.from_torch(
             self.torch_input_tensor, ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper
         )
+        # Compute expected output for the single device batch size
         self.torch_output_tensor = torch_model(self.torch_input_tensor)[0]
 
     def run(self):
@@ -79,10 +84,25 @@ class YOLOv8xPerformanceRunnerInfra:
 
         assert torch_input_tensor.ndim == 4, "Expected input tensor to have shape (BS, C, H, W)"
 
-        input_tensor = [torch_input_tensor[i].unsqueeze(0) for i in range(torch_input_tensor.shape[0])]
-        tt_inputs_host = ttnn.from_host_shards(
-            [ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) for t in input_tensor], device.shape
-        )
+        # For multi-device scenarios, create shards that match the mesh size
+        if device.get_num_devices() > 1:
+            # Create exactly the number of shards needed for the mesh
+            num_shards_needed = device.get_num_devices()
+
+            # Split the input tensor into the required number of shards
+            # For batch size 1 with 2 devices, we need to replicate the same input for both devices
+            input_tensor = []
+            for i in range(num_shards_needed):
+                # Use the same input tensor for all shards (replication)
+                input_tensor.append(torch_input_tensor)
+
+            tt_inputs_host = ttnn.from_host_shards(
+                [ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) for t in input_tensor],
+                device.shape,
+            )
+        else:
+            # Single device scenario
+            tt_inputs_host = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper)
 
         return tt_inputs_host, input_mem_config
 
@@ -106,8 +126,22 @@ class YOLOv8xPerformanceRunnerInfra:
         return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
 
     def validate(self, output_tensor=None):
-        output_tensor = self.output_tensor if output_tensor is None else output_tensor
-        output_tensor = ttnn.to_torch(self.output_tensor, mesh_composer=self.outputs_mesh_composer)
+        if output_tensor is None:
+            # Use self.output_tensor (original behavior)
+            output_tensor = self.output_tensor
+        else:
+            # Handle output from pipeline (which might be a list or multi-device tensor)
+            if isinstance(output_tensor, (list, tuple)):
+                # Extract the first element from the list
+                output_tensor = output_tensor[0]
+
+        output_tensor = ttnn.to_torch(output_tensor, mesh_composer=self.outputs_mesh_composer)
+
+        # For multi-device scenarios, we only validate against the first device's output
+        # since all devices should produce identical results with the same input
+        if self.num_devices > 1 and output_tensor.shape[0] > 1:
+            # Take only the first device's output for validation
+            output_tensor = output_tensor[0:1]  # Keep the batch dimension
 
         valid_pcc = 0.978
         self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
@@ -115,4 +149,5 @@ class YOLOv8xPerformanceRunnerInfra:
         logger.info(f"Yolov8x batch_size={self.batch_size}, PCC={self.pcc_message}")
 
     def dealloc_output(self):
-        ttnn.deallocate(self.output_tensor)
+        if hasattr(self, "output_tensor") and self.output_tensor is not None:
+            ttnn.deallocate(self.output_tensor)

--- a/models/demos/yolov8x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8x/tests/perf/test_e2e_performant.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import time
-
 import pytest
 import torch
 from loguru import logger
@@ -12,42 +10,174 @@ from loguru import logger
 import ttnn
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.yolov8x.common import YOLOV8X_L1_SMALL_SIZE
-from models.demos.yolov8x.runner.performant_runner import YOLOv8xPerformantRunner
-from models.utility_functions import run_for_wormhole_b0
+from models.demos.yolov8x.runner.performant_runner_infra import YOLOv8xPerformanceRunnerInfra
+from models.perf.perf_utils import prep_perf_report
+from models.tt_cnn.tt.pipeline import PipelineConfig, create_pipeline_from_config
+from models.utility_functions import profiler, run_for_wormhole_b0
 
 
-def run_yolov8x_trace_2cqs_inference(
-    model_location_generator,
+def _run_model_pipeline(
+    device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations, num_command_queues, trace
+):
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
+
+    def model_wrapper(l1_input_tensor):
+        test_infra.input_tensor = l1_input_tensor
+        test_infra.run()
+        return test_infra.output_tensor
+
+    pipeline = create_pipeline_from_config(
+        config=PipelineConfig(
+            use_trace=trace, num_command_queues=num_command_queues, all_transfers_on_separate_command_queue=False
+        ),
+        model=model_wrapper,
+        device=device,
+        dram_input_memory_config=sharded_mem_config_DRAM,
+        l1_input_memory_config=input_mem_config,
+    )
+
+    logger.info(f"Running model warmup with input shape {list(tt_inputs_host.shape)}")
+    profiler.start("compile")
+    pipeline.compile(tt_inputs_host)
+    profiler.end("compile")
+
+    host_inputs = [tt_inputs_host] * num_measurement_iterations
+
+    pipeline.preallocate_output_tensors_on_host(
+        num_measurement_iterations,
+    )
+
+    logger.info(
+        f"Starting performance pipeline for {num_measurement_iterations} iterations with batch_size={test_infra.batch_size} and num_devices={test_infra.num_devices}"
+    )
+    profiler.start(f"run_model_pipeline_{num_command_queues}cqs")
+    outputs = pipeline.enqueue(host_inputs).pop_all()
+    profiler.end(f"run_model_pipeline_{num_command_queues}cqs")
+
+    for i, output in enumerate(outputs):
+        test_infra.validate(output)
+        logger.info(f"Output {i} validation passed")
+
+    pipeline.cleanup()
+
+
+def run_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=1,
+        trace=False,
+    )
+
+
+def run_trace_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=1,
+        trace=True,
+    )
+
+
+def run_2cq_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=2,
+        trace=False,
+    )
+
+
+def run_trace_2cq_model_pipeline(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
+    _run_model_pipeline(
+        device,
+        tt_inputs,
+        test_infra,
+        num_warmup_iterations,
+        num_measurement_iterations,
+        num_command_queues=2,
+        trace=True,
+    )
+
+
+def run_perf_e2e_yolov8x(
     device,
     batch_size_per_device,
+    model_location_generator,
+    expected_inference_throughput,
+    model_version="yolov8x_trace_2cqs",
 ):
-    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+    profiler.clear()
+
+    inputs_mesh_mapper, _, output_mesh_composer = get_mesh_mappers(device)
+
+    test_infra = YOLOv8xPerformanceRunnerInfra(
+        device,
+        batch_size_per_device,
+        model_location_generator=model_location_generator,
+        inputs_mesh_mapper=inputs_mesh_mapper,
+        outputs_mesh_composer=output_mesh_composer,
+    )
 
     num_devices = device.get_num_devices()
     batch_size = batch_size_per_device * num_devices
-    performant_runner = YOLOv8xPerformantRunner(
-        device,
-        batch_size,
-        model_location_generator=model_location_generator,
-        inputs_mesh_mapper=inputs_mesh_mapper,
-        weights_mesh_mapper=weights_mesh_mapper,
-        outputs_mesh_composer=outputs_mesh_composer,
-    )
 
-    input_shape = (batch_size, 3, 640, 640)
+    input_shape = (batch_size_per_device * num_devices, 3, 640, 640)
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
 
-    t0 = time.time()
-    for _ in range(10):
-        _ = performant_runner.run(torch_input_tensor)
-    ttnn.synchronize_device(device)
-    t1 = time.time()
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper)
 
-    performant_runner.release()
-    inference_time_avg = round((t1 - t0) / 10, 6)
-    logger.info(
-        f"Model: ttnn_yolov8x - batch_size: {batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size / inference_time_avg)}"
+    num_warmup_iterations = 5
+    num_measurement_iterations = 15
+
+    if "yolov8x_trace_2cqs" in model_version:
+        run_trace_2cq_model_pipeline(
+            device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations
+        )
+    elif "yolov8x_trace" in model_version:
+        run_trace_model_pipeline(
+            device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations
+        )
+    elif "yolov8x_2cqs" in model_version:
+        run_2cq_model_pipeline(device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations)
+    elif "yolov8x" in model_version:
+        run_model_pipeline(device, ttnn_input_tensor, test_infra, num_warmup_iterations, num_measurement_iterations)
+    else:
+        assert False, f"Model version to run {model_version} not found"
+
+    first_iter_time = profiler.get("compile")
+
+    # ensuring inference time fluctuations is not noise
+    num_cqs = 2 if "2cqs" in model_version else 1
+    inference_time_avg = profiler.get(f"run_model_pipeline_{num_cqs}cqs") / num_measurement_iterations
+
+    compile_time = first_iter_time - 2 * inference_time_avg
+    expected_inference_time = batch_size / expected_inference_throughput
+
+    prep_perf_report(
+        model_name=f"ttnn_{model_version}_batch_size{batch_size}",
+        batch_size=batch_size,
+        inference_and_compile_time=first_iter_time,
+        inference_time=inference_time_avg,
+        expected_compile_time=1,
+        expected_inference_time=expected_inference_time,
+        comments=f"640x640_batchsize{batch_size}",
+        inference_time_cpu=0.0,
     )
+
+    logger.info(
+        f"YoloV8x 640x640 batch_size{batch_size} inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
+    )
+    logger.info(f"YoloV8x compile time: {compile_time}")
 
 
 @run_for_wormhole_b0()
@@ -66,10 +196,12 @@ def test_run_yolov8x_performant(
     device,
     batch_size_per_device,
 ):
-    run_yolov8x_trace_2cqs_inference(
-        model_location_generator,
+    run_perf_e2e_yolov8x(
         device,
         batch_size_per_device,
+        model_location_generator,
+        expected_inference_throughput=50,
+        model_version="yolov8x_trace_2cqs",
     )
 
 
@@ -90,8 +222,10 @@ def test_run_yolov8x_performant_dp(
     mesh_device,
     batch_size_per_device,
 ):
-    run_yolov8x_trace_2cqs_inference(
-        model_location_generator,
+    run_perf_e2e_yolov8x(
         mesh_device,
         batch_size_per_device,
+        model_location_generator,
+        expected_inference_throughput=100,
+        model_version="yolov8x_trace_2cqs",
     )

--- a/models/demos/yolov8x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8x/tests/perf/test_e2e_performant.py
@@ -148,7 +148,7 @@ def test_run_yolov8x_performant(
         device,
         batch_size_per_device,
         model_location_generator,
-        expected_inference_throughput=50,
+        expected_inference_throughput=47.5,
     )
 
 
@@ -173,5 +173,5 @@ def test_run_yolov8x_performant_dp(
         mesh_device,
         batch_size_per_device,
         model_location_generator,
-        expected_inference_throughput=100,
+        expected_inference_throughput=95,
     )

--- a/models/tt_cnn/tt/pipeline.py
+++ b/models/tt_cnn/tt/pipeline.py
@@ -114,7 +114,9 @@ class Pipeline:
     def preallocate_output_tensors_on_host(
         self, number_of_tensors_to_allocate, output_shape, output_dtype, output_layout
     ):
-        logger.debug(f"Preallocating memory for {number_of_tensors_to_allocate} output tensors on host")
+        logger.debug(
+            f"Preallocating memory for {number_of_tensors_to_allocate} output tensors (shape={list(output_shape)}, dype={output_dtype}, layout={output_layout}) on host"
+        )
         self.preallocated_output_tensors = True
         if not isinstance(output_shape, ttnn.Shape):
             output_shape = ttnn.Shape(output_shape)

--- a/models/tt_cnn/tt/pipeline.py
+++ b/models/tt_cnn/tt/pipeline.py
@@ -86,43 +86,72 @@ class Pipeline:
         self.executor = executor
         self.output_tensors = []
         self.preallocated_output_tensors = False
+        self.output_schema = None
 
     def compile(self, host_input):
         logger.debug(f"Compiling pipeline model with input_shape={list(host_input.shape)}")
         self.executor.compile(host_input)
+        self.output_schema = self.executor.get_output_schema()
         return self
+
+    def _copy_to_structured_host_tensor(self, device_struct, host_struct, cq_id):
+        if isinstance(device_struct, ttnn.Tensor):
+            ttnn.copy_device_to_host_tensor(device_struct, host_struct, blocking=False, cq_id=cq_id)
+        elif isinstance(device_struct, (list, tuple)):
+            for device_t, host_t in zip(device_struct, host_struct):
+                self._copy_to_structured_host_tensor(device_t, host_t, cq_id)
+        else:
+            raise TypeError(f"Unsupported type in model output: {type(device_struct)}")
+
+    def _cpu_structured_tensor(self, device_struct, cq_id):
+        if isinstance(device_struct, ttnn.Tensor):
+            return device_struct.cpu(blocking=False, cq_id=cq_id)
+        elif isinstance(device_struct, (list, tuple)):
+            return [self._cpu_structured_tensor(t, cq_id) for t in device_struct]
+        else:
+            return device_struct
 
     def enqueue(self, host_inputs: list):
         if not all([input.storage_type() == ttnn.StorageType.HOST for input in host_inputs]):
             raise ValueError("All input tensors must be on host")
+
+        device_outputs = self.executor.execute(host_inputs)
+
         if self.preallocated_output_tensors:
             if len(host_inputs) > len(self.output_tensors):
                 raise ValueError(
-                    f"Number of inputs ({len(host_inputs)}) exceeds the number of pre-allocated output tensors ({len(self.output_tensors)})."
+                    f"Number of inputs ({len(host_inputs)}) exceeds the number of pre-allocated output slots ({len(self.output_tensors)})."
                 )
-            for i, output_tensor in enumerate(self.executor.execute(host_inputs)):
-                ttnn.copy_device_to_host_tensor(
-                    output_tensor, self.output_tensors[i], blocking=False, cq_id=self.executor.get_read_cq()
+            for i, device_output_struct in enumerate(device_outputs):
+                host_output_struct = self.output_tensors[i]
+                self._copy_to_structured_host_tensor(
+                    device_output_struct, host_output_struct, self.executor.get_read_cq()
                 )
         else:
             self.output_tensors = []
-            for t in self.executor.execute(host_inputs):
-                host_tensor = t.cpu(blocking=False, cq_id=self.executor.get_read_cq())
-                self.output_tensors.append(host_tensor)
+            for device_output_struct in device_outputs:
+                host_output_struct = self._cpu_structured_tensor(device_output_struct, self.executor.get_read_cq())
+                self.output_tensors.append(host_output_struct)
         return self
 
-    def preallocate_output_tensors_on_host(
-        self, number_of_tensors_to_allocate, output_shape, output_dtype, output_layout
-    ):
-        logger.debug(
-            f"Preallocating memory for {number_of_tensors_to_allocate} output tensors (shape={list(output_shape)}, dype={output_dtype}, layout={output_layout}) on host"
-        )
+    def _create_structured_host_tensor(self, schema):
+        # Check if schema is a leaf node (shape, dtype, layout) or a structure
+        if isinstance(schema, (list, tuple)) and not all(isinstance(x, int) for x in schema[0]):
+            return [self._create_structured_host_tensor(s) for s in schema]
+        else:
+            shape, dtype, layout = schema
+            if not isinstance(shape, ttnn.Shape):
+                shape = ttnn.Shape(shape)
+            return ttnn.allocate_tensor_on_host(shape, dtype, layout, self.executor.device)
+
+    def preallocate_output_tensors_on_host(self, number_of_tensors_to_allocate: int):
+        if self.output_schema is None:
+            raise RuntimeError("Pipeline must be compiled before pre-allocating output tensors.")
+
+        logger.debug(f"Preallocating memory for {number_of_tensors_to_allocate} output slots on host")
         self.preallocated_output_tensors = True
-        if not isinstance(output_shape, ttnn.Shape):
-            output_shape = ttnn.Shape(output_shape)
         self.output_tensors = [
-            ttnn.allocate_tensor_on_host(output_shape, output_dtype, output_layout, self.executor.device)
-            for _ in range(number_of_tensors_to_allocate)
+            self._create_structured_host_tensor(self.output_schema) for _ in range(number_of_tensors_to_allocate)
         ]
         return self
 


### PR DESCRIPTION
### Summary
This PR refactors the performance tests for YOLO models (YoloV4, YoloV7, and YoloV8x) to use the TT-CNN pipeline API.

- YoloV4: Refactored `models/demos/yolov4/tests/perf/test_e2e_performant.py` to use TT-CNN pipeline with `create_pipeline_from_config()` and `preallocate_output_tensors_on_host()`; 
    - Performance at 320x320 improved from 109 → 130 FPS
    - Performance at 640x640 improved from 48 → 65 FPS
- YoloV4: Updated demo script to use TT-CNN pipeline
- YoloV7: Updated `models/demos/yolov7/tests/perf/test_e2e_performant.py` to use TT-CNN pipeline
- YoloV8x: Refactored `models/demos/yolov8x/tests/perf/test_e2e_performant.py` to use TT-CNN pipeline
- Updated `models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py `to use output tensor preallocation using `preallocate_output_tensors_on_host()` to reduce memory allocation overhead during inference
- Removed the need to specify output tensor shape/dtype/layout when using preallocated host tensors
- Added support for models with multiple outputs in the TT-CNN pipeline framework
- Updated executor implementations to handle structured outputs (lists/tuples of tensors)

### Future Work
- Update demo and web demo code to use TT-CNN pipeline API so that we can remove the trace+2CQ implementations for each YoloV4/YoloV7/YoloV8x
   
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17245014334
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17245023027
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17295374211
- [x] [Model regression (T3K)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17237134779/job/48905250102
- [ ] [Demo tests (single card)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17296665803