### PR TITLE
Fix incorrect n300 test

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -76,9 +76,9 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& devices = fixture->get_devices();
 
-    // Need at least 2 devices for smoke test
-    if (devices.size() == 2) {
-        GTEST_SKIP() << "Smoke test requires at least 2 devices";
+    // Need exactly 2 devices for smoke test
+    if (devices.size() != 2) {
+        GTEST_SKIP() << "Smoke test requires exactly 2 devices";
     }
 
     // Use first two devices for simple smoke test


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Used wrong comparator

### What's changed
Corrected incorrect comparator

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes