### PR TITLE
Added support for a precomputed grid in grid sample

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/pool/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         grid_sample/device/grid_sample_op.cpp
         grid_sample/device/grid_sample_program_factory.cpp
         grid_sample/grid_sample.cpp
+        grid_sample/grid_sample_prepare_grid.cpp
         pool_utils.cpp
         upsample/device//upsample_bilinear_program_factory_multicore.cpp
         upsample/device/upsample_op.cpp

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -487,7 +487,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_scalar_cb_id_1,              // 10
         out_cb_id,                      // 11
         one_scalar_per_core,
-        num_of_pages_to_reserve_back};          // 12
+        num_of_pages_to_reserve_back};  // 12
 
     auto compute_config = tt::tt_metal::ComputeConfig{
         .math_fidelity = MathFidelity::HiFi4,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
@@ -24,7 +24,16 @@ void GridSample::validate(const std::vector<Tensor>& input_tensors) const {
     // Shape validation
     TT_FATAL(input_tensor.logical_shape().rank() == 4, "Input tensor must be 4D (N, C, H, W)");
     TT_FATAL(grid_tensor.logical_shape().rank() == 4, "Grid tensor must be 4D (N, H_out, W_out, 2)");
-    TT_FATAL(grid_tensor.logical_shape()[-1] == 2, "Grid tensor last dimension must be 2 (x, y coordinates)");
+
+    if (use_precomputed_grid_) {
+        TT_FATAL(
+            grid_tensor.logical_shape()[-1] == 6,
+            "Grid tensor last dimension must be 6 (h_nw, w_nw, weight_nw, weight_ne, weight_sw, weight_se)");
+    } else {
+        TT_FATAL(
+            grid_tensor.logical_shape()[-1] == 2, "Grid tensor last dimension must be 2 (x, y relative coordinates)");
+    }
+
     TT_FATAL(
         input_tensor.logical_shape()[0] == grid_tensor.logical_shape()[0],
         "Batch size mismatch between input and grid");
@@ -40,7 +49,6 @@ void GridSample::validate(const std::vector<Tensor>& input_tensors) const {
     // Parameter validation - currently only support fixed configuration
     TT_FATAL(mode_ == "bilinear", "Only bilinear interpolation mode is currently supported");
     TT_FATAL(padding_mode_ == "zeros", "Only zeros padding mode is currently supported");
-    TT_FATAL(!use_precomputed_grid_, "Only use_precomputed_grid=false is currently supported");
 
     // Memory layout validation - for now only support interleaved
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -215,8 +215,17 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp";
 
+    // Create reader defines for precomputed grid
+    std::map<std::string, std::string> reader_defines;
+    if (use_precomputed_grid) {
+        reader_defines["USE_PRECOMPUTED_GRID"] = "1";
+    }
+
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, reader_kernel_path, all_cores, tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        program,
+        reader_kernel_path,
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program, writer_kernel_path, all_cores, tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
+#include "grid_sample_prepare_grid.hpp"
 
 namespace ttnn {
 namespace operations {
@@ -43,5 +44,8 @@ struct ExecuteGridSample {
 // Register the operation
 constexpr auto grid_sample =
     ttnn::register_operation<"ttnn::grid_sample", ttnn::operations::grid_sample::ExecuteGridSample>();
+
+// Import prepare function to main ttnn namespace
+using ttnn::operations::grid_sample::prepare_grid_sample_grid;
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_sample_prepare_grid.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
+#include "tt-metalium/bfloat16.hpp"
+#include "tt-metalium/host_buffer.hpp"
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+namespace ttnn {
+namespace operations {
+namespace grid_sample {
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Helper function to create host buffer for grid preprocessing
+template <typename InputType, typename OutputType>
+tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_shape,
+    const std::vector<uint32_t>& tensor_input_shape,
+    DataType output_dtype) {
+    auto input_buffer = tt::tt_metal::host_buffer::get_as<InputType>(input_tensor);
+    std::vector<OutputType> output_buffer(output_shape.volume());
+
+    // Extract dimensions
+    uint32_t batch_size = tensor_input_shape[0];
+    uint32_t input_h = tensor_input_shape[1];
+    uint32_t input_w = tensor_input_shape[2];
+    uint32_t channels = tensor_input_shape[3];
+
+    // Extract dimensions from grid tensor shape
+    auto grid_shape = input_tensor.logical_shape();
+    uint32_t grid_n = grid_shape[0];
+    uint32_t grid_h = grid_shape[1];
+    uint32_t grid_w = grid_shape[2];
+
+    // Scale factors for coordinate transformation (align_corners=False)
+    float height_scale = static_cast<float>(input_h) * 0.5f;
+    float height_offset = height_scale - 0.5f;
+    float width_scale = static_cast<float>(input_w) * 0.5f;
+    float width_offset = width_scale - 0.5f;
+
+    // Process each grid point
+    for (uint32_t n = 0; n < grid_n; n++) {
+        for (uint32_t h = 0; h < grid_h; h++) {
+            for (uint32_t w = 0; w < grid_w; w++) {
+                // Calculate input indices for grid coordinates
+                uint32_t x_idx = ((n * grid_h + h) * grid_w + w) * 2 + 0;  // x coordinate
+                uint32_t y_idx = ((n * grid_h + h) * grid_w + w) * 2 + 1;  // y coordinate
+
+                // Extract normalized coordinates [-1, 1]
+                float x_coord = static_cast<float>(input_buffer[x_idx]);
+                float y_coord = static_cast<float>(input_buffer[y_idx]);
+
+                // Transform to image coordinates
+                float h_coord_image = y_coord * height_scale + height_offset;
+                float w_coord_image = x_coord * width_scale + width_offset;
+
+                // Get corner pixel coordinates (floor operation)
+                int32_t h0 = static_cast<int32_t>(std::floor(h_coord_image));
+                int32_t w0 = static_cast<int32_t>(std::floor(w_coord_image));
+                int32_t h1 = h0 + 1;
+                int32_t w1 = w0 + 1;
+
+                // Boundary checks
+                bool h0_valid = (h0 >= 0) && (h0 < static_cast<int32_t>(input_h));
+                bool h1_valid = (h1 >= 0) && (h1 < static_cast<int32_t>(input_h));
+                bool w0_valid = (w0 >= 0) && (w0 < static_cast<int32_t>(input_w));
+                bool w1_valid = (w1 >= 0) && (w1 < static_cast<int32_t>(input_w));
+
+                // Calculate interpolation weights
+                float h_frac = h_coord_image - static_cast<float>(h0);
+                float w_frac = w_coord_image - static_cast<float>(w0);
+                float h_frac_inv = 1.0f - h_frac;
+                float w_frac_inv = 1.0f - w_frac;
+
+                // Compute bilinear weights with boundary conditions
+                float weight_nw = (h0_valid && w0_valid) ? h_frac_inv * w_frac_inv : 0.0f;
+                float weight_ne = (h0_valid && w1_valid) ? h_frac_inv * w_frac : 0.0f;
+                float weight_sw = (h1_valid && w0_valid) ? h_frac * w_frac_inv : 0.0f;
+                float weight_se = (h1_valid && w1_valid) ? h_frac * w_frac : 0.0f;
+
+                // Clamp coordinates to 16-bit range for storing as bfloat16
+                int16_t h0_clamped = static_cast<int16_t>(std::clamp(h0, -32768, 32767));
+                int16_t w0_clamped = static_cast<int16_t>(std::clamp(w0, -32768, 32767));
+
+                // Calculate output indices
+                uint32_t base_idx = ((n * grid_h + h) * grid_w + w) * 6;
+
+                // Store results
+                if constexpr (std::is_same_v<OutputType, bfloat16>) {
+                    // Reinterpret int16 bits as bfloat16 for coordinates
+                    uint16_t h0_bits = static_cast<uint16_t>(h0_clamped);
+                    uint16_t w0_bits = static_cast<uint16_t>(w0_clamped);
+                    output_buffer[base_idx + 0] = bfloat16(h0_bits);
+                    output_buffer[base_idx + 1] = bfloat16(w0_bits);
+
+                    // Convert weights to bfloat16
+                    output_buffer[base_idx + 2] = bfloat16(weight_nw);
+                    output_buffer[base_idx + 3] = bfloat16(weight_ne);
+                    output_buffer[base_idx + 4] = bfloat16(weight_sw);
+                    output_buffer[base_idx + 5] = bfloat16(weight_se);
+                } else {
+                    // For other types, store as-is (mainly for float32)
+                    output_buffer[base_idx + 0] = static_cast<OutputType>(h0_clamped);
+                    output_buffer[base_idx + 1] = static_cast<OutputType>(w0_clamped);
+                    output_buffer[base_idx + 2] = static_cast<OutputType>(weight_nw);
+                    output_buffer[base_idx + 3] = static_cast<OutputType>(weight_ne);
+                    output_buffer[base_idx + 4] = static_cast<OutputType>(weight_sw);
+                    output_buffer[base_idx + 5] = static_cast<OutputType>(weight_se);
+                }
+            }
+        }
+    }
+
+    return tt::tt_metal::HostBuffer(std::move(output_buffer));
+}
+
+// Template function to convert tensor based on input and output types
+template <typename InputType, typename OutputType>
+Tensor convert_grid_tensor(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_shape,
+    const std::vector<uint32_t>& tensor_input_shape,
+    DataType output_dtype) {
+    auto compute = [&](const tt::tt_metal::HostBuffer& input_host_buffer) {
+        return create_host_buffer_for_grid_preprocessing<InputType, OutputType>(
+            input_tensor, output_shape, tensor_input_shape, output_dtype);
+    };
+
+    const TensorSpec output_spec(
+        output_shape,
+        tt::tt_metal::TensorLayout(output_dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
+
+    TT_FATAL(is_cpu_tensor(input_tensor), "Prepare_grid_sample_grid only supports host tensors");
+
+    return Tensor(
+        input_tensor.host_storage().transform(compute),
+        output_spec,
+        input_tensor.distributed_tensor_config(),
+        input_tensor.tensor_topology());
+}
+
+}  // anonymous namespace
+
+ttnn::Tensor prepare_grid_sample_grid(
+    const ttnn::Tensor& grid,
+    const std::vector<uint32_t>& input_shape,
+    const std::string& padding_mode,
+    const std::optional<DataType>& output_dtype) {
+    // Validate inputs
+    TT_FATAL(is_cpu_tensor(grid), "Grid tensor must be on host");
+    TT_FATAL(grid.layout() == Layout::ROW_MAJOR, "Grid tensor must be in row major layout");
+    TT_FATAL(grid.logical_shape().rank() == 4, "Grid tensor must be 4D");
+    TT_FATAL(grid.logical_shape()[-1] == 2, "Grid tensor last dimension must be 2 (x, y coordinates)");
+    TT_FATAL(padding_mode == "zeros", "Currently only 'zeros' padding mode is supported");
+    TT_FATAL(input_shape.size() == 4, "Input shape must have 4 dimensions [N, H, W, C]");
+
+    // Determine output data type
+    DataType out_dtype = output_dtype.value_or(DataType::BFLOAT16);
+
+    // Validate input grid data type
+    TT_FATAL(grid.dtype() == DataType::FLOAT32, "Currently only float32 input grid is supported");
+
+    // Calculate output shape: (N, H_out, W_out, 6)
+    auto grid_shape = grid.logical_shape();
+    ttnn::Shape output_shape({grid_shape[0], grid_shape[1], grid_shape[2], 6});
+
+    // Dispatch based on output data type
+    switch (out_dtype) {
+        case DataType::BFLOAT16:
+            return convert_grid_tensor<float, bfloat16>(grid, output_shape, input_shape, out_dtype);
+        case DataType::FLOAT32: return convert_grid_tensor<float, float>(grid, output_shape, input_shape, out_dtype);
+        default: TT_THROW("Unsupported output data type for prepare_grid_sample_grid: {}", out_dtype);
+    }
+}
+
+}  // namespace grid_sample
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+#include <vector>
+#include <optional>
+
+namespace ttnn {
+namespace operations {
+namespace grid_sample {
+
+/**
+ * Precomputes grid sample data for optimized kernel execution.
+ *
+ * This function takes a normalized grid tensor and precomputes the pixel coordinates
+ * and bilinear interpolation weights needed for grid sampling. This preprocessing
+ * allows for more efficient kernel execution by avoiding repeated coordinate
+ * transformations during the actual sampling operation.
+ *
+ * @param grid Grid tensor of shape (N, H_out, W_out, 2) with normalized coordinates in [-1, 1]
+ * @param input_shape Array containing input tensor dimensions [N, H_in, W_in, C] in NHWC format
+ * @param padding_mode How to handle out-of-bounds coordinates (currently only "zeros" supported)
+ * @param output_dtype Data type for the output tensor (default: bfloat16)
+ *
+ * @return Precomputed grid tensor of shape (N, H_out, W_out, 6) where:
+ *         - [:, :, :, 0]: North-west height coordinate (as integer stored in bfloat16)
+ *         - [:, :, :, 1]: North-west width coordinate (as integer stored in bfloat16)
+ *         - [:, :, :, 2]: Weight for north-west pixel
+ *         - [:, :, :, 3]: Weight for north-east pixel
+ *         - [:, :, :, 4]: Weight for south-west pixel
+ *         - [:, :, :, 5]: Weight for south-east pixel
+ *
+ * The function expects the input grid to be on host with float32 data type and
+ * returns a tensor on host with the specified output data type.
+ */
+ttnn::Tensor prepare_grid_sample_grid(
+    const ttnn::Tensor& grid,
+    const std::vector<uint32_t>& input_shape,
+    const std::string& padding_mode = "zeros",
+    const std::optional<DataType>& output_dtype = std::nullopt);
+
+}  // namespace grid_sample
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_pybind.cpp
@@ -28,18 +28,20 @@ void bind_grid_sample(py::module& module) {
 
         Args:
             input_tensor (ttnn.Tensor): Input tensor of shape (N, H_in, W_in, C) - channel last format
-            grid (ttnn.Tensor): Sampling grid of shape (N, H_out, W_out, 2) containing
-                               normalized coordinates in range [-1, 1]. The last dimension
-                               contains (x, y) coordinates where:
-                               * x=-1 corresponds to leftmost input column
-                               * x=+1 corresponds to rightmost input column
-                               * y=-1 corresponds to topmost input row
-                               * y=+1 corresponds to bottommost input row
+            grid (ttnn.Tensor): Sampling grid with two possible formats:
+                               * Standard mode (use_precomputed_grid=False): Shape (N, H_out, W_out, 2) containing
+                                 normalized coordinates in range [-1, 1]. The last dimension contains (x, y) coordinates where:
+                                 - x=-1 corresponds to leftmost input column, x=+1 to rightmost input column
+                                 - y=-1 corresponds to topmost input row, y=+1 to bottommost input row
+                               * Precomputed mode (use_precomputed_grid=True): Shape (N, H_out, W_out, 6) containing
+                                 precomputed pixel coordinates and bilinear interpolation weights from ttnn.prepare_grid_sample_grid()
 
         Keyword Args:
             mode (str): Interpolation mode. Currently only "bilinear" is supported.
             padding_mode (str): How to handle out-of-bounds coordinates. Currently only "zeros" is supported.
-            use_precomputed_grid (bool): Whether to use precomputed grid coordinates. Currently only False is supported.
+            use_precomputed_grid (bool): Whether to use precomputed grid coordinates.
+                                   When False (default): grid should be normalized coordinates in [-1, 1]
+                                   When True: grid should be preprocessed using ttnn.prepare_grid_sample_grid()
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation.
 
         Returns:
@@ -54,9 +56,25 @@ void bind_grid_sample(py::module& module) {
             >>> grid = torch.nn.functional.affine_grid(theta, (1, 32, 4, 4), align_corners=False)
             >>> grid_tensor = ttnn.from_torch(grid.to(torch.bfloat16), device=device)
 
-            >>> # Apply grid sample
+            >>> # Method 1: Standard grid sampling
             >>> output = ttnn.grid_sample(input_tensor, grid_tensor)
             >>> print(output.shape)  # [1, 4, 4, 32]
+
+            >>> # Method 2: Using precomputed grid for better performance
+            >>> # First, create float32 grid on host for preprocessing
+            >>> grid_float32 = ttnn.from_torch(grid, dtype=ttnn.float32)
+            >>> input_shape = [1, 4, 4, 32]  # [N, H, W, C] format
+            >>>
+            >>> # Precompute grid coordinates and bilinear weights
+            >>> prepared_grid = ttnn.prepare_grid_sample_grid(
+            ...     grid_float32, input_shape, padding_mode="zeros", output_dtype=ttnn.bfloat16
+            ... )
+            >>> # Move prepared grid to device
+            >>> prepared_grid = ttnn.to_device(prepared_grid, device)
+            >>>
+            >>> # Apply grid sample with precomputed grid
+            >>> output_precomputed = ttnn.grid_sample(input_tensor, prepared_grid, use_precomputed_grid=True)
+            >>> print(output_precomputed.shape)  # [1, 4, 4, 32]
         )doc";
 
     ttnn::bind_registered_operation(
@@ -109,11 +127,28 @@ void bind_prepare_grid_sample_grid(py::module& module) {
                         - [:, :, :, 5]: Weight for south-east pixel
 
         Example:
-            >>> # Create a normalized grid
-            >>> grid = ttnn.from_torch(torch.randn(1, 8, 8, 2), dtype=ttnn.float32)
-            >>> input_shape = [1, 32, 32, 64]  # N, H, W, C
-            >>> precomputed_grid = ttnn.prepare_grid_sample_grid(grid, input_shape)
+            >>> # Create a normalized grid with coordinates in [-1, 1] range
+            >>> torch_grid = torch.randn(1, 8, 8, 2) * 0.8  # Keep within valid range
+            >>> grid = ttnn.from_torch(torch_grid, dtype=ttnn.float32)
+            >>> input_shape = [1, 32, 32, 64]  # N, H, W, C format
+            >>>
+            >>> # Precompute grid for optimized sampling
+            >>> precomputed_grid = ttnn.prepare_grid_sample_grid(
+            ...     grid, input_shape, padding_mode="zeros", output_dtype=ttnn.bfloat16
+            ... )
             >>> print(precomputed_grid.shape)  # [1, 8, 8, 6]
+            >>>
+            >>> # The output contains:
+            >>> # precomputed_grid[:, :, :, 0] = North-west height coordinates
+            >>> # precomputed_grid[:, :, :, 1] = North-west width coordinates
+            >>> # precomputed_grid[:, :, :, 2] = North-west pixel weight
+            >>> # precomputed_grid[:, :, :, 3] = North-east pixel weight
+            >>> # precomputed_grid[:, :, :, 4] = South-west pixel weight
+            >>> # precomputed_grid[:, :, :, 5] = South-east pixel weight
+            >>>
+            >>> # Use with grid_sample for better performance on repeated operations
+            >>> precomputed_grid_device = ttnn.to_device(precomputed_grid, device)
+            >>> output = ttnn.grid_sample(input_tensor, precomputed_grid_device, use_precomputed_grid=True)
         )doc");
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_pybind.hpp
@@ -10,4 +10,9 @@ namespace ttnn::operations::grid_sample {
 
 void py_bind_grid_sample(pybind11::module& module);
 
+namespace detail {
+void bind_grid_sample(pybind11::module& module);
+void bind_prepare_grid_sample_grid(pybind11::module& module);
+}  // namespace detail
+
 }  // namespace ttnn::operations::grid_sample

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -389,6 +389,10 @@ from ttnn._ttnn.operations.conv import (
     convert_conv_weight_tensor_to_grouped_layout,
 )
 
+from ttnn.operations.pool import (
+    prepare_grid_sample_grid,
+)
+
 from ttnn._ttnn.operations.experimental import Conv3dConfig
 
 Conv1dConfig = ttnn._ttnn.operations.conv.Conv2dConfig

--- a/ttnn/ttnn/operations/pool.py
+++ b/ttnn/ttnn/operations/pool.py
@@ -46,3 +46,37 @@ def golden_global_avg_pool2d(input_tensor: ttnn.Tensor):
 
 
 ttnn.attach_golden_function(ttnn.global_avg_pool2d, golden_global_avg_pool2d)
+
+
+def prepare_grid_sample_grid(*args, **kwargs):
+    """
+    Precomputes grid sample data for optimized kernel execution.
+
+    This function takes a normalized grid tensor and precomputes the pixel coordinates
+    and bilinear interpolation weights needed for grid sampling.
+
+    Args:
+        grid (ttnn.Tensor): Grid tensor of shape (N, H_out, W_out, 2) with normalized coordinates in [-1, 1]
+        input_shape (List[int]): Input tensor dimensions [N, H_in, W_in, C] in NHWC format
+
+    Keyword Args:
+        padding_mode (str): How to handle out-of-bounds coordinates. Currently only "zeros" is supported.
+        output_dtype (ttnn.DataType, optional): Data type for the output tensor. Default: bfloat16
+
+    Returns:
+        ttnn.Tensor: Precomputed grid tensor of shape (N, H_out, W_out, 6) where:
+                    - [:, :, :, 0]: North-west height coordinate (as integer stored in bfloat16)
+                    - [:, :, :, 1]: North-west width coordinate (as integer stored in bfloat16)
+                    - [:, :, :, 2]: Weight for north-west pixel
+                    - [:, :, :, 3]: Weight for north-east pixel
+                    - [:, :, :, 4]: Weight for south-west pixel
+                    - [:, :, :, 5]: Weight for south-east pixel
+
+    Example:
+        >>> # Create a normalized grid
+        >>> grid = ttnn.from_torch(torch.randn(1, 8, 8, 2), dtype=ttnn.float32)
+        >>> input_shape = [1, 32, 32, 64]  # N, H, W, C
+        >>> precomputed_grid = ttnn.prepare_grid_sample_grid(grid, input_shape)
+        >>> print(precomputed_grid.shape)  # [1, 8, 8, 6]
+    """
+    return ttnn._ttnn.operations.pool.prepare_grid_sample_grid(*args, **kwargs)


### PR DESCRIPTION
### Problem description

Computing the bilinear interpolaton weights and coordinates for the grid sample operation is expensive. If the grid is known prior to the execution, it is possible to precompute it and save expensive floating point operations on risc.

### What's changed
- Added support for the usage of a precomputed grid in the grid sample op
- Added ttnn.prepare_grid_sample_grid, that takes in a ttnn tensor on host and converts it to an appropriate format. Example usage can be seen in tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py  

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17132216197)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17132220518)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/17132249139)