### PR TITLE
Fix incorrect branching in reduce scatter minimal

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -248,6 +248,8 @@ def run_reduce_scatter_impl(
         (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
         (8, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
         (8, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
+        (8, [1, 1, 256, 128], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        (8, [1, 1, 256, 128], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, False),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -261,6 +263,8 @@ def run_reduce_scatter_impl(
         "composite_rs_test_one",
         "composite_rs_test_two",
         "composite_rs_test_three",
+        "forge_test_tiled",
+        "forge_test_row_major",
     ],
 )
 @pytest.mark.parametrize(
@@ -300,8 +304,8 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1234944}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1234944}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
     ids=["fabric_ring", "fabric_linear"],

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -15,14 +15,8 @@
 
 namespace ttnn::operations::experimental::ccl {
 
-bool use_composite_reduce_scatter(
-    const ttnn::Tensor& input_tensor, const int32_t dim, std::optional<uint32_t> cluster_axis) {
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_width = tile_shape[1];
-
-    int32_t rank = input_tensor.logical_shape().rank();
-    int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
-
+namespace detail {
+uint32_t get_num_devices(const ttnn::Tensor& input_tensor, std::optional<uint32_t> cluster_axis) {
     uint32_t num_devices;
     if (cluster_axis.has_value()) {
         auto mesh_device = input_tensor.mesh_device();
@@ -31,6 +25,19 @@ bool use_composite_reduce_scatter(
     } else {
         num_devices = ttnn::ccl::get_active_physical_devices(input_tensor).size();
     }
+    return num_devices;
+}
+}  // namespace detail
+
+bool use_composite_reduce_scatter(
+    const ttnn::Tensor& input_tensor, const int32_t dim, std::optional<uint32_t> cluster_axis) {
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_width = tile_shape[1];
+
+    int32_t rank = input_tensor.logical_shape().rank();
+    int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
+
+    uint32_t num_devices = detail::get_num_devices(input_tensor, cluster_axis);
 
     // Must scatter evenly
     auto input_shape = input_tensor.logical_shape();
@@ -69,14 +76,16 @@ ttnn::Tensor composite_reduce_scatter(
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
-
-    auto input_shape = input_tensor.logical_shape();
-
+    uint32_t num_devices = detail::get_num_devices(input_tensor, cluster_axis);
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
 
+    auto input_shape = input_tensor.logical_shape();
+    auto output_shape = input_shape;
+    output_shape[scatter_dim] /= num_devices;
+
     bool is_tiled_and_not_tile_aligned = input_tensor.layout() == Layout::TILE &&
-                                         (input_shape[2] % tile_height != 0 || input_shape[3] % tile_width != 0);
+                                         (output_shape[2] % tile_height != 0 || output_shape[3] % tile_width != 0);
 
     // If we need to convert to row-major, then if the input dtype is bfloat8_b we need to typecast before untilizing
     // and after re-tilizing


### PR DESCRIPTION
### Ticket
#27403

### Problem description
We did not route to the composite when the output shape is sub-tile, only doing it when the input is sub-tile.

### What's changed
Correct the logic to use the output shape. When input_dim % 32 != 0, input_dim/n % 32 != 0 so the old logic is also covered in this case.

### Checklist
- [ ] T3K tests: https://github.com/tenstorrent/tt-metal/actions/runs/17242670507