### PR TITLE
#27446: [skip ci] Skip WH 6u demo repeat test in upstream container

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -182,7 +182,8 @@ test_suite_wh_6u_llama_demo_tests() {
 
     pytest models/demos/llama3_70b_galaxy/tests/test_llama_model.py -k "quick"
     pytest models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_model_prefill.py
-    pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat"
+    # Repeat test seeing AssertionError on token mismatches: Issue #27446
+    # pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat"
     # Some AssertionError: Throughput is out of targets 49 - 53 t/s/u in 200 iterations
     # assert 200 <= 20
     # pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27446

### Problem description
Test failing after https://github.com/tenstorrent/tt-metal/commit/f8f13f6dcad3730b0538d60110a53c29c8b62d8c

### What's changed
Skip the test for now

### Checklist
- [x] Upstream tests (6u only): https://github.com/tenstorrent/tt-metal/actions/runs/17249206363/job/48948612377