### PR TITLE
rename fabric router files to be topology agnostic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ class CMakeBuild(build_ext):
             "core_descriptors/*.yaml",
             "fabric/hw/**/*",
             "fabric/mesh_graph_descriptors/*.yaml",
-            "fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp",
+            "fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp",
             "fabric/impl/kernels/tt_fabric_mux.cpp",
             "hw/**/*",
             "hostdevcommon/api/hostdevcommon/**/*",

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -111,7 +111,7 @@ target_sources(
             impl/dispatch/kernels/cq_dispatch.cpp
             impl/dispatch/kernels/cq_dispatch_subordinate.cpp
             impl/dispatch/kernels/cq_prefetch.cpp
-            fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+            fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
             fabric/impl/kernels/tt_fabric_mux.cpp
             kernels/compute/blank.cpp
             kernels/compute/eltwise_binary.cpp

--- a/tt_metal/fabric/ccl/ccl_common.cpp
+++ b/tt_metal/fabric/ccl/ccl_common.cpp
@@ -60,7 +60,7 @@ tt::tt_metal::KernelHandle generate_edm_kernel(
         program,
         device,
         edm_builder,
-        "tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp",
+        "tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp",
         eth_core,
         risc_id,
         noc_id,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -8,7 +8,7 @@
 #include "fabric/fabric_edm_packet_header.hpp"
 #include "edm_fabric_worker_adapters.hpp"
 #include "fabric_edm_types.hpp"
-#include "tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp"
 #include <cstdint>
 
 // If the hop/distance counter equals to the below value, it indicates that it has

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -402,15 +402,21 @@ constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_se
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
-            to_sender_0_pkts_acked_id, to_sender_1_pkts_acked_id, to_sender_2_pkts_acked_id,
-            to_sender_3_pkts_acked_id, to_sender_4_pkts_acked_id});
+            to_sender_0_pkts_acked_id,
+            to_sender_1_pkts_acked_id,
+            to_sender_2_pkts_acked_id,
+            to_sender_3_pkts_acked_id,
+            to_sender_4_pkts_acked_id});
 
 // data section
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_completed_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
-            to_sender_0_pkts_completed_id, to_sender_1_pkts_completed_id, to_sender_2_pkts_completed_id,
-            to_sender_3_pkts_completed_id, to_sender_4_pkts_completed_id});
+            to_sender_0_pkts_completed_id,
+            to_sender_1_pkts_completed_id,
+            to_sender_2_pkts_completed_id,
+            to_sender_3_pkts_completed_id,
+            to_sender_4_pkts_completed_id});
 
 // Miscellaneous configuration
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_transaction_id_tracker.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_transaction_id_tracker.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp"
 
 #include "risc_attribs.h"  // for FORCE_INLINE
 #include "utils/utils.h"   // for is_power_of_2

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp"
 #include "tt_metal/hw/inc/ethernet/tt_eth_api.h"
 #include "tt_metal/hw/inc/ethernet/tunneling.h"
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_mux.hpp
+++ b/tt_metal/fabric/hw/inc/tt_fabric_mux.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 // this is needed for inclusion of fabric_erisc_datamover_channels.hpp, since we are not
-// including 1d_fabric_constants.hpp here, where the constant is originally defined
+// including fabric_erisc_router_ct_args.hpp here, where the constant is originally defined
 namespace tt::tt_fabric {
 static constexpr uint8_t worker_handshake_noc = 0;
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/api/tt-metalium/edm_fabric_counters.hpp"
 #include "tt_metal/api/tt-metalium/fabric_edm_types.hpp"
 
-#include "tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_eriscs_router_ct_args.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_header_validate.hpp"
@@ -266,7 +266,7 @@ using PerfTelemetryRecorder = std::conditional_t<
     std::conditional_t<PERF_TELEMETRY_DISABLED, bool, std::nullptr_t>>;
 
 // Defined here because sender_channel_0_free_slots_stream_id does not come from
-// 1d_fabric_constants.hpp
+// fabric_erisc_router_ct_args.hpp
 static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_free_slots_stream_ids = {
     WorkerToFabricEdmSenderImpl<0>::sender_channel_0_free_slots_stream_id,
     sender_channel_1_free_slots_stream_id,
@@ -2126,11 +2126,19 @@ void kernel_main() {
     const auto& local_sender_buffer_addresses =
         take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
             std::array<size_t, MAX_NUM_SENDER_CHANNELS>{
-                local_sender_0_channel_address, local_sender_1_channel_address, local_sender_2_channel_address, local_sender_3_channel_address, local_sender_4_channel_address});
+                local_sender_0_channel_address,
+                local_sender_1_channel_address,
+                local_sender_2_channel_address,
+                local_sender_3_channel_address,
+                local_sender_4_channel_address});
     const auto& remote_sender_buffer_addresses =
         take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
             std::array<size_t, MAX_NUM_SENDER_CHANNELS>{
-                remote_sender_0_channel_address, remote_sender_1_channel_address, remote_sender_2_channel_address, remote_sender_3_channel_address, remote_sender_4_channel_address});
+                remote_sender_0_channel_address,
+                remote_sender_1_channel_address,
+                remote_sender_2_channel_address,
+                remote_sender_3_channel_address,
+                remote_sender_4_channel_address});
     const auto& local_receiver_buffer_addresses =
         take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
             std::array<size_t, MAX_NUM_RECEIVER_CHANNELS>{

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -17,7 +17,7 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
-#include "tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_transaction_id_tracker.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_transaction_id_tracker.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_tmp_utils.hpp"

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/api/tt-metalium/edm_fabric_counters.hpp"
 #include "tt_metal/api/tt-metalium/fabric_edm_types.hpp"
 
-#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_eriscs_router_ct_args.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_header_validate.hpp"

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1257,7 +1257,7 @@ std::unique_ptr<Program> create_and_compile_tt_fabric_program(IDevice* device) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
             auto kernel = tt::tt_metal::CreateKernel(
                 *fabric_program_ptr,
-                "tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp",
+                "tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp",
                 eth_logical_core,
                 tt::tt_metal::EthernetConfig{
                     .noc = edm_builder.config.risc_configs[risc_id].get_configured_noc(),


### PR DESCRIPTION
these files were originally added when only 1D fabric was supported. Since their creation, additional topology support has been added, so file names have been generalized.

[#20350](https://github.com/tenstorrent/tt-metal/issues/20350)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/17249060340
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/17249065246