### PR TITLE
Fix invalid memory access (gcc15)

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -56,7 +56,9 @@ public:
                 reinterpret_cast<volatile uint32_t*>(this->buffer_addresses[i])[j] = 0;
             }
         }
-        set_cached_next_buffer_slot_addr(this->buffer_addresses[0]);
+        if constexpr (NUM_BUFFERS) {
+            set_cached_next_buffer_slot_addr(this->buffer_addresses[0]);
+        }
     }
 
     EthChannelBuffer(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Invalid memory access / out of bounds static access in the Fabric Router
- Some EthChannels may have NUM_BUFFERS = 0. In this case, accessing index 0 is invalid
- gcc15 has better safety checking. It generates an `ebreak` instruction which will halt the core but there's no error on the host.

### What's changed
- Fix the invalid access

### Checklist
Trivial change