### PR TITLE
Change DeepSeek to route to minimal all gather

### DIFF
--- a/models/demos/deepseek_v3/tt/ccl_1d.py
+++ b/models/demos/deepseek_v3/tt/ccl_1d.py
@@ -19,14 +19,25 @@ class CCL1D:
         self.gather_sems = []
         self.from_sems = []
         self.to_sems = []
+        self.point_to_point_sems = []
         for _ in range(len(list(mesh_device.shape))):
             self.gather_sems.append([])
             self.from_sems.append([])
             self.to_sems.append([])
+            self.point_to_point_sems.append([])
             for _ in range(2):
-                self.gather_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
+                self.gather_sems[-1].append(
+                    [
+                        ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
+                        ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
+                    ]
+                )  # use two semaphores to use minimal version of all_gather_async
                 self.from_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
                 self.to_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
+                self.point_to_point_sems[-1].append(
+                    ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0)
+                )
+
         self.sem_cnt = [0, 0]
 
     def get_max_links(self, axis):
@@ -74,3 +85,11 @@ class CCL1D:
         buffer = None
 
         return buffer
+
+    def get_point_to_point_sem(self, axis):
+        """
+        Get a semaphore for the given axis.
+        """
+        sem = self.point_to_point_sems[axis][self.sem_cnt[axis]]
+        self.sem_cnt[axis] = (self.sem_cnt[axis] + 1) % 2
+        return sem

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
@@ -131,7 +131,7 @@ class MoEDecoderBlock(DecoderBlockBase):
             ],
             "shared_expert": SharedExpert.create_state(hf_config, mesh_device, ccl),
             "apply_dp": {
-                "semaphore": ccl.get_gather_sem(0),
+                "semaphore": ccl.get_point_to_point_sem(0),
             },
             "revert_dp": {
                 "multi_device_global_semaphore": ccl.get_gather_sem(0),

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -240,7 +240,7 @@ class LMHead(AbstractModule):
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "mesh_scatter": {
-                "semaphores": (ccl.get_gather_sem(0), ccl.get_gather_sem(1)),
+                "semaphores": (ccl.get_point_to_point_sem(0), ccl.get_point_to_point_sem(1)),
             },
         }
 

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -197,7 +197,7 @@ class Model1D(SharedStateAddOn, AbstractModule):
                 for _ in range(cls.NUM_MLP_META_LAYERS)
             ],
             "transfer_row": {
-                "semaphore": ccl.get_gather_sem(0),
+                "semaphore": ccl.get_point_to_point_sem(0),
             },
             "norm": DistributedRMSNorm.create_state(hf_config, mesh_device, ccl),
         }


### PR DESCRIPTION
### Ticket
#27377

### Problem description
DeepSeek routes to the command processor all gather which does not have all the optimizations or handshaking that minimal all gather does, resulting in a race and poor performance.

### What's changed
Use two semaphores instead of one, which will route you to the final all gather. Create a different set of semaphores for the point to point operation.

### TODO
Part of our plan going forward is to delete the command processor version and internalize the semaphore creation. We don't want to internalize the semaphore creation to a deprecated implementation, so we want to delete the command processor version. To do that, we need to first remove it from the codebase.

### Checklist
- [ ] DeepSeek Pipelines: https://github.com/tenstorrent/tt-metal/actions/runs/17254517296