### PR TITLE
[tt-train] Modify if statement to call sync grads only ddp is enabled

### DIFF
--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -944,7 +944,7 @@ int main(int argc, char **argv) {
             if (gradient_accumulator_helper.should_step()) {
                 // synchronize gradients for multi-device case, no-op if single device
                 auto parameters = get_model_parameters(model);
-                if (!device_config.enable_tp && !config.enable_mpi) {
+                if (device_config.enable_ddp && !config.enable_mpi) {
                     ttml::core::distributed::synchronize_parameters(parameters);
                 }
 


### PR DESCRIPTION
### Problem description
We might call synchronize_gradients if it's not needed. 

### What's changed
Modify if statement to run gradients synchronization only if needed. 

### Checklist
- [x] New/Existing tests provide coverage for changes