### PR TITLE
[skip ci] Switch from ECR to GCR

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -4,7 +4,7 @@
 
 # Accept an argument to specify the Ubuntu version
 ARG UBUNTU_VERSION=22.04
-FROM public.ecr.aws/ubuntu/ubuntu:${UBUNTU_VERSION} AS base
+FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -1,5 +1,5 @@
 ARG UBUNTU_VERSION=22.04
-FROM public.ecr.aws/ubuntu/ubuntu:${UBUNTU_VERSION} AS base
+FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION} AS base
 # Re-declare ARG make it available in the build stage
 ARG UBUNTU_VERSION
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
```
#2 [internal] load metadata for public.ecr.aws/ubuntu/ubuntu:22.04
#2 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://public.ecr.aws/v2/ubuntu/ubuntu/manifests/sha256:4308681229e935f06b70ccf05d00417d24f01632bd0cc643a4b75fa5f2456902: 429 Too Many Requests
toomanyrequests: Data limit exceeded
------
 > [internal] load metadata for public.ecr.aws/ubuntu/ubuntu:22.04:
------

 1 warning found (use docker --debug to expand):
 - ConsistentInstructionCasing: Command 'run' should match the case of the command majority (uppercase) (line 192)
Dockerfile:7
--------------------
   5 |     # Accept an argument to specify the Ubuntu version
   6 |     ARG UBUNTU_VERSION=22.04
   7 | >>> FROM public.ecr.aws/ubuntu/ubuntu:${UBUNTU_VERSION} AS base
   8 |     
   9 |     ENV DEBIAN_FRONTEND=noninteractive
--------------------
ERROR: failed to build: failed to solve: public.ecr.aws/ubuntu/ubuntu:22.04: failed to resolve source metadata for public.ecr.aws/ubuntu/ubuntu:22.04: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://public.ecr.aws/v2/ubuntu/ubuntu/manifests/sha256:4308681229e935f06b70ccf05d00417d24f01632bd0cc643a4b75fa5f2456902: 429 Too Many Requests
toomanyrequests: Data limit exceeded
Reference
```

### What's changed
Since we are data / rate limited by ECR  ... then switch to GCR