### PR TITLE
adding action yaml for detecting merge gate failures on main

### DIFF
--- a/.github/actions/slack-report-merge-gate-main/action.yaml
+++ b/.github/actions/slack-report-merge-gate-main/action.yaml
@@ -1,0 +1,27 @@
+name: "Report Workflow Status to Slack"
+description: "Report the workflow status to Slack to help identify breakages faster."
+inputs:
+  owner:
+    description: "The Slack ID of the person to be tagged."
+    default: "U014XCQ9CF8" # @Raymond Kim
+  slack_webhook_url:
+    description: "Webhook URL for the Slack channel to be posted to. Generated via slack app!"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Format Slack User Mentions
+      id: format_mentions
+      run: |
+        MENTIONS=$(echo "<@${{ inputs.owner }}>" | sed 's/,/> <@/g')
+        echo "mentions=$MENTIONS" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Report Github Pipeline Status Slack Action
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "text": "${{ steps.format_mentions.outputs.mentions }} 🚨ALERT🚨 🚨ALERT🚨 🚨ALERT🚨 ${{ github.workflow }} IS FAILING ON MAIN 🙀: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \nfailing commit: https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}


### PR DESCRIPTION
### Ticket
NA


adding action yaml to eventually ping all of metal-infra when merge gate fails on main


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes