### PR TITLE
 #27457: Update the reference to the new version of docker run action that uses GCR

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
       run: |
         docker pull ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
-    - uses: tenstorrent/docker-run-action@v5
+    - uses: tenstorrent/docker-run-action@v6
       with:
         shell: bash
         username: ${{ inputs.docker_username }}


### PR DESCRIPTION
Update the reference to the new version of docker run action that uses GCR
### Ticket

#27457

### Problem description
Running into the quota limits for pulling ECR images.

### What's changed

The version of docker run action has been bumped to v6. This version has the PR of https://github.com/tenstorrent/docker-run-action/pull/1 which is switching the Docker Image to Google Artifact Registry. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/17271923302

! Some unrelated failures in APC. 

- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/17275006869
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/17275537031
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/17275017131
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes