### PR TITLE
Add tests for non-4B multiple WriteToL1/DRAM.

### DIFF
--- a/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
@@ -25,6 +25,14 @@ inline void writeL1Backdoor(
     log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
     tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], coord, address, data);
 }
+inline void writeL1Backdoor(
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
+    CoreCoord coord,
+    uint32_t address,
+    std::span<const uint8_t> data) {
+    log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], coord, address, data);
+}
 inline void readL1Backdoor(
     tt::tt_metal::IDevice* device, CoreCoord coord, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, byte_size);
@@ -39,6 +47,14 @@ inline void readL1Backdoor(
     log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, byte_size);
     tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], coord, address, byte_size, data);
 }
+inline void readL1Backdoor(
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
+    CoreCoord coord,
+    uint32_t address,
+    std::span<uint8_t> data) {
+    log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, data.size());
+    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], coord, address, data);
+}
 inline void writeDramBackdoor(
     tt::tt_metal::IDevice* device, uint32_t channel, uint32_t address, std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- channel={} address={}", __FUNCTION__, channel, address);
@@ -49,6 +65,14 @@ inline void writeDramBackdoor(
     uint32_t channel,
     uint32_t address,
     std::vector<uint32_t>& data) {
+    log_info(tt::LogTest, "{} -- channel={} address={}", __FUNCTION__, channel, address);
+    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, data);
+}
+inline void writeDramBackdoor(
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t channel,
+    uint32_t address,
+    std::span<const uint8_t> data) {
     log_info(tt::LogTest, "{} -- channel={} address={}", __FUNCTION__, channel, address);
     tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, data);
 }
@@ -65,5 +89,13 @@ inline void readDramBackdoor(
     std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- channel={} address={} byte_size={}", __FUNCTION__, channel, address, byte_size);
     tt_metal::detail::ReadFromDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, byte_size, data);
+}
+inline void readDramBackdoor(
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t channel,
+    uint32_t address,
+    std::span<uint8_t> data) {
+    log_info(tt::LogTest, "{} -- channel={} address={} byte_size={}", __FUNCTION__, channel, address, data.size());
+    tt_metal::detail::ReadFromDeviceDRAMChannel(mesh_device->get_devices()[0], channel, address, data);
 }
 }  // namespace tt::test::buffer::detail

--- a/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
@@ -38,26 +38,12 @@ using namespace tt::test::buffer::detail;
 using namespace tt::tt_metal;
 
 namespace tt::test::buffer::detail {
-bool SimpleL1ReadOnly(std::shared_ptr<distributed::MeshDevice> mesh_device, size_t local_address, size_t byte_size) {
-    std::vector<uint32_t> inputs =
-        generate_uniform_random_vector<uint32_t>(0, UINT32_MAX, byte_size / sizeof(uint32_t));
-    std::vector<uint32_t> outputs;
+bool SimpleL1Loopback(std::shared_ptr<distributed::MeshDevice> mesh_device, size_t local_address, size_t byte_size) {
+    std::vector<uint8_t> inputs = generate_uniform_random_vector<uint8_t>(0, UINT8_MAX, byte_size);
+    std::vector<uint8_t> outputs(byte_size);
     CoreCoord bank0_logical_core = mesh_device->allocator()->get_logical_core_from_bank_id(0);
     writeL1Backdoor(mesh_device, bank0_logical_core, local_address, inputs);
-    readL1Backdoor(mesh_device, bank0_logical_core, local_address, byte_size, outputs);
-    bool pass = (inputs == outputs);
-    if (not pass) {
-        log_info(tt::LogTest, "Mismatch at Core={}, Packet Size(in Bytes)={}", bank0_logical_core.str(), byte_size);
-    }
-    return pass;
-}
-bool SimpleL1WriteOnly(std::shared_ptr<distributed::MeshDevice> mesh_device, size_t local_address, size_t byte_size) {
-    std::vector<uint32_t> inputs =
-        generate_uniform_random_vector<uint32_t>(0, UINT32_MAX, byte_size / sizeof(uint32_t));
-    std::vector<uint32_t> outputs;
-    CoreCoord bank0_logical_core = mesh_device->allocator()->get_logical_core_from_bank_id(0);
-    writeL1Backdoor(mesh_device, bank0_logical_core, local_address, inputs);
-    readL1Backdoor(mesh_device, bank0_logical_core, local_address, byte_size, outputs);
+    readL1Backdoor(mesh_device, bank0_logical_core, local_address, outputs);
     bool pass = (inputs == outputs);
     if (not pass) {
         log_info(tt::LogTest, "Mismatch at Core={}, Packet Size(in Bytes)={}", bank0_logical_core.str(), byte_size);
@@ -158,51 +144,31 @@ bool SimpleTiledL1WriteCBRead(
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceFixture, TestSimpleL1BufferReadOnlyLo) {
+TEST_F(MeshDeviceFixture, TestSimpleL1BufferLo) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         size_t lo_address = this->devices_.at(id)->l1_size_per_core() -
                             this->devices_.at(id)->allocator()->get_bank_size(tt::tt_metal::BufferType::L1);
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), lo_address, 4));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), lo_address, 8));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), lo_address, 16));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), lo_address, 32));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), lo_address, 1024));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), lo_address, 16 * 1024));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 1));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 2));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 4));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 8));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 16));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 32));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 1024));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 16 * 1024));
     }
 }
-TEST_F(MeshDeviceFixture, TestSimpleL1BufferReadOnlyHi) {
+TEST_F(MeshDeviceFixture, TestSimpleL1BufferHi) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         size_t hi_address = this->devices_.at(id)->l1_size_per_core() - (16 * 1024);
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), hi_address, 4));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), hi_address, 8));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), hi_address, 16));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), hi_address, 32));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), hi_address, 1024));
-        ASSERT_TRUE(SimpleL1ReadOnly(this->devices_.at(id), hi_address, 16 * 1024));
-    }
-}
-TEST_F(MeshDeviceFixture, TestSimpleL1BufferWriteOnlyLo) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t lo_address = this->devices_.at(id)->l1_size_per_core() -
-                            this->devices_.at(id)->allocator()->get_bank_size(tt::tt_metal::BufferType::L1);
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), lo_address, 4));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), lo_address, 8));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), lo_address, 16));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), lo_address, 32));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), lo_address, 1024));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), lo_address, 16 * 1024));
-    }
-}
-
-TEST_F(MeshDeviceFixture, TestSimpleL1BufferWriteOnlyHi) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t hi_address = this->devices_.at(id)->l1_size_per_core() - (16 * 1024);
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), hi_address, 4));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), hi_address, 8));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), hi_address, 16));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), hi_address, 32));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), hi_address, 1024));
-        ASSERT_TRUE(SimpleL1WriteOnly(this->devices_.at(id), hi_address, 16 * 1024));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 1));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 2));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 4));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 8));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 16));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 32));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 1024));
+        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 16 * 1024));
     }
 }
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <span>
 #include <vector>
 
 #include <hostdevcommon/common_values.hpp>
@@ -214,6 +215,22 @@ uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, 
  */
 DeviceProgramId DecodePerDeviceProgramID(uint32_t device_program_id);
 
+// clang-format off
+/**
+ * Copies data from a host buffer into a buffer within the device DRAM channel
+ *
+ * Return value: bool
+ *
+ * | Argument     | Description                                            | Data type                | Valid range                               | required |
+ * |--------------|--------------------------------------------------------|--------------------------|-------------------------------------------|----------|
+ * | device       | The device whose DRAM to write data into               | IDevice*                 |                                           | Yes      |
+ * | dram_channel | Channel index of DRAM to write into                    | int                      | On Grayskull, [0, 7] inclusive            | Yes      |
+ * | address      | Starting address on DRAM channel to begin writing data | uint32_t                 | [DRAM_UNRESERVED_BASE, dram_size)         | Yes      |
+ * | host_buffer  | Buffer on host to copy data from                       | std::span<const uint8_t> | Host buffer must be fully fit DRAM buffer | Yes      |
+ */
+// clang-format on
+bool WriteToDeviceDRAMChannel(
+    IDevice* device, int dram_channel, uint32_t address, std::span<const uint8_t> host_buffer);
 /**
  * Copies data from a host buffer into a buffer within the device DRAM channel
  *
@@ -229,6 +246,22 @@ DeviceProgramId DecodePerDeviceProgramID(uint32_t device_program_id);
  * std::vector<uint32_t> | Host buffer must be fully fit DRAM buffer | Yes      |
  */
 bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::vector<uint32_t>& host_buffer);
+
+// clang-format off
+/**
+ * Copy data from a device DRAM channel to a host buffer
+ *
+ * Return value: bool
+ *
+ * | Argument     | Description                                                  | Data type             | Valid range                    | required |
+ * |--------------|--------------------------------------------------------------|-----------------------|--------------------------------|----------|
+ * | device       | The device whose DRAM to read data from                      | IDevice*              |                                | Yes      |
+ * | dram_channel | Channel index of DRAM to read from                           | int                   | On Grayskull, [0, 7] inclusive | Yes      |
+ * | address      | Starting address on DRAM channel from which to begin reading | uint32_t              |                                | Yes      |
+ * | host_buffer  | Buffer on host to copy data into                             | std::span<uint8_t>    |                                | Yes      |
+ */
+// clang-format on
+bool ReadFromDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::span<uint8_t> host_buffer);
 
 /**
  * Copy data from a device DRAM channel to a host buffer
@@ -248,6 +281,26 @@ bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addres
 bool ReadFromDeviceDRAMChannel(
     IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer);
 
+// clang-format off
+/**
+ * Copy data from a host buffer into an L1 buffer. (Note: Current Can not be a CircularBuffer.)
+ *
+ * Return value: bool
+ *
+ * | Argument      | Description                                     | Data type                | Valid range                                         | required |
+ * |---------------|-------------------------------------------------|--------------------------|-----------------------------------------------------|----------|
+ * | device        | The device whose DRAM to write data into        | IDevice*                 |                                                     | Yes      |
+ * | logical_core  | Logical coordinate of core whose L1 to write to | CoreCoord                | On Grayskull, any valid logical worker coordinate   | Yes      |
+ * | address       | Starting address in L1 to write into            | uint32_t                 | Any non-reserved address in L1 that fits for buffer | Yes      |
+ * | host_buffer   | Buffer on host whose data to copy from          | std::span<const uint8_t> | Buffer must fit into L1                             | Yes      |
+ */
+// clang-format on
+bool WriteToDeviceL1(
+    IDevice* device,
+    const CoreCoord& logical_core,
+    uint32_t address,
+    std::span<const uint8_t> host_buffer,
+    CoreType core_type = CoreType::WORKER);
 /**
  * Copy data from a host buffer into an L1 buffer. (Note: Current Can not be a CircularBuffer.)
  *
@@ -269,6 +322,27 @@ bool WriteToDeviceL1(
     CoreType core_type = CoreType::WORKER);
 
 bool WriteRegToDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, const uint32_t& regval);
+
+// clang-format off
+/**
+ * Copy data from an L1 buffer into a host buffer. Must be a buffer, and not a CB.
+ *
+ * Return value: bool
+ *
+ * | Argument             | Description                                 | Data type             | Valid range                                       | required |
+ * |----------------------|---------------------------------------------|-----------------------|---------------------------------------------------|----------|
+ * | device               | The device whose DRAM to read data from     | IDevice*              |                                                   | Yes      |
+ * | logical_core         | Logical coordinate of core whose L1 to read | CoreCoord             | On Grayskull, any valid logical worker coordinate | Yes      |
+ * | address              | Starting address in L1 to read from         | uint32_t              |                                                   | Yes      |
+ * | host_buffer          | Buffer on host to copy data into            | std::span<uint8_t>    | Buffer must fit L1 buffer                         | Yes      |
+ */
+// clang-format on
+bool ReadFromDeviceL1(
+    IDevice* device,
+    const CoreCoord& logical_core,
+    uint32_t address,
+    std::span<uint8_t> host_buffer,
+    CoreType core_type = CoreType::WORKER);
 
 /**
  * Copy data from an L1 buffer into a host buffer. Must be a buffer, and not a CB.

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -289,7 +289,7 @@ bool ReadFromDeviceDRAMChannel(
  *
  * | Argument      | Description                                     | Data type                | Valid range                                         | required |
  * |---------------|-------------------------------------------------|--------------------------|-----------------------------------------------------|----------|
- * | device        | The device whose DRAM to write data into        | IDevice*                 |                                                     | Yes      |
+ * | device        | The device whose L1 to write data into          | IDevice*                 |                                                     | Yes      |
  * | logical_core  | Logical coordinate of core whose L1 to write to | CoreCoord                | On Grayskull, any valid logical worker coordinate   | Yes      |
  * | address       | Starting address in L1 to write into            | uint32_t                 | Any non-reserved address in L1 that fits for buffer | Yes      |
  * | host_buffer   | Buffer on host whose data to copy from          | std::span<const uint8_t> | Buffer must fit into L1                             | Yes      |
@@ -331,7 +331,7 @@ bool WriteRegToDevice(IDevice* device, const CoreCoord& logical_core, uint32_t a
  *
  * | Argument             | Description                                 | Data type             | Valid range                                       | required |
  * |----------------------|---------------------------------------------|-----------------------|---------------------------------------------------|----------|
- * | device               | The device whose DRAM to read data from     | IDevice*              |                                                   | Yes      |
+ * | device               | The device whose L1 to read data from       | IDevice*              |                                                   | Yes      |
  * | logical_core         | Logical coordinate of core whose L1 to read | CoreCoord             | On Grayskull, any valid logical worker coordinate | Yes      |
  * | address              | Starting address in L1 to read from         | uint32_t              |                                                   | Yes      |
  * | host_buffer          | Buffer on host to copy data into            | std::span<uint8_t>    | Buffer must fit L1 buffer                         | Yes      |

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -330,14 +330,19 @@ bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addres
         std::span(reinterpret_cast<const std::uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(uint32_t)));
 }
 
-bool ReadFromDeviceDRAMChannel(
-    IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer) {
+bool ReadFromDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::span<uint8_t> host_buffer) {
     bool pass = true;
     tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
-    host_buffer.resize((size + sizeof(uint32_t) - 1) / sizeof(uint32_t));
     tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-        host_buffer.data(), size, device->id(), dram_channel, address);
+        host_buffer.data(), host_buffer.size(), device->id(), dram_channel, address);
     return pass;
+}
+
+bool ReadFromDeviceDRAMChannel(
+    IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer) {
+    host_buffer.resize((size + sizeof(uint32_t) - 1) / sizeof(uint32_t));
+    return ReadFromDeviceDRAMChannel(
+        device, dram_channel, address, std::span(reinterpret_cast<std::uint8_t*>(host_buffer.data()), size));
 }
 
 bool WriteToDeviceL1(
@@ -370,6 +375,19 @@ bool WriteRegToDevice(IDevice* device, const CoreCoord& logical_core, uint32_t a
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
         &regval, tt_cxy_pair(device->id(), worker_core), address);
+    return true;
+}
+
+bool ReadFromDeviceL1(
+    IDevice* device,
+    const CoreCoord& logical_core,
+    uint32_t address,
+    std::span<uint8_t> host_buffer,
+    CoreType core_type) {
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+    auto virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
+    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        host_buffer.data(), host_buffer.size(), tt_cxy_pair(device->id(), virtual_core), address);
     return true;
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27413

### What's changed
Add tests for new functions WriteToDeviceDRAMChannel and WriteToDeviceL1 when the buffer size is not a multiple of 4B.  This is recently supported, with #27463.

To test that, I need to expose the new function signatures to API, together with new versions of Read* functions that supports reading of non-4B-multiple buffers.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17280487122) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17280488841) CI passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes