### PR TITLE
Support CQ ID  for any TT-NN Operation

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -148,7 +149,9 @@ public:
     virtual uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const = 0;
 
     virtual SystemMemoryManager& sysmem_manager() = 0;
-    virtual CommandQueue& command_queue(size_t cq_id = 0) = 0;
+
+    // If cq_id is not provided, the current command queue is returned from the current thread
+    virtual CommandQueue& command_queue(std::optional<uint8_t> cq_id = std::nullopt) = 0;
 
     virtual uint32_t get_trace_buffers_size() const = 0;
     virtual void set_trace_buffers_size(uint32_t size) = 0;

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -955,6 +955,26 @@ bool EventQuery(const std::shared_ptr<Event>& event);
 void Synchronize(
     IDevice* device, std::optional<uint8_t> cq_id = std::nullopt, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
+// clang-format off
+/**
+ * Set the current command queue id to be used for synchronization.
+ * Return value: void
+ * | Argument     | Description                                                                       | Type                          | Valid Range                        | Required |
+ * |--------------|-----------------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | cq_id        | The command queue id to set as current.                                           | uint8_t                       |                                    | Yes      |
+ */
+// clang-format on
+// todo: consider if returning a guard on this level is better vs if guard belongs to the layer above
+void SetCurrentCommandQueueId(uint8_t cq_id);
+
+// clang-format off
+/**
+ * Get the current command queue id.
+ * Return value: uint8_t
+ */
+// clang-format on
+uint8_t GetCurrentCommandQueueId();
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -964,7 +964,6 @@ void Synchronize(
  * | cq_id        | The command queue id to set as current.                                           | uint8_t                       |                                    | Yes      |
  */
 // clang-format on
-// todo: consider if returning a guard on this level is better vs if guard belongs to the layer above
 void SetCurrentCommandQueueId(uint8_t cq_id);
 
 // clang-format off

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -197,12 +197,13 @@ public:
     uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const override;
     uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const override;
     SystemMemoryManager& sysmem_manager() override;
-    CommandQueue& command_queue(size_t cq_id = 0) override;
+    CommandQueue& command_queue(std::optional<uint8_t> cq_id = std::nullopt) override;
 
     // MeshTrace Internal APIs - these should be used to deprecate the single device backed trace APIs
-    void begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
-    void end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
-    void replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking);
+    // If cq_id is not provided, the current command queue is returned from the current thread
+    void begin_mesh_trace(std::optional<uint8_t> cq_id, const MeshTraceId& trace_id);
+    void end_mesh_trace(std::optional<uint8_t> cq_id, const MeshTraceId& trace_id);
+    void replay_mesh_trace(std::optional<uint8_t> cq_id, const MeshTraceId& trace_id, bool blocking);
     void release_mesh_trace(const MeshTraceId& trace_id);
     std::shared_ptr<MeshTraceBuffer> get_mesh_trace(const MeshTraceId& trace_id);
     uint32_t get_trace_buffers_size() const override;
@@ -308,7 +309,8 @@ public:
 
     // This method will get removed once in favour of the ones in IDevice* and TT-Mesh bringup
     // These are prefixed with "mesh_" to avoid conflicts with the IDevice* methods
-    MeshCommandQueue& mesh_command_queue(std::size_t cq_id = 0) const;
+    // If cq_id is not provided, the current command queue is returned from the current thread
+    MeshCommandQueue& mesh_command_queue(std::optional<uint8_t> cq_id = std::nullopt) const;
 
     // Currently expose users to the dispatch thread pool through the MeshDevice
     void enqueue_to_thread_pool(std::function<void()>&& f);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -673,14 +673,15 @@ std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address(sub_device_ids);
 }
 
-CommandQueue& Device::command_queue(size_t cq_id) {
+CommandQueue& Device::command_queue(std::optional<uint8_t> cq_id) {
     detail::DispatchStateCheck(using_fast_dispatch_);
     if (!using_fast_dispatch_) {
         return *(CommandQueue*)(IDevice*)this;
     }
-    TT_FATAL(cq_id < command_queues_.size(), "cq_id {} is out of range", cq_id);
+    auto actual_cq_id = cq_id.value_or(GetCurrentCommandQueueId());
+    TT_FATAL(actual_cq_id < command_queues_.size(), "cq_id {} is out of range", actual_cq_id);
     TT_FATAL(this->is_initialized(), "Device has not been initialized, did you forget to call InitializeDevice?");
-    return *command_queues_[cq_id];
+    return *command_queues_[actual_cq_id];
 }
 
 bool Device::using_slow_dispatch() const { return !using_fast_dispatch(); }

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -119,7 +119,7 @@ public:
     uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const override;
 
     SystemMemoryManager& sysmem_manager() override { return *sysmem_manager_; }
-    CommandQueue& command_queue(size_t cq_id = 0) override;
+    CommandQueue& command_queue(std::optional<uint8_t> cq_id = std::nullopt) override;
 
     // Metal trace device capture mode
     uint32_t get_trace_buffers_size() const override { return trace_buffers_size_; }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1422,6 +1422,14 @@ void Synchronize(IDevice* device, const std::optional<uint8_t> cq_id, tt::stl::S
     }
 }
 
+namespace {
+thread_local uint8_t current_command_queue_id = 0;
+}
+
+void SetCurrentCommandQueueId(uint8_t cq_id) { current_command_queue_id = cq_id; }
+
+uint8_t GetCurrentCommandQueueId() { return current_command_queue_id; }
+
 namespace experimental {
 
 GlobalCircularBuffer CreateGlobalCircularBuffer(

--- a/ttnn/api/ttnn/core.hpp
+++ b/ttnn/api/ttnn/core.hpp
@@ -37,6 +37,9 @@ void segfault_handler(int sig);
 
 void dump_stack_trace_on_segfault();
 
+uint8_t get_current_command_queue_id();
+void set_current_command_queue_id(uint8_t cq_id);
+
 }  // namespace core
 
 using core::get_memory_config;

--- a/ttnn/core/core.cpp
+++ b/ttnn/core/core.cpp
@@ -6,6 +6,8 @@
 #include <tt_stl/caseless_comparison.hpp>
 #include <enchantum/enchantum.hpp>
 
+#include <tt-metalium/host_api.hpp>
+
 namespace ttnn::core {
 
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {
@@ -35,6 +37,14 @@ void dump_stack_trace_on_segfault() {
         exit(EXIT_FAILURE);
     }
 }
+
+uint8_t get_current_command_queue_id() { return tt::tt_metal::GetCurrentCommandQueueId(); }
+
+void set_current_command_queue_id(uint8_t cq_id) {
+    log_debug(tt::LogTTNN, "Setting current command queue id to {}", cq_id);
+    tt::tt_metal::SetCurrentCommandQueueId(cq_id);
+}
+
 }  // namespace ttnn::core
 
 namespace ttnn {

--- a/ttnn/cpp/ttnn-pybind/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/core.cpp
@@ -85,6 +85,16 @@ void py_module(py::module& module) {
         )doc");
 
     module.def("dump_stack_trace_on_segfault", &ttnn::core::dump_stack_trace_on_segfault);
+
+    module.def("get_current_command_queue_id", &ttnn::core::get_current_command_queue_id);
+    module.def(
+        "set_current_command_queue_id",
+        &ttnn::core::set_current_command_queue_id,
+        py::arg("cq_id"),
+        R"doc(
+        Set the current command queue id for the current thread.
+        This command queue will be used by default for all operations on the current thread.
+    )doc");
 }
 
 }  // namespace ttnn::core

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -277,7 +277,7 @@ from ttnn.core import (
     load_memory_config,
     dump_stack_trace_on_segfault,
     num_cores_to_corerangeset,
-    num_cores_to_corerangeset_in_subcoregrids
+    num_cores_to_corerangeset_in_subcoregrids,
 )
 
 import ttnn.reflection

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -277,9 +277,7 @@ from ttnn.core import (
     load_memory_config,
     dump_stack_trace_on_segfault,
     num_cores_to_corerangeset,
-    num_cores_to_corerangeset_in_subcoregrids,
-    set_current_command_queue_id,
-    get_current_command_queue_id,
+    num_cores_to_corerangeset_in_subcoregrids
 )
 
 import ttnn.reflection

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -278,6 +278,8 @@ from ttnn.core import (
     dump_stack_trace_on_segfault,
     num_cores_to_corerangeset,
     num_cores_to_corerangeset_in_subcoregrids,
+    set_current_command_queue_id,
+    get_current_command_queue_id,
 )
 
 import ttnn.reflection

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -359,8 +359,4 @@ def create_sharded_memory_config_(
 dump_memory_config = ttnn._ttnn.tensor.dump_memory_config
 load_memory_config = ttnn._ttnn.tensor.load_memory_config
 
-set_current_command_queue_id = ttnn._ttnn.core.set_current_command_queue_id
-get_current_command_queue_id = ttnn._ttnn.core.get_current_command_queue_id
-
-
 __all__ = []

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -359,5 +359,8 @@ def create_sharded_memory_config_(
 dump_memory_config = ttnn._ttnn.tensor.dump_memory_config
 load_memory_config = ttnn._ttnn.tensor.load_memory_config
 
+set_current_command_queue_id = ttnn._ttnn.core.set_current_command_queue_id
+get_current_command_queue_id = ttnn._ttnn.core.get_current_command_queue_id
+
 
 __all__ = []

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -103,11 +103,10 @@ POST_OPERATION_HOOKS = []
 
 # Stack to track cq_id contexts and restoration info
 # Below hook and context manager allows user to do:
-# with ttnn.command_queue(5):
-#    ttnn.operation1(tensor)           # No cq_id → uses current global cq_id (5)
-#    ttnn.operation2(tensor, cq_id=3)  # Has cq_id → uses 3, then restores to 5
-#    ttnn.operation3(tensor)           # No cq_id → uses current global cq_id (5)
-
+# with ttnn.command_queue(1):
+#    ttnn.operation1(tensor)           # No cq_id → uses current global cq_id (1)
+#    ttnn.operation2(tensor, cq_id=0)  # Has cq_id → uses 3, then restores to 0
+#    ttnn.operation3(tensor)           # No cq_id → uses current global cq_id (1)
 CQ_ID_STACK = []
 
 
@@ -116,23 +115,20 @@ def cq_id_pre_hook(operation, function_args, function_kwargs):
     cq_id = None
 
     # Check for cq_id from operation kwargs (highest priority)
-    if "cq_id" in function_kwargs and function_kwargs["cq_id"] is not None:
-        cq_id = function_kwargs["cq_id"]
-        # Remove cq_id from kwargs so underlying operation doesn't see it
-        function_kwargs.pop("cq_id")
-        logger.info(f"Using cq_id {function_kwargs['cq_id']} from operation kwargs")
+    if "cq_id" in function_kwargs:
+        cq_id = function_kwargs.pop("cq_id")
+        if cq_id is not None:
+            logger.info(f"Using cq_id {cq_id} from operation kwargs")
+        # Even if None, it's popped to avoid passing to the operation
 
     # If we have a cq_id to use, save current state and switch
     if cq_id is not None:
-        try:
-            old_cq_id = get_current_command_queue_id()
-            CQ_ID_STACK.append(old_cq_id)
-            set_current_command_queue_id(cq_id)
-            logger.info(
-                f"Switched command queue id from {old_cq_id} to {cq_id} for {operation.python_fully_qualified_name}"
-            )
-        except Exception as e:
-            logger.warning(f"Failed to handle cq_id in {operation.python_fully_qualified_name}: {e}")
+        old_cq_id = get_current_command_queue_id()
+        CQ_ID_STACK.append(old_cq_id)
+        set_current_command_queue_id(cq_id)
+        logger.debug(
+            f"Switched command queue id from {old_cq_id} to {cq_id} for {operation.python_fully_qualified_name}"
+        )
 
     return None
 
@@ -142,19 +138,15 @@ def cq_id_post_hook(operation, function_args, function_kwargs, output):
     if not CQ_ID_STACK:
         return None
 
-    prev_cq_id = CQ_ID_STACK[-1]
-    if prev_cq_id is None:
-        return None
-
+    prev_cq_id = CQ_ID_STACK.pop()
     set_current_command_queue_id(prev_cq_id)
-    CQ_ID_STACK.pop()
-    logger.info(f"Restored command queue id to {prev_cq_id} for {operation.python_fully_qualified_name}")
+    logger.debug(f"Restored command queue id to {prev_cq_id} for {operation.python_fully_qualified_name}")
 
     return None
 
 
 @contextmanager
-def command_queue(cq_id):
+def command_queue(cq_id: int):
     """Context manager to set a default command queue for all TTNN operations within this context.
 
     Operations within this context will use the specified cq_id unless they explicitly
@@ -168,12 +160,15 @@ def command_queue(cq_id):
             result = ttnn.some_operation(tensor)  # Will use cq_id 1
             result2 = ttnn.other_operation(tensor, cq_id=2)  # Will use cq_id 2 (overrides context)
     """
+    if cq_id is None:
+        raise ValueError("cq_id cannot be None in command_queue context")
+
     # Save the command queue state before entering context
     old_cq_id = get_current_command_queue_id()
 
+    logger.debug(f"Switching command queue id from {old_cq_id} to {cq_id}")
+    set_current_command_queue_id(cq_id)
     try:
-        logger.info(f"Switching command queue id from {old_cq_id} to {cq_id}")
-        set_current_command_queue_id(cq_id)
         yield
     finally:
         # Check if command queue is in expected state when exiting context
@@ -182,11 +177,11 @@ def command_queue(cq_id):
             logger.warning(
                 f"command_queue({cq_id}) context exiting with unexpected command queue ID: {current_cq_id}. "
                 f"This might indicate an operation didn't properly restore the command queue state. "
-                f"Restoring to expected value {cq_id}."
+                f"Restoring to original value {old_cq_id}."
             )
 
         # Restore the original command queue state from before entering context
-        logger.info(f"Restoring command queue id back to {old_cq_id}")
+        logger.debug(f"Restoring command queue id back to {old_cq_id}")
         set_current_command_queue_id(old_cq_id)
 
 

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -76,6 +76,7 @@ PRE_OPERATION_HOOKS = []
 set_current_command_queue_id = ttnn._ttnn.core.set_current_command_queue_id
 get_current_command_queue_id = ttnn._ttnn.core.get_current_command_queue_id
 
+
 @contextmanager
 def register_pre_operation_hook(hook):
     """


### PR DESCRIPTION
### Ticket
None

### Problem description
Half of TT-NN operations support CQ_ID
Half pretend to support, but don't really support it because don't fully propagate cq_id value in a composite chain.

### What's changed
Introduce 2 new metal apis (**threadlocal**):

```cpp
void PushCurrentCommandQueueId(uint8_t cq_id);
uint8_t PopCurrentCommandQueueId();
uint8_t GetCurrentCommandQueueId();
```
Push and Pop (thanks @dmakoviichuk-tt) allow you to easily change / revert the value. 
In contrast to Get/Set it allows to accomplish things in just 2 calls instead of 3 (`push, pop` instead of `get old value, set new, set old`)

TT-NN api adds another method
```cpp
uint8_t get_current_command_queue_id();
void push_command_queue_id(uint8_t cq_id);
void pop_command_queue_id();
ScopeGuard with_command_queue_id(uint8_t cq_id);
ScopeGuard with_command_queue_id(uint8_t cq_id, lambda);
```

The last lambda allows you things like this
```cpp
ttnn::with_command_queue_id(workload_dispatch_cq, [&](auto guard) {
   output_tensor = ttnn::neg(output_tensor);
});
```

> [!Note]
> I am not a big fan of globals and threadlocals, but I think this is way better than a having a feature that will never work.


Introduced a Context and a Hook in Python level to allow calls like
```py
with ttnn.command_queue(1):
    ttnn.operation1(tensor)           # No cq_id → uses current global cq_id (1)
    ttnn.operation2(tensor, cq_id=0)  # Has cq_id → uses 3, then restores to 0
    ttnn.operation3(tensor)           # No cq_id → uses current global cq_id (1)
```
**Context** allows `with:` calls.

**Hook** captures all calls to a registered TT-NN operation
* handles cq_id kwarg by setting current cq_id
* restores it back after the op finished
* The benefit is that it means ALL ops now support cq_id. 
* **The cost is** that we now do 2 calls from py to cpp instead of 1 when cq_id is specified. 
* If many calls are made it is better to use `with` clause.

> [!Note]
> Things are kind of nice in python here but not in C++. For C++ to be nice too, we need to return a guard. Not sure if guard should be returned in metal api level or should be a TT-NN candy. Please share your thoughts.

> [!Note]
> This PR does not remove handling of CQ ID from ops in C++ yes, and does not update bindings yet. I want to merge this change once we confirm things work as intended. I prefer to make a separate PR for removal of QueueId param from ops and bindings.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17285081865) CI passes
- [ ] [demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17285656474)
- [ ] [t3k unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17285655303)
- [ ] [single card model perf](https://github.com/tenstorrent/tt-metal/actions/runs/17285658396)
- [ ] [t3k model perf](https://github.com/tenstorrent/tt-metal/actions/runs/17285654220)
- [ ] [t3k frequent](https://github.com/tenstorrent/tt-metal/actions/runs/17285681387)