### PR TITLE
#25975: Port CCL OPs to TensorAccessor

### DIFF
--- a/tt_metal/hw/inc/accessor/tensor_accessor.h
+++ b/tt_metal/hw/inc/accessor/tensor_accessor.h
@@ -375,15 +375,17 @@ public:
 
     template <typename Accessor>
     AbstractTensorAccessorWrapper(const Accessor& accessor) : accessor_ptr(&accessor) {
-        get_noc_addr_fn = [](const void* accessor, uint32_t page_idx) {
-            return static_cast<const Accessor*>(accessor)->get_noc_addr(page_idx);
+        get_noc_addr_fn = [](const void* accessor, uint32_t page_idx, uint32_t offset, uint8_t noc) {
+            return static_cast<const Accessor*>(accessor)->get_noc_addr(page_idx, offset, noc);
         };
     }
 
-    uint64_t get_noc_addr(uint32_t page_idx) const { return get_noc_addr_fn(accessor_ptr, page_idx); }
+    uint64_t get_noc_addr(uint32_t page_idx, uint32_t offset = 0, uint8_t noc = noc_index) const {
+        return get_noc_addr_fn(accessor_ptr, page_idx, offset, noc);
+    }
 
 private:
-    using GetNocAddrFn = uint64_t (*)(const void*, uint32_t);
+    using GetNocAddrFn = uint64_t (*)(const void*, uint32_t, uint32_t, uint8_t);
 
     const void* accessor_ptr = nullptr;
     GetNocAddrFn get_noc_addr_fn = nullptr;

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/reader_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/reader_all_to_all_combine.cpp
@@ -21,9 +21,9 @@ inline uint32_t get_data_page_idx(const uint32_t e, const uint32_t token) {
     }
 }
 
-template <uint32_t DeviceIdx, uint32_t NumMappingPages, uint32_t MappingPageSizeBytes, bool MappingIsDram>
+template <uint32_t DeviceIdx, uint32_t NumMappingPages, uint32_t MappingPageSizeBytes, typename AddrGen>
 void get_device_expert_indices(
-    const InterleavedAddrGen<MappingIsDram>& mapping_addrgen,
+    const AddrGen& mapping_addrgen,
     const uint32_t mapping_l1_buffer_addr,
     const uint32_t mapping_page_size,
     volatile tt_l1_ptr uint16_t* output_ptr) {
@@ -58,10 +58,10 @@ void kernel_main() {
     constexpr uint32_t selected_experts_k = get_compile_time_arg_val(10);
     constexpr uint32_t mapping_page_size_bytes = get_compile_time_arg_val(11);
     constexpr uint32_t metadata_page_size_bytes = get_compile_time_arg_val(12);
-    constexpr bool data_is_dram = get_compile_time_arg_val(13);
-    constexpr bool mapping_is_dram = get_compile_time_arg_val(14);
-    constexpr bool metadata_is_dram = get_compile_time_arg_val(15);
-    constexpr bool locally_reduced = get_compile_time_arg_val(16);
+    constexpr bool locally_reduced = get_compile_time_arg_val(13);
+    constexpr auto data_args = TensorAccessorArgs<14>();
+    constexpr auto mapping_args = TensorAccessorArgs<data_args.next_compile_time_args_offset()>();
+    constexpr auto metadata_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();
 
     const auto mapping_tensor_addr = get_arg_val<uint32_t>(0);
     const auto metadata_tensor_addr = get_arg_val<uint32_t>(1);
@@ -69,12 +69,9 @@ void kernel_main() {
     const auto token_start_idx = get_arg_val<uint32_t>(3);
     const auto token_end_idx = get_arg_val<uint32_t>(4);
 
-    InterleavedAddrGen<metadata_is_dram> metadata_addrgen{
-        .bank_base_address = metadata_tensor_addr, .page_size = metadata_page_size_bytes};
-
-    InterleavedAddrGen<mapping_is_dram>
-        mapping_addrgen{.bank_base_address = mapping_tensor_addr, .page_size = mapping_page_size_bytes};
-    InterleavedAddrGen<data_is_dram> data_addrgen{.bank_base_address = data_tensor_addr, .page_size = data_size_bytes};
+    const auto metadata_addrgen = TensorAccessor(metadata_args, metadata_tensor_addr, metadata_page_size_bytes);
+    const auto mapping_addrgen = TensorAccessor(mapping_args, mapping_tensor_addr, mapping_page_size_bytes);
+    const auto data_addrgen = TensorAccessor(data_args, data_tensor_addr, data_size_bytes);
 
     // this gets sent to writer
     cb_reserve_back(local_experts_cb_id,1);
@@ -85,9 +82,8 @@ void kernel_main() {
     uint32_t mapping_buffer_addr = get_write_ptr(mapping_cb_id);
     cb_push_back(mapping_cb_id, 1);
 
-    detail::
-        get_device_expert_indices<linearized_mesh_coord, num_mapping_pages, mapping_page_size_bytes, mapping_is_dram>(
-            mapping_addrgen, mapping_buffer_addr, mapping_page_size_bytes, local_experts_ptr);
+    detail::get_device_expert_indices<linearized_mesh_coord, num_mapping_pages, mapping_page_size_bytes>(
+        mapping_addrgen, mapping_buffer_addr, mapping_page_size_bytes, local_experts_ptr);
     cb_push_back(local_experts_cb_id,1);
     for (uint32_t token = token_start_idx; token < token_end_idx; ++token) {
         cb_reserve_back(metadata_cb_id,1);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
@@ -57,13 +57,13 @@ void kernel_main() {
     constexpr uint32_t src_chip_id = get_compile_time_arg_val(9);
     constexpr uint32_t data_size_bytes = get_compile_time_arg_val(10);  // hidden dim * datum size
     constexpr uint32_t alignment = get_compile_time_arg_val(11);
-    constexpr uint32_t output_is_dram = get_compile_time_arg_val(12);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(13);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(14);  // ew_dim
-    constexpr uint32_t fabric_max_packet_size_bytes = get_compile_time_arg_val(15);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(16);
-    constexpr tt::tt_fabric::Topology topology = tt::tt_fabric::Topology(get_compile_time_arg_val(17));
-    constexpr uint32_t locally_reduced = get_compile_time_arg_val(18);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(12);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(13);  // ew_dim
+    constexpr uint32_t fabric_max_packet_size_bytes = get_compile_time_arg_val(14);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(15);
+    constexpr tt::tt_fabric::Topology topology = tt::tt_fabric::Topology(get_compile_time_arg_val(16));
+    constexpr uint32_t locally_reduced = get_compile_time_arg_val(17);
+    constexpr auto output_args = TensorAccessorArgs<18>();
 
 #ifdef REPLICATE_GROUP_AXIS
     constexpr ReplicateGroup replicate_axis = ReplicateGroup(REPLICATE_GROUP_AXIS);
@@ -108,8 +108,7 @@ void kernel_main() {
     std::array<WorkerToFabricEdmSender, Num_Directions> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_arg_count);
 
-    InterleavedAddrGen<output_is_dram> output_addrgen{
-        .bank_base_address = output_base_addr, .page_size = data_size_bytes};
+    const auto output_addrgen = TensorAccessor(output_args, output_base_addr, data_size_bytes);
 
     volatile PACKET_HEADER_TYPE * packet_headers[2];
     for(uint8_t i =0;i<2;++i){

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <limits>
 
 namespace ttnn::operations::ccl {
@@ -316,12 +317,6 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
 
     std::vector<uint32_t> reader_compile_time_args = {
-        input_tensor.buffer()->is_dram(),
-        indices_tensor.buffer()->is_dram(),
-        mapping_tensor.buffer()->is_dram(),
-        output_tensor.buffer()->is_dram(),
-        metadata_tensor.buffer()->is_dram(),
-
         input_tensor_cb_id,
         indices_tensor_cb_id,
         mapping_tensor_cb_id,
@@ -368,6 +363,11 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
         operation_attributes.impl == AllToAllTransferType::PageByPage ? 1 : 0,
         linearized_mesh_coord,
     };
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(mapping_tensor.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(reader_compile_time_args);
 
     const auto& writer_compile_time_args = reader_compile_time_args;
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/reader_all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/reader_all_to_all_dispatch.cpp
@@ -9,38 +9,38 @@
 using namespace ttnn::operations::ccl::common;
 
 void kernel_main() {
-    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(2);
 
-    constexpr uint32_t input_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(7);
-    constexpr uint32_t mapping_pages = get_compile_time_arg_val(8);
+    constexpr uint32_t input_pages = get_compile_time_arg_val(5);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t mapping_pages = get_compile_time_arg_val(7);
 
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(11);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(12);
-    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(13);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(14);
 
-    constexpr uint32_t num_devices = get_compile_time_arg_val(16);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(21);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(15);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(20);
 
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(23);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(24);
 
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(26);  // ew_dim
 
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
-    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(32);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(28);
+    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(29);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(31);
 
-    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(35);
+    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(34);
 
-    constexpr bool write_page_by_page = get_compile_time_arg_val(36);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(37);
+    constexpr bool write_page_by_page = get_compile_time_arg_val(35);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    constexpr auto input_args = TensorAccessorArgs<38>();
+    constexpr auto input_args = TensorAccessorArgs<37>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto output_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/reader_all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/reader_all_to_all_dispatch.cpp
@@ -9,41 +9,42 @@
 using namespace ttnn::operations::ccl::common;
 
 void kernel_main() {
-    constexpr bool input_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr bool indices_is_dram = (bool)get_compile_time_arg_val(1);
-    constexpr bool mapping_is_dram = (bool)get_compile_time_arg_val(2);
-    constexpr bool metadata_is_dram = (bool)get_compile_time_arg_val(4);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(3);
 
-    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(5);
-    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(6);
-    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(7);
+    constexpr uint32_t input_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t mapping_pages = get_compile_time_arg_val(8);
 
-    constexpr uint32_t input_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t mapping_pages = get_compile_time_arg_val(12);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(15);
 
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(16);
-    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(16);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(21);
 
-    constexpr uint32_t num_devices = get_compile_time_arg_val(20);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(25);
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
 
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(28);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(29);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
 
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(30);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(31);  // ew_dim
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
+    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(32);
 
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(33);
-    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(34);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(36);
+    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(35);
 
-    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(39);
+    constexpr bool write_page_by_page = get_compile_time_arg_val(36);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(37);
 
-    constexpr bool write_page_by_page = get_compile_time_arg_val(40);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(41);
+    constexpr auto input_args = TensorAccessorArgs<38>();
+    constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    constexpr auto mapping_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+    constexpr auto output_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();
+    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
@@ -66,11 +67,10 @@ void kernel_main() {
     uint32_t token_start_idx = get_arg_val<uint32_t>(rt_ags++);
     uint32_t token_end_idx = get_arg_val<uint32_t>(rt_ags++);
 
-    const auto input_addr_gen = get_interleaved_addr_gen<input_is_dram, input_page_size>(input_tensor_address);
-    const auto indices_addr_gen = get_interleaved_addr_gen<indices_is_dram, indices_page_size>(indices_tensor_address);
-    const auto mapping_addr_gen = get_interleaved_addr_gen<mapping_is_dram, mapping_page_size>(mapping_tensor_address);
-    const auto metadata_addr_gen =
-        get_interleaved_addr_gen<metadata_is_dram, metadata_page_size>(metadata_tensor_address);
+    const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, input_page_size);
+    const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, indices_page_size);
+    const auto mapping_addr_gen = TensorAccessor(mapping_args, mapping_tensor_address, mapping_page_size);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
 
     // read the expert mapping table
     cb_reserve_back(mapping_tensor_cb_id, mapping_pages);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/writer_all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/writer_all_to_all_dispatch.cpp
@@ -48,55 +48,55 @@ void zero_buffer_barrier() { noc_async_read_barrier(); }
 using namespace ttnn::operations::ccl::common;
 
 void kernel_main() {
-    constexpr bool input_is_dram = (bool)get_compile_time_arg_val(0);
-    constexpr bool indices_is_dram = (bool)get_compile_time_arg_val(1);
-    constexpr bool mapping_is_dram = (bool)get_compile_time_arg_val(2);
-    constexpr bool output_is_dram = (bool)get_compile_time_arg_val(3);
-    constexpr bool metadata_is_dram = (bool)get_compile_time_arg_val(4);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t send_preparation_buffer_cb_id = get_compile_time_arg_val(5);
 
-    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(5);
-    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(6);
-    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(7);
-    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(8);
-    constexpr uint32_t send_preparation_buffer_cb_id = get_compile_time_arg_val(9);
+    constexpr uint32_t input_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t mapping_pages = get_compile_time_arg_val(8);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(9);
+    constexpr uint32_t metadata_pages = get_compile_time_arg_val(10);
 
-    constexpr uint32_t input_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t mapping_pages = get_compile_time_arg_val(12);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(13);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(14);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(14);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(15);
 
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(16);
-    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(16);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(17);
+    constexpr uint32_t batch_size = get_compile_time_arg_val(18);
+    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(19);
+    constexpr uint32_t experts = get_compile_time_arg_val(20);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(21);
 
-    constexpr uint32_t num_devices = get_compile_time_arg_val(20);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(21);
-    constexpr uint32_t batch_size = get_compile_time_arg_val(22);
-    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(23);
-    constexpr uint32_t experts = get_compile_time_arg_val(24);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(25);
+    constexpr uint32_t num_links = get_compile_time_arg_val(22);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(23);
 
-    constexpr uint32_t num_links = get_compile_time_arg_val(26);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(27);
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(28);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
+    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(31);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(32);
 
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(28);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(29);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(30);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(31);  // ew_dim
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(32);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(33);
-    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(34);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(35);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(36);
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(33);
+    constexpr uint32_t alignment = get_compile_time_arg_val(34);
+    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(35);
+    constexpr uint32_t write_page_by_page = get_compile_time_arg_val(36);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(37);
 
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(37);
-    constexpr uint32_t alignment = get_compile_time_arg_val(38);
-    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(39);
-    constexpr uint32_t write_page_by_page = get_compile_time_arg_val(40);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(41);
+    constexpr auto input_args = TensorAccessorArgs<38>();
+    constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    constexpr auto mapping_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+    constexpr auto output_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();
+    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
     size_t rt_args_idx = 0;
     uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
@@ -149,8 +149,8 @@ void kernel_main() {
     constexpr uint32_t device_stride = 1;
 #endif
 
-    auto output_addr_gen = get_interleaved_addr_gen<output_is_dram, output_page_size>(output_tensor_address);
-    auto metadata_addr_gen = get_interleaved_addr_gen<metadata_is_dram, metadata_page_size>(metadata_tensor_address);
+    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, output_page_size);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
 
     uint32_t packet_header_buffer_address = get_read_ptr(packet_header_cb_id);
     auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/writer_all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/writer_all_to_all_dispatch.cpp
@@ -48,51 +48,51 @@ void zero_buffer_barrier() { noc_async_read_barrier(); }
 using namespace ttnn::operations::ccl::common;
 
 void kernel_main() {
-    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(4);
-    constexpr uint32_t send_preparation_buffer_cb_id = get_compile_time_arg_val(5);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t send_preparation_buffer_cb_id = get_compile_time_arg_val(4);
 
-    constexpr uint32_t input_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(7);
-    constexpr uint32_t mapping_pages = get_compile_time_arg_val(8);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(9);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t input_pages = get_compile_time_arg_val(5);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t mapping_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(8);
+    constexpr uint32_t metadata_pages = get_compile_time_arg_val(9);
 
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(11);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(12);
-    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(13);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(14);
 
-    constexpr uint32_t num_devices = get_compile_time_arg_val(16);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(17);
-    constexpr uint32_t batch_size = get_compile_time_arg_val(18);
-    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(19);
-    constexpr uint32_t experts = get_compile_time_arg_val(20);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(21);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(15);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(16);
+    constexpr uint32_t batch_size = get_compile_time_arg_val(17);
+    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(18);
+    constexpr uint32_t experts = get_compile_time_arg_val(19);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(20);
 
-    constexpr uint32_t num_links = get_compile_time_arg_val(22);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(23);
+    constexpr uint32_t num_links = get_compile_time_arg_val(21);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(22);
 
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(28);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
-    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(31);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(32);
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(23);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(24);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(26);  // ew_dim
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(27);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(28);
+    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(29);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(30);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(31);
 
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(33);
-    constexpr uint32_t alignment = get_compile_time_arg_val(34);
-    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(35);
-    constexpr uint32_t write_page_by_page = get_compile_time_arg_val(36);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(37);
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(32);
+    constexpr uint32_t alignment = get_compile_time_arg_val(33);
+    constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(34);
+    constexpr uint32_t write_page_by_page = get_compile_time_arg_val(35);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    constexpr auto input_args = TensorAccessorArgs<38>();
+    constexpr auto input_args = TensorAccessorArgs<37>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto output_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -137,7 +137,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
 
     // slightly abusing this functionality since here we also have a single page if any experts are activated
     constexpr bool local_reduce = true;
-    const std::vector<uint32_t> reader_ct_args = {
+    std::vector<uint32_t> reader_ct_args = {
         mapping_tensor_cb_id,
         local_experts_cb_id,
         metadata_cb_id,
@@ -151,10 +151,10 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         selected_experts_k,
         mapping_page_size_bytes,
         metadata_page_size_bytes,
-        topk_is_dram,
-        mapping_is_dram,
-        metadata_is_dram,
         local_reduce};
+    tt::tt_metal::TensorAccessorArgs(topk_tensor.buffer()).append_to(reader_ct_args);
+    tt::tt_metal::TensorAccessorArgs(mapping_tensor.buffer()).append_to(reader_ct_args);
+    tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(reader_ct_args);
 
     tt::tt_metal::KernelHandle ternary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
 
@@ -131,22 +132,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
 
     // Tensor Info
-    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
 
     // KERNEL CREATION
     // Reader
     std::vector<uint32_t> reader_compile_args = {
-        static_cast<uint32_t>(input_tensor_buffer_type),  // buffer0_type
-        src0_cb_index,                                    // cb0_id
-        num_pages_per_packet,                             // packet_size_in_pages
-        op_config.get_page_size(),                        // tensor0_page_size
+        src0_cb_index,              // cb0_id
+        num_pages_per_packet,       // packet_size_in_pages
+        op_config.get_page_size(),  // tensor0_page_size
     };
 
     if (!tilized) {
         reader_compile_args = {
-            static_cast<uint32_t>(input_tensor_buffer_type),      // buffer0_type
             src0_cb_index,                                        // cb0_id
             num_width_shards > 1 ? buffer_page_size : page_size,  // page_size
             row_size,
@@ -156,22 +153,20 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     }
 
     std::vector<uint32_t> writer_compile_args = {
-        reserved_packet_header_CB_index,                   // reserved_packet_header_cb_id
-        num_packet_headers_storable,                       // num_packet_headers_storable
-        static_cast<uint32_t>(output_tensor_buffer_type),  // buffer0_type
-        src0_cb_index,                                     // cb0_id
-        num_pages_per_packet,                              // packet_size_in_pages
-        op_config.get_page_size(),                         // tensor0_page_size
-        num_targets_forward,                               // num_targets_forward_direction
-        num_targets_backward,                              // num_targets_backward_direction
+        reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+        num_packet_headers_storable,      // num_packet_headers_storable
+        src0_cb_index,                    // cb0_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_targets_forward_direction
+        num_targets_backward,             // num_targets_backward_direction
     };
 
     if (!tilized) {
         writer_compile_args = {
-            reserved_packet_header_CB_index,                   // reserved_packet_header_cb_id
-            num_packet_headers_storable,                       // num_packet_headers_storable
-            static_cast<uint32_t>(output_tensor_buffer_type),  // buffer0_type
-            src0_cb_index,                                     // cb0_id
+            reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+            num_packet_headers_storable,      // num_packet_headers_storable
+            src0_cb_index,                    // cb0_id
             num_width_shards > 1 ? buffer_page_size : page_size,
             row_size,
             max_packet_size,
@@ -187,6 +182,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
         kernel_defines["SHARDED"] = "1";
         shard_builder::extend_sharding_compile_time_args(input_tensor, reader_compile_args);
         shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(writer_compile_args);
     }
     auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_reader.cpp
@@ -3,25 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
 
-constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(0));
-constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
-constexpr uint32_t page_size = get_compile_time_arg_val(2);
-constexpr uint32_t row_size = get_compile_time_arg_val(3);
-constexpr uint32_t num_packets_per_row = get_compile_time_arg_val(4);
-constexpr uint32_t max_packet_size = get_compile_time_arg_val(5);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(0);
+constexpr uint32_t page_size = get_compile_time_arg_val(1);
+constexpr uint32_t row_size = get_compile_time_arg_val(2);
+constexpr uint32_t num_packets_per_row = get_compile_time_arg_val(3);
+constexpr uint32_t max_packet_size = get_compile_time_arg_val(4);
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -38,17 +35,15 @@ void kernel_main() {
     uint32_t row_id_start = get_arg_val<uint32_t>(arg_idx++);
     uint32_t row_id_end = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
-
 #ifdef SHARDED
     typedef ShardedInfo<
+        get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
         get_compile_time_arg_val(8),
         get_compile_time_arg_val(9),
         get_compile_time_arg_val(10),
-        get_compile_time_arg_val(11),
-        get_compile_time_arg_val(12)>
+        get_compile_time_arg_val(11)>
         tensor_shard_info;
 
     const auto [mapping_table, rt_increment] =
@@ -56,8 +51,8 @@ void kernel_main() {
     experimental::ShardedAddrGen<tensor_shard_info> tensor0_addrgen = {
         .bank_base_address = tensor_address0, .shard_array = mapping_table};
 #else
-    // interleaved addrgen
-    const auto tensor0_addrgen = get_interleaved_addr_gen<is_dram, row_size>(tensor_address0);
+    constexpr auto tensor0_args = TensorAccessorArgs<5>();
+    auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0, row_size);
 #endif
 
     uint32_t row_id = row_id_start;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
@@ -15,7 +14,6 @@
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -23,20 +21,19 @@ using tt::tt_metal::BufferType;
 
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(1);
-constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(2));
-constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
-constexpr uint32_t page_size = get_compile_time_arg_val(4);
-constexpr uint32_t row_size = get_compile_time_arg_val(5);
-constexpr uint32_t max_packet_size = get_compile_time_arg_val(6);
-constexpr uint32_t num_packets_per_row = get_compile_time_arg_val(7);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(8);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(9);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(2);
+constexpr uint32_t page_size = get_compile_time_arg_val(3);
+constexpr uint32_t row_size = get_compile_time_arg_val(4);
+constexpr uint32_t max_packet_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_packets_per_row = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(7);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(8);
 constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<10>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<9>();
 constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<10 + ccl_routing_utils::num_line_multicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<9 + ccl_routing_utils::num_line_multicast_args>();
 
-inline constexpr uint32_t sharded_args_start_idx = 10 + 2 * ccl_routing_utils::num_line_multicast_args;
+inline constexpr uint32_t sharded_args_start_idx = 9 + 2 * ccl_routing_utils::num_line_multicast_args;
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -80,10 +77,9 @@ void kernel_main() {
     size_t fab_idx = arg_for_fab + rt_increment;
     auto fabric_connection = FabricConnectionManager::build_from_args(fab_idx);
 #else
-    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
-    const auto tensor0_addrgen = get_interleaved_addr_gen<is_dram, row_size>(tensor_address0);
+    constexpr auto tensor0_args = TensorAccessorArgs<sharded_args_start_idx>();
+    auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0, row_size);
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
-
 #endif
 
     // packet header cb

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_reader.cpp
@@ -3,23 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
 
-constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(0));
-constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(2);
-constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(3);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(0);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(1);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -35,17 +32,16 @@ void kernel_main() {
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
     uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
-    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
 
 #ifdef SHARDED
     typedef ShardedInfo<
+        get_compile_time_arg_val(3),
         get_compile_time_arg_val(4),
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
         get_compile_time_arg_val(8),
-        get_compile_time_arg_val(9),
-        get_compile_time_arg_val(10)>
+        get_compile_time_arg_val(9)>
         tensor_shard_info;
     // Sharded addrgen
     const auto [mapping_table, rt_increment] =
@@ -53,9 +49,8 @@ void kernel_main() {
     experimental::ShardedAddrGen<tensor_shard_info> tensor0_addrgen = {
         .bank_base_address = tensor_address0, .shard_array = mapping_table};
 #else
-    // interleaved addrgen
-    auto tensor0_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = tensor_address0, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
+    constexpr auto tensor0_args = TensorAccessorArgs<3>();
+    auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0, tensor0_page_size);
 #endif
 
     uint32_t tile_id = tile_id_start;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -15,7 +14,6 @@
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -23,18 +21,17 @@ using tt::tt_metal::BufferType;
 
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(1);
-constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(2));
-constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
-constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(2);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(3);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(4);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(6);
 constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<8>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<7>();
 constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<8 + ccl_routing_utils::num_line_multicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<7 + ccl_routing_utils::num_line_multicast_args>();
 
-inline constexpr uint32_t sharded_args_start_idx = 8 + 2 * ccl_routing_utils::num_line_multicast_args;
+inline constexpr uint32_t sharded_args_start_idx = 7 + 2 * ccl_routing_utils::num_line_multicast_args;
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -78,10 +75,8 @@ void kernel_main() {
     size_t fab_idx = arg_for_fab + rt_increment;
     auto fabric_connection = FabricConnectionManager::build_from_args(fab_idx);
 #else
-    // interleaved addrgen
-    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
-    auto tensor0_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = tensor_address0, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
+    constexpr auto tensor0_args = TensorAccessorArgs<sharded_args_start_idx>();
+    auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0, tensor0_page_size);
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -143,9 +143,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
     std::optional<uint32_t> num_buffers_per_channel,
     const CoreCoord core_grid_offset) {
     // Tensor Info
-    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
     const auto& input_tensor_shape = input_tensor.padded_shape();
     const auto& output_tensor_shape = output_tensor.padded_shape();
 
@@ -384,17 +382,15 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
 
                 // Reader
                 std::vector<uint32_t> sender_reader_compile_args = {
-                    ring_index,                                        // my_chip_id
-                    static_cast<uint32_t>(input_tensor_buffer_type),   // input_buffer_type
-                    static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
-                    sender_cb_index,                                   // cb_forward_id
-                    num_tiles_to_write_per_packet,                     // num_tiles_to_write_per_packet
-                    page_size,                                         // tensor0_page_size
-                    num_targets_forward,                               // num_slices_forward_direction
-                    num_targets_backward,                              // num_slices_backward_direction
-                    static_cast<uint32_t>(topology),                   // topology
-                    dir,                                               // direction
-                    fuse_op,                                           // fused op
+                    ring_index,                       // my_chip_id
+                    sender_cb_index,                  // cb_forward_id
+                    num_tiles_to_write_per_packet,    // num_tiles_to_write_per_packet
+                    page_size,                        // tensor0_page_size
+                    num_targets_forward,              // num_slices_forward_direction
+                    num_targets_backward,             // num_slices_backward_direction
+                    static_cast<uint32_t>(topology),  // topology
+                    dir,                              // direction
+                    fuse_op,                          // fused op
                     chunks_per_sync_val,
                 };
                 if (input_is_sharded) {
@@ -463,18 +459,17 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
 
                 // Writer
                 std::vector<uint32_t> sender_writer_compile_args = {
-                    ring_index,                                        // my_chip_id
-                    reserved_packet_header_CB_index,                   // reserved_packet_header_cb_id
-                    num_packet_headers_storable,                       // num_packet_headers_storable
-                    static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
-                    sender_cb_index,                                   // cb_forward_id
-                    num_tiles_to_write_per_packet,                     // num_tiles_to_write_per_packet
-                    page_size,                                         // tensor0_page_size
-                    num_targets_forward,                               // num_targets_forward_direction
-                    num_targets_backward,                              // num_targets_backward_direction
-                    fuse_op,                                           // fused op
-                    static_cast<uint32_t>(topology),                   // topology
-                    dir,                                               // direction
+                    ring_index,                       // my_chip_id
+                    reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+                    num_packet_headers_storable,      // num_packet_headers_storable
+                    sender_cb_index,                  // cb_forward_id
+                    num_tiles_to_write_per_packet,    // num_tiles_to_write_per_packet
+                    page_size,                        // tensor0_page_size
+                    num_targets_forward,              // num_targets_forward_direction
+                    num_targets_backward,             // num_targets_backward_direction
+                    fuse_op,                          // fused op
+                    static_cast<uint32_t>(topology),  // topology
+                    dir,                              // direction
                     chunks_per_sync_val,
                 };
                 fabric_mux_connection_ct_args(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
 
@@ -398,9 +399,13 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                 };
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
                 }
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(output_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_reader_compile_args);
                 }
                 auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
                     program,
@@ -496,6 +501,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                 }
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
                 }
                 auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
                     program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -110,7 +110,7 @@ void kernel_main() {
     arg_idx += rt_increment;
 #else
     constexpr auto output_tensor_args = TensorAccessorArgs<sharded_args_start_idx>();
-    const auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_address, output_page_size);
+    const auto output_addrgen = TensorAccessor(output_tensor_args, output_address, output_page_size);
 #endif
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -16,7 +15,6 @@
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////
@@ -26,38 +24,37 @@ using ttnn::ccl::Topology;
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
 constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
-constexpr BufferType output_type = static_cast<BufferType>(get_compile_time_arg_val(3));
-constexpr uint32_t cb_output_id = get_compile_time_arg_val(4);
-constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(5);
-constexpr uint32_t output_page_size = get_compile_time_arg_val(6);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(7);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(8);
-constexpr bool fuse_op = get_compile_time_arg_val(9);
-constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(10));
-constexpr bool direction = get_compile_time_arg_val(11);  // 1 is forward, 0 is backward
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(12);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(3);
+constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(4);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+constexpr bool fuse_op = get_compile_time_arg_val(8);
+constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(9));
+constexpr bool direction = get_compile_time_arg_val(10);  // 1 is forward, 0 is backward
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(11);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(13);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(14);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(15);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(16);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(17);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(18);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(19);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(20);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(23);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(25);
+constexpr bool is_termination_master = get_compile_time_arg_val(12);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(13);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(14);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(15);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(16);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(17);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(18);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(19);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(20);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(21);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(22);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(24);
 
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<26>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<25>();
 constexpr ccl_routing_utils::line_multicast_route_info_t barrier_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<26 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<25 + ccl_routing_utils::num_line_unicast_args>();
 
 inline constexpr uint32_t sharded_args_start_idx =
-    26 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+    25 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -112,11 +109,8 @@ void kernel_main() {
 
     arg_idx += rt_increment;
 #else
-    constexpr bool output_is_dram = output_type == tt::tt_metal::BufferType::DRAM;
-    const InterleavedAddrGenFast<output_is_dram> output_addrgen = {
-        .bank_base_address = output_address,
-        .page_size = output_page_size,
-        .data_format = get_dataformat(cb_output_id)};
+    constexpr auto output_tensor_args = TensorAccessorArgs<sharded_args_start_idx>();
+    const auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_address, output_page_size);
 #endif
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_program_factory.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
 
@@ -269,9 +270,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
      */
 
     // Tensor Info
-    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const auto output_tensor_buffer_type = output_buffer.buffer()->buffer_type();
 
     const uint32_t N_DRAM_BANKS = device->num_dram_channels();
 
@@ -286,15 +285,15 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
     // Reader
     auto reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
     reader_kernel_config.compile_args = {
-        ring_index,                                       // my_chip_id
-        ring_size,                                        // num_chips
-        static_cast<uint32_t>(input_tensor_buffer_type),  // buffer0_type
-        tt::CB::c_in0,                                    // cb0_id
-        pages_per_packet,                                 // packet_size_in_pages
-        op_config.get_page_size(),                        // tensor0_page_size
-        num_targets_forward,                              // num_targets_forward_direction
-        num_targets_backward                              // num_targets_backward_direction
+        ring_index,                 // my_chip_id
+        ring_size,                  // num_chips
+        tt::CB::c_in0,              // cb0_id
+        pages_per_packet,           // packet_size_in_pages
+        op_config.get_page_size(),  // tensor0_page_size
+        num_targets_forward,        // num_targets_forward_direction
+        num_targets_backward        // num_targets_backward_direction
     };
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_kernel_config.compile_args);
     log_trace(tt::LogOp, "Reader Compile Args:");
     for ([[maybe_unused]] const auto& arg : reader_kernel_config.compile_args) {
         log_trace(tt::LogOp, "\t{}", arg);
@@ -309,21 +308,22 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
     // Writer
     auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
     writer_kernel_config.compile_args = {
-        ring_index,                                        // my_chip_id
-        ring_size,                                         // num_chips
-        tt::CB::c_in1,                                     // reserved_packet_header_cb_id
-        all_to_all_detail::PACKET_HEADER_BUFFER_SIZE,      // num_packet_headers_storable
-        static_cast<uint32_t>(output_tensor_buffer_type),  // buffer0_type
-        tt::CB::c_in0,                                     // cb0_id
-        pages_per_packet,                                  // packet_size_in_pages
-        op_config.get_page_size(),                         // tensor0_page_size
-        num_targets_forward,                               // num_targets_forward_direction
-        num_targets_backward,                              // num_targets_backward_direction
-        dynamic_alternate,                                 // alternate
-        chunk_granularity,                                 // granularity of signaling to receiver
-        contig_pages_advanced,                             // contig_pages_advanced
-        N_DRAM_BANKS                                       // num_dram_banks
+        ring_index,                                    // my_chip_id
+        ring_size,                                     // num_chips
+        tt::CB::c_in1,                                 // reserved_packet_header_cb_id
+        all_to_all_detail::PACKET_HEADER_BUFFER_SIZE,  // num_packet_headers_storable
+        tt::CB::c_in0,                                 // cb0_id
+        pages_per_packet,                              // packet_size_in_pages
+        op_config.get_page_size(),                     // tensor0_page_size
+        num_targets_forward,                           // num_targets_forward_direction
+        num_targets_backward,                          // num_targets_backward_direction
+        dynamic_alternate,                             // alternate
+        chunk_granularity,                             // granularity of signaling to receiver
+        contig_pages_advanced,                         // contig_pages_advanced
+        N_DRAM_BANKS                                   // num_dram_banks
     };
+    tt::tt_metal::TensorAccessorArgs(intermediate_buffer.buffer()).append_to(writer_kernel_config.compile_args);
+    tt::tt_metal::TensorAccessorArgs(output_buffer.buffer()).append_to(writer_kernel_config.compile_args);
     for ([[maybe_unused]] const auto& arg : writer_kernel_config.compile_args) {
         log_trace(tt::LogOp, "\t{}", arg);
     }
@@ -345,6 +345,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
         num_chunks_per_shard,
         op_config.get_page_size(),
         receiver_cb_index};
+    tt::tt_metal::TensorAccessorArgs(output_buffer.buffer()).append_to(receiver_writer_kernel_config.compile_args);
 
     auto receiver_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -365,6 +366,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
         receiver_cb_index,
         pages_per_packet,
         N_DRAM_BANKS};
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(receiver_reader_kernel_config.compile_args);
+    tt::tt_metal::TensorAccessorArgs(intermediate_buffer.buffer())
+        .append_to(receiver_reader_kernel_config.compile_args);
     auto receiver_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
@@ -3,12 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -16,12 +14,11 @@ using tt::tt_metal::BufferType;
 
 constexpr uint32_t my_ring_id = get_compile_time_arg_val(0);
 constexpr uint32_t ring_size = get_compile_time_arg_val(1);
-constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(2));
-constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
-constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(2);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(3);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(4);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(6);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -39,10 +36,8 @@ void kernel_main() {
     uint32_t out_row_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_col_offset = get_arg_val<uint32_t>(arg_idx++);
 
-    // interleaved addrgen
-    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
-    auto tensor0_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = tensor_address0, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
+    constexpr auto tensor0_args = TensorAccessorArgs<7>();
+    auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0, tensor0_page_size);
 
     bool cur_is_forward = num_targets_forward_direction > num_targets_backward_direction;
     uint32_t forward_hops = 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
@@ -45,11 +45,10 @@ void kernel_main() {
     uint32_t out_row_end = out_row_start + input_shard_row_tiles;
     uint32_t out_col_end = out_col_start + input_shard_col_tiles;
 
-    constexpr bool is_dram = true;
-    auto input_tensor_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = input_buffer_addr, .page_size = page_size, .data_format = get_dataformat(cb_id)};
-    auto intermediate_tensor_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = intermediate_buffer_addr, .page_size = page_size, .data_format = get_dataformat(cb_id)};
+    constexpr auto input_tensor_args = TensorAccessorArgs<7>();
+    auto input_tensor_addrgen = TensorAccessor(input_tensor_args, input_buffer_addr, page_size);
+    constexpr auto intermediate_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
+    auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_buffer_addr, page_size);
 
     if (my_ring_id == remote_device_ring_id) {
         // Follows same logic as sender reader for local copy.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
     uint32_t out_row_end = out_row_start + input_shard_row_tiles;
     uint32_t out_col_end = out_col_start + input_shard_col_tiles;
 
-    constexpr auto input_tensor_args = TensorAccessorArgs<7>();
+    constexpr auto input_tensor_args = TensorAccessorArgs<10>();
     auto input_tensor_addrgen = TensorAccessor(input_tensor_args, input_buffer_addr, page_size);
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_buffer_addr, page_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
@@ -39,9 +39,8 @@ void kernel_main() {
     uint32_t out_row_end = out_row_start + input_shard_row_tiles;
     uint32_t out_col_end = out_col_start + input_shard_col_tiles;
 
-    constexpr bool is_dram = true;
-    auto output_tensor_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = output_buffer_addr, .page_size = page_size, .data_format = get_dataformat(cb_id)};
+    constexpr auto output_tensor_args = TensorAccessorArgs<8>();
+    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_buffer_addr, page_size);
 
     if (my_ring_id == remote_device_ring_id) {
         // Follows same logic as sender reader for local copy.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
@@ -84,14 +84,11 @@ void kernel_main() {
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
 
-    // interleaved addrgen
-    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
-    auto intermediate_tensor_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = intermediate_buffer_addr,
-        .page_size = tensor0_page_size,
-        .data_format = get_dataformat(cb0_id)};
-    auto output_tensor_addrgen = InterleavedAddrGenFast<is_dram>{
-        .bank_base_address = output_buffer_addr, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
+    constexpr auto intermediate_tensor_args = TensorAccessorArgs<14>();
+    auto intermediate_tensor_addrgen =
+        TensorAccessor(intermediate_tensor_args, intermediate_buffer_addr, tensor0_page_size);
+    constexpr auto output_tensor_args = TensorAccessorArgs<intermediate_tensor_args.next_compile_time_args_offset()>();
+    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_buffer_addr, tensor0_page_size);
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open_finish();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -11,7 +10,6 @@
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -21,16 +19,15 @@ constexpr uint32_t my_ring_id = get_compile_time_arg_val(0);
 constexpr uint32_t ring_size = get_compile_time_arg_val(1);
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(2);
 constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(3);
-constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(4));
-constexpr uint32_t cb0_id = get_compile_time_arg_val(5);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(6);
-constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(7);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(8);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(9);
-constexpr bool dynamic_alternate = get_compile_time_arg_val(10);
-constexpr uint32_t chunk_granularity = get_compile_time_arg_val(11);
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(12);
-constexpr uint32_t N_DRAM_BANKS = get_compile_time_arg_val(13);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(4);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(5);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(7);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(8);
+constexpr bool dynamic_alternate = get_compile_time_arg_val(9);
+constexpr uint32_t chunk_granularity = get_compile_time_arg_val(10);
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(11);
+constexpr uint32_t N_DRAM_BANKS = get_compile_time_arg_val(12);
 
 constexpr uint32_t num_max_targets = std::max(num_targets_forward_direction, num_targets_backward_direction);
 constexpr uint32_t num_sync_targets_forward = dynamic_alternate ? num_max_targets : num_targets_forward_direction;
@@ -84,7 +81,7 @@ void kernel_main() {
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
 
-    constexpr auto intermediate_tensor_args = TensorAccessorArgs<14>();
+    constexpr auto intermediate_tensor_args = TensorAccessorArgs<13>();
     auto intermediate_tensor_addrgen =
         TensorAccessor(intermediate_tensor_args, intermediate_buffer_addr, tensor0_page_size);
     constexpr auto output_tensor_args = TensorAccessorArgs<intermediate_tensor_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -124,8 +124,7 @@ void kernel_main() {
 #else
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx>();
     constexpr uint32_t ct_offset = intermediate_tensor_args.num_compile_time_args();
-    auto intermediate_tensor_addrgen =
-        TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
+    auto intermediate_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -148,7 +147,7 @@ void kernel_main() {
     arg_idx += output_rt_increment;
 #else
     constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset>();
-    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
+    auto output_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
 #endif
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -19,7 +18,6 @@
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////
@@ -28,44 +26,42 @@ using ttnn::ccl::Topology;
 
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
-constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);  // 4
-constexpr BufferType intermediate_type = static_cast<BufferType>(get_compile_time_arg_val(3));
-constexpr BufferType output_type = static_cast<BufferType>(get_compile_time_arg_val(4));
-constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(5);
-constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(6);
-constexpr uint32_t tile_granularity = get_compile_time_arg_val(7);
-constexpr uint32_t intermediate_page_size = get_compile_time_arg_val(8);
-constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(9);
-constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(10);
-constexpr uint32_t ring_size = get_compile_time_arg_val(11);
-constexpr uint32_t num_batches = get_compile_time_arg_val(12);
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(13);
-constexpr bool is_forward = get_compile_time_arg_val(14);
-constexpr bool is_first_device_in_direction = get_compile_time_arg_val(15);
-constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(16);
-constexpr uint32_t num_intermediate_reduction_steps = get_compile_time_arg_val(17);
-constexpr bool do_final_reduction = get_compile_time_arg_val(18);
-constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(19);
-constexpr bool sync_with_other_direction = get_compile_time_arg_val(20);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(21);
+constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
+constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(3);
+constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(4);
+constexpr uint32_t tile_granularity = get_compile_time_arg_val(5);
+constexpr uint32_t intermediate_page_size = get_compile_time_arg_val(6);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(7);
+constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(8);
+constexpr uint32_t ring_size = get_compile_time_arg_val(9);
+constexpr uint32_t num_batches = get_compile_time_arg_val(10);
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(11);
+constexpr bool is_forward = get_compile_time_arg_val(12);
+constexpr bool is_first_device_in_direction = get_compile_time_arg_val(13);
+constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(14);
+constexpr uint32_t num_intermediate_reduction_steps = get_compile_time_arg_val(15);
+constexpr bool do_final_reduction = get_compile_time_arg_val(16);
+constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(17);
+constexpr bool sync_with_other_direction = get_compile_time_arg_val(18);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(19);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(22);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(23);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(24);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(28);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(30);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(31);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(32);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(33);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(34);
+constexpr bool is_termination_master = get_compile_time_arg_val(20);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(21);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(22);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(24);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(27);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(28);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(29);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(30);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(31);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(32);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<35>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<33>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<35 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<33 + ccl_routing_utils::num_line_unicast_args>();
 
 constexpr uint32_t batch_num_pages = batch_slice_num_pages * ring_size;
 constexpr uint32_t intermediate_num_pages = batch_num_pages * num_batches;
@@ -103,7 +99,8 @@ void kernel_main() {
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr uint32_t ct_idx = 35 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+    constexpr uint32_t ct_idx =
+        33 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -125,13 +122,10 @@ void kernel_main() {
     arg_idx += intermediate_rt_increment;
 
 #else
-    constexpr uint32_t ct_offset = 0;
-
-    constexpr bool intermediate_is_dram = intermediate_type == tt::tt_metal::BufferType::DRAM;
-    auto intermediate_addrgen = InterleavedAddrGenFast<intermediate_is_dram>{
-        .bank_base_address = intermediate_address,
-        .page_size = intermediate_page_size,
-        .data_format = get_dataformat(cb_compute_output_id)};
+    constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx>();
+    constexpr uint32_t ct_offset = intermediate_tensor_args.num_compile_time_args();
+    auto intermediate_tensor_addrgen =
+        TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -153,11 +147,8 @@ void kernel_main() {
 
     arg_idx += output_rt_increment;
 #else
-    constexpr bool output_is_dram = output_type == tt::tt_metal::BufferType::DRAM;
-    auto output_addrgen = InterleavedAddrGenFast<output_is_dram>{
-        .bank_base_address = output_address,
-        .page_size = intermediate_page_size,
-        .data_format = get_dataformat(cb_compute_output_id)};
+    constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset>();
+    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
 #endif
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -18,7 +17,6 @@
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////
@@ -28,37 +26,35 @@ using ttnn::ccl::Topology;
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
 constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);  // 4
-constexpr BufferType intermediate_type = static_cast<BufferType>(get_compile_time_arg_val(3));
-constexpr BufferType output_type = static_cast<BufferType>(get_compile_time_arg_val(4));
-constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(5);
-constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(6);
-constexpr uint32_t tile_granularity = get_compile_time_arg_val(7);
-constexpr uint32_t intermediate_page_size = get_compile_time_arg_val(8);
-constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(9);
-constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(10);
-constexpr uint32_t ring_size = get_compile_time_arg_val(11);
-constexpr uint32_t num_batches = get_compile_time_arg_val(12);
-constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(13);
-constexpr bool direction = get_compile_time_arg_val(14);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(15);
+constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(3);
+constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(4);
+constexpr uint32_t tile_granularity = get_compile_time_arg_val(5);
+constexpr uint32_t intermediate_page_size = get_compile_time_arg_val(6);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(7);
+constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(8);
+constexpr uint32_t ring_size = get_compile_time_arg_val(9);
+constexpr uint32_t num_batches = get_compile_time_arg_val(10);
+constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(11);
+constexpr bool direction = get_compile_time_arg_val(12);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(13);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(16);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(17);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(18);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(19);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(20);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(26);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(28);
+constexpr bool is_termination_master = get_compile_time_arg_val(14);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(15);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(16);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(17);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(18);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(19);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(20);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(21);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(22);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(24);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(26);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<29>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<27>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<29 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<27 + ccl_routing_utils::num_line_unicast_args>();
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -93,7 +89,8 @@ void kernel_main() {
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr uint32_t ct_idx = 29 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+    constexpr uint32_t ct_idx =
+        27 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -115,13 +112,10 @@ void kernel_main() {
     arg_idx += intermediate_rt_increment;
 
 #else
-    constexpr uint32_t ct_offset = 0;
-
-    constexpr bool intermediate_is_dram = intermediate_type == tt::tt_metal::BufferType::DRAM;
-    auto intermediate_addrgen = InterleavedAddrGenFast<intermediate_is_dram>{
-        .bank_base_address = intermediate_address,
-        .page_size = intermediate_page_size,
-        .data_format = get_dataformat(cb_compute_output_id)};
+    constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx>();
+    constexpr uint32_t ct_offset = intermediate_tensor_args.num_compile_time_args();
+    auto intermediate_tensor_addrgen =
+        TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -143,11 +137,8 @@ void kernel_main() {
 
     arg_idx += output_rt_increment;
 #else
-    constexpr bool output_is_dram = output_type == tt::tt_metal::BufferType::DRAM;
-    auto output_addrgen = InterleavedAddrGenFast<output_is_dram>{
-        .bank_base_address = output_address,
-        .page_size = intermediate_page_size,
-        .data_format = get_dataformat(cb_compute_output_id)};
+    constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset>();
+    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
 #endif
 
     auto mux_connection_handle = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -114,8 +114,7 @@ void kernel_main() {
 #else
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx>();
     constexpr uint32_t ct_offset = intermediate_tensor_args.num_compile_time_args();
-    auto intermediate_tensor_addrgen =
-        TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
+    auto intermediate_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -138,7 +137,7 @@ void kernel_main() {
     arg_idx += output_rt_increment;
 #else
     constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset>();
-    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
+    auto output_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
 #endif
 
     auto mux_connection_handle = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
 
@@ -283,10 +284,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     CoreRangeSet mux_backward_core_range_set = CoreRangeSet(mux_backward_core_ranges);
 
     // Tensor Info
-    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
-    const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
     const auto& input_tensor_shape = input_tensor.padded_shape();
-    const auto intermediate_tensor_buffer_type = intermediate_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
     const auto num_batches = input_tensor_shape[0];
     const auto batch_slice_num_pages = input_tensor_num_pages / ring_size / num_batches;
@@ -438,27 +436,30 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                     std::max((tiles_to_read - tiles_read) / tile_granularity / 2, (uint32_t)1));
 
                 std::vector<uint32_t> sender_reader_compile_args = {
-                    ring_index,                                              // my_chip_id
-                    static_cast<uint32_t>(input_tensor_buffer_type),         // input_buffer_type
-                    static_cast<uint32_t>(intermediate_tensor_buffer_type),  // intermediate_buffer_type
-                    input_cb_index,                                          // cb_input_id
-                    intermediate_cb_index,                                   // cb_intermediate_id
-                    reader_output_cb_index,                                  // cb_reader_output_id
-                    tile_granularity,                                        // packet_size_in_pages
-                    page_size,                                               // tensor0_page_size
-                    input_tensor_Wt,                                         // input_tensor_Wt
-                    batch_slice_num_pages,                                   // batch_slice_num_pages
-                    ring_size,                                               // ring_size
-                    num_batches,                                             // num_batches
-                    fuse_op,                                                 // fused op
-                    dir,                                                     // direction
+                    ring_index,              // my_chip_id
+                    input_cb_index,          // cb_input_id
+                    intermediate_cb_index,   // cb_intermediate_id
+                    reader_output_cb_index,  // cb_reader_output_id
+                    tile_granularity,        // packet_size_in_pages
+                    page_size,               // tensor0_page_size
+                    input_tensor_Wt,         // input_tensor_Wt
+                    batch_slice_num_pages,   // batch_slice_num_pages
+                    ring_size,               // ring_size
+                    num_batches,             // num_batches
+                    fuse_op,                 // fused op
+                    dir,                     // direction
                     chunks_per_sync_val,
                 };
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
                 }
                 if (intermediate_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
+                        .append_to(sender_reader_compile_args);
                 }
                 auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
                     program,
@@ -501,21 +502,19 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
 
                 // Writer
                 std::vector<uint32_t> sender_writer_compile_args = {
-                    ring_index,                                              // my_chip_id
-                    reserved_packet_header_CB_index,                         // reserved_packet_header_cb_id
-                    num_packet_headers_storable,                             // num_packet_headers_storable
-                    static_cast<uint32_t>(intermediate_tensor_buffer_type),  // intermediate_buffer_type
-                    static_cast<uint32_t>(output_tensor_buffer_type),        // output_buffer_type
-                    compute_output_cb_index,                                 // cb_compute_output_id
-                    reader_output_cb_index,                                  // cb_reader_output_id
-                    tile_granularity,                                        // packet_size_in_pages
-                    page_size,                                               // tensor0_page_size
-                    input_tensor_Wt,                                         // input_tensor_Wt
-                    batch_slice_num_pages,                                   // batch_slice_num_pages
-                    ring_size,                                               // ring_size
-                    num_batches,                                             // num_batches
-                    num_tiles_to_write_per_packet,                           // num_tiles_to_write_per_packet
-                    dir,                                                     // direction
+                    ring_index,                       // my_chip_id
+                    reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+                    num_packet_headers_storable,      // num_packet_headers_storable
+                    compute_output_cb_index,          // cb_compute_output_id
+                    reader_output_cb_index,           // cb_reader_output_id
+                    tile_granularity,                 // packet_size_in_pages
+                    page_size,                        // tensor0_page_size
+                    input_tensor_Wt,                  // input_tensor_Wt
+                    batch_slice_num_pages,            // batch_slice_num_pages
+                    ring_size,                        // ring_size
+                    num_batches,                      // num_batches
+                    num_tiles_to_write_per_packet,    // num_tiles_to_write_per_packet
+                    dir,                              // direction
                     chunks_per_sync_val,
                 };
                 append_fabric_mux_connection_ct_args(
@@ -542,9 +541,14 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                 }
                 if (intermediate_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_writer_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
+                        .append_to(sender_writer_compile_args);
                 }
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
                 }
                 auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
                     program,
@@ -841,10 +845,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
     CreateCircularBuffer(program, sender_worker_core_range_set, cb_reserved_packet_header_config);
 
     // Tensor Info
-    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
-    const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
     const auto& input_tensor_shape = input_tensor.padded_shape();
-    const auto intermediate_tensor_buffer_type = intermediate_tensor.buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
     const auto num_batches = input_tensor_shape[0];
     const auto batch_slice_num_pages = input_tensor_num_pages / ring_size / num_batches;
@@ -981,22 +982,19 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
 
                 // Reader
                 std::vector<uint32_t> sender_reader_compile_args = {
-                    ring_index,                                              // my_chip_id
-                    static_cast<uint32_t>(input_tensor_buffer_type),         // input_buffer_type
-                    static_cast<uint32_t>(intermediate_tensor_buffer_type),  // intermediate_buffer_type
-                    static_cast<uint32_t>(output_tensor_buffer_type),        // output_buffer_type
-                    input_cb_index,                                          // cb_input_id
-                    intermediate_cb_index,                                   // cb_intermediate_id
-                    reader_output_cb_index,                                  // cb_reader_output_id
-                    tile_granularity,                                        // packet_size_in_pages
-                    page_size,                                               // tensor0_page_size
-                    input_tensor_Wt,                                         // input_tensor_Wt
-                    batch_slice_num_pages,                                   // batch_slice_num_pages
-                    ring_size,                                               // ring_size
-                    num_batches,                                             // num_batches
-                    fuse_op,                                                 // fused op
-                    tiles_to_write_per_packet,                               // contig_pages_advanced
-                    is_forward,                                              // direction
+                    ring_index,                 // my_chip_id
+                    input_cb_index,             // cb_input_id
+                    intermediate_cb_index,      // cb_intermediate_id
+                    reader_output_cb_index,     // cb_reader_output_id
+                    tile_granularity,           // packet_size_in_pages
+                    page_size,                  // tensor0_page_size
+                    input_tensor_Wt,            // input_tensor_Wt
+                    batch_slice_num_pages,      // batch_slice_num_pages
+                    ring_size,                  // ring_size
+                    num_batches,                // num_batches
+                    fuse_op,                    // fused op
+                    tiles_to_write_per_packet,  // contig_pages_advanced
+                    is_forward,                 // direction
                     is_first_device_in_direction,
                     num_targets_in_direction,
                     num_intermediate_reduction_steps,
@@ -1007,12 +1005,19 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                 };
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
                 }
                 if (intermediate_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
+                        .append_to(sender_reader_compile_args);
                 }
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(output_tensor, sender_reader_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_reader_compile_args);
                 }
                 auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
                     program,
@@ -1048,21 +1053,19 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                     mesh_device->worker_core_from_logical_core(termination_master_logical_core);
                 // Writer
                 std::vector<uint32_t> sender_writer_compile_args = {
-                    ring_index,                                              // my_chip_id
-                    reserved_packet_header_CB_index,                         // reserved_packet_header_cb_id
-                    num_packet_headers_storable,                             // num_packet_headers_storable
-                    static_cast<uint32_t>(intermediate_tensor_buffer_type),  // intermediate_buffer_type
-                    static_cast<uint32_t>(output_tensor_buffer_type),        // output_buffer_type
-                    compute_output_cb_index,                                 // cb_compute_output_id
-                    reader_output_cb_index,                                  // cb_reader_output_id
-                    tile_granularity,                                        // packet_size_in_pages
-                    page_size,                                               // tensor0_page_size
-                    input_tensor_Wt,                                         // input_tensor_Wt
-                    batch_slice_num_pages,                                   // batch_slice_num_pages
-                    ring_size,                                               // ring_size
-                    num_batches,                                             // num_batches
-                    tiles_to_write_per_packet,                               // contig_pages_advanced
-                    is_forward,                                              // direction
+                    ring_index,                       // my_chip_id
+                    reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+                    num_packet_headers_storable,      // num_packet_headers_storable
+                    compute_output_cb_index,          // cb_compute_output_id
+                    reader_output_cb_index,           // cb_reader_output_id
+                    tile_granularity,                 // packet_size_in_pages
+                    page_size,                        // tensor0_page_size
+                    input_tensor_Wt,                  // input_tensor_Wt
+                    batch_slice_num_pages,            // batch_slice_num_pages
+                    ring_size,                        // ring_size
+                    num_batches,                      // num_batches
+                    tiles_to_write_per_packet,        // contig_pages_advanced
+                    is_forward,                       // direction
                     is_first_device_in_direction,
                     num_targets_in_direction,
                     num_intermediate_reduction_steps,
@@ -1095,9 +1098,14 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                 }
                 if (intermediate_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_writer_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
+                        .append_to(sender_writer_compile_args);
                 }
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
+                } else {
+                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
                 }
                 auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
                     program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include <cstdint>
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -17,20 +17,24 @@ using ttnn::ccl::Topology;
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
-constexpr BufferType input_buffer_type = static_cast<BufferType>(get_compile_time_arg_val(1));
-constexpr BufferType output_buffer_type = static_cast<BufferType>(get_compile_time_arg_val(2));
-constexpr uint32_t cb_output_id = get_compile_time_arg_val(3);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);  // 2
-constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(5);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
-constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(8));
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(9);  // 2
-constexpr uint32_t num_inputs = get_compile_time_arg_val(10);
-constexpr bool direction = get_compile_time_arg_val(11);  // 1 is forward, 0 is backward
-constexpr bool fuse_op = get_compile_time_arg_val(12);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(1);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(2);  // 2
+constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(3);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(4);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(5);
+constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(6));
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(7);  // 2
+constexpr uint32_t num_inputs = get_compile_time_arg_val(8);
+constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is backward
+constexpr bool fuse_op = get_compile_time_arg_val(10);
 
 void kernel_main() {
+    constexpr uint32_t page_size_base_idx = 11;
+    constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+    constexpr auto outputs_args = make_tensor_accessor_args_tuple<
+        num_inputs,
+        std::get<num_inputs - 1>(inputs_args).next_compile_time_args_offset()>();
+
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
@@ -46,14 +50,13 @@ void kernel_main() {
     uint32_t input_tile_id_end = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_size = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    address_t input_tensor_addresses[num_inputs];
-    address_t output_tensor_addresses[num_inputs];
-    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
-        address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
-        input_tensor_addresses[input_idx] = input_tensor_address;
-        output_tensor_addresses[input_idx] = output_tensor_address;
-    }
+
+    auto inputs_tuple = make_tensor_accessor_tuple(inputs_args, arg_idx, page_size_base_idx);
+    arg_idx += num_inputs;
+    auto input_tensor_addrgens = make_abstract_tensor_accessor_wrappers(inputs_tuple);
+    auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx, page_size_base_idx);
+    arg_idx += num_inputs;
+    auto output_tensor_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
 
     OpSignaler op_signaler;
     if constexpr (fuse_op) {
@@ -62,15 +65,6 @@ void kernel_main() {
 
     const uint32_t payload_size_bytes = input_tensor_page_size * contig_pages_advanced;
     // Push out our local slice
-    constexpr bool input_tensor_is_dram = input_buffer_type == tt::tt_metal::BufferType::DRAM;
-    InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_addrgens[num_inputs];
-    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        auto input_tensor_addrgen = InterleavedAddrGenFast<input_tensor_is_dram>{
-            .bank_base_address = input_tensor_addresses[input_idx],
-            .page_size = input_tensor_page_size,
-            .data_format = get_dataformat(cb_output_id)};
-        input_tensor_addrgens[input_idx] = input_tensor_addrgen;
-    }
 
     uint32_t tiles_read = input_tile_id_start;
     uint32_t tiles_to_read = input_tile_id_end;
@@ -83,8 +77,8 @@ void kernel_main() {
                 const uint32_t l1_write_addr_base = get_write_ptr(cb_output_id);
                 uint32_t l1_write_addr = l1_write_addr_base;
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                    noc_async_read_tile(
-                        output_tile_id_start + tiles_read, input_tensor_addrgens[input_idx], l1_write_addr);
+                    auto read_addr = input_tensor_addrgens[input_idx].get_noc_addr(output_tile_id_start + tiles_read);
+                    noc_async_read(read_addr, l1_write_addr, input_tensor_page_size);
                     l1_write_addr += payload_size_bytes;
                     tiles_read += contig_pages_advanced;
                 }
@@ -96,16 +90,6 @@ void kernel_main() {
             output_tile_id_start += input_tensor_Wt * input_tensor_Ht;
         }
         output_tile_id_start = 0;
-    }
-
-    constexpr bool output_tensor_is_dram = output_buffer_type == tt::tt_metal::BufferType::DRAM;
-    InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_addrgens[num_inputs];
-    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        auto output_tensor_addrgen = InterleavedAddrGenFast<output_tensor_is_dram>{
-            .bank_base_address = output_tensor_addresses[input_idx],
-            .page_size = input_tensor_page_size,
-            .data_format = get_dataformat(cb_output_id)};
-        output_tensor_addrgens[input_idx] = output_tensor_addrgen;
     }
 
     uint32_t slices_received = 0;
@@ -185,10 +169,9 @@ void kernel_main() {
                         cb_reserve_back(cb_output_id, packet_size_in_pages);
                         size_t l1_write_addr = get_write_ptr(cb_output_id);
                         for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                            noc_async_read_tile(
-                                output_tile_id_start + row_offset + pages_read_in_row,
-                                output_tensor_addrgens[input_idx],
-                                l1_write_addr);
+                            auto read_addr = output_tensor_addrgens[input_idx].get_noc_addr(
+                                output_tile_id_start + row_offset + pages_read_in_row);
+                            noc_async_read(read_addr, l1_write_addr, input_tensor_page_size);
                             l1_write_addr += payload_size_bytes;
                             tiles_read += contig_pages_advanced;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
@@ -13,7 +12,6 @@
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////
@@ -23,20 +21,22 @@ using ttnn::ccl::Topology;
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
 constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
-constexpr BufferType output_type = static_cast<BufferType>(get_compile_time_arg_val(3));
-constexpr uint32_t cb_output_id = get_compile_time_arg_val(4);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(5);
-constexpr uint32_t output_page_size = get_compile_time_arg_val(6);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(7);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(8);
-constexpr bool dynamic_alternate = get_compile_time_arg_val(9);
-constexpr bool fuse_op = get_compile_time_arg_val(10);
-constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(11));
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(12);
-constexpr uint32_t num_inputs = get_compile_time_arg_val(13);
-constexpr bool direction = get_compile_time_arg_val(14);  // 1 is forward, 0 is backward
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(3);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+constexpr bool dynamic_alternate = get_compile_time_arg_val(8);
+constexpr bool fuse_op = get_compile_time_arg_val(9);
+constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(10));
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(11);
+constexpr uint32_t num_inputs = get_compile_time_arg_val(12);
+constexpr bool direction = get_compile_time_arg_val(13);  // 1 is forward, 0 is backward
 
 void kernel_main() {
+    constexpr uint32_t page_size_base_idx = 14;
+    constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
@@ -53,11 +53,9 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_size = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    address_t output_addresses[num_inputs];
-    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        address_t output_address = get_arg_val<address_t>(arg_idx++);
-        output_addresses[input_idx] = output_address;
-    }
+    auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx, page_size_base_idx);
+    arg_idx += num_inputs;
+    auto output_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 
@@ -80,17 +78,6 @@ void kernel_main() {
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
     pkt_hdr->to_chip_unicast(1);
-
-    // interleaved addrgen
-    constexpr bool output_is_dram = output_type == tt::tt_metal::BufferType::DRAM;
-    InterleavedAddrGenFast<output_is_dram> output_addrgens[num_inputs];
-    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        auto output_addrgen = InterleavedAddrGenFast<output_is_dram>{
-            .bank_base_address = output_addresses[input_idx],
-            .page_size = output_page_size,
-            .data_format = get_dataformat(cb_output_id)};
-        output_addrgens[input_idx] = output_addrgen;
-    }
 
     fabric_connection.open();
 
@@ -126,8 +113,7 @@ void kernel_main() {
 
                 // for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                 uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
-                uint64_t noc0_dest_noc_addr =
-                    get_noc_addr(tile_id, output_addrgens[input_idx], 0 /*offset*/, 0 /*noc_id*/);
+                uint64_t noc0_dest_noc_addr = output_addrgens[input_idx].get_noc_addr(tile_id, 0, 0);
 
                 pages_read_in_row++;
                 if (pages_read_in_row >= input_tensor_Wt) {
@@ -137,14 +123,12 @@ void kernel_main() {
 
                 if (num_pages_to_read == 2) {
                     uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
-                    uint64_t second_noc0_dest_noc_addr =
-                        get_noc_addr(second_tile_id, output_addrgens[input_idx], 0 /*offset*/, 0 /*noc_id*/);
+                    uint64_t second_noc0_dest_noc_addr = output_addrgens[input_idx].get_noc_addr(second_tile_id, 0, 0);
 
                     if constexpr (direction == 1) {
                         // Backwards does local write
-                        noc_async_write_tile(tile_id, output_addrgens[input_idx], l1_read_addr);
-                        noc_async_write_tile(
-                            second_tile_id, output_addrgens[input_idx], l1_read_addr + output_page_size);
+                        noc_async_write(noc0_dest_noc_addr, l1_read_addr, output_page_size);
+                        noc_async_write(second_noc0_dest_noc_addr, l1_read_addr + output_page_size, output_page_size);
                     }
 
                     if constexpr (num_targets_in_direction) {
@@ -166,7 +150,7 @@ void kernel_main() {
                 } else {
                     ASSERT(num_pages_to_read == 1);
                     if constexpr (direction == 1) {
-                        noc_async_write_tile(tile_id, output_addrgens[input_idx], l1_read_addr);
+                        noc_async_write(noc0_dest_noc_addr, l1_read_addr, output_page_size);
                     }
                     if constexpr (num_targets_in_direction) {
                         // Has valid targets to send to

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -127,8 +127,12 @@ void kernel_main() {
 
                     if constexpr (direction == 1) {
                         // Backwards does local write
-                        noc_async_write(noc0_dest_noc_addr, l1_read_addr, output_page_size);
-                        noc_async_write(second_noc0_dest_noc_addr, l1_read_addr + output_page_size, output_page_size);
+                        noc_async_write(
+                            l1_read_addr, output_addrgens[input_idx].get_noc_addr(tile_id), output_page_size);
+                        noc_async_write(
+                            l1_read_addr + output_page_size,
+                            output_addrgens[input_idx].get_noc_addr(second_tile_id),
+                            output_page_size);
                     }
 
                     if constexpr (num_targets_in_direction) {
@@ -150,7 +154,8 @@ void kernel_main() {
                 } else {
                     ASSERT(num_pages_to_read == 1);
                     if constexpr (direction == 1) {
-                        noc_async_write(noc0_dest_noc_addr, l1_read_addr, output_page_size);
+                        noc_async_write(
+                            l1_read_addr, output_addrgens[input_idx].get_noc_addr(tile_id), output_page_size);
                     }
                     if constexpr (num_targets_in_direction) {
                         // Has valid targets to send to

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -250,11 +250,8 @@ void kernel_main() {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
                     cb_wait_front(cb_output_id, packet_size_in_pages);
                     size_t l1_read_addr = get_read_ptr(cb_output_id);
-                    uint64_t noc0_dest_noc_addr = get_noc_addr(
-                        tile_id_start + row_offset + pages_read_in_row,
-                        output_addrgens[input_idx],
-                        0 /*offset*/,
-                        0 /*noc_id*/);
+                    uint64_t noc0_dest_noc_addr = output_addrgens[input_idx].get_noc_addr(
+                        tile_id_start + row_offset + pages_read_in_row, 0 /*offset*/, 0 /*noc_id*/);
                     pages_read_in_row++;
                     if (pages_read_in_row >= slice_Wt) {
                         row_offset += stride_Wt;
@@ -262,11 +259,8 @@ void kernel_main() {
                     }
 
                     if (num_pages_to_read == 2) {
-                        uint64_t second_noc0_dest_noc_addr = get_noc_addr(
-                            tile_id_start + row_offset + pages_read_in_row,
-                            output_addrgens[input_idx],
-                            0 /*offset*/,
-                            0 /*noc_id*/);
+                        uint64_t second_noc0_dest_noc_addr = output_addrgens[input_idx].get_noc_addr(
+                            tile_id_start + row_offset + pages_read_in_row, 0 /*offset*/, 0 /*noc_id*/);
                         pages_read_in_row++;
                         if (pages_read_in_row >= slice_Wt) {
                             row_offset += stride_Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_program.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
 
@@ -175,9 +176,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     CreateCircularBuffer(program, sender_backward_core_ranges, cb_reserved_packet_header_backward_config);
 
     // Tensor Info
-    const auto input_tensor_buffer_type = input_tensor[0].buffer()->buffer_type();
     const auto input_tensor_num_pages = input_tensor[0].buffer()->num_pages();
-    const auto output_tensor_buffer_type = output_tensor[0].buffer()->buffer_type();
     const auto input_tensor_shape = input_tensor[0].padded_shape();
     const auto output_tensor_shape = output_tensor[0].padded_shape();
     const uint32_t num_inputs = input_tensor.size();
@@ -188,20 +187,29 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     // Reader
     auto sender_reader_forward_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
     sender_reader_forward_kernel_config.compile_args = {
-        ring_index,                                        // my_chip_id
-        static_cast<uint32_t>(input_tensor_buffer_type),   // input_buffer_type
-        static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
-        sender_forward_cb_index,                           // cb_forward_id
-        num_pages_per_packet,                              // packet_size_in_pages
-        op_config.get_page_size(),                         // tensor0_page_size
-        num_targets_forward,                               // num_slices_forward_direction
-        num_targets_backward,                              // num_slices_backward_direction
-        static_cast<uint32_t>(topology),                   // topology
-        tiles_to_write_per_packet,                         // contig_pages_advanced
-        num_inputs,                                        // num_inputs
-        1,                                                 // direction
-        fuse_op,                                           // fused op
+        ring_index,                       // my_chip_id
+        sender_forward_cb_index,          // cb_forward_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_slices_forward_direction
+        num_targets_backward,             // num_slices_backward_direction
+        static_cast<uint32_t>(topology),  // topology
+        tiles_to_write_per_packet,        // contig_pages_advanced
+        num_inputs,                       // num_inputs
+        1,                                // direction
+        fuse_op,                          // fused op
     };
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        sender_reader_forward_kernel_config.compile_args.push_back(op_config.get_page_size());
+    }
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        tt::tt_metal::TensorAccessorArgs(input_tensor[i].buffer())
+            .append_to(sender_reader_forward_kernel_config.compile_args);
+    }
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_reader_forward_kernel_config.compile_args);
+    }
     auto worker_sender_reader_forward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
@@ -212,22 +220,28 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     // Writer
     auto sender_writer_forward_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
     sender_writer_forward_kernel_config.compile_args = {
-        ring_index,                                        // my_chip_id
-        reserved_packet_header_forward_CB_index,           // reserved_packet_header_cb_id
-        num_packet_headers_storable,                       // num_packet_headers_storable
-        static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
-        sender_forward_cb_index,                           // cb_forward_id
-        num_pages_per_packet,                              // packet_size_in_pages
-        op_config.get_page_size(),                         // tensor0_page_size
-        num_targets_forward,                               // num_targets_forward_direction
-        num_targets_backward,                              // num_targets_backward_direction
-        dynamic_alternate,                                 // alternate
-        fuse_op,                                           // fused op
-        static_cast<uint32_t>(topology),                   // topology
-        tiles_to_write_per_packet,                         // contig_pages_advanced
-        num_inputs,                                        // num_inputs
-        1,                                                 // direction
+        ring_index,                               // my_chip_id
+        reserved_packet_header_forward_CB_index,  // reserved_packet_header_cb_id
+        num_packet_headers_storable,              // num_packet_headers_storable
+        sender_forward_cb_index,                  // cb_forward_id
+        num_pages_per_packet,                     // packet_size_in_pages
+        op_config.get_page_size(),                // tensor0_page_size
+        num_targets_forward,                      // num_targets_forward_direction
+        num_targets_backward,                     // num_targets_backward_direction
+        dynamic_alternate,                        // alternate
+        fuse_op,                                  // fused op
+        static_cast<uint32_t>(topology),          // topology
+        tiles_to_write_per_packet,                // contig_pages_advanced
+        num_inputs,                               // num_inputs
+        1,                                        // direction
     };
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        sender_writer_forward_kernel_config.compile_args.push_back(op_config.get_page_size());
+    }
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_writer_forward_kernel_config.compile_args);
+    }
     auto worker_sender_writer_forward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
@@ -239,20 +253,29 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     // Reader
     auto sender_reader_backward_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
     sender_reader_backward_kernel_config.compile_args = {
-        ring_index,                                        // my_chip_id
-        static_cast<uint32_t>(input_tensor_buffer_type),   // input_buffer_type
-        static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
-        sender_backward_cb_index,                          // cb_backward_id
-        num_pages_per_packet,                              // packet_size_in_pages
-        op_config.get_page_size(),                         // tensor0_page_size
-        num_targets_forward,                               // num_slices_forward_direction
-        num_targets_backward,                              // num_slices_backward_direction
-        static_cast<uint32_t>(topology),                   // topology
-        tiles_to_write_per_packet,                         // contig_pages_advanced
-        num_inputs,                                        // num_inputs
-        0,                                                 // direction
-        fuse_op,                                           // fused op
+        ring_index,                       // my_chip_id
+        sender_backward_cb_index,         // cb_backward_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_slices_forward_direction
+        num_targets_backward,             // num_slices_backward_direction
+        static_cast<uint32_t>(topology),  // topology
+        tiles_to_write_per_packet,        // contig_pages_advanced
+        num_inputs,                       // num_inputs
+        0,                                // direction
+        fuse_op,                          // fused op
     };
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        sender_reader_backward_kernel_config.compile_args.push_back(op_config.get_page_size());
+    }
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        tt::tt_metal::TensorAccessorArgs(input_tensor[i].buffer())
+            .append_to(sender_reader_backward_kernel_config.compile_args);
+    }
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_reader_backward_kernel_config.compile_args);
+    }
     auto worker_sender_reader_backward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
@@ -263,22 +286,28 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
     // Writer
     auto sender_writer_backward_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
     sender_writer_backward_kernel_config.compile_args = {
-        ring_index,                                        // my_chip_id
-        reserved_packet_header_backward_CB_index,          // reserved_packet_header_cb_id
-        num_packet_headers_storable,                       // num_packet_headers_storable
-        static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
-        sender_backward_cb_index,                          // cb_backward_id
-        num_pages_per_packet,                              // packet_size_in_pages
-        op_config.get_page_size(),                         // tensor0_page_size
-        num_targets_forward,                               // num_targets_forward_direction
-        num_targets_backward,                              // num_targets_backward_direction
-        dynamic_alternate,                                 // alternate
-        fuse_op,                                           // fused op
-        static_cast<uint32_t>(topology),                   // topology
-        tiles_to_write_per_packet,                         // contig_pages_advanced
-        num_inputs,                                        // num_inputs
-        0,                                                 // direction
+        ring_index,                                // my_chip_id
+        reserved_packet_header_backward_CB_index,  // reserved_packet_header_cb_id
+        num_packet_headers_storable,               // num_packet_headers_storable
+        sender_backward_cb_index,                  // cb_backward_id
+        num_pages_per_packet,                      // packet_size_in_pages
+        op_config.get_page_size(),                 // tensor0_page_size
+        num_targets_forward,                       // num_targets_forward_direction
+        num_targets_backward,                      // num_targets_backward_direction
+        dynamic_alternate,                         // alternate
+        fuse_op,                                   // fused op
+        static_cast<uint32_t>(topology),           // topology
+        tiles_to_write_per_packet,                 // contig_pages_advanced
+        num_inputs,                                // num_inputs
+        0,                                         // direction
     };
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        sender_writer_backward_kernel_config.compile_args.push_back(op_config.get_page_size());
+    }
+    for (uint32_t i = 0; i < num_inputs; i++) {
+        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_writer_backward_kernel_config.compile_args);
+    }
     auto worker_sender_writer_backward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
@@ -332,6 +361,8 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
         reader_sender_rt_offset = reader_forward_rt_args.size();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(input_tensor[input_idx].buffer()->address());
+        }
+        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(output_tensor[input_idx].buffer()->address());
         }
         if (fuse_op) {
@@ -357,6 +388,8 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
         };
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer()->address());
+        }
+        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(output_tensor[input_idx].buffer()->address());
         }
         if (fuse_op) {
@@ -496,13 +529,13 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_attention_all_gather_async_mu
                 worker_writer_sender_backward_runtime_args[11] = semaphore.at(0).address();
                 for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
                     // sender reader
-                    worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + 2 * input_idx] =
+                    worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + input_idx] =
                         input_tensors[input_idx].buffer()->address();
-                    worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + 2 * input_idx + 1] =
+                    worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + num_inputs + input_idx] =
                         output_tensors[input_idx].buffer()->address();
-                    worker_reader_sender_backward_runtime_args[reader_sender_rt_offset + 2 * input_idx] =
+                    worker_reader_sender_backward_runtime_args[reader_sender_rt_offset + input_idx] =
                         input_tensors[input_idx].buffer()->address();
-                    worker_reader_sender_backward_runtime_args[reader_sender_rt_offset + 2 * input_idx + 1] =
+                    worker_reader_sender_backward_runtime_args[reader_sender_rt_offset + num_inputs + input_idx] =
                         output_tensors[input_idx].buffer()->address();
                     // sender writer
                     worker_writer_sender_forward_runtime_args[writer_sender_rt_offset + input_idx] =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -29,26 +29,26 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(9);
 
     constexpr bool fuse_gamma = get_compile_time_arg_val(10) == 1;
-    constexpr bool gamma_is_dram = get_compile_time_arg_val(11) == 1;
-    constexpr uint32_t block_w = get_compile_time_arg_val(12);
+    constexpr uint32_t block_w = get_compile_time_arg_val(11);
 
     // Circular Buffer CTs
-    constexpr uint32_t cb_out_resharded = get_compile_time_arg_val(13);
-    constexpr uint32_t cb_out = get_compile_time_arg_val(14);
-    constexpr uint32_t eps_cb_id = get_compile_time_arg_val(15);
-    constexpr uint32_t post_cb_in_4 = get_compile_time_arg_val(16);
-    constexpr uint32_t cb_gamma = get_compile_time_arg_val(17);
+    constexpr uint32_t cb_out_resharded = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(13);
+    constexpr uint32_t eps_cb_id = get_compile_time_arg_val(14);
+    constexpr uint32_t post_cb_in_4 = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_gamma = get_compile_time_arg_val(16);
 
     // Data type CTs
