### PR TITLE
Change binary/ternary SFPU API and kernels to use tile idx directly

### DIFF
--- a/docs/source/tt-metalium/tt_metal/advanced_topics/compute_engines_and_dataflow_within_tensix.rst
+++ b/docs/source/tt-metalium/tt_metal/advanced_topics/compute_engines_and_dataflow_within_tensix.rst
@@ -250,7 +250,7 @@ For example, to compute the element-wise sum of two tiles:
 
         // Add Dst tiles 0 and 1 together. Store the result back into Dst tile 0.
         // Pseudocode: dst_tile[0] = dst_tile[0] + dst_tile[1]
-        add_binary_tile(/*dst_idx_a*/0, /*dst_idx_b*/1);
+        add_binary_tile(/*dst_idx_a*/0, /*dst_idx_b*/1, /*dst_idx_out*/0);
         // More operations can be chained here, e.g., applying sigmoid.
         // sigmoid_tile(0);
 

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/dequant_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/dequant_tile.rst
@@ -2,4 +2,4 @@ dequant_tile
 ============
 
 .. doxygenfunction:: dequant_tile_init(const uint32_t zero_point)
-.. doxygenfunction:: dequant_tile(uint32_t idst0, uint32_t idst1)
+.. doxygenfunction:: dequant_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/quant_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/quant_tile.rst
@@ -2,4 +2,4 @@ quant_tile
 ==========
 
 .. doxygenfunction:: quant_tile_init(const uint32_t zero_point)
-.. doxygenfunction:: quant_tile(uint32_t idst0, uint32_t idst1)
+.. doxygenfunction:: quant_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/requant_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/requant_tile.rst
@@ -2,4 +2,4 @@ requant_tile
 ============
 
 .. doxygenfunction:: requant_tile_init(const uint32_t zero_point)
-.. doxygenfunction:: requant_tile(uint32_t idst0, uint32_t idst1)
+.. doxygenfunction:: requant_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
@@ -90,7 +90,7 @@ void find_max_value_in_row() {
                     copy_tile(cb_max_mask, /* tile_idx */ 0, /* register idx */ mask_register);
 
                     add_binary_tile_init();
-                    add_binary_tile(working_register, mask_register);
+                    add_binary_tile(working_register, mask_register, working_register);
                 }
             }
 
@@ -143,7 +143,7 @@ void find_max_value_in_row() {
                     copy_tile(cb_max_mask, /* tile_idx */ 0, /* register idx */ mask_register);
 
                     add_binary_tile_init();
-                    add_binary_tile(working_register, mask_register);
+                    add_binary_tile(working_register, mask_register, working_register);
                 }
             }
 
@@ -219,7 +219,7 @@ void calculate_sum_exp_x() {
         copy_tile(cb_input, /* tile_idx */ col, /* register_idx */ working_register);
 
         sub_binary_tile_init();
-        sub_binary_tile(working_register, max_value_register);  // subtract max value from each tile
+        sub_binary_tile(working_register, max_value_register, working_register);  // subtract max value from each tile
 
         exp_tile_init<false>();
         exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
@@ -239,7 +239,7 @@ void calculate_sum_exp_x() {
 
         if (col > 0) {
             add_binary_tile_init();
-            add_binary_tile(accum_register, working_register);
+            add_binary_tile(accum_register, working_register, accum_register);
         }
     }
     tile_regs_commit();
@@ -280,7 +280,8 @@ void calculate_sum_exp_x() {
             copy_tile(cb_input, /* tile_idx */ block_idx, /* register_idx */ working_register);
 
             sub_binary_tile_init();
-            sub_binary_tile(working_register, max_value_register);  // subtract max value from each tile
+            sub_binary_tile(
+                working_register, max_value_register, working_register);  // subtract max value from each tile
 
             exp_tile_init<false>();
             exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
@@ -301,7 +302,7 @@ void calculate_sum_exp_x() {
 
             if (col > 0) {
                 add_binary_tile_init();
-                add_binary_tile(accum_register, working_register);
+                add_binary_tile(accum_register, working_register, accum_register);
             }
         }
         cb_pop_front(cb_input, block_size);
@@ -413,7 +414,7 @@ void MAIN {
                 exp_tile</* approx */ false>(block_idx);  // calculate exp for each tile in tile register
 
                 mul_binary_tile_init();
-                mul_binary_tile(block_idx, sum_exp_register);  // multiply by scaler
+                mul_binary_tile(block_idx, sum_exp_register, block_idx);  // multiply by scaler
 
                 binop_with_scalar_tile_init();
                 mul_unary_tile(block_idx, scaler_bits);  // multiply by scaler

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
@@ -83,7 +83,7 @@ void find_max_value_in_row() {
                 copy_tile(cb_max_mask, /* tile_idx */ 0, /* register idx */ mask_register);
 
                 add_binary_tile_init();
-                add_binary_tile(working_register, mask_register);
+                add_binary_tile(working_register, mask_register, working_register);
             }
         }
 
@@ -134,7 +134,7 @@ void find_max_value_in_row() {
                     copy_tile(cb_max_mask, /* tile_idx */ 0, /* register idx */ mask_register);
 
                     add_binary_tile_init();
-                    add_binary_tile(working_register, mask_register);
+                    add_binary_tile(working_register, mask_register, working_register);
                 }
             }
 
@@ -209,7 +209,7 @@ void calculate_sum_exp_x() {
         copy_tile(cb_input, /* tile_idx */ col, /* register_idx */ working_register);
 
         sub_binary_tile_init();
-        sub_binary_tile(working_register, max_value_register);  // subtract max value from each tile
+        sub_binary_tile(working_register, max_value_register, working_register);  // subtract max value from each tile
 
         exp_tile_init();
         exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
@@ -229,7 +229,7 @@ void calculate_sum_exp_x() {
 
         if (col > 0) {
             add_binary_tile_init();
-            add_binary_tile(accum_register, working_register);
+            add_binary_tile(accum_register, working_register, accum_register);
         }
     }
     tile_regs_commit();
@@ -269,7 +269,8 @@ void calculate_sum_exp_x() {
             copy_tile(cb_input, /* tile_idx */ block_idx, /* register_idx */ working_register);
 
             sub_binary_tile_init();
-            sub_binary_tile(working_register, max_value_register);  // subtract max value from each tile
+            sub_binary_tile(
+                working_register, max_value_register, working_register);  // subtract max value from each tile
 
             exp_tile_init();
             exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
@@ -290,7 +291,7 @@ void calculate_sum_exp_x() {
 
             if (col > 0) {
                 add_binary_tile_init();
-                add_binary_tile(accum_register, working_register);
+                add_binary_tile(accum_register, working_register, accum_register);
             }
         }
         cb_pop_front(cb_input, block_size);

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/compute/rmsnorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/compute/rmsnorm_bw_kernel.cpp
@@ -63,7 +63,7 @@ inline void compute_gained_dL_dout(uint32_t col, uint32_t working_register, uint
     copy_tile_init(cb_dL_out_idx);
     copy_tile(cb_dL_out_idx, col, tile_register);
     mul_binary_tile_init();
-    mul_binary_tile(working_register, tile_register);
+    mul_binary_tile(working_register, tile_register, working_register);
 }
 
 inline void compute_dL_da(
@@ -86,17 +86,17 @@ inline void compute_dL_da(
     copy_tile_init(cb_recip_rms_a_bcasted_idx);
     copy_tile(cb_recip_rms_a_bcasted_idx, /* tile_idx */ 0, tile_register);
     mul_binary_tile_init();
-    mul_binary_tile(rhs_register, tile_register);
-    mul_binary_tile(rhs_register, tile_register);
+    mul_binary_tile(rhs_register, tile_register, rhs_register);
+    mul_binary_tile(rhs_register, tile_register, rhs_register);
     copy_tile_init(cb_scaler_idx);
     copy_tile(cb_scaler_idx, /* tile_idx */ 0, tile_register);
     mul_binary_tile_init();
-    mul_binary_tile(rhs_register, tile_register);
+    mul_binary_tile(rhs_register, tile_register, rhs_register);
 
     // Compute final result: dL_da = gained_dL_dout - rhs
     compute_gained_dL_dout(input_tile_idx, dL_da_register, tile_register);
     sub_binary_tile_init();
-    sub_binary_tile(dL_da_register, rhs_register);
+    sub_binary_tile(dL_da_register, rhs_register, dL_da_register);
 }
 
 inline void compute_dL_dgamma_components(
@@ -119,7 +119,7 @@ inline void compute_dL_dgamma_components(
     copy_tile_init(cb_dL_out_idx);
     copy_tile(cb_dL_out_idx, /* tile_idx */ input_tile_idx, tile_register);
     mul_binary_tile_init();
-    mul_binary_tile(dL_dg_components_register, tile_register);
+    mul_binary_tile(dL_dg_components_register, tile_register, dL_dg_components_register);
 }
 
 // ============================================================================
@@ -166,7 +166,7 @@ inline void compute_scale(const uint32_t row) {
         copy_tile_init(cb_input_idx);
         copy_tile(cb_input_idx, col, tile_register);
         mul_binary_tile_init();
-        mul_binary_tile(working_register, tile_register);
+        mul_binary_tile(working_register, tile_register, working_register);
 
         // Mask the tile if needed
         if constexpr (do_mask_w) {
@@ -185,7 +185,7 @@ inline void compute_scale(const uint32_t row) {
         // Add scale_components to scale
         if (col > 0) {
             add_binary_tile_init();
-            add_binary_tile(scale_register, working_register);
+            add_binary_tile(scale_register, working_register, scale_register);
         }
     }
     tile_regs_commit();
@@ -239,7 +239,7 @@ inline void compute_scale(const uint32_t row) {
             copy_tile_init(cb_input_idx);
             copy_tile(cb_input_idx, block_idx, tile_register);
             mul_binary_tile_init();
-            mul_binary_tile(working_register, tile_register);
+            mul_binary_tile(working_register, tile_register, working_register);
 
             // Mask the tile if needed
             if constexpr (do_mask_w) {
@@ -259,7 +259,7 @@ inline void compute_scale(const uint32_t row) {
             // Add scale_components to scale
             if (col > 0) {
                 add_binary_tile_init();
-                add_binary_tile(scale_register, working_register);
+                add_binary_tile(scale_register, working_register, scale_register);
             }
         }
         // Pop tiles that are not needed anymore.

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/compute/rmsnorm_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/compute/rmsnorm_fw_kernel.cpp
@@ -77,11 +77,11 @@ void calculate_sum_x_squared() {
             }
         }
         mul_binary_tile_init();
-        mul_binary_tile(working_register, working_register);
+        mul_binary_tile(working_register, working_register, working_register);
 
         if (col > 0) {
             add_binary_tile_init();
-            add_binary_tile(accum_register, working_register);
+            add_binary_tile(accum_register, working_register, accum_register);
         }
     }
     tile_regs_commit();
@@ -125,10 +125,10 @@ void calculate_sum_x_squared() {
             }
 
             mul_binary_tile_init();
-            mul_binary_tile(working_register, working_register);
+            mul_binary_tile(working_register, working_register, working_register);
             if (col > 0) {
                 add_binary_tile_init();
-                add_binary_tile(accum_register, working_register);
+                add_binary_tile(accum_register, working_register, accum_register);
             }
         }
 
@@ -314,7 +314,7 @@ void MAIN {
 
             reconfig_data_format(cb_rms_before_reduction_intermediate, cb_eps);
             add_binary_tile_init();
-            add_binary_tile(reduction_register, eps_register);
+            add_binary_tile(reduction_register, eps_register, reduction_register);
 
             sqrt_tile_init();
             sqrt_tile(reduction_register);

--- a/tt-train/sources/ttml/metal/ops/softmax/device/kernels/compute/softmax_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/kernels/compute/softmax_kernel.cpp
@@ -90,7 +90,7 @@ void find_max_value_in_row() {
                     copy_tile(cb_max_mask, /* tile_idx */ 0, /* register idx */ mask_register);
 
                     add_binary_tile_init();
-                    add_binary_tile(working_register, mask_register);
+                    add_binary_tile(working_register, mask_register, working_register);
                 }
             }
 
@@ -143,7 +143,7 @@ void find_max_value_in_row() {
                     copy_tile(cb_max_mask, /* tile_idx */ 0, /* register idx */ mask_register);
 
                     add_binary_tile_init();
-                    add_binary_tile(working_register, mask_register);
+                    add_binary_tile(working_register, mask_register, working_register);
                 }
             }
 
@@ -251,7 +251,7 @@ void calculate_sum_exp_x() {
 
         if (col > 0) {
             add_binary_tile_init();
-            add_binary_tile(working_register, tile_register);
+            add_binary_tile(working_register, tile_register, working_register);
         }
     }
     tile_regs_commit();
@@ -312,7 +312,7 @@ void calculate_sum_exp_x() {
 
             if (col > 0) {
                 add_binary_tile_init();
-                add_binary_tile(accum_register, working_register);
+                add_binary_tile(accum_register, working_register, accum_register);
             }
         }
         cb_pop_front(cb_input, block_size);
@@ -428,7 +428,7 @@ void MAIN {
 #endif
 
                 mul_binary_tile_init();
-                mul_binary_tile(block_idx, sum_exp_register);  // multiply by scaler
+                mul_binary_tile(block_idx, sum_exp_register, block_idx);  // multiply by scaler
             }
             tile_regs_commit();
 

--- a/tt-train/sources/ttml/metal/ops/softmax/device/kernels/compute/softmax_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/kernels/compute/softmax_kernel.cpp
@@ -291,7 +291,8 @@ void calculate_sum_exp_x() {
             copy_tile(cb_input, /* tile_idx */ block_idx, /* register_idx */ working_register);
 
             sub_binary_tile_init();
-            sub_binary_tile(working_register, max_value_register);  // subtract max value from each tile
+            sub_binary_tile(
+                working_register, max_value_register, working_register);  // subtract max value from each tile
 
             exp_tile_init<false>();
             exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -152,6 +152,7 @@ template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8, bool is_f
 inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (BINOP == BinaryOp::POW) {
         for (int d = 0; d < ITERATIONS; d++) {
+            // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
             constexpr uint dst_tile_size_sfpi = 32;
             sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
             sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -152,13 +152,13 @@ template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8, bool is_f
 inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (BINOP == BinaryOp::POW) {
         for (int d = 0; d < ITERATIONS; d++) {
-            constexpr uint dst_tile_size = 32;
-            sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
-            sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
+            constexpr uint dst_tile_size_sfpi = 32;
+            sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+            sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
             sfpi::vFloat result = _sfpu_binary_power_<is_fp32_dest_acc_en>(in0, in1);
 
-            sfpi::dst_reg[dst_index_out * dst_tile_size] = result;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
             sfpi::dst_reg++;
         }
     } else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -149,20 +149,20 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
 }
 
 template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
-inline void calculate_sfpu_binary(const uint dst_offset) {
+inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (BINOP == BinaryOp::POW) {
         for (int d = 0; d < ITERATIONS; d++) {
             constexpr uint dst_tile_size = 32;
-            sfpi::vFloat in0 = sfpi::dst_reg[0];
-            sfpi::vFloat in1 = sfpi::dst_reg[dst_offset * dst_tile_size];
+            sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
+            sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
 
             sfpi::vFloat result = _sfpu_binary_power_<is_fp32_dest_acc_en>(in0, in1);
 
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[dst_index_out * dst_tile_size] = result;
             sfpi::dst_reg++;
         }
     } else {
-        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
+        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_out);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_bitwise.h
@@ -18,8 +18,10 @@ template <
     BinaryBitwiseOp BITWISE_OP,
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
     int ITERATIONS = 8>
-inline void calculate_sfpu_binary_bitwise(const uint dst_offset) {
-    _calculate_sfpu_binary_bitwise_<APPROXIMATION_MODE, BITWISE_OP, INSTRUCTION_MODE, ITERATIONS>(dst_offset);
+inline void calculate_sfpu_binary_bitwise(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _calculate_sfpu_binary_bitwise_<APPROXIMATION_MODE, BITWISE_OP, INSTRUCTION_MODE, ITERATIONS>(
+        dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -13,19 +13,19 @@ namespace ckernel {
 namespace sfpu {
 
 template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min(const uint dst_offset) {
+inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);  // a
+        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in0 * dst_tile_size);  // a
         if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
             TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
             TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
         }
 
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, dst_offset * dst_tile_size);  // b
+        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in1 * dst_tile_size);  // b
         if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
             TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
             TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
@@ -39,13 +39,13 @@ inline void calculate_binary_max_min(const uint dst_offset) {
                 TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
                 TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
             }
-            TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_out * dst_tile_size);
         } else {
             if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
                 TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
                 TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
             }
-            TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_out * dst_tile_size);
         }
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -17,6 +17,7 @@ inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_in
     constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
 
         TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in0 * dst_tile_size);  // a

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -16,6 +16,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
         constexpr uint dst_tile_size_sfpi = 32;
         dst_reg[dst_index_in0 * dst_tile_size_sfpi] = dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -16,8 +16,8 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
-        constexpr uint dst_tile_size = 32;
-        dst_reg[dst_index_in0 * dst_tile_size] = dst_reg[dst_index_in1 * dst_tile_size];
+        constexpr uint dst_tile_size_sfpi = 32;
+        dst_reg[dst_index_in0 * dst_tile_size_sfpi] = dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -13,15 +13,11 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool IDST0_BIGGER, int ITERATIONS = 8>
-void copy_dest_value(const uint dst_offset) {
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 32;
-        if constexpr (IDST0_BIGGER) {
-            dst_reg[dst_offset * dst_tile_size] = dst_reg[0];
-        } else {
-            dst_reg[0] = dst_reg[dst_offset * dst_tile_size];
-        }
+        dst_reg[dst_index_in0 * dst_tile_size] = dst_reg[dst_index_in1 * dst_tile_size];
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -54,6 +54,7 @@ template <int ITERATIONS = 8>
 inline void calculate_sfpu_gcd(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Binary GCD algorithm.
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in the dest is 64 rows
         constexpr uint dst_tile_size = 64;
 
         TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -51,18 +51,17 @@ inline void calculate_sfpu_gcd_body() {
 }
 
 template <int ITERATIONS = 8>
-inline void calculate_sfpu_gcd(const uint dst_offset)
-{
+inline void calculate_sfpu_gcd(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Binary GCD algorithm.
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
-        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+        TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
         calculate_sfpu_gcd_body<31>();
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 4, 3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -52,13 +52,12 @@ inline void calculate_sfpu_mul_u16_to_u32_body() {
 }
 
 template <int ITERATIONS = 8>
-inline void calculate_sfpu_lcm(const uint dst_offset)
-{
+inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
-        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+        TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
         // Binary GCD algorithm; assumes abs(a) < 2^15 and abs(b) < 2^15, hence gcd(a, b) < 2^15
         calculate_sfpu_gcd_body<15>();
@@ -87,11 +86,11 @@ inline void calculate_sfpu_lcm(const uint dst_offset)
         TTI_SFPSETEXP(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
 
 	// Load a and multiply by 1/gcd(a, b)
-        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);
         TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);
         TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0);
 
 	// Convert a/gcd(a, b) to int32
@@ -100,7 +99,7 @@ inline void calculate_sfpu_lcm(const uint dst_offset)
 	// Finally, compute lcm(a, b) = a/gcd(a, b) * b
         calculate_sfpu_mul_u16_to_u32_body();
 
-        TTI_SFPSTORE(p_sfpu::LREG4, 4, 3, 0);
+        TT_SFPSTORE(p_sfpu::LREG4, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -54,6 +54,7 @@ inline void calculate_sfpu_mul_u16_to_u32_body() {
 template <int ITERATIONS = 8>
 inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
 
         TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -14,6 +14,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
         // operand A - int32
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_in0 * dst_tile_size);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -11,14 +11,14 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void mul_int32(const uint dst_offset) {
+inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
         // operand A - int32
-        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
         // operand B - int32
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
 
         // INT32 split into 8-bit inputs
         // mask
@@ -113,9 +113,9 @@ inline void mul_int32(const uint dst_offset) {
 
         // Load operands again to extract a3 and b3
         // operand A - int32
-        TTI_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
         // operand B - int32
-        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
         // mask
         TTI_SFPLOADI(p_sfpu::LREG4, SFPLOADI_MOD0_USHORT, 0xFF);
 
@@ -145,7 +145,7 @@ inline void mul_int32(const uint dst_offset) {
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
-        TTI_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -14,18 +14,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_quant_int32(const uint dst_offset) {
-    _quant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _quant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_requant_int32(const uint dst_offset) {
-    _requant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _requant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_dequant_int32(const uint dst_offset) {
-    _dequant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_dequant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _dequant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -11,18 +11,19 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_rsub_int32(const uint dst_offset) {
+inline void calculate_rsub_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
         // operand A - int32
-        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
         // operand B - int32 (offset by dst_offset * dest tile size)
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_offset * 64);
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
         // Reverse subtraction is performed using 2's complement by adding B to the negation of A: LREG1 + (-LREG0)
         // Use 6 as imod to convert operand A to 2's complement
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 6);
         // Store result from LREG_0 to dest
-        TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -14,6 +14,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_rsub_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
         // operand A - int32
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_in0 * dst_tile_size);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
@@ -18,8 +18,9 @@ template <
     int ITERATIONS = 8,
     InstrModLoadStore INSTRUCTION_MODE = INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_binary_left_shift(const uint dst_offset) {
-    _calculate_binary_left_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_binary_left_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _calculate_binary_left_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(
+        dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <
@@ -27,8 +28,9 @@ template <
     int ITERATIONS = 8,
     InstrModLoadStore INSTRUCTION_MODE = INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_binary_right_shift(const uint dst_offset) {
-    _calculate_binary_right_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_binary_right_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _calculate_binary_right_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(
+        dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -9,16 +9,9 @@
 namespace ckernel {
 namespace sfpu {
 
-/*
-Expects following input in Dst register:
-Index 0 ( Tile 0 ) -> condition tensor
-Index 32 ( Tile 1 ) -> true tensor
-Index 64 ( Tile 2 ) -> false tensor
-
-*/
-
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_where_int32() {
+inline void calculate_where_int32(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out) {
     constexpr uint dst_tile_size = 32;
 
     sfpi::vInt output_tensor = 0;
@@ -27,14 +20,14 @@ inline void calculate_where_int32() {
     sfpi::vInt cond = sfpi::dst_reg[0];
 
     for (int i = 0; i < ITERATIONS; i++) {
-        cond = sfpi::dst_reg[0];
-        true_tensor = sfpi::dst_reg[dst_tile_size];
-        false_tensor = sfpi::dst_reg[dst_tile_size * 2];
+        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
+        true_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
+        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size];
         output_tensor = false_tensor;
 
         v_if(cond != 0) { output_tensor = true_tensor; }
         v_endif;
-        sfpi::dst_reg[0] = output_tensor;
+        sfpi::dst_reg[dst_index_out * dst_tile_size] = output_tensor;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -12,6 +12,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_where_int32(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
     sfpi::vInt output_tensor = 0;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -12,22 +12,22 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_where_int32(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out) {
-    constexpr uint dst_tile_size = 32;
+    constexpr uint dst_tile_size_sfpi = 32;
 
     sfpi::vInt output_tensor = 0;
     sfpi::vInt true_tensor = 0;
     sfpi::vInt false_tensor = 0;
-    sfpi::vInt cond = sfpi::dst_reg[0];
+    sfpi::vInt cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
 
     for (int i = 0; i < ITERATIONS; i++) {
-        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
-        true_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
-        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size];
+        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        true_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
         output_tensor = false_tensor;
 
         v_if(cond != 0) { output_tensor = true_tensor; }
         v_endif;
-        sfpi::dst_reg[dst_index_out * dst_tile_size] = output_tensor;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -22,11 +22,12 @@ template <
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_add_int(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_add_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -20,9 +20,9 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, true>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 // Binary minimum
@@ -33,9 +33,9 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, false>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
@@ -19,11 +19,13 @@ inline void llk_math_eltwise_binary_sfpu_binop_init() {
 }
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
-inline void llk_math_eltwise_binary_sfpu_binop(uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_binop(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_sfpu_binary<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -22,11 +22,12 @@ template <
     ckernel::sfpu::BinaryBitwiseOp BITWISE_OP,
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32>
 inline void llk_math_eltwise_binary_sfpu_bitwise(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_sfpu_binary_bitwise<APPROXIMATE, BITWISE_OP, INSTRUCTION_MODE>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -13,14 +13,8 @@ namespace ckernel {
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    // Note: this if is required due to the issue described in https://github.com/tenstorrent/tt-metal/issues/19442
-    if (dst_index0 > dst_index1) {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-            sfpu::copy_dest_value<APPROXIMATE, 1>, dst_index0, dst_index1, vector_mode);
-    } else {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-            sfpu::copy_dest_value<APPROXIMATE, 0>, dst_index0, dst_index1, vector_mode);
-    }
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::copy_dest_value<APPROXIMATE>, dst_index0, dst_index1, 0 /*odst not used*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -20,8 +20,9 @@ inline void llk_math_eltwise_binary_sfpu_gcd_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, vector_mode);
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -20,8 +20,9 @@ inline void llk_math_eltwise_binary_sfpu_lcm_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, vector_mode);
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -18,9 +18,9 @@ inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_mul_int(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -19,9 +19,9 @@ inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
@@ -20,9 +20,10 @@ inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point)
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_quant_int32(uint dst_index0, uint dst_index1, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_quant_int32(
+    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -33,9 +34,10 @@ inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_poin
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_requant_int32(uint dst_index0, uint dst_index1, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_requant_int32(
+    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -46,9 +48,10 @@ inline void llk_math_eltwise_binary_sfpu_dequant_int32_init(const uint zero_poin
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_dequant_int32(uint dst_index0, uint dst_index1, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_dequant_int32(
+    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
@@ -19,9 +19,9 @@ inline void llk_math_eltwise_binary_sfpu_rsub_int32_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_rsub_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_rsub_int32<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_rsub_int32<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -19,31 +19,34 @@ inline void llk_math_eltwise_binary_sfpu_shift_init() {
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_left_shift(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_left_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_right_shift(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_right_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_logical_right_shift_<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -22,11 +22,12 @@ template <
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_sub_int(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_sub_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
@@ -18,11 +18,13 @@ inline void llk_math_eltwise_binary_sfpu_xlogy_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_xlogy(uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_xlogy(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_sfpu_binary_<APPROXIMATE, BinaryOp::XLOGY, ITERATIONS>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -13,31 +13,33 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where(
-    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float16_b, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_fp32(
-    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float32, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_int32(
-    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_where_int32<APPROXIMATE, 8>, dst_index0, dst_index1, dst_index2, vector_mode);
+        ckernel::sfpu::calculate_where_int32<APPROXIMATE, 8>, dst_index0, dst_index1, dst_index2, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -149,12 +149,12 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
 }
 
 template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
-inline void calculate_sfpu_binary(const uint dst_offset) {
+inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (BINOP == BinaryOp::POW) {
         for (int d = 0; d < ITERATIONS; d++) {
             constexpr uint dst_tile_size = 32;
             sfpi::vFloat in0 = sfpi::dst_reg[0];
-            sfpi::vFloat in1 = sfpi::dst_reg[dst_offset * dst_tile_size];
+            sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
 
             sfpi::vFloat result = _sfpu_binary_power_<is_fp32_dest_acc_en>(in0, in1);
 
@@ -162,7 +162,7 @@ inline void calculate_sfpu_binary(const uint dst_offset) {
             sfpi::dst_reg++;
         }
     } else {
-        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
+        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_index_in0, dst_index_in1, dst_index_out);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -152,6 +152,7 @@ template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8, bool is_f
 inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (BINOP == BinaryOp::POW) {
         for (int d = 0; d < ITERATIONS; d++) {
+            // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
             constexpr uint dst_tile_size_sfpi = 32;
             sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
             sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -152,13 +152,13 @@ template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8, bool is_f
 inline void calculate_sfpu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (BINOP == BinaryOp::POW) {
         for (int d = 0; d < ITERATIONS; d++) {
-            constexpr uint dst_tile_size = 32;
-            sfpi::vFloat in0 = sfpi::dst_reg[0];
-            sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
+            constexpr uint dst_tile_size_sfpi = 32;
+            sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+            sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
             sfpi::vFloat result = _sfpu_binary_power_<is_fp32_dest_acc_en>(in0, in1);
 
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
             sfpi::dst_reg++;
         }
     } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_bitwise.h
@@ -18,8 +18,10 @@ template <
     BinaryBitwiseOp BITWISE_OP,
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
     int ITERATIONS = 8>
-inline void calculate_sfpu_binary_bitwise(const uint dst_offset) {
-    _calculate_sfpu_binary_bitwise_<APPROXIMATION_MODE, BITWISE_OP, INSTRUCTION_MODE, ITERATIONS>(dst_offset);
+inline void calculate_sfpu_binary_bitwise(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _calculate_sfpu_binary_bitwise_<APPROXIMATION_MODE, BITWISE_OP, INSTRUCTION_MODE, ITERATIONS>(
+        dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -13,21 +13,21 @@ namespace ckernel {
 namespace sfpu {
 
 template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min(const uint dst_offset) {
+inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);                          // a
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
+        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, dst_index_in0 * dst_tile_size);  // a
+        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, dst_index_in1 * dst_tile_size);  // b
 
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
 
         if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, dst_index_out * dst_tile_size);
         } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, dst_index_out * dst_tile_size);
         }
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -16,6 +16,7 @@ template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATI
 inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
 
         TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, dst_index_in0 * dst_tile_size);  // a

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -16,6 +16,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
         constexpr uint dst_tile_size_sfpi = 32;
         dst_reg[dst_index_in0 * dst_tile_size_sfpi] = dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -16,8 +16,8 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
-        constexpr uint dst_tile_size = 32;
-        dst_reg[dst_index_in0 * dst_tile_size] = dst_reg[dst_index_in1 * dst_tile_size];
+        constexpr uint dst_tile_size_sfpi = 32;
+        dst_reg[dst_index_in0 * dst_tile_size_sfpi] = dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -13,15 +13,11 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool IDST0_BIGGER, int ITERATIONS = 8>
-void copy_dest_value(const uint dst_offset) {
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 32;
-        if constexpr (IDST0_BIGGER) {
-            dst_reg[dst_offset * dst_tile_size] = dst_reg[0];
-        } else {
-            dst_reg[0] = dst_reg[dst_offset * dst_tile_size];
-        }
+        dst_reg[dst_index_in0 * dst_tile_size] = dst_reg[dst_index_in1 * dst_tile_size];
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -54,6 +54,7 @@ template <int ITERATIONS = 8>
 inline void calculate_sfpu_gcd(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Binary GCD algorithm.
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
 
         TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -51,18 +51,17 @@ inline void calculate_sfpu_gcd_body() {
 }
 
 template <int ITERATIONS = 8>
-inline void calculate_sfpu_gcd(const uint dst_offset)
-{
+inline void calculate_sfpu_gcd(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Binary GCD algorithm.
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
-        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+        TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
         calculate_sfpu_gcd_body<31>();
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 4, 3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -52,13 +52,12 @@ inline void calculate_sfpu_mul_u16_to_u32_body() {
 }
 
 template <int ITERATIONS = 8>
-inline void calculate_sfpu_lcm(const uint dst_offset)
-{
+inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
-        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+        TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
         // Binary GCD algorithm; assumes abs(a) < 2^15 and abs(b) < 2^15, hence gcd(a, b) < 2^15
         calculate_sfpu_gcd_body<15>();
@@ -87,11 +86,11 @@ inline void calculate_sfpu_lcm(const uint dst_offset)
         TTI_SFPSETEXP(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
 
 	// Load a and multiply by 1/gcd(a, b)
-        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);
         TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);
         TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0);
 
 	// Convert a/gcd(a, b) to int32
@@ -100,7 +99,7 @@ inline void calculate_sfpu_lcm(const uint dst_offset)
 	// Finally, compute lcm(a, b) = a/gcd(a, b) * b
         calculate_sfpu_mul_u16_to_u32_body();
 
-        TTI_SFPSTORE(p_sfpu::LREG4, 4, 3, 0);
+        TT_SFPSTORE(p_sfpu::LREG4, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -54,6 +54,7 @@ inline void calculate_sfpu_mul_u16_to_u32_body() {
 template <int ITERATIONS = 8>
 inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
 
         TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -11,14 +11,14 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void mul_int32(const uint dst_offset) {
+inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
         // operand A - int32
-        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);
         // operand B - int32
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
 
         // INT32 split into 8-bit inputs
         // mask
@@ -155,7 +155,7 @@ inline void mul_int32(const uint dst_offset) {
         TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
-        TTI_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -121,9 +121,9 @@ inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const 
 
         // Load operands again to extract a3 and b3
         // operand A - int32
-        TTI_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);
         // operand B - int32
-        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_3, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
         // mask
         TTI_SFPLOADI(p_sfpu::LREG4, SFPLOADI_MOD0_USHORT, 0xFF);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -14,6 +14,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
         // operand A - int32
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_quant.h
@@ -14,18 +14,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_quant_int32(const uint dst_offset) {
-    _quant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_quant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _quant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_requant_int32(const uint dst_offset) {
-    _requant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_requant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _requant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_dequant_int32(const uint dst_offset) {
-    _dequant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_dequant_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _dequant_int32_<APPROXIMATION_MODE, ITERATIONS, SIGN_MAGNITUDE_FORMAT>(dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -14,6 +14,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_rsub_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
         // operand A - int32
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -11,18 +11,19 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_rsub_int32(const uint dst_offset) {
+inline void calculate_rsub_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
         // operand A - int32
-        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);
         // operand B - int32 (offset by dst_offset * dest tile size)
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_offset * 64);
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
         // Reverse subtraction is performed using 2's complement by adding B to the negation of A: LREG1 + (-LREG0)
         // Use 6 as imod to convert operand A to 2's complement
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 6);
         // Store result from LREG_0 to dest
-        TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
@@ -18,8 +18,9 @@ template <
     int ITERATIONS = 8,
     InstrModLoadStore INSTRUCTION_MODE = INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_binary_left_shift(const uint dst_offset) {
-    _calculate_binary_left_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_binary_left_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _calculate_binary_left_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(
+        dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 template <
@@ -27,8 +28,9 @@ template <
     int ITERATIONS = 8,
     InstrModLoadStore INSTRUCTION_MODE = INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
-inline void calculate_binary_right_shift(const uint dst_offset) {
-    _calculate_binary_right_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(dst_offset);
+inline void calculate_binary_right_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    _calculate_binary_right_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(
+        dst_index_in0, dst_index_in1, dst_index_out);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -12,6 +12,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_where_int32(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
     sfpi::vInt output_tensor = 0;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -9,33 +9,26 @@
 namespace ckernel {
 namespace sfpu {
 
-/*
-Expects following input in Dst register:
-Index 0 ( Tile 0 ) -> condition tensor
-Index 32 ( Tile 1 ) -> true tensor
-Index 64 ( Tile 2 ) -> false tensor
-
-*/
-
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_where_int32() {
+inline void calculate_where_int32(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out) {
     constexpr uint dst_tile_size = 32;
 
     sfpi::vInt output_tensor = 0;
     sfpi::vInt true_tensor = 0;
     sfpi::vInt false_tensor = 0;
-    sfpi::vInt cond = sfpi::dst_reg[0];
+    sfpi::vInt cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
 
     for (int i = 0; i < ITERATIONS; i++) {
-        cond = sfpi::dst_reg[0];
-        true_tensor = sfpi::dst_reg[dst_tile_size];
-        false_tensor = sfpi::dst_reg[dst_tile_size * 2];
+        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
+        true_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
+        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size];
         output_tensor = false_tensor;
 
         v_if(cond != 0) { output_tensor = true_tensor; }
         v_endif;
 
-        sfpi::dst_reg[0] = output_tensor;
+        sfpi::dst_reg[dst_index_out * dst_tile_size] = output_tensor;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -12,23 +12,23 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_where_int32(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_in2, const uint dst_index_out) {
-    constexpr uint dst_tile_size = 32;
+    constexpr uint dst_tile_size_sfpi = 32;
 
     sfpi::vInt output_tensor = 0;
     sfpi::vInt true_tensor = 0;
     sfpi::vInt false_tensor = 0;
-    sfpi::vInt cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
+    sfpi::vInt cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
 
     for (int i = 0; i < ITERATIONS; i++) {
-        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size];
-        true_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size];
-        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size];
+        cond = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        true_tensor = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        false_tensor = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
         output_tensor = false_tensor;
 
         v_if(cond != 0) { output_tensor = true_tensor; }
         v_endif;
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size] = output_tensor;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = output_tensor;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -22,11 +22,12 @@ template <
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_add_int(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_add_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -20,9 +20,9 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, true>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 // Binary minimum
@@ -33,9 +33,9 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, false>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
@@ -19,11 +19,13 @@ inline void llk_math_eltwise_binary_sfpu_binop_init() {
 }
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
-inline void llk_math_eltwise_binary_sfpu_binop(uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_binop(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_sfpu_binary<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -22,11 +22,12 @@ template <
     ckernel::sfpu::BinaryBitwiseOp BITWISE_OP,
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32>
 inline void llk_math_eltwise_binary_sfpu_bitwise(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_sfpu_binary_bitwise<APPROXIMATE, BITWISE_OP, INSTRUCTION_MODE>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -13,14 +13,8 @@ namespace ckernel {
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    // Note: this if is required due to the issue described in https://github.com/tenstorrent/tt-metal/issues/19442
-    if (dst_index0 > dst_index1) {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-            sfpu::copy_dest_value<APPROXIMATE, 1>, dst_index0, dst_index1, vector_mode);
-    } else {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-            sfpu::copy_dest_value<APPROXIMATE, 0>, dst_index0, dst_index1, vector_mode);
-    }
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::copy_dest_value<APPROXIMATE>, dst_index0, dst_index1, 0 /*odst not used*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -20,8 +20,9 @@ inline void llk_math_eltwise_binary_sfpu_gcd_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, vector_mode);
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -20,8 +20,9 @@ inline void llk_math_eltwise_binary_sfpu_lcm_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, vector_mode);
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -18,9 +18,9 @@ inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_mul_int(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -19,9 +19,9 @@ inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
@@ -20,9 +20,10 @@ inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point)
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_quant_int32(uint dst_index0, uint dst_index1, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_quant_int32(
+    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -33,9 +34,10 @@ inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_poin
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_requant_int32(uint dst_index0, uint dst_index1, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_requant_int32(
+    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -46,9 +48,10 @@ inline void llk_math_eltwise_binary_sfpu_dequant_int32_init(const uint zero_poin
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_dequant_int32(uint dst_index0, uint dst_index1, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_dequant_int32(
+    uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int32.h
@@ -19,9 +19,9 @@ inline void llk_math_eltwise_binary_sfpu_rsub_int32_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_rsub_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_rsub_int32<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_rsub_int32<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -19,31 +19,34 @@ inline void llk_math_eltwise_binary_sfpu_shift_init() {
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_left_shift(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_left_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_right_shift(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_right_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_logical_right_shift_<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -22,11 +22,12 @@ template <
     InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_sub_int(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_sub_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
@@ -18,11 +18,13 @@ inline void llk_math_eltwise_binary_sfpu_xlogy_init() {
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_binary_sfpu_xlogy(uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+inline void llk_math_eltwise_binary_sfpu_xlogy(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_sfpu_binary_<APPROXIMATE, BinaryOp::XLOGY, ITERATIONS>,
         dst_index0,
         dst_index1,
+        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -13,31 +13,33 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where(
-    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float16_b, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_fp32(
-    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float32, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
+        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_int32(
-    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_where_int32<APPROXIMATE, 8>, dst_index0, dst_index1, dst_index2, vector_mode);
+        ckernel::sfpu::calculate_where_int32<APPROXIMATE, 8>, dst_index0, dst_index1, dst_index2, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api/add_int_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/add_int_sfpu.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise add operation with the two integer inputs: y = add(x0,x1)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -27,23 +27,23 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
- * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | sign_magnitude_format | Whether the Int32 values are in sign-magnitude format (not 2's complement)  | bool     |                                                       | False    |
+ * | Argument | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0    | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1    | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst     | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void add_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_add_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1)));
+ALWI void add_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_add_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1, odst)));
 }
 
-ALWI void add_uint16_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_add_int<APPROX, 8, InstrModLoadStore::LO16, false>(idst0, idst1)));
+ALWI void add_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_add_int<APPROX, 8, InstrModLoadStore::LO16, false>(idst0, idst1, odst)));
 }
 
-ALWI void add_uint32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_add_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1)));
+ALWI void add_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_add_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/binary_bitwise_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/binary_bitwise_sfpu.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise binary bitwise operation with the two inputs: y = bitwise(x0,x1)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -31,36 +31,37 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void bitwise_and_binary_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void bitwise_and_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::AND, InstrModLoadStore::INT32>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void bitwise_and_uint16_binary_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void bitwise_and_uint16_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::AND, InstrModLoadStore::LO16>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void bitwise_or_binary_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void bitwise_or_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::OR, InstrModLoadStore::INT32>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void bitwise_or_uint16_binary_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void bitwise_or_uint16_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::OR, InstrModLoadStore::LO16>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void bitwise_xor_binary_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void bitwise_xor_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::XOR, InstrModLoadStore::INT32>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void bitwise_xor_uint16_binary_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void bitwise_xor_uint16_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::XOR, InstrModLoadStore::LO16>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/binary_max_min.h
+++ b/tt_metal/include/compute_kernel_api/binary_max_min.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise maximum operation on inputs of int32 data type at idst0, idst1: y = max(x0, x1).
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -31,16 +31,17 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX, InstrModLoadStore::INT32_2S_COMP>(idst0, idst1)));
+ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX, InstrModLoadStore::INT32_2S_COMP>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise maximum operation on inputs at idst0, idst1: y = max(x0, x1).
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -53,10 +54,11 @@ ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1) {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX, InstrModLoadStore::DEFAULT>(idst0, idst1)));
+ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX, InstrModLoadStore::DEFAULT>(idst0, idst1, odst)));
 }
 
 /**
@@ -67,7 +69,7 @@ ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max
 // clang-format off
 /**
  * Performs an elementwise maximum operation on inputs of int32 data type at idst0, idst1: y = min(x0, x1).
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -80,16 +82,17 @@ ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX, InstrModLoadStore::INT32_2S_COMP>(idst0, idst1)));
+ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX, InstrModLoadStore::INT32_2S_COMP>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise minimum operation on inputs at idst0, idst1: y = min(x0, x1).
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -102,10 +105,11 @@ ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1) {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX, InstrModLoadStore::DEFAULT>(idst0, idst1)));
+ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX, InstrModLoadStore::DEFAULT>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/binary_shift.h
+++ b/tt_metal/include/compute_kernel_api/binary_shift.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise shift operation to the left on the input at idst0, by input at idst1: y = x0 << x1
- * Both inputs must be of Int32 data type only. Output overwrites first operand in DST.
+ * Both inputs must be of Int32 data type only. Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -31,26 +31,27 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_left_shift_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX>(idst0, idst1)));
+ALWI void binary_left_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX>(idst0, idst1, odst)));
 }
 
 template <bool sign_magnitude_format = false>
-ALWI void binary_left_shift_uint32_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void binary_left_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::INT32, sign_magnitude_format>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1)));
+ALWI void binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise shift operation to the right on the input at idst0, by input at idst1: y = x0 >> x1
- * Both inputs must be of Int32 data type only. Output overwrites first operand in DST.
+ * Both inputs must be of Int32 data type only. Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -63,26 +64,27 @@ ALWI void binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_right_shift_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX>(idst0, idst1)));
+ALWI void binary_right_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX>(idst0, idst1, odst)));
 }
 
 template <bool sign_magnitude_format = false>
-ALWI void binary_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void binary_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32, sign_magnitude_format>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1)));
+ALWI void binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise logical shift operation to the right on the input at idst0, by input at idst1: y = x0 >> x1
- * Both inputs must be of Int32 data type only. Output overwrites first operand in DST.
+ * Both inputs must be of Int32 data type only. Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -95,20 +97,21 @@ ALWI void binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void binary_logical_right_shift_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX>(idst0, idst1)));
+ALWI void binary_logical_right_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX>(idst0, idst1, odst)));
 }
 
 template <bool sign_magnitude_format = false>
-ALWI void binary_logical_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1) {
+ALWI void binary_logical_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX, InstrModLoadStore::INT32, sign_magnitude_format>(
-        idst0, idst1)));
+        idst0, idst1, odst)));
 }
 
-ALWI void binary_logical_right_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1)));
+ALWI void binary_logical_right_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise binop operation with the two floating point inputs: y = binop(x0,x1)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -31,30 +31,31 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void add_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::ADD>(idst0, idst1)));
+ALWI void add_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::ADD>(idst0, idst1, odst)));
 }
 
-ALWI void sub_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::SUB>(idst0, idst1)));
+ALWI void sub_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::SUB>(idst0, idst1, odst)));
 }
 
-ALWI void mul_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::MUL>(idst0, idst1)));
+ALWI void mul_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::MUL>(idst0, idst1, odst)));
 }
 
-ALWI void div_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::DIV>(idst0, idst1)));
+ALWI void div_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::DIV>(idst0, idst1, odst)));
 }
 
-ALWI void rsub_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::RSUB>(idst0, idst1)));
+ALWI void rsub_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::RSUB>(idst0, idst1, odst)));
 }
 
-ALWI void power_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::POW, DST_ACCUM_MODE>(idst0, idst1)));
+ALWI void power_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::BinaryOp::POW, DST_ACCUM_MODE>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
@@ -18,28 +18,29 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise where operation with the three inputs: y = where(x0,x1,x2)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
  *
- * | Argument              | Description                                                                  | Type     | Valid Range                                           | Required |
- * |-----------------------|------------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as condition operand     | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1                 | The index of the tile in DST register buffer to use as first operand         | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst2                 | The index of the tile in DST register buffer to use as second operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | Argument              | Description                                                              | Type     | Valid Range                                           | Required |
+ * |-----------------------|--------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as condition operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as first operand     | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst2                 | The index of the tile in DST register buffer to use as second operand    | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst                  | The index of the tile in DST register buffer to use as output            | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void where_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2) {
-    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX>(idst0, idst1, idst2)));
+ALWI void where_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
+    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX>(idst0, idst1, idst2, odst)));
 }
 
-ALWI void where_fp32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_fp32<APPROX>(idst0, idst1, idst2)));
+ALWI void where_fp32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
+    MATH((llk_math_eltwise_ternary_sfpu_where_fp32<APPROX>(idst0, idst1, idst2, odst)));
 }
 
-ALWI void where_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_int32<APPROX>(idst0, idst1, idst2)));
+ALWI void where_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
+    MATH((llk_math_eltwise_ternary_sfpu_where_int32<APPROX>(idst0, idst1, idst2, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/gcd.h
+++ b/tt_metal/include/compute_kernel_api/gcd.h
@@ -19,7 +19,7 @@ namespace ckernel {
 /**
  * Performs an elementwise GCD operation on two inputs: y = gcd(x0, x1).
  * Both inputs must be int32.
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -30,10 +30,11 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
- // clang-format on
-ALWI void gcd_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_gcd<APPROX>(idst0, idst1)));
+// clang-format on
+ALWI void gcd_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_gcd<APPROX>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/lcm.h
+++ b/tt_metal/include/compute_kernel_api/lcm.h
@@ -19,7 +19,7 @@ namespace ckernel {
 /**
  * Performs an elementwise LCM operation on two inputs: y = lcm(x0, x1).
  * Both inputs must be int32 with values constrained to |value| ≤ 2^15-1 (32,767).
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -30,10 +30,11 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
- // clang-format on
-ALWI void lcm_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_lcm<APPROX>(idst0, idst1)));
+// clang-format on
+ALWI void lcm_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_lcm<APPROX>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/mul_int32_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/mul_int32_sfpu.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise mul operation with the two int32 inputs: y = mul(x0,x1)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -27,14 +27,15 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
- * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | Argument              | Description                                                           | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst                  | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void mul_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_mul_int32<APPROX>(idst0, idst1)));
+ALWI void mul_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_mul_int32<APPROX>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/mul_int_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/mul_int_sfpu.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise mul operation with the two integer inputs: y = mul(x0,x1)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -27,14 +27,15 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
- * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | Argument              | Description                                                           | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst                  | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void mul_uint16_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_mul_int<APPROX, 8>(idst0, idst1)));
+ALWI void mul_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_mul_int<APPROX, 8>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/quantization.h
+++ b/tt_metal/include/compute_kernel_api/quantization.h
@@ -18,7 +18,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise per-tensor affine quantization operation on the first operand using the scaling factor in the second operand.
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * Return value: None
  *
@@ -26,16 +26,17 @@ namespace ckernel {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void quant_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_quant_int32<APPROX>(idst0, idst1)));
+ALWI void quant_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_quant_int32<APPROX>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise per-tensor affine re-quantization operation on the first operand using the scaling factor in the second operand.
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * Return value: None
  *
@@ -43,16 +44,17 @@ ALWI void quant_tile(uint32_t idst0, uint32_t idst1) {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void requant_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_requant_int32<APPROX>(idst0, idst1)));
+ALWI void requant_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_requant_int32<APPROX>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise per-tensor affine de-quantization operation on the first operand using the scaling factor in the second operand.
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * Return value: None
  *
@@ -60,10 +62,11 @@ ALWI void requant_tile(uint32_t idst0, uint32_t idst1) {
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void dequant_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_dequant_int32<APPROX>(idst0, idst1)));
+ALWI void dequant_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_dequant_int32<APPROX>(idst0, idst1, odst)));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/sub_int_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/sub_int_sfpu.h
@@ -19,7 +19,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise sub operation with the two integer inputs: y = sub(x0,x1)
- * Output overwrites first operand in DST.
+ * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -28,23 +28,23 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
- * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | sign_magnitude_format | Whether the Int32 values are in sign-magnitude format (not 2's complement)  | bool     |                                                       | False    |
+ * | Argument              | Description                                                           | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst                  | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void sub_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1)));
+ALWI void sub_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1, odst)));
 }
 
-ALWI void sub_uint32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1)));
+ALWI void sub_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::INT32, false>(idst0, idst1, odst)));
 }
 
-ALWI void sub_uint16_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::LO16, false>(idst0, idst1)));
+ALWI void sub_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::LO16, false>(idst0, idst1, odst)));
 }
 
 ALWI void rsub_int32_tile(uint32_t idst0, uint32_t idst1) {

--- a/tt_metal/include/compute_kernel_api/sub_int_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/sub_int_sfpu.h
@@ -47,8 +47,8 @@ ALWI void sub_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_sub_int<APPROX, 8, InstrModLoadStore::LO16, false>(idst0, idst1, odst)));
 }
 
-ALWI void rsub_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_rsub_int32<APPROX>(idst0, idst1)));
+ALWI void rsub_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_rsub_int32<APPROX>(idst0, idst1, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/xlogy.h
+++ b/tt_metal/include/compute_kernel_api/xlogy.h
@@ -24,14 +24,15 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
- * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | Argument              | Description                                                           | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst                  | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void xlogy_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_xlogy<APPROX>(idst0, idst1)));
+ALWI void xlogy_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_xlogy<APPROX>(idst0, idst1, odst)));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -442,7 +442,7 @@ std::map<std::string, std::string> get_defines_fp32(
             TT_FATAL(false, "Undefined op type for binary sfpu operation {}", op_type);
     }
 
-    new_defines.insert({"BINARY_SFPU_OP", fmt::format("{}({}, {});", op_name, idst1, idst2)});
+    new_defines.insert({"BINARY_SFPU_OP", fmt::format("{}({}, {}, {});", op_name, idst1, idst2, idst1)});
 
     if (fused_activations.has_value()) {
         if (op_type == BinaryOpType::ADD and fused_activations.value().size() == 1 and

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -69,7 +69,7 @@ ALWI void process_tile(
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_rhs, i, i * 2 + 1);
 
-            BINARY_SFPU_OP(i * 2, i * 2 + 1);
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
             PROCESS_POST_ACTIVATIONS(i * 2);
         }
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -66,7 +66,7 @@ void MAIN {
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_rhs, i, i * 2 + 1);
 
-            BINARY_SFPU_OP(i * 2, i * 2 + 1);
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
             PROCESS_POST_ACTIVATIONS(i * 2);
         }
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -62,7 +62,7 @@ void MAIN {
         copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_rhs, i, i * 2 + 1);
-            BINARY_SFPU_OP(i * 2, i * 2 + 1);
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
             PROCESS_POST_ACTIVATIONS(i * 2);
         }
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -87,7 +87,7 @@ void MAIN {
         for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_right, i, i * 2 + 1);
 
-            BINARY_SFPU_OP(i * 2, i * 2 + 1);
+            BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
             PROCESS_POST_ACTIVATIONS(i * 2);
         }
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_col_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_col_bcast_ttt.cpp
@@ -60,7 +60,7 @@ ALWI void process_tile(
 
         // Perform the where operation
         where_tile_init();
-        WHERE_LLK(0, 1, 2);  // where(predicate, true, false)
+        WHERE_LLK(0, 1, 2, 0);  // where(predicate, true, false)
 
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_no_bcast_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_no_bcast_tst.cpp
@@ -49,7 +49,7 @@ void MAIN {
         copy_tile(cb_pre_in2, 0, 2);  // Copy to dst reg 2
 
         where_tile_init();
-        WHERE_LLK(0, 1, 2);
+        WHERE_LLK(0, 1, 2, 0);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_no_bcast_tts.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_no_bcast_tts.cpp
@@ -47,7 +47,7 @@ void MAIN {
 #endif
 
         where_tile_init();
-        WHERE_LLK(0, 1, 2);
+        WHERE_LLK(0, 1, 2, 0);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_no_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/device/kernels/compute/where_sfpu_no_bcast_ttt.cpp
@@ -41,7 +41,7 @@ void MAIN {
         copy_tile(cb_pre_in3, 0, 2);  // Copy to dst reg 2
 
         where_tile_init();
-        WHERE_LLK(0, 1, 2);
+        WHERE_LLK(0, 1, 2, 0);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -418,11 +418,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::WHERE_TSS: {
             std::string where_call;
             if (input_dtype == DataType::INT32) {
-                where_call = fmt::format("where_int32_tile({}, {}, {});", idst, 1, 2);
+                where_call = fmt::format("where_int32_tile({0}, {1}, {2}, {0});", idst, 1, 2);
             } else if (input_dtype == DataType::FLOAT32) {
-                where_call = fmt::format("where_fp32_tile({}, {}, {});", idst, 1, 2);
+                where_call = fmt::format("where_fp32_tile({0}, {1}, {2}, {0});", idst, 1, 2);
             } else {
-                where_call = fmt::format("where_tile({}, {}, {});", idst, 1, 2);
+                where_call = fmt::format("where_tile({0}, {1}, {2}, {0});", idst, 1, 2);
             }
             op_init_and_name = std::make_pair("where_tile_init();", where_call);
             break;
@@ -539,7 +539,7 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype.value() == DataType::INT32) {
-                op_init_and_name = {"mul_int32_tile_init();", fmt::format("mul_int32_tile({0}, {0});", idst)};
+                op_init_and_name = {"mul_int32_tile_init();", fmt::format("mul_int32_tile({0}, {0}, {0});", idst)};
             } else {
                 op_init_and_name = {"square_tile_init();", fmt::format("square_tile({});", idst)};
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel_sfpu.cpp
@@ -37,10 +37,10 @@ void MAIN {
             copy_tile_to_dst_init_short(cb_input);
             copy_tile(cb_input, 0, 1);
             add_binary_tile_init();
-            add_binary_tile(0, 1);
+            add_binary_tile(0, 1, 0);
             ltz_tile(0);
             mul_binary_tile_init();
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
 
             tile_regs_commit();
 
@@ -58,16 +58,16 @@ void MAIN {
             copy_tile_to_dst_init_short(cb_input);
             copy_tile(cb_input, 0, 0);
             sub_binary_tile_init();
-            sub_binary_tile(0, 1);
+            sub_binary_tile(0, 1, 0);
             gtz_tile(0);
             copy_tile_to_dst_init_short(cb_input);
             copy_tile(cb_input, 0, 1);
             mul_binary_tile_init();
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
             copy_tile_to_dst_init_short(cb_tmp0);
             copy_tile(cb_tmp0, 0, 1);
             add_binary_tile_init();
-            add_binary_tile(0, 1);
+            add_binary_tile(0, 1, 0);
 
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel_sfpu.cpp
@@ -37,7 +37,7 @@ void MAIN {
             hardsigmoid_tile(0);
 
             mul_binary_tile_init();
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
 
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
@@ -128,7 +128,7 @@ void MAIN {
             copy_tile_to_dst_init_short(cb_add);
             copy_tile(cb_add, 0, 1);
             mul_binary_tile_init();
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
 #endif
 
             tile_regs_commit();
@@ -159,10 +159,10 @@ void MAIN {
             copy_tile(cb_tanh_exp, 0, 2);
             where_tile_init();
 #ifdef TANH_FP32
-            where_fp32_tile(0, 1, 2);
+            where_fp32_tile(0, 1, 2, 0);
 #endif
 #ifdef TANH_BF16
-            where_tile(0, 1, 2);
+            where_tile(0, 1, 2, 0);
 #endif
             tile_regs_commit();
             tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_none.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_none.cpp
@@ -54,14 +54,14 @@ void MAIN {
 
             // Step 1: erf(x / sqrt(2))
             fill_tile(3, kAlpha);
-            mul_binary_tile(1, 3);  // tile[1] = x / sqrt(2)
+            mul_binary_tile(1, 3, 1);  // tile[1] = x / sqrt(2)
             erf_tile(1);            // tile[1] = erf( x / sqrt(2) )
 
             // cdf_term = 0.5 * (1.0 + erf(x / sqrt(2)))
             fill_tile(3, 1.0f);
-            add_binary_tile(1, 3);  // tile[1] += 1.0
+            add_binary_tile(1, 3, 1);  // tile[1] += 1.0
             fill_tile(3, 0.5f);
-            mul_binary_tile(1, 3);  // tile[1] *= 0.5
+            mul_binary_tile(1, 3, 1);  // tile[1] *= 0.5
 
             // Now tile[1] holds cdf_term
 
@@ -69,25 +69,25 @@ void MAIN {
             //   tile[2] will hold exp(- x^2 / 2)
             square_tile(2);  // tile[2] = x^2
             fill_tile(3, -0.5f);
-            mul_binary_tile(2, 3);  // tile[2] = -0.5 * x^2
+            mul_binary_tile(2, 3, 2);  // tile[2] = -0.5 * x^2
             exp_tile(2);            // tile[2] = exp(- x^2 / 2)
 
             // multiply by (1 / sqrt(2π))
             fill_tile(3, kBeta);
-            mul_binary_tile(2, 3);  // tile[2] *= 1 / sqrt(2π)
+            mul_binary_tile(2, 3, 2);  // tile[2] *= 1 / sqrt(2π)
 
             // multiply by x
-            mul_binary_tile(2, 4);  // tile[2] *= x
+            mul_binary_tile(2, 4, 2);  // tile[2] *= x
 
             // tile[2] now has pdf_term
 
             // Step 3: cdf_term + pdf_term
-            add_binary_tile(1, 2);
+            add_binary_tile(1, 2, 1);
 
             // Step 4: multiply by grad => tile[0]
             //   tile[0] = grad
             //   tile[1] = cdf_term + pdf_term
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
             pack_tile(0, cb_grad_in);
 
             // // store to output

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
@@ -54,18 +54,18 @@ void MAIN {
 
             // tile[1] = x^3
             square_tile(1);
-            mul_binary_tile(1, 2);
+            mul_binary_tile(1, 2, 1);
 
             // tile[1] = 0.044715 * x^3
             fill_tile(3, kKappa);
-            mul_binary_tile(1, 3);
+            mul_binary_tile(1, 3, 1);
 
             // tile[1] = x + 0.044715 * x^3
-            add_binary_tile(1, 2);
+            add_binary_tile(1, 2, 1);
 
             // tile[1] = sqrt(2/π) * (x + 0.044715 * x^3)
             fill_tile(3, kBeta);
-            mul_binary_tile(1, 3);
+            mul_binary_tile(1, 3, 1);
 
             // tile[1] = tanh(sqrt(2/π) * (x + 0.044715 * x^3))
             tanh_tile_init();
@@ -74,36 +74,36 @@ void MAIN {
 
             // CDF term: tile[1] = 0.5 * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
             fill_tile(3, 1.0f);
-            add_binary_tile(1, 3);
+            add_binary_tile(1, 3, 1);
             fill_tile(3, 0.5f);
-            mul_binary_tile(1, 3);
+            mul_binary_tile(1, 3, 1);
 
             // tile[4] = 1 - tanh^2
             square_tile(4);
             fill_tile(3, 1.0f);
-            sub_binary_tile(3, 4);
+            sub_binary_tile(3, 4, 3);
             copy_dest_values(4, 3);
 
             // tile[2] = (1 + 0.134145 * x**2)
             fill_tile(3, kKappa * 3.0f);
             square_tile(2);         // x^2
-            mul_binary_tile(2, 3);  // 0.134145 * x**2
+            mul_binary_tile(2, 3, 2);  // 0.134145 * x**2
             fill_tile(3, 1.0f);
-            add_binary_tile(2, 3);  // 1 + 0.134145 * x**2
+            add_binary_tile(2, 3, 2);  // 1 + 0.134145 * x**2
 
             // PDF term: tile[2] = 0.5 * sqrt(2/π) * (1 + 0.134145 * x^2) * (1 - tanh^2)
-            mul_binary_tile(2, 4);
+            mul_binary_tile(2, 4, 2);
             fill_tile(3, kBeta / 2.0f);
-            mul_binary_tile(2, 3);
+            mul_binary_tile(2, 3, 2);
 
             // tile[2] = x * pdf tern
             copy_dest_values(3, 8);
-            mul_binary_tile(2, 3);
+            mul_binary_tile(2, 3, 2);
 
             // result: tile[1] = grad * (cdf_term + x * pdf_term)
-            add_binary_tile(1, 2);  // cdf_term + x * pdf_term
+            add_binary_tile(1, 2, 1);  // cdf_term + x * pdf_term
             // tile[0] = grad * (cdf_term + x * pdf_term)
-            mul_binary_tile(0, 1);
+            mul_binary_tile(0, 1, 0);
 
             pack_tile(0, cb_grad_in);
             tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -47,7 +47,7 @@ ALWI void batchnorm_bcast_tiles(
     for (uint32_t i = 0; i < onetile; ++i) {
         copy_tile(cb_eps, i, i * 2 + 1);
 
-        add_binary_tile(i * 2, i * 2 + 1);
+        add_binary_tile(i * 2, i * 2 + 1, i * 2);
     }
     rsqrt_tile_init();
     for (uint32_t i = 0; i < onetile; ++i) {
@@ -81,7 +81,7 @@ ALWI void batchnorm_bcast_tiles(
         copy_tile_to_dst_init_short_with_dt(cb_other, cb_bcast);
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_bcast, i, i * 2 + 1);
-            sub_binary_tile(i * 2, i * 2 + 1);
+            sub_binary_tile(i * 2, i * 2 + 1, i * 2);
         }
         cb_pop_front(cb_other, onetile);
 
@@ -91,7 +91,7 @@ ALWI void batchnorm_bcast_tiles(
         copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_den);
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_den, i, i * 2 + 1);
-            mul_binary_tile(i * 2, i * 2 + 1);
+            mul_binary_tile(i * 2, i * 2 + 1, i * 2);
 
             pack_tile(i * 2, cb_affine_or_out);
         }
@@ -112,7 +112,7 @@ ALWI void batchnorm_bcast_tiles(
             copy_tile_to_dst_init_short_with_dt(cb_affine_or_out, cb_weight);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_weight, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
 
                 pack_tile(i * 2, cb_scaled_output);
             }
@@ -135,7 +135,7 @@ ALWI void batchnorm_bcast_tiles(
             copy_tile_to_dst_init_short_with_dt(cb_tmp_1, cb_bias);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_bias, i, i * 2 + 1);
-                add_binary_tile(i * 2, i * 2 + 1);
+                add_binary_tile(i * 2, i * 2 + 1, i * 2);
 
                 pack_tile(i * 2, cb_output_0);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -51,7 +51,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_one, cb_momentum);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_momentum, i, i * 2 + 1);
-                sub_binary_tile(i * 2, i * 2 + 1);
+                sub_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_tmp1);
             }
@@ -71,7 +71,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_batch_mean, cb_momentum);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_momentum, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_tmp2);
             }
@@ -92,7 +92,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_old_running_mean, cb_tmp1);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_tmp1, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_tmp3);
             }
@@ -117,7 +117,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_tmp3, cb_tmp2);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_tmp2, i, i * 2 + 1);
-                add_binary_tile(i * 2, i * 2 + 1);
+                add_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_updated_running_mean);
             }
@@ -139,7 +139,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_one, cb_momentum);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_momentum, i, i * 2 + 1);
-                sub_binary_tile(i * 2, i * 2 + 1);
+                sub_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_tmp1);
             }
@@ -159,7 +159,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_momentum);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_momentum, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_tmp2);
             }
@@ -180,7 +180,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_old_running_var, cb_tmp1);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_tmp1, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_tmp3);
             }
@@ -205,7 +205,7 @@ void MAIN {
             copy_tile_to_dst_init_short_with_dt(cb_tmp3, cb_tmp2);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_tmp2, i, i * 2 + 1);
-                add_binary_tile(i * 2, i * 2 + 1);
+                add_binary_tile(i * 2, i * 2 + 1, i * 2);
                 tile_regs_commit();
                 pack_tile(i * 2, cb_updated_running_var);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp
@@ -464,7 +464,7 @@ void reduce_cb(
         } else {
             // path if we are doing a sum redudce
             add_binary_tile_init();
-            add_binary_tile(0, 1);
+            add_binary_tile(0, 1, 0);
         }
         cb_pop_front(cb_prev_out, 1);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -47,7 +47,7 @@ void MAIN {
             } else if (accumulation_op == AccumulationOp::CUMSUM) {
 #ifdef CUMSUM_USE_INT32
                 add_int_tile_init();
-                add_int32_tile(INT32_TILE_DEST, INT32_TILE_ACC);
+                add_int32_tile(INT32_TILE_DEST, INT32_TILE_ACC, INT32_TILE_DEST);
 #else
                 add_tiles_init(cb_in, cb_op);
                 add_tiles(cb_in, cb_op, FIRST_TILE, FIRST_TILE, WORKING_REG);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19442
https://github.com/tenstorrent/tt-llk/issues/580

### Problem description
We used to take the min(tile_idx0, tile_idx1, ...) and program the Dest math offset to that in order to perform SFPU kernels by passing down just the "offset" between operands. This broke when the second operand was located in an earlier tile_idx than the first for non-commutative OPs. Also, the tile at offset 0 was always used as output with no flexibility.

### What's changed
For both BH and WH:
- change the API and kernels to accept an idx for each tile used (input tiles and output tile) and update the kernels accordingly
- update all binary sfpu calls in metal to have an out_tile (set to same as input tile 0 arg since that was the previous default)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17303734096) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17303737605) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/17275855237) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17275857042) CI passes (if applicable)