### PR TITLE
Update ttnn.plus_one op to support skipping addition on negative entries with skip_negative_entries flag

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -290,7 +290,6 @@ jobs:
             tests/ttnn/unit_tests/operations/test_moreh_full.py \
             tests/ttnn/unit_tests/operations/test_non_zero_indices.py \
             tests/ttnn/unit_tests/operations/test_paged_cache_mask.py \
-            tests/ttnn/unit_tests/operations/test_plus_one.py \
             tests/ttnn/unit_tests/operations/test_polyval.py \
             tests/ttnn/unit_tests/operations/test_prefetcher_TG.py \
             tests/ttnn/unit_tests/operations/test_reallocate.py \

--- a/models/demos/llama3_70b_galaxy/demo/demo_decode.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_decode.py
@@ -380,10 +380,7 @@ def run_llama3_demo(
         logger.info(f"Sampling done")
 
     if not stress_test:
-        ttnn.plus_one(
-            current_pos_tensor,
-            sub_core_grids=model_args.sub_core_grids,
-        )
+        ttnn.plus_one(current_pos_tensor, sub_core_grids=model_args.sub_core_grids, skip_negative_entries=True)
         ttnn.plus_one(
             rot_mat_idxs,
             sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
@@ -416,10 +413,7 @@ def run_llama3_demo(
     _ = tt_sampling(tt_out[0], tt_out_tok=tt_out_tok)
 
     if not stress_test:
-        ttnn.plus_one(
-            current_pos_tensor,
-            sub_core_grids=model_args.sub_core_grids,
-        )
+        ttnn.plus_one(current_pos_tensor, sub_core_grids=model_args.sub_core_grids, skip_negative_entries=True)
         ttnn.plus_one(
             rot_mat_idxs,
             sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),

--- a/models/demos/llama3_70b_galaxy/demo/demo_performance.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_performance.py
@@ -249,6 +249,7 @@ def run_llama3_decode_performance(
     ttnn.plus_one(
         current_pos_tensor,
         sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        skip_negative_entries=True,
     )
 
     # Capture Trace

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py
@@ -244,6 +244,7 @@ def test_tt_model_acc(
         ttnn.plus_one(
             current_pos_tensor,
             sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+            skip_negative_entries=True,
         )
         ttnn.plus_one(
             rot_mat_idxs,

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention.py
@@ -260,10 +260,7 @@ def test_llama_attention_inference(
             all_tests_pass = False
 
         # Increment position
-        ttnn.plus_one(
-            current_pos_tensor,
-            sub_core_grids=model_args.sub_core_grids,
-        )
+        ttnn.plus_one(current_pos_tensor, sub_core_grids=model_args.sub_core_grids, skip_negative_entries=True)
         check_kv_cache = True
         if check_kv_cache:
             # PyTorch output --------------------------------------------------------------------

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -552,6 +552,7 @@ class TtTransformer(LightweightModule):
             sub_core_grids=self.args.sub_core_grids
             if is_cur_pos_sharded
             else ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+            skip_negative_entries=True,
         )
         ttnn.plus_one(
             rot_mat_idxs,

--- a/models/experimental/gemma3_4b/tt/gemma_text_model.py
+++ b/models/experimental/gemma3_4b/tt/gemma_text_model.py
@@ -344,17 +344,7 @@ class Gemma3Transformer(LightweightModule):
         )
 
     def _increment_decode_positions_device(self, current_pos, rot_mat_idxs_global, rot_mat_idxs_local):
-        # ttnn.ne currently requires the input to be in TILE_LAYOUT
-        current_pos_tiled = ttnn.to_layout(current_pos, layout=ttnn.TILE_LAYOUT)
-        # Update only active positions (current_pos != -1)
-        predicate = ttnn.ne(current_pos_tiled, -1)
-        result = ttnn.where(
-            predicate,
-            ttnn.add(current_pos_tiled, 1),
-            current_pos_tiled,
-        )
-        ttnn.copy(ttnn.to_layout(result, layout=ttnn.ROW_MAJOR_LAYOUT), current_pos)
-
+        ttnn.plus_one(current_pos, skip_negative_entries=True)
         ttnn.plus_one(rot_mat_idxs_global)
         if rot_mat_idxs_local is not None:
             ttnn.plus_one(rot_mat_idxs_local)

--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -1,0 +1,475 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import bz2
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
+from models.tt_transformers.tt.model import Transformer
+from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
+from models.tt_transformers.tt.rope import get_rot_mats
+
+
+def get_accuracy_thresholds(model_args, optimizations):
+    """Parse accuracy thresholds from PERF.md for the given model, optimization mode, and device."""
+    # Read PERF.md
+    perf_file = Path(__file__).parent.parent / "PERF.md"
+    with open(perf_file, "r") as f:
+        content = f.read()
+
+    # Split into sections based on optimization mode
+    sections = content.split("## ")
+    if callable(optimizations):
+        optimizations = optimizations(model_args)
+    first_decoder_conf = optimizations.decoder_optimizations[0]
+    target_section = next(s for s in sections if s.lower().startswith(f"{first_decoder_conf.__name__}\n"))
+
+    # Parse the table and find the row for our model and device
+    # Potential lines have the form "| Llama-3.1-8b    | T3K    | 91        | 99        | 49.8          |"
+    base_model_name = model_args.base_model_name
+    device_name = model_args.device_name
+    correct_line = (
+        lambda line: "|" in line
+        and base_model_name.lower() in line.split("|")[1].strip().lower()
+        and device_name.lower() in line.split("|")[2].strip().lower()
+        and not "(DP=".lower() in line.lower()  # ignore DP/HP report for now
+    )
+    rows = [
+        line.split("|")[1:]  # Each row starts with a separator
+        for line in target_section.split("\n")
+        if correct_line(line)
+    ]
+    if not rows:
+        raise ValueError(
+            f"Could not find accuracy data for {base_model_name} on {device_name} in {optimizations.__name__} mode"
+        )
+
+    assert (
+        len(rows) == 1
+    ), f"Found multiple rows for {base_model_name} on {device_name} in {optimizations.__name__} mode in PERF.md"
+    row = rows[0]
+    top1_acc = float(row[2].strip())
+    top5_acc = float(row[3].strip())
+
+    # Allow for rounding
+    return top1_acc - 0.5, top5_acc - 0.5
+
+
+@torch.no_grad()
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize(
+    "prefill_len, decode_len, max_seq_len",  # Max seqlen should be at least prefill_len + decode_len
+    ((512, 511, 1024),),
+    #    ((131072-8192, 8192-1, 131072),),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "N150x4": (1, 4), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "optimizations",
+    [
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
+    ],
+    ids=["performance", "accuracy"],
+)
+@pytest.mark.parametrize(
+    "paged_attention",
+    (
+        True,
+        # False
+    ),
+    ids=(
+        "paged_attention",
+        # "default_attention"
+    ),
+)
+@pytest.mark.parametrize(
+    "page_params",
+    [{"page_block_size": 32, "page_max_num_blocks": 1024}],
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1,),
+)
+@pytest.mark.parametrize(
+    "use_reference_file",
+    [
+        pytest.param(True, id="reference_file"),
+        pytest.param(False, id="reference_text"),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+def test_tt_model_acc(
+    prefill_len,
+    decode_len,
+    max_seq_len,
+    batch_size,
+    paged_attention,
+    page_params,
+    optimizations,
+    mesh_device,
+    use_reference_file,
+    reset_seeds,
+    ensure_gc,
+    is_ci_env,
+    request,
+):
+    if is_ci_env and not use_reference_file:
+        pytest.skip("CI test only runs vs reference file")
+
+    dtype = ttnn.bfloat8_b
+
+    json_config_file = request.config.getoption("--decoder_config_file")
+    if json_config_file:
+        optimizations = parse_decoder_json(json_config_file)
+    else:
+        optimizations = request.config.getoption("--optimizations") or optimizations
+
+    # Load model args and tokenizer
+    model_args = ModelArgs(
+        mesh_device, optimizations=optimizations, max_batch_size=batch_size, max_seq_len=max_seq_len, cache_hf=True
+    )
+    logger.info(f"Optimizations: {model_args.optimizations._full_name}")
+
+    tokenizer = model_args.tokenizer
+
+    # Load state_dict for TT model
+    logger.info("Loading weights...")
+    state_dict = model_args.load_state_dict()
+    logger.info("Finished loading weights...")
+
+    # Load the reference data
+
+    if use_reference_file:
+        # Existing reference file loading logic
+        reference_data_file = f"models/tt_transformers/tests/reference_outputs/{model_args.model_name}.refpt"
+        logger.info(f"Loading reference data from {reference_data_file}")
+        assert os.path.exists(reference_data_file)
+        reference_data = torch.load(reference_data_file)
+        reference_tokens = reference_data["reference_tokens"]
+        top5_tokens = reference_data["top5_tokens"]
+    else:
+        # Load and encode the reference text
+        current_file_path = os.path.dirname(os.path.abspath(__file__))
+        prompt_file = os.path.join(current_file_path, "tale-of-two-cities.txt.bz2")
+        with bz2.open(prompt_file, "rt", encoding="utf-8") as f:
+            text = f.read()
+
+        # Encode text to tokens
+        encoded_tokens = model_args.encode_prompt(text, system_prompt_text=None, instruct=False)
+        total_length = prefill_len + decode_len + 1
+        reference_tokens = torch.tensor(encoded_tokens[:total_length]).unsqueeze(0)
+        top5_tokens = None  # Will be computed during inference
+
+    N = prefill_len + decode_len
+    input_ids = reference_tokens[:, : N + 1]  # Shape [1, N+1]
+
+    page_table_tt = None
+    paged_attention_config = None
+
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtual blocks to physical
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, -2) if batch_size > 1 else (None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+    # Initialize TT model
+    tt_model = Transformer(
+        args=model_args,
+        mesh_device=mesh_device,
+        dtype=dtype,
+        state_dict=state_dict,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        paged_attention_config=paged_attention_config,
+    )
+    # Initialize embedding
+    embd = model_args.reference_embedding()
+    state_dict_prefix = model_args.get_state_dict_prefix("", None)
+    embd.load_state_dict({"emb.weight": state_dict[f"{state_dict_prefix}tok_embeddings.weight"]})
+
+    # Skip prefill if prefill_len is 0
+    if prefill_len > 0:
+        logger.info(f"Starting prefill...")
+        batch_id = 0
+        input_prompts = [tokenizer.decode(reference_tokens[0, :prefill_len].tolist())]
+        (
+            input_tokens_prefill_pt,
+            encoded_prompts,
+            decoding_pos,
+            prefill_lens,
+        ) = preprocess_inputs_prefill(
+            input_prompts,
+            tokenizer,
+            [model_args],
+            instruct=False,
+            max_generated_tokens=decode_len,
+            max_prefill_len=prefill_len,
+        )
+        pt_prefill_input = [embd(input_tokens_prefill_pt[b]).view(1, prefill_lens[b], -1) for b in range(1)]
+
+        # Pre-compute the rotational embedding matrix and send to device
+        rot_mats_prefill = get_rot_mats(
+            head_dim=model_args.head_dim,
+            device=mesh_device,
+            seq_len=prefill_lens[0],
+            theta=model_args.rope_theta,
+            rope_scaling=model_args.rope_scaling,
+        )
+        prefill_input = model_args.prepare_residual_tensor_prefill(
+            pt_prefill_input[batch_id],
+        )
+
+        tt_out = tt_model(
+            prefill_input,
+            current_pos=None,
+            rot_mats_global=rot_mats_prefill,
+            user_id=batch_id,
+            mode="prefill",
+            page_table=page_table_tt,
+            get_last_token=((decoding_pos[batch_id] - 1) // 32) * 32,
+        )
+
+    # Start decoding
+    logger.info(f"Starting decode...")
+    generation_start_pos = prefill_len
+    generation_length = decode_len
+
+    # Initial positions
+    decoding_pos = [generation_start_pos] * model_args.max_batch_size
+    current_pos = torch.tensor([decoding_pos[b] for b in range(model_args.max_batch_size)])
+    current_pos_tensor = ttnn.from_torch(
+        current_pos,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            mesh_shape=model_args.cluster_shape,
+        ),
+    )
+
+    # Get cos/sin matrices for the current position of each user
+    rot_mats = tt_model.rope_setup.get_rot_mats(current_pos)
+
+    # Print table header
+    if use_reference_file:
+        logger.info(f"{'Progress':<15}{'Correct':<8}{'True':<15}{'Actual':<15}{'Top 5 Predictions':<75}")
+    else:
+        logger.info(f"{'Progress':<15}{'Correct':<8}{'True':<15}{'Top 5 Predictions':<75}")
+    logger.info("-" * 113)
+
+    top1_correct = []
+    top5_correct = []
+    errors = []  # New list to store error information
+
+    for i in range(generation_length):
+        # Input is reference token at each step
+        ref_token = input_ids[0, prefill_len + i].item()
+        # Get the true next token (if available)
+        true_token = input_ids[0, prefill_len + i + 1].item() if i < generation_length - 1 else None
+        # Convert to torch tensor
+        ref_token = torch.tensor([[ref_token]], dtype=torch.int32)  # Shape [1,1]
+        # Get embedding
+        pt_decode_input = embd(ref_token).view(1, 1, -1)
+        # Prepare input for TT model
+        decode_input = model_args.prepare_residual_tensor_decode(
+            pt_decode_input,
+            model_args.model_config["DECODE_RESIDUAL_MEMCFG"],
+        )
+        # Run TT model
+        tt_out = tt_model(
+            decode_input,
+            current_pos_tensor,
+            rot_mats_global=rot_mats,
+            mode="decode",
+            page_table=page_table_tt,
+        )
+
+        if tt_model.args.num_devices > 1:
+            cluster_axis = 0 if tt_model.args.is_galaxy else None
+            num_links = tt_model.args.num_all_gather_links if tt_model.args.is_galaxy else 1
+            tt_out_gathered = ttnn.experimental.all_gather_async(
+                tt_out,
+                persistent_output_buffer=None,
+                dim=3,
+                multi_device_global_semaphore=tt_model.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+                num_links=num_links,
+                memory_config=tt_out.memory_config(),
+                cluster_axis=cluster_axis,
+                topology=tt_model.args.ccl_topology() if tt_model.args.is_galaxy else ttnn.Topology.Linear,
+                barrier_semaphore=tt_model.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                chunks_per_sync=10,
+                num_workers_per_link=2,
+                num_buffers_per_channel=2,
+            )
+
+            ttnn.deallocate(tt_out)
+        else:
+            tt_out_gathered = tt_out
+        tt_out_rm = ttnn.untilize(tt_out_gathered, use_multicore=True)
+        ttnn.deallocate(tt_out_gathered)
+        tt_out_tok = ttnn.argmax(
+            tt_out_rm,
+            dim=3,
+            keepdim=True,
+            use_multicore=True if model_args.max_batch_size == 1 else False,
+        )
+        if not use_reference_file:
+            tt_logits = ttnn.to_torch(tt_out_rm, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1))[0, 0, 0, :]
+        ttnn.deallocate(tt_out_rm)
+
+        tt_argmax_token = ttnn.to_torch(tt_out_tok, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1))[
+            0, 0, 0, 0
+        ]
+
+        ttnn.plus_one(current_pos_tensor, skip_negative_entries=True)
+
+        # Update rot_mats for next iteration
+        current_pos += 1
+        rot_mats = tt_model.rope_setup.get_rot_mats(current_pos)
+
+        # Modify the accuracy checking section when using reference text
+        if not use_reference_file:
+            # Get probabilities from model output
+            probs = torch.softmax(tt_logits, dim=-1)
+            _, tt_top5_tokens = torch.topk(probs, k=5, dim=-1)
+
+            # Check against actual next token
+            true_token = input_ids[0, prefill_len + i + 1].item()
+            top1_match = tt_argmax_token.item() == true_token
+            top5_match = true_token in tt_top5_tokens
+            ref_top5_text = [tokenizer.decode([t]) for t in tt_top5_tokens]
+        else:
+            # Existing logic for reference file comparison
+            ref_top5_tokens = top5_tokens[prefill_len + i]
+            top1_match = tt_argmax_token.item() == ref_top5_tokens[0].item()
+            top5_match = tt_argmax_token in ref_top5_tokens
+            ref_top5_text = [tokenizer.decode([t]) for t in ref_top5_tokens]
+
+        # Check top-1 and top-5 accuracy
+        top1_correct.append(top1_match)
+        top5_correct.append(top5_match)
+        true_match = (
+            tt_argmax_token.item() == input_ids[0, prefill_len + i + 1].item() if i < generation_length - 1 else False
+        )
+
+        # Store error information vs reference model if top5 is incorrect
+        if use_reference_file and not top5_match:
+            context_start = max(0, prefill_len + i - 9)
+            context_tokens = input_ids[0, context_start : prefill_len + i + 1]
+            context_text = tokenizer.decode(context_tokens.tolist())
+            incorrect_token = tokenizer.decode([tt_argmax_token])
+            expected_tokens = [tokenizer.decode([t]) for t in ref_top5_tokens]
+            errors.append(
+                {
+                    "position": prefill_len + i,
+                    "context": context_text,
+                    "incorrect": incorrect_token,
+                    "expected": expected_tokens,
+                    "predicted_id": tt_argmax_token.item(),
+                    "expected_ids": ref_top5_tokens.tolist(),
+                }
+            )
+
+        sanitize = lambda x: repr(x)[1:-1]  # Use repr() and remove the outer quotes
+
+        # Decode tokens to text
+        tt_argmax_text = tokenizer.decode([tt_argmax_token])
+        true_text = tokenizer.decode([true_token]) if true_token is not None else "N/A"
+
+        # Prepare table row
+        progress_str = f"{i+1}/{generation_length}"
+        correct = "x" if top1_match else ("-" if top5_match else ("!" if true_match else " "))
+        tt_argmax_text = sanitize(tt_argmax_text)
+        true_text = sanitize(true_text)
+        ref_top5_str = " ".join(f"{sanitize(t):<14}" for t in ref_top5_text)
+
+        # Print table row
+        if use_reference_file:
+            logger.info(f"{progress_str:<15}{correct:<8}{true_text:<15}{tt_argmax_text:<15}{ref_top5_str}")
+        else:
+            logger.info(f"{progress_str:<15}{correct:<8}{true_text:<15}{ref_top5_str}")
+
+    # Compute accuracies over every 100 tokens
+    num_tokens = len(top1_correct)
+    num_segments = (num_tokens + 99) // 100
+    for seg in range(num_segments):
+        start = seg * 100
+        end = min(start + 100, num_tokens)
+        top1_acc = 100 * sum(top1_correct[start:end]) / (end - start)
+        top5_acc = 100 * sum(top5_correct[start:end]) / (end - start)
+        max_width = len(str(decode_len))
+        logger.info(
+            f"Tokens {start:{max_width}d}-{end:{max_width}d}: Top-1 accuracy: {top1_acc:3.0f} %, Top-5 accuracy: {top5_acc:3.0f} %"
+        )
+
+    # Report total accuracies
+    total_top1_acc = 100 * sum(top1_correct) / num_tokens
+    total_top5_acc = 100 * sum(top5_correct) / num_tokens
+    logger.info(
+        f"Total tokens {num_tokens}: Top-1 accuracy: {total_top1_acc:3.1f} %, Top-5 accuracy: {total_top5_acc:3.1f} %"
+    )
+
+    # Only show error summary when using reference files
+    if use_reference_file:
+        logger.info("\nError Summary (only showing errors where reference top-1 matches true token):")
+        logger.info("-" * 120)
+        for error in errors:
+            if error["position"] + 1 < input_ids.shape[1]:
+                true_token = input_ids[0, error["position"] + 1].item()
+            else:
+                true_token = None
+            if error["expected_ids"][0] == true_token:
+                sanitize = lambda x: repr(x)[1:-1]  # Use repr() and remove the outer quotes
+                context = sanitize(error["context"])
+                incorrect = sanitize(error["incorrect"])
+                expected = " | ".join(sanitize(t) for t in error["expected"])
+                true_word = sanitize(tokenizer.decode([true_token]))
+                logger.info(f"{error['position']}: {context}[{incorrect}] != [{expected}], true: [{true_word}]")
+
+    if use_reference_file:
+        logger.info(f"Top-1: {total_top1_acc:.0f}% | Top-5: {total_top5_acc:.0f}%")
+
+        if not json_config_file:
+            # Get accuracy thresholds from PERF.md, unless the configuration is from a json
+            min_top1_acc, min_top5_acc = get_accuracy_thresholds(
+                model_args,
+                optimizations,
+            )
+            assert (
+                total_top1_acc >= min_top1_acc
+            ), f"Top-1 accuracy {total_top1_acc:.1f}% is too low (expected >={min_top1_acc}%)"
+            assert (
+                total_top5_acc >= min_top5_acc
+            ), f"Top-5 accuracy {total_top5_acc:.1f}% is too low (expected >={min_top5_acc}%)"

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -371,17 +371,7 @@ class Transformer(LightweightModule):
         )
 
     def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):
-        # ttnn.ne currently requires the input to be in TILE_LAYOUT
-        current_pos_tiled = ttnn.to_layout(current_pos, layout=ttnn.TILE_LAYOUT)
-        # Update only active positions (current_pos != -1)
-        predicate = ttnn.ne(current_pos_tiled, -1)
-        result = ttnn.where(
-            predicate,
-            ttnn.add(current_pos_tiled, 1),
-            current_pos_tiled,
-        )
-        ttnn.copy(ttnn.to_layout(result, layout=ttnn.ROW_MAJOR_LAYOUT), current_pos)
-
+        ttnn.plus_one(current_pos, skip_negative_entries=True)
         ttnn.plus_one(rot_mat_idxs)
 
     def update_attention_masks(self, current_pos):

--- a/tests/ttnn/unit_tests/operations/test_plus_one.py
+++ b/tests/ttnn/unit_tests/operations/test_plus_one.py
@@ -52,3 +52,31 @@ def test_plus_one_subdevice_nd(device, input_shape):
     )
     output_tensor = ttnn.to_torch(input_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("w", [1, 4, 8, 32])
+@pytest.mark.parametrize("val", [-1, -100])
+def test_plus_one_with_neg_entries(device, w, val):
+    torch_input_tensor = torch.randint(32000, (w,))
+    mask = torch.rand(w) < 0.3
+    torch_input_tensor[mask] = val
+    torch_output_tensor = torch.where(torch_input_tensor < 0, torch_input_tensor, torch_input_tensor + 1)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, device=device)
+    ttnn.plus_one(input_tensor, skip_negative_entries=True)
+    output_tensor = ttnn.to_torch(input_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("input_shape", [(16, 32), (32, 32), (4, 16, 32), (4, 8, 16, 32)])
+@pytest.mark.parametrize("val", [-1, -100])
+def test_plus_one_with_neg_entries_nd(device, input_shape, val):
+    torch_input_tensor = torch.randint(32000, input_shape)
+    mask = torch.rand(input_shape) < 0.3
+    torch_input_tensor[mask] = val
+    torch_output_tensor = torch.where(torch_input_tensor < 0, torch_input_tensor, torch_input_tensor + 1)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, device=device)
+    ttnn.plus_one(input_tensor, skip_negative_entries=True)
+    output_tensor = ttnn.to_torch(input_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-
+#include <limits.h>
 #include "dataflow_api.h"
 
 void kernel_main() {
@@ -14,8 +14,9 @@ void kernel_main() {
     constexpr uint32_t stick_size = get_compile_time_arg_val(2);
     constexpr uint32_t W = get_compile_time_arg_val(3);
     constexpr uint32_t H = get_compile_time_arg_val(4);
+    constexpr bool skip_negative_entries = get_compile_time_arg_val(5);
 
-    constexpr auto s0_args = TensorAccessorArgs<5>();
+    constexpr auto s0_args = TensorAccessorArgs<6>();
     const auto s0 = TensorAccessor(s0_args, src_addr, stick_size);
 
     // Use cb as L1 scratch memory
@@ -28,9 +29,16 @@ void kernel_main() {
             noc_async_read_barrier();
         }
         for (uint32_t i = 0; i < W; i++) {
-            uint32_t val = stick[i];
-            stick[i] = val + 1;
-            // DPRINT << "val: " << val << ENDL();
+            int32_t val = stick[i];
+            if constexpr (skip_negative_entries) {
+                // NOTE: If you increment beyond INT32_MAX you will wrap around and get a negative result
+                //  values greater than INT32_MAX will overflow and become negative
+                if (val < INT32_MAX) {
+                    stick[i] = val + 1;
+                }
+            } else {
+                stick[i] = val + 1;
+            }
         }
         if (src0_is_dram) {
             uint64_t dst_noc_addr = s0.get_noc_addr(h);

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
@@ -34,7 +34,7 @@ std::vector<Tensor> PlusOne::create_output_tensors(
 tt::tt_metal::operation::ProgramWithCallbacks PlusOne::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return detail::plusone_single_core(input_tensor, sub_core_grids);
+    return detail::plusone_single_core(input_tensor, sub_core_grids, skip_negative_entries);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.hpp
@@ -13,6 +13,7 @@ namespace ttnn::operations::experimental {
 
 struct PlusOne {
     const std::optional<CoreRangeSet> sub_core_grids;
+    const bool skip_negative_entries;
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -15,9 +15,8 @@ namespace ttnn::operations::experimental::detail {
 using namespace tt::constants;
 
 tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
-    const Tensor& input, const std::optional<CoreRangeSet>& sub_core_grids, const bool& skip_negative_entries) {
+    const Tensor& input, const std::optional<CoreRangeSet>& sub_core_grids, bool skip_negative_entries) {
     tt::tt_metal::Program program{};
-    bool skip_negative_entries_flag = false;
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_unit_size = input.element_size();
 
@@ -38,8 +37,6 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
         }
     }
 
-    skip_negative_entries_flag = skip_negative_entries;
-
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = W;
     uint32_t aligned_input_page_size = round_up_to_mul32(num_input_units * input_unit_size);
@@ -55,7 +52,7 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     std::vector<uint32_t> reader_compile_time_args = {
-        src0_cb_index, src_is_dram, aligned_input_page_size, W, H, skip_negative_entries_flag};
+        src0_cb_index, src_is_dram, aligned_input_page_size, W, H, skip_negative_entries};
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
     std::map<std::string, std::string> kernel_defines;
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.hpp
@@ -8,6 +8,6 @@ namespace ttnn::operations::experimental::detail {
 using namespace tt::constants;
 
 tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
-    const Tensor& input, const std::optional<CoreRangeSet>& sub_core_grids, const bool& skip_negative_entries);
+    const Tensor& input, const std::optional<CoreRangeSet>& sub_core_grids, bool skip_negative_entries);
 
 }  // namespace ttnn::operations::experimental::detail

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.hpp
@@ -8,6 +8,6 @@ namespace ttnn::operations::experimental::detail {
 using namespace tt::constants;
 
 tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
-    const Tensor& input, const std::optional<CoreRangeSet>& sub_core_grids);
+    const Tensor& input, const std::optional<CoreRangeSet>& sub_core_grids, const bool& skip_negative_entries);
 
 }  // namespace ttnn::operations::experimental::detail

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
@@ -12,10 +12,7 @@
 namespace ttnn::operations::experimental {
 
 ttnn::Tensor PlusOneOperation::invoke(
-    QueueId queue_id,
-    const Tensor& input_tensor,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const bool& skip_negative_entries) {
+    const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids, bool skip_negative_entries) {
     return tt::tt_metal::operation::run(PlusOne{sub_core_grids, skip_negative_entries}, {input_tensor}, {}, {}).at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
@@ -11,8 +11,12 @@
 
 namespace ttnn::operations::experimental {
 
-ttnn::Tensor PlusOneOperation::invoke(const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids) {
-    return tt::tt_metal::operation::run(PlusOne{sub_core_grids}, {input_tensor}, {}, {}).at(0);
+ttnn::Tensor PlusOneOperation::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const bool& skip_negative_entries) {
+    return tt::tt_metal::operation::run(PlusOne{sub_core_grids, skip_negative_entries}, {input_tensor}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
@@ -13,7 +13,9 @@ namespace operations::experimental {
 
 struct PlusOneOperation {
     static ttnn::Tensor invoke(
-        const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+        const Tensor& input_tensor,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+        const bool& skip_negative_entries = false);
 };
 
 }  // namespace operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
@@ -15,7 +15,7 @@ struct PlusOneOperation {
     static ttnn::Tensor invoke(
         const Tensor& input_tensor,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-        const bool& skip_negative_entries = false);
+        bool skip_negative_entries = false);
 };
 
 }  // namespace operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone_pybind.cpp
@@ -42,7 +42,7 @@ void bind_experimental_plusone_operation(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
                const std::optional<CoreRangeSet>& sub_core_grids,
-               const bool& skip_negative_entries) { return self(input_tensor, sub_core_grids, skip_negative_entries); },
+               bool skip_negative_entries) { return self(input_tensor, sub_core_grids, skip_negative_entries); },
             py::arg("input_tensor").noconvert(),
             py::arg("sub_core_grids") = std::nullopt,
             py::arg("skip_negative_entries") = false});

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone_pybind.cpp
@@ -16,8 +16,10 @@ void bind_experimental_plusone_operation(py::module& module) {
             Returns input tensor elements increased by 1.
             Input tensor must have UINT32 data type, ROW_MAJOR layout, and 1-D shape.
             This op only gives decent performance for small tensors (up to 100 elements).
-            Specify the core to use in the sub_core_grids argument.
-
+            This op allows you to skip the addition on negative entries using the skip_negative_entries flag. If enabled, only positive entries will be incremented by checking if tensor values overflow INT32_MAX / are negative.
+            This op also allows you to specify the core to use in the sub_core_grids argument.
+            If the input tensor is L1 sharded on the sub core grid, each individual shard will be incremented with output residing in L1 of same sub core grid.
+            If the input tensor is DRAM interleaved, only 1 core should be used as the sub core grid (uses 1 core by default).
             Equivalent pytorch code:
 
             .. code-block:: python
@@ -26,6 +28,8 @@ void bind_experimental_plusone_operation(py::module& module) {
 
             Args:
                 * :attr:`input_tensor`: Input Tensor for plusone.
+                * :attr:`sub_core_grids`: Sub core grid of cores where the addition would take place
+                * :attr:`skip_negative_entries`: bool flag to skip incrementing values that are negative or overflow past INT32_MAX. Defaults to False
 
         )doc";
 
@@ -37,9 +41,11 @@ void bind_experimental_plusone_operation(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const std::optional<CoreRangeSet>& sub_core_grids) { return self(input_tensor, sub_core_grids); },
+               const std::optional<CoreRangeSet>& sub_core_grids,
+               const bool& skip_negative_entries) { return self(input_tensor, sub_core_grids, skip_negative_entries); },
             py::arg("input_tensor").noconvert(),
-            py::arg("sub_core_grids") = std::nullopt});
+            py::arg("sub_core_grids") = std::nullopt,
+            py::arg("skip_negative_entries") = false});
 }
 
 }  // namespace ttnn::operations::experimental::plusone::detail


### PR DESCRIPTION
### Ticket
#27494

### Problem Description
- in vLLM we want to skip addition of current position if the values are -1 since -1 indicates these users are inactive
- currently the implementation in TTT is to use a collection of ops shown below

```
def _increment_decode_positions_device(self, current_pos, rot_mat_idxs_global, rot_mat_idxs_local):
        # ttnn.ne currently requires the input to be in TILE_LAYOUT
        current_pos_tiled = ttnn.to_layout(current_pos, layout=ttnn.TILE_LAYOUT)
        # Update only active positions (current_pos != -1)
        predicate = ttnn.ne(current_pos_tiled, -1)
        result = ttnn.where(
            predicate,
            ttnn.add(current_pos_tiled, 1),
            current_pos_tiled,
        )
        ttnn.copy(ttnn.to_layout(result, layout=ttnn.ROW_MAJOR_LAYOUT), current_pos)
```

however, TG llama already has an existing custom plus_one op that handles the addition of current position, this op is currently not used anywhere else but we aim to extend its usage to TTT. So we wish to replace these ops with 1 invocation of ttnn.plus_one

### What's changed
- Added test case for negative entries
- We allow the user to choose the option of skipping the increments on negative entries so only positive elements in the tensor are incremented

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/17268694398)
- [ ] [6u Pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17537788716)