### PR TITLE
Dispatch updates to support multi erisc

### DIFF
--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -152,7 +152,6 @@ void notify_dispatch_core_done(uint64_t dispatch_addr) {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
         while (!noc_cmd_buf_ready(n, NCRISC_AT_CMD_BUF));
     }
-    DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
     noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
         noc_index,
         NCRISC_AT_CMD_BUF,

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -156,10 +156,11 @@ inline __attribute__((always_inline)) void configure_gathering() {
 inline __attribute__((always_inline)) void configure_l1_data_cache() {
 #if defined(ARCH_BLACKHOLE)
 #if defined(DISABLE_L1_DATA_CACHE)
-    // Disables Blackhole's L1 cache by setting bit 3. Grayskull and Wormhole do not have L1 cache
+    // Flush and Disables Blackhole's L1 cache by setting bit 3. Grayskull and Wormhole do not have L1 cache
     // L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
     // export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR*,ER*>
     asm(R"ASM(
+            fence
             li t1, 0x8
             csrrs zero, 0x7c0, t1
              )ASM" ::

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -197,12 +197,12 @@ inline __attribute__((always_inline)) void flush_erisc_icache() {
 #ifdef ARCH_BLACKHOLE
 #pragma GCC unroll 2048
     for (int i = 0; i < 2048; i++) {
-        asm("nop");
+        __asm__ volatile("nop");
     }
 #else
 #pragma GCC unroll 128
     for (int i = 0; i < 128; i++) {
-        asm("nop");
+        __asm__ volatile("nop");
     }
 #endif
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -592,60 +592,6 @@ void MetalContext::initialize_control_plane() {
 void MetalContext::reset_cores(chip_id_t device_id) {
     ZoneScoped;
 
-    auto get_active_erisc_launch_flag_addr = [&]() {
-        auto core_type_idx = hal_->get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-        std::uint32_t launch_erisc_addr = hal_->get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
-        return launch_erisc_addr;
-    };
-
-    auto erisc_app_still_running = [&](CoreCoord virtual_core) {
-        // Check if the kernel/erisc_app is still running on a ethernet core with context switching enabled
-        // The LAUNCH_ERISC_APP_FLAG is reset to 0 after reset/reboot, and set to 1 when Metal runtime launches erisc
-        // app FW Only applicable to WORMHOLE ethernet cores today, but could in theory extend to other cores, remove
-        // assert if so
-        if (cluster_->arch() != ARCH::WORMHOLE_B0) {
-            return false;
-        }
-        TT_ASSERT(
-            cluster_->is_ethernet_core(virtual_core, device_id),
-            "Invalid core {} for context switch check",
-            virtual_core.str());
-        std::uint32_t launch_erisc_addr = get_active_erisc_launch_flag_addr();
-        auto data = cluster_->read_core(device_id, virtual_core, launch_erisc_addr, sizeof(std::uint32_t));
-        return (data[0] != 0);
-    };
-
-    // Send exit_erisc_kernel to the launch message
-    auto erisc_send_exit_signal = [&](CoreCoord virtual_core, bool is_idle_eth) {
-        go_msg_t go_msg{};
-        std::memset(&go_msg, 0, sizeof(go_msg_t));
-        log_info(
-            tt::LogMetal,
-            "While initializing device {}, {} ethernet dispatch core {} detected as still "
-            "running, issuing exit signal.",
-            device_id,
-            is_idle_eth ? "idle" : "active",
-            virtual_core.str());
-
-        DeviceAddr launch_addr = hal_->get_dev_addr(
-            is_idle_eth ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH,
-            HalL1MemAddrType::LAUNCH);
-
-        std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
-        data = cluster_->read_core(device_id, virtual_core, launch_addr, sizeof(launch_msg_t));
-
-        launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
-        launch_msg->kernel_config.exit_erisc_kernel = 1;
-        llrt::write_launch_msg_to_core(device_id, virtual_core, launch_msg, &go_msg, launch_addr, false);
-
-        if (!is_idle_eth) {
-            // Active
-            std::vector<uint32_t> clear_flag_data = {0};
-            cluster_->write_core_immediate(
-                device_id, virtual_core, clear_flag_data, get_active_erisc_launch_flag_addr());
-        }
-    };
-
     // Assert worker cores + dispatch cores, in case they were in a bad state from before.
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> device_to_early_exit_cores;
 
@@ -654,8 +600,8 @@ void MetalContext::reset_cores(chip_id_t device_id) {
         for (const auto& logical_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
             CoreCoord virtual_core =
                 cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
-            if (erisc_app_still_running(virtual_core)) {
-                erisc_send_exit_signal(virtual_core, false /* is_idle_eth */);
+            if (erisc_app_still_running(device_id, virtual_core)) {
+                erisc_send_exit_signal(device_id, virtual_core, false /* is_idle_eth */);
                 device_to_early_exit_cores[device_id].insert(virtual_core);
             }
         }
@@ -1240,5 +1186,49 @@ void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {
     }
     log_debug(LogDevice, "Firmware init complete");
 }
+
+uint32_t MetalContext::get_active_erisc_launch_flag_addr() {
+    auto core_type_idx = hal_->get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+    std::uint32_t launch_erisc_addr = hal_->get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
+    return launch_erisc_addr;
+};
+
+bool MetalContext::erisc_app_still_running(chip_id_t device_id, CoreCoord virtual_core) {
+    // Check if the kernel/erisc_app is still running on a ethernet core with context switching enabled
+    // The LAUNCH_ERISC_APP_FLAG is reset to 0 after reset/reboot, and set to 1 when Metal runtime launches erisc
+    // app FW Only applicable to WORMHOLE ethernet cores today, but could in theory extend to other cores, remove
+    // assert if so
+    if (cluster_->arch() != ARCH::WORMHOLE_B0) {
+        return false;
+    }
+    TT_ASSERT(
+        cluster_->is_ethernet_core(virtual_core, device_id),
+        "Invalid core {} for context switch check",
+        virtual_core.str());
+    std::uint32_t launch_erisc_addr = get_active_erisc_launch_flag_addr();
+    auto data = cluster_->read_core(device_id, virtual_core, launch_erisc_addr, sizeof(std::uint32_t));
+    return (data[0] != 0);
+};
+
+// Send exit_erisc_kernel to the launch message
+void MetalContext::erisc_send_exit_signal(chip_id_t device_id, CoreCoord virtual_core, bool is_idle_eth) {
+    go_msg_t go_msg{};
+    DeviceAddr launch_addr = hal_->get_dev_addr(
+        is_idle_eth ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH,
+        HalL1MemAddrType::LAUNCH);
+
+    std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
+    data = cluster_->read_core(device_id, virtual_core, launch_addr, sizeof(launch_msg_t));
+
+    launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
+    launch_msg->kernel_config.exit_erisc_kernel = 1;
+    llrt::write_launch_msg_to_core(device_id, virtual_core, launch_msg, &go_msg, launch_addr, false);
+
+    if (!is_idle_eth) {
+        // Active
+        std::vector<uint32_t> clear_flag_data = {0};
+        cluster_->write_core_immediate(device_id, virtual_core, clear_flag_data, get_active_erisc_launch_flag_addr());
+    }
+};
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -107,6 +107,13 @@ private:
     void reset_cores(chip_id_t device_id);
     void assert_cores(chip_id_t device_id);
 
+    // Returns the ERISC Launch Flag address
+    uint32_t get_active_erisc_launch_flag_addr();
+    // Returns true if metal firmware or a kernel is running on the virtual ethernet core
+    bool erisc_app_still_running(chip_id_t device_id, CoreCoord virtual_core);
+    // Send a message to exit the erisc app
+    void erisc_send_exit_signal(chip_id_t device_id, CoreCoord virtual_core, bool is_idle_eth);
+
     // Functions used to init/run firmware on devices
     CoreCoord virtual_noc0_coordinate(chip_id_t device_id, uint8_t noc_index, CoreCoord coord);
     void generate_device_bank_to_noc_tables(chip_id_t device_id);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -671,7 +671,7 @@ bool EthernetKernel::configure(
     const ll_api::memory& binary_mem =
         *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
 
-    if (tt::tt_metal::MetalContext::instance().hal().get_core_has_kernel_config_buffer(
+    if (tt::tt_metal::MetalContext::instance().hal().get_core_kernel_stored_in_config_buffer(
             this->get_kernel_programmable_core_type())) {
         uint32_t offset_idx = enchantum::to_underlying(HalProcessorClassType::DM) + enchantum::to_underlying(this->config_.processor);
         llrt::write_binary_to_address(binary_mem, device_id, ethernet_core, base_address + offsets[offset_idx]);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -556,12 +556,13 @@ void EthernetKernel::read_binaries(IDevice* device) {
     std::vector<const ll_api::memory*> binaries;
     uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
+    constexpr auto k_EthDmClassIndex = enchantum::to_underlying(HalProcessorClassType::DM);
     int erisc_id = enchantum::to_underlying(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
+        device->build_id(), erisc_core_type, erisc_id, k_EthDmClassIndex);
     // TODO: fix when active eth supports relo
-    auto load_type = MetalContext::instance().hal().get_jit_build_config(erisc_core_type, erisc_id, 0).memory_load;
+    auto load_type =
+        MetalContext::instance().hal().get_jit_build_config(erisc_core_type, erisc_id, k_EthDmClassIndex).memory_load;
     const ll_api::memory& binary_mem = llrt::get_risc_binary(
         build_state.get_target_out_path(this->kernel_full_name_), load_type, [this](ll_api::memory& binary_mem) {
             if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
@@ -670,15 +671,17 @@ bool EthernetKernel::configure(
     const ll_api::memory& binary_mem =
         *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
 
-    if (this->config_.eth_mode == Eth::IDLE) {
+    if (tt::tt_metal::MetalContext::instance().hal().get_core_has_kernel_config_buffer(
+            this->get_kernel_programmable_core_type())) {
         uint32_t offset_idx = enchantum::to_underlying(HalProcessorClassType::DM) + enchantum::to_underlying(this->config_.processor);
         llrt::write_binary_to_address(binary_mem, device_id, ethernet_core, base_address + offsets[offset_idx]);
     } else {
-        uint32_t erisc_core_type =
+        const auto erisc_core_index =
             MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
         uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
         int erisc_id = enchantum::to_underlying(this->config_.processor);
-        tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, ethernet_core, erisc_core_type, dm_class_idx, erisc_id);
+        tt::llrt::test_load_write_read_risc_binary(
+            binary_mem, device_id, ethernet_core, erisc_core_index, dm_class_idx, erisc_id);
     }
 
     return true;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -83,6 +83,21 @@ std::shared_ptr<Kernel> GetKernel(const ProgramImpl& program, KernelHandle kerne
 namespace program_dispatch {
 
 namespace {
+
+struct CommandConstants {
+    CoreType dispatch_core_type;
+    NOC noc_index;
+    uint32_t max_prefetch_command_size;
+    uint32_t packed_write_max_unicast_sub_cmds;
+};
+
+enum DispatchWriteOffsets {
+    DISPATCH_WRITE_OFFSET_ZERO = 0,
+    DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE = 1,
+    DISPATCH_WRITE_OFFSET_TENSIX_BINARY_L1_CONFIG_BASE = 2,
+    DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE = 3,
+};
+
 CoreCoord get_sub_device_worker_origin(
     const tt::tt_metal::IDevice* device,
     tt::tt_metal::SubDeviceId sub_device_id,
@@ -94,20 +109,18 @@ CoreCoord get_sub_device_worker_origin(
     return grid.bounding_box().start_coord;
 }
 
-struct CommandConstants {
-    CoreType dispatch_core_type;
-    NOC noc_index;
-    uint32_t max_prefetch_command_size;
-    uint32_t packed_write_max_unicast_sub_cmds;
-};
-};  // namespace
+DispatchWriteOffsets get_dispatch_write_offset(HalProgrammableCoreType core_type, bool prefer_zero = false) {
+    switch (core_type) {
+        case HalProgrammableCoreType::ACTIVE_ETH:
+        case HalProgrammableCoreType::IDLE_ETH: return DispatchWriteOffsets::DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE;
+        case HalProgrammableCoreType::TENSIX:
+            return prefer_zero ? DispatchWriteOffsets::DISPATCH_WRITE_OFFSET_ZERO
+                               : DispatchWriteOffsets::DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE;
+        default: TT_THROW("Invalid core type get_dispatch_write_offset {}", enchantum::to_string(core_type));
+    }
+}
 
-enum DispatchWriteOffsets {
-    DISPATCH_WRITE_OFFSET_ZERO = 0,
-    DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE = 1,
-    DISPATCH_WRITE_OFFSET_TENSIX_BINARY_L1_CONFIG_BASE = 2,
-    DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE = 3,
-};
+};  // namespace
 
 uint32_t configure_rta_offsets_for_kernel_groups(
     uint32_t programmable_core_type_index,
@@ -295,59 +308,53 @@ uint32_t finalize_kernel_bins(
 
         for (int class_id = 0; class_id < DISPATCH_CLASS_MAX; class_id++) {
             auto& optional_id = kg->kernel_ids[class_id];
-            if (optional_id) {
-                const auto& kernel = kernels.at(optional_id.value());
-                const auto& kernel_impl = KernelImpl::from(*kernel);
-                const std::vector<const ll_api::memory*>& binaries = kernel_impl.binaries(
-                    BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
-                // TODO: this is really ugly, save me future-HAL!
-                if (programmable_core_type_index ==
-                    hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
-                    uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
+            if (!optional_id.has_value()) {
+                continue;
+            }
+            const auto& kernel = kernels.at(optional_id.value());
+            const auto& kernel_impl = KernelImpl::from(*kernel);
+            const std::vector<const ll_api::memory*>& binaries = kernel_impl.binaries(
+                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+            // TODO: this is really ugly, save me future-HAL!
+            if (programmable_core_type_index == hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
+                const auto binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
 
-                    if (class_id == DISPATCH_CLASS_TENSIX_DM0) {
-                        kg->kernel_bin_sizes[0] = binary_packed_size;
-                        kg->kernel_text_offsets[0] = offset;
-                        kg->launch_msg.kernel_config.kernel_text_offset[0] = offset;
+                if (class_id == DISPATCH_CLASS_TENSIX_COMPUTE) {
+                    constexpr uint32_t k_MaxMathProcessorsCount = 3;
+                    for (uint32_t proc_type_index = 0; proc_type_index < k_MaxMathProcessorsCount; proc_type_index++) {
+                        uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, proc_type_index);
+                        kg->kernel_bin_sizes[2 + proc_type_index] = binary_packed_size;
+                        kg->kernel_text_offsets[2 + proc_type_index] = offset;
+                        kg->launch_msg.kernel_config.kernel_text_offset[2 + proc_type_index] = offset;
                         offset += binary_packed_size;
                         offset = tt::align(offset, l1_alignment);
-                    } else if (class_id == DISPATCH_CLASS_TENSIX_DM1) {
-                        kg->kernel_bin_sizes[1] = binary_packed_size;
-                        kg->kernel_text_offsets[1] = offset;
-                        kg->launch_msg.kernel_config.kernel_text_offset[1] = offset;
-                        offset += binary_packed_size;
-                        offset = tt::align(offset, l1_alignment);
-
-                        uint32_t binary_text_size = kernel_impl.get_binary_text_size(device, 0);
-                        TT_ASSERT(binary_text_size >> 4 <= std::numeric_limits<uint16_t>::max());
-                        kg->launch_msg.kernel_config.ncrisc_kernel_size16 = (binary_text_size + 15) >> 4;
-                    } else {
-                        constexpr uint32_t max_math_processors_count = 3;
-                        for (uint32_t proc_type_index = 0; proc_type_index < max_math_processors_count;
-                             proc_type_index++) {
-                            uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, proc_type_index);
-                            kg->kernel_bin_sizes[2 + proc_type_index] = binary_packed_size;
-                            kg->kernel_text_offsets[2 + proc_type_index] = offset;
-                            kg->launch_msg.kernel_config.kernel_text_offset[2 + proc_type_index] = offset;
-                            offset += binary_packed_size;
-                            offset = tt::align(offset, l1_alignment);
-                        }
                     }
                 } else {
-                    uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
                     kg->kernel_bin_sizes[class_id] = binary_packed_size;
+                    kg->kernel_text_offsets[class_id] = offset;
+                    kg->launch_msg.kernel_config.kernel_text_offset[class_id] = offset;
+                    offset += binary_packed_size;
+                    offset = tt::align(offset, l1_alignment);
 
-                    // No kernel config buffer on active eth yet
-                    if (hal.get_programmable_core_type(kg->programmable_core_type_index) ==
-                        HalProgrammableCoreType::IDLE_ETH) {
-                        kg->kernel_text_offsets[class_id] = offset;
-                        kg->launch_msg.kernel_config.kernel_text_offset[class_id] = offset;
-                        offset += binary_packed_size;
-                        offset = tt::align(offset, l1_alignment);
-                    } else {
-                        kg->kernel_text_offsets[class_id] = binaries[0]->get_text_addr();
-                        kg->launch_msg.kernel_config.kernel_text_offset[class_id] = binaries[0]->get_text_addr();
-                    }
+                    // Provide text size for copying to NCRISC IRAM (not used in other processors)
+                    const auto binary_text_size = kernel_impl.get_binary_text_size(device, 0);
+                    TT_ASSERT(binary_text_size >> 4 <= std::numeric_limits<uint16_t>::max());
+                    kg->launch_msg.kernel_config.ncrisc_kernel_size16 = (binary_text_size + 15) >> 4;
+                }
+            } else {
+                // All other core types
+                const auto binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
+                kg->kernel_bin_sizes[class_id] = binary_packed_size;
+
+                if (hal.get_core_has_kernel_config_buffer(
+                        hal.get_programmable_core_type(programmable_core_type_index))) {
+                    kg->kernel_text_offsets[class_id] = offset;
+                    kg->launch_msg.kernel_config.kernel_text_offset[class_id] = offset;
+                    offset += binary_packed_size;
+                    offset = tt::align(offset, l1_alignment);
+                } else {
+                    kg->kernel_text_offsets[class_id] = binaries[0]->get_text_addr();
+                    kg->launch_msg.kernel_config.kernel_text_offset[class_id] = binaries[0]->get_text_addr();
                 }
             }
         }
@@ -707,7 +714,8 @@ BatchedTransfers assemble_runtime_args_commands(
     }
 
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
-        if (hal.get_programmable_core_type(index) == HalProgrammableCoreType::IDLE_ETH) {
+        auto programmable_core_type = hal.get_programmable_core_type(index);
+        if (programmable_core_type == HalProgrammableCoreType::IDLE_ETH) {
             // Fast dispatch not supported on IDLE_ETH yet
             // TODO: can't just loop here as code below confuses ACTIVE/IDLE
             continue;
@@ -763,8 +771,7 @@ BatchedTransfers assemble_runtime_args_commands(
                     unique_rt_args_data,
                     constants,
                     false,
-                    core_type == CoreType::WORKER ? DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE
-                                                  : DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
+                    get_dispatch_write_offset(programmable_core_type));
                 for (auto& data_per_kernel : unique_rt_data_and_sizes) {
                     for (auto& data_and_sizes : data_per_kernel) {
                         RecordDispatchData(program.get_id(), DISPATCH_DATA_RTARGS, std::get<1>(data_and_sizes));
@@ -861,8 +868,7 @@ BatchedTransfers assemble_runtime_args_commands(
                                 common_rt_args_data,
                                 constants,
                                 true,
-                                core_type == CoreType::WORKER ? DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE
-                                                              : DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
+                                get_dispatch_write_offset(programmable_core_type));
                             sub_cmds.clear();
                         },
                         common_sub_cmds);
@@ -1103,11 +1109,19 @@ public:
                     kernel_bins_unicast_cmds.emplace_back(2 * hal.get_alignment(HalMemType::HOST));
                     constexpr bool flush_prefetch = false;
                     calculator.add_dispatch_write_linear<flush_prefetch>(0);
+
+                    // Set write offset if required
+                    auto write_offset = DISPATCH_WRITE_OFFSET_ZERO;
+                    if (hal.get_core_has_kernel_config_buffer(kg_transfer_info.core_type)) {
+                        write_offset = get_dispatch_write_offset(kg_transfer_info.core_type, true);
+                    }
                     kernel_bins_unicast_cmds.back().add_dispatch_write_linear<flush_prefetch>(
                         num_mcast_dests,  // num_mcast_dests
                         noc_encoding,     // noc_xy_addr
                         kg_transfer_info.dst_base_addrs[kernel_idx],
-                        kg_transfer_info.lengths[kernel_idx]);
+                        kg_transfer_info.lengths[kernel_idx],
+                        nullptr,
+                        write_offset);
                     RecordDispatchData(
                         program.get_id(),
                         DISPATCH_DATA_BINARY,
@@ -1796,8 +1810,12 @@ void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr, 
     // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the
     // previous launch message.
     config_buffer_mgr.init_add_buffer(0, launch_msg_buffer_num_entries - 1);
-    // There's no ring buffer for active ethernet binaries, so keep track of them separately.
-    config_buffer_mgr.init_add_buffer(0, 1);
+    if (hal.get_core_has_kernel_config_buffer(HalProgrammableCoreType::ACTIVE_ETH)) {
+        // Keeping it the same
+        config_buffer_mgr.init_add_buffer(0, 1);
+    } else {
+        config_buffer_mgr.init_add_buffer(0, 1);
+    }
 }
 
 void reserve_space_in_kernel_config_buffer(

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1248,7 +1248,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                         kernel_ids.push_back(device_local_kernel_id);
 
                         // Update destination address by kernel config offset
-                        if (hal.get_core_has_kernel_config_buffer(hal.get_programmable_core_type(index))) {
+                        if (hal.get_core_kernel_stored_in_config_buffer(hal.get_programmable_core_type(index))) {
                             int proc_sub_class = 0;
                             for (uint32_t& dst_addr : kernel_transfer_info.at(device_local_kernel_id).dst_base_addrs) {
                                 dst_addr = kernel_group->kernel_text_offsets[dispatch_class + proc_sub_class];

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1206,8 +1206,8 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
         for (const auto& kernel_group : this->get_kernel_groups(index)) {
-            // TODO: add a bit in the hal that says if this core type is unicast/multicast
-            if (core_type == CoreType::WORKER) {
+            if (hal.get_supports_receiving_multicasts(index)) {
+                // Below assumes core has a kernel config buffer
                 std::vector<multicast_transfer_info> dst_noc_multicast_info =
                     extract_dst_noc_multicast_info(device, kernel_group->core_ranges.ranges(), core_type);
                 std::vector<KernelHandle> kernel_ids;
@@ -1232,14 +1232,30 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                     }
                 }
             } else {
+                // Below assumes ethernet dispatch class
                 TT_ASSERT(core_type == CoreType::ETH);
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info =
                     extract_dst_noc_unicast_info(kernel_group->core_ranges.ranges(), core_type);
 
+                // No checks for max dispatch class
+                // Validated during CreateKernel if the requested processor is supported
+                constexpr auto k_SupportedDispatchClasses = std::array{DISPATCH_CLASS_ETH_DM0, DISPATCH_CLASS_ETH_DM1};
                 std::vector<KernelHandle> kernel_ids;
-                if (kernel_group->kernel_ids[DISPATCH_CLASS_ETH_DM0]) {
-                    KernelHandle device_local_kernel_id = program_dispatch::get_device_local_kernel_handle(kernel_group->kernel_ids[DISPATCH_CLASS_ETH_DM0].value());
-                    kernel_ids.push_back(device_local_kernel_id);
+                for (auto dispatch_class : k_SupportedDispatchClasses) {
+                    if (kernel_group->kernel_ids[dispatch_class].has_value()) {
+                        KernelHandle device_local_kernel_id = program_dispatch::get_device_local_kernel_handle(
+                            kernel_group->kernel_ids[dispatch_class].value());
+                        kernel_ids.push_back(device_local_kernel_id);
+
+                        // Update destination address by kernel config offset
+                        if (hal.get_core_has_kernel_config_buffer(hal.get_programmable_core_type(index))) {
+                            int proc_sub_class = 0;
+                            for (uint32_t& dst_addr : kernel_transfer_info.at(device_local_kernel_id).dst_base_addrs) {
+                                dst_addr = kernel_group->kernel_text_offsets[dispatch_class + proc_sub_class];
+                                proc_sub_class++;
+                            }
+                        }
+                    }
                 }
 
                 for (const auto &[cores, num_mcast_dsts] : dst_noc_unicast_info) {

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -293,7 +293,7 @@ void Hal::initialize_bh() {
 
     this->device_features_func_ = [](DispatchFeature feature) -> bool {
         switch (feature) {
-            case DispatchFeature::ETH_FW_API: return true;
+            case DispatchFeature::ETH_MAILBOX_API: return true;
             // Active eth kernel config buffer is not needed until 2 ERISCs
             case DispatchFeature::DISPATCH_ACTIVE_ETH_KERNEL_CONFIG_BUFFER: return false;
             case DispatchFeature::DISPATCH_IDLE_ETH_KERNEL_CONFIG_BUFFER: return true;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -243,8 +243,12 @@ void Hal::initialize_bh() {
     this->mem_alignments_with_pcie_[static_cast<std::size_t>(HalMemType::HOST)] =
         std::lcm(PCIE_ALIGNMENT, PCIE_ALIGNMENT);
 
-    this->relocate_func_ = [](uint64_t addr, uint64_t local_init_addr) {
+    this->relocate_func_ = [](uint64_t addr, uint64_t local_init_addr, bool has_shared_local_mem) {
         if ((addr & MEM_LOCAL_BASE) == MEM_LOCAL_BASE) {
+            // For RISC0 we have a shared local memory with base firmware so offset by that
+            // if (has_shared_local_mem) {
+            //     addr -= MEM_ERISC_BASE_FW_LOCAL_SIZE;
+            // }
             // Move addresses in the local memory range to l1 (copied by kernel)
             return (addr & ~MEM_LOCAL_BASE) + local_init_addr;
         }
@@ -279,9 +283,23 @@ void Hal::initialize_bh() {
     this->noc_ucast_addr_y_func_ = [](uint64_t addr) -> uint64_t { return NOC_UNICAST_ADDR_Y(addr); };
     this->noc_local_addr_func_ = [](uint64_t addr) -> uint64_t { return NOC_LOCAL_ADDR(addr); };
 
-    this->eth_fw_arg_addr_func_ = [&](uint32_t arg_index) -> uint32_t {
-        return get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::ETH_FW_MAILBOX) +
-               offsetof(blackhole::EthFwMailbox, arg) + arg_index * sizeof(((blackhole::EthFwMailbox*)0)->arg[0]);
+    this->eth_fw_arg_addr_func_ = [&](int mailbox_index, uint32_t arg_index) -> uint32_t {
+        // +1 because of the message
+        uint32_t mailbox_base =
+            MEM_SYSENG_ETH_MAILBOX_ADDR + (mailbox_index * (MEM_SYSENG_ETH_MAILBOX_NUM_ARGS + 1) * sizeof(uint32_t));
+        return mailbox_base + offsetof(blackhole::EthFwMailbox, arg) +
+               (arg_index * sizeof(((blackhole::EthFwMailbox*)0)->arg[0]));
+    };
+
+    this->device_features_func_ = [](DispatchFeature feature) -> bool {
+        switch (feature) {
+            case DispatchFeature::ETH_FW_API: return true;
+            // Active eth kernel config buffer is not needed until 2 ERISCs
+            case DispatchFeature::DISPATCH_ACTIVE_ETH_KERNEL_CONFIG_BUFFER: return false;
+            case DispatchFeature::DISPATCH_IDLE_ETH_KERNEL_CONFIG_BUFFER: return true;
+            case DispatchFeature::DISPATCH_TENSIX_KERNEL_CONFIG_BUFFER: return true;
+            default: TT_THROW("Invalid Blackhole dispatch feature {}", static_cast<int>(feature));
+        }
     };
 
     this->num_nocs_ = NUM_NOCS;

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -310,7 +310,7 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
 
     this->device_features_func_ = [](DispatchFeature feature) -> bool {
         switch (feature) {
-            case DispatchFeature::ETH_FW_API: return false;
+            case DispatchFeature::ETH_MAILBOX_API: return false;
             case DispatchFeature::DISPATCH_ACTIVE_ETH_KERNEL_CONFIG_BUFFER: return false;
             case DispatchFeature::DISPATCH_IDLE_ETH_KERNEL_CONFIG_BUFFER: return true;
             case DispatchFeature::DISPATCH_TENSIX_KERNEL_CONFIG_BUFFER: return true;

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -309,7 +309,7 @@ void send_msg_to_eth_mailbox(
     constexpr auto k_sleep_time = std::chrono::nanoseconds{50};
     constexpr auto k_CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_FW_API)) {
+    if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {
         TT_THROW("Ethernet mailbox API not supported on device {}", device_id);
     }
 
@@ -401,7 +401,7 @@ void send_msg_to_eth_mailbox(
 void wait_for_heartbeat(chip_id_t device_id, const CoreCoord& virtual_core, int timeout_ms) {
     constexpr auto k_CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_FW_API)) {
+    if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {
         TT_THROW("Ethernet mailbox API not supported on device {}", device_id);
     }
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/control_plane.hpp>
 #include "hal_types.hpp"
@@ -172,9 +173,16 @@ bool test_load_write_read_risc_binary(
                                    .get_jit_build_config(core_type_idx, processor_class_idx, processor_type_idx)
                                    .local_init_addr;
 
+    auto core_type = get_core_type(chip_id, core);
+    // Depending on the arch, active ethernet may be shared local memory with the base firmware
+    // Primary risc is shared
+    // TODO: Move this query into the HAL
+    bool local_mem_offset = processor_class_idx == 0 && core_type == tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
+
     log_debug(tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size()*sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
-        uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
+        uint64_t relo_addr =
+            tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, local_mem_offset);
 
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), relo_addr);
@@ -294,63 +302,62 @@ void send_msg_to_eth_mailbox(
     chip_id_t device_id,
     const CoreCoord& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
+    int mailbox_index,
     std::vector<uint32_t> args,
     bool wait_for_ack,
     int timeout_ms) {
+    constexpr auto k_sleep_time = std::chrono::nanoseconds{50};
     constexpr auto k_CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_FW_API)) {
+        TT_THROW("Ethernet mailbox API not supported on device {}", device_id);
+    }
+
     bool is_eth_core = internal_::is_active_eth_core(device_id, virtual_core);
     TT_ASSERT(
         is_eth_core,
         "target core for send_msg_to_eth_mailbox {} (virtual) must be an active ethernet core",
         virtual_core.str());
 
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    uint32_t mailbox_addr = hal.get_dev_addr(k_CoreType, tt_metal::HalL1MemAddrType::ETH_FW_MAILBOX);
+    const auto max_args = hal.get_eth_fw_mailbox_arg_count();
+    const auto mailbox_addr = hal.get_eth_fw_mailbox_address(mailbox_index);
+    const auto status_mask = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_STATUS_MASK);
+    const auto call = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_CALL);
+    const auto done_message = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_DONE);
 
-    // Mailbox not supported
-    if (mailbox_addr == 0) {
-        return;
-    }
-
-    auto status_mask = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_STATUS_MASK);
-    auto call = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_CALL);
-
-    auto wait_for_mailbox = [&](std::function<bool(uint32_t)> cond) {
-        constexpr auto k_sleep_time = std::chrono::milliseconds{500};
-        const auto start = std::chrono::high_resolution_clock::now();
-
-        while (true) {
-            tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
+    // Check mailbox is empty/ready
+    uint32_t msg_status = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                              device_id, virtual_core, mailbox_addr, sizeof(uint32_t))[0] &
+                          status_mask;
+    {
+        const auto start_time = std::chrono::steady_clock::now();
+        while (msg_status != done_message && msg_status != 0) {
             uint32_t mailbox_val = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                 device_id, virtual_core, mailbox_addr, sizeof(uint32_t))[0];
-            log_debug(tt::LogLLRuntime, "Device {}: Eth {} Mailbox {:#x}", device_id, virtual_core.str(), mailbox_val);
-
-            const auto timenow = std::chrono::high_resolution_clock::now();
-            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(timenow - start).count();
+            msg_status = mailbox_val & status_mask;
+            const auto timenow = std::chrono::steady_clock::now();
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(timenow - start_time).count();
             if (elapsed > timeout_ms) {
-                TT_THROW(
-                    "Device {}: Eth mailbox timeout ({} ms) waiting for active eth core {} mailbox {:#x}",
+                log_debug(
+                    tt::LogMetal,
+                    "Device {}: Timed out while waiting for ack when trying to launch Metal ethernet firmware on "
+                    "ethernet core {}. Last message status: {:#x}",
                     device_id,
-                    timeout_ms,
                     virtual_core.str(),
                     mailbox_val);
-            }
 
-            if (cond(mailbox_val)) {
-                break;
+                TT_THROW("Device {} Firmware update is required. Minimum tt-firmware verison is 18.8.0", device_id);
             }
             std::this_thread::sleep_for(k_sleep_time);
         }
-    };
-    wait_for_mailbox([=](uint32_t mailbox_val) { return (mailbox_val & status_mask) != call; });
+    }
 
     // Must write args first.
-    const auto max_args = hal.get_eth_fw_mailbox_arg_count();
-    TT_ASSERT(args.size() <= max_args, "Too many args provided {} max args {}", args.size(), max_args);
+    // Pad remaining args to zero
     args.resize(max_args, 0);
-    uint32_t first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(0);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
-        device_id, virtual_core, args, first_arg_addr);
+    uint32_t first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(mailbox_index, 0);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
+        args.data(), tt_cxy_pair(device_id, virtual_core), first_arg_addr);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
 
     const auto msg_val = hal.get_eth_fw_mailbox_val(msg_type);
@@ -362,13 +369,68 @@ void send_msg_to_eth_mailbox(
         virtual_core.str(),
         mailbox_addr,
         msg);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core_immediate(
-        device_id, virtual_core, std::vector<uint32_t>{msg}, mailbox_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
+        std::vector<uint32_t>{msg}.data(), tt_cxy_pair(device_id, virtual_core), mailbox_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
 
     // Wait for ack
     if (wait_for_ack) {
-        auto done_message = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_DONE);
-        wait_for_mailbox([=](uint32_t mailbox_val) { return (mailbox_val & status_mask) == done_message; });
+        const auto start_time = std::chrono::steady_clock::now();
+        do {
+            uint32_t mailbox_val = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                device_id, virtual_core, mailbox_addr, sizeof(uint32_t))[0];
+            msg_status = mailbox_val & status_mask;
+            const auto timenow = std::chrono::steady_clock::now();
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(timenow - start_time).count();
+            if (elapsed > timeout_ms) {
+                log_debug(
+                    tt::LogMetal,
+                    "Device {}: Timed out while waiting for ack when trying to launch Metal ethernet firmware on "
+                    "ethernet core {}. Last message status: {:#x}",
+                    device_id,
+                    virtual_core.str(),
+                    mailbox_val);
+
+                TT_THROW("Device {} Firmware update is required. Minimum tt-firmware verison is 18.8.0", device_id);
+            }
+            std::this_thread::sleep_for(k_sleep_time);
+        } while (msg_status != done_message);
+    }
+}
+
+void wait_for_heartbeat(chip_id_t device_id, const CoreCoord& virtual_core, int timeout_ms) {
+    constexpr auto k_CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_FW_API)) {
+        TT_THROW("Ethernet mailbox API not supported on device {}", device_id);
+    }
+
+    const auto heartbeat_addr = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::HEARTBEAT);
+
+    uint32_t heartbeat_val = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        device_id, virtual_core, heartbeat_addr, sizeof(uint32_t))[0];
+    uint32_t previous_heartbeat_val = heartbeat_val;
+    const auto start = std::chrono::steady_clock::now();
+    constexpr auto k_sleep_time = std::chrono::nanoseconds{50};
+
+    while (heartbeat_val == previous_heartbeat_val) {
+        std::this_thread::sleep_for(k_sleep_time);
+        previous_heartbeat_val = heartbeat_val;
+        heartbeat_val = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            device_id, virtual_core, heartbeat_addr, sizeof(uint32_t))[0];
+        if (timeout_ms > 0) {
+            const auto now = std::chrono::steady_clock::now();
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+            if (elapsed > timeout_ms) {
+                auto core_type_idx =
+                    hal.get_programmable_core_type_index(tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
+                TT_THROW(
+                    "Device {}: Timed out while waiting for active ethernet core {} to become active again. "
+                    "Try resetting the board. Is the firmware updated? Minimum tt-firmware version is 18.8.0",
+                    device_id,
+                    virtual_core.str());
+            }
+        }
     }
 }
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -95,9 +95,14 @@ void send_msg_to_eth_mailbox(
     chip_id_t device_id,
     const CoreCoord& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
+    int mailbox_index,
     std::vector<uint32_t> args,
     bool wait_for_ack = true,
-    int timeout_ms = 30000);
+    int timeout_ms = 10000);
+
+// Wait for a heartbeat from the active ethernet core, if supported
+// Used to check if the base firmware is running and ready to service the eth mailbox
+void wait_for_heartbeat(chip_id_t device_id, const CoreCoord& virtual_core, int timeout_ms = 10000);
 
 }  // namespace internal_
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25830
https://github.com/tenstorrent/tt-metal/issues/25427

### Problem description
Dispatch changes to support running 2 ERISCs on Blackhole

### What's changed
- Some refactoring in MetalContext
- Add a query function in the HAL to query whether a given core type supports the Kernel Config ring buffer
  -  For 2 ERISCs `CoreType::ACTIVE_ETH` will support using the ring buffer (Not enabled right now)
- Update Fast Dispatch program command generators to use offsets or not depending on the HAL
- Wait for heartbeat function to check if Blackhole base firmware is running

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/17308530994
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/17329613930
https://github.com/tenstorrent/tt-metal/actions/runs/17408701805
BH
https://github.com/tenstorrent/tt-metal/actions/runs/17329608182