-    constexpr uint32_t stick_size = get_compile_time_arg_val(18);
-    constexpr bool FLOAT32_DTYPE_GAMMA = get_compile_time_arg_val(19) == 1;
+    constexpr uint32_t stick_size = get_compile_time_arg_val(17);
+    constexpr bool FLOAT32_DTYPE_GAMMA = get_compile_time_arg_val(18) == 1;
 
     // Reshard writer
-    constexpr uint32_t worker_core_stride_w_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t storage_core_stride_w_bytes = get_compile_time_arg_val(21);
-    constexpr uint32_t stats_set_semaphore_id = get_compile_time_arg_val(22);
-    constexpr uint32_t signaling_cb = get_compile_time_arg_val(23);
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(24);
+    constexpr uint32_t worker_core_stride_w_bytes = get_compile_time_arg_val(19);
+    constexpr uint32_t storage_core_stride_w_bytes = get_compile_time_arg_val(20);
+    constexpr uint32_t stats_set_semaphore_id = get_compile_time_arg_val(21);
+    constexpr uint32_t signaling_cb = get_compile_time_arg_val(22);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(23);
+    constexpr auto gamma_args = TensorAccessorArgs<24>();
 
     uint32_t stats_set_semaphore_addr = get_semaphore(stats_set_semaphore_id);
     size_t arg_idx = 0;
@@ -190,7 +190,7 @@ void kernel_main() {
 
     if constexpr (fuse_gamma) {
         const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
-        const auto gamma = get_interleaved_addr_gen<gamma_is_dram, stick_size>(gamma_addr);
+        const auto gamma = TensorAccessor(gamma_args, gamma_addr, stick_size);
 
         constexpr uint32_t bytes_in_faceline = FLOAT32_DTYPE_GAMMA ? 64 : 32;
         constexpr uint32_t bytes_in_two_facelines = bytes_in_faceline * 2;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/fabric.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
@@ -668,7 +669,6 @@ operation::ProgramWithCallbacks frmsnorm_multi_core_sharded(
         num_targets_backward,             // num_targets_backward_direction
         num_links,
         (std::uint32_t)gamma.has_value(),
-        (std::uint32_t)is_dram(gamma),
         (std::uint32_t)block_wt,
         output_reshard_cb_index,
         output_cb_index,
@@ -692,6 +692,7 @@ operation::ProgramWithCallbacks frmsnorm_multi_core_sharded(
     writer_compile_time_args.push_back(stats_filled_semaphore);
     writer_compile_time_args.push_back(signaling_cb);
     writer_compile_time_args.push_back(num_blocks);
+    tt::tt_metal::TensorAccessorArgs(gamma ? gamma->buffer() : nullptr).append_to(writer_compile_time_args);
 
     tt::tt_metal::NOC reader_noc = NOC::NOC_1;
     tt::tt_metal::NOC writer_noc = NOC::NOC_1;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25975

### Problem description
We need to migrate all kernels to use TensorAccessor instead of InterleavedAddrGen to make them support ND sharding. This is the first step of adding universal sharding support to all OPs.

### What's changed
Ported all kernels in `operations/ccl` and `operations/experimantal/ccl` to use TensorAccessor, with the exception of `ccl_send.cpp`, `ccl_send_reader_two_input.cpp`, and `command_processor.hpp` which are scheduled to be removed soon.
Updated their corresponding factories.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17288898576)
- [x] [T3K frequent CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17291352899)
- [x] [T3K nightly CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17288911698)
- [x] [T3K unit tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17288917517)
- [x] New/Existing tests provide coverage for changes