### PR TITLE
#25355: Clean up some "pass through" methods in MeshDevice

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -147,5 +147,6 @@ TEST_F(MeshDeviceTest, CheckFabricNodeIds) {
             fabric_node_id);
     }
 }
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
         auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
         device_is_mmio = device->get_devices()[0]->is_mmio_capable();
 
-        if (!device->using_fast_dispatch()) {
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             log_info(LogTest, "Skip! This test needs to be run with fast dispatch enabled");
             return 1;
         }

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -153,10 +153,6 @@ public:
     virtual uint32_t get_trace_buffers_size() const = 0;
     virtual void set_trace_buffers_size(uint32_t size) = 0;
 
-    // Light Metal
-    virtual bool using_slow_dispatch() const = 0;
-    virtual bool using_fast_dispatch() const = 0;
-
     // Checks that the given arch is on the given pci_slot and that it's responding
     // Puts device into reset
     virtual bool initialize(

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -73,7 +73,7 @@ private:
     size_t trace_region_size{};
     size_t worker_l1_size{};
     std::vector<uint32_t> l1_bank_remap;
-    bool using_fast_dispatch_{};
+    bool using_fast_dispatch_ = false;
     bool init_profiler_ = true;
     bool initialize_fabric_and_dispatch_fw_ = false;
     // This variable tracks the state of dispatch firmware on device.

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -73,7 +73,7 @@ private:
     size_t trace_region_size{};
     size_t worker_l1_size{};
     std::vector<uint32_t> l1_bank_remap;
-    bool using_fast_dispatch{};
+    bool using_fast_dispatch_{};
     bool init_profiler_ = true;
     bool initialize_fabric_and_dispatch_fw_ = false;
     // This variable tracks the state of dispatch firmware on device.

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -208,9 +208,6 @@ public:
     uint32_t get_trace_buffers_size() const override;
     void set_trace_buffers_size(uint32_t size) override;
 
-    bool using_slow_dispatch() const override;
-    bool using_fast_dispatch() const override;
-
     // Initialization APIs
     bool initialize(
         uint8_t num_hw_cqs,

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -21,7 +21,7 @@ void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, co
 }
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking) {
-    if (mesh_cq.device()->using_fast_dispatch()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
         mesh_workload.impl().compile(mesh_cq.device());
         mesh_workload.impl().load_binaries(mesh_cq);
         mesh_workload.impl().generate_dispatch_commands(mesh_cq);
@@ -46,7 +46,7 @@ MeshEvent EnqueueRecordEventToHost(
 void EnqueueWaitForEvent(MeshCommandQueue& mesh_cq, const MeshEvent& event) { mesh_cq.enqueue_wait_for_event(event); }
 
 void EventSynchronize(const MeshEvent& event) {
-    if (event.device()->using_slow_dispatch()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
         return;
     }
     for (const auto& coord : event.device_range()) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -675,7 +675,8 @@ CoreCoord MeshDevice::logical_grid_size() const {
         this->get_devices(), [](const auto* device) { return device->logical_grid_size(); });
 }
 CoreCoord MeshDevice::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
-    TT_THROW("virtual_noc0_coordinate() is not supported on MeshDevice - use individual devices instead");
+    TT_FATAL(num_devices() == 1, "virtual_noc0_coordinate() is only supported on unit MeshDevice.");
+    return get_devices().front()->virtual_noc0_coordinate(noc_index, coord);
 }
 std::vector<CoreCoord> MeshDevice::worker_cores_from_logical_cores(const std::vector<CoreCoord>& logical_cores) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_cores](const auto* device) {
@@ -683,9 +684,10 @@ std::vector<CoreCoord> MeshDevice::worker_cores_from_logical_cores(const std::ve
     });
 }
 std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
-    TT_THROW(
-        "get_optimal_dram_bank_to_logical_worker_assignment() is not supported on MeshDevice - use individual devices "
-        "instead");
+    TT_FATAL(
+        num_devices() == 1,
+        "get_optimal_dram_bank_to_logical_worker_assignment() is only supported on unit MeshDevice.");
+    return get_devices().front()->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
 CoreCoord MeshDevice::virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_coord, core_type](const auto* device) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -499,9 +499,7 @@ CoreCoord MeshDevice::compute_with_storage_grid_size() const {
         this->get_devices(), [](const auto* device) { return device->compute_with_storage_grid_size(); });
 }
 
-tt::ARCH MeshDevice::arch() const {
-    return validate_and_get_reference_value(this->get_devices(), [](const auto* device) { return device->arch(); });
-}
+tt::ARCH MeshDevice::arch() const { return tt::tt_metal::MetalContext::instance().get_cluster().arch(); }
 
 size_t MeshDevice::num_rows() const { return view_->num_rows(); }
 
@@ -667,16 +665,6 @@ CoreCoord MeshDevice::dram_grid_size() const {
         this->get_devices(), [](const auto* device) { return device->dram_grid_size(); });
 }
 
-bool MeshDevice::using_slow_dispatch() const {
-    return validate_and_get_reference_value(
-        this->get_devices(), [](const auto* device) { return device->using_slow_dispatch(); });
-}
-
-bool MeshDevice::using_fast_dispatch() const {
-    return validate_and_get_reference_value(
-        this->get_devices(), [](const auto* device) { return device->using_fast_dispatch(); });
-}
-
 // Device property methods that can be delegated to reference device
 CoreCoord MeshDevice::grid_size() const {
     return validate_and_get_reference_value(
@@ -687,9 +675,7 @@ CoreCoord MeshDevice::logical_grid_size() const {
         this->get_devices(), [](const auto* device) { return device->logical_grid_size(); });
 }
 CoreCoord MeshDevice::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
-    return validate_and_get_reference_value(this->get_devices(), [noc_index, coord](const auto* device) {
-        return device->virtual_noc0_coordinate(noc_index, coord);
-    });
+    TT_THROW("virtual_noc0_coordinate() is not supported on MeshDevice - use individual devices instead");
 }
 std::vector<CoreCoord> MeshDevice::worker_cores_from_logical_cores(const std::vector<CoreCoord>& logical_cores) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_cores](const auto* device) {
@@ -697,9 +683,9 @@ std::vector<CoreCoord> MeshDevice::worker_cores_from_logical_cores(const std::ve
     });
 }
 std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
-    return validate_and_get_reference_value(this->get_devices(), [noc](auto* device) {
-        return device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
-    });
+    TT_THROW(
+        "get_optimal_dram_bank_to_logical_worker_assignment() is not supported on MeshDevice - use individual devices "
+        "instead");
 }
 CoreCoord MeshDevice::virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_coord, core_type](const auto* device) {
@@ -915,7 +901,7 @@ bool MeshDevice::initialize(
     // as the number of virtual ethernet cores seen by the MeshDevice
     num_virtual_eth_cores_ = DevicePool::instance().get_max_num_eth_cores_across_all_devices();
     mesh_command_queues_.reserve(this->num_hw_cqs());
-    if (this->using_fast_dispatch()) {
+    if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
             mesh_command_queues_.push_back(std::make_unique<FDMeshCommandQueue>(
                 this,

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -364,7 +364,7 @@ uint32_t MeshWorkloadImpl::get_sem_base_addr(
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
     return base_addr + get_program_config(
                            MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type),
-                           mesh_device->using_fast_dispatch())
+                           tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch())
                            .sem_offset;
 }
 
@@ -392,7 +392,7 @@ uint32_t MeshWorkloadImpl::get_cb_base_addr(
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
     return base_addr + get_program_config(
                            MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type),
-                           mesh_device->using_fast_dispatch())
+                           tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch())
                            .cb_offset;
 }
 

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -136,7 +136,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         distributed::EnqueueWriteMeshBuffer(
             mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
     } else {
-        if (device_->using_slow_dispatch()) {
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             detail::WriteToBuffer(*cb_config_buffer_.get_buffer(), cb_config_host_buffer);
             tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_->id());
         } else {

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -65,7 +65,7 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     // Only block for the slow dispatch case
 
     std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
-    if (device_->using_slow_dispatch()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
         detail::WriteToBuffer(*buffer_.get_buffer(), host_buffer);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_->id());
     } else {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -287,7 +287,6 @@ void Device::configure_command_queue_programs() {
 }
 
 void Device::init_command_queue_host() {
-    using_fast_dispatch_ = true;
     sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, this->num_hw_cqs());
 
     auto cq_shared_state = std::make_shared<CQSharedState>();
@@ -394,8 +393,8 @@ void Device::configure_fabric() {
 
     fabric_program_->finalize_offsets(this);
 
-    detail::WriteRuntimeArgsToDevice(this, *fabric_program_, this->using_fast_dispatch());
-    detail::ConfigureDeviceWithProgram(this, *fabric_program_, this->using_fast_dispatch());
+    detail::WriteRuntimeArgsToDevice(this, *fabric_program_, using_fast_dispatch_);
+    detail::ConfigureDeviceWithProgram(this, *fabric_program_, using_fast_dispatch_);
 
     // Note: the l1_barrier below is needed to be sure writes to cores that
     // don't get the GO mailbox (eg, storage cores) have all landed
@@ -446,10 +445,8 @@ bool Device::initialize(
         num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS,
         "num_hw_cqs can be between 1 and {}",
         dispatch_core_manager::MAX_NUM_HW_CQS);
-    this->using_fast_dispatch_ = false;
-    // Trying to preserve logic that was in device_pool.cpp
-    // However, I honestly don't understand it
-    this->num_hw_cqs_ = num_hw_cqs;
+    using_fast_dispatch_ = MetalContext::instance().rtoptions().get_fast_dispatch();
+    num_hw_cqs_ = num_hw_cqs;
     const auto& hal = MetalContext::instance().hal();
     if (worker_l1_size == 0) {
         worker_l1_size = hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -682,10 +679,6 @@ CommandQueue& Device::command_queue(size_t cq_id) {
     TT_FATAL(this->is_initialized(), "Device has not been initialized, did you forget to call InitializeDevice?");
     return *command_queues_[cq_id];
 }
-
-bool Device::using_slow_dispatch() const { return !using_fast_dispatch(); }
-
-bool Device::using_fast_dispatch() const { return using_fast_dispatch_; }
 
 void Device::enable_program_cache() {
     log_info(tt::LogMetal, "Enabling program cache on device {}", this->id_);

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -125,9 +125,6 @@ public:
     uint32_t get_trace_buffers_size() const override { return trace_buffers_size_; }
     void set_trace_buffers_size(uint32_t size) override { trace_buffers_size_ = size; }
 
-    bool using_slow_dispatch() const override;
-    bool using_fast_dispatch() const override;
-
     // Checks that the given arch is on the given pci_slot and that it's responding
     // Puts device into reset
     bool initialize(
@@ -215,6 +212,7 @@ private:
 
     std::vector<std::unique_ptr<Program>> command_queue_programs_;
     bool using_fast_dispatch_ = false;
+
     // TODO #20966: Remove this member
     std::weak_ptr<distributed::MeshDevice> mesh_device;
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -250,7 +250,7 @@ void DevicePool::initialize(
     _inst->l1_bank_remap.assign(l1_bank_remap.begin(), l1_bank_remap.end());
     _inst->init_profiler_ = init_profiler;
     _inst->initialize_fabric_and_dispatch_fw_ = initialize_fabric_and_dispatch_fw;
-    _inst->using_fast_dispatch = tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
+    _inst->using_fast_dispatch_ = tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
 
     std::vector<chip_id_t> device_ids_to_open = device_ids;
     // Never skip for TG Cluster
@@ -260,7 +260,7 @@ void DevicePool::initialize(
 
     // Fabric requires all devices to be open even though dispatch
     // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
-    if (_inst->using_fast_dispatch) {
+    if (_inst->using_fast_dispatch_) {
         // Check if fabric needs to be enabled (any remote devices).
         // Note, all devices must be open to use fabric. This check will happen in add_devices_to_pool.
         for (auto dev_id : device_ids_to_open) {
@@ -339,7 +339,7 @@ void DevicePool::initialize(
 }
 
 void DevicePool::initialize_fabric_and_dispatch_fw() const {
-    if (using_fast_dispatch && tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+    if (using_fast_dispatch_ && tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
         // Due to galaxy taking potentially taking a 2-3 minutes to compile all the firmware kernels
         log_info(
             tt::LogMetal, "Initializing Fabric and Dispatch Firmware for Galaxy cluster (this may take a few minutes)");
@@ -354,7 +354,7 @@ void DevicePool::initialize_host(IDevice* dev) const {
 
     // Create system memory writer for this device to have an associated interface to hardware command queue (i.e.
     // hugepage). Need to do this before FW init so we know what dispatch cores to reset.
-    if (this->using_fast_dispatch) {
+    if (using_fast_dispatch_) {
         detail::DispatchStateCheck(true);
         dev->init_command_queue_host();
     } else {
@@ -404,7 +404,7 @@ void DevicePool::initialize_active_devices() const {
 
     // Activate FD kernels
     // Remaining steps are for setting up FD
-    if (!this->using_fast_dispatch) {
+    if (!using_fast_dispatch_) {
         return;
     }
 
@@ -602,7 +602,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
 
-    if (this->using_fast_dispatch) {
+    if (using_fast_dispatch_) {
         populate_fd_kernels(devices_to_activate, this->num_hw_cqs);
     }
 }
@@ -737,7 +737,7 @@ void DevicePool::teardown_fd(const std::unordered_set<chip_id_t>& devices_to_clo
     for (const auto& dev_id : devices_to_close) {
         // Device is still active at this point
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
-        if (!dev->using_fast_dispatch()) {
+        if (!using_fast_dispatch_) {
             continue;
         }
 
@@ -830,7 +830,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     // Dispatch kernels internally have a sync at the end to ensure all credits are returned
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
-        if (!dev->is_mmio_capable() || !dev->using_fast_dispatch()) {
+        if (!dev->is_mmio_capable() || !using_fast_dispatch_) {
             continue;
         }
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1278,7 +1278,8 @@ std::unique_ptr<Program> create_and_compile_tt_fabric_program(IDevice* device) {
             num_local_fabric_routers);
     }
 
-    detail::CompileProgram(device, *fabric_program_ptr, /*force_slow_dispatch=*/device->using_fast_dispatch());
+    detail::CompileProgram(
+        device, *fabric_program_ptr, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
     return fabric_program_ptr;
 }
 

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -25,6 +25,7 @@
 #include "assert.hpp"
 #include "core_coord.hpp"
 #include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
 #include "mesh_command_queue.hpp"
 #include "mesh_device.hpp"
 #include <tt_stl/strong_type.hpp>
@@ -87,7 +88,9 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
 }
 
 void SubDeviceManagerTracker::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
-    TT_FATAL(!device_->using_slow_dispatch(), "Using sub device managers is unsupported with slow dispatch");
+    TT_FATAL(
+        tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch(),
+        "Using sub device managers is unsupported with slow dispatch");
     if (active_sub_device_manager_->id() == sub_device_manager_id) {
         return;
     }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1305,7 +1305,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDevic
 void DeallocateBuffer(Buffer& buffer) { buffer.deallocate(); }
 
 void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program) {
-    detail::DispatchStateCheck(not buffer->device()->using_slow_dispatch());
+    detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
     program.add_buffer(buffer);
 }
 
@@ -1356,7 +1356,7 @@ void SetRuntimeArgs(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const std::shared_ptr<RuntimeArgs>& runtime_args) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-    detail::DispatchStateCheck(not device->using_slow_dispatch());
+    detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureSetRuntimeArgs, device, kernel, core_spec, runtime_args);
     SetRuntimeArgsImpl(kernel, core_spec, std::move(runtime_args), false);
 }
@@ -1371,7 +1371,7 @@ void SetRuntimeArgs(
         "Mismatch between number of cores {} and number of runtime args {} getting updated",
         core_spec.size(),
         runtime_args.size());
-    detail::DispatchStateCheck(not device->using_slow_dispatch());
+    detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
     SetRuntimeArgsImpl(kernel, core_spec, runtime_args, false);
 }
 


### PR DESCRIPTION
### Ticket
#25355

### Problem description
`MeshDevice` should not have any "passthrough" methods that delegate to individual devices.

### What's changed
1. Get rid of `using_fast_dispatch` / `using_slow_dispatch`. This is property of `MetalContext`.
2. Make `virtual_noc0_coordinate` and `get_optimal_dram_bank_to_logical_worker_assignment` throw unconditionally, unless query is on unit mesh. This is device specific method, and fundamentally not supported on `MeshDevice`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17328115186) - pending