### PR TITLE
Revert "SDPA Optimizations: Reading cur pos + page table sharded (#26…

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -157,7 +157,11 @@ def create_tt_model(
         # Page table which maps virtual blocks to physical
         reverse_permutation = torch.argsort(permutation)
         page_table = reverse_permutation.reshape(
-            tt_model_args.max_batch_size, paged_attention_config.max_num_blocks // tt_model_args.max_batch_size
+            max_batch_size, paged_attention_config.max_num_blocks // max_batch_size
+        )
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
         )
 
     model = TtTransformer(
@@ -192,7 +196,7 @@ def create_tt_model(
 #
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, prefill_profile, num_layers, print_outputs, is_cur_pos_sharded, is_page_table_sharded",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, prefill_profile, num_layers, print_outputs",
     [
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -210,8 +214,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # Batch-1 run (Throughput) - 1 user, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -229,8 +231,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # evals-1 run (Throughput) - 1 user, smaller prompts, batch repeat 32
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/eval_repeat_prompts.json",  # input_prompts
@@ -248,8 +248,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            False,  # is_cur_pos_sharded
-            False,  # is_page_table_sharded
         ),
         (  # evals-32 run (Throughput) - 32 users, smaller prompts, batch repeat 32
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/eval_repeat_prompts.json",  # input_prompts
@@ -267,8 +265,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            False,  # is_cur_pos_sharded
-            False,  # is_page_table_sharded
         ),
         (  # evals-long-prompts run (Throughput) - 1 user, smaller prompts, batch repeat 12
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/eval_repeat_prompts_very_long.json",  # input_prompts
@@ -286,8 +282,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            False,  # is_cur_pos_sharded
-            False,  # is_page_table_sharded
         ),
         (  # Repeat2 (Batch-1) run (Throughput) - 1 user, small prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -305,8 +299,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            False,  # is_cur_pos_sharded
-            False,  # is_page_table_sharded
         ),
         (  # long-4k-b1 - Single user, 4K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -324,8 +316,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # long-8k-b1 - Single user, 8K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
@@ -343,8 +333,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # long-16k-b32 - 32 users, 16K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
@@ -362,8 +350,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # long-32k-b1 - Single user, 32K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
@@ -381,8 +367,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # long-64k-b1 - Single user, 64K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
@@ -400,8 +384,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # long-128k-b1 - Single user, 128K long prompt
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
@@ -419,8 +401,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # prefill-profile [default 4K seqlen] - Runs 1L prefill-only
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -438,8 +418,6 @@ def create_tt_model(
             True,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # apc-test Run for PCC check, perf and functionality check: Batch-32 run (Throughput) - 32 users, prompt is "This is a test"
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_reference.json",  # input_prompts
@@ -457,8 +435,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
         (  # pcc-80L - CI Run for PCC check for 80 Layers + Teacher Forced: Batch-32 run (Throughput) - 32 users, prompt is "This is a test"
             "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_questions_reference.json",  # input_prompts
@@ -476,8 +452,6 @@ def create_tt_model(
             False,  # prefill-only profile
             80,  # num layers
             False,  # print_outputs
-            True,  # is_cur_pos_sharded
-            True,  # is_page_table_sharded
         ),
     ],
     ids=[
@@ -515,7 +489,7 @@ def create_tt_model(
             "trace_region_size": 102000000,
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "worker_l1_size": 1345000,
+            "worker_l1_size": 1344544,
             "fabric_config": True,
         }
     ],
@@ -551,8 +525,6 @@ def test_demo_text(
     request,
     galaxy_type,
     print_outputs,
-    is_cur_pos_sharded,
-    is_page_table_sharded,
 ):
     """
     Simple demo with limited dependence on reference code.
@@ -898,7 +870,6 @@ def test_demo_text(
         top_1_accs = []
         read_events = []
         tt_out_toks = []
-
         while users_decoding:
             if iteration == 0:  # First iteration also accounts for compile time
                 profiler.start(f"compile_decode", iteration=batch_idx)
@@ -924,8 +895,6 @@ def test_demo_text(
                     sampling_params=device_sampling_params,
                     reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
-                    is_cur_pos_sharded=is_cur_pos_sharded,
-                    is_page_table_sharded=is_page_table_sharded,
                 )
                 read_events.append(read_event)
                 tt_out_toks.append(tt_out_tok)

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
@@ -51,8 +51,6 @@ from models.utility_functions import skip_for_grayskull
         "default_attention",
     ),
 )
-@pytest.mark.parametrize("is_cur_pos_sharded", (True,))
-@pytest.mark.parametrize("is_page_table_sharded", (True,))
 @pytest.mark.parametrize(
     "page_params",
     [{"page_block_size": 64, "page_max_num_blocks": 4096}],
@@ -84,7 +82,7 @@ from models.utility_functions import skip_for_grayskull
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "worker_l1_size": 1345000,
+            "worker_l1_size": 1344544,
             "fabric_config": True,
         }
     ],
@@ -103,8 +101,6 @@ def test_llama_model_inference(
     mesh_device,
     reset_seeds,
     ensure_gc,
-    is_cur_pos_sharded,
-    is_page_table_sharded,
 ):
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
@@ -209,36 +205,19 @@ def test_llama_model_inference(
         # Page table which maps virtual blocks to physical
         reverse_permutation = torch.argsort(permutation)
         page_table = reverse_permutation.reshape(
-            batch_size,
-            paged_attention_config.max_num_blocks // batch_size,
-        )
-        page_table_chunks = page_table.split(batch_size // model_args.cluster_shape[1], dim=0)
-        repeated_page_table_chunks = [
-            chunk.repeat(model_args.sub_core_grids.num_cores(), 1) for chunk in page_table_chunks
-        ]
-        page_table = torch.cat(repeated_page_table_chunks, dim=0)
-        page_table_shard_spec = ttnn.ShardSpec(
-            model_args.sub_core_grids,
-            (
-                batch_size,
-                paged_attention_config.max_num_blocks // batch_size,
-            ),
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        page_table_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
+            model_args.batch_size_per_device_group,
+            paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
         )
         page_table_tt = ttnn.from_torch(
             page_table,
             device=mesh_device,
-            dtype=ttnn.uint16,
+            dtype=ttnn.int32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device,
-                dims=(None, 0),
+                dims=(None, None),
                 mesh_shape=model_args.cluster_shape,
             ),
-            memory_config=page_table_memory_config,
         )
 
     # Load TTNN model
@@ -264,6 +243,7 @@ def test_llama_model_inference(
 
     seqlen = 1  # Generating one token per user at a time
     batch = model_args.max_batch_size
+
     # Select the first token from the prompts for initial decoding
     encoded_prompts_tensor = torch.tensor(encoded_prompts)  # [:,0]
     pt_decode_input = embd(encoded_prompts_tensor[:, 0]).view(batch, seqlen, -1)
@@ -276,32 +256,22 @@ def test_llama_model_inference(
 
     # Initial positions
     current_pos = torch.tensor([generation_start_pos for _ in range(batch)])
-    if is_cur_pos_sharded:
-        current_pos_sram = torch.tensor(
-            [[generation_start_pos for _ in range(batch)]] * model_args.sub_core_grids.num_cores()
-        )
-        cur_pos_shard_spec = ttnn.ShardSpec(
-            model_args.sub_core_grids, (1, batch // mesh_device.shape[1]), ttnn.ShardOrientation.ROW_MAJOR
-        )
-        cur_pos_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cur_pos_shard_spec
-        )
     current_pos_tensor = ttnn.from_torch(
-        current_pos_sram if is_cur_pos_sharded else current_pos,
+        current_pos,
         device=mesh_device,
         dtype=ttnn.int32,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device,
-            dims=(None, 1 if is_cur_pos_sharded else 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
+            dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
             mesh_shape=model_args.cluster_shape,
         ),
-        memory_config=cur_pos_memory_config,
     )
     all_pccs = []
 
     try:
         for i in range(generation_length):
             logger.info(f"[Llama3 Model] Generating token {i}")
+
             decode_input = model_args.prepare_residual_tensor_decode(
                 tt_decode_input,
                 model_args.model_config["DECODE_RESIDUAL_MEMCFG"],
@@ -340,21 +310,16 @@ def test_llama_model_inference(
                 ref_output = reference_model(pt_decode_input, current_pos[0])
 
             # Increment position
-            current_pos = torch.full((batch,), generation_start_pos + i)
-
-            current_pos_sram = torch.full((model_args.sub_core_grids.num_cores(), batch), generation_start_pos + i)
+            current_pos = torch.tensor([generation_start_pos + i for _ in range(batch)])
             current_pos_tensor = ttnn.from_torch(
-                current_pos_sram,
+                current_pos,
                 device=mesh_device,
                 dtype=ttnn.int32,
                 mesh_mapper=ttnn.ShardTensor2dMesh(
                     mesh_device,
-                    dims=(None, 1 if is_cur_pos_sharded else 0)
-                    if (model_args.is_galaxy and batch_size > 1)
-                    else (None, None),
+                    dims=(None, 0) if (model_args.is_galaxy and batch_size > 1) else (None, None),
                     mesh_shape=model_args.cluster_shape,
                 ),
-                memory_config=cur_pos_memory_config,
             )
 
             # Append the generated token to the list of outputs

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
@@ -162,34 +162,19 @@ def test_llama_tg_LayerNorm(
     "start_core, sub_core_grids",
     [
         (
-            ttnn.CoreCoord(1, 0),
+            ttnn.CoreCoord(3, 0),
             ttnn.CoreRangeSet(
                 [
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
-                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+                    # ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(6, 9)),
                 ]
             ),
         ),
     ],
 )
-@pytest.mark.parametrize("is_cur_pos_sharded", [True])
-@pytest.mark.parametrize("is_page_table_sharded", [True])
 @pytest.mark.parametrize("q_layout", [ttnn.ROW_MAJOR_LAYOUT], ids=["row_major"])
 def test_llama_tg_ScaledDotProductAttentionDecode(
-    device,
-    b,
-    nh,
-    nkv,
-    s,
-    d,
-    dtype,
-    grid_size,
-    q_dtype,
-    start_core,
-    sub_core_grids,
-    q_layout,
-    is_cur_pos_sharded,
-    is_page_table_sharded,
+    device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, start_core, sub_core_grids, q_layout
 ):
     run_test_sdpa_decode_paged_attention_single_iter(
         device,
@@ -210,8 +195,6 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
         start_core=start_core,
         sub_core_grids=sub_core_grids,
         q_layout=q_layout,
-        is_cur_pos_sharded=is_cur_pos_sharded,
-        is_page_table_sharded=is_page_table_sharded,
     )
     assert device.num_program_cache_entries() == 1
 
@@ -295,8 +278,6 @@ def test_llama_tg_BinaryDeviceOperation(device, batch_size, seq_len, dim, num_he
     "chunk_sizes, cur_positions",
     (([0, 128, 256, 512], [31, 63, 95, 127, 255, 511, 1023, 2559, 4095]),),
 )
-@pytest.mark.parametrize("is_cur_pos_sharded", [True])
-@pytest.mark.parametrize("is_page_table_sharded", [True])
 def test_llama_tg_ScaledDotProductAttentionDecodeSweep(
     device,
     chunk_sizes,
@@ -311,8 +292,6 @@ def test_llama_tg_ScaledDotProductAttentionDecodeSweep(
     q_dtype,
     start_core,
     sub_core_grids,
-    is_cur_pos_sharded,
-    is_page_table_sharded,
 ):
     for chunk_size in chunk_sizes:
         for cur_pos in cur_positions:
@@ -334,8 +313,6 @@ def test_llama_tg_ScaledDotProductAttentionDecodeSweep(
                 sharded_out=True,
                 start_core=start_core,
                 sub_core_grids=sub_core_grids,
-                is_cur_pos_sharded=is_cur_pos_sharded,
-                is_page_table_sharded=is_page_table_sharded,
             )
 
     # OP caches on chunk size
@@ -431,8 +408,6 @@ def test_llama_tg_NLPConcatHeadsDecodeDeviceOperation(
 @pytest.mark.parametrize("cache_idx", [127])
 @pytest.mark.parametrize("cache_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("pcc", [0.9995])
-@pytest.mark.parametrize("is_cur_pos_sharded", [True])
-@pytest.mark.parametrize("is_page_table_sharded", [True])
 def test_llama_tg_PagedUpdateCacheDeviceOperation(
     device,
     paged_update,
@@ -445,8 +420,6 @@ def test_llama_tg_PagedUpdateCacheDeviceOperation(
     input_dtype,
     cache_dtype,
     pcc,
-    is_cur_pos_sharded,
-    is_page_table_sharded,
 ):
     run_test_paged_fused_update_cache_decode(
         paged_update,
@@ -460,8 +433,6 @@ def test_llama_tg_PagedUpdateCacheDeviceOperation(
         cache_dtype,
         device,
         pcc,
-        is_cur_pos_sharded=is_cur_pos_sharded,
-        is_page_table_sharded=is_page_table_sharded,
     )
 
 
@@ -475,8 +446,6 @@ def test_llama_tg_PagedUpdateCacheDeviceOperation(
 @pytest.mark.parametrize("cache_idx", [127])
 @pytest.mark.parametrize("cache_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("pcc", [0.9995])
-@pytest.mark.parametrize("is_cur_pos_sharded", [True])
-@pytest.mark.parametrize("is_page_table_sharded", [True])
 def test_llama_tg_RowMajorPagedUpdateCacheDeviceOperation(
     device,
     paged_update,
@@ -489,10 +458,8 @@ def test_llama_tg_RowMajorPagedUpdateCacheDeviceOperation(
     input_dtype,
     cache_dtype,
     pcc,
-    is_cur_pos_sharded,
-    is_page_table_sharded,
 ):
-    for _ in range(1):
+    for _ in range(2):
         run_test_paged_fused_update_cache_decode(
             paged_update,
             cache_idx,
@@ -506,8 +473,6 @@ def test_llama_tg_RowMajorPagedUpdateCacheDeviceOperation(
             device,
             pcc,
             row_major=True,
-            is_cur_pos_sharded=is_cur_pos_sharded,
-            is_page_table_sharded=is_page_table_sharded,
         )
     assert device.num_program_cache_entries() == 1
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -347,11 +347,13 @@ class TtLlamaAttention(LightweightModule):
         ttnn.deallocate(v_heads_1BKD)
 
         # print("done update cache")
+
         # NOTE: Varying the batch size will result in slightly different outputs.
         # For example, a prompt w/ 1 user vs, the same prompt repeated N times for N users, will produce different outputs
         # This is because the SDPA op in decode mode has different number of reductions depending on batch size
         # Which leads to slightly different outputs from attention (due to accumulated errors)
         sdpa_out_mem_cfg = self.model_config["SCORES_BATCHED_MM_OUTPUT_MEMCFG"](self.batch_size_per_device_group)
+
         if page_table:
             attn_output_1G4D_sharded = ttnn.transformer.paged_scaled_dot_product_attention_decode(
                 q_heads_1BQD,

--- a/models/demos/llama3_70b_galaxy/tt/llama_common.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_common.py
@@ -208,7 +208,7 @@ def num_to_core_range_set(x):
     )
 
 
-def copy_host_to_device(host_tensors, device_tensors=None, shard_specs=None, mesh_device=None):
+def copy_host_to_device(host_tensors, device_tensors=None, mesh_device=None):
     """
     Helper function which copies host tensors to device tensors.
     If no device_tensors are provided, it creates new device tensors and returns them.
@@ -217,10 +217,7 @@ def copy_host_to_device(host_tensors, device_tensors=None, shard_specs=None, mes
         assert mesh_device is not None, "mesh_device is required when device_tensors is None"
         ret = []
         for i in range(len(host_tensors)):
-            if shard_specs and shard_specs[i] is not None:
-                on_device = host_tensors[i].to(mesh_device, shard_specs[i]) if host_tensors[i] else None
-            else:
-                on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
+            on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
             ret.append(on_device)
         return ret
     else:

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -377,12 +377,7 @@ def num_to_core_range_set(x):
     )
 
 
-def copy_host_to_device(
-    host_tensors,
-    device_tensors=None,
-    mesh_device=None,
-    shard_specs=None,
-):
+def copy_host_to_device(host_tensors, device_tensors=None, mesh_device=None):
     """
     Helper function which copies host tensors to device tensors.
     If no device_tensors are provided, it creates new device tensors and returns them.
@@ -391,10 +386,7 @@ def copy_host_to_device(
         assert mesh_device is not None, "mesh_device is required when device_tensors is None"
         ret = []
         for i in range(len(host_tensors)):
-            if shard_specs and shard_specs[i] is not None:
-                on_device = host_tensors[i].to(mesh_device, shard_specs[i]) if host_tensors[i] else None
-            else:
-                on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
+            on_device = ttnn.to_device(host_tensors[i], device=mesh_device) if host_tensors[i] else None
             ret.append(on_device)
         return ret
     else:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -846,8 +846,6 @@ def run_test_sdpa_decode_paged_attention_single_iter(
     start_core=ttnn.CoreCoord(0, 0),
     sub_core_grids=None,
     q_layout=ttnn.TILE_LAYOUT,
-    is_cur_pos_sharded=False,
-    is_page_table_sharded=False,
 ):
     torch.manual_seed(1234)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -887,6 +885,7 @@ def run_test_sdpa_decode_paged_attention_single_iter(
     paged_k = to_paged_cache(K, b, nkv, max_num_blocks_per_seq, block_size, d, s)
     paged_v = to_paged_cache(V, b, nkv, max_num_blocks_per_seq, block_size, d, s)
 
+    # We need a random permutation to shuffle pages in the cache
     permutation = torch.randperm(max_num_blocks)
     reverse_permutation = torch.argsort(permutation)
     page_table = reverse_permutation.reshape(b, max_num_blocks_per_seq)
@@ -943,28 +942,12 @@ def run_test_sdpa_decode_paged_attention_single_iter(
     tt_V = ttnn.as_tensor(
         paged_v_shuffled, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg
     )
-
-    # We need a random permutation to shuffle pages in the cache
-    if is_page_table_sharded:
-        page_table = page_table.repeat(compute_sub_core_grids.num_cores(), 1)
-        page_table_shard_spec = ttnn.ShardSpec(
-            compute_sub_core_grids, (b, max_num_blocks_per_seq), ttnn.ShardOrientation.ROW_MAJOR
-        )
-        page_table_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, page_table_shard_spec
-        )
-        tt_page_table = ttnn.as_tensor(
-            page_table,
-            device=device,
-            dtype=ttnn.uint16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            memory_config=page_table_memory_config,
-        )
-    else:
-        tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
+    tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
     scale = d**-0.5
     start_indices = [cur_pos] * b
+
+    tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
     program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=grid_size,
@@ -983,23 +966,7 @@ def run_test_sdpa_decode_paged_attention_single_iter(
         layout=q_layout,
         memory_config=Q_height_sharded_memcfg if sharded_in else dram_memcfg,
     )
-
-    if is_cur_pos_sharded:
-        cur_pos_core_grids = ttnn.CoreRangeSet(
-            [
-                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
-                ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 0)),
-            ]
-        )
-        cur_pos_shard_spec = ttnn.ShardSpec(cur_pos_core_grids, (1, b), ttnn.ShardOrientation.ROW_MAJOR)
-        cur_pos_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cur_pos_shard_spec
-        )
-        start_indices_pt = torch.tensor([start_indices] * cur_pos_core_grids.num_cores())
-        start_indices_tt = ttnn.Tensor(start_indices_pt, ttnn.int32).to(device, mem_config=cur_pos_memory_config)
-    else:
-        start_indices_pt = torch.tensor(start_indices)
-        start_indices_tt = ttnn.Tensor(start_indices_pt, ttnn.int32).to(device)
+    start_indices_tt = ttnn.Tensor(torch.tensor(start_indices), ttnn.int32).to(device)
 
     tt_back = ttnn.transformer.paged_scaled_dot_product_attention_decode(
         tt_Q,

--- a/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
@@ -54,15 +54,11 @@ def run_test_update_cache_decode(
         cache_idxs = [cache_idx + i for i in range(num_users)]
     else:
         cache_idxs = [cache_idx + i * 17 for i in range(num_users)]
-
     if cache_idx_tensor and not share_cache:
         cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
         cachett = ttnn.experimental.paged_update_cache(cachett, xt, update_idxs_tensor=cache_idxs_tt, share_cache=False)
     else:
-        cache_idxs_tt = ttnn.Tensor(torch.tensor(cache_idxs), ttnn.int32).to(device)
-        cachett = ttnn.experimental.paged_update_cache(
-            cachett, xt, update_idxs_tensor=cache_idxs_tt, share_cache=share_cache
-        )
+        cachett = ttnn.experimental.paged_update_cache(cachett, xt, update_idxs=cache_idxs, share_cache=share_cache)
 
     for i in range(num_users):
         update_idx = cache_idxs[i]

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
@@ -50,7 +50,6 @@ void kernel_main() {
 
     const uint32_t St = get_compile_time_arg_val(20);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));  // semaphore for receiver
-    constexpr uint32_t batch_size = get_compile_time_arg_val(22);
 
     constexpr uint32_t head_offset_t = Wt * St;
 
@@ -73,14 +72,13 @@ void kernel_main() {
     if constexpr (use_index_tensor) {
         const InterleavedAddrGen<index_is_dram> addrg = {
             .bank_base_address = index_tensor_addr, .page_size = index_stick_size_B};
+
         cb_reserve_back(cb_index_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
-        if constexpr (index_is_dram) {
-            // index_tensor has one page to read
-            uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
-            noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-            noc_async_read_barrier();
-        }
+        // index_tensor has one page to read
+        uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
+        noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
+        noc_async_read_barrier();
         cb_push_back(cb_index_id, 1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
@@ -90,36 +88,19 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
-                cb_reserve_back(page_table_cb_id, num_pages_to_read);
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
+                cb_reserve_back(page_table_cb_id, 1);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
-
-                if constexpr (page_table_is_dram) {
-                    const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
-                        .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
-                    uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
-                    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-                    noc_async_read_barrier();
-                } else {
-                    page_table_cb_wr_ptr += my_batch_idx * page_table_stick_size;
-                }
-
-                cb_push_back(page_table_cb_id, num_pages_to_read);
-                // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
-                volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
-                volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
-
-                if constexpr (page_table_is_dram) {
-                    page_table_ptr_u32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
-                } else {
-                    page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);
-                }
+                uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
+                noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
+                noc_async_read_barrier();
+                cb_push_back(page_table_cb_id, 1);
+                volatile tt_l1_ptr uint32_t* page_table_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
 
                 const uint32_t virtual_block_id = update_idx / block_size;
-                const uint32_t physical_block_id = (page_table_is_dram)
-                                                       ? page_table_ptr_u32[virtual_block_id]
-                                                       : static_cast<uint32_t>(page_table_ptr_u16[virtual_block_id]);
-
+                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
                 const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 
     const uint32_t St = get_compile_time_arg_val(20);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));  // semaphore for receiver
-    constexpr uint32_t batch_size = get_compile_time_arg_val(22);
+
     constexpr uint32_t head_offset_t = Wt * St;
 
     // Kick off compute
@@ -76,51 +76,31 @@ void kernel_main() {
         cb_reserve_back(cb_index_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
         // index_tensor has one page to read
-        if constexpr (index_is_dram) {
-            uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
-            noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-            noc_async_read_barrier();
-        }
-
+        uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
+        noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
+        noc_async_read_barrier();
         cb_push_back(cb_index_id, 1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
         const uint32_t update_idx = index_ptr[my_batch_idx];
-
         if (update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
-
-                cb_reserve_back(page_table_cb_id, num_pages_to_read);
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
+                cb_reserve_back(page_table_cb_id, 1);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
-
-                if constexpr (page_table_is_dram) {
-                    const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
-                        .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
-                    uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
-                    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-                    noc_async_read_barrier();
-                } else {
-                    page_table_cb_wr_ptr += my_batch_idx * page_table_stick_size;
-                }
-                cb_push_back(page_table_cb_id, num_pages_to_read);
-                // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
-                volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
-                volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
-                if constexpr (page_table_is_dram) {
-                    page_table_ptr_u32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
-                } else {
-                    page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);
-                }
+                uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
+                noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
+                noc_async_read_barrier();
+                cb_push_back(page_table_cb_id, 1);
+                volatile tt_l1_ptr uint32_t* page_table_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
 
                 const uint32_t virtual_block_id = update_idx / block_size;
-                const uint32_t physical_block_id = (page_table_is_dram)
-                                                       ? page_table_ptr_u32[virtual_block_id]
-                                                       : static_cast<uint32_t>(page_table_ptr_u16[virtual_block_id]);
-
+                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
                 const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -42,9 +42,6 @@ void kernel_main() {
     constexpr uint32_t St = get_compile_time_arg_val(16);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
     constexpr uint32_t head_offset_t = Wt * St;
-    constexpr uint32_t batch_size = get_compile_time_arg_val(18);
-    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(19);
-    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(20);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
@@ -70,25 +67,13 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
-                cb_wait_front(page_table_cb_id, num_pages_to_read);
+                cb_wait_front(page_table_cb_id, 1);
                 uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
-                if constexpr (!page_table_is_dram) {
-                    page_table_cb_rd_ptr += my_batch_idx * page_table_stick_size;
-                }
-                // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
-                volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
-                volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
-                if constexpr (page_table_is_dram) {
-                    page_table_ptr_u32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
-                } else {
-                    page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_rd_ptr);
-                }
+                volatile tt_l1_ptr uint32_t* page_table_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
 
                 const uint32_t virtual_block_id = update_idx / block_size;
-                const uint32_t physical_block_id = (page_table_is_dram)
-                                                       ? page_table_ptr_u32[virtual_block_id]
-                                                       : static_cast<uint32_t>(page_table_ptr_u16[virtual_block_id]);
+                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
                 const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -82,28 +82,11 @@ void PagedUpdateCacheDeviceOperation::validate(
             TT_FATAL(optional_input_tensors.at(0).has_value(), "Paged cache requires update_idxs tensor");
 
             auto page_table = optional_input_tensors.at(1).value();
-
-            if (page_table.is_sharded()) {
-                TT_FATAL(page_table.dtype() == DataType::UINT16, "Expect page table to have datatype UINT16");
-            } else {
-                TT_FATAL(page_table.dtype() == DataType::INT32, "Expect page table to have datatype INT32");
-            }
-
-            TT_FATAL(page_table.layout() == Layout::ROW_MAJOR, "Expect page table to have memory layout in ROW MAJOR");
-
-            if (page_table.is_sharded()) {
-                uint32_t num_cores = page_table.memory_config().shard_spec()->grid.num_cores();
-                uint32_t page_table_shard_height = page_table.padded_shape()[0] / num_cores;
-                TT_FATAL(
-                    page_table_shard_height == input_tensor.padded_shape()[1],
-                    "Batch size in input tensor {} should match page table shard height {}",
-                    input_tensor.padded_shape()[1],
-                    page_table_shard_height);
-            } else {
-                TT_FATAL(
-                    page_table.padded_shape()[0] == input_tensor.padded_shape()[1],
-                    "Batch size between page_table and input_tensor must match");
-            }
+            TT_FATAL(page_table.dtype() == DataType::INT32, "Error");
+            TT_FATAL(page_table.layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL(
+                page_table.padded_shape()[0] == input_tensor.padded_shape()[1],
+                "Batch size between page_table and input_tensor must match");
             TT_FATAL(
                 page_table.padded_shape()[1] <= cache_tensor.padded_shape()[0],
                 "max_num_blocks_per_seq must be less than max_num_blocks: max_num_blocks_per_seq={}, "
@@ -120,75 +103,32 @@ void PagedUpdateCacheDeviceOperation::validate(
             optional_input_tensors.at(0).has_value() != update_idxs.size() > 0,
             "Only an update tensor or an update vector can be provided. Not both or neither.");
 
-        uint32_t num_indices = 0;
-        uint32_t num_cores_cur_pos = 0;
+        uint32_t num_indices;
         if (optional_input_tensors.at(0).has_value()) {
             const auto& update_idxs_tensor = optional_input_tensors.at(0).value();
-            TT_FATAL(update_idxs_tensor.dtype() == DataType::INT32, "Expected update_idxs to have datatype INT32");
-            TT_FATAL(
-                update_idxs_tensor.layout() == Layout::ROW_MAJOR,
-                "Expected update_idxs to have memory layout in ROW MAJOR");
+            TT_FATAL(update_idxs_tensor.dtype() == DataType::INT32, "Error");
+            TT_FATAL(update_idxs_tensor.layout() == Layout::ROW_MAJOR, "Error");
+            num_indices = update_idxs_tensor.padded_shape()[0];
 
-            if (optional_input_tensors.at(0)->is_sharded()) {
-                TT_FATAL(
-                    update_idxs_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-                    "Expect update_idxs to be HEIGHT SHARDED if sharded");
-                TT_FATAL(
-                    update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::L1,
-                    "Expect update_idxs to have buffer type L1 if sharded");
-                num_cores_cur_pos = update_idxs_tensor.padded_shape()[0];
-                num_indices = update_idxs_tensor.logical_shape()[1];
-            } else {
-                TT_FATAL(
-                    update_idxs_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                    "Expect update_idxs to be DRAM INTERLEAVED");
-                TT_FATAL(
-                    update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
-                    "Expect update_idxs to have buffer type DRAM");
-                num_cores_cur_pos = 0;
-                num_indices = update_idxs_tensor.padded_shape()[0];
-            }
+            TT_FATAL(update_idxs_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+            TT_FATAL(update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Error");
         } else {
             num_indices = update_idxs.size();
         }
-        if (optional_input_tensors.at(0)->is_sharded()) {
-            uint32_t in_num_cores_cur_pos = optional_input_tensors.at(0)->shard_spec().value().grid.num_cores();
-            TT_FATAL(
-                input_tensor.logical_shape()[1] == num_indices,
-                "Number of update_idxs ({}) should match batch size ({}) if sharded",
-                num_indices,
-                input_tensor.logical_shape()[1]);
-            TT_FATAL(
-                in_num_cores_cur_pos == num_cores_cur_pos,
-                "Number of cores sharded on L1 ({}) should match dimension of update_idxs at 0 ({})",
-                in_num_cores_cur_pos,
-                num_cores_cur_pos);
-        } else {
-            TT_FATAL(
-                input_tensor.padded_shape()[1] == num_indices,
-                "Number of update_idxs ({}) should match batch size ({})",
-                num_indices,
-                input_tensor.padded_shape()[1]);
-        }
+
+        TT_FATAL(input_tensor.padded_shape()[1] == num_indices, "Number of update_idxs should match batch size");
     };
 
     const auto validateSharding = [](const Tensor& input_tensor) {
-        TT_FATAL(input_tensor.is_sharded(), "Expect input_tensor to be sharded");
+        TT_FATAL(input_tensor.is_sharded(), "Error");
         if (input_tensor.is_sharded()) {
-            TT_FATAL(
-                input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                "Expect input_tensor to have memory layout WIDTH SHARDED");
-            TT_FATAL(
-                input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
-                "Expect input_tensor to have ");
+            TT_FATAL(input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1], "Error");
             TT_FATAL(
                 (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) %
                         input_tensor.shard_spec().value().shape[0] ==
                     0,
-                "Input tensor's height must be divisible by the number of shards along the height dimension. Got "
-                "height = {}, number of shards = {}.",
-                (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]),
-                input_tensor.shard_spec().value().shape[0]);
+                "Error");
             TT_FATAL(
                 input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
                 "Only ROW_MAJOR sharding is supported");
@@ -211,7 +151,7 @@ void PagedUpdateCacheDeviceOperation::validate(
         validateUpdateIndices(input_tensor, optional_input_tensors, update_idxs);
         validateSharding(input_tensor);
 
-        TT_FATAL(batch_offset == 0, "batch_offset must be 0");
+        TT_FATAL(batch_offset == 0, "Error");
     };
 
     const auto validateFillOperation = [](const Tensor& cache_tensor,
@@ -223,19 +163,15 @@ void PagedUpdateCacheDeviceOperation::validate(
                 cache_tensor.dtype() == DataType::BFLOAT8_B || cache_tensor.dtype() == DataType::BFLOAT4_B,
             "Data type of input tensor for fill cache must be FLOAT32, BFLOAT16, or BFLOAT8_b");
 
-        TT_FATAL(
-            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-            "Expect input_tensor to have memory layout INTERLEAVED");
-        TT_FATAL(
-            page_table_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-            "Expect page_table_tensor to have memory layout INTERLEAVED");
-        TT_FATAL(page_table_tensor.dtype() == DataType::INT32, "Expect page_table_tensor to have datatype INT32");
+        TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(page_table_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(page_table_tensor.dtype() == DataType::INT32, "Error");
 
         auto cache_shape = cache_tensor.padded_shape();
         auto input_shape = input_tensor.padded_shape();
         auto page_table_shape = page_table_tensor.padded_shape();
 
-        TT_FATAL(batch_idx <= cache_shape[0], "Batch idx must fit in cache batch size");
+        TT_FATAL(batch_idx <= cache_shape[0], "Error");
         TT_FATAL(
             input_shape[2] <= cache_shape[2] * page_table_shape[1], "Input seq_len must fit in max_num_blocks_per_seq");
     };

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
@@ -92,9 +92,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     tt::DataFormat interm_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     uint32_t interm_single_tile_size = tt_metal::detail::TileSize(interm_cb_data_format);
 
-    const uint32_t B = input_tensor1.padded_shape()[1];
-    const uint32_t num_heads = cache_tensor1.padded_shape()[1];
-
     // Index tensor-specific parameters
     bool use_index_tensor = update_idxs_tensor.has_value();
     uint32_t index_tensor_tile_size = 0;
@@ -103,9 +100,7 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
     bool index_is_dram = true;
-    Buffer* index_buffer_ptr = nullptr;
     if (use_index_tensor) {
-        index_buffer_ptr = update_idxs_tensor.value().is_sharded() ? update_idxs_tensor.value().buffer() : nullptr;
         index_buffer_addr = use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_tensor_tile_size = tt_metal::detail::TileSize(index_data_format);
@@ -120,19 +115,18 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     uint32_t max_blocks_per_seq = 0;
     uint32_t page_table_stick_size = 0;
     uint32_t log2_page_table_stick_size = 0;
-    uint32_t num_pages_page_table = 1;
     tt::DataFormat page_table_data_format = tt::DataFormat::Int32;
     bool page_table_is_dram = true;
-    Buffer* page_table_buffer_ptr = nullptr;
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
-        page_table_buffer_ptr = page_table.value().is_sharded() ? page_table_tensor.buffer() : nullptr;
-        num_pages_page_table = page_table.value().is_sharded() ? B : 1;
+
         block_size = cache_tensor1.padded_shape()[2];
         block_size_t = block_size / TILE_HEIGHT;
         max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-        page_table_stick_size = page_table.value().buffer()->aligned_page_size();
+        page_table_stick_size = page_table_tensor.padded_shape()[-1] * page_table_tensor.element_size();
+
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
+
         page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     }
 
@@ -146,6 +140,8 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
                     : cache_total_num_tiles /
                           cache_tensor1.padded_shape()[0];  // if share cache, we can set cache batch num tiles to 0
                                                             // so batch offset would be 0 in future calculations
+    uint32_t B = input_tensor1.padded_shape()[1];
+    uint32_t num_heads = cache_tensor1.padded_shape()[1];
 
     log_debug(tt::LogOp, "cache_cb_data_format: {}", cache_cb_data_format);
     log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
@@ -214,24 +210,12 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
     auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
         program, all_cores_bb, 0);  // used for share cache for signaling when the cache is ready to be read
 
-    CBHandle cb_cur_pos_id = 0;
     if (use_index_tensor) {
-        auto [_3, cb_src5] =
-            create_cb(cb_index_id, program, all_cores_bb, index_stick_size, 1, index_data_format, index_buffer_ptr);
-        cb_cur_pos_id = cb_src5;
+        create_cb(cb_index_id, program, all_cores_bb, index_tensor_tile_size, 1, index_data_format);
     }
 
-    CBHandle cb_page_table_id = 0;
     if (is_paged_cache) {
-        auto [_4, cb_src7] = create_cb(
-            cb_pagetable_id,
-            program,
-            all_cores_bb,
-            page_table_stick_size,
-            num_pages_page_table,
-            page_table_data_format,
-            page_table_buffer_ptr);
-        cb_page_table_id = cb_src7;
+        create_cb(cb_pagetable_id, program, all_cores_bb, page_table_stick_size, 1, page_table_data_format);
     }
 
     auto dst1_buffer = cache_tensor1.buffer();
@@ -265,7 +249,7 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-        B};
+    };
 
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)dst_is_dram,
@@ -288,9 +272,7 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-        B,
-        page_table_stick_size,
-        page_table_is_dram};
+    };
 
     std::vector<uint32_t> compute_kernel_args = {
         src1_cb_index,
@@ -463,8 +445,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
          Wt,
          cb_src1,
          cb_src3,
-         cb_cur_pos_id,
-         cb_page_table_id,
          cache_batch_num_tiles,
          use_index_tensor,
          is_paged_cache](
@@ -482,8 +462,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
             auto dst1_buffer = input_tensors.at(0).buffer();
             auto dst2_buffer = input_tensors.at(2).buffer();
 
-            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : 0;
-            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : 0;
             auto index_tensor_addr = use_index_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             auto page_table_tensor_addr = is_paged_cache ? optional_input_tensors.at(1).value().buffer()->address() : 0;
 
@@ -493,6 +471,7 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
             if (input_tensors.at(3).is_sharded()) {
                 UpdateDynamicCircularBufferAddress(program, cb_src3, *src2_buffer);
             }
+
             auto& reader_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
 
@@ -539,12 +518,6 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
                     runtime_args[3] = tile_update_offset_B;
                 }
             }
-            if (use_index_tensor and optional_input_tensors.at(0)->is_sharded()) {
-                UpdateDynamicCircularBufferAddress(program, cb_cur_pos_id, *index_tensor_buffer);
-            }
-            if (is_paged_cache and optional_input_tensors.at(1)->is_sharded()) {
-                UpdateDynamicCircularBufferAddress(program, cb_page_table_id, *page_table_buffer);
-            }
         };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
@@ -576,9 +549,6 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const tt::DataFormat interm_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const uint32_t interm_single_tile_size = tt_metal::detail::TileSize(interm_cb_data_format);
 
-    const uint32_t B = input_tensor1.padded_shape()[1];
-    const uint32_t num_heads = cache_tensor1.padded_shape()[1];
-
     // Index tensor-specific parameters
     const bool use_index_tensor = update_idxs_tensor.has_value();
     uint32_t index_tensor_tile_size = 0;
@@ -586,10 +556,8 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const uint32_t log2_page_size = 0;
     uint32_t index_stick_size = 0;
     tt::DataFormat index_data_format = tt::DataFormat::Int32;
-    Buffer* index_buffer_ptr = nullptr;
     bool index_is_dram = true;
     if (use_index_tensor) {
-        index_buffer_ptr = update_idxs_tensor.value().is_sharded() ? update_idxs_tensor.value().buffer() : nullptr;
         index_buffer_addr = use_index_tensor ? update_idxs_tensor.value().buffer()->address() : 0;
         index_data_format = tt_metal::datatype_to_dataformat_converter(update_idxs_tensor.value().dtype());
         index_tensor_tile_size = tt_metal::detail::TileSize(index_data_format);
@@ -606,17 +574,16 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const uint32_t log2_page_table_stick_size = 0;
     tt::DataFormat page_table_data_format = tt::DataFormat::Int32;
     bool page_table_is_dram = true;
-    uint32_t num_pages_page_table = 1;
-    Buffer* page_table_buffer_ptr = nullptr;
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
-        page_table_buffer_ptr = page_table.value().is_sharded() ? page_table_tensor.buffer() : nullptr;
-        num_pages_page_table = page_table.value().is_sharded() ? B : 1;
+
         block_size = cache_tensor1.padded_shape()[2];
         block_size_t = block_size / TILE_HEIGHT;
         max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-        page_table_stick_size = page_table.value().buffer()->aligned_page_size();
+        page_table_stick_size = page_table_tensor.padded_shape()[-1] * page_table_tensor.element_size();
+
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.dtype());
+
         page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     }
 
@@ -630,6 +597,8 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
                     : cache_total_num_tiles /
                           cache_tensor1.padded_shape()[0];  // if share cache, we can set cache batch num tiles to 0
                                                             // so batch offset would be 0 in future calculations
+    const uint32_t B = input_tensor1.padded_shape()[1];
+    const uint32_t num_heads = cache_tensor1.padded_shape()[1];
 
     log_debug(tt::LogOp, "cache_cb_data_format: {}", cache_cb_data_format);
     log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
@@ -702,24 +671,12 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
     const auto in0_sequential_mode_semaphore_id = tt_metal::CreateSemaphore(
         program, all_cores_bb, 0);  // used for share cache for signaling when the cache is ready to be read
 
-    CBHandle cb_cur_pos_id = 0;
     if (use_index_tensor) {
-        auto [_3, cb_src5] =
-            create_cb(cb_index_id, program, all_cores_bb, index_stick_size, 1, index_data_format, index_buffer_ptr);
-        cb_cur_pos_id = cb_src5;
+        create_cb(cb_index_id, program, all_cores_bb, index_tensor_tile_size, 1, index_data_format);
     }
 
-    CBHandle cb_page_table_id = 0;
     if (is_paged_cache) {
-        auto [_4, cb_src7] = create_cb(
-            cb_pagetable_id,
-            program,
-            all_cores_bb,
-            page_table_stick_size,
-            num_pages_page_table,
-            page_table_data_format,
-            page_table_buffer_ptr);
-        cb_page_table_id = cb_src7;
+        create_cb(cb_pagetable_id, program, all_cores_bb, page_table_stick_size, 1, page_table_data_format);
     }
 
     const auto dst1_buffer = cache_tensor1.buffer();
@@ -753,7 +710,7 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-        B};
+    };
 
     std::vector<uint32_t> writer_compile_time_args = {
         dst_is_dram,
@@ -777,9 +734,7 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
-        B,
-        page_table_stick_size,
-        page_table_is_dram};
+    };
 
     std::vector<uint32_t> compute_kernel_args = {
         src1_cb_index,
@@ -954,8 +909,6 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
          Wt,
          cb_src1,
          cb_src3,
-         cb_cur_pos_id,
-         cb_page_table_id,
          cache_batch_num_tiles,
          use_index_tensor,
          is_paged_cache](
@@ -973,8 +926,6 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
             const auto dst1_buffer = input_tensors.at(0).buffer();
             const auto dst2_buffer = input_tensors.at(2).buffer();
 
-            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : 0;
-            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : 0;
             const auto index_tensor_addr =
                 use_index_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             const auto page_table_tensor_addr =
@@ -986,6 +937,7 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
             if (input_tensors.at(3).is_sharded()) {
                 UpdateDynamicCircularBufferAddress(program, cb_src3, *src2_buffer);
             }
+
             auto& reader_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
 
@@ -1031,12 +983,6 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
                     runtime_args[2] = cache_start_id;
                     runtime_args[3] = tile_update_offset_B;
                 }
-            }
-            if (use_index_tensor and optional_input_tensors.at(0)->is_sharded()) {
-                UpdateDynamicCircularBufferAddress(program, cb_cur_pos_id, *index_tensor_buffer);
-            }
-            if (is_paged_cache and optional_input_tensors.at(1)->is_sharded()) {
-                UpdateDynamicCircularBufferAddress(program, cb_page_table_id, *page_table_buffer);
             }
         };
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
@@ -6,6 +6,8 @@
 
 #include "dataflow_api.h"
 
+// #include "debug/dprint.h"
+
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
 
@@ -22,19 +24,17 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* stick = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_addr);
 
     for (uint32_t h = 0; h < H; h++) {
-        if (src0_is_dram) {
-            noc_async_read_page(h, s0, cb_addr);
-            noc_async_read_barrier();
-        }
+        noc_async_read_page(h, s0, cb_addr);
+        noc_async_read_barrier();
         for (uint32_t i = 0; i < W; i++) {
             uint32_t val = stick[i];
             stick[i] = val + 1;
             // DPRINT << "val: " << val << ENDL();
         }
-        if (src0_is_dram) {
-            uint64_t dst_noc_addr = get_noc_addr(h, s0);
-            noc_async_write(cb_addr, dst_noc_addr, stick_size);
-            noc_async_write_barrier();
-        }
+
+        uint64_t dst_noc_addr = get_noc_addr(h, s0);
+
+        noc_async_write(cb_addr, dst_noc_addr, stick_size);
+        noc_async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -32,7 +32,7 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
     const auto& input_shape = input.padded_shape();
     uint32_t W = input_shape[-1];
     uint32_t H = 1;
-    if (!input.is_sharded() && input_shape.size() > 1) {
+    if (input_shape.size() > 1) {
         for (uint32_t i = 0; i < input_shape.size() - 1; ++i) {
             H *= input_shape[i];
         }
@@ -40,22 +40,19 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = W;
-    uint32_t aligned_input_page_size = round_up_to_mul32(num_input_units * input_unit_size);
+    uint32_t aligned_input_unit_size = round_up_to_mul32(num_input_units * input_unit_size);
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
+            .set_page_size(src0_cb_index, aligned_input_unit_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
     auto src_buffer = input.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(aligned_input_page_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, aligned_input_page_size);
-    if (input.is_sharded()) {
-        cb_src0_config.set_globally_allocated_address(*src_buffer);
-    }
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     std::vector<uint32_t> reader_compile_time_args = {
         src0_cb_index,
         src_is_dram,
-        aligned_input_page_size,
+        aligned_input_unit_size,
         W,
         H,
     };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include <vector>
+
 /******************************************************************************
  *                                                                             *
  *                   Common Functions for Dataflow Kernels                     *
@@ -22,28 +23,19 @@ constexpr uint32_t get_barrier_read_threshold() {
 /******************************************************************************
  *                   Page Cache Functions            *
  ******************************************************************************/
-template <typename PageT, uint32_t num_heads, uint32_t block_size_t, uint32_t Wt>
+template <uint32_t num_heads, uint32_t block_size_t, uint32_t Wt>
 uint32_t virtual_seq_tile_id_to_physical_tile_id(
-    uint32_t seq_tile_idx, uint32_t cur_head, const volatile tt_l1_ptr PageT* const page_table_ptr) {
+    uint32_t seq_tile_idx, uint32_t cur_head, const volatile tt_l1_ptr uint32_t* const page_table_ptr) {
     // Given some index in the sequence tiles in range [0, max_seq_len_t]
     // Return the physical tile id for that tile row
     constexpr uint32_t block_stride = num_heads * block_size_t * Wt;
     const uint32_t head_offset = cur_head * block_size_t * Wt;
 
     const uint32_t virtual_block = seq_tile_idx / block_size_t;
-
-    const uint32_t physical_block = static_cast<uint32_t>(page_table_ptr[virtual_block]);
+    const uint32_t physical_block = page_table_ptr[virtual_block];
     const uint32_t block_row_offset = seq_tile_idx % block_size_t;
     const uint32_t block_offset = block_row_offset * Wt;
     return physical_block * block_stride + head_offset + block_offset;
-}
-
-// Backward-compatible overload (defaults to uint32_t page table entries)
-template <uint32_t num_heads, uint32_t block_size_t, uint32_t Wt>
-uint32_t virtual_seq_tile_id_to_physical_tile_id(
-    uint32_t seq_tile_idx, uint32_t cur_head, const volatile tt_l1_ptr uint32_t* const page_table_ptr) {
-    return virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_heads, block_size_t, Wt>(
-        seq_tile_idx, cur_head, page_table_ptr);
 }
 
 /******************************************************************************

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -8,7 +8,6 @@
 
 #include "ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp"
 #include "dataflow_common.hpp"
-// #include "debug/dprint.h"
 
 void kernel_main() {
     /*
@@ -43,11 +42,9 @@ void kernel_main() {
     constexpr bool reuse_k = get_compile_time_arg_val(24) == 1;
     constexpr bool use_half_tile = get_compile_time_arg_val(25);
     constexpr uint32_t q_chunk_size_bytes = get_compile_time_arg_val(26);
-    constexpr bool is_cur_pos_tensor_sharded = get_compile_time_arg_val(27);
-    constexpr bool is_page_table_sharded = get_compile_time_arg_val(28);
-    constexpr uint32_t q_page_size_bytes = get_compile_time_arg_val(29);
+    constexpr uint32_t q_page_size_bytes = get_compile_time_arg_val(27);
 
-    constexpr auto k_args = TensorAccessorArgs<30>();
+    constexpr auto k_args = TensorAccessorArgs<28>();
     constexpr auto q_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -86,17 +83,16 @@ void kernel_main() {
             cur_pos = cur_pos_arg;
         } else {
             constexpr uint32_t cb_index_id = tt::CBIndex::c_8;
+            const InterleavedAddrGen<true> addrg = {.bank_base_address = pos_addr, .page_size = index_stick_size_B};
+
             cb_reserve_back(cb_index_id, 1);
             uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
+            const auto addrg = TensorAccessor(pos_args, pos_addr, index_stick_size_B);
 
-            if constexpr (!is_cur_pos_tensor_sharded) {
-                const auto addrg = TensorAccessor(pos_args, pos_addr, index_stick_size_B);
-
-                // index_tensor has one page to read
-                uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
-                noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-                noc_async_read_barrier();
-            }
+            // index_tensor has one page to read
+            uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
+            noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
+            noc_async_read_barrier();
 
             cb_push_back(cb_index_id, 1);
             volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
@@ -227,32 +223,17 @@ void kernel_main() {
     }
 
     volatile tt_l1_ptr uint32_t* page_table_ptr;
-    uint32_t page_table_cb_wr_ptr = 0;
-    // Typed pointers for page table entries in L1
-    volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
-    volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
     if constexpr (is_paged_attention) {
         constexpr uint32_t cb_id_page_table = tt::CBIndex::c_9;
-        uint32_t num_pages_to_read = is_page_table_sharded ? B : 1;
-        cb_reserve_back(cb_id_page_table, num_pages_to_read);
-
-        // Read page table from DRAM
-        if constexpr (!is_page_table_sharded) {
-            page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
-            const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr, page_table_page_size);
-            uint64_t page_table_noc_addr = page_table_gen.get_noc_addr((cur_batch / q_heads_parallel_factor));
-            noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_page_size);
-            noc_async_read_barrier();
-            page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
-            page_table_ptr_u32 = page_table_ptr;
-
-        } else {  // Read page table from dyanmically allocated L1 buffer
-            page_table_cb_wr_ptr =
-                get_write_ptr(cb_id_page_table) + (cur_batch / q_heads_parallel_factor) * page_table_page_size;
-            page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);
-        }
-
-        cb_push_back(cb_id_page_table, num_pages_to_read);
+        const InterleavedAddrGen<true> page_table_gen = {
+            .bank_base_address = page_table_addr, .page_size = page_table_page_size};
+        cb_reserve_back(cb_id_page_table, 1);
+        uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
+        uint64_t page_table_noc_addr = get_noc_addr((cur_batch / q_heads_parallel_factor), page_table_gen);
+        noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_page_size);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_page_table, 1);
+        page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
     }
 
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
@@ -275,13 +256,9 @@ void kernel_main() {
                     for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
                         uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
                         uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
-
                         uint32_t physical_k_tile_id =
-                            (is_page_table_sharded)
-                                ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
-                                      virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
-                                : virtual_seq_tile_id_to_physical_tile_id<num_kv_heads, block_size_t, DHt>(
-                                      virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
+                            virtual_seq_tile_id_to_physical_tile_id<num_kv_heads, block_size_t, DHt>(
+                                virtual_k_tile_row_num, cur_head, page_table_ptr);
                         for (uint32_t col = 0; col < DHt; ++col) {
                             noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
                             physical_k_tile_id += 1;                               // Go to next tile in row
@@ -327,15 +304,10 @@ void kernel_main() {
 
                         for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
                             uint32_t virtual_v_tile_row_num = k_chunk_start_row_num + row;
-                            uint32_t physical_v_tile_id =
-                                (is_page_table_sharded)
-                                    ? virtual_seq_tile_id_to_physical_tile_id<
-                                          uint16_t,
-                                          num_kv_heads,
-                                          block_size_t,
-                                          DHt>(virtual_v_tile_row_num, cur_head, page_table_ptr_u16)
-                                    : virtual_seq_tile_id_to_physical_tile_id<num_kv_heads, block_size_t, DHt>(
-                                          virtual_v_tile_row_num, cur_head, page_table_ptr_u32);
+                            uint32_t physical_v_tile_id = virtual_seq_tile_id_to_physical_tile_id<
+                                num_kv_heads,
+                                block_size_t,
+                                DHt /* Use K's head dim */>(virtual_v_tile_row_num, cur_head, page_table_ptr);
                             for (uint32_t col = 0; col < vDHt; ++col) {
                                 noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
                                 physical_v_tile_id += 1;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -390,7 +390,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     const bool use_half_tile =
         (is_causal and num_q_heads <= 16 and q_df == tt::DataFormat::Float16_b and
          device->arch() == tt::ARCH::WORMHOLE_B0);
-
     if (use_half_tile) {
         q_tile = half_tile;
         mask_tile = half_tile;
@@ -416,8 +415,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
     uint32_t pos_tensor_tile_size = 0;
     uint32_t index_stick_size = 0;
-    bool is_cur_pos_tensor_sharded = false;
-    CBHandle cb_in8_id = 0;
     if (use_cur_pos_tensor) {
         auto pos_buffer = cur_pos_tensor.value().buffer();
         tt::DataFormat pos_df = tt_metal::datatype_to_dataformat_converter(cur_pos_tensor.value().dtype());
@@ -425,33 +422,21 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         index_stick_size = pos_buffer->aligned_page_size();
 
         // cb pos
-        auto c_in8_config = CircularBufferConfig(index_stick_size, {{CBIndex::c_8, pos_df}})
-                                .set_page_size(CBIndex::c_8, index_stick_size);
-        if (cur_pos_tensor.value().is_sharded()) {
-            is_cur_pos_tensor_sharded = true;
-            c_in8_config.set_globally_allocated_address(*pos_buffer);
-        }
-        cb_in8_id = CreateCircularBuffer(program, core_grid, c_in8_config);
+        auto c_in8_config = CircularBufferConfig(pos_tensor_tile_size, {{CBIndex::c_8, pos_df}})
+                                .set_page_size(CBIndex::c_8, pos_tensor_tile_size);
+        CreateCircularBuffer(program, core_grid, c_in8_config);
     }
 
     uint32_t page_table_stick_size = 0;
-    uint32_t shard_size = 0;
-    bool is_page_table_sharded = false;
-    CBHandle cb_in9_id = 0;
     if (is_paged_attention) {
         auto page_table_buffer = page_table_tensor.value().buffer();
-        is_page_table_sharded = page_table_tensor.value().is_sharded();
         tt::DataFormat page_table_df = tt_metal::datatype_to_dataformat_converter(page_table_tensor.value().dtype());
         page_table_stick_size = page_table_buffer->aligned_page_size();
-        shard_size = is_page_table_sharded ? B * page_table_stick_size : page_table_stick_size;
-        // cb page_table
-        auto c_in9_config = CircularBufferConfig(shard_size, {{CBIndex::c_9, page_table_df}})
-                                .set_page_size(CBIndex::c_9, page_table_stick_size);
 
-        if (is_page_table_sharded) {
-            c_in9_config.set_globally_allocated_address(*page_table_buffer);
-        }
-        cb_in9_id = CreateCircularBuffer(program, core_grid, c_in9_config);
+        // cb page_table
+        auto c_in9_config = CircularBufferConfig(page_table_stick_size, {{CBIndex::c_9, page_table_df}})
+                                .set_page_size(CBIndex::c_9, page_table_stick_size);
+        CreateCircularBuffer(program, core_grid, c_in9_config);
     }
 
     log_debug(tt::LogOp, "q_data_format: {}", q_df);
@@ -512,11 +497,10 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     CreateCircularBuffer(program, core_grid, c_in7_config);
 
     // tilizedQ input
-
-    auto c_tilized_q_config = CircularBufferConfig(q_tiles * q_tile_size, {{CBIndex::c_10, q_df}})
-                                  .set_page_size(CBIndex::c_10, q_tile_size)
-                                  .set_tile_dims(CBIndex::c_10, q_tile);
-    auto cb_tilized_q_id = CreateCircularBuffer(program, core_grid, c_tilized_q_config);
+    auto c_in8_config = CircularBufferConfig(q_tiles * q_tile_size, {{CBIndex::c_10, q_df}})
+                            .set_page_size(CBIndex::c_10, q_tile_size)
+                            .set_tile_dims(CBIndex::c_10, q_tile);
+    CreateCircularBuffer(program, core_grid, c_in8_config);
 
     // cb_col_identity
     auto col_identity_tile = full_tile;
@@ -739,8 +723,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         (uint32_t)use_mla,
         use_half_tile,
         q_chunk_size_bytes,
-        is_cur_pos_tensor_sharded,
-        is_page_table_sharded,
         full_tile.get_tile_size(q_df),
     };
     tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);
@@ -996,8 +978,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
          num_cores_per_batch,
          num_cores_per_head,
          num_output_cores,
-         cb_in8_id,
-         cb_in9_id,
          is_output_sharded,
          cb_out4_id,
          B,
@@ -1021,16 +1001,10 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
             auto v_buffer = use_mla ? input_tensors.at(1).buffer() : input_tensors.at(2).buffer();
 
             auto out0_buffer = output_tensors.at(0).buffer();
-
             uint32_t q_addr = q_buffer->address();
             uint32_t k_addr = k_buffer->address();
             uint32_t v_addr = v_buffer->address();
-            uint32_t out_addr = out0_buffer->address();
-
-            const auto& cur_pos_tensor = optional_input_tensors.at(0);
-            const auto& page_table_tensor = optional_input_tensors.at(1);
-            uint32_t pos_addr = use_cur_pos_tensor ? cur_pos_tensor.value().buffer()->address() : 0;
-
+            uint32_t pos_addr = use_cur_pos_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             uint32_t page_table_addr =
                 is_paged_attention ? optional_input_tensors.at(1).value().buffer()->address() : 0;
             uint32_t attn_mask_addr = use_attention_mask ? optional_input_tensors.at(2).value().buffer()->address() : 0;
@@ -1038,6 +1012,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
                 use_attention_sink ? optional_input_tensors.at(3).value().buffer()->address() : 0;
             auto page_table_buffer = is_paged_attention ? optional_input_tensors.at(1).value().buffer() : nullptr;
             uint32_t page_table_stick_size = is_paged_attention ? page_table_buffer->aligned_page_size() : 0;
+            uint32_t out_addr = out0_buffer->address();
 
             auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernels_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernels_id);
@@ -1103,16 +1078,13 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
                 compute_args[arg_idx++] = core_num_in_output;
                 compute_args[arg_idx++] = cur_pos;
             }
-            if (use_cur_pos_tensor and cur_pos_tensor.value().is_sharded()) {
-                UpdateDynamicCircularBufferAddress(program, cb_in8_id, *cur_pos_tensor.value().buffer());
-            }
-            if (is_paged_attention and page_table_tensor.value().is_sharded()) {
-                UpdateDynamicCircularBufferAddress(program, cb_in9_id, *page_table_tensor.value().buffer());
-            }
+
             if (is_output_sharded) {
                 UpdateDynamicCircularBufferAddress(program, cb_out4_id, *out0_buffer);
             }
         };
+
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
+
 }  // namespace ttnn::operations::transformer::detail


### PR DESCRIPTION
This reverts commit b8415d02e028d68a5a1e8a688490800eb4e2cd05.

### Problem description
Currently causing ND hang on evals-long-prompt, investigation is underway

### What's changed
- revert the commit that added page table and cur pos sharding used by SDPA, paged cache update and plus one

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes