### PR TITLE
implement slack pings when merge queue fails on main

### DIFF
--- a/.github/actions/slack-report-merge-gate-main/action.yaml
+++ b/.github/actions/slack-report-merge-gate-main/action.yaml
@@ -1,0 +1,27 @@
+name: "Report Workflow Status to Slack"
+description: "Report the workflow status to Slack to help identify breakages faster."
+inputs:
+  owner:
+    description: "The Slack ID of the person to be tagged."
+    default: "U014XCQ9CF8" # @Raymond Kim
+  slack_webhook_url:
+    description: "Webhook URL for the Slack channel to be posted to. Generated via slack app!"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Format Slack User Mentions
+      id: format_mentions
+      run: |
+        MENTIONS=$(echo "<@${{ inputs.owner }}>" | sed 's/,/> <@/g')
+        echo "mentions=$MENTIONS" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Report Github Pipeline Status Slack Action
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "text": "${{ steps.format_mentions.outputs.mentions }} 🚨ALERT🚨 🚨ALERT🚨 🚨ALERT🚨 ${{ github.workflow }} IS FAILING ON MAIN 🙀: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \nfailing commit: https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -283,3 +283,8 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
           owner: "U08GTDV8MDH,U0908S3LUMD"
+      - if: (failure() && github.ref == 'refs/heads/main')
+        uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
+          owner: "U08GTDV8MDH,U0908S3LUMD"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -287,4 +287,4 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
-          owner: "U08GTDV8MDH,U0908S3LUMD"
+          owner: "U08GTDV8MDH,U0908S3LUMD,U0982FCD80N,U08VC9954CE,U08TVGQGGAE,U08LG51QALX,U08DEGUJY3H,U08BNDNLUCD,U084DCKE0B0,U0883RN6CRE,U088NCP32NP,U07J3K6KS1K,U07HTBQPHFG,U085LTYEC00,U014XCQ9CF8"


### PR DESCRIPTION
ping all of metal-infra when merge queue fails on main

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes