### PR TITLE
Add 6u profiler pipeline

### DIFF
--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -5,8 +5,6 @@ on:
   workflow_call:
   schedule:
     - cron: "0 2 * * *" # This cron schedule runs the workflow every day at 2am
-  pull_request:
-  push:
 
 jobs:
   build-artifact-profiler:

--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -1,4 +1,4 @@
-name: "(T3K) T3000 profiler tests"
+name: "Galaxy profiler tests"
 
 on:
   workflow_dispatch:
@@ -21,8 +21,7 @@ jobs:
     secrets: inherit
     runs-on:
       - arch-wormhole_b0
-      - config-t3000
-      - pipeline-functional
+      - topology-6u
     uses: ./.github/workflows/profiler-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}

--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 2 * * *" # This cron schedule runs the workflow every day at 2am
   pull_request:
+  push:
 
 jobs:
   build-artifact-profiler:

--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -5,6 +5,7 @@ on:
   workflow_call:
   schedule:
     - cron: "0 2 * * *" # This cron schedule runs the workflow every day at 2am
+  pull_request:
 
 jobs:
   build-artifact-profiler:

--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -19,11 +19,9 @@ jobs:
   profiler-tests:
     needs: build-artifact-profiler
     secrets: inherit
-    runs-on:
-      - arch-wormhole_b0
-      - topology-6u
     uses: ./.github/workflows/profiler-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      topology: topology-6u

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "in-service"
+      topology:
+        required: false
+        type: string
+        default: "config-t3000"
 
 jobs:
   profiler-tests:
@@ -23,6 +27,8 @@ jobs:
       fail-fast: false
     name: "profiler tests"
     runs-on:
+      - arch-wormhole_b0
+      - ${{ inputs.topology }}
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -1,4 +1,4 @@
-name: "[internal] T3000 profiler tests impl"
+name: "[internal] profiler tests impl"
 
 on:
   workflow_call:
@@ -18,14 +18,11 @@ on:
         default: "in-service"
 
 jobs:
-  t3000-profiler-tests:
+  profiler-tests:
     strategy:
       fail-fast: false
-    name: "T3000 profiler tests"
+    name: "profiler tests"
     runs-on:
-      - arch-wormhole_b0
-      - config-t3000
-      - pipeline-functional
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -19,10 +19,6 @@ jobs:
   profiler-tests:
     needs: build-artifact-profiler
     secrets: inherit
-    runs-on:
-      - arch-wormhole_b0
-      - config-t3000
-      - pipeline-functional
     uses: ./.github/workflows/profiler-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -28,3 +28,4 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      topology: config-t3000


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/26816

Add a pipeline for running profiler tests on 6Us.
Changed `.github/workflows/t3000-profiler-tests.yaml` to `.github/workflows/profiler-tests.yaml` to be reused in 6U wrapper yaml.

Testing
6U: https://github.com/tenstorrent/tt-metal/actions/runs/17250377687
t3k: https://github.com/tenstorrent/tt-metal/actions/runs/17250211662