### PR TITLE
[skip ci] bugprone-suspicious-include

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,7 @@ Checks: >
   -bugprone-reserved-identifier,
   -bugprone-sizeof-expression,
   -bugprone-string-integer-assignment,
-  -bugprone-suspicious-include,
+  bugprone-suspicious-include,
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-switch-missing-default-case,
   -bugprone-unchecked-optional-access,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,6 @@ Checks: >
   -bugprone-reserved-identifier,
   -bugprone-sizeof-expression,
   -bugprone-string-integer-assignment,
-  bugprone-suspicious-include,
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-switch-missing-default-case,
   -bugprone-unchecked-optional-access,


### PR DESCRIPTION
### Ticket
#19041 
Closes #27480 

### Problem description
This check is disabled. At one point there was a cpp file being included in ttnn.

https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-include.html

### What's changed
- Enable check