### PR TITLE
Fix clang-tidy warning about multiple moves in mesh_device.cpp

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -98,12 +98,15 @@ decltype(auto) validate_and_get_reference_value(
         TT_THROW("{} [{}:{}] failed: MeshDevice has no devices", loc.function_name(), loc.file_name(), loc.line());
     }
 
+    // Forward the callable once to preserve its value category.
+    auto&& callable = std::forward<F>(func);
+
     // Get reference to first device's value
-    decltype(auto) reference_value = std::forward<F>(func)(devices.front());
+    decltype(auto) reference_value = callable(devices.front());
 
     // Validate all other devices match
     for (auto it = devices.begin() + 1; it != devices.end(); ++it) {
-        const auto& current_value = std::forward<F>(func)(*it);
+        decltype(auto) current_value = callable(*it);
         if (current_value != reference_value) {
             TT_THROW(
                 "{} [{}:{}] failed: Device at index {} returned value that differs from reference. "


### PR DESCRIPTION
### Ticket
[N/A
](https://github.com/tenstorrent/tt-metal/issues/27474)

### Problem description
Clang-tidy warned about using std::forward multiple times on the same callable in validate_and_get_reference_value. While safe for stateless lambdas, this pattern is problematic for stateful callables (functors, capturing lambdas) where multiple forwards can cause undefined behavior by moving from an already-moved object.

### What's changed
- Modified mesh_device.cpp to forward the callable only once at the beginning of the function
- Store the forwarded callable in a local variable to preserve its value category
- Use the stored callable for all subsequent invocations instead of forwarding multiple times

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes