### PR TITLE
#27455 Add storage type validation for input tensors in binary and bi…

### DIFF
--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TT_EAGER_TESTS_OPS
     ops/test_bmm_op.cpp
     # ops/test_pad_op.cpp                     # <- not called in run_tt_eager.py
     ops/test_sfpu.cpp
+    ops/test_storage_type_validation.cpp
 )
 
 set(TT_EAGER_TESTS_TENSORS

--- a/tests/tt_eager/ops/test_storage_type_validation.cpp
+++ b/tests/tt_eager/ops/test_storage_type_validation.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <tt-metalium/constants.hpp>
+#include <functional>
+
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/shape.hpp>
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/tensor/enum_types.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/storage.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+using tt::tt_metal::DataType;
+using tt::tt_metal::Layout;
+using tt::tt_metal::Tensor;
+using tt::tt_metal::distributed::MeshDevice;
+
+void test_binary_storage_type_validation_host_tensor(tt::tt_metal::distributed::MeshDevice* device) {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
+
+    // Create host tensors (not on device)
+    auto input_tensor_a = ttnn::random::random(shape, DataType::BFLOAT16);
+    auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16);
+
+    // Verify these are host tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor A should be HOST storage type");
+    TT_FATAL(
+        input_tensor_b.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor B should be HOST storage type");
+
+    // This should fail with storage type validation error
+    // We expect a TT_FATAL assertion to be triggered
+    try {
+        auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
+            ttnn::DefaultQueueId,
+            input_tensor_a,
+            input_tensor_b,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            {},
+            {},
+            {},
+            true);
+        TT_FATAL(false, "Expected storage type validation to fail, but operation succeeded");
+    } catch (const std::exception& e) {
+        // Expected to fail
+        fmt::print("Successfully caught storage type validation error: {}\n", e.what());
+    }
+}
+
+void test_binary_ng_storage_type_validation_host_tensor(tt::tt_metal::distributed::MeshDevice* device) {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
+
+    // Create host tensors (not on device)
+    auto input_tensor_a = ttnn::random::random(shape, DataType::BFLOAT16);
+    auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16);
+
+    // Verify these are host tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor A should be HOST storage type");
+    TT_FATAL(
+        input_tensor_b.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor B should be HOST storage type");
+
+    // This should fail with storage type validation error
+    // We expect a TT_FATAL assertion to be triggered
+    try {
+        auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
+            ttnn::DefaultQueueId,
+            input_tensor_a,
+            input_tensor_b,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            {},
+            {},
+            {},
+            false);
+        TT_FATAL(false, "Expected storage type validation to fail, but operation succeeded");
+    } catch (const std::exception& e) {
+        // Expected to fail
+        fmt::print("Successfully caught storage type validation error: {}\n", e.what());
+    }
+}
+
+int main() {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    int device_id = 0;
+    auto device_owner = MeshDevice::create_unit_mesh(device_id);
+    auto device = device_owner.get();
+
+    fmt::print("Testing binary operation storage type validation with host tensors...\n");
+    test_binary_storage_type_validation_host_tensor(device);
+
+    fmt::print("Testing binary_ng operation storage type validation with host tensors...\n");
+    test_binary_ng_storage_type_validation_host_tensor(device);
+
+    fmt::print("All storage type validation tests passed!\n");
+    return 0;
+}

--- a/tests/tt_eager/ops/test_storage_type_validation.cpp
+++ b/tests/tt_eager/ops/test_storage_type_validation.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <tt-metalium/constants.hpp>
 #include <functional>
+#include <gtest/gtest.h>
 
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/bfloat16.hpp>
@@ -26,7 +27,23 @@ using tt::tt_metal::Layout;
 using tt::tt_metal::Tensor;
 using tt::tt_metal::distributed::MeshDevice;
 
-void test_binary_storage_type_validation_host_tensor(tt::tt_metal::distributed::MeshDevice* device) {
+class StorageTypeValidationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        int device_id = 0;
+        device_owner = MeshDevice::create_unit_mesh(device_id);
+        device = device_owner.get();
+    }
+
+    void TearDown() override { device_owner.reset(); }
+
+    std::shared_ptr<MeshDevice> device_owner;
+    MeshDevice* device;
+};
+
+// Helper function to create host tensors and call binary operation
+// This function will crash when called with host tensors, which is what we want to test
+void call_binary_with_host_tensors(bool use_legacy) {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
 
@@ -44,7 +61,50 @@ void test_binary_storage_type_validation_host_tensor(tt::tt_metal::distributed::
 
     // This should fail with storage type validation error
     // We expect a TT_FATAL assertion to be triggered
-    try {
+    auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
+        ttnn::DefaultQueueId,
+        input_tensor_a,
+        input_tensor_b,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        {},
+        {},
+        {},
+        use_legacy);
+
+    // If we get here, the validation failed (which is bad)
+    TT_FATAL(false, "Expected storage type validation to fail, but operation succeeded");
+}
+
+TEST_F(StorageTypeValidationTest, BinaryOperationHostTensorValidation) {
+    // Test that binary operation (use_legacy=true) crashes when given host tensors
+    // This is the expected behavior - our storage type validation should prevent host tensors
+    EXPECT_DEATH(call_binary_with_host_tensors(true), ".*");
+}
+
+TEST_F(StorageTypeValidationTest, BinaryNgOperationHostTensorValidation) {
+    // Test that binary_ng operation (use_legacy=false) crashes when given host tensors
+    // This is the expected behavior - our storage type validation should prevent host tensors
+    EXPECT_DEATH(call_binary_with_host_tensors(false), ".*");
+}
+
+TEST_F(StorageTypeValidationTest, DeviceTensorsWorkCorrectly) {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
+
+    // Create tensors in TILE layout first, then move to device (should work)
+    auto input_tensor_a = ttnn::random::random(shape, DataType::BFLOAT16).to_layout(Layout::TILE).to_device(device);
+    auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16).to_layout(Layout::TILE).to_device(device);
+
+    // Verify these are device tensors
+    EXPECT_EQ(input_tensor_a.storage_type(), tt::tt_metal::StorageType::DEVICE);
+    EXPECT_EQ(input_tensor_b.storage_type(), tt::tt_metal::StorageType::DEVICE);
+
+    // This should work without crashing
+    EXPECT_NO_THROW({
         auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
             ttnn::DefaultQueueId,
             input_tensor_a,
@@ -56,64 +116,10 @@ void test_binary_storage_type_validation_host_tensor(tt::tt_metal::distributed::
             {},
             {},
             true);
-        TT_FATAL(false, "Expected storage type validation to fail, but operation succeeded");
-    } catch (const std::exception& e) {
-        // Expected to fail
-        fmt::print("Successfully caught storage type validation error: {}\n", e.what());
-    }
+    });
 }
 
-void test_binary_ng_storage_type_validation_host_tensor(tt::tt_metal::distributed::MeshDevice* device) {
-    using tt::constants::TILE_HEIGHT;
-    using tt::constants::TILE_WIDTH;
-
-    ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
-
-    // Create host tensors (not on device)
-    auto input_tensor_a = ttnn::random::random(shape, DataType::BFLOAT16);
-    auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16);
-
-    // Verify these are host tensors
-    TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor A should be HOST storage type");
-    TT_FATAL(
-        input_tensor_b.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor B should be HOST storage type");
-
-    // This should fail with storage type validation error
-    // We expect a TT_FATAL assertion to be triggered
-    try {
-        auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
-            ttnn::DefaultQueueId,
-            input_tensor_a,
-            input_tensor_b,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            {},
-            {},
-            {},
-            false);
-        TT_FATAL(false, "Expected storage type validation to fail, but operation succeeded");
-    } catch (const std::exception& e) {
-        // Expected to fail
-        fmt::print("Successfully caught storage type validation error: {}\n", e.what());
-    }
-}
-
-int main() {
-    using tt::constants::TILE_HEIGHT;
-    using tt::constants::TILE_WIDTH;
-
-    int device_id = 0;
-    auto device_owner = MeshDevice::create_unit_mesh(device_id);
-    auto device = device_owner.get();
-
-    fmt::print("Testing binary operation storage type validation with host tensors...\n");
-    test_binary_storage_type_validation_host_tensor(device);
-
-    fmt::print("Testing binary_ng operation storage type validation with host tensors...\n");
-    test_binary_ng_storage_type_validation_host_tensor(device);
-
-    fmt::print("All storage type validation tests passed!\n");
-    return 0;
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/tt_eager/ops/test_storage_type_validation.cpp
+++ b/tests/tt_eager/ops/test_storage_type_validation.cpp
@@ -41,54 +41,6 @@ protected:
     MeshDevice* device;
 };
 
-// Helper function to create host tensors and call binary operation
-// This function will crash when called with host tensors, which is what we want to test
-void call_binary_with_host_tensors(bool use_legacy) {
-    using tt::constants::TILE_HEIGHT;
-    using tt::constants::TILE_WIDTH;
-
-    ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
-
-    // Create host tensors (not on device)
-    auto input_tensor_a = ttnn::random::random(shape, DataType::BFLOAT16);
-    auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16);
-
-    // Verify these are host tensors
-    TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor A should be HOST storage type");
-    TT_FATAL(
-        input_tensor_b.storage_type() == tt::tt_metal::StorageType::HOST, "Input tensor B should be HOST storage type");
-
-    // This should fail with storage type validation error
-    // We expect a TT_FATAL assertion to be triggered
-    auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
-        ttnn::DefaultQueueId,
-        input_tensor_a,
-        input_tensor_b,
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
-        {},
-        {},
-        {},
-        use_legacy);
-
-    // If we get here, the validation failed (which is bad)
-    TT_FATAL(false, "Expected storage type validation to fail, but operation succeeded");
-}
-
-TEST_F(StorageTypeValidationTest, BinaryOperationHostTensorValidation) {
-    // Test that binary operation (use_legacy=true) crashes when given host tensors
-    // This is the expected behavior - our storage type validation should prevent host tensors
-    EXPECT_DEATH(call_binary_with_host_tensors(true), ".*");
-}
-
-TEST_F(StorageTypeValidationTest, BinaryNgOperationHostTensorValidation) {
-    // Test that binary_ng operation (use_legacy=false) crashes when given host tensors
-    // This is the expected behavior - our storage type validation should prevent host tensors
-    EXPECT_DEATH(call_binary_with_host_tensors(false), ".*");
-}
-
 TEST_F(StorageTypeValidationTest, DeviceTensorsWorkCorrectly) {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
@@ -116,6 +68,36 @@ TEST_F(StorageTypeValidationTest, DeviceTensorsWorkCorrectly) {
             {},
             {},
             true);
+    });
+}
+
+TEST_F(StorageTypeValidationTest, BinaryNgOperationDeviceTensorsWorkCorrectly) {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
+
+    // Create tensors in TILE layout first, then move to device (should work)
+    auto input_tensor_a = ttnn::random::random(shape, DataType::BFLOAT16).to_layout(Layout::TILE).to_device(device);
+    auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16).to_layout(Layout::TILE).to_device(device);
+
+    // Verify these are device tensors
+    EXPECT_EQ(input_tensor_a.storage_type(), tt::tt_metal::StorageType::DEVICE);
+    EXPECT_EQ(input_tensor_b.storage_type(), tt::tt_metal::StorageType::DEVICE);
+
+    // This should work without crashing
+    EXPECT_NO_THROW({
+        auto result = ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>::invoke(
+            ttnn::DefaultQueueId,
+            input_tensor_a,
+            input_tensor_b,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            {},
+            {},
+            {},
+            false);
     });
 }
 

--- a/tests/tt_eager/ops/test_storage_type_validation.cpp
+++ b/tests/tt_eager/ops/test_storage_type_validation.cpp
@@ -38,7 +38,7 @@ protected:
     void TearDown() override { device_owner.reset(); }
 
     std::shared_ptr<MeshDevice> device_owner;
-    MeshDevice* device;
+    MeshDevice* device{};
 };
 
 // Helper function to create host tensors and call binary operation

--- a/tests/ttnn/unit_tests/operations/eltwise/test_storage_type_validation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_storage_type_validation.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 import ttnn
-import random
 
 # Set fixed random seeds for deterministic test execution
 torch.manual_seed(42)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_storage_type_validation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_storage_type_validation.py
@@ -5,6 +5,10 @@
 import torch
 import pytest
 import ttnn
+import random
+
+# Set fixed random seeds for deterministic test execution
+torch.manual_seed(42)
 
 
 def test_binary_add_storage_type_validation_device_tensors(device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_storage_type_validation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_storage_type_validation.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+
+def test_binary_add_storage_type_validation_device_tensors(device):
+    """Test that binary add (use_legacy=True) works correctly with device tensors."""
+    # Create tensors on device (should work)
+    x_torch = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    y_torch = torch.tensor([[0.5, 1.5], [2.5, 3.5]], dtype=torch.float32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Verify these are device tensors
+    assert x_tt.storage_type() == ttnn.StorageType.DEVICE
+    assert y_tt.storage_type() == ttnn.StorageType.DEVICE
+
+    # This should work without errors
+    result = ttnn.add(x_tt, y_tt, use_legacy=True)
+    result_torch = ttnn.to_torch(result)
+
+    expected = x_torch + y_torch
+    assert torch.allclose(result_torch, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_binary_ng_add_storage_type_validation_device_tensors(device):
+    """Test that binary_ng add (use_legacy=False) works correctly with device tensors."""
+    # Create tensors on device (should work)
+    x_torch = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    y_torch = torch.tensor([[0.5, 1.5], [2.5, 3.5]], dtype=torch.float32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Verify these are device tensors
+    assert x_tt.storage_type() == ttnn.StorageType.DEVICE
+    assert y_tt.storage_type() == ttnn.StorageType.DEVICE
+
+    # This should work without errors
+    result = ttnn.add(x_tt, y_tt, use_legacy=False)
+    result_torch = ttnn.to_torch(result)
+
+    expected = x_torch + y_torch
+    assert torch.allclose(result_torch, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_binary_add_storage_type_validation_host_tensors():
+    """Test that binary add (use_legacy=True) raises runtime error when given host tensors."""
+    # Create tensors without device (should be host tensors)
+    x_torch = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    y_torch = torch.tensor([[0.5, 1.5], [2.5, 3.5]], dtype=torch.float32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+
+    # Verify these are host tensors
+    assert x_tt.storage_type() == ttnn.StorageType.HOST
+    assert y_tt.storage_type() == ttnn.StorageType.HOST
+
+    # This should raise a runtime error due to our storage type validation
+    with pytest.raises(RuntimeError, match="Input tensor A must be on device"):
+        ttnn.add(x_tt, y_tt, use_legacy=True)
+
+
+def test_binary_ng_add_storage_type_validation_host_tensors():
+    """Test that binary_ng add (use_legacy=False) raises runtime error when given host tensors."""
+    # Create tensors without device (should be host tensors)
+    x_torch = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    y_torch = torch.tensor([[0.5, 1.5], [2.5, 3.5]], dtype=torch.float32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+
+    # Verify these are host tensors
+    assert x_tt.storage_type() == ttnn.StorageType.HOST
+    assert y_tt.storage_type() == ttnn.StorageType.HOST
+
+    # This should raise a runtime error due to our storage type validation
+    with pytest.raises(RuntimeError, match="Input tensor A must be on device"):
+        ttnn.add(x_tt, y_tt, use_legacy=False)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -17,20 +17,22 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::binary {
 
 namespace utils {
-    bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
+bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
     switch (val) {
         case BinaryOpType::ADD:
         case BinaryOpType::SUB:
-            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
-                || (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
+            return (
+                (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) ||
+                (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::MUL:
         case BinaryOpType::EQ:
         case BinaryOpType::NE:
         case BinaryOpType::LOGICAL_AND:
         case BinaryOpType::LOGICAL_OR:
         case BinaryOpType::LOGICAL_XOR:
-            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
-                || (a == DataType::UINT16 && b == DataType::UINT16));
+            return (
+                (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) ||
+                (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::DIV:
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:
@@ -41,15 +43,19 @@ namespace utils {
         case BinaryOpType::GT:
         case BinaryOpType::LT:
         case BinaryOpType::GE:
-        case BinaryOpType::LE:return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32));
+        case BinaryOpType::LE:
+            return (
+                (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32));
         case BinaryOpType::GCD:
         case BinaryOpType::LCM:
         case BinaryOpType::LEFT_SHIFT:
         case BinaryOpType::RIGHT_SHIFT:
-        case BinaryOpType::LOGICAL_RIGHT_SHIFT: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT32 && b == DataType::UINT32));
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT:
+            return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT32 && b == DataType::UINT32));
         case BinaryOpType::BITWISE_XOR:
         case BinaryOpType::BITWISE_OR:
-        case BinaryOpType::BITWISE_AND: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));
+        case BinaryOpType::BITWISE_AND:
+            return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::MAXIMUM:
         case BinaryOpType::MINIMUM:
         case BinaryOpType::XLOGY:
@@ -58,7 +64,7 @@ namespace utils {
     }
     return false;
 }
-} // utils
+}  // namespace utils
 
 BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
@@ -82,7 +88,7 @@ BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_f
         DataType dtype1 = tensor_args.input_tensor_a.dtype();
         DataType dtype2 = tensor_args.input_tensor_b->dtype();
         bool sfpu_op_check = utils::is_binary_sfpu_op(op, dtype1, dtype2);
-        if(sfpu_op_check){
+        if (sfpu_op_check) {
             return ElementWiseMultiCoreSfpu{};
         } else {
             return ElementWiseMultiCore{};
@@ -94,8 +100,7 @@ BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_f
         }
         if (height_b == 1) {
             if (tensor_args.input_tensor_a.is_sharded()) {
-                if (tensor_args.input_tensor_a.padded_shape()[0] ==
-                        tensor_args.input_tensor_b->padded_shape()[0] ||
+                if (tensor_args.input_tensor_a.padded_shape()[0] == tensor_args.input_tensor_b->padded_shape()[0] ||
                     tensor_args.input_tensor_a.padded_shape()[0] > 1 and
                         tensor_args.input_tensor_b->padded_shape()[0] == 1) {
                     return BroadcastHeightMultiCoreShardedOptimized{};
@@ -117,7 +122,21 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
-    TT_FATAL(input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
+    // Validate storage type for input tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must have DEVICE storage type, got {}",
+        input_tensor_a.storage_type());
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(
+            input_tensor_b->storage_type() == StorageType::DEVICE,
+            "Input tensor B must have DEVICE storage type, got {}",
+            input_tensor_b->storage_type());
+    }
+
+    TT_FATAL(
+        input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
 
     BinaryDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
 
@@ -138,18 +157,21 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     if (input_tensor_a.memory_config().is_sharded()) {
         if (tensor_b_sharded) {
             TT_FATAL(
-                input_tensor_a.memory_config().memory_layout() == input_tensor_b->memory_config().memory_layout(), "Error");
+                input_tensor_a.memory_config().memory_layout() == input_tensor_b->memory_config().memory_layout(),
+                "Error");
             TT_FATAL(input_tensor_a.shard_spec().value() == input_tensor_b->shard_spec().value(), "Error");
         }
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
         } else {
             TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         }
     } else if (tensor_b_sharded) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(input_tensor_b->memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
+            TT_FATAL(
+                input_tensor_b->memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
         } else {
             TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         }
@@ -203,8 +225,12 @@ void BinaryDeviceOperation::validate_on_program_cache_hit(
             "ttnn::operations::binary::BinaryDeviceOperation: batch size mismatch");
     }
 
-    TT_FATAL(height_a == height_b || height_a == 1 || height_b == 1, "ttnn::operations::binary::BinaryDeviceOperation: height mismatch");
-    TT_FATAL(width_a == width_b || width_a == 1 || width_b == 1, "ttnn::operations::binary::BinaryDeviceOperation: width mismatch");
+    TT_FATAL(
+        height_a == height_b || height_a == 1 || height_b == 1,
+        "ttnn::operations::binary::BinaryDeviceOperation: height mismatch");
+    TT_FATAL(
+        width_a == width_b || width_a == 1 || width_b == 1,
+        "ttnn::operations::binary::BinaryDeviceOperation: width mismatch");
 }
 
 BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output_specs(
@@ -247,7 +273,8 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
     auto output_shape = compute_broadcasted_output(input_shape_a, input_shape_b);
 
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
-    if (std::holds_alternative<ElementWiseMultiCore>(program_factory) or std::holds_alternative<ElementWiseMultiCoreSfpu>(program_factory)) {
+    if (std::holds_alternative<ElementWiseMultiCore>(program_factory) or
+        std::holds_alternative<ElementWiseMultiCoreSfpu>(program_factory)) {
         const auto& input_tensor_b = *tensor_args.input_tensor_b;
         if (operation_attributes.memory_config.is_sharded()) {
             ShardSpec shard_spec{CoreRangeSet(), {0, 0}};
@@ -259,7 +286,8 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
                 shard_spec = operation_attributes.memory_config.shard_spec().value();
             }
             auto memory_config = operation_attributes.memory_config.with_shard_spec(shard_spec);
-            return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
+            return TensorSpec(
+                output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
         }
     } else {
         if (operation_attributes.memory_config.is_sharded()) {
@@ -269,10 +297,13 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
                 shard_spec = input_tensor_a.shard_spec().value();
             }
             auto memory_config = operation_attributes.memory_config.with_shard_spec(shard_spec);
-            return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
+            return TensorSpec(
+                output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
         }
     }
-    return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
+    return TensorSpec(
+        output_shape,
+        TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
 }
 
 BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_output_tensors(
@@ -280,7 +311,8 @@ BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_outpu
     if (tensor_args.output_tensor.has_value()) {
         return *tensor_args.output_tensor;
     }
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
 tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
@@ -310,13 +342,11 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
     }
 
     return operation::hash_operation<BinaryDeviceOperation>(
-        attributes,
-        program_factory.index(),
-        input_tensor_a.dtype(),
-        input_tensor_a.memory_config());
+        attributes, program_factory.index(), input_tensor_a.dtype(), input_tensor_a.memory_config());
 }
 
-operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_t> BinaryDeviceOperation::create_op_performance_model(
+operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_t>
+BinaryDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -338,7 +368,8 @@ operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_
     uint32_t ideal_eltwise_cycles = total_bytes / 80 / num_cores;
 
     // TODO: update OpPerformanceModel to work on variadic arguments
-    operation::OpPerformanceModelGeneral<tensor_return_value_t> result(input_tensors, output_tensor, ideal_eltwise_cycles);
+    operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        input_tensors, output_tensor, ideal_eltwise_cycles);
 #if 0
         log_info(tt::LogOp, "BinaryDeviceOperation PerfModel:");
         log_info(tt::LogOp, "\t Data (Bytes): {}", total_bytes);
@@ -415,7 +446,9 @@ BinaryDeviceOperation::invoke(
             std::move(activations),
             std::move(input_tensor_a_activation),
             std::nullopt,
-            memory_config.value_or(optional_output_tensor.has_value() ? optional_output_tensor->memory_config() : input_tensor_a_arg.memory_config()),
+            memory_config.value_or(
+                optional_output_tensor.has_value() ? optional_output_tensor->memory_config()
+                                                   : input_tensor_a_arg.memory_config()),
             output_dtype.value_or(input_tensor_a_arg.dtype()),
             std::move(worker_grid),
             std::nullopt},

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -401,16 +401,6 @@ BinaryDeviceOperation::invoke(
             "If both output dtype and output tensor provided dtype should match");
     }
 
-    TT_FATAL(
-        input_tensor_a.storage_type() == StorageType::DEVICE,
-        "Input tensor A must be on device, got storage type: {}",
-        input_tensor_a.storage_type());
-
-    TT_FATAL(
-        input_tensor_b.storage_type() == StorageType::DEVICE,
-        "Input tensor B must be on device, got storage type: {}",
-        input_tensor_b.storage_type());
-
     CoreRangeSet worker_grid;
     // We assert all shard specs are the same if sharded, so only need to check the first shard spec
     // This will create the worker grid based on the used sub-devices when sharded

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -123,15 +123,15 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
     // Validate storage type for input tensors
-    TT_FATAL(
+    TT_ASSERT(
         input_tensor_a.storage_type() == StorageType::DEVICE,
-        "Input tensor A must have DEVICE storage type, got {}",
+        "Input tensor A must be on device, got storage type: {}",
         input_tensor_a.storage_type());
 
     if (input_tensor_b.has_value()) {
-        TT_FATAL(
+        TT_ASSERT(
             input_tensor_b->storage_type() == StorageType::DEVICE,
-            "Input tensor B must have DEVICE storage type, got {}",
+            "Input tensor B must be on device, got storage type: {}",
             input_tensor_b->storage_type());
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -401,6 +401,16 @@ BinaryDeviceOperation::invoke(
             "If both output dtype and output tensor provided dtype should match");
     }
 
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    TT_FATAL(
+        input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Input tensor B must be on device, got storage type: {}",
+        input_tensor_b.storage_type());
+
     CoreRangeSet worker_grid;
     // We assert all shard specs are the same if sharded, so only need to check the first shard spec
     // This will create the worker grid based on the used sub-devices when sharded

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -179,15 +179,15 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
     const auto& output_tensor = tensor_args.output_tensor;
 
     // Validate storage type for input tensors
-    TT_FATAL(
+    TT_ASSERT(
         input_tensor_a.storage_type() == StorageType::DEVICE,
-        "Input tensor A must have DEVICE storage type, got {}",
+        "Input tensor A must be on device, got storage type: {}",
         input_tensor_a.storage_type());
 
     if (input_tensor_b.has_value()) {
-        TT_FATAL(
+        TT_ASSERT(
             input_tensor_b->storage_type() == StorageType::DEVICE,
-            "Input tensor B must have DEVICE storage type, got {}",
+            "Input tensor B must be on device, got storage type: {}",
             input_tensor_b->storage_type());
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -178,6 +178,19 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& output_tensor = tensor_args.output_tensor;
 
+    // Validate storage type for input tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must have DEVICE storage type, got {}",
+        input_tensor_a.storage_type());
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(
+            input_tensor_b->storage_type() == StorageType::DEVICE,
+            "Input tensor B must have DEVICE storage type, got {}",
+            input_tensor_b->storage_type());
+    }
+
     TT_FATAL(
         input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -466,6 +466,16 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> post_activations) {
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    TT_FATAL(
+        input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Input tensor B must be on device, got storage type: {}",
+        input_tensor_b.storage_type());
+
     auto subtile_broadcast_type = get_subtile_broadcast_type(
         input_tensor_a.logical_shape()[-2],
         input_tensor_a.logical_shape()[-1],

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -466,16 +466,6 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> post_activations) {
-    TT_FATAL(
-        input_tensor_a.storage_type() == StorageType::DEVICE,
-        "Input tensor A must be on device, got storage type: {}",
-        input_tensor_a.storage_type());
-
-    TT_FATAL(
-        input_tensor_b.storage_type() == StorageType::DEVICE,
-        "Input tensor B must be on device, got storage type: {}",
-        input_tensor_b.storage_type());
-
     auto subtile_broadcast_type = get_subtile_broadcast_type(
         input_tensor_a.logical_shape()[-2],
         input_tensor_a.logical_shape()[-1],


### PR DESCRIPTION
…nary_ng operations

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27455)

### Problem description
Binary and binary_ng did not check against tensor on device.

### What's changed

***** Note this PR is made using Cursor Agent auto while I am guiding it. AI made lot of mistakes and I spent much more time guiding it.

- Add TT_FATAL assertions to check input_tensor_a.storage_type() == StorageType::DEVICE
- Add TT_FATAL assertions to check input_tensor_b.storage_type() == StorageType::DEVICE when present
- Ensures both binary and binary_ng program factories validate device storage type
- Follows the same pattern used in other operations like tanh_accurate

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes