### PR TITLE
[DM]: Refactoring posted vs non posted specification in DM APIs

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/write_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/write_one_packet.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
         uint64_t dst_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, subordinate_l1_addr);
         noc_async_write_one_packet_set_state(dst_noc_addr, packet_size_bytes);
         for (uint32_t i = 0; i < num_packets; i++) {
-            noc_async_write_one_packet_with_state<true>(master_l1_addr, subordinate_l1_addr);
+            noc_async_write_one_packet_with_state(master_l1_addr, subordinate_l1_addr);
         }
         noc_async_write_barrier();
     }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -890,17 +890,17 @@ inline void noc_async_write_multicast(
  * | size                           | Size of data transfer in bytes                         | uint32_t  | 0..1MB                           | True     |
  * | noc                            | Which NOC to use for the transaction                   | uint8_t   | 0 or 1                           | False    |
  * | vc                             | Which VC to use for the transaction                    | uint8_t   | 0-3                              | False    |
- * | non_posted (template argument) | Whether the write is nonposted (i.e. ack required)     | bool      | true or false                    | False    |
+ * | posted (template argument)     | Whether the write is posted (i.e. no ack required)     | bool      | true or false                    | False    |
  */
 // clang-format on
-template <bool non_posted = true>
+template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
     uint64_t dst_noc_addr, uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc);
 
     WAYPOINT("NWPW");
-    ncrisc_noc_write_set_state<non_posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
+    ncrisc_noc_write_set_state<!posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
     WAYPOINT("NWPD");
 }
 
@@ -920,10 +920,10 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
  * | src_local_l1_addr              | Address in local L1 memory on source core          | uint32_t  | 0..1MB        | True     |
  * | dst_local_l1_addr              | Address in local L1 memory on destination core     | uint32_t  | 0..1MB        | True     |
  * | noc                            | Which NOC to use for the transaction               | uint8_t   | 0 or 1        | False    |
- * | non_posted (template argument) | Whether the write is nonposted (i.e. ack required) | bool      | true or false | False    |
+ * | posted (template argument)     | Whether the write is posted (i.e. no ack required) | bool      | true or false | False    |
  */
 // clang-format on
-template <bool non_posted = true>
+template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
     uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
@@ -932,7 +932,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_local_l1_addr, src_local_l1_addr);
 
     WAYPOINT("NWPW");
-    ncrisc_noc_write_with_state<noc_mode, non_posted, true /* update_counter */, true /* one_packet */>(
+    ncrisc_noc_write_with_state<noc_mode, !posted, true /* update_counter */, true /* one_packet */>(
         noc, write_cmd_buf, src_local_l1_addr, dst_local_l1_addr);
     WAYPOINT("NWPD");
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -900,7 +900,7 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc);
 
     WAYPOINT("NWPW");
-    ncrisc_noc_write_set_state<!posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
+    ncrisc_noc_write_set_state<posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
     WAYPOINT("NWPD");
 }
 
@@ -932,7 +932,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_local_l1_addr, src_local_l1_addr);
 
     WAYPOINT("NWPW");
-    ncrisc_noc_write_with_state<noc_mode, !posted, true /* update_counter */, true /* one_packet */>(
+    ncrisc_noc_write_with_state<noc_mode, posted, true /* update_counter */, true /* one_packet */>(
         noc, write_cmd_buf, src_local_l1_addr, dst_local_l1_addr);
     WAYPOINT("NWPD");
 }
@@ -2160,7 +2160,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, dst_noc_addr, 0, vc);
 
-    ncrisc_noc_write_set_state<!posted, false /* one_packet */>(noc, cmd_buf, dst_noc_addr, 0 /* len_bytes */, vc);
+    ncrisc_noc_write_set_state<posted, false /* one_packet */>(noc, cmd_buf, dst_noc_addr, 0 /* len_bytes */, vc);
     WAYPOINT("NAWD");
 }
 
@@ -2202,7 +2202,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
 
     WAYPOINT("NWPW");
     ncrisc_noc_set_transaction_id(noc, cmd_buf, trid);
-    ncrisc_noc_write_with_state<noc_mode, !posted, update_counter>(
+    ncrisc_noc_write_with_state<noc_mode, posted, update_counter>(
         noc, cmd_buf, src_local_l1_addr, dst_local_l1_addr, size);
     WAYPOINT("NWPD");
 }

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -346,14 +346,14 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
             NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, remote_noc_xy_ptr[0]), DYNAMIC_NOC_Y(noc, remote_noc_xy_ptr[1])));
         uint64_t dest_noc_addr = get_noc_addr_helper(remote_noc_xy, dest_addr);
 
-        noc_async_write_one_packet_set_state<non_posted>(dest_noc_addr, coalesced_page_size, noc);
+        noc_async_write_one_packet_set_state<posted>(dest_noc_addr, coalesced_page_size, noc);
 
         for (uint32_t h = 0; h < num_rows; ++h) {
             uint32_t prev_src_addr = src_addr;
             for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
                 dest_noc_addr = get_noc_addr_helper(remote_noc_xy, dest_addr);
 
-                noc_async_write_one_packet_with_state<non_posted>(src_addr, dest_noc_addr, noc);
+                noc_async_write_one_packet_with_state<posted>(src_addr, dest_noc_addr, noc);
 
                 src_addr += coalesced_page_size;
                 dest_addr += coalesced_page_size;

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -864,11 +864,11 @@ inline __attribute__((always_inline)) void ncrisc_noc_read_any_len_with_state(
  * | dst_noc_addr                    | Encoding of the destination NOC location (x,y)+address   | uint64_t  | Results of \a get_noc_addr calls | True     |
  * | len_bytes                       | Size of the transaction in bytes.                        | uint32_t  | 0..1 MB                          | False    |
  * | vc                              | Which VC to use for the transaction                      | uint32_t  | 0 - 3                            | False    |
- * | non_posted (template parameter) | Whether the transaction is nonposted (i.e. requires ack) | bool      | true or false                    | False    |
+ * | posted (template parameter)     | Whether the transaction is posted (i.e. no ack required) | bool      | true or false                    | False    |
  * | one_packet (template parameter) | Whether transaction size is <= NOC_MAX_BURST_SIZE        | bool      | true or false                    | False    |
  */
 // clang-format on
-template <bool non_posted = true, bool one_packet = false>
+template <bool posted = false, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
     uint32_t noc, uint32_t cmd_buf, uint64_t dst_noc_addr, uint32_t len_bytes = 0, const uint32_t vc = 0) {
     while (!noc_cmd_buf_ready(noc, cmd_buf));
@@ -876,7 +876,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
                              0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
                              0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
-                             (non_posted ? NOC_CMD_RESP_MARKED : 0x0);
+                             (!posted ? NOC_CMD_RESP_MARKED : 0x0);
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(
@@ -906,24 +906,20 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
  * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
  * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | False    |
  * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
- * | non_posted (template parameter)     | Whether the transaction is nonposted (i.e. requires ack) | bool      | true or false                                            | False    |
+ * | posted (template parameter)         | Whether the transaction is posted (i.e. no ack required) | bool      | true or false                                            | False    |
  * | update_counter (template parameter) | Whether to increment write counters                      | bool      | true or false                                            | False    |
  * | one_packet (template parameter)     | Whether transaction size is <= NOC_MAX_BURST_SIZE        | bool      | true or false                                            | False    |
  */
 // clang-format on
-template <
-    uint8_t noc_mode = DM_DEDICATED_NOC,
-    bool non_posted = true,
-    bool update_counter = true,
-    bool one_packet = false>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool posted = false, bool update_counter = true, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes = 0) {
     if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
-        if constexpr (non_posted) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-        } else {
-            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
         }
     }
 
@@ -937,11 +933,11 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
     if constexpr (update_counter && noc_mode == DM_DEDICATED_NOC) {
-        if constexpr (non_posted) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
             noc_nonposted_writes_num_issued[noc] += 1;
             noc_nonposted_writes_acked[noc] += 1;
-        } else {
-            noc_posted_writes_num_issued[noc] += 1;
         }
     }
 }
@@ -961,11 +957,11 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_with_state(
  * | dst_local_addr                      | Address in local L1 memory on destination core           | uint32_t  | 0..1 MB                                                  | True     |
  * | len_bytes                           | Size of transaction in bytes                             | uint32_t  | 0..1 MB                                                  | True     |
  * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t   | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
- * | non_posted (template parameter)     | Whether the transaction is nonposted (i.e. requires ack) | bool      | true or false                                            | False    |
+ * | posted (template parameter)         | Whether the transaction is posted (i.e. no ack required) | bool      | true or false                                            | False    |
  * | update_counter (template parameter) | Whether to increment write counters                      | bool      | true or false                                            | False    |
  */
 // clang-format on
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool non_posted = true, bool update_counter = true>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool posted = false, bool update_counter = true>
 inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes) {
     if (len_bytes > NOC_MAX_BURST_SIZE) {
@@ -973,7 +969,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, NOC_MAX_BURST_SIZE);
 
         while (len_bytes > NOC_MAX_BURST_SIZE) {
-            ncrisc_noc_write_with_state<noc_mode, non_posted, update_counter, true /* one_packet */>(
+            ncrisc_noc_write_with_state<noc_mode, posted, update_counter, true /* one_packet */>(
                 noc, cmd_buf, src_local_addr, dst_local_addr);
 
             len_bytes -= NOC_MAX_BURST_SIZE;
@@ -983,7 +979,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_any_len_with_state(
     }
 
     // left-over packet
-    ncrisc_noc_write_with_state<noc_mode, non_posted, update_counter>(
+    ncrisc_noc_write_with_state<noc_mode, posted, update_counter>(
         noc, cmd_buf, src_local_addr, dst_local_addr, len_bytes);
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26444)

### Problem description
Some of the `dataflow` and `noc_nonblocking` APIs have a template argument with the "posted" keyword and some with the "non_posted" keyword. These are exact opposites and should be refactored for consistency.

### What's changed
All instances of the "non_posted" keyword has been changed to the "posted" keyword along with the logic inside the functions. The callstack has also been updated accordingly. "posted" keyword was chosen as the unifier since it was already deployed more prevalently in dataflow and noc nonblocking APIs as well as kernels in Metal that use these APIs.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17277099281) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17277102178) CI passes