### PR TITLE
RoPE freqs_cis are complex and cannot be bfloat16

### DIFF
--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -58,7 +58,7 @@ class RotaryEmbedding(nn.Module):
         emb = torch.cat((freqs, freqs), dim=-1)
         cos = emb.cos()
         sin = emb.sin()
-        self.register_buffer("freqs_cis", torch.complex(cos.to(dtype), sin.to(dtype)), persistent=False)
+        self.register_buffer("freqs_cis", torch.complex(cos.float(), sin.float()), persistent=False)
 
         cos, sin = self.permute_to_meta_format(cos, sin)
         self.register_buffer("cos_cached", cos.to(dtype), persistent=False)
@@ -101,7 +101,7 @@ class ScaledRotaryEmbedding(RotaryEmbedding, ABC):
         freqs = torch.outer(t, freqs).float()
         cos = torch.cos(freqs)
         sin = torch.sin(freqs)
-        self.register_buffer("freqs_cis", torch.complex(cos.to(dtype), sin.to(dtype)), persistent=False)
+        self.register_buffer("freqs_cis", torch.complex(cos.float(), sin.float()), persistent=False)
 
         cos, sin = gather_cos_sin(torch.arange(seq_len), cos, sin)
         self.register_buffer("cos_cached", cos.to(dtype), persistent=False)


### PR DESCRIPTION
### Ticket
n/a

### Problem description
T3k freq pipeline - llama3.2 90b vision failing with:
`RuntimeError: Expected both inputs to be Half, Float or Double tensors but got BFloat16 and BFloat16`
https://github.com/tenstorrent/tt-metal/actions/runs/17202943004/job/48797643618#step:5:162

### What's changed
freqs_ci are complex, and therefore always a combination of floats.

### Checklist
- [x] [(T3K) T3000 frequent tests ](https://github.com/tenstorrent/tt-metal/actions/runs/17237518033) ✅