### PR TITLE
Remove cq id from TT-NN OPs 🐒

### DIFF
--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
                         ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), DataType::BFLOAT16, Layout::TILE, *device);
 
                     for (auto bcast_math : enchantum::values_generator<ttnn::BcastOpMath>) {
-                        Tensor c = ttnn::bcast(ttnn::DefaultQueueId, a, b, bcast_math, bcast_dim);
+                        Tensor c = ttnn::bcast(a, b, bcast_math, bcast_dim);
                         Tensor d = c.cpu();
 
                         ////////////////////////////////////////////////////////////////////////////
@@ -88,28 +88,28 @@ int main(int argc, char** argv) {
             {
                 Tensor a = ttnn::random::random(Shape({1, 1, 32, 4544})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 4544}), DataType::BFLOAT16, Layout::TILE, *device);
-                Tensor c = ttnn::bcast(ttnn::DefaultQueueId, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::H);
+                Tensor c = ttnn::bcast(a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::H);
                 Tensor d = c.cpu();
             }
 
             {
                 Tensor a = ttnn::random::random(Shape({1, 1, 32, 4544})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 4544}), DataType::BFLOAT16, Layout::TILE, *device);
-                Tensor c = ttnn::bcast(ttnn::DefaultQueueId, a, b, ttnn::BcastOpMath::ADD, ttnn::BcastOpDim::H);
+                Tensor c = ttnn::bcast(a, b, ttnn::BcastOpMath::ADD, ttnn::BcastOpDim::H);
                 Tensor d = c.cpu();
             }
 
             {
                 Tensor a = ttnn::random::random(Shape({1, 71, 32, 32})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 32}), DataType::BFLOAT16, Layout::TILE, *device);
-                Tensor c = ttnn::bcast(ttnn::DefaultQueueId, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
+                Tensor c = ttnn::bcast(a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
                 Tensor d = c.cpu();
             }
 
             {
                 Tensor a = ttnn::random::random(Shape({1, 71, 32, 64})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 32}), DataType::BFLOAT16, Layout::TILE, *device);
-                Tensor c = ttnn::bcast(ttnn::DefaultQueueId, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
+                Tensor c = ttnn::bcast(a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
                 Tensor d = c.cpu();
             }
         };

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
@@ -6,11 +6,13 @@
 
 #include <stdexcept>
 #include <cmath>
+#include <variant>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
+#include <tt-metalium/host_api.hpp>
 
 namespace ttnn::test_utils {
 
@@ -48,15 +50,21 @@ Tensor dispatch_ops_to_device(Tensor input_tensor, QueueId cq_id) {
     using ttnn::operations::unary::UnaryOpType;
     using ttnn::operations::unary::UnaryWithParam;
 
-    Tensor output_tensor = ttnn::mul_sfpu(cq_id, input_tensor, 2);
+    auto last_cq_id = tt::tt_metal::GetCurrentQueueId();
+    tt::tt_metal::SetCurrentQueueId(cq_id);
+
+    Tensor output_tensor = ttnn::mul_sfpu(input_tensor, 2);
     for (int i = 0; i < 3; i++) {
-        output_tensor = ttnn::neg(cq_id, output_tensor);
-        output_tensor = ttnn::neg(cq_id, output_tensor);
-        output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
+        output_tensor = ttnn::neg(output_tensor);
+        output_tensor = ttnn::neg(output_tensor);
+        output_tensor = ttnn::mul_sfpu(output_tensor, 2);
     }
-    output_tensor = ttnn::neg(cq_id, output_tensor);
-    output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
-    output_tensor = ttnn::add_sfpu(cq_id, output_tensor, 128);
+    output_tensor = ttnn::neg(output_tensor);
+    output_tensor = ttnn::mul_sfpu(output_tensor, 2);
+    output_tensor = ttnn::add_sfpu(output_tensor, 128);
+
+    tt::tt_metal::SetCurrentQueueId(last_cq_id);
+
     return output_tensor;
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -14,6 +14,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -129,10 +130,15 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             ttnn::wait_for_event(device_->mesh_command_queue(*workload_dispatch_cq), write_event);
 
             // Run operation on cq 0
-            Tensor output_tensor = ttnn::sqrt(workload_dispatch_cq, input_tensor);
+            auto last_cq_id = tt::tt_metal::GetCurrentQueueId();
+            tt::tt_metal::SetCurrentQueueId(workload_dispatch_cq);
+            Tensor output_tensor = ttnn::sqrt(input_tensor);
+            tt::tt_metal::SetCurrentQueueId(last_cq_id);
             auto dummy_buffer_0 =
                 tt::tt_metal::tensor_impl::allocate_device_buffer(device_, TensorSpec(shape, tensor_layout));
-            output_tensor = ttnn::neg(workload_dispatch_cq, output_tensor);
+            tt::tt_metal::SetCurrentQueueId(workload_dispatch_cq);
+            output_tensor = ttnn::neg(output_tensor);
+            tt::tt_metal::SetCurrentQueueId(last_cq_id);
             // Allocate this buffer to stress test async allocation across op execution and explicit allocation
             auto dummy_buffer_1 =
                 tt::tt_metal::tensor_impl::allocate_device_buffer(device_, TensorSpec(shape, tensor_layout));

--- a/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
@@ -160,7 +160,6 @@ TEST_P(Conv2DFixture, Conv2DCalculateCorrectly) {
 
         // Run Conv2D
         auto [output_tensor, output_dimensions] = std::get<static_cast<int>(ResultType::OUTPUT_DIM)>(ttnn::conv2d(
-            DefaultQueueId,
             input_tensor,
             weight_tensor,
             device.get(),

--- a/tests/ttnn/unit_tests/test_command_queue.py
+++ b/tests/ttnn/unit_tests/test_command_queue.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from models.utility_functions import torch_random
+
+
+def test_command_queue(device):
+    """Test command_queue context manager and cq_id parameter functionality"""
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch_random((1, 32, 32), -1, 1, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Save initial command queue ID
+    initial_cq_id = ttnn.get_current_command_queue_id()
+
+    # Test command_queue context manager
+    with ttnn.command_queue(1):
+        assert ttnn.get_current_command_queue_id() == 1
+
+        # Test operation within context
+        result = ttnn.exp(input_tensor)
+        assert ttnn.get_current_command_queue_id() == 1
+
+        # Test operation with explicit cq_id (should override context)
+        result = ttnn.exp(input_tensor, cq_id=0)
+        assert ttnn.get_current_command_queue_id() == 1  # Should restore to context's cq_id
+
+    # Verify command queue is restored to initial value
+    assert ttnn.get_current_command_queue_id() == initial_cq_id
+
+    # Test operation with cq_id parameter outside context
+    result = ttnn.exp(input_tensor, cq_id=1)
+    assert ttnn.get_current_command_queue_id() == initial_cq_id

--- a/ttnn/api/ttnn/decorators.hpp
+++ b/ttnn/api/ttnn/decorators.hpp
@@ -67,10 +67,6 @@ concept HasInvoke = requires {
     { Op::invoke(std::declval<Args>()...) };
 };
 
-template <typename T, typename... Args>
-concept FirstArgIs =
-    sizeof...(Args) > 0 && std::same_as<std::decay_t<std::tuple_element_t<0, std::tuple<Args&&...>>>, T>;
-
 template <reflect::fixed_string cpp_fully_qualified_name, typename operation_t>
 struct registered_operation_t {
     static constexpr auto is_primitive = PrimitiveOperationConcept<operation_t>;
@@ -86,30 +82,10 @@ struct registered_operation_t {
         return detail::python_fully_qualified_name(std::string{cpp_fully_qualified_name});
     }
 
-    // --- operator() Overloads ---
-
-    // (1) Overload when the first argument is a QueueId.
-    template <typename First, typename... Rest>
-        requires std::same_as<std::decay_t<First>, QueueId>
-    auto operator()(First&& first, Rest&&... rest) const {
-        return traced_invoke(std::forward<First>(first), std::forward<Rest>(rest)...);
-    }
-
-    // (2a) Overload when no QueueId is provided AND the operation is invocable without a QueueId.
     template <typename... Args>
-        requires(sizeof...(Args) == 0 || (!FirstArgIs<QueueId, Args...> && HasInvoke<operation_t, Args && ...>))
+        requires(HasInvoke<operation_t, Args && ...>)
     auto operator()(Args&&... args) const {
         return traced_invoke(std::forward<Args>(args)...);
-    }
-
-    // (2b) Overload when no QueueId is provided but the operation is NOT invocable without a QueueId,
-    // so we inject DefaultQueueId.
-    template <typename... Args>
-        requires(
-            sizeof...(Args) == 0 || (!FirstArgIs<QueueId, Args...> && !HasInvoke<operation_t, Args && ...> &&
-                                     HasInvoke<operation_t, QueueId, Args && ...>))
-    auto operator()(Args&&... args) const {
-        return traced_invoke(DefaultQueueId, std::forward<Args>(args)...);
     }
 
 private:
@@ -127,20 +103,14 @@ private:
 
     template <typename... args_t>
         requires PrimitiveOperationConcept<operation_t>
-    auto invoke(QueueId queue_id, args_t&&... args) const {
+    auto invoke(args_t&&... args) const {
         static_assert(
             requires { operation_t::invoke(std::forward<decltype(args)>(args)...); },
             "Primitive Operation must implement invoke() method to be invoked.");
         ZoneScopedN("Run primitive ttnn operation");
         ZoneName(static_cast<const char*>(cpp_fully_qualified_name.data), cpp_fully_qualified_name.size());
         auto [operation_attributes, tensors_args] = operation_t::invoke(std::forward<decltype(args)>(args)...);
-        return ttnn::device_operation::detail::invoke<operation_t>(queue_id, operation_attributes, tensors_args);
-    }
-
-    template <typename... args_t>
-        requires(PrimitiveOperationConcept<operation_t>)
-    auto invoke(args_t&&... args) const {
-        return invoke(DefaultQueueId, std::forward<args_t>(args)...);
+        return ttnn::device_operation::detail::invoke<operation_t>(operation_attributes, tensors_args);
     }
 
     template <typename... args_t>

--- a/ttnn/api/ttnn/decorators.hpp
+++ b/ttnn/api/ttnn/decorators.hpp
@@ -8,12 +8,8 @@
 
 #include <tt-metalium/graph_tracking.hpp>
 #include <tracy/Tracy.hpp>
-#include "ttnn/common/queue_id.hpp"
-#include "ttnn/core.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operation.hpp"
-#include "ttnn/run_operation.hpp"
-#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn {
 namespace decorators {

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -188,7 +188,6 @@ inline void log_operation(
 
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void enqueue_mesh_workload(
-    QueueId cq_id,
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
     const typename mesh_device_operation_t::tensor_args_t& tensor_args,
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
@@ -200,7 +199,7 @@ void enqueue_mesh_workload(
     }
     {
         ZoneScopedN("EnqueueMeshWorkload");
-        tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
+        tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
     }
 
     TracyOpMeshWorkload(
@@ -226,7 +225,6 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
 
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void handle_mesh_adapter_cache_hit(
-    QueueId cq_id,
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
     const typename mesh_device_operation_t::tensor_args_t& tensor_args,
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
@@ -250,19 +248,13 @@ void handle_mesh_adapter_cache_hit(
                 cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
 
             enqueue_mesh_workload<mesh_device_operation_t>(
-                cq_id,
-                operation_attributes,
-                tensor_args,
-                tensor_return_value,
-                mesh_device,
-                cached_mesh_workload.workload);
+                operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_mesh_workload.workload);
         });
 }
 
 // Helper for creating and caching a mesh workload
 template <DeviceOperationConcept mesh_device_operation_t>
 void create_and_cache_mesh_workload(
-    QueueId cq_id,
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
     const typename mesh_device_operation_t::tensor_args_t& tensor_args,
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
@@ -303,15 +295,10 @@ void create_and_cache_mesh_workload(
                 auto& cached_program_factory = program_cache.get(program_hash);
                 auto& workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload;
                 enqueue_mesh_workload<mesh_device_operation_t>(
-                    cq_id, operation_attributes, tensor_args, tensor_return_value, mesh_device, workload);
+                    operation_attributes, tensor_args, tensor_return_value, mesh_device, workload);
             } else {
                 enqueue_mesh_workload<mesh_device_operation_t>(
-                    cq_id,
-                    operation_attributes,
-                    tensor_args,
-                    tensor_return_value,
-                    mesh_device,
-                    cached_workload.workload);
+                    operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_workload.workload);
             }
         });
 }
@@ -319,7 +306,6 @@ void create_and_cache_mesh_workload(
 // Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void launch_operation_with_adapter(
-    QueueId cq_id,
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
     const typename mesh_device_operation_t::tensor_args_t& tensor_args,
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
@@ -356,16 +342,15 @@ void launch_operation_with_adapter(
 
     if (program_cache_hit) {
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
-            cq_id, operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
     } else {
         create_and_cache_mesh_workload<mesh_device_operation_t>(
-            cq_id, operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
     }
 }
 
 template <DeviceOperationConcept device_operation_t>
 typename device_operation_t::tensor_return_value_t launch_on_device(
-    QueueId cq_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     ZoneScopedN("Launch Device Operation");
@@ -379,13 +364,12 @@ typename device_operation_t::tensor_return_value_t launch_on_device(
     auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     auto mesh_device = first_tensor.device();
     launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(
-        cq_id, operation_attributes, tensor_args, tensor_return_value, mesh_device);
+        operation_attributes, tensor_args, tensor_return_value, mesh_device);
     return tensor_return_value;
 }
 
 template <DeviceOperationConcept device_operation_t>
 typename device_operation_t::tensor_return_value_t invoke(
-    QueueId cq_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     ZoneScopedN("Run Device Operation");
@@ -404,7 +388,7 @@ typename device_operation_t::tensor_return_value_t invoke(
     tensor_return_value_t tensor_return_value;
 
     TT_FATAL(std::holds_alternative<tt::tt_metal::DeviceStorage>(storage), "Unsupported storage type");
-    tensor_return_value = detail::launch_on_device<device_operation_t>(cq_id, operation_attributes, tensor_args);
+    tensor_return_value = detail::launch_on_device<device_operation_t>(operation_attributes, tensor_args);
 
     // Should every output tensor be tracked?
     /*

--- a/ttnn/api/ttnn/run_operation.hpp
+++ b/ttnn/api/ttnn/run_operation.hpp
@@ -24,21 +24,18 @@ OutputTensors run(
     DeviceOperation<OutputTensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
-    const OptionalTensors& optional_output_tensors = {},
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+    const OptionalTensors& optional_output_tensors = {});
 
 template <typename ConcreteOperation>
 inline auto run(
     ConcreteOperation&& concrete_op,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
-    const OptionalTensors& optional_output_tensors = {},
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId) -> ProgramOutputTensors<ConcreteOperation> {
+    const OptionalTensors& optional_output_tensors = {}) -> ProgramOutputTensors<ConcreteOperation> {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     if constexpr (detail::is_device_operation<ConcreteOperation>()) {
         auto operation = DeviceOperation(concrete_op);
-        return run<OutputTensors>(
-            std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
+        return run<OutputTensors>(std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
     } else {
         static_assert(tt::stl::concepts::always_false_v<ConcreteOperation>, "Unsupported Operation");
     }
@@ -49,19 +46,17 @@ OutputTensors run_without_autoformat(
     DeviceOperation<OutputTensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
-    const OptionalTensors& optional_output_tensors = {},
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+    const OptionalTensors& optional_output_tensors = {});
 template <typename ConcreteOperation>
 inline auto run_without_autoformat(
     ConcreteOperation&& concrete_op,
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {},
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId) -> ProgramOutputTensors<ConcreteOperation> {
+    const std::vector<std::optional<Tensor>>& optional_output_tensors = {}) -> ProgramOutputTensors<ConcreteOperation> {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     auto operation = DeviceOperation<OutputTensors>(concrete_op);
     return run_without_autoformat<OutputTensors>(
-        std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
+        std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
 }
 
 Tensors run_with_autoformat(
@@ -69,8 +64,7 @@ Tensors run_with_autoformat(
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
     const OptionalTensors& optional_output_tensors = {},
-    float pad_value = 0,
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+    float pad_value = 0);
 
 template <typename ConcreteOperation>
 inline auto run_with_autoformat(
@@ -78,11 +72,10 @@ inline auto run_with_autoformat(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
     const std::vector<std::optional<Tensor>>& optional_output_tensors = {},
-    const float pad_value = 0,
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId) -> Tensors {
+    const float pad_value = 0) -> Tensors {
     auto operation = DeviceOperation<Tensors>(concrete_op);
     return run_with_autoformat(
-        std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors, pad_value, cq_id);
+        std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors, pad_value);
 }
 
 Tensors run_with_autoformat(
@@ -92,8 +85,7 @@ Tensors run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const OptionalConstTensors& optional_input_tensors = {},
     const std::vector<std::optional<FormatParams>>& optional_input_formatting = {},
-    const OptionalTensors& optional_output_tensors = {},
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+    const OptionalTensors& optional_output_tensors = {});
 
 template <typename ConcreteOperation>
 inline auto run_with_autoformat(
@@ -103,8 +95,7 @@ inline auto run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
     const std::vector<std::optional<FormatParams>>& optional_input_formatting = {},
-    const OptionalTensors& optional_output_tensors = {},
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId) -> ProgramOutputTensors<ConcreteOperation> {
+    const OptionalTensors& optional_output_tensors = {}) -> ProgramOutputTensors<ConcreteOperation> {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     auto operation = DeviceOperation<OutputTensors>(concrete_op);
     return run_with_autoformat(
@@ -114,8 +105,7 @@ inline auto run_with_autoformat(
         output_layouts,
         optional_input_tensors,
         optional_input_formatting,
-        optional_output_tensors,
-        cq_id);
+        optional_output_tensors);
 }
 
 namespace detail {

--- a/ttnn/api/ttnn/run_operation.hpp
+++ b/ttnn/api/ttnn/run_operation.hpp
@@ -9,7 +9,6 @@
 
 #include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 #include "ttnn/operation.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/device.hpp>
 #include <tt_stl/type_name.hpp>
 

--- a/ttnn/core/run_operation.cpp
+++ b/ttnn/core/run_operation.cpp
@@ -227,7 +227,7 @@ Tensors run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const OptionalConstTensors& optional_input_tensors,
     const std::vector<std::optional<FormatParams>>& optional_input_formatting,
-    const OptionalTensors& optional_output_tensors {
+    const OptionalTensors& optional_output_tensors) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     ZoneScoped;
     distributed::MeshDevice* device = detail::get_device(input_tensors, optional_input_tensors);

--- a/ttnn/core/run_operation.cpp
+++ b/ttnn/core/run_operation.cpp
@@ -72,14 +72,13 @@ OutputTensors run(
     DeviceOperation<OutputTensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& optional_output_tensors,
-    QueueId cq_id) {
+    const OptionalTensors& optional_output_tensors) {
     if constexpr (std::is_same_v<OutputTensors, Tensors>) {
         return ttnn::prim::old_infra_device_operation(
-            cq_id, std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
+            std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
     } else {
         return ttnn::prim::old_infra_device_operation_with_optional_output_tensors(
-            cq_id, std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
+            std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
     }
 }
 
@@ -87,23 +86,20 @@ template Tensors run(
     DeviceOperation<Tensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& optional_output_tensors,
-    QueueId cq_id);
+    const OptionalTensors& optional_output_tensors);
 
 template OptionalTensors run(
     DeviceOperation<OptionalTensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& optional_output_tensors,
-    QueueId cq_id);
+    const OptionalTensors& optional_output_tensors);
 
 template <class OutputTensors>
 OutputTensors run_without_autoformat(
     DeviceOperation<OutputTensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& optional_output_tensors,
-    QueueId cq_id) {
+    const OptionalTensors& optional_output_tensors) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     ZoneScoped;
     distributed::MeshDevice* device = detail::get_device(input_tensors, optional_input_tensors);
@@ -127,22 +123,20 @@ OutputTensors run_without_autoformat(
         }
     }
     return run<OutputTensors>(
-        std::move(operation), input_tensors_on_dev, optional_input_tensors_on_dev, optional_output_tensors, cq_id);
+        std::move(operation), input_tensors_on_dev, optional_input_tensors_on_dev, optional_output_tensors);
 }
 
 template Tensors run_without_autoformat<Tensors>(
     DeviceOperation<Tensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& optional_output_tensors,
-    QueueId cq_id);
+    const OptionalTensors& optional_output_tensors);
 
 template OptionalTensors run_without_autoformat<OptionalTensors>(
     DeviceOperation<OptionalTensors>&& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& optional_output_tensors,
-    QueueId cq_id);
+    const OptionalTensors& optional_output_tensors);
 
 std::vector<Shape> extract_padded_shapes(
     const std::vector<ttnn::TensorSpec>& tensor_specs,
@@ -166,8 +160,7 @@ Tensors run_with_autoformat(
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& optional_output_tensors,
-    const float pad_value,
-    QueueId cq_id) {
+    const float pad_value) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     ZoneScoped;
     distributed::MeshDevice* device = detail::get_device(input_tensors, optional_input_tensors);
@@ -205,11 +198,7 @@ Tensors run_with_autoformat(
 
     auto output_specs = operation.compute_output_specs(input_tensors, optional_output_tensors);
     auto output_tensors = run<Tensors>(
-        std::move(operation),
-        formatted_input_tensors,
-        formatted_optional_input_tensors,
-        optional_output_tensors,
-        cq_id);
+        std::move(operation), formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors);
 
     auto padded_output_shapes = extract_padded_shapes(
         std::move(output_specs),
@@ -238,8 +227,7 @@ Tensors run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const OptionalConstTensors& optional_input_tensors,
     const std::vector<std::optional<FormatParams>>& optional_input_formatting,
-    const OptionalTensors& optional_output_tensors,
-    ttnn::QueueId cq_id) {
+    const OptionalTensors& optional_output_tensors {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     ZoneScoped;
     distributed::MeshDevice* device = detail::get_device(input_tensors, optional_input_tensors);
@@ -278,11 +266,7 @@ Tensors run_with_autoformat(
 
     auto output_specs = operation.compute_output_specs(input_tensors, optional_output_tensors);
     auto output_tensors = run<Tensors>(
-        std::move(operation),
-        formatted_input_tensors,
-        formatted_optional_input_tensors,
-        optional_output_tensors,
-        cq_id);
+        std::move(operation), formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors);
 
     auto legacy_output_shapes = extract_padded_shapes(
         std::move(output_specs),

--- a/ttnn/cpp/ttnn-pybind/decorators.hpp
+++ b/ttnn/cpp/ttnn-pybind/decorators.hpp
@@ -104,16 +104,6 @@ void def_call_operator(py_operation_t& py_operation, const pybind_overload_t<fun
         overload.args.value);
 }
 
-template <typename py_operation_t, typename function_t, typename... py_args_t>
-void def_primitive_operation_method(
-    py_operation_t& py_operation, const pybind_overload_t<function_t, py_args_t...>& overload, auto name, auto method) {
-    std::apply(
-        [&py_operation, &overload, &name, &method](auto... args) {
-            py_operation.def(name, resolve_primitive_operation_method(overload.function, method), args...);
-        },
-        overload.args.value);
-}
-
 template <reflect::fixed_string cpp_fully_qualified_name, typename operation_t, typename... overload_t>
 auto bind_registered_operation(
     py::module& module,

--- a/ttnn/cpp/ttnn-pybind/decorators.hpp
+++ b/ttnn/cpp/ttnn-pybind/decorators.hpp
@@ -47,8 +47,8 @@ constexpr auto resolve_primitive_operation_call_method(F) {
     using traits = function_traits<F>;
 
     return []<typename TSelf, typename... TArgs>(arg_traits<TSelf, TArgs...>) {
-        return [](TSelf self, TArgs... args, QueueId queue_id) ->
-               typename traits::return_t { return self(queue_id, static_cast<decltype(args)&&>(args)...); };
+        return [](TSelf self, TArgs... args) ->
+               typename traits::return_t { return self(static_cast<decltype(args)&&>(args)...); };
     }(typename traits::arg_tuple{});
 }
 
@@ -86,11 +86,7 @@ template <
 void def_call_operator(py_operation_t& py_operation, const pybind_overload_t<function_t, py_args_t...>& overload) {
     std::apply(
         [&py_operation, &overload](auto... args) {
-            py_operation.def(
-                "__call__",
-                resolve_primitive_operation_call_method(overload.function),
-                args...,
-                py::arg("queue_id") = DefaultQueueId);
+            py_operation.def("__call__", resolve_primitive_operation_call_method(overload.function), args...);
         },
         overload.args.value);
 }

--- a/ttnn/cpp/ttnn-pybind/operations/copy.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/copy.cpp
@@ -20,7 +20,7 @@ namespace {
 
 void bind_global_typecast(py::module& module) {
     auto doc = fmt::format(
-        R"doc({0}(input_tensor: ttnn.Tensor, dtype: ttnn.DataType, *, memory_config: Optional[ttnn.MemoryConfig] = None, output_tensor : Optional[ttnn.Tensor] = None, queue_id : Optional[int]) -> ttnn.Tensor
+        R"doc({0}(input_tensor: ttnn.Tensor, dtype: ttnn.DataType, *, memory_config: Optional[ttnn.MemoryConfig] = None, output_tensor : Optional[ttnn.Tensor] = None) -> ttnn.Tensor
 
 Applies {0} to :attr:`input_tensor`.
 
@@ -52,17 +52,15 @@ Example::
                const DataType dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const std::optional<CoreRangeSet>& sub_core_grids,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, dtype, memory_config, output_tensor, sub_core_grids);
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
+                return self(input_tensor, dtype, memory_config, output_tensor, sub_core_grids);
             },
             py::arg("input_tensor"),
             py::arg("dtype"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("sub_core_grids") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+            py::arg("sub_core_grids") = std::nullopt},
 
         ttnn::pybind_overload_t{
             [](const TypecastType& self,
@@ -71,10 +69,8 @@ Example::
                const DataType output_dtype,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<Tensor>& output_tensor,
-               const std::optional<CoreRangeSet>& sub_core_grids,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(
-                    queue_id, input_tensor, input_dtype, output_dtype, memory_config, output_tensor, sub_core_grids);
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
+                return self(input_tensor, input_dtype, output_dtype, memory_config, output_tensor, sub_core_grids);
             },
             py::arg("input_tensor"),
             py::arg("input_dtype"),
@@ -82,11 +78,7 @@ Example::
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("sub_core_grids") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId}
-
-    );
-}
+            py::arg("sub_core_grids") = std::nullopt});
 
 }  // namespace
 

--- a/ttnn/cpp/ttnn-pybind/operations/copy.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/copy.cpp
@@ -16,8 +16,6 @@
 
 namespace ttnn::operations::copy {
 
-namespace {
-
 void bind_global_typecast(py::module& module) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor: ttnn.Tensor, dtype: ttnn.DataType, *, memory_config: Optional[ttnn.MemoryConfig] = None, output_tensor : Optional[ttnn.Tensor] = None) -> ttnn.Tensor
@@ -79,8 +77,7 @@ Example::
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt});
-
-}  // namespace
+}
 
 void py_module(py::module& module) { bind_global_typecast(module); }
 

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -87,12 +87,11 @@ void py_module(py::module& module) {
 
     module.def(
         "to_device",
-        py::overload_cast<const ttnn::Tensor&, MeshDevice*, const std::optional<MemoryConfig>&, QueueId>(
+        py::overload_cast<const ttnn::Tensor&, MeshDevice*, const std::optional<MemoryConfig>&>(
             &ttnn::operations::core::to_device),
         py::arg("tensor"),
         py::arg("device"),
         py::arg("memory_config") = std::nullopt,
-        py::arg("cq_id") = ttnn::DefaultQueueId,
         R"doc(
             Copy tensor from host to device.
 
@@ -100,7 +99,6 @@ void py_module(py::module& module) {
                 tensor (ttnn.Tensor): The tensor to be copied from host to device.
                 device (ttnn.Device | ttnn.MeshDevice): The target device where the tensor will be copied.
                 memory_config (ttnn.MemoryConfig, optional): The memory configuration to use. Defaults to `None`.
-                cq_id (int, optional): The command queue ID to use. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: The device tensor copy.
@@ -117,17 +115,12 @@ void py_module(py::module& module) {
         &ttnn::operations::core::from_device,
         py::arg("tensor"),
         py::arg("blocking") = true,
-        py::kw_only(),
-        py::arg("cq_id") = ttnn::DefaultQueueId,
         R"doc(
             Copy tensor from device to host.
 
             Args:
                 tensor (ttnn.Tensor): the tensor to be copied from device to host.
                 blocking (bool, optional): whether the operation should be blocked until the copy is complete. Defaults to `True`.
-
-            Keyword args:
-                cq_id (int, optional): the command queue ID to use. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the host tensor copy.

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -14,6 +14,7 @@
 #include "ttnn-pybind/decorators.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::core {

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -19,7 +19,7 @@
 namespace ttnn::operations::core {
 
 void py_module_types(py::module& module) {
-    py::enum_<ttnn::operations::compute_throttle_utils::ThrottleLevel>(module, "ThrottleLevel", R"doc(
+    py::enum_<compute_throttle_utils::ThrottleLevel>(module, "ThrottleLevel", R"doc(
         Enum for controlling compute throttling.
 
         Higher levels insert NOP instructions to reduce compute throughput:
@@ -31,12 +31,12 @@ void py_module_types(py::module& module) {
 
         Used to prevent di/dt (power supply current) issues on large core counts.
     )doc")
-        .value("NO_THROTTLE", ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE)
-        .value("LEVEL_1", ttnn::operations::compute_throttle_utils::ThrottleLevel::LEVEL_1)
-        .value("LEVEL_2", ttnn::operations::compute_throttle_utils::ThrottleLevel::LEVEL_2)
-        .value("LEVEL_3", ttnn::operations::compute_throttle_utils::ThrottleLevel::LEVEL_3)
-        .value("LEVEL_4", ttnn::operations::compute_throttle_utils::ThrottleLevel::LEVEL_4)
-        .value("LEVEL_5", ttnn::operations::compute_throttle_utils::ThrottleLevel::LEVEL_5);
+        .value("NO_THROTTLE", compute_throttle_utils::ThrottleLevel::NO_THROTTLE)
+        .value("LEVEL_1", compute_throttle_utils::ThrottleLevel::LEVEL_1)
+        .value("LEVEL_2", compute_throttle_utils::ThrottleLevel::LEVEL_2)
+        .value("LEVEL_3", compute_throttle_utils::ThrottleLevel::LEVEL_3)
+        .value("LEVEL_4", compute_throttle_utils::ThrottleLevel::LEVEL_4)
+        .value("LEVEL_5", compute_throttle_utils::ThrottleLevel::LEVEL_5);
 
     py::class_<DeviceComputeKernelConfig>(module, "DeviceComputeKernelConfig");
 
@@ -60,7 +60,7 @@ void py_module_types(py::module& module) {
             py::arg("fp32_dest_acc_en") = false,
             py::arg("packer_l1_acc") = false,
             py::arg("dst_full_sync_en") = false,
-            py::arg("throttle_level") = ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE)
+            py::arg("throttle_level") = compute_throttle_utils::ThrottleLevel::NO_THROTTLE)
         .def_readwrite("math_fidelity", &WormholeComputeKernelConfig::math_fidelity)
         .def_readwrite("math_approx_mode", &WormholeComputeKernelConfig::math_approx_mode)
         .def_readwrite("fp32_dest_acc_en", &WormholeComputeKernelConfig::fp32_dest_acc_en)

--- a/ttnn/cpp/ttnn-pybind/operations/core.hpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.hpp
@@ -10,6 +10,5 @@ namespace ttnn::operations::core {
 
 namespace py = pybind11;
 void py_module_types(py::module& module);
-;
 void py_module(py::module& module);
 }  // namespace ttnn::operations::core

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -32,10 +32,8 @@ auto create_pybind_full_overload() {
            const std::optional<Layout>& layout,
            const std::optional<std::reference_wrapper<MeshDevice>> device,
            const std::optional<MemoryConfig>& memory_config,
-           std::optional<ttnn::Tensor>& optional_output_tensor,
-           QueueId queue_id) -> ttnn::Tensor {
-            return self(
-                queue_id, ttnn::Shape(shape), fill_value, dtype, layout, device, memory_config, optional_output_tensor);
+           std::optional<ttnn::Tensor>& optional_output_tensor) -> ttnn::Tensor {
+            return self(ttnn::Shape(shape), fill_value, dtype, layout, device, memory_config, optional_output_tensor);
         },
         py::arg("shape"),
         py::arg("fill_value"),
@@ -43,8 +41,7 @@ auto create_pybind_full_overload() {
         py::arg("layout") = std::nullopt,
         py::arg("device") = std::nullopt,
         py::arg("memory_config") = std::nullopt,
-        py::arg("optional_tensor") = std::nullopt,
-        py::arg("queue_id") = ttnn::DefaultQueueId};
+        py::arg("optional_tensor") = std::nullopt};
 }
 
 template <typename creation_operation_t, typename fill_value_t>
@@ -57,9 +54,8 @@ auto create_pybind_full_like_overload() {
            const std::optional<Layout>& layout,
            const std::optional<std::reference_wrapper<MeshDevice>> device,
            const std::optional<MemoryConfig>& memory_config,
-           std::optional<ttnn::Tensor>& optional_output_tensor,
-           QueueId queue_id) -> ttnn::Tensor {
-            return self(queue_id, tensor, fill_value, dtype, layout, device, memory_config, optional_output_tensor);
+           std::optional<ttnn::Tensor>& optional_output_tensor) -> ttnn::Tensor {
+            return self(tensor, fill_value, dtype, layout, device, memory_config, optional_output_tensor);
         },
         py::arg("tensor"),
         py::arg("fill_value"),
@@ -67,8 +63,7 @@ auto create_pybind_full_like_overload() {
         py::arg("layout") = std::nullopt,
         py::arg("device") = std::nullopt,
         py::arg("memory_config") = std::nullopt,
-        py::arg("optional_tensor") = std::nullopt,
-        py::arg("queue_id") = ttnn::DefaultQueueId};
+        py::arg("optional_tensor") = std::nullopt};
 }
 
 template <typename creation_operation_t>
@@ -144,7 +139,6 @@ void bind_full_operation(py::module& module, const creation_operation_t& operati
             device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Note:
             ROW_MAJOR_LAYOUT requires last dimension (shape[-1]) to be a multiple of 2 with dtype BFLOAT16 or UINT16.
@@ -242,7 +236,6 @@ void bind_full_like_operation(py::module& module, const creation_operation_t& op
             device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: A filled tensor.
@@ -281,7 +274,6 @@ void bind_full_like_operation_with_hard_coded_value(
             device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: A tensor filled with {1}.
@@ -313,17 +305,15 @@ void bind_full_like_operation_with_hard_coded_value(
                const std::optional<Layout>& layout,
                const std::optional<std::reference_wrapper<MeshDevice>> device,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor>& optional_output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, tensor, dtype, layout, device, memory_config, optional_output_tensor);
+               std::optional<ttnn::Tensor>& optional_output_tensor) -> ttnn::Tensor {
+                return self(tensor, dtype, layout, device, memory_config, optional_output_tensor);
             },
             py::arg("tensor"),
             py::arg("dtype") = std::nullopt,
             py::arg("layout") = std::nullopt,
             py::arg("device") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("optional_tensor") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+            py::arg("optional_tensor") = std::nullopt});
 }
 
 template <typename creation_operation_t>

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
-
 #include <tt-metalium/constants.hpp>
 
 #include "all_to_all_combine.hpp"
@@ -17,7 +15,6 @@
 namespace ttnn::operations::ccl {
 
 ttnn::Tensor ExecuteAllToAllCombine::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& expert_mapping_tensor,
     const ttnn::Tensor& expert_metadata_tensor,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.hpp
@@ -14,7 +14,6 @@ namespace operations::ccl {
 
 struct ExecuteAllToAllCombine {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& expert_mapping_tensor,
         const ttnn::Tensor& expert_metadata_tensor,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine_pybind.cpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::ccl {
 
 void py_bind_all_to_all_combine(py::module& module) {
     auto doc =
-        R"doc(all_to_all_combine(input_tensor: ttnn.Tensor, expert_indices_tensor: ttnn.Tensor, expert_mapping_tensor: ttnn.Tensor, local_reduce: bool = false, num_links: Optional[int] = 1, topology: Optional[ttnn.Topology] = std::nullopt, memory_config: Optional[ttnn.MemoryConfig] = std::nullopt, axis: Optional[int] = std::nullopt, subdevice_id: Optional[ttnn.SubDeviceId] = std::nullopt, optional_output_tensor: Optional[ttnn.Tensor] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+        R"doc(all_to_all_combine(input_tensor: ttnn.Tensor, expert_indices_tensor: ttnn.Tensor, expert_mapping_tensor: ttnn.Tensor, local_reduce: bool = false, num_links: Optional[int] = 1, topology: Optional[ttnn.Topology] = std::nullopt, memory_config: Optional[ttnn.MemoryConfig] = std::nullopt, axis: Optional[int] = std::nullopt, subdevice_id: Optional[ttnn.SubDeviceId] = std::nullopt, optional_output_tensor: Optional[ttnn.Tensor] = std::nullopt)) -> ttnn.Tensor
 
             All to all combine operation for combining the output tokens from the experts, based on the expert indices and expert mapping tensors. If cluster axis is specified then we combine the tokens only on that axis.
             B = batch size
@@ -45,7 +45,6 @@ void py_bind_all_to_all_combine(py::module& module) {
                 axis (int, optional): the cluster axis to combine along. Defaults to `None` though we assert out when it is not specified.
                 subdevice_id (ttnn.SubDeviceId, optional): the subdevice id for the subdevice on which we allocate the worker cores. Defaults to `None`.
                 optional_output_tensor (ttnn.Tensor, optional): the optional output tensor to use for the combined tokens. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: The combined tokens tensor. The tensor is expected to be [K, B, S, H] ([K, B/D[A], S, H] per device) where each row is either a token if that token was dispatched to that device, or a placeholder row if that token was not dispatched to that device. The tensor is expected to be in Row Major, Interleaved format.
@@ -60,8 +59,7 @@ void py_bind_all_to_all_combine(py::module& module) {
                                         topology=topology,
                                         memory_config=output_memory_config,
                                         local_reduce=local_reduce,
-                                        axis=axis,
-                                        queue_id=queue_id)
+                                        axis=axis)
             )doc";
 
     using OperationType = decltype(ttnn::all_to_all_combine);
@@ -80,10 +78,8 @@ void py_bind_all_to_all_combine(py::module& module) {
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<uint32_t>& axis,
                const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
-               const std::optional<ttnn::Tensor>& optional_output_tensor,
-               QueueId queue_id) {
+               const std::optional<ttnn::Tensor>& optional_output_tensor) {
                 return self(
-                    queue_id,
                     input_tensor,
                     expert_mapping_tensor,
                     expert_metadata_tensor,
@@ -105,9 +101,7 @@ void py_bind_all_to_all_combine(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("axis") = std::nullopt,
             py::arg("subdevice_id") = std::nullopt,
-            py::arg("optional_output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("optional_output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
-
 #include <tt-metalium/constants.hpp>
 
 #include "all_to_all_dispatch.hpp"
@@ -18,7 +16,6 @@
 namespace ttnn::operations::ccl {
 
 std::array<ttnn::Tensor, 2> ExecuteAllToAllDispatch::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& expert_indices_tensor,
     const ttnn::Tensor& expert_mapping_tensor,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.hpp
@@ -13,7 +13,6 @@ namespace operations::ccl {
 
 struct ExecuteAllToAllDispatch {
     static std::array<ttnn::Tensor, 2> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& expert_indices_tensor,
         const ttnn::Tensor& expert_mapping_tensor,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_pybind.cpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::ccl {
 
 void py_bind_all_to_all_dispatch(py::module& module) {
     auto doc =
-        R"doc(all_to_all_dispatch(input_tensor: ttnn.Tensor, expert_indices_tensor: ttnn.Tensor, expert_mapping_tensor: ttnn.Tensor, num_links: int = 1, topology: ttnn.Topology = ttnn.Topology.Linear, memory_config: Optional[ttnn.MemoryConfig] = std::nullopt, subdevice_id: Optional[ttnn.SubDeviceId] = std::nullopt, queue_id: int = 0) -> Tuple[ttnn.Tensor, ttnn.Tensor]
+        R"doc(all_to_all_dispatch(input_tensor: ttnn.Tensor, expert_indices_tensor: ttnn.Tensor, expert_mapping_tensor: ttnn.Tensor, num_links: int = 1, topology: ttnn.Topology = ttnn.Topology.Linear, memory_config: Optional[ttnn.MemoryConfig] = std::nullopt, subdevice_id: Optional[ttnn.SubDeviceId] = std::nullopt)) -> Tuple[ttnn.Tensor, ttnn.Tensor]
 
             All to all dispatch operation for dispatching the input tokens to devices with the selected experts, based on the expert indices and expert mapping tensors. If cluster axis is specified then we dispatch the tokens to the experts only on that axis.
             B = batch size
@@ -44,7 +44,6 @@ void py_bind_all_to_all_dispatch(py::module& module) {
                 topology (ttnn.Topology, optional): the topology to use when dispatching the tokens. Defaults to what the mesh topology is initialized with. CAREFUL: no guarantees that the topology is valid for the given Fabric Init unless it matches the topology of the mesh.
                 memory_config (ttnn.MemoryConfig, optional): Output memory configuration for the output tensors. Defaults to `None`.
                 subdevice_id (ttnn.SubDeviceId, optional): the subdevice id for the subdevice on which we allocate the worker cores. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
            Returns:
                Tuple[ttnn.Tensor, ttnn.Tensor]: The sparse output tokens tensor and the metadata tensor. The output tensor on each device is sparsely populated with all the tokens that are dispatched to that device. The non-dispatched tokens have placeholder rows populated with garbage. The metadata tensor is used to track the expert indices.
@@ -62,8 +61,7 @@ void py_bind_all_to_all_dispatch(py::module& module) {
                                 num_links=num_links,
                                 topology=topology,
                                 memory_config=memory_config,
-                                subdevice_id=subdevice_id,
-                                queue_id=queue_id))doc";
+                                subdevice_id=subdevice_id)doc";
 
     using OperationType = decltype(ttnn::all_to_all_dispatch);
     ttnn::bind_registered_operation(
@@ -80,10 +78,8 @@ void py_bind_all_to_all_dispatch(py::module& module) {
                const std::optional<uint32_t> num_links,
                const std::optional<tt::tt_fabric::Topology> topology,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
-               QueueId queue_id) {
+               const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id) {
                 return self(
-                    queue_id,
                     input_tensor,
                     expert_indices_tensor,
                     expert_mapping_tensor,
@@ -103,9 +99,7 @@ void py_bind_all_to_all_dispatch(py::module& module) {
             py::arg("num_links") = 1,
             py::arg("topology") = tt::tt_fabric::Topology::Linear,
             py::arg("memory_config") = std::nullopt,
-            py::arg("subdevice_id") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("subdevice_id") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/barrier_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/barrier_pybind.cpp
@@ -41,7 +41,6 @@ void py_bind_barrier(pybind11::module& module) {
         module,
         ttnn::barrier,
         R"doc(
-
         Performs a barrier operation among all the devices covered in the input multi-device tensor to reduce skew between chips upon completion of the operation
 
         Args:

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
-
 #include <tt-metalium/constants.hpp>
 
 #include "mesh_partition.hpp"
@@ -15,7 +13,6 @@
 namespace ttnn::operations::ccl {
 
 ttnn::Tensor ExecuteMeshPartition::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     int32_t dim,
     std::optional<uint32_t> cluster_axis,

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition.hpp
@@ -14,7 +14,6 @@ namespace operations::ccl {
 
 struct ExecuteMeshPartition {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         int32_t dim,
         std::optional<uint32_t> cluster_axis,

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.cpp
@@ -14,7 +14,7 @@ namespace ttnn::operations::ccl {
 
 void py_bind_mesh_partition(py::module& module) {
     auto doc =
-        R"doc(mesh_partition(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+        R"doc(mesh_partition(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt)) -> ttnn.Tensor
 
             Partitions the input tensor across the mesh such that each device has the i/num_devices-th partition of the input tensor along the specified dimension. This is the inverse of all_gather
 
@@ -25,7 +25,6 @@ void py_bind_mesh_partition(py::module& module) {
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
            Returns:
                ttnn.Tensor: the output tensor.
@@ -48,16 +47,14 @@ void py_bind_mesh_partition(py::module& module) {
                const ttnn::Tensor& input_tensor,
                int32_t dim,
                std::optional<uint32_t> cluster_axis,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, input_tensor, dim, cluster_axis, memory_config); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, dim, cluster_axis, memory_config);
+            },
             py::arg("input_tensor").noconvert(),
             py::arg("dim"),
             py::arg("cluster_axis") = std::nullopt,
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-
-        });
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
@@ -36,7 +36,6 @@ using sliding_window::SlidingWindowConfig;
 namespace conv1d {
 
 Result conv1d(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -79,7 +78,6 @@ Result conv1d(
 
     auto [output_tensor, output_dimensions, weights_and_bias] =
         std::get<static_cast<int>(ResultType::OUTPUT_DIM_WEIGHTS_AND_BIAS)>(ttnn::conv2d(
-            queue_id,
             input_tensor_4d,
             weight_tensor,
             device,
@@ -113,7 +111,6 @@ Result conv1d(
     };
 }
 Result Conv1dOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -134,7 +131,6 @@ Result Conv1dOperation::invoke(
     bool return_output_dim,
     bool return_weights_and_bias) {
     return conv1d(
-        queue_id,
         input_tensor,
         weight_tensor,
         device,

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
@@ -29,7 +29,6 @@ using Result = std::variant<
 using Conv1dConfig = ttnn::operations::conv::conv2d::Conv2dConfig;
 
 Result conv1d(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -55,7 +54,6 @@ Result conv1d(
 // The input and weight tensors are reshaped to 4D tensors before invoking the Conv2dOperation.
 struct Conv1dOperation {
     static Result invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         MeshDevice* device,

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_pybind.cpp
@@ -74,10 +74,8 @@ void py_bind_conv1d(py::module& module) {
                const std::optional<const DeviceComputeKernelConfig>& compute_config,
                const std::optional<const MemoryConfig>& memory_config,
                bool return_output_dim,
-               bool return_weights_and_bias,
-               QueueId queue_id) -> Result {
+               bool return_weights_and_bias) -> Result {
                 return self(
-                    queue_id,
                     input_tensor,
                     weight_tensor,
                     device,
@@ -117,7 +115,6 @@ void py_bind_conv1d(py::module& module) {
             py::arg("compute_config") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("return_output_dim") = false,
-            py::arg("return_weights_and_bias") = false,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("return_weights_and_bias") = false});
 }
 }  // namespace ttnn::operations::conv::conv1d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -33,7 +33,6 @@ using ResultWithOptions = std::variant<
         std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>>;
 
 Result conv2d_L1(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -54,7 +53,6 @@ Result conv2d_L1(
     const std::optional<const MemoryConfig>& memory_config = std::nullopt);
 
 Result conv2d_DRAM(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -77,7 +75,6 @@ Result conv2d_DRAM(
         .slice_type = Conv2dSliceConfig::SliceType::WIDTH, .num_slices = 0});
 
 ResultWithOptions conv2d(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -102,7 +99,6 @@ ResultWithOptions conv2d(
 
 struct Conv2dOperation {
     static ResultWithOptions invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         MeshDevice* device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -84,10 +84,8 @@ void py_bind_conv2d(py::module& module) {
                const std::optional<const MemoryConfig>& memory_config,
                const std::optional<const Conv2dSliceConfig>& slice_config_,
                bool return_output_dim,
-               bool return_weights_and_bias,
-               QueueId queue_id) -> ResultWithOptions {
+               bool return_weights_and_bias) -> ResultWithOptions {
                 return self(
-                    queue_id,
                     input_tensor,
                     weight_tensor,
                     device,
@@ -131,8 +129,7 @@ void py_bind_conv2d(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("slice_config") = std::nullopt,
             py::arg("return_output_dim") = false,
-            py::arg("return_weights_and_bias") = false,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("return_weights_and_bias") = false});
     module.def(
         "prepare_conv_weights",
         prepare_conv_weights,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -159,7 +159,6 @@ Result conv_transpose2d(
         sliding_window_config.snap_to_tile = true;
 
         halo_output = ttnn::halo(
-            DefaultQueueId,
             input_tensor_post_tm,
             sliding_window_config,
             0,
@@ -312,7 +311,6 @@ Result conv_transpose2d(
 }
 
 Result ConvTranpose2dOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
@@ -26,7 +26,6 @@ using Result = std::variant<
 
 struct ConvTranpose2dOperation {
     static Result invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         IDevice* device,
@@ -51,7 +50,6 @@ struct ConvTranpose2dOperation {
         bool return_weights_and_bias = false);
 
     static Result invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         MeshDevice* device,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
@@ -67,7 +67,6 @@ void py_bind_conv_transpose2d(py::module& module) {
         :param ttnn.Conv2dConfig, None conv_config: configuration for convolution. Default: None
         :param ttnn.DeviceComputeKernelConfig, None compute_config: configuration for compute kernel. Default: None
         :param bool mirror_kernel: Determines if the op should mirror the kernel internally. Should be set to True if the kernel has already been mirrored.
-        :param int queue_id: the queue id to use for the operation. Default: `0`.
         :param bool return_output_dim:  If true, the op also returns the height and width of the output tensor in [N, H, W, C] format,
         :param bool return_weights_and_bias:  If true, the op also returns the preprocessed weight and bias on device .
 
@@ -102,10 +101,8 @@ void py_bind_conv_transpose2d(py::module& module) {
                const std::optional<const MemoryConfig>& memory_config,
                bool mirror_kernel,
                const bool return_output_dim,
-               const bool return_weights_and_bias,
-               QueueId queue_id) -> Result {
+               const bool return_weights_and_bias) -> Result {
                 return self(
-                    queue_id,
                     input_tensor,
                     weight_tensor,
                     device,
@@ -151,8 +148,7 @@ void py_bind_conv_transpose2d(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("mirror_kernel") = true,
             py::arg("return_output_dim") = false,
-            py::arg("return_weights_and_bias") = false,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("return_weights_and_bias") = false});
 
     module.def(
         "prepare_conv_transpose2d_weights",

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
@@ -13,7 +13,6 @@ namespace copy {
 namespace detail {
 
 inline Tensor typecast_impl(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const DataType& output_dtype,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -30,7 +29,6 @@ inline Tensor typecast_impl(
                                     ? optional_output_tensor.value().memory_config()
                                     : memory_config.value_or(input_tensor.memory_config());
     return ttnn::prim::typecast(
-        queue_id,
         input_tensor,
         output_dtype,
         output_memory_config,
@@ -43,7 +41,6 @@ inline Tensor typecast_impl(
 }  // namespace detail
 
 Tensor Typecast::invoke(
-    const QueueId queue_id,
     const Tensor& input,
     const DataType& output_dtype,
     const std::optional<MemoryConfig>& memory_config_arg,
@@ -55,13 +52,11 @@ Tensor Typecast::invoke(
             "If both output dtype and output tensor provided dtype should match");
     }
 
-    return detail::typecast_impl(
-        queue_id, input, output_dtype, memory_config_arg, optional_output_tensor, sub_core_grids);
+    return detail::typecast_impl(input, output_dtype, memory_config_arg, optional_output_tensor, sub_core_grids);
 }
 
 // eltwise_typecast is not currently supported on Grayskull
 Tensor Typecast::invoke(
-    const QueueId queue_id,
     const Tensor& input_tensor,
     const DataType& tt_input_dtype,
     const DataType& tt_output_dtype,
@@ -74,8 +69,7 @@ Tensor Typecast::invoke(
             tt_output_dtype == optional_output_tensor.value().dtype(),
             "If both output dtype and output tensor provided dtype should match");
     }
-    return detail::typecast_impl(
-        queue_id, input_tensor, tt_output_dtype, memory_config, optional_output_tensor, sub_core_grids);
+    return detail::typecast_impl(input_tensor, tt_output_dtype, memory_config, optional_output_tensor, sub_core_grids);
 }
 
 }  // namespace copy

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.hpp
@@ -12,7 +12,6 @@ namespace copy {
 
 struct Typecast {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const DataType& output_dtype,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
@@ -20,7 +19,6 @@ struct Typecast {
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const DataType& tt_input_dtype,
         const DataType& tt_output_dtype,

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -44,17 +44,12 @@ ttnn::Tensor squeeze_from_4D(const ttnn::Tensor& tensor, const int rank) {
 }
 
 ttnn::Tensor to_device(
-    const ttnn::Tensor& tensor,
-    MeshDevice* mesh_device,
-    const std::optional<MemoryConfig>& memory_config,
-    QueueId cq_id) {
+    const ttnn::Tensor& tensor, MeshDevice* mesh_device, const std::optional<MemoryConfig>& memory_config) {
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
-    return tensor.to_device(mesh_device, mem_config, cq_id);
+    return tensor.to_device(mesh_device, mem_config);
 }
 
-ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking, QueueId cq_id) {
-    return tensor.cpu(blocking, cq_id);
-}
+ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking) { return tensor.cpu(blocking); }
 
 void deallocate(Tensor& tensor, bool force) { tensor.deallocate(force); }
 

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -25,12 +25,9 @@ ttnn::Tensor unsqueeze_to_4D(const ttnn::Tensor& tensor);
 ttnn::Tensor squeeze_from_4D(const ttnn::Tensor& tensor, int rank);
 
 ttnn::Tensor to_device(
-    const ttnn::Tensor& tensor,
-    MeshDevice* mesh_device,
-    const std::optional<MemoryConfig>& memory_config,
-    ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+    const ttnn::Tensor& tensor, MeshDevice* mesh_device, const std::optional<MemoryConfig>& memory_config);
 
-ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true, ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true);
 
 void deallocate(Tensor& tensor, bool force = true);
 

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -233,16 +233,6 @@ struct FullLikeWith {
         std::optional<Tensor> optional_output_tensor = std::nullopt) {
         return full_like_impl(tensor, fill_value, dtype, layout, device, memory_config, optional_output_tensor);
     }
-
-    static Tensor invoke(
-        const Tensor& tensor,
-        const std::optional<DataType>& dtype = std::nullopt,
-        const std::optional<Layout>& layout = std::nullopt,
-        std::optional<std::reference_wrapper<MeshDevice>> device = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt) {
-        return full_like_impl(tensor, fill_value, dtype, layout, device, memory_config, optional_output_tensor);
-    }
 };
 
 struct ZerosLike : FullLikeWith<0.0f> {};
@@ -319,42 +309,9 @@ struct Full {
             memory_config,
             optional_output_tensor);
     }
-
-    template <typename FillValueType>
-        requires std::is_same_v<FillValueType, int> or std::is_same_v<FillValueType, float>
-    static Tensor invoke(
-        const ttnn::Shape& shape,
-        const FillValueType fill_value,
-        const std::optional<DataType>& dtype = std::nullopt,
-        const std::optional<Layout>& layout = std::nullopt,
-        std::optional<std::reference_wrapper<MeshDevice>> device = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt) {
-        return full_impl(
-            shape,
-            fill_value,
-            dtype,
-            layout,
-            device.has_value() ? &device->get() : nullptr,
-            memory_config,
-            optional_output_tensor);
-    }
 };
 
 struct FullLike {
-    template <typename FillValueType>
-        requires std::is_same_v<FillValueType, int> or std::is_same_v<FillValueType, float>
-    static Tensor invoke(
-        const Tensor& tensor,
-        const FillValueType fill_value,
-        const std::optional<DataType>& dtype = std::nullopt,
-        const std::optional<Layout>& layout = std::nullopt,
-        std::optional<std::reference_wrapper<MeshDevice>> device = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt) {
-        return full_like_impl(tensor, fill_value, dtype, layout, device, memory_config, optional_output_tensor);
-    }
-
     template <typename FillValueType>
         requires std::is_same_v<FillValueType, int> or std::is_same_v<FillValueType, float>
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -12,7 +12,6 @@ namespace ttnn::operations::data_movement {
 
 // Does a broadcast
 Tensor BcastOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     BcastOpMath bcast_op,
@@ -61,8 +60,7 @@ Tensor BcastOperation::invoke(
                {input_tensor_a, input_tensor_b},
                {},
                {output_tensor},
-               0, /* pad_value*/
-               queue_id)
+               0 /* pad_value*/)
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/run_operation.hpp"
 
 namespace ttnn::operations::data_movement {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.hpp
@@ -12,7 +12,6 @@ namespace operations::data_movement {
 
 struct BcastOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         ttnn::BcastOpMath bcast_op,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast_pybind.cpp
@@ -38,7 +38,6 @@ void py_bind_bcast(py::module& module) {
                 "dim", "Dimension on which to broadcast", "BcastOpDim", "W, H, HW", "Yes"
                 "memory_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "Optional preallocated output tensor", "Tensor", "Default is None", "No"
-                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
 
             Args:
                 * :attr:`input_tensor_a`: First Input Tensor for bcast.
@@ -64,10 +63,8 @@ void py_bind_bcast(py::module& module) {
                ttnn::BcastOpMath bcast_op,
                ttnn::BcastOpDim bcast_dim,
                std::optional<Tensor> output_tensor,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) {
-                return self(
-                    queue_id, input_tensor_a, input_tensor_b, bcast_op, bcast_dim, memory_config, output_tensor);
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor_a, input_tensor_b, bcast_op, bcast_dim, memory_config, output_tensor);
             },
             py::arg("input_a").noconvert(),
             py::arg("input_b").noconvert(),
@@ -75,8 +72,7 @@ void py_bind_bcast(py::module& module) {
             py::arg("dim"),
             py::kw_only(),
             py::arg("output_tensor") = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -496,7 +496,6 @@ bool is_enough_space(
 }
 
 ttnn::Tensor pad_to_tile_vol(
-    QueueId queue_id,
     const ttnn::Tensor& tensor,
     const float value,
     const bool use_multicore,
@@ -515,7 +514,7 @@ ttnn::Tensor pad_to_tile_vol(
         padding_vec.emplace_back(0, padded_height - padded_shape[-2]);
         padding_vec.emplace_back(0, padded_width - padded_shape[-1]);
 
-        auto padded_output = ttnn::pad(queue_id, tensor, padding_vec, value, use_multicore, memory_config);
+        auto padded_output = ttnn::pad(tensor, padding_vec, value, use_multicore, memory_config);
         TT_FATAL(
             padded_output.padded_shape()[-1] % tt::constants::TILE_WIDTH == 0 &&
                 padded_output.padded_shape()[-2] % tt::constants::TILE_HEIGHT == 0,

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
@@ -61,11 +61,7 @@ bool is_enough_space(
     uint32_t num_tiles_per_row);
 
 ttnn::Tensor pad_to_tile_vol(
-    QueueId queue_id,
-    const ttnn::Tensor& tensor,
-    float value,
-    bool use_multicore,
-    const std::optional<MemoryConfig>& memory_config);
+    const ttnn::Tensor& tensor, float value, bool use_multicore, const std::optional<MemoryConfig>& memory_config);
 
 uint32_t wrap_index(int index, int size);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -91,7 +90,7 @@ MassagedConcat build_unsqueeze_concat(int input_rank, const MemoryConfig& output
 }
 
 MassagedConcat build_untilize_rm_retilize_concat(
-    QueueId queue_id, const MemoryConfig& output_memory_config, ttnn::Shape& logical_output_shape) {
+    const MemoryConfig& output_memory_config, ttnn::Shape& logical_output_shape) {
     return MassagedConcat(MassagedConcatParams{
         .predicate = [](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> bool {
             // untilize_rm_retilize if the concat dim is padded for tilized tensors
@@ -102,9 +101,8 @@ MassagedConcat build_untilize_rm_retilize_concat(
             concat_db_print(res, "untilize_rm_retilize required");
             return res;
         },
-        .pre_transform =
-            [queue_id, output_memory_config](
-                const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> OwnedConcatArgs {
+        .pre_transform = [output_memory_config](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups)
+            -> OwnedConcatArgs {
             std::vector<ttnn::Tensor> itensors;
             itensors.reserve(tensors.size());
             std::transform(
@@ -118,11 +116,11 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     ttnn::SmallVector<uint32_t> ends(
                         input_tensor.logical_shape().cbegin(), input_tensor.logical_shape().cend());
                     std::transform(ends.begin(), ends.end(), ends.begin(), [](const auto l) { return l - 1; });
-                    return ttnn::untilize_with_unpadding(queue_id, input_tensor, ttnn::Shape(ends), std::nullopt);
+                    return ttnn::untilize_with_unpadding(input_tensor, ttnn::Shape(ends), std::nullopt);
                 });
             return std::make_tuple(itensors, dim, groups);
         },
-        .post_transform = [&logical_output_shape, queue_id](const ttnn::Tensor& output) -> ttnn::Tensor {
+        .post_transform = [&logical_output_shape](const ttnn::Tensor& output) -> ttnn::Tensor {
             // now we have a rm tensor, so we need to re-tilize it
             if (output.layout() != ttnn::TILE_LAYOUT) {
                 return ttnn::tilize_with_val_padding(
@@ -139,8 +137,7 @@ MassagedConcat build_untilize_rm_retilize_concat(
         }});
 }
 
-MassagedConcat build_prepost_transpose_concat(
-    QueueId queue_id, const MemoryConfig& output_memory_config, int dim1, int dim2) {
+MassagedConcat build_prepost_transpose_concat(const MemoryConfig& output_memory_config, int dim1, int dim2) {
     return MassagedConcat(MassagedConcatParams{
         .predicate = [dim1, dim2](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> bool {
             bool res = dim1 != dim2;
@@ -183,7 +180,7 @@ MassagedConcat build_prepost_transpose_concat(
 }
 
 MassagedConcat build_non_aligned_last_dim_concat(
-    const std::vector<ttnn::Tensor>& tensors, QueueId queue_id, const MemoryConfig& output_memory_config) {
+    const std::vector<ttnn::Tensor>& tensors, const MemoryConfig& output_memory_config) {
     // this is a special case of pre-post transpose concat where we're
     // concatting on the last dim and the last dims of the input tensors are
     // not all aligned
@@ -210,14 +207,13 @@ MassagedConcat build_non_aligned_last_dim_concat(
         return false;
     };
 
-    auto transpose_concat = build_prepost_transpose_concat(queue_id, output_memory_config, -2, -1);
+    auto transpose_concat = build_prepost_transpose_concat(output_memory_config, -2, -1);
     transpose_concat.set_predicate(predicate);
     return transpose_concat;
 }
 
 // Wrapper for TTDNN
 ttnn::Tensor ConcatOperation::invoke(
-    QueueId queue_id,
     const std::vector<ttnn::Tensor>& input_tensors,
     int dim,
     const std::optional<MemoryConfig>& memory_config,
@@ -285,8 +281,8 @@ ttnn::Tensor ConcatOperation::invoke(
 
     ttnn::Shape logical_output_shape = compute_output_shape(input_tensors, dim);
 
-    auto untilize_rm_retilize_concat = build_untilize_rm_retilize_concat(queue_id, mem_config, logical_output_shape);
-    auto non_aligned_last_dim_concat = build_non_aligned_last_dim_concat(input_tensors, queue_id, mem_config);
+    auto untilize_rm_retilize_concat = build_untilize_rm_retilize_concat(mem_config, logical_output_shape);
+    auto non_aligned_last_dim_concat = build_non_aligned_last_dim_concat(input_tensors, mem_config);
     auto massaged_concat = untilize_rm_retilize_concat.sequence(non_aligned_last_dim_concat);
 
     const std::vector<ttnn::Tensor>& itensors(input_tensors);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
@@ -16,7 +16,6 @@ namespace data_movement {
 struct ConcatOperation {
     // Wrapper for TTDNN
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const std::vector<ttnn::Tensor>& input_tensors,
         int dim,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat_pybind.cpp
@@ -23,7 +23,6 @@ Args:
 
 Keyword Args:
     memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-    queue_id (int, optional): command queue id. Defaults to `0`.
     output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
     groups (int, optional): When `groups` is set to a value greater than 1, the inputs are split into N `groups` partitions, and elements are interleaved from each group into the output tensor. Each group is processed independently, and elements from each group are concatenated in an alternating pattern based on the number of groups. This is useful for recombining grouped convolution outputs during residual concatenation. Defaults to `1`. Currently, groups > `1` is only supported for two height sharded input tensors.
 
@@ -51,18 +50,13 @@ Example:
                const int dim,
                std::optional<ttnn::Tensor>& optional_output_tensor,
                std::optional<ttnn::MemoryConfig>& memory_config,
-               const int groups,
-               QueueId queue_id) {
-                return self(queue_id, tensors, dim, memory_config, optional_output_tensor, groups);
-            },
+               const int groups) { return self(tensors, dim, memory_config, optional_output_tensor, groups); },
             py::arg("tensors"),
             py::arg("dim") = 0,
             py::kw_only(),
             py::arg("output_tensor").noconvert() = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("groups") = 1,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("groups") = 1});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/copy.hpp
@@ -12,12 +12,11 @@ namespace ttnn {
 namespace operations::data_movement {
 
 struct CopyOperation {
-    static ttnn::Tensor invoke(QueueId queue_id, const Tensor& src_tensor, const Tensor& dst_tensor);
+    static ttnn::Tensor invoke(const Tensor& src_tensor, const Tensor& dst_tensor);
 };
 
 struct AssignOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const MemoryConfig& output_mem_config,
         std::optional<const DataType> output_dtype = std::nullopt,
@@ -28,7 +27,7 @@ struct AssignOperation {
         const MemoryConfig& output_mem_config,
         std::optional<const DataType> output_dtype = std::nullopt);
 
-    static ttnn::Tensor invoke(QueueId queue_id, const Tensor& input_a, const Tensor& input_b);
+    static ttnn::Tensor invoke(const Tensor& input_a, const Tensor& input_b);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/copy_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/copy_pybind.cpp
@@ -67,14 +67,12 @@ void py_bind_copy(py::module& module) {
         ttnn::copy,
         doc,
         ttnn::pybind_overload_t{
-            [](const decltype(ttnn::copy)& self,
-               const ttnn::Tensor& input_a,
-               const ttnn::Tensor& input_b,
-               QueueId queue_id) { return self(queue_id, input_a, input_b); },
+            [](const decltype(ttnn::copy)& self, const ttnn::Tensor& input_a, const ttnn::Tensor& input_b) {
+                return self(input_a, input_b);
+            },
             py::arg("input_a").noconvert(),
             py::arg("input_b").noconvert(),
-            py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId});
+            py::kw_only()});
 }
 
 void py_bind_assign(py::module& module) {
@@ -94,7 +92,6 @@ void py_bind_assign(py::module& module) {
 
         "input_a", "Tensor assign is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
         "input_b", "Input tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-        "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
 
     )doc");
 
@@ -107,22 +104,20 @@ void py_bind_assign(py::module& module) {
                const ttnn::Tensor& input,
                const ttnn::MemoryConfig& memory_config,
                const std::optional<const ttnn::DataType> dtype,
-               std::optional<ttnn::Tensor>& optional_output_tensor,
-               QueueId queue_id) { return self(queue_id, input, memory_config, dtype, optional_output_tensor); },
+               std::optional<ttnn::Tensor>& optional_output_tensor) {
+                return self(input, memory_config, dtype, optional_output_tensor);
+            },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("memory_config"),
             py::arg("dtype") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+            py::arg("output_tensor") = std::nullopt},
         ttnn::pybind_overload_t{
-            [](const decltype(ttnn::assign)& self,
-               const ttnn::Tensor& input_a,
-               const ttnn::Tensor& input_b,
-               QueueId queue_id) { return self(queue_id, input_a, input_b); },
+            [](const decltype(ttnn::assign)& self, const ttnn::Tensor& input_a, const ttnn::Tensor& input_b) {
+                return self(input_a, input_b);
+            },
             py::arg("input_a").noconvert(),
-            py::arg("input_b").noconvert(),
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("input_b").noconvert()});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "expand.hpp"
 #include <tt-metalium/constants.hpp>
@@ -34,9 +33,8 @@ ttnn::SmallVector<uint32_t> create_repetition_vector(const Tensor& tensor, std::
 ttnn::Tensor ExpandOperation::invoke(
     const ttnn::Tensor& tensor,
     const tt::stl::Span<const int32_t> shape_vector,
-    const std::optional<MemoryConfig>& memory_config,
-    const QueueId& queue_id) {
-    return ttnn::repeat(tensor, create_repetition_vector(tensor, shape_vector), memory_config, queue_id);
+    const std::optional<MemoryConfig>& memory_config) {
+    return ttnn::repeat(tensor, create_repetition_vector(tensor, shape_vector), memory_config);
 }
 
 }  // namespace ttnn::operations::expand

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.hpp
@@ -12,8 +12,7 @@ struct ExpandOperation {
     static Tensor invoke(
         const ttnn::Tensor& input,
         tt::stl::Span<const int32_t> shape_vector,
-        const std::optional<MemoryConfig>& memory_config,
-        const QueueId& queue_id = DefaultQueueId);
+        const std::optional<MemoryConfig>& memory_config);
 };
 }  // namespace ttnn::operations::expand
 

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand_pybind.cpp
@@ -24,13 +24,13 @@ void py_bind_expand(py::module& module, const data_movement_operation_t& operati
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<int32_t> output_shape,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const QueueId queue_id) { return self(input_tensor, output_shape, memory_config, queue_id); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, output_shape, memory_config);
+            },
             py::arg("input_tensor"),
             py::arg("output_shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.hpp
@@ -12,7 +12,6 @@ namespace data_movement {
 
 struct FillPadOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         float fill_value,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_pybind.cpp
@@ -33,8 +33,7 @@ void bind_fill_pad_op(py::module& module) {
                 value greater than 0 fill_value (float): Value to fill the tensor padding with.
 
             Keyword args:
-                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to
-                `None`. queue_id (int, optional): command queue id. Defaults to `0`.
+                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -51,13 +50,13 @@ void bind_fill_pad_op(py::module& module) {
             [](const OperationType& self,
                const Tensor& input_tensor,
                const float fill_value,
-               const std::optional<MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, input_tensor, fill_value, memory_config); },
+               const std::optional<MemoryConfig>& memory_config) {
+                return self(input_tensor, fill_value, memory_config);
+            },
             py::arg("input_tensor"),
             py::arg("fill_value"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_pybind.cpp
@@ -16,7 +16,6 @@ namespace py = pybind11;
 void bind_fill_pad_op(py::module& module) {
     auto doc = fmt::format(
         R"doc(
-
             Fills the implicit padding of a tiled input tensor with the specified value.
             Specifically, any nD tensor will have the implicit padding of the last 2 dims that exists from [height:tile_height, width:tile_width] filled with the specified value.
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
@@ -6,14 +6,12 @@
 #include "device/fill_rm_op.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor FillRMOperation::invoke(
-    QueueId queue_id,
     uint32_t N,
     uint32_t C,
     uint32_t H,
@@ -26,12 +24,11 @@ ttnn::Tensor FillRMOperation::invoke(
     const std::optional<ttnn::MemoryConfig>& memory_config) {
     auto output_memory_config = memory_config.value_or(any.memory_config());
     return operation::run_without_autoformat(
-               FillRM{N, C, H, W, hFill, wFill, val_hi, val_lo, output_memory_config}, {any}, {}, {}, queue_id)
+               FillRM{N, C, H, W, hFill, wFill, val_hi, val_lo, output_memory_config}, {any}, {}, {})
         .at(0);
 }
 
 ttnn::Tensor FillOnesRMOperation::invoke(
-    QueueId queue_id,
     uint32_t N,
     uint32_t C,
     uint32_t H,
@@ -42,7 +39,7 @@ ttnn::Tensor FillOnesRMOperation::invoke(
     const std::optional<ttnn::MemoryConfig>& memory_config) {
     auto output_memory_config = memory_config.value_or(any.memory_config());
     return operation::run_without_autoformat(
-               FillRM{N, C, H, W, hFill, wFill, 1.0f, 0.0f, output_memory_config}, {any}, {}, {}, queue_id)
+               FillRM{N, C, H, W, hFill, wFill, 1.0f, 0.0f, output_memory_config}, {any}, {}, {})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.hpp
@@ -12,7 +12,6 @@ namespace data_movement {
 
 struct FillRMOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         uint32_t N,
         uint32_t C,
         uint32_t H,
@@ -27,7 +26,6 @@ struct FillRMOperation {
 
 struct FillOnesRMOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         uint32_t N,
         uint32_t C,
         uint32_t H,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_pybind.cpp
@@ -70,7 +70,6 @@ void bind_fill_rm_op(py::module& module) {
 
             Keyword args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -94,9 +93,8 @@ void bind_fill_rm_op(py::module& module) {
                const Tensor& any,
                const float val_hi,
                const float val_lo,
-               const std::optional<MemoryConfig>& memory_config,
-               QueueId queue_id) {
-                return self(queue_id, N, C, H, W, hOnes, wOnes, any, val_hi, val_lo, memory_config);
+               const std::optional<MemoryConfig>& memory_config) {
+                return self(N, C, H, W, hOnes, wOnes, any, val_hi, val_lo, memory_config);
             },
             py::arg("N"),
             py::arg("C"),
@@ -108,8 +106,7 @@ void bind_fill_rm_op(py::module& module) {
             py::arg("val_hi"),
             py::arg("val_lo"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 void bind_fill_ones_rm_op(py::module& module) {
@@ -147,7 +144,6 @@ void bind_fill_ones_rm_op(py::module& module) {
 
             Keyword args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -168,8 +164,9 @@ void bind_fill_ones_rm_op(py::module& module) {
                uint32_t hOnes,
                uint32_t wOnes,
                const Tensor& any,
-               const std::optional<MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, N, C, H, W, hOnes, wOnes, any, memory_config); },
+               const std::optional<MemoryConfig>& memory_config) {
+                return self(N, C, H, W, hOnes, wOnes, any, memory_config);
+            },
             py::arg("N"),
             py::arg("C"),
             py::arg("H"),
@@ -178,8 +175,7 @@ void bind_fill_ones_rm_op(py::module& module) {
             py::arg("wOnes"),
             py::arg("any"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -335,18 +335,4 @@ Tensor FoldOperation::invoke(
     return ttnn::prim::fold(input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
 }
 
-Tensor FoldOperation::invoke(
-    const ttnn::Tensor& input_tensor,
-    uint32_t stride_h,
-    uint32_t stride_w,
-    bool use_transpose_as_fold,
-    const std::optional<const ttnn::Shape>& output_shape,
-    uint32_t pad_c,
-    uint32_t pad_h,
-    uint32_t pad_w,
-    const std::optional<CoreRangeSet>& core_grid,
-    const std::optional<MemoryConfig>& override_memory_config) {
-    return invoke(
-        input_tensor, stride_h, stride_w, use_transpose_as_fold, output_shape, pad_c, pad_h, pad_w, core_grid);
-}
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -21,7 +21,6 @@
 namespace ttnn::operations::data_movement {
 
 std::vector<Tensor> fold_with_transpose_(
-    QueueId queue_id,
     const Tensor& input,
     const std::optional<const ttnn::Shape>& output_shape,
     uint32_t stride_h,
@@ -144,7 +143,6 @@ ttnn::MemoryConfig create_sharded_memory_config(
 }
 
 std::vector<Tensor> fold_with_transpose_sharded_(
-    QueueId queue_id,
     const Tensor& input,
     const std::optional<const ttnn::Shape>& output_shape,
     uint32_t stride_h,
@@ -286,7 +284,6 @@ std::vector<Tensor> fold_with_transpose_sharded_(
 }
 
 Tensor FoldOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     uint32_t stride_h,
     uint32_t stride_w,
@@ -301,7 +298,6 @@ Tensor FoldOperation::invoke(
         if (input_tensor.is_sharded()) {
             if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
                 return fold_with_transpose_sharded_(
-                           queue_id,
                            input_tensor,
                            output_shape,
                            stride_h,
@@ -316,8 +312,7 @@ Tensor FoldOperation::invoke(
                 TT_THROW("fold op does not support non height-sharding!");
             }
         } else {
-            return fold_with_transpose_(queue_id, input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w)
-                .at(0);
+            return fold_with_transpose_(input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w).at(0);
         }
     }
     if (input_tensor.memory_config().is_dram()) {
@@ -328,8 +323,7 @@ Tensor FoldOperation::invoke(
         auto input_height = input_tensor.logical_shape()[1];
         auto input_width = input_tensor.logical_shape()[2];
         auto in_channels = input_tensor.logical_shape()[3];
-        auto output_tensor =
-            ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
+        auto output_tensor = ttnn::prim::fold(input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
         if (input_tensor.layout() == Layout::TILE) {
             return ttnn::reshape(
                 output_tensor,
@@ -338,7 +332,7 @@ Tensor FoldOperation::invoke(
         }
         return output_tensor;
     }
-    return ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
+    return ttnn::prim::fold(input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
 }
 
 Tensor FoldOperation::invoke(
@@ -352,17 +346,7 @@ Tensor FoldOperation::invoke(
     uint32_t pad_w,
     const std::optional<CoreRangeSet>& core_grid,
     const std::optional<MemoryConfig>& override_memory_config) {
-    QueueId queue_id = DefaultQueueId;
     return invoke(
-        queue_id,
-        input_tensor,
-        stride_h,
-        stride_w,
-        use_transpose_as_fold,
-        output_shape,
-        pad_c,
-        pad_h,
-        pad_w,
-        core_grid);
+        input_tensor, stride_h, stride_w, use_transpose_as_fold, output_shape, pad_c, pad_h, pad_w, core_grid);
 }
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
@@ -29,18 +29,6 @@ struct FoldOperation {
         uint32_t pad_w = 0,
         const std::optional<CoreRangeSet>& core_grid = std::nullopt,
         const std::optional<MemoryConfig>& override_memory_config = std::nullopt);
-    static ttnn::Tensor invoke(
-        QueueId queue_id,
-        const ttnn::Tensor& input_tensor,
-        uint32_t stride_h,
-        uint32_t stride_w,
-        bool use_transpose_as_fold = false,
-        const std::optional<const ttnn::Shape>& output_shape = std::nullopt,
-        uint32_t pad_c = 0,
-        uint32_t pad_h = 0,
-        uint32_t pad_w = 0,
-        const std::optional<CoreRangeSet>& core_grid = std::nullopt,
-        const std::optional<MemoryConfig>& override_memory_config = std::nullopt);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold_pybind.cpp
@@ -38,10 +38,8 @@ void bind_fold_operation(py::module& module) {
                uint32_t pad_h,
                uint32_t pad_w,
                std::optional<CoreRangeSet> grid_size,
-               std::optional<MemoryConfig> override_memory_config,
-               QueueId queue_id) -> ttnn::Tensor {
+               std::optional<MemoryConfig> override_memory_config) -> ttnn::Tensor {
                 return op(
-                    queue_id,
                     input,
                     stride_h,
                     stride_w,
@@ -62,9 +60,7 @@ void bind_fold_operation(py::module& module) {
             py::arg("pad_h") = 0,
             py::arg("pad_w") = 0,
             py::arg("grid_size") = std::nullopt,
-            py::arg("override_memory_config") = std::nullopt,
-            py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("override_memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
@@ -7,7 +7,6 @@
 
 #include "device/gather_device_operation.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
@@ -92,7 +91,6 @@ Tensor post_gather_transform_tensor(
 }  // namespace
 
 Tensor ExecuteGather::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const int8_t dim,
     const Tensor& input_index_tensor,
@@ -142,13 +140,7 @@ Tensor ExecuteGather::invoke(
     }
 
     Tensor gather_tensor = ttnn::prim::gather(
-        queue_id,
-        padded_input_tensor,
-        dim,
-        padded_index_tensor,
-        sparse_grad,
-        memory_config_value,
-        optional_output_tensor_value);
+        padded_input_tensor, dim, padded_index_tensor, sparse_grad, memory_config_value, optional_output_tensor_value);
 
     return CMAKE_UNIQUE_NAMESPACE::post_gather_transform_tensor(
         input_index_tensor, gather_tensor, dim, input_index_tensor_is_dim_last_idx, original_index_tensor_lshape);

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.hpp
@@ -11,7 +11,6 @@
 namespace ttnn::operations::data_movement {
 struct ExecuteGather {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int8_t dim,
         const Tensor& input_index_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
@@ -70,16 +70,8 @@ void bind_gather_operation(py::module& module) {
                const ttnn::Tensor& input_index_tensor,
                const bool sparse_grad,
                std::optional<ttnn::Tensor> optional_output_tensor,
-               const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
-               QueueId queue_id) -> Tensor {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    dim,
-                    input_index_tensor,
-                    sparse_grad,
-                    memory_config,
-                    optional_output_tensor);
+               const std::optional<tt::tt_metal::MemoryConfig>& memory_config) -> Tensor {
+                return self(input_tensor, dim, input_index_tensor, sparse_grad, memory_config, optional_output_tensor);
             },
             py::arg("input").noconvert(),
             py::arg("dim"),
@@ -87,8 +79,7 @@ void bind_gather_operation(py::module& module) {
             py::kw_only(),
             py::arg("sparse_grad") = false,
             py::arg("out") = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa.cpp
@@ -7,7 +7,6 @@
 
 #include "../gather.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
@@ -34,7 +33,6 @@ Tensor pre_tosa_gather_transform_input_index_tensor(const Tensor& input_tensor, 
 }  // namespace
 
 Tensor ExecuteTosaGather::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const Tensor& input_index_tensor,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
@@ -73,13 +71,7 @@ Tensor ExecuteTosaGather::invoke(
         CMAKE_UNIQUE_NAMESPACE::pre_tosa_gather_transform_input_index_tensor(input_index_tensor, dim, C);
 
     return ttnn::gather(
-        queue_id,
-        input_tensor,
-        dim,
-        expanded_index_tensor,
-        sparse_grad,
-        memory_config_value,
-        optional_output_tensor_value);
+        input_tensor, dim, expanded_index_tensor, sparse_grad, memory_config_value, optional_output_tensor_value);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa.hpp
@@ -11,7 +11,6 @@
 namespace ttnn::operations::data_movement {
 struct ExecuteTosaGather {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const Tensor& input_index_tensor,
         const std::optional<tt::tt_metal::MemoryConfig>& memory_config);

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa_pybind.cpp
@@ -72,12 +72,12 @@ void bind_gather_tosa_operation(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::Tensor& input_index_tensor,
-               const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
-               QueueId queue_id) -> Tensor { return self(queue_id, input_tensor, input_index_tensor, memory_config); },
+               const std::optional<tt::tt_metal::MemoryConfig>& memory_config) -> Tensor {
+                return self(input_tensor, input_index_tensor, memory_config);
+            },
             py::arg("input").noconvert(),
             py::arg("index"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill.cpp
@@ -4,14 +4,12 @@
 
 #include "ttnn/operations/data_movement/indexed_fill/indexed_fill.hpp"
 #include "ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor IndexedFillOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& batch_id,
     const ttnn::Tensor& input_tensor_a,
     const ttnn::Tensor& input_tensor_b,
@@ -19,7 +17,7 @@ ttnn::Tensor IndexedFillOperation::invoke(
     int64_t dim) {
     auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
     return operation::run_without_autoformat(
-               IndexedFill{output_memory_config, dim}, {batch_id, input_tensor_a, input_tensor_b}, {}, {}, queue_id)
+               IndexedFill{output_memory_config, dim}, {batch_id, input_tensor_a, input_tensor_b}, {}, {})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill.hpp
@@ -13,7 +13,6 @@ namespace data_movement {
 
 struct IndexedFillOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& batch_id,
         const ttnn::Tensor& input_tensor_a,
         const ttnn::Tensor& input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill_pybind.cpp
@@ -26,7 +26,6 @@ void bind_indexed_fill(pybind11::module& module) {
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dim (int, optional): Dimension value. Defaults to `0`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -50,17 +49,13 @@ void bind_indexed_fill(pybind11::module& module) {
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               int64_t dim,
-               QueueId queue_id) {
-                return self(queue_id, batch_id, input_tensor_a, input_tensor_b, memory_config, dim);
-            },
+               int64_t dim) { return self(batch_id, input_tensor_a, input_tensor_b, memory_config, dim); },
             pybind11::arg("batch_id").noconvert(),
             pybind11::arg("input_tensor_a").noconvert(),
             pybind11::arg("input_tensor_b").noconvert(),
             pybind11::kw_only(),
             pybind11::arg("memory_config") = std::nullopt,
-            pybind11::arg("dim") = 0,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("dim") = 0});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill_pybind.cpp
@@ -15,7 +15,6 @@ namespace detail {
 void bind_indexed_fill(pybind11::module& module) {
     auto doc = fmt::format(
         R"doc(
-
             Replaces batch of input in input_b denoted by batch_ids into input_a.
 
             Args:

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.cpp
@@ -4,7 +4,6 @@
 
 #include <tt-metalium/constants.hpp>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 
 #include "moe_expert_token_remap.hpp"
@@ -12,7 +11,6 @@
 namespace ttnn::operations::data_movement {
 
 std::vector<ttnn::Tensor> ExecuteMoeExpertTokenRemap::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& topk_tensor,
     const ttnn::Tensor& expert_mapping_tensor,
     const ttnn::Tensor& expert_metadata_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp
@@ -13,7 +13,6 @@ namespace operations::data_movement {
 struct ExecuteMoeExpertTokenRemap {
     static constexpr auto REDUCTION_SIZE = MoeExpertTokenRemapDeviceOperation::REDUCTION_SIZE;
     static std::vector<ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& expert_mapping_tensor,
         const ttnn::Tensor& expert_metadata_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap_pybind.cpp
@@ -29,7 +29,6 @@ Args:
 
 Keyword Args:
     memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-    queue_id (int, optional): command queue id. Defaults to `0`.
     output_mapping_tensor (ttnn.Tensor, optional): Preallocated output mapping tensor. Defaults to `None`.
     output_reduced_tensor (ttnn.Tensor, optional): Preallocated output reduced tensor. Defaults to `None`.
     reduction_size (int, optional): reduction chunk size
@@ -54,10 +53,8 @@ Returns:
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
                const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
-               const uint32_t reduction_size,
-               QueueId queue_id) {
+               const uint32_t reduction_size) {
                 return self(
-                    queue_id,
                     topk_tensor,
                     expert_mapping_tensor,
                     expert_metadata_tensor,
@@ -74,7 +71,6 @@ Returns:
             py::arg("optional_output_mapping_tensor") = std::nullopt,
             py::arg("optional_output_reduced_tensor") = std::nullopt,
             py::arg("reduction_size") = ExecuteMoeExpertTokenRemap::REDUCTION_SIZE,
-            py::arg("queue_id") = DefaultQueueId,
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.hpp
@@ -12,9 +12,7 @@ namespace operations::data_movement {
 
 struct MoveOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
-        const Tensor& input_tensor,
-        const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+        const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move_pybind.cpp
@@ -31,12 +31,10 @@ void py_bind_move(pybind11::module& module) {
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::move)& self,
                const ttnn::Tensor& input_tensor,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, input_tensor, memory_config); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) { return self(input_tensor, memory_config); },
             pybind11::arg("input_tensor").noconvert(),
             pybind11::kw_only(),
-            pybind11::arg("memory_config") = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices.cpp
@@ -6,16 +6,15 @@
 #include "device/non_zero_indices_op.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
 std::vector<ttnn::Tensor> NonZeroIndicesOperation::invoke(
-    QueueId queue_id, const ttnn::Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config_arg) {
+    const ttnn::Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config_arg) {
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
-    return operation::run(NonZeroIndices{memory_config}, {input_tensor}, {}, {}, queue_id);
+    return operation::run(NonZeroIndices{memory_config}, {input_tensor}, {}, {});
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices.hpp
@@ -13,7 +13,7 @@ namespace operations::data_movement {
 
 struct NonZeroIndicesOperation {
     static std::vector<ttnn::Tensor> invoke(
-        QueueId queue_id, const ttnn::Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config);
+        const ttnn::Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices_pybind.cpp
@@ -24,7 +24,6 @@ void bind_non_zero(py::module& module) {
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 List of ttnn.Tensor: the output tensors.
@@ -44,12 +43,10 @@ void bind_non_zero(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, input_tensor, memory_config); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) { return self(input_tensor, memory_config); },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/non_zero_indices_pybind.cpp
@@ -16,7 +16,6 @@ namespace py = pybind11;
 void bind_non_zero(py::module& module) {
     auto doc = fmt::format(
         R"doc(
-
             Returns the number of elements (N) that are non-zero as well as a tensor of the same shape as input where the first N elements are the indices of non-zero elements.
 
             Args:

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
@@ -7,7 +7,6 @@
 #include "ttnn/tensor/types.hpp"
 #include <ranges>
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn {
 namespace operations::data_movement {
@@ -21,7 +20,6 @@ struct ExecutePad {
     // This function signature is similar to pytorch's signature
     // Any rank tensor supported
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<PadSpecDim>& padding,
         float value,
@@ -29,7 +27,6 @@ struct ExecutePad {
         const std::optional<MemoryConfig>& memory_config_arg);
 
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<std::array<uint32_t, 2>>& padding,
         float value,
@@ -38,7 +35,6 @@ struct ExecutePad {
 
     // legacy API
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const tt::tt_metal::Array4D& output_shape,
         const tt::tt_metal::Array4D& input_tensor_start,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.cpp
@@ -17,7 +17,6 @@ namespace py = pybind11;
 void bind_pad(py::module& module) {
     auto doc =
         R"doc(
-
             Returns a padded tensor, with a specified value at the specified location. If the input tensor is on host, the pad will be performed on host, and if its on device it will be performed on device.
             Any rank of tensor is supported, however tensors with rank > 4 can only apply padding to the lower 3 dimensions.
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.cpp
@@ -29,7 +29,6 @@ void bind_pad(py::module& module) {
             Keyword Args:
                 * :attr:`use_multicore`: (Optional[bool]) switch to use multicore implementation
                 * :attr:`memory_config`: (Optional[ttnn.MemoryConfig]): Memory configuration for the operation. Defaults to `None`.
-                * :attr:`queue_id`: (Optional[int]): command queue id. Defaults to `0`.
 
             Returns:
                List of ttnn.Tensor: the output tensor.
@@ -54,16 +53,15 @@ void bind_pad(py::module& module) {
                ttnn::SmallVector<std::array<uint32_t, 2>> padding,
                const float value,
                const bool use_multicore,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, input_tensor, padding, value, use_multicore, memory_config); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, padding, value, use_multicore, memory_config);
+            },
             py::arg("input_tensor"),
             py::arg("padding"),
             py::arg("value"),
             py::kw_only(),
             py::arg("use_multicore") = true,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        },
+            py::arg("memory_config") = std::nullopt},
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
@@ -71,16 +69,8 @@ void bind_pad(py::module& module) {
                const tt::tt_metal::Array4D& input_tensor_start,
                const float value,
                const bool use_multicore,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    output_padded_shape,
-                    input_tensor_start,
-                    value,
-                    use_multicore,
-                    memory_config);
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, output_padded_shape, input_tensor_start, value, use_multicore, memory_config);
             },
             py::arg("input_tensor"),
             py::arg("output_padded_shape"),
@@ -88,7 +78,6 @@ void bind_pad(py::module& module) {
             py::arg("value"),
             py::kw_only(),
             py::arg("use_multicore") = false,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -175,9 +175,7 @@ struct PermuteDeviceOperation {
     // API call to map user arguments to operation attributes and tensor args.
     // This is the only method that is called by the user
     // The user will be able to call the operation using `tensor_return_value_t output =
-    // ttnn::prim::example(input_tensor)` after the op is registered Keep in mind that the the overload with `queue_id`
-    // argument will be added automatically for primitive operations So, the user can also call this operation using
-    // `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
+    // ttnn::prim::example(input_tensor)` after the op is registered
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,
         const SmallVector<uint32_t>& dims,

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -4,7 +4,6 @@
 
 #include "permute.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 
@@ -158,7 +157,6 @@ bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& di
 }  // namespace detail
 
 ttnn::Tensor ExecutePermute::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
@@ -206,7 +204,7 @@ ttnn::Tensor ExecutePermute::invoke(
 
 ttnn::Tensor ExecutePermute::invoke(
     const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int64_t>& dims, const std::optional<float>& pad_value) {
-    return invoke(DefaultQueueId, input_tensor, dims, std::nullopt, pad_value);
+    return invoke(input_tensor, dims, std::nullopt, pad_value);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -11,7 +11,6 @@ namespace operations::data_movement {
 
 struct ExecutePermute {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const SmallVector<int64_t>& dims,
         const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
@@ -16,7 +16,7 @@ namespace py = pybind11;
 
 void bind_permute(py::module& module) {
     auto doc =
-        R"doc(permute(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+        R"doc(permute(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt)) -> ttnn.Tensor
 
             Permutes the dimensions of the input tensor according to the specified permutation.
 
@@ -26,7 +26,6 @@ void bind_permute(py::module& module) {
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
                 pad_value (float, optional): padding value for when tiles are broken in a transpose. Defaults to `0.0`. If set to None, it will be random garbage values.
 
            Returns:
@@ -49,15 +48,11 @@ void bind_permute(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<int64_t>& dims,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id,
-               const std::optional<float>& pad_value) {
-                return self(queue_id, input_tensor, dims, memory_config, pad_value);
-            },
+               const std::optional<float>& pad_value) { return self(input_tensor, dims, memory_config, pad_value); },
             py::arg("input_tensor").noconvert(),
             py::arg("dims"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("pad_value") = 0.0f,
         });
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp"
 #include "ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp"
@@ -35,11 +34,7 @@ struct LastRepeatDims {
 };
 
 ttnn::Tensor repeat_upper_dims_rm(
-    const ttnn::Tensor& tensor,
-    const uint32_t dim,
-    const uint32_t repetitions,
-    QueueId queue_id,
-    const MemoryConfig& output_mem_config) {
+    const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
     // collapse upper dims to 4D or append 1s
     // collapse lower dims or insert 1s
     // op
@@ -61,10 +56,9 @@ ttnn::Tensor repeat_upper_dims_rm(
     auto input_tensor = ttnn::view(tensor, ttnn::Shape(collapsed_shape_vector));
 
     constexpr bool is_final_dim = false;
-    auto out_tensor =
-        tt::tt_metal::operation::run(
-            RepeatDeviceOperation{repetitions, is_final_dim, output_mem_config}, {input_tensor}, {}, {}, queue_id)
-            .at(0);
+    auto out_tensor = tt::tt_metal::operation::run(
+                          RepeatDeviceOperation{repetitions, is_final_dim, output_mem_config}, {input_tensor}, {}, {})
+                          .at(0);
     auto expected_shape = input_shape;
     expected_shape[dim] *= repetitions;
 
@@ -72,7 +66,7 @@ ttnn::Tensor repeat_upper_dims_rm(
 }
 
 ttnn::Tensor repeat_last_dim_rm(
-    const ttnn::Tensor& tensor, const uint32_t repetitions, QueueId queue_id, const MemoryConfig& output_mem_config) {
+    const ttnn::Tensor& tensor, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
     // collapse to 2D
     // op
     // un-collapse
@@ -87,10 +81,9 @@ ttnn::Tensor repeat_last_dim_rm(
     auto input_tensor = ttnn::view(tensor, ttnn::Shape(collapsed_shape_vector));
 
     constexpr bool is_final_dim = true;
-    auto out_tensor =
-        tt::tt_metal::operation::run(
-            RepeatDeviceOperation{repetitions, is_final_dim, output_mem_config}, {input_tensor}, {}, {}, queue_id)
-            .at(0);
+    auto out_tensor = tt::tt_metal::operation::run(
+                          RepeatDeviceOperation{repetitions, is_final_dim, output_mem_config}, {input_tensor}, {}, {})
+                          .at(0);
 
     auto expected_shape = input_shape;
     expected_shape[-1] *= repetitions;
@@ -139,8 +132,7 @@ std::tuple<ttnn::Tensor, ttnn::SmallVector<uint32_t>> match_input_rank(
 ttnn::Tensor RepeatOperation::invoke(
     const ttnn::Tensor& tensor,
     const ttnn::SmallVector<uint32_t>& provided_repetition_vector,
-    const std::optional<MemoryConfig>& provided_output_mem_config,
-    QueueId queue_id) {
+    const std::optional<MemoryConfig>& provided_output_mem_config) {
     auto [working_tensor, repetition_vector] = detail::match_input_rank(tensor, provided_repetition_vector);
     MemoryConfig output_mem_config = provided_output_mem_config.value_or(tensor.memory_config());
     auto working_output_mem_config = output_mem_config;
@@ -166,7 +158,7 @@ ttnn::Tensor RepeatOperation::invoke(
     // Sharded -> interleaved
     if (tensor.memory_config().is_sharded()) {
         MemoryConfig working_memory_config{TensorMemoryLayout::INTERLEAVED, tensor.memory_config().buffer_type()};
-        working_tensor = ttnn::sharded_to_interleaved(queue_id, tensor, working_memory_config, std::nullopt);
+        working_tensor = ttnn::sharded_to_interleaved(tensor, working_memory_config, std::nullopt);
     }
     if (working_output_mem_config.is_sharded()) {
         working_output_mem_config =
@@ -186,12 +178,12 @@ ttnn::Tensor RepeatOperation::invoke(
         }
         // if last dim
         if (it == repetition_vector.crbegin()) {
-            working_tensor = detail::repeat_last_dim_rm(working_tensor, *it, queue_id, working_output_mem_config);
+            working_tensor = detail::repeat_last_dim_rm(working_tensor, *it, working_output_mem_config);
         }
         // if not last dim
         else {
             auto i = repetition_vector.crend() - it - 1;  // forward index
-            working_tensor = detail::repeat_upper_dims_rm(working_tensor, i, *it, queue_id, working_output_mem_config);
+            working_tensor = detail::repeat_upper_dims_rm(working_tensor, i, *it, working_output_mem_config);
         }
     }
 
@@ -202,7 +194,7 @@ ttnn::Tensor RepeatOperation::invoke(
 
     // Interleaved to OG mem layout
     if (output_mem_config.is_sharded()) {
-        working_tensor = ttnn::interleaved_to_sharded(queue_id, working_tensor, output_mem_config, std::nullopt);
+        working_tensor = ttnn::interleaved_to_sharded(working_tensor, output_mem_config, std::nullopt);
     }
 
     return working_tensor;
@@ -210,7 +202,7 @@ ttnn::Tensor RepeatOperation::invoke(
 
 ttnn::Tensor RepeatOperation::invoke(const ttnn::Tensor& input_tensor, const ttnn::Shape& repeat_dims) {
     return RepeatOperation::invoke(
-        input_tensor, SmallVector<uint32_t>(repeat_dims.cbegin(), repeat_dims.cend()), std::nullopt, DefaultQueueId);
+        input_tensor, SmallVector<uint32_t>(repeat_dims.cbegin(), repeat_dims.cend()), std::nullopt);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.hpp
@@ -13,8 +13,7 @@ struct RepeatOperation {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<uint32_t>& repetition_vector,
-        const std::optional<MemoryConfig>& provided_output_mem_config,
-        QueueId queue_id);
+        const std::optional<MemoryConfig>& provided_output_mem_config);
 
     static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const ttnn::Shape& repeat_dims);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat_pybind.cpp
@@ -23,14 +23,13 @@ void bind_repeat(py::module& module, const data_movement_operation_t& operation,
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<uint32_t>& repetition_vector,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(input_tensor, repetition_vector, memory_config, queue_id); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, repetition_vector, memory_config);
+            },
             py::arg("input_tensor"),
             py::arg("repeat_dims"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -49,7 +49,6 @@ static Tensor manual_insertion(
 }  // namespace detail
 
 ttnn::Tensor ReshapeOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Shape& logical_output_shape,
     const ttnn::Shape& padded_output_shape,
@@ -88,19 +87,17 @@ ttnn::Tensor ReshapeOperation::invoke(
 }
 
 ttnn::Tensor ReshapeOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Shape& logical_output_shape,
     const std::optional<MemoryConfig>& memory_config_arg) {
-    return invoke(queue_id, input_tensor, logical_output_shape, logical_output_shape, memory_config_arg);
+    return invoke(input_tensor, logical_output_shape, logical_output_shape, memory_config_arg);
 }
 
 ttnn::Tensor ReshapeOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const int32_t> shape_vector,
     const std::optional<MemoryConfig>& memory_config_arg) {
-    return invoke(queue_id, input_tensor, infer_dims_for_reshape(input_tensor, shape_vector), memory_config_arg);
+    return invoke(input_tensor, infer_dims_for_reshape(input_tensor, shape_vector), memory_config_arg);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp
@@ -11,20 +11,17 @@ namespace operations::data_movement {
 
 struct ReshapeOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const ttnn::Shape& padded_shape,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt);
 
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt);
 
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_pybind.cpp
@@ -28,9 +28,8 @@ void bind_reshape(pybind11::module& module, const data_movement_operation_t& ope
                int Z,
                int Y,
                int X,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, ttnn::SmallVector<int32_t>{W, Z, Y, X}, memory_config);
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
+                return self(input_tensor, ttnn::SmallVector<int32_t>{W, Z, Y, X}, memory_config);
             },
             py::arg("input_tensor"),
             py::arg("W"),
@@ -38,8 +37,7 @@ void bind_reshape(pybind11::module& module, const data_movement_operation_t& ope
             py::arg("Y"),
             py::arg("X"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail
@@ -72,7 +70,6 @@ void py_bind_reshape(pybind11::module& module) {
 
         Keyword Args:
             * :attr:`memory_config`: Memory Config of the output tensor
-            * :attr:`queue_id` (Optional[uint8]): command queue id
 
         Example:
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -6,8 +6,6 @@
 
 #include <tt-metalium/constants.hpp>
 
-#include "ttnn/common/queue_id.hpp"
-
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -37,7 +35,6 @@ ttnn::Tensor convert_tile_to_rm(
     const uint32_t tile_first_dim,
     const uint32_t tile_second_dim,
     const MemoryConfig& memory_config,
-    const QueueId queue_id,
     const PadValue& pad_value) {
     // Convert the 3D->3D reshaping to row major and back to tile
     TT_FATAL(
@@ -47,8 +44,7 @@ ttnn::Tensor convert_tile_to_rm(
         "illegal dimensions for a bfloat8 tensor");
     auto new_tensor = (tensor.dtype() == DataType::BFLOAT8_B) ? ttnn::typecast(tensor, DataType::BFLOAT16) : tensor;
     new_tensor = ttnn::to_layout(tensor, ttnn::ROW_MAJOR_LAYOUT);
-    new_tensor =
-        ReshapeViewOperation::invoke(queue_id, new_tensor, logical_shape, padded_shape, memory_config, pad_value);
+    new_tensor = ReshapeViewOperation::invoke(new_tensor, logical_shape, padded_shape, memory_config, pad_value);
     new_tensor = ttnn::to_layout(new_tensor, ttnn::TILE_LAYOUT, new_tensor.dtype(), memory_config);
     new_tensor = (tensor.dtype() == DataType::BFLOAT8_B) ? ttnn::typecast(new_tensor, tensor.dtype()) : new_tensor;
     return new_tensor;
@@ -59,12 +55,11 @@ ttnn::Tensor perform_reshape_on_2D_RM(
     const ttnn::Shape& logical_shape,
     const ttnn::Shape& padded_shape,
     const MemoryConfig& memory_config,
-    const QueueId queue_id) {
     auto temp_tensor = tensor;
     auto intermediate_out_memory_config = memory_config;
     if (tensor.memory_config().is_sharded()) {
         MemoryConfig temp_memory_config{TensorMemoryLayout::INTERLEAVED, tensor.memory_config().buffer_type()};
-        temp_tensor = ttnn::sharded_to_interleaved(queue_id, tensor, temp_memory_config, std::nullopt);
+        temp_tensor = ttnn::sharded_to_interleaved(tensor, temp_memory_config, std::nullopt);
     }
     if (memory_config.is_sharded()) {
         intermediate_out_memory_config =
@@ -76,11 +71,10 @@ ttnn::Tensor perform_reshape_on_2D_RM(
                             ReshapeDeviceOperation{logical_shape, padded_shape, intermediate_out_memory_config},
                             {temp_tensor},
                             {},
-                            {},
-                            queue_id)
+                            {})
                             .at(0);
     if (memory_config.is_sharded()) {
-        return ttnn::interleaved_to_sharded(queue_id, temp_tensor2, memory_config, std::nullopt);
+    return ttnn::interleaved_to_sharded(temp_tensor2, memory_config, std::nullopt);
     } else {
         return temp_tensor2;
     }
@@ -93,7 +87,6 @@ ttnn::Tensor fix_shape_and_perform_reshape_on_2D_RM(
     const uint32_t tile_first_dim,
     const uint32_t tile_second_dim,
     const MemoryConfig& memory_config,
-    const QueueId queue_id) {
     //This function turns a RM 2D->MD into an equivalent 2D->2D conversion and then turns the 2D output back to MD using a 0 cost view
     TT_FATAL((logical_shape.rank() != 0), "Can't do reshape to rank 0 tensor");
     //Collapse into the second last dimension
@@ -106,8 +99,7 @@ ttnn::Tensor fix_shape_and_perform_reshape_on_2D_RM(
             tensor,
             ttnn::Shape({second_dim, logical_shape[-1]}),
             ttnn::Shape({second_dim, logical_shape[-1]}),
-            memory_config,
-            queue_id),
+            memory_config),
         logical_shape,
         padded_shape,
         tile_first_dim,
@@ -122,7 +114,6 @@ ttnn::Tensor reshape_rm(
     const uint32_t tile_first_dim,
     const uint32_t tile_second_dim,
     const MemoryConfig& memory_config,
-    const QueueId queue_id,
     const PadValue& pad_value) {
     // This function turns ND -> MD into 2D->MD for row major and 3D->MD for tiled using a 0 cost view
     const auto& tensor_shape = tensor.logical_shape();
@@ -146,8 +137,7 @@ ttnn::Tensor reshape_rm(
         padded_shape,
         tile_first_dim,
         tile_second_dim,
-        memory_config,
-        queue_id);
+        memory_config);
 }
 }  // namespace detail
 
@@ -202,7 +192,6 @@ ttnn::Tensor reshape_tiled(
     const ttnn::Tensor& tensor,
     const ttnn::Shape& logical_shape,
     const MemoryConfig& memory_config,
-    const QueueId queue_id,
     const PadValue& pad_value) {
     // squeeze input tensor and requested shape to 3D
 
@@ -225,7 +214,7 @@ ttnn::Tensor reshape_tiled(
 
     if (tensor.memory_config().is_sharded()) {
         MemoryConfig working_input_memory_config{TensorMemoryLayout::INTERLEAVED, tensor.memory_config().buffer_type()};
-        tensor3d = ttnn::sharded_to_interleaved(queue_id, tensor, working_input_memory_config, std::nullopt);
+        tensor3d = ttnn::sharded_to_interleaved(tensor, working_input_memory_config, std::nullopt);
     }
 
     if (tensor.dtype() == DataType::BFLOAT8_B) {
@@ -243,12 +232,11 @@ ttnn::Tensor reshape_tiled(
             ReshapeDeviceOperation{requested_shape_3d, requested_padded_shape_3d, working_output_memory_config},
             {tensor3d},
             {},
-            {},
-            queue_id)
+            {})
             .at(0);
 
     if (memory_config.is_sharded()) {
-        output_tensor_3d = ttnn::interleaved_to_sharded(queue_id, output_tensor_3d, memory_config, std::nullopt);
+        output_tensor_3d = ttnn::interleaved_to_sharded(output_tensor_3d, memory_config, std::nullopt);
     }
 
     if (tensor.dtype() == DataType::BFLOAT8_B) {
@@ -259,7 +247,6 @@ ttnn::Tensor reshape_tiled(
 }
 
 ttnn::Tensor ReshapeViewOperation::invoke(
-    const QueueId queue_id,
     const ttnn::Tensor& tensor,
     const ttnn::Shape& logical_input_shape,
     const ttnn::Shape& padded_input_shape,
@@ -339,30 +326,26 @@ ttnn::Tensor ReshapeViewOperation::invoke(
             tile_first_dim,
             tile_second_dim,
             mem_config,
-            queue_id,
             pad_value.value_or(default_pad_value));
     } else {
-        return reshape_tiled(tensor, logical_shape, mem_config, queue_id, pad_value.value_or(default_pad_value));
+        return reshape_tiled(tensor, logical_shape, mem_config, pad_value.value_or(default_pad_value));
     }
 }
 
 ttnn::Tensor ReshapeViewOperation::invoke(
-    const QueueId queue_id,
     const ttnn::Tensor& tensor,
     const ttnn::Shape& shape,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value) {
-    return invoke(queue_id, tensor, shape, shape, memory_config, pad_value);
+    return invoke(tensor, shape, shape, memory_config, pad_value);
 }
 
 ttnn::Tensor ReshapeViewOperation::invoke(
-    const QueueId queue_id,
     const ttnn::Tensor& tensor,
     tt::stl::Span<const int32_t> shape_vector,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value) {
-    return invoke(
-        queue_id, tensor, tt::tt_metal::infer_dims_for_reshape(tensor, shape_vector), memory_config, pad_value);
+    return invoke(tensor, tt::tt_metal::infer_dims_for_reshape(tensor, shape_vector), memory_config, pad_value);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -54,9 +54,10 @@ ttnn::Tensor perform_reshape_on_2D_RM(
     const ttnn::Tensor& tensor,
     const ttnn::Shape& logical_shape,
     const ttnn::Shape& padded_shape,
-    const MemoryConfig& memory_config,
+    const MemoryConfig& memory_config) {
     auto temp_tensor = tensor;
     auto intermediate_out_memory_config = memory_config;
+
     if (tensor.memory_config().is_sharded()) {
         MemoryConfig temp_memory_config{TensorMemoryLayout::INTERLEAVED, tensor.memory_config().buffer_type()};
         temp_tensor = ttnn::sharded_to_interleaved(tensor, temp_memory_config, std::nullopt);
@@ -86,7 +87,7 @@ ttnn::Tensor fix_shape_and_perform_reshape_on_2D_RM(
     const ttnn::Shape& padded_shape,
     const uint32_t tile_first_dim,
     const uint32_t tile_second_dim,
-    const MemoryConfig& memory_config,
+    const MemoryConfig& memory_config) {
     //This function turns a RM 2D->MD into an equivalent 2D->2D conversion and then turns the 2D output back to MD using a 0 cost view
     TT_FATAL((logical_shape.rank() != 0), "Can't do reshape to rank 0 tensor");
     //Collapse into the second last dimension

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
@@ -24,20 +24,17 @@ ttnn::Tensor PerformView(
 
 struct ReshapeViewOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<PadValue>& pad_value = std::nullopt);
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const ttnn::Shape& padded_shape,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<PadValue>& pad_value = std::nullopt);
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
@@ -27,13 +27,11 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
                const ttnn::Tensor& input_tensor,
                const ttnn::Shape& shape,
                const std::optional<MemoryConfig>& memory_config,
-               const QueueId queue_id,
                const std::optional<PadValue>& pad_value) -> ttnn::Tensor { return self(input_tensor, shape); },
             py::arg("input_tensor"),
             py::arg("shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("pad_value") = std::nullopt},
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self,
@@ -41,7 +39,6 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
                const ttnn::Shape& logical_shape,
                const ttnn::Shape& padded_shape,
                const std::optional<MemoryConfig>& memory_config,
-               const QueueId queue_id,
                const std::optional<PadValue>& pad_value) -> ttnn::Tensor {
                 return self(input_tensor, logical_shape, padded_shape);
             },
@@ -50,20 +47,17 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
             py::arg("padded_shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("pad_value") = std::nullopt},
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<int32_t> shape,
                const std::optional<MemoryConfig>& memory_config,
-               const QueueId queue_id,
                const std::optional<PadValue>& pad_value) -> ttnn::Tensor { return self(input_tensor, shape); },
             py::arg("input_tensor"),
             py::arg("shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("pad_value") = std::nullopt});
 }
 
@@ -86,7 +80,6 @@ void py_bind_reshape_view(pybind11::module& module) {
 
         Keyword Args:
             * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config
-            * :attr:`queue_id`: command queue id. Default is 0.
             * :attr:`pad_value` (number): Value to pad the output tensor. Default is 0
 
         Returns:

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
@@ -69,7 +69,6 @@ void py_bind_reshape_view(pybind11::module& module) {
         ttnn::reshape,
 
         R"doc(
-
         Note: for a 0 cost view, the following conditions must be met:
             * the last dimension must not change
             * In Tiled the second last two dimensions must not change OR there is no padding on the second last dimension

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
@@ -101,8 +101,7 @@ ScatterDeviceOperation::invocation_result_t ScatterDeviceOperation::invoke(
     const Tensor& index_tensor,
     const Tensor& source_tensor,
     const MemoryConfig& output_memory_config,
-    const std::optional<ScatterReductionType>& opt_reduction,
-    const QueueId& queue_id) {
+    const std::optional<ScatterReductionType>& opt_reduction) {
     return {
         operation_attributes_t{dim, output_memory_config, opt_reduction},
         tensor_args_t{input_tensor, index_tensor, source_tensor}};

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
@@ -48,8 +48,7 @@ struct ScatterDeviceOperation {
         const Tensor& index_tensor,
         const Tensor& source_tensor,
         const MemoryConfig& output_memory_config,
-        const std::optional<ScatterReductionType>& opt_reduction,
-        const QueueId& queue_id = DefaultQueueId);
+        const std::optional<ScatterReductionType>& opt_reduction);
 };
 
 }  // namespace ttnn::operations::data_movement::scatter

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
@@ -189,7 +189,6 @@ Tensor post_scatter_transform_tensor(
 }  // namespace
 
 Tensor ScatterOperation::invoke(
-    const QueueId& queue_id,
     const Tensor& input_tensor,
     const int32_t& dim,
     const Tensor& index_tensor,
@@ -235,8 +234,7 @@ Tensor ScatterOperation::invoke(
         transformed_index_tensor,
         transformed_source_tensor,
         final_memory_config,
-        std::nullopt,
-        queue_id);
+        std::nullopt);
     output = CMAKE_UNIQUE_NAMESPACE::post_scatter_transform_tensor(
         output,
         after_transpose_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.hpp
@@ -16,7 +16,6 @@ namespace operations::data_movement {
 
 struct ScatterOperation {
     static Tensor invoke(
-        const QueueId& queue_id,
         const Tensor& input_tensor,
         const int32_t& dim,
         const Tensor& index_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter_pybind.cpp
@@ -64,10 +64,8 @@ void bind_scatter(py::module& module) {
                const ttnn::Tensor& index_tensor,
                const ttnn::Tensor& source_tensor,
                const std::optional<tt::tt_metal::MemoryConfig>& opt_out_memory_config,
-               const std::optional<scatter::ScatterReductionType>& opt_reduction,
-               const QueueId& queue_id = DefaultQueueId) -> Tensor {
-                return self(
-                    queue_id, input_tensor, dim, index_tensor, source_tensor, opt_out_memory_config, opt_reduction);
+               const std::optional<scatter::ScatterReductionType>& opt_reduction) -> Tensor {
+                return self(input_tensor, dim, index_tensor, source_tensor, opt_out_memory_config, opt_reduction);
             },
             py::arg("input").noconvert(),
             py::arg("dim"),
@@ -75,8 +73,7 @@ void bind_scatter(py::module& module) {
             py::arg("src").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("reduce") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("reduce") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter.cpp
@@ -119,7 +119,6 @@ void validate_tensors(const Shape& input_shape, const Shape& index_shape, const 
 }  // namespace
 
 Tensor TOSAScatterOperation::invoke(
-    const QueueId& queue_id,
     const Tensor& input_tensor,
     const Tensor& index_tensor,
     const Tensor& source_tensor,
@@ -153,8 +152,7 @@ Tensor TOSAScatterOperation::invoke(
         processed_index_tensor,
         processed_source_tensor,
         final_memory_config,
-        std::nullopt,
-        queue_id);
+        std::nullopt);
     return CMAKE_UNIQUE_NAMESPACE::post_tosa_scatter_transform_tensor(output, N, K, W, C, input_tensor.layout());
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter.hpp
@@ -14,7 +14,6 @@ namespace operations::data_movement {
 
 struct TOSAScatterOperation {
     static Tensor invoke(
-        const QueueId& queue_id,
         const Tensor& input_tensor,
         const Tensor& index_tensor,
         const Tensor& source_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/tosa_scatter_pybind.cpp
@@ -55,16 +55,14 @@ void bind_tosa_scatter(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const ttnn::Tensor& index_tensor,
                const ttnn::Tensor& source_tensor,
-               const std::optional<tt::tt_metal::MemoryConfig>& opt_out_memory_config,
-               const QueueId& queue_id = DefaultQueueId) -> Tensor {
-                return self(queue_id, input_tensor, index_tensor, source_tensor, opt_out_memory_config);
+               const std::optional<tt::tt_metal::MemoryConfig>& opt_out_memory_config) -> Tensor {
+                return self(input_tensor, index_tensor, source_tensor, opt_out_memory_config);
             },
             py::arg("input").noconvert(),
             py::arg("index").noconvert(),
             py::arg("src").noconvert(),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "device/interleaved_to_sharded_op.hpp"
 #include "interleaved_to_sharded.hpp"
@@ -13,7 +12,6 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor InterleavedToShardedOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const MemoryConfig& sharded_memory_config,
     const std::optional<DataType>& data_type_arg,
@@ -28,7 +26,6 @@ ttnn::Tensor InterleavedToShardedOperation::invoke(
 }
 
 ttnn::Tensor InterleavedToShardedOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::variant<CoreCoord, CoreRangeSet>& grid,
     const std::array<uint32_t, 2> shard_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp
@@ -12,13 +12,11 @@ namespace operations::data_movement {
 
 struct InterleavedToShardedOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const MemoryConfig& sharded_memory_config,
         const std::optional<DataType>& data_type_arg,
         const std::optional<bool>& keep_l1_aligned = std::nullopt);
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const std::variant<CoreCoord, CoreRangeSet>& grid,
         std::array<uint32_t, 2> shard_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded_pybind.cpp
@@ -29,17 +29,9 @@ void bind_interleaved_to_sharded(
                tt::tt_metal::TensorMemoryLayout shard_scheme,
                tt::tt_metal::ShardOrientation shard_orientation,
                const std::optional<ttnn::DataType>& output_dtype,
-               QueueId queue_id,
                const std::optional<bool>& keep_l1_aligned) -> ttnn::Tensor {
                 return self(
-                    queue_id,
-                    input_tensor,
-                    grid,
-                    shard_shape,
-                    shard_scheme,
-                    shard_orientation,
-                    output_dtype,
-                    keep_l1_aligned);
+                    input_tensor, grid, shard_shape, shard_scheme, shard_orientation, output_dtype, keep_l1_aligned);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("grid"),
@@ -48,7 +40,6 @@ void bind_interleaved_to_sharded(
             py::arg("shard_orientation"),
             py::arg("output_dtype") = std::nullopt,
             py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("keep_l1_aligned") = false,
 
         },
@@ -57,15 +48,13 @@ void bind_interleaved_to_sharded(
                const ttnn::Tensor& input_tensor,
                const MemoryConfig& sharded_memory_config,
                const std::optional<ttnn::DataType>& output_dtype,
-               QueueId queue_id,
                const std::optional<bool>& keep_l1_aligned) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, sharded_memory_config, output_dtype, keep_l1_aligned);
+                return self(input_tensor, sharded_memory_config, output_dtype, keep_l1_aligned);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("sharded_memory_config"),
             py::arg("output_dtype") = std::nullopt,
             py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("keep_l1_aligned") = false,
 
         });
@@ -92,7 +81,6 @@ void py_bind_interleaved_to_sharded(pybind11::module& module) {
 
         Keyword Args:
             * :attr:`output_dtype` (Optional[ttnn.DataType]): Output data type, defaults to same as input.
-            * :attr:`queue_id`: command queue id
 
         Example 1 (using grid, shape, scheme, orienttion):
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard.cpp
@@ -11,7 +11,6 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor ReshardOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const MemoryConfig& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard.hpp
@@ -12,7 +12,6 @@ namespace operations::data_movement {
 
 struct ReshardOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const MemoryConfig& memory_config,
         const std::optional<Tensor>& optional_output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard_pybind.cpp
@@ -24,15 +24,12 @@ void bind_reshard(pybind11::module& module, const data_movement_sharded_operatio
             [](const data_movement_sharded_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const MemoryConfig& output_memory_config,
-               const std::optional<Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, output_memory_config, output_tensor);
+               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, output_memory_config, output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("output_memory_config"),
             py::arg("output_tensor").noconvert() = std::nullopt,
-            py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId,
 
         });
 }
@@ -51,9 +48,6 @@ void py_bind_reshard(pybind11::module& module) {
         Args:
             * :attr:`input_tensor` (ttnn.Tensor): input tensor
             * :attr:`output_memory_config` (MemoryConfig): Memory config with shard spec of output tensor
-
-        Keyword Args:
-            * :attr:`queue_id`: command queue id
 
         Example:
             >>> sharded_memory_config_dict = dict(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "device/sharded_to_interleaved_op.hpp"
 #include "sharded_to_interleaved.hpp"
@@ -10,7 +9,6 @@
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor ShardedToInterleavedOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const MemoryConfig& memory_config,
     const std::optional<DataType>& output_dtype,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp
@@ -11,7 +11,6 @@ namespace operations::data_movement {
 
 struct ShardedToInterleavedOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const MemoryConfig& memory_config,
         const std::optional<DataType>& output_dtype,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved_pybind.cpp
@@ -27,10 +27,8 @@ void bind_sharded_to_interleaved(
                const ttnn::Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType>& output_dtype,
-               QueueId queue_id,
                const std::optional<bool>& is_l1_aligned) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor,
                     memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
                     output_dtype,
@@ -40,7 +38,6 @@ void bind_sharded_to_interleaved(
             py::arg("memory_config") = std::nullopt,
             py::arg("output_dtype") = std::nullopt,
             py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId,
             py::arg("is_l1_aligned") = false,
         });
 }
@@ -52,7 +49,7 @@ void py_bind_sharded_to_interleaved(pybind11::module& module) {
     detail::bind_sharded_to_interleaved(
         module,
         ttnn::sharded_to_interleaved,
-        R"doc(sharded_to_interleaved(input_tensor: ttnn.Tensor,  memory_config: ttnn.MemoryConfig, *,  queue_id: int) -> ttnn.Tensor
+        R"doc(sharded_to_interleaved(input_tensor: ttnn.Tensor,  memory_config: ttnn.MemoryConfig, *) -> ttnn.Tensor
 
         Converts a tensor from sharded to interleaved memory layout
 
@@ -61,7 +58,6 @@ void py_bind_sharded_to_interleaved(pybind11::module& module) {
             * :attr:`memory_config` (ttnn.MemoryConfig): Memory configuration for the operation, must be Interleaved.
 
         Keyword Args:
-            * :attr:`queue_id`: command queue id
             * :attr:`output_dtype` (Optional[ttnn.DataType]): Output data type, defaults to same as input.
 
         Example:

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "device/interleaved_to_sharded_partial_op.hpp"
 #include "interleaved_to_sharded_partial.hpp"
@@ -13,7 +12,6 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor InterleavedToShardedPartialOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::variant<CoreCoord, CoreRangeSet>& grid,
     const std::array<uint32_t, 2>& shard_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.hpp
@@ -12,7 +12,6 @@ namespace operations::data_movement {
 
 struct InterleavedToShardedPartialOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const std::variant<CoreCoord, CoreRangeSet>& grid,
         const std::array<uint32_t, 2>& shard_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_pybind.cpp
@@ -30,10 +30,8 @@ void bind_interleaved_to_sharded_partial(
                int64_t& slice_index,
                tt::tt_metal::TensorMemoryLayout shard_scheme,
                tt::tt_metal::ShardOrientation shard_orientation,
-               const std::optional<ttnn::DataType>& output_dtype,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<ttnn::DataType>& output_dtype) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor,
                     grid,
                     shard_shape,
@@ -52,8 +50,6 @@ void bind_interleaved_to_sharded_partial(
             py::arg("shard_orientation"),
             py::kw_only(),
             py::arg("output_dtype") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-
         });
 }
 
@@ -78,7 +74,6 @@ void py_bind_interleaved_to_sharded_partial(pybind11::module& module) {
 
         Keyword Args:
             * :attr:`output_dtype` (Optional[ttnn.DataType]): Output data type, defaults to same as input.
-            * :attr:`queue_id`: command queue id
 
         Example:
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "device/sharded_to_interleaved_partial_op.hpp"
 #include "sharded_to_interleaved_partial.hpp"
@@ -12,7 +11,6 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor ShardedToInterleavedPartialOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& cache_tensor,
     int64_t& num_slices,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.hpp
@@ -11,7 +11,6 @@ namespace operations::data_movement {
 
 struct ShardedToInterleavedPartialOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& cache_tensor,
         int64_t& num_slices,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial_pybind.cpp
@@ -27,9 +27,8 @@ void bind_sharded_to_interleaved_partial(
                int64_t& num_slices,
                int64_t& slice_index,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::DataType>& output_dtype,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, cache_tensor, num_slices, slice_index, memory_config, output_dtype);
+               const std::optional<ttnn::DataType>& output_dtype) -> ttnn::Tensor {
+                return self(input_tensor, cache_tensor, num_slices, slice_index, memory_config, output_dtype);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("cache_tensor").noconvert(),
@@ -38,8 +37,6 @@ void bind_sharded_to_interleaved_partial(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_dtype") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-
         });
 }
 
@@ -63,7 +60,6 @@ void py_bind_sharded_to_interleaved_partial(pybind11::module& module) {
         Keyword Args:
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
             * :attr:`output_dtype` (Optional[ttnn.DataType]): Output data type, defaults to same as input.
-            * :attr:`queue_id`: command queue id
 
         Example:
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -176,19 +176,6 @@ ttnn::Tensor SliceOperation::invoke(
     return ret_adjustment(res);
 }
 
-template <typename T>
-ttnn::Tensor SliceOperation::invoke(
-    const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const T> begins,
-    tt::stl::Span<const T> ends,
-    tt::stl::Span<const T> step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value) {
-    return SliceOperation::invoke<T>(
-        input_tensor, begins, ends, step, memory_config_arg, optional_output_tensor, pad_value);
-}
-
 template <typename T, std::size_t N>
 ttnn::Tensor SliceOperation::invoke(
     const ttnn::Tensor& input_tensor,
@@ -264,39 +251,12 @@ ttnn::Tensor SliceOperation::invoke(
         pad_value);
 }
 
-template <typename T>
-ttnn::Tensor SliceOperation::invoke(
+// Template instantiations for SliceOperation::invoke
+template ttnn::Tensor SliceOperation::invoke<int32_t>(
     const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& output_tensor_start,
-    const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<T>>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value) {
-    return SliceOperation::invoke<T>(
-        input_tensor,
-        output_tensor_start,
-        output_tensor_end,
-        step,
-        memory_config_arg,
-        optional_output_tensor,
-        pad_value);
-}
-
-template ttnn::Tensor SliceOperation::invoke<int>(
-    const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int> begins,
-    tt::stl::Span<const int> ends,
-    tt::stl::Span<const int> step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<int>(
-    const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int> begins,
-    tt::stl::Span<const int> ends,
-    tt::stl::Span<const int> step,
+    tt::stl::Span<const int32_t> begins,
+    tt::stl::Span<const int32_t> ends,
+    tt::stl::Span<const int32_t> step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value);
@@ -306,87 +266,6 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     tt::stl::Span<const uint32_t> begins,
     tt::stl::Span<const uint32_t> ends,
     tt::stl::Span<const uint32_t> step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t>(
-    const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const uint32_t> begins,
-    tt::stl::Span<const uint32_t> ends,
-    tt::stl::Span<const uint32_t> step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 4>& output_tensor_start,
-    const std::array<uint32_t, 4>& output_tensor_end,
-    const std::array<uint32_t, 4>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 4>& output_tensor_start,
-    const std::array<uint32_t, 4>& output_tensor_end,
-    const std::array<uint32_t, 4>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 3>& output_tensor_start,
-    const std::array<uint32_t, 3>& output_tensor_end,
-    const std::array<uint32_t, 3>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 3>& output_tensor_start,
-    const std::array<uint32_t, 3>& output_tensor_end,
-    const std::array<uint32_t, 3>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 1>& output_tensor_start,
-    const std::array<uint32_t, 1>& output_tensor_end,
-    const std::array<uint32_t, 1>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 1>& output_tensor_start,
-    const std::array<uint32_t, 1>& output_tensor_end,
-    const std::array<uint32_t, 1>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t>(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& output_tensor_start,
-    const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<uint32_t>>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value);
-
-template ttnn::Tensor SliceOperation::invoke<uint32_t>(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& output_tensor_start,
-    const ttnn::Tensor& output_tensor_end,
-    const std::optional<ttnn::SmallVector<uint32_t>>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -5,7 +5,6 @@
 #include "device/slice_op.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/common/constants.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -17,7 +16,6 @@ namespace ttnn::operations::data_movement {
 
 template <typename T>
 ttnn::Tensor SliceOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const T> begins,
     tt::stl::Span<const T> ends,
@@ -163,8 +161,7 @@ ttnn::Tensor SliceOperation::invoke(
                 ttnn::Shape(modified_begins), ttnn::Shape(padded_ends), ttnn::Shape(modified_step), memory_config},
             {input},
             {},
-            {optional_output_tensor},
-            queue_id)
+            {optional_output_tensor})
             .at(0);
     res = ttnn::experimental::view(res, actual_shape, final_padded_shape);
 
@@ -189,12 +186,11 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value) {
     return SliceOperation::invoke<T>(
-        ttnn::DefaultQueueId, input_tensor, begins, ends, step, memory_config_arg, optional_output_tensor, pad_value);
+        input_tensor, begins, ends, step, memory_config_arg, optional_output_tensor, pad_value);
 }
 
 template <typename T, std::size_t N>
 ttnn::Tensor SliceOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::array<T, N>& output_tensor_start,
     const std::array<T, N>& output_tensor_end,
@@ -206,7 +202,7 @@ ttnn::Tensor SliceOperation::invoke(
     tt::stl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
     tt::stl::Span<const T> step_vec(step.begin(), step.end());
     return SliceOperation::invoke<T>(
-        queue_id, input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor, pad_value);
+        input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor, pad_value);
 }
 
 template <typename T, std::size_t N>
@@ -219,7 +215,6 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value) {
     return SliceOperation::invoke<T, N>(
-        ttnn::DefaultQueueId,
         input_tensor,
         output_tensor_start,
         output_tensor_end,
@@ -231,7 +226,6 @@ ttnn::Tensor SliceOperation::invoke(
 
 template <typename T>
 ttnn::Tensor SliceOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,
@@ -261,7 +255,6 @@ ttnn::Tensor SliceOperation::invoke(
     ttnn::SmallVector<T> step_value = step.value_or(ttnn::SmallVector<T>(output_tensor_start_span.size(), 1));
 
     return SliceOperation::invoke<T>(
-        queue_id,
         input_tensor,
         output_tensor_start_span,
         output_tensor_end_span,
@@ -281,7 +274,6 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value) {
     return SliceOperation::invoke<T>(
-        ttnn::DefaultQueueId,
         input_tensor,
         output_tensor_start,
         output_tensor_end,
@@ -292,7 +284,6 @@ ttnn::Tensor SliceOperation::invoke(
 }
 
 template ttnn::Tensor SliceOperation::invoke<int>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const int> begins,
     tt::stl::Span<const int> ends,
@@ -311,7 +302,6 @@ template ttnn::Tensor SliceOperation::invoke<int>(
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const uint32_t> begins,
     tt::stl::Span<const uint32_t> ends,
@@ -330,7 +320,6 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::array<uint32_t, 4>& output_tensor_start,
     const std::array<uint32_t, 4>& output_tensor_end,
@@ -349,7 +338,6 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::array<uint32_t, 3>& output_tensor_start,
     const std::array<uint32_t, 3>& output_tensor_end,
@@ -368,7 +356,6 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::array<uint32_t, 1>& output_tensor_start,
     const std::array<uint32_t, 1>& output_tensor_end,
@@ -396,7 +383,6 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor_start,
     const ttnn::Tensor& output_tensor_end,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -192,25 +192,6 @@ ttnn::Tensor SliceOperation::invoke(
         input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor, pad_value);
 }
 
-template <typename T, std::size_t N>
-ttnn::Tensor SliceOperation::invoke(
-    const ttnn::Tensor& input_tensor,
-    const std::array<T, N>& output_tensor_start,
-    const std::array<T, N>& output_tensor_end,
-    const std::array<T, N>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<float>& pad_value) {
-    return SliceOperation::invoke<T, N>(
-        input_tensor,
-        output_tensor_start,
-        output_tensor_end,
-        step,
-        memory_config_arg,
-        optional_output_tensor,
-        pad_value);
-}
-
 template <typename T>
 ttnn::Tensor SliceOperation::invoke(
     const ttnn::Tensor& input_tensor,
@@ -266,6 +247,26 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     tt::stl::Span<const uint32_t> begins,
     tt::stl::Span<const uint32_t> ends,
     tt::stl::Span<const uint32_t> step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
+
+// Template instantiations for std::array version
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 4>& output_tensor_start,
+    const std::array<uint32_t, 4>& output_tensor_end,
+    const std::array<uint32_t, 4>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
+
+// Template instantiations for Tensor version
+template ttnn::Tensor SliceOperation::invoke<uint32_t>(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor_start,
+    const ttnn::Tensor& output_tensor_end,
+    const std::optional<ttnn::SmallVector<uint32_t>>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -24,35 +24,6 @@ struct SliceOperation {
     template <typename T>
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const T> output_tensor_start,
-        tt::stl::Span<const T> output_tensor_end,
-        tt::stl::Span<const T> step,
-        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        const std::optional<float>& pad_value = std::nullopt);
-
-    template <typename T>
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::SmallVector<T>& begins,
-        const ttnn::SmallVector<T>& ends,
-        const ttnn::SmallVector<T>& step,
-        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        const std::optional<float>& pad_value = std::nullopt) {
-        return invoke(
-            input_tensor,
-            tt::stl::Span<const T>(begins),
-            tt::stl::Span<const T>(ends),
-            tt::stl::Span<const T>(step),
-            memory_config_arg,
-            optional_output_tensor,
-            pad_value);
-    }
-
-    template <typename T>
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<T>& begins,
         const ttnn::SmallVector<T>& ends,
         const ttnn::SmallVector<T>& step,
@@ -75,26 +46,6 @@ struct SliceOperation {
         const std::array<T, N>& output_tensor_start,
         const std::array<T, N>& output_tensor_end,
         const std::array<T, N>& step,
-        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        const std::optional<float>& pad_value = std::nullopt);
-
-    template <typename T, std::size_t N>
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input_tensor,
-        const std::array<T, N>& output_tensor_start,
-        const std::array<T, N>& output_tensor_end,
-        const std::array<T, N>& step,
-        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        const std::optional<float>& pad_value = std::nullopt);
-
-    template <typename T>
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& output_tensor_start,
-        const ttnn::Tensor& output_tensor_end,
-        const std::optional<ttnn::SmallVector<T>>& step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<float>& pad_value = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -13,7 +13,6 @@ namespace data_movement {
 struct SliceOperation {
     template <typename T>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const T> begins,
         tt::stl::Span<const T> ends,
@@ -34,7 +33,6 @@ struct SliceOperation {
 
     template <typename T>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<T>& begins,
         const ttnn::SmallVector<T>& ends,
@@ -43,7 +41,6 @@ struct SliceOperation {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<float>& pad_value = std::nullopt) {
         return invoke(
-            queue_id,
             input_tensor,
             tt::stl::Span<const T>(begins),
             tt::stl::Span<const T>(ends),
@@ -74,7 +71,6 @@ struct SliceOperation {
 
     template <typename T, std::size_t N>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const std::array<T, N>& output_tensor_start,
         const std::array<T, N>& output_tensor_end,
@@ -95,7 +91,6 @@ struct SliceOperation {
 
     template <typename T>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& output_tensor_start,
         const ttnn::Tensor& output_tensor_end,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
@@ -27,7 +27,6 @@ void bind_slice(py::module& module) {
 
             Keyword Args:
                 memory_config Memory Config of the output tensor
-                queue_id (uint8, optional) command queue id
                 pad_value: Optional value to fill padding for tiled tensors. Padding values are unmodified (and undefined) by default
 
             Returns:
@@ -58,17 +57,9 @@ void bind_slice(py::module& module) {
                const std::optional<ttnn::SmallVector<uint32_t>>& step,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
-               const std::optional<float>& pad_value,
-               QueueId queue_id) {
+               const std::optional<float>& pad_value) {
                 return self(
-                    queue_id,
-                    input_tensor,
-                    slice_start,
-                    slice_end,
-                    step,
-                    memory_config,
-                    optional_output_tensor,
-                    pad_value);
+                    input_tensor, slice_start, slice_end, step, memory_config, optional_output_tensor, pad_value);
             },
             py::arg("input_tensor"),
             py::arg("starts"),
@@ -78,7 +69,6 @@ void bind_slice(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("pad_value") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
         },
         ttnn::pybind_overload_t{
             [](const OperationType& self,
@@ -88,10 +78,8 @@ void bind_slice(py::module& module) {
                const std::array<uint32_t, 4>& step,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
-               const std::optional<float>& pad_value,
-               QueueId queue_id) {
-                return self(
-                    queue_id, input_tensor, begins, ends, step, memory_config, optional_output_tensor, pad_value);
+               const std::optional<float>& pad_value) {
+                return self(input_tensor, begins, ends, step, memory_config, optional_output_tensor, pad_value);
             },
             py::arg("input_tensor"),
             py::arg("starts"),
@@ -101,7 +89,6 @@ void bind_slice(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("pad_value") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
         },
         ttnn::pybind_overload_t{
             [](const OperationType& self,
@@ -111,10 +98,10 @@ void bind_slice(py::module& module) {
                const std::optional<ttnn::SmallVector<int>>& step,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
-               QueueId queue_id) {
+               const std::optional<float>& pad_value) {
                 const auto step_value = step.value_or(ttnn::SmallVector<int>(slice_end.size(), 1));
                 return self(
-                    queue_id, input_tensor, slice_start, slice_end, step_value, memory_config, optional_output_tensor);
+                    input_tensor, slice_start, slice_end, step_value, memory_config, optional_output_tensor, pad_value);
             },
             py::arg("input_tensor"),
             py::arg("slice_start"),
@@ -123,7 +110,7 @@ void bind_slice(py::module& module) {
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = 0,
+            py::arg("pad_value") = std::nullopt,
         }
 
     );

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/docs/Sort.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/docs/Sort.md
@@ -59,7 +59,7 @@ const bool stable = false;
 std::optional<std::tuple<ttnn::Tensor&, ttnn::Tensor&>> optional_output_tensors;
 const std::optional<ttnn::MemoryConfig> memory_config;
 
-std::vector<Tensor> sorted_tensors = ttnn::sortinput_tensor, dim, descending, stable, memory_config, optional_output_tensors);
+std::vector<Tensor> sorted_tensors = ttnn::sort(input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
 ```
 
 ### Usage Limitations

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/docs/Sort.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/docs/Sort.md
@@ -59,7 +59,7 @@ const bool stable = false;
 std::optional<std::tuple<ttnn::Tensor&, ttnn::Tensor&>> optional_output_tensors;
 const std::optional<ttnn::MemoryConfig> memory_config;
 
-std::vector<Tensor> sorted_tensors = ttnn::sort(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
+std::vector<Tensor> sorted_tensors = ttnn::sortinput_tensor, dim, descending, stable, memory_config, optional_output_tensors);
 ```
 
 ### Usage Limitations

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -5,7 +5,6 @@
 #include "sort.hpp"
 #include "device/sort_device_operation.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
@@ -152,7 +151,6 @@ void convert_tensor_dtype(Tensor& tensor, const DataType& target_dtype, MeshDevi
 }  // namespace
 
 std::vector<Tensor> ExecuteSort::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const int8_t dim,
     const bool descending,
@@ -203,7 +201,7 @@ std::vector<Tensor> ExecuteSort::invoke(
     }
 
     auto sorted_tensors =
-        ttnn::prim::sort(queue_id, padded_input_tensor, dim, descending, stable, memory_config_value, output_tensors);
+        ttnn::prim::sort(padded_input_tensor, dim, descending, stable, memory_config_value, output_tensors);
 
     auto post_transform_output_tensors = CMAKE_UNIQUE_NAMESPACE::post_sort_transform_tensor(
         input_tensor, sorted_tensors, dim, is_dim_last_idx, original_lshape, memory_config_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.hpp
@@ -12,7 +12,6 @@ namespace ttnn::operations::data_movement {
 
 struct ExecuteSort {
     static std::vector<Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int8_t dim,
         bool descending,

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort_pybind.cpp
@@ -73,9 +73,8 @@ void bind_sort_operation(py::module& module) {
                const bool descending,
                const bool stable,
                std::optional<std::tuple<ttnn::Tensor&, ttnn::Tensor&>> optional_output_tensors,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) -> std::vector<ttnn::Tensor> {
-                return self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                return self(input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim") = -1,
@@ -84,7 +83,7 @@ void bind_sort_operation(py::module& module) {
             py::kw_only(),
             py::arg("out") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
@@ -54,7 +53,6 @@ std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, 
 }
 
 std::vector<ttnn::Tensor> split_with_slice_impl(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::SmallVector<int64_t>& split_sizes,
     const int32_t dim,
@@ -77,7 +75,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
     ends[dim] = 0;
     for (const auto& s : split_sizes) {
         ends[dim] = std::min(static_cast<uint32_t>(ends[dim] + s), input_shape[dim]);
-        results.emplace_back(ttnn::slice(queue_id, input_tensor, sbegins, sends, ssteps, memory_config));
+        results.emplace_back(ttnn::slice(input_tensor, sbegins, sends, ssteps, memory_config));
         begins[dim] += s;
     }
 
@@ -86,7 +84,6 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
 }  // namespace detail
 
 std::vector<ttnn::Tensor> SplitOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const SmallVector<int64_t>& split_sizes,
     const int64_t dim = 0,
@@ -127,12 +124,11 @@ std::vector<ttnn::Tensor> SplitOperation::invoke(
         return outputs;
 
     } else {
-        return detail::split_with_slice_impl(queue_id, input_tensor, split_sizes, dim, memory_config);
+        return detail::split_with_slice_impl(input_tensor, split_sizes, dim, memory_config);
     }
 }
 
 std::vector<ttnn::Tensor> SplitOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const int64_t split_size,
     const int64_t dim = 0,
@@ -143,7 +139,7 @@ std::vector<ttnn::Tensor> SplitOperation::invoke(
         std::ceil(static_cast<float>(input_tensor.logical_shape()[dim]) / static_cast<float>(split_size));
 
     const ttnn::SmallVector<int64_t> split_sizes(num_chunks, split_size);
-    return SplitOperation::invoke(queue_id, input_tensor, split_sizes, dim, memory_config);
+    return SplitOperation::invoke(input_tensor, split_sizes, dim, memory_config);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
@@ -11,14 +11,12 @@ namespace operations::data_movement {
 
 struct SplitOperation {
     static std::vector<ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<int64_t>& split_sizes,
         int64_t dim,
         const std::optional<MemoryConfig>& memory_config_arg);
 
     static std::vector<ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         int64_t split_size,
         int64_t dim,

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split_pybind.cpp
@@ -34,7 +34,6 @@ void bind_split(py::module& module) {
 
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor
-                * :attr:`queue_id` (Optional[uint8]): command queue id
         )doc";
 
     using OperationType = decltype(ttnn::split);
@@ -47,28 +46,28 @@ void bind_split(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const int64_t split_size,
                const int64_t dim,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) { return self(queue_id, input_tensor, split_size, dim, memory_config); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, split_size, dim, memory_config);
+            },
             py::arg("input_tensor"),
             py::arg("split_size"),
             py::arg("dim") = 0,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = 0,
         },
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<int64_t>& split_sizes,
                const int64_t dim,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const QueueId queue_id) { return self(queue_id, input_tensor, split_sizes, dim, memory_config); },
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input_tensor, split_sizes, dim, memory_config);
+            },
             py::arg("input_tensor"),
             py::arg("split_size"),
             py::arg("dim") = 0,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
         });
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -5,7 +5,6 @@
 #include "tilize.hpp"
 
 #include "device/tilize_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
@@ -36,7 +35,6 @@ MassagedTilize build_ndiml_tilize(BaseTilizeType base_tilize) {
 }
 
 ttnn::Tensor ExecuteTilize::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
@@ -69,8 +67,7 @@ ttnn::Tensor ExecuteTilize::invoke(
                 enough_space_height},
             {input_tensor},
             {},
-            {},
-            queue_id)[0];
+            {})[0];
     };
 
     return build_ndiml_tilize(base_tilize)(input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
@@ -11,7 +11,6 @@ namespace operations::data_movement {
 
 struct ExecuteTilize {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DataType> output_dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize_pybind.cpp
@@ -29,7 +29,6 @@ void bind_tilize(py::module& module) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (data type, optional): Data type of the output tensor. Defaults to `None`.
                 use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -46,14 +45,11 @@ void bind_tilize(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<DataType> output_dtype,
-               bool use_multicore,
-               QueueId queue_id) { return self(queue_id, input_tensor, memory_config, output_dtype, use_multicore); },
+               bool use_multicore) { return self(input_tensor, memory_config, output_dtype, use_multicore); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("use_multicore") = true,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("use_multicore") = true});
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -5,7 +5,6 @@
 #include "tilize_with_val_padding.hpp"
 
 #include "device/tilize_with_val_padding_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
@@ -53,7 +52,6 @@ ttnn::Shape squeeze_output_shape(const ttnn::Shape& output_shape) {
 }
 
 ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Shape& output_padded_shape,
     const PadValue pad_value,
@@ -87,15 +85,13 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
                 enough_space_height},
             {input_tensor},
             {},
-            {},
-            queue_id)[0];
+            {})[0];
     };
 
     return build_ndiml_tilize_val(base_tilize)(input_tensor);
 }
 
 ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::SmallVector<uint32_t>& output_padded_shape,
     const PadValue pad_value,
@@ -103,17 +99,10 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
     std::optional<DataType> output_dtype,
     bool use_multicore) {
     return invoke(
-        queue_id,
-        input_tensor,
-        ttnn::Shape{output_padded_shape},
-        pad_value,
-        memory_config,
-        output_dtype,
-        use_multicore);
+        input_tensor, ttnn::Shape{output_padded_shape}, pad_value, memory_config, output_dtype, use_multicore);
 }
 
 ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
@@ -134,7 +123,7 @@ ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
         pad_value = (uint32_t)0;
     }
     return ExecuteTilizeWithValPadding::invoke(
-        queue_id, input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore);
+        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -7,7 +7,6 @@
 #include "device/tilize_with_val_padding_op.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "tilize_with_val_padding_common.hpp"
 
 namespace ttnn {
@@ -16,7 +15,6 @@ namespace operations::data_movement {
 
 struct ExecuteTilizeWithValPadding {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<uint32_t>& output_padded_shape,
         PadValue pad_value,
@@ -25,7 +23,6 @@ struct ExecuteTilizeWithValPadding {
         bool use_multicore = true);
 
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& output_padded_shape,
         PadValue pad_value,
@@ -36,7 +33,6 @@ struct ExecuteTilizeWithValPadding {
 
 struct ExecuteTilizeWithZeroPadding {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DataType> output_dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.cpp
@@ -31,7 +31,6 @@ void bind_tilize_with_val_padding(py::module& module) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (data type, optional): Data type of the output tensor. Defaults to `None`.
                 use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -50,10 +49,8 @@ void bind_tilize_with_val_padding(py::module& module) {
                const PadValue value,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<DataType> output_dtype,
-               bool use_multicore,
-               QueueId queue_id) {
-                return self(
-                    queue_id, input_tensor, output_padded_shape, value, memory_config, output_dtype, use_multicore);
+               bool use_multicore) {
+                return self(input_tensor, output_padded_shape, value, memory_config, output_dtype, use_multicore);
             },
             py::arg("input_tensor"),
             py::arg("output_tensor_shape"),
@@ -61,9 +58,7 @@ void bind_tilize_with_val_padding(py::module& module) {
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("use_multicore") = true,
-            py::arg("queue_id") = DefaultQueueId,
-        }
+            py::arg("use_multicore") = true}
 
     );
 }
@@ -71,7 +66,7 @@ void bind_tilize_with_val_padding(py::module& module) {
 void bind_tilize_with_zero_padding(py::module& module) {
     auto doc =
         R"doc(
-            tilize_with_zero_padding(input_tensor: ttnn.Tensor, *, memory_config: Optional[MemoryConfig] = None, dtype: Optional[DataType] = None, use_multicore: bool = False, queue_id: int = 0) -> ttnn.Tensor
+            tilize_with_zero_padding(input_tensor: ttnn.Tensor, *, memory_config: Optional[MemoryConfig] = None, dtype: Optional[DataType] = None, use_multicore: bool = False)) -> ttnn.Tensor
 
             Changes data layout of input tensor to TILE. Pads to the nearest multiple of TILE width/height with zero value.
 
@@ -86,7 +81,6 @@ void bind_tilize_with_zero_padding(py::module& module) {
                 * :attr:`memory_config`: Memory Config of the output tensor.
                 * :attr:`dtype`: Data type of the output tensor.
                 * :attr:`use_multicore`: Whether to use multicore.
-                * :attr:`queue_id`: command queue id.
         )doc";
 
     using OperationType = decltype(ttnn::tilize_with_zero_padding);
@@ -99,15 +93,12 @@ void bind_tilize_with_zero_padding(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<DataType> output_dtype,
-               bool use_multicore,
-               QueueId queue_id) { return self(queue_id, input_tensor, memory_config, output_dtype, use_multicore); },
+               bool use_multicore) { return self(input_tensor, memory_config, output_dtype, use_multicore); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_dtype") = std::nullopt,
-            py::arg("use_multicore") = true,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("use_multicore") = true});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/run_operation.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/decorators.hpp"
 #include "device/transpose_op.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -81,7 +80,6 @@ ttnn::Tensor transpose_nd(
 }  // namespace detail
 
 ttnn::Tensor ExecuteTranspose::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const int64_t& dim1,
     const int64_t& dim2,
@@ -149,7 +147,7 @@ ttnn::Tensor ExecuteTranspose::invoke(
 
 ttnn::Tensor ExecuteTranspose::invoke(
     const ttnn::Tensor& input_tensor, const int64_t& dim1, const int64_t& dim2, const std::optional<float>& pad_value) {
-    return invoke(DefaultQueueId, input_tensor, dim1, dim2, std::nullopt, pad_value);
+    return invoke(input_tensor, dim1, dim2, std::nullopt, pad_value);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.hpp
@@ -11,7 +11,6 @@ namespace operations::data_movement {
 
 struct ExecuteTranspose {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const int64_t& dim1,
         const int64_t& dim2,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
@@ -55,7 +55,8 @@ void bind_transpose(py::module& module) {
             py::arg("dim1"),
             py::arg("dim2"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt py::arg("pad_value") = 0.0f,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("pad_value") = 0.0f,
         });
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
@@ -35,7 +35,6 @@ void bind_transpose(py::module& module) {
 
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor
-                * :attr:`queue_id` (Optional[uint8]): command queue id
         )doc";
 
     using OperationType = decltype(ttnn::transpose);
@@ -49,17 +48,14 @@ void bind_transpose(py::module& module) {
                const int64_t& dim1,
                const int64_t& dim2,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id,
                const std::optional<float>& pad_value) {
-                return self(queue_id, input_tensor, dim1, dim2, memory_config, pad_value);
+                return self(input_tensor, dim1, dim2, memory_config, pad_value);
             },
             py::arg("input_tensor"),
             py::arg("dim1"),
             py::arg("dim2"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-            py::arg("pad_value") = 0.0f,
+            py::arg("memory_config") = std::nullopt py::arg("pad_value") = 0.0f,
         });
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -5,7 +5,6 @@
 #include "untilize.hpp"
 
 #include "device/untilize_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
@@ -36,7 +35,6 @@ MassagedUntilize build_ndiml_untilize(BaseUntilizeType base_untilize) {
 }
 
 ttnn::Tensor ExecuteUntilize::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
@@ -73,8 +71,7 @@ ttnn::Tensor ExecuteUntilize::invoke(
                     input_tensor)},
             {input_tensor},
             {},
-            {},
-            queue_id)[0];
+            {})[0];
     };
 
     return build_ndiml_untilize(base_untilize)(input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
@@ -12,7 +12,6 @@ namespace operations::data_movement {
 
 struct ExecuteUntilize {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         bool use_multicore = true,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
@@ -31,7 +31,6 @@ void bind_untilize(py::module& module) {
                 use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
                 use_pack_untilize (bool, optional): Whether to use pack untilize. Defaults to `True`.
                 sub_core_grids (ttnn.CoreRangeSet, optional): Sub core grids. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 List of ttnn.Tensor: the output tensor.
@@ -49,17 +48,14 @@ void bind_untilize(py::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
                bool use_pack_untilize,
-               const std::optional<CoreRangeSet>&& sub_core_grids,
-               QueueId queue_id) {
-                return self(queue_id, input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids);
+               const std::optional<CoreRangeSet>&& sub_core_grids) {
+                return self(input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids);
             },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("use_multicore") = true,
             py::arg("use_pack_untilize") = true,
-            py::arg("sub_core_grids") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("sub_core_grids") = std::nullopt});
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -5,7 +5,6 @@
 #include "untilize_with_unpadding.hpp"
 
 #include "device/untilize_with_unpadding_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -56,7 +55,6 @@ MassagedUntilizeVal build_ndiml_untilize_val(BaseUntilizeValType base_untilize) 
 }
 
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Shape& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
@@ -104,8 +102,7 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
                                   enough_space_height},
             {input_tensor},
             {},
-            {},
-            queue_id)[0];
+            {})[0];
     };
 
     return build_ndiml_untilize_val(base_untilize)(input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -11,7 +11,6 @@ namespace operations::data_movement {
 
 struct ExecuteUntilizeWithUnpadding {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.cpp
@@ -30,7 +30,6 @@ void bind_untilize_with_unpadding(py::module& module) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
                 use_pack_untilize (bool, optional): Whether to use pack untilize. Defaults to `True`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 List of ttnn.Tensor: the output tensor.
@@ -47,18 +46,15 @@ void bind_untilize_with_unpadding(py::module& module) {
                const ttnn::Shape& output_tensor_end,
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
-               bool use_pack_untilize,
-               QueueId queue_id) {
-                return self(queue_id, input_tensor, output_tensor_end, memory_config, use_multicore, use_pack_untilize);
+               bool use_pack_untilize) {
+                return self(input_tensor, output_tensor_end, memory_config, use_multicore, use_pack_untilize);
             },
             py::arg("input_tensor"),
             py::arg("output_tensor_end"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("use_multicore") = true,
-            py::arg("use_pack_untilize") = true,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("use_pack_untilize") = true});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/view/view_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/view/view_pybind.cpp
@@ -43,7 +43,6 @@ void py_bind_view(pybind11::module& module) {
         module,
         ttnn::view,
         R"doc(
-
         This is a 0 cost view operation that returns the same tensor that was passed to it but with a new shape
 
         Note: The following conditions must be met:

--- a/ttnn/cpp/ttnn/operations/debug/apply_device_delay.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/apply_device_delay.cpp
@@ -25,7 +25,6 @@ using namespace tt::tt_metal::distributed;
 void apply_device_delay(
     ttnn::MeshDevice& mesh_device,
     const std::vector<std::vector<uint32_t>>& delays,
-    ttnn::QueueId queue_id,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id) {
     SubDeviceId sd = subdevice_id.value_or(mesh_device.get_sub_device_ids().at(0));
     auto subdevice_core_range_set = mesh_device.worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd);

--- a/ttnn/cpp/ttnn/operations/debug/apply_device_delay.hpp
+++ b/ttnn/cpp/ttnn/operations/debug/apply_device_delay.hpp
@@ -10,7 +10,6 @@
 
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/sub_device.hpp>
-#include <ttnn/common/queue_id.hpp>
 #include <ttnn/distributed/types.hpp>
 
 namespace ttnn::operations::debug {
@@ -22,7 +21,6 @@ namespace ttnn::operations::debug {
 void apply_device_delay(
     ttnn::MeshDevice& mesh_device,
     const std::vector<std::vector<uint32_t>>& delays,
-    ttnn::QueueId queue_id = ttnn::DefaultQueueId,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt);
 
 }  // namespace ttnn::operations::debug

--- a/ttnn/cpp/ttnn/operations/debug/apply_device_delay_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/apply_device_delay_pybind.cpp
@@ -44,8 +44,8 @@ void py_bind_apply_device_delay(py::module& module) {
     module.def(
         "apply_device_delay",
         [](MeshDevice& mesh_device,
-           const std::vector<std::vector<uint32_t>>& const delays
-               std::optional<tt::tt_metal::SubDeviceId>& subdevice_id) {
+           const std::vector<std::vector<uint32_t>>& delays,
+           std::optional<tt::tt_metal::SubDeviceId> subdevice_id) {
             ttnn::operations::debug::apply_device_delay(mesh_device, delays, subdevice_id);
         },
         py::arg("mesh_device"),

--- a/ttnn/cpp/ttnn/operations/debug/apply_device_delay_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/apply_device_delay_pybind.cpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::debug {
 
 void py_bind_apply_device_delay(py::module& module) {
     auto doc =
-        R"doc(apply_device_delay(mesh_device: ttnn.MeshDevice, delays: List[List[int]], queue_id: int = 0, subdevice_id: Optional[ttnn.SubDeviceId] = None) -> None
+        R"doc(apply_device_delay(mesh_device: ttnn.MeshDevice, delays: List[List[int]], subdevice_id: Optional[ttnn.SubDeviceId] = None) -> None
 
             Applies per-device delays by launching a single-core kernel on each device in the mesh that spins
             for the specified number of cycles. The shape of `delays` must match the mesh view shape
@@ -30,7 +30,6 @@ void py_bind_apply_device_delay(py::module& module) {
             Args:
                 mesh_device (ttnn.MeshDevice): The mesh device to apply delays to.
                 delays (List[List[int]]): A 2D list of delay cycles, where delays[row][col] specifies the delay for device at position (row, col) in the mesh.
-                queue_id (int, optional): Command queue ID. Defaults to `0`.
                 subdevice_id (ttnn.SubDeviceId, optional): The subdevice ID for the subdevice on which we schedule the worker core. Defaults to `None`.
 
             Returns:
@@ -39,21 +38,19 @@ void py_bind_apply_device_delay(py::module& module) {
             Example:
                 >>> # For a 2x2 mesh, apply different delays to each device
                 >>> delays = [[1000, 2000], [3000, 4000]]  # cycles
-                >>> ttnn.apply_device_delay(mesh_device, delays, queue_id=0)
+                >>> ttnn.apply_device_delay(mesh_device, delays)
         )doc";
 
     module.def(
         "apply_device_delay",
         [](MeshDevice& mesh_device,
-           const std::vector<std::vector<uint32_t>>& delays,
-           ttnn::QueueId queue_id,
-           const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id) {
-            ttnn::operations::debug::apply_device_delay(mesh_device, delays, queue_id, subdevice_id);
+           const std::vector<std::vector<uint32_t>>& const delays
+               std::optional<tt::tt_metal::SubDeviceId>& subdevice_id) {
+            ttnn::operations::debug::apply_device_delay(mesh_device, delays, subdevice_id);
         },
         py::arg("mesh_device"),
         py::arg("delays"),
         py::kw_only(),
-        py::arg("queue_id") = DefaultQueueId,
         py::arg("subdevice_id") = std::nullopt,
         doc);
 }

--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.hpp
@@ -15,7 +15,6 @@
 #include <ttnn/decorators.hpp>
 #include <ttnn/device_operation.hpp>
 #include <ttnn/distributed/types.hpp>
-#include <ttnn/common/queue_id.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -101,22 +101,22 @@ inline Tensor binary_impl(
     const std::optional<Tensor>& output = std::nullopt) {
     auto output_tensor = lhs;
     if (binary_op_type == BinaryOpType::GT) {
-        output_tensor = ttnn::gt_unarylhs, rhs, memory_config, output);
+        output_tensor = ttnn::gt_unary(lhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::LT) {
-        output_tensor = ttnn::lt_unarylhs, rhs, memory_config, output);
+        output_tensor = ttnn::lt_unary(lhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::NE) {
-        output_tensor = ttnn::ne_unarylhs, rhs, memory_config, output);
+        output_tensor = ttnn::ne_unary(lhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::GE) {
-        output_tensor = ttnn::ge_unarylhs, rhs, memory_config, output);
+        output_tensor = ttnn::ge_unary(lhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::LE) {
-        output_tensor = ttnn::le_unarylhs, rhs, memory_config, output);
+        output_tensor = ttnn::le_unary(lhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::EQ) {
-        output_tensor = ttnn::eq_unarylhs, rhs, memory_config, output);
+        output_tensor = ttnn::eq_unary(lhs, rhs, memory_config, output);
     } else {
         TT_THROW("Unsupported operation");
     }
     if (dtype.has_value()) {
-        output_tensor = ttnn::typecastoutput_tensor, *dtype, std::nullopt, output);
+        output_tensor = ttnn::typecast(output_tensor, *dtype, std::nullopt, output);
     }
     return output_tensor;
 }
@@ -129,13 +129,13 @@ inline Tensor binary_impl(
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& output = std::nullopt) {
     if (binary_op_type == BinaryOpType::GE) {
-        return ttnn::gezttnn::sub_sfpulhs, rhs, memory_config), memory_config, output);
+        return ttnn::gez(ttnn::sub_sfpu(lhs, rhs, memory_config), memory_config, output);
     }
     if (binary_op_type == BinaryOpType::LE) {
-        return ttnn::lezttnn::sub_sfpulhs, rhs, memory_config), memory_config, output);
+        return ttnn::lez(ttnn::sub_sfpu(lhs, rhs, memory_config), memory_config, output);
     }
     if (binary_op_type == BinaryOpType::EQ) {
-        return ttnn::eqzttnn::sub_sfpulhs, rhs, memory_config), memory_config, output);
+        return ttnn::eqz(ttnn::sub_sfpu(lhs, rhs, memory_config), memory_config, output);
     }
 
     TT_THROW("Unsupported operation");
@@ -505,7 +505,6 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
-
         lhs,
         rhs,
         binary_op_type,
@@ -530,7 +529,6 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
-
         lhs,
         rhs,
         binary_op_type,
@@ -555,7 +553,6 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
-
         lhs,
         rhs,
         binary_op_type,
@@ -588,7 +585,6 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     }
 
     return detail::invoke_binary_ng(
-
         lhs,
         rhs,
         binary_op_type,
@@ -620,7 +616,6 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return RelationalBinary<binary_op_type>::invoke(
-
         lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
@@ -633,7 +628,6 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return RelationalBinary<binary_op_type>::invoke(
-
         lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
@@ -646,7 +640,6 @@ Tensor InplaceLogicalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
-
         lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
@@ -659,7 +652,6 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
-
         lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
@@ -672,7 +664,6 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
-
         lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
@@ -688,7 +679,6 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return detail::invoke_binary_ng(
-
         lhs,
         rhs,
         binary_op_type,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -604,7 +604,7 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    return detail::binary_implbinary_op_type, lhs, rhs, memory_config, output);
+    return detail::binary_impl(binary_op_type, lhs, rhs, memory_config, output);
 }
 
 template <BinaryOpType binary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -93,7 +93,6 @@ constexpr bool is_associative(BinaryOpType op) {
 
 // Tensor - Scalar
 inline Tensor binary_impl(
-    QueueId queue_id,
     BinaryOpType binary_op_type,
     const ttnn::Tensor& lhs,
     const float rhs,
@@ -102,42 +101,41 @@ inline Tensor binary_impl(
     const std::optional<Tensor>& output = std::nullopt) {
     auto output_tensor = lhs;
     if (binary_op_type == BinaryOpType::GT) {
-        output_tensor = ttnn::gt_unary(queue_id, lhs, rhs, memory_config, output);
+        output_tensor = ttnn::gt_unarylhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::LT) {
-        output_tensor = ttnn::lt_unary(queue_id, lhs, rhs, memory_config, output);
+        output_tensor = ttnn::lt_unarylhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::NE) {
-        output_tensor = ttnn::ne_unary(queue_id, lhs, rhs, memory_config, output);
+        output_tensor = ttnn::ne_unarylhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::GE) {
-        output_tensor = ttnn::ge_unary(queue_id, lhs, rhs, memory_config, output);
+        output_tensor = ttnn::ge_unarylhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::LE) {
-        output_tensor = ttnn::le_unary(queue_id, lhs, rhs, memory_config, output);
+        output_tensor = ttnn::le_unarylhs, rhs, memory_config, output);
     } else if (binary_op_type == BinaryOpType::EQ) {
-        output_tensor = ttnn::eq_unary(queue_id, lhs, rhs, memory_config, output);
+        output_tensor = ttnn::eq_unarylhs, rhs, memory_config, output);
     } else {
         TT_THROW("Unsupported operation");
     }
     if (dtype.has_value()) {
-        output_tensor = ttnn::typecast(queue_id, output_tensor, *dtype, std::nullopt, output);
+        output_tensor = ttnn::typecastoutput_tensor, *dtype, std::nullopt, output);
     }
     return output_tensor;
 }
 
 // Scalar - Tensor
 inline Tensor binary_impl(
-    QueueId queue_id,
     BinaryOpType binary_op_type,
     const float lhs,
     const ttnn::Tensor& rhs,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& output = std::nullopt) {
     if (binary_op_type == BinaryOpType::GE) {
-        return ttnn::gez(queue_id, ttnn::sub_sfpu(queue_id, lhs, rhs, memory_config), memory_config, output);
+        return ttnn::gezttnn::sub_sfpulhs, rhs, memory_config), memory_config, output);
     }
     if (binary_op_type == BinaryOpType::LE) {
-        return ttnn::lez(queue_id, ttnn::sub_sfpu(queue_id, lhs, rhs, memory_config), memory_config, output);
+        return ttnn::lezttnn::sub_sfpulhs, rhs, memory_config), memory_config, output);
     }
     if (binary_op_type == BinaryOpType::EQ) {
-        return ttnn::eqz(queue_id, ttnn::sub_sfpu(queue_id, lhs, rhs, memory_config), memory_config, output);
+        return ttnn::eqzttnn::sub_sfpulhs, rhs, memory_config), memory_config, output);
     }
 
     TT_THROW("Unsupported operation");
@@ -398,7 +396,6 @@ template bool is_legacy_only<int32_t>(
 namespace detail {
 
 inline auto invoke_binary_ng(
-    QueueId queue_id,
     const Tensor& lhs,
     const auto& rhs,
     BinaryOpType binary_op_type,
@@ -419,11 +416,10 @@ inline auto invoke_binary_ng(
         if constexpr (requires { detail::preprocess_inputs(binary_op_type, lhs, rhs); }) {
             auto [a, b] = detail::preprocess_inputs(binary_op_type, lhs, rhs);
 
-            return ttnn::prim::binary(
-                queue_id, a, b, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
+            return ttnn::prim::binary(a, b, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
         } else {
             return ttnn::prim::binary(
-                queue_id, lhs, rhs, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
+                lhs, rhs, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
         }
     }
 
@@ -456,7 +452,6 @@ inline auto invoke_binary_ng(
         }
 
         auto result = ttnn::prim::binary_ng(
-            queue_id,
             input_a,
             input_b,
             binary_op_type,
@@ -482,7 +477,6 @@ inline auto invoke_binary_ng(
             output_preallocated and typecast_out ? ttnn::typecast(*output, DataType::BFLOAT16) : output;
 
         Tensor result = ttnn::prim::binary_ng(
-            queue_id,
             input_a,
             input_b,
             binary_op_type,
@@ -501,7 +495,6 @@ inline auto invoke_binary_ng(
 
 template <BinaryOpType binary_op_type>
 Tensor BinaryOperation<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     const std::optional<const DataType>& dtype,
@@ -512,7 +505,7 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
-        queue_id,
+
         lhs,
         rhs,
         binary_op_type,
@@ -527,7 +520,6 @@ Tensor BinaryOperation<binary_op_type>::invoke(
 
 template <BinaryOpType binary_op_type>
 Tensor BinaryOperation<binary_op_type>::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& lhs,
     float rhs,
     const std::optional<const DataType>& dtype,
@@ -538,7 +530,7 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
-        queue_id,
+
         lhs,
         rhs,
         binary_op_type,
@@ -553,7 +545,6 @@ Tensor BinaryOperation<binary_op_type>::invoke(
 
 template <BinaryOpType binary_op_type>
 Tensor RelationalBinary<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     const std::optional<const DataType>& dtype,
@@ -564,7 +555,7 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
-        queue_id,
+
         lhs,
         rhs,
         binary_op_type,
@@ -579,7 +570,6 @@ Tensor RelationalBinary<binary_op_type>::invoke(
 
 template <BinaryOpType binary_op_type>
 Tensor RelationalBinary<binary_op_type>::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& lhs,
     const float rhs,
     const std::optional<const DataType>& dtype,
@@ -593,12 +583,12 @@ Tensor RelationalBinary<binary_op_type>::invoke(
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
                          (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
         {
-            return detail::binary_impl(DefaultQueueId, binary_op_type, lhs, rhs, dtype, memory_config, output);
+            return detail::binary_impl(binary_op_type, lhs, rhs, dtype, memory_config, output);
         }
     }
 
     return detail::invoke_binary_ng(
-        queue_id,
+
         lhs,
         rhs,
         binary_op_type,
@@ -613,18 +603,16 @@ Tensor RelationalBinary<binary_op_type>::invoke(
 // scalar - tensor combination not available on Pytorch for this op
 template <BinaryOpType binary_op_type>
 Tensor RelationalBinary<binary_op_type>::invoke(
-    QueueId queue_id,
     const float lhs,
     const ttnn::Tensor& rhs,
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    return detail::binary_impl(DefaultQueueId, binary_op_type, lhs, rhs, memory_config, output);
+    return detail::binary_implbinary_op_type, lhs, rhs, memory_config, output);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor InplaceRelationalBinary<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
@@ -632,21 +620,12 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return RelationalBinary<binary_op_type>::invoke(
-        queue_id,
-        lhs,
-        rhs,
-        std::nullopt,
-        std::nullopt,
-        lhs,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy);
+
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor InplaceRelationalBinary<binary_op_type>::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
@@ -654,21 +633,12 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return RelationalBinary<binary_op_type>::invoke(
-        queue_id,
-        lhs,
-        rhs,
-        std::nullopt,
-        std::nullopt,
-        lhs,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy);
+
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor InplaceLogicalBinary<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
@@ -676,21 +646,12 @@ Tensor InplaceLogicalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
-        queue_id,
-        lhs,
-        rhs,
-        std::nullopt,
-        std::nullopt,
-        lhs,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy);
+
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor InplaceBinaryOperation<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
@@ -698,21 +659,12 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
-        queue_id,
-        lhs,
-        rhs,
-        std::nullopt,
-        std::nullopt,
-        lhs,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy);
+
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor InplaceBinaryOperation<binary_op_type>::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
@@ -720,21 +672,12 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
-        queue_id,
-        lhs,
-        rhs,
-        std::nullopt,
-        std::nullopt,
-        lhs,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy);
+
+        lhs, rhs, std::nullopt, std::nullopt, lhs, post_activations, lhs_activations, rhs_activations, use_legacy);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor BinaryOperationSfpu<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     const std::optional<const DataType>& dtype,
@@ -745,7 +688,7 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return detail::invoke_binary_ng(
-        queue_id,
+
         lhs,
         rhs,
         binary_op_type,
@@ -760,7 +703,6 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
 
 template <BinaryOpType binary_op_type>
 Tensor BinaryOperationAddalpha<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     float alpha,
@@ -768,12 +710,11 @@ Tensor BinaryOperationAddalpha<binary_op_type>::invoke(
     const std::optional<Tensor>& output) {
     SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
-        queue_id, lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
+        lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
 
 template <BinaryOpType binary_op_type>
 Tensor BinaryOperationSubalpha<binary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
     float alpha,
@@ -781,7 +722,7 @@ Tensor BinaryOperationSubalpha<binary_op_type>::invoke(
     const std::optional<Tensor>& output) {
     SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
-        queue_id, lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
+        lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
 
 template struct BinaryOperation<BinaryOpType::ADD>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -28,7 +28,6 @@ bool is_legacy_only(
 template <BinaryOpType binary_op_type>
 struct BinaryOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -40,7 +39,6 @@ struct BinaryOperation {
         const std::optional<bool>& use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& lhs,
         float rhs,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -55,7 +53,6 @@ struct BinaryOperation {
 template <BinaryOpType binary_op_type>
 struct RelationalBinary {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -67,7 +64,6 @@ struct RelationalBinary {
         const std::optional<bool>& use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& lhs,
         float rhs,
         const std::optional<const DataType>& dtype = std::nullopt,
@@ -80,7 +76,6 @@ struct RelationalBinary {
 
     // rhs - tensor combination not available on Pytorch for this op
     static Tensor invoke(
-        QueueId queue_id,
         float rhs,
         const ttnn::Tensor& lhs,
         const std::optional<const DataType>& dtype = std::nullopt,
@@ -91,7 +86,6 @@ struct RelationalBinary {
 template <BinaryOpType binary_op_type>
 struct InplaceRelationalBinary {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
@@ -100,7 +94,6 @@ struct InplaceRelationalBinary {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         float rhs,
         tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
@@ -112,7 +105,6 @@ struct InplaceRelationalBinary {
 template <BinaryOpType binary_op_type>
 struct InplaceLogicalBinary {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
@@ -124,7 +116,6 @@ struct InplaceLogicalBinary {
 template <BinaryOpType binary_op_type>
 struct InplaceBinaryOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
@@ -133,7 +124,6 @@ struct InplaceBinaryOperation {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         float rhs,
         tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
@@ -145,7 +135,6 @@ struct InplaceBinaryOperation {
 template <BinaryOpType binary_op_type>
 struct BinaryOperationSfpu {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -160,7 +149,6 @@ struct BinaryOperationSfpu {
 template <BinaryOpType binary_op_type>
 struct BinaryOperationAddalpha {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         float alpha,
@@ -171,7 +159,6 @@ struct BinaryOperationAddalpha {
 template <BinaryOpType binary_op_type>
 struct BinaryOperationSubalpha {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         float alpha,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/eltwise/binary/device/binary_composite_op.hpp"
 #include "ttnn/operations/eltwise/binary/device/binary_device_operation.hpp"
@@ -29,21 +28,18 @@ namespace binary {
  */
 struct ExecutePower {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t exponent,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float exponent,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         float input_a,
         const Tensor& exponent,
         const std::optional<const DataType>& dtype = std::nullopt,
@@ -55,7 +51,6 @@ struct ExecutePower {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const Tensor& exponent,
         const std::optional<const DataType>& dtype = std::nullopt,
@@ -107,7 +102,6 @@ struct ExecuteDivLikeOps {
 
 struct ExecuteDiv {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
         bool accurate_mode = false,
@@ -121,7 +115,6 @@ struct ExecuteDiv {
         const std::optional<bool>& use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& lhs,
         float rhs,
         bool accurate_mode = false,
@@ -138,7 +131,6 @@ struct ExecuteDiv {
 template <BinaryOpType binary_op_type>
 struct ExecuteBiasGelu {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -149,7 +141,6 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt) {
         return BinaryOperation<binary_op_type>::invoke(
-            queue_id,
             input_tensor_a_arg,
             input_tensor_b_arg,
             output_dtype,
@@ -162,7 +153,6 @@ struct ExecuteBiasGelu {
     }
 
     static Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_a,
         const float bias,
         const std::optional<const DataType>& dtype = std::nullopt,
@@ -173,15 +163,13 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt) {
         return ttnn::gelu(
-            queue_id,
-            ttnn::add(queue_id, input_tensor_a, bias, std::nullopt, memory_config, optional_output_tensor),
+            ttnn::addinput_tensor_a, bias, std::nullopt, memory_config, optional_output_tensor),
             true,
             memory_config,
             optional_output_tensor);
     }
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -191,7 +179,6 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
         tt::stl::Span<const unary::UnaryWithParam> post_activations = {}) {
         return BinaryOperation<binary_op_type>::invoke(
-            queue_id,
             input_tensor_a,
             input_tensor_b,
             output_dtype,
@@ -203,7 +190,6 @@ struct ExecuteBiasGelu {
     }
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         float scalar,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -213,7 +199,6 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
         tt::stl::Span<const unary::UnaryWithParam> post_activations = {}) {
         return BinaryOperation<binary_op_type>::invoke(
-            queue_id,
             input_tensor_a,
             scalar,
             output_dtype,
@@ -257,7 +242,6 @@ struct ExecuteBinaryRemainder {
 
 struct ExecuteLCM {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -271,7 +255,6 @@ struct ExecuteLCM {
 
 struct ExecuteGCD {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -285,7 +268,6 @@ struct ExecuteGCD {
 
 struct ExecuteMaximum {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -297,7 +279,6 @@ struct ExecuteMaximum {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_a,
         std::variant<int32_t, float> value,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -311,7 +292,6 @@ struct ExecuteMaximum {
 
 struct ExecuteMinimum {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -323,7 +303,6 @@ struct ExecuteMinimum {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_a,
         std::variant<int32_t, float> value,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -352,7 +331,6 @@ struct ExecutePrelu {
 
 struct ExecuteRsub {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -364,7 +342,6 @@ struct ExecuteRsub {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float input_b,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -378,7 +355,6 @@ struct ExecuteRsub {
 
 struct ExecuteBitwiseAnd {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -389,7 +365,6 @@ struct ExecuteBitwiseAnd {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -402,7 +377,6 @@ struct ExecuteBitwiseAnd {
 
 struct ExecuteBitwiseOr {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -413,7 +387,6 @@ struct ExecuteBitwiseOr {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -426,7 +399,6 @@ struct ExecuteBitwiseOr {
 
 struct ExecuteBitwiseXor {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -437,7 +409,6 @@ struct ExecuteBitwiseXor {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -450,7 +421,6 @@ struct ExecuteBitwiseXor {
 
 struct ExecuteBitwiseLeftShift {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -461,7 +431,6 @@ struct ExecuteBitwiseLeftShift {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -474,7 +443,6 @@ struct ExecuteBitwiseLeftShift {
 
 struct ExecuteBitwiseRightShift {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -485,7 +453,6 @@ struct ExecuteBitwiseRightShift {
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -163,7 +163,7 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt) {
         return ttnn::gelu(
-            ttnn::addinput_tensor_a, bias, std::nullopt, memory_config, optional_output_tensor),
+            ttnn::add(input_tensor_a, bias, std::nullopt, memory_config, optional_output_tensor),
             true,
             memory_config,
             optional_output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -34,7 +34,6 @@ void bind_primitive_binary_operation(
             * :attr:`dtype` (Optional[ttnn.DataType]): data type for the output tensor
             * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
             * :attr:`activations` (Optional[List[str]]): list of activation functions to apply to the output tensor
-            * :attr:`queue_id` (Optional[uint8]): command queue id
 
         Example:
 
@@ -106,7 +105,7 @@ void bind_binary_operation(
             dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             activations (List[str], optional): list of activation functions to apply to the output tensor{4}Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -156,10 +155,8 @@ void bind_binary_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     scalar,
                     dtype,
@@ -179,8 +176,7 @@ void bind_binary_operation(
             py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+            py::arg("use_legacy") = std::nullopt},
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -193,10 +189,8 @@ void bind_binary_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     dtype,
@@ -217,7 +211,7 @@ void bind_binary_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -249,7 +243,7 @@ void bind_binary_gcd_lcm_operation(
             dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             activations (List[str], optional): list of activation functions to apply to the output tensor{4}Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -299,10 +293,8 @@ void bind_binary_gcd_lcm_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     dtype,
@@ -323,7 +315,7 @@ void bind_binary_gcd_lcm_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -346,7 +338,7 @@ void bind_binary_unary_max_operation(
             dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             activations (List[str], optional): list of activation functions to apply to the output tensor{4}Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -393,10 +385,8 @@ void bind_binary_unary_max_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     scalar,
                     dtype,
@@ -417,7 +407,7 @@ void bind_binary_unary_max_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -430,10 +420,8 @@ void bind_binary_unary_max_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     dtype,
@@ -454,7 +442,7 @@ void bind_binary_unary_max_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -482,7 +470,7 @@ void bind_binary_unary_operation(
             dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             activations (List[str], optional): list of activation functions to apply to the output tensor{4}Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -531,10 +519,8 @@ void bind_binary_unary_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     scalar,
                     dtype,
@@ -555,7 +541,7 @@ void bind_binary_unary_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -568,10 +554,8 @@ void bind_binary_unary_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     dtype,
@@ -592,7 +576,7 @@ void bind_binary_unary_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -618,7 +602,7 @@ void bind_binary_with_float_param(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -663,9 +647,8 @@ void bind_binary_with_float_param(
                const Tensor& input_tensor_b,
                float alpha,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor_a, input_tensor_b, alpha, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor_a, input_tensor_b, alpha, memory_config, output_tensor);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -673,7 +656,7 @@ void bind_binary_with_float_param(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -699,7 +682,7 @@ void bind_bitwise_binary_ops_operation(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -747,10 +730,8 @@ void bind_bitwise_binary_ops_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     scalar,
                     memory_config,
@@ -769,7 +750,7 @@ void bind_bitwise_binary_ops_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -781,10 +762,8 @@ void bind_bitwise_binary_ops_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     memory_config,
@@ -803,7 +782,7 @@ void bind_bitwise_binary_ops_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -829,7 +808,7 @@ void bind_logical_binary_ops_operation(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -874,10 +853,8 @@ void bind_logical_binary_ops_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     dtype,
@@ -895,7 +872,7 @@ void bind_logical_binary_ops_operation(
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -1250,7 +1227,7 @@ void bind_div(
             accurate_mode (bool, optional): `false` if input_tensor_b is non-zero, else `true` (Only if the input tensor is not ComplexTensor). Defaults to `false`.
             round_mode (string, optional): can be `None`, `floor` and `trunc` (only if the input tensor is not ComplexTensor). Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -1299,10 +1276,8 @@ void bind_div(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     accurate_mode,
@@ -1327,7 +1302,7 @@ void bind_div(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         ttnn::pybind_overload_t{
             [](const binary_operation_t& self,
@@ -1341,10 +1316,8 @@ void bind_div(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     value,
                     accurate_mode,
@@ -1369,7 +1342,7 @@ void bind_div(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -1587,10 +1560,8 @@ void bind_inplace_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               const QueueId queue_id) {
+               const std::optional<bool>& use_legacy) {
                 return self(
-                    queue_id,
                     input_tensor,
                     scalar,
                     activations,
@@ -1604,7 +1575,7 @@ void bind_inplace_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -1614,10 +1585,8 @@ void bind_inplace_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               const QueueId queue_id) {
+               const std::optional<bool>& use_legacy) {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     activations,
@@ -1632,7 +1601,7 @@ void bind_inplace_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -1696,10 +1665,8 @@ void bind_logical_inplace_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               const QueueId queue_id) {
+               const std::optional<bool>& use_legacy) {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     activations,
@@ -1713,7 +1680,7 @@ void bind_logical_inplace_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -1749,10 +1716,8 @@ void bind_binary_inplace_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               const QueueId queue_id) {
+               const std::optional<bool>& use_legacy) {
                 return self(
-                    queue_id,
                     input_tensor,
                     scalar,
                     activations,
@@ -1767,7 +1732,7 @@ void bind_binary_inplace_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -1777,10 +1742,8 @@ void bind_binary_inplace_operation(
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               const QueueId queue_id) {
+               const std::optional<bool>& use_legacy) {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     activations,
@@ -1795,7 +1758,7 @@ void bind_binary_inplace_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+        });
 }
 
 template <typename binary_operation_t>
@@ -1814,7 +1777,7 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -1853,16 +1816,15 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
                const Tensor& input_tensor,
                uint32_t exponent,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               const QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, exponent, memory_config, output_tensor);
+               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, exponent, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("exponent"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         // float exponent
         ttnn::pybind_overload_t{
@@ -1870,16 +1832,15 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
                const Tensor& input_tensor,
                float exponent,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               const QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, exponent, memory_config, output_tensor);
+               std::optional<Tensor> output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, exponent, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("exponent"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // tensor exponent
         ttnn::pybind_overload_t{
@@ -1892,10 +1853,8 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor,
                     exponent,
                     dtype,
@@ -1916,7 +1875,7 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // scalar input - tensor exponent
         ttnn::pybind_overload_t{
@@ -1929,10 +1888,8 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
                const ttnn::SmallVector<unary::UnaryWithParam>& activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input,
                     exponent,
                     dtype,
@@ -1953,7 +1910,7 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 }  // namespace detail
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -9,7 +9,6 @@
 #include <variant>
 
 #include <tt-metalium/command_queue.hpp>
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
 #include "ttnn/operations/eltwise/complex/complex.hpp"
@@ -88,7 +87,6 @@ struct ExecuteBackwardMin {
 
 struct ExecuteBackwardMul {
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         float scalar,
@@ -96,7 +94,6 @@ struct ExecuteBackwardMul {
         std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const Tensor& other_tensor_arg,
@@ -114,14 +111,12 @@ struct ExecuteBackwardMul {
 
 struct ExecuteBackwardAssign {
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> input_a_grad = std::nullopt);
 
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const Tensor& other_tensor_arg,
@@ -149,7 +144,6 @@ struct ExecuteBackwardBiasGelu {
 
 struct ExecuteBackwardLT {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const Tensor& other_tensor_arg,
@@ -159,7 +153,6 @@ struct ExecuteBackwardLT {
         std::optional<Tensor> other_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         float other,
@@ -169,7 +162,6 @@ struct ExecuteBackwardLT {
 
 struct ExecuteBackwardAdd {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         float scalar,
@@ -177,7 +169,6 @@ struct ExecuteBackwardAdd {
         std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
@@ -196,7 +187,6 @@ struct ExecuteBackwardAdd {
 
 struct ExecuteBackwardSub {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         float scalar,
@@ -204,7 +194,6 @@ struct ExecuteBackwardSub {
         std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
@@ -223,7 +212,6 @@ struct ExecuteBackwardSub {
 
 struct ExecuteBackwardDiv {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         float scalar,
@@ -232,7 +220,6 @@ struct ExecuteBackwardDiv {
         std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const Tensor& other_tensor_arg,
@@ -279,7 +266,6 @@ struct ExecuteBackwardFmod {
 
 struct ExecuteAddalphaBW {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
@@ -292,7 +278,6 @@ struct ExecuteAddalphaBW {
 
 struct ExecuteBackwardSubAlpha {
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
@@ -305,7 +290,6 @@ struct ExecuteBackwardSubAlpha {
 
 struct ExecuteBackwardRsub {
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
@@ -317,7 +301,6 @@ struct ExecuteBackwardRsub {
 
 struct ExecuteBackwardConcat {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.cpp
@@ -122,7 +122,7 @@ void bind_binary_backward_concat(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_a`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_b`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
 
         Returns:
@@ -175,8 +175,7 @@ void bind_binary_backward_concat(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
                     grad_tensor,
                     input_tensor_a,
@@ -196,7 +195,7 @@ void bind_binary_backward_concat(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_a_grad") = std::nullopt,
             py::arg("input_b_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 
 template <typename binary_backward_operation_t>
@@ -225,7 +224,7 @@ void bind_binary_backward_addalpha(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_a`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_b`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
 
         Returns:
@@ -279,10 +278,9 @@ void bind_binary_backward_addalpha(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_b_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor_a,
                     input_tensor_b,
@@ -301,7 +299,7 @@ void bind_binary_backward_addalpha(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_a_grad") = std::nullopt,
             py::arg("input_b_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 
 template <typename binary_backward_operation_t>
@@ -431,7 +429,7 @@ void bind_binary_backward_sub_alpha(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_a`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_b`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Note:
             Supported dtypes, layouts, and ranks:
@@ -477,10 +475,9 @@ void bind_binary_backward_sub_alpha(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -499,7 +496,7 @@ void bind_binary_backward_sub_alpha(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
             py::arg("other_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 
 template <typename binary_backward_operation_t>
@@ -523,7 +520,7 @@ void bind_binary_backward_rsub(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_a`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_b`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Note:
             Supported dtypes, layouts, and ranks:
@@ -564,10 +561,9 @@ void bind_binary_backward_rsub(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -584,7 +580,7 @@ void bind_binary_backward_rsub(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
             py::arg("other_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 
 template <typename binary_backward_operation_t>
@@ -607,7 +603,7 @@ void bind_binary_bw_mul(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_a`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_b`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -655,9 +651,8 @@ void bind_binary_bw_mul(
                const Tensor& input_tensor_a,
                const float scalar,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, scalar, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor_a, scalar, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -665,7 +660,7 @@ void bind_binary_bw_mul(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -676,10 +671,9 @@ void bind_binary_bw_mul(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -696,7 +690,7 @@ void bind_binary_bw_mul(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
             py::arg("other_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // complex tensor
         ttnn::pybind_overload_t{
@@ -737,7 +731,7 @@ void bind_binary_bw(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_a`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor_b`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Note:
             Supported dtypes, layouts, and ranks:
@@ -785,9 +779,8 @@ void bind_binary_bw(
                const Tensor& input_tensor_a,
                const float scalar,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, scalar, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor_a, scalar, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -795,7 +788,7 @@ void bind_binary_bw(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -806,10 +799,9 @@ void bind_binary_bw(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -826,7 +818,7 @@ void bind_binary_bw(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
             py::arg("other_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // complex tensor
         ttnn::pybind_overload_t{
@@ -868,7 +860,7 @@ void bind_binary_bw_div(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `other_tensor`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -921,9 +913,8 @@ void bind_binary_bw_div(
                const float scalar,
                const std::optional<std::string> round_mode,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, scalar, round_mode, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor_a, scalar, round_mode, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -932,7 +923,7 @@ void bind_binary_bw_div(
             py::arg("round_mode") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -944,10 +935,9 @@ void bind_binary_bw_div(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -966,7 +956,7 @@ void bind_binary_bw_div(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
             py::arg("other_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // complex tensor
         ttnn::pybind_overload_t{
@@ -1096,7 +1086,7 @@ void bind_binary_backward_assign(
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `other_tensor`. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
             round_mode (str, optional): Round mode for the operation. Defaults to `None`.
 
         Note:
@@ -1137,16 +1127,15 @@ void bind_binary_backward_assign(
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("input_a_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId},
+        },
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -1157,10 +1146,9 @@ void bind_binary_backward_assign(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_b_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-                    queue_id,
+
                     grad_tensor,
                     input_tensor_a,
                     input_tensor_b,
@@ -1177,7 +1165,7 @@ void bind_binary_backward_assign(
             py::arg("memory_config") = std::nullopt,
             py::arg("input_a_grad") = std::nullopt,
             py::arg("input_b_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+        });
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.cpp
@@ -175,7 +175,7 @@ void bind_binary_backward_concat(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
                     grad_tensor,
                     input_tensor_a,
@@ -278,9 +278,8 @@ void bind_binary_backward_addalpha(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor_a,
                     input_tensor_b,
@@ -316,7 +315,6 @@ void bind_binary_backward_bias_gelu(
     const std::string_view note = "") {
     auto doc = fmt::format(
         R"doc(
-
         {7}
 
         Args:
@@ -415,7 +413,6 @@ void bind_binary_backward_sub_alpha(
     const std::string_view supported_dtype = "BFLOAT16") {
     auto doc = fmt::format(
         R"doc(
-
         {5}
 
         Args:
@@ -475,9 +472,8 @@ void bind_binary_backward_sub_alpha(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -507,7 +503,6 @@ void bind_binary_backward_rsub(
     const std::string_view supported_dtype = "BFLOAT16") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:
@@ -561,9 +556,8 @@ void bind_binary_backward_rsub(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -651,7 +645,7 @@ void bind_binary_bw_mul(
                const Tensor& input_tensor_a,
                const float scalar,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(grad_tensor, input_tensor_a, scalar, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
@@ -671,9 +665,8 @@ void bind_binary_bw_mul(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -717,7 +710,6 @@ void bind_binary_bw(
     const std::string_view note = "") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
         Supports broadcasting.
 
@@ -779,7 +771,7 @@ void bind_binary_bw(
                const Tensor& input_tensor_a,
                const float scalar,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(grad_tensor, input_tensor_a, scalar, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
@@ -799,9 +791,8 @@ void bind_binary_bw(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -846,7 +837,6 @@ void bind_binary_bw_div(
     const std::string_view supported_dtype = "BFLOAT16") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:
@@ -913,7 +903,7 @@ void bind_binary_bw_div(
                const float scalar,
                const std::optional<std::string> round_mode,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(grad_tensor, input_tensor_a, scalar, round_mode, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
@@ -935,9 +925,8 @@ void bind_binary_bw_div(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
-               const std::optional<ttnn::Tensor>& other_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& other_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor,
                     other_tensor,
@@ -983,7 +972,6 @@ void bind_binary_backward_overload(
     const std::string& note = "") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:
@@ -1073,7 +1061,6 @@ void bind_binary_backward_assign(
     const std::string_view supported_dtype = "BFLOAT16") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:
@@ -1127,7 +1114,7 @@ void bind_binary_backward_assign(
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(grad_tensor, input_tensor, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
@@ -1146,9 +1133,8 @@ void bind_binary_backward_assign(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad, ) -> std::vector<std::optional<ttnn::Tensor>> {
+               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<std::optional<ttnn::Tensor>> {
                 return self(
-
                     grad_tensor,
                     input_tensor_a,
                     input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -177,7 +177,7 @@ Tensor QuantOp::invoke(
         const Tensor scale_full = reshape_per_channel_vector_args(*scale_p, input_shape, axis_v, a_dtype);
         const Tensor zero_point_full = reshape_per_channel_vector_args(*zero_point_p, input_shape, axis_v, a_dtype);
         const Tensor input_scaled =
-            ttnn::divideinput_a, scale_full, a_dtype, std::nullopt, std::nullopt, none, none, none, false);
+            ttnn::divide(input_a, scale_full, a_dtype, std::nullopt, std::nullopt, none, none, none, false);
         return ttnn::typecast(
             ttnn::add(
                 input_scaled,
@@ -232,7 +232,6 @@ Tensor QuantOp::invoke(
                     ttnn::divide(input_a, scale, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
                 return ttnn::typecast(
                     ttnn::add(
-
                         input_scaled,
                         zero_point.dtype() == a_dtype ? zero_point : ttnn::typecast(zero_point, a_dtype),
                         a_dtype,
@@ -259,7 +258,6 @@ Tensor QuantOp::invoke(
                     false);
                 return ttnn::typecast(
                     ttnn::add(
-
                         input_scaled,
                         zero_point.dtype() == a_dtype ? zero_point : ttnn::typecast(zero_point, a_dtype),
                         a_dtype,
@@ -490,7 +488,6 @@ Tensor DequantOp::invoke(
                 check_per_tensor_zero_point(zero_point);
                 const Tensor input_shifted = ttnn::typecast(
                     ttnn::subtract(
-
                         input_tensor, zero_point, std::nullopt, std::nullopt, std::nullopt, none, none, none, false),
                     c_dtype);
                 return ttnn::multiply(
@@ -501,7 +498,6 @@ Tensor DequantOp::invoke(
                 check_per_tensor_zero_point(zero_point);
                 const Tensor input_shifted = ttnn::typecast(
                     ttnn::subtract(
-
                         input_tensor, zero_point, std::nullopt, std::nullopt, std::nullopt, none, none, none, false),
                     c_dtype);
                 return ttnn::multiply(

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.hpp
@@ -13,7 +13,6 @@ namespace ttnn::operations::quantization {
 
 struct QuantOp {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::variant<Tensor, float>& scale,
         const std::variant<Tensor, int32_t>& zero_point,
@@ -25,7 +24,6 @@ struct QuantOp {
 
 struct RequantOp {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::variant<Tensor, float>& in_scale,
         const std::variant<Tensor, int32_t>& in_zero_point,
@@ -39,7 +37,6 @@ struct RequantOp {
 
 struct DequantOp {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::variant<Tensor, float>& scale,
         const std::variant<Tensor, int32_t>& zero_point,

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
@@ -79,7 +79,7 @@ void bind_quantize_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
-            return self(input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
+                return self(input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("scale"),
@@ -88,7 +88,7 @@ void bind_quantize_operation(
             py::arg("axis") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename T>
@@ -178,8 +178,8 @@ void bind_requantize_operation(
             py::arg("axis") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
-}
+            py::arg("output_tensor") = std::nullopt});
+};
 
 template <typename T>
 void bind_dequantize_operation(
@@ -242,7 +242,7 @@ void bind_dequantize_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
-                    return self(input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
+                return self(input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("scale"),
@@ -251,8 +251,8 @@ void bind_dequantize_operation(
             py::arg("axis") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
-}
+            py::arg("output_tensor") = std::nullopt});
+};
 
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
@@ -78,9 +78,8 @@ void bind_quantize_operation(
                const std::optional<int32_t> axis,
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+            return self(input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("scale"),
@@ -89,8 +88,7 @@ void bind_quantize_operation(
             py::arg("axis") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename T>
@@ -159,10 +157,8 @@ void bind_requantize_operation(
                const std::optional<int32_t> axis,
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
                 return self(
-                    queue_id,
                     input_tensor,
                     in_scale,
                     in_zero_point,
@@ -182,8 +178,7 @@ void bind_requantize_operation(
             py::arg("axis") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename T>
@@ -246,9 +241,8 @@ void bind_dequantize_operation(
                const std::optional<int32_t> axis,
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                    return self(input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("scale"),
@@ -257,8 +251,7 @@ void bind_dequantize_operation(
             py::arg("axis") = std::nullopt,
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
@@ -143,14 +143,14 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
                const std::variant<float, Tensor>& false_value,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<Tensor> output_tensor) {
-            return self(predicate, true_value, false_value, memory_config, output_tensor);
+                return self(predicate, true_value, false_value, memory_config, output_tensor);
             },
             py::arg("predicate"),
             py::arg("true_value"),
             py::arg("false_value"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename ternary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
@@ -105,7 +105,6 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
 
         Note:
@@ -143,17 +142,15 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
                const std::variant<float, Tensor>& true_value,
                const std::variant<float, Tensor>& false_value,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, predicate, true_value, false_value, memory_config, output_tensor);
+               std::optional<Tensor> output_tensor) {
+            return self(predicate, true_value, false_value, memory_config, output_tensor);
             },
             py::arg("predicate"),
             py::arg("true_value"),
             py::arg("false_value"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename ternary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
@@ -155,9 +155,8 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
 
 template <typename ternary_operation_t>
 void bind_ternary_lerp(py::module& module, const ternary_operation_t& operation, const std::string& description) {
-    auto doc = fmt::format(
-        R"doc(
-
+        auto doc = fmt::format(
+            R"doc(
         {2}
 
         .. math::
@@ -196,37 +195,41 @@ void bind_ternary_lerp(py::module& module, const ternary_operation_t& operation,
             >>> tensor3 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor1, tensor2, tensor3/scalar)
         )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        description);
+            operation.base_name(),
+            operation.python_fully_qualified_name(),
+            description);
 
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const ternary_operation_t& self,
-               const Tensor& input,
-               const Tensor& end,
-               const Tensor& weight,
-               const std::optional<MemoryConfig>& memory_config) { return self(input, end, weight, memory_config); },
-            py::arg("input"),
-            py::arg("end"),
-            py::arg("weight"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt},
+        bind_registered_operation(
+            module,
+            operation,
+            doc,
+            ttnn::pybind_overload_t{
+                [](const ternary_operation_t& self,
+                   const Tensor& input,
+                   const Tensor& end,
+                   const Tensor& weight,
+                   const std::optional<MemoryConfig>& memory_config) {
+                    return self(input, end, weight, memory_config);
+                },
+                py::arg("input"),
+                py::arg("end"),
+                py::arg("weight"),
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt},
 
-        ttnn::pybind_overload_t{
-            [](const ternary_operation_t& self,
-               const Tensor& input,
-               const Tensor& end,
-               float weight,
-               const std::optional<MemoryConfig>& memory_config) { return self(input, end, weight, memory_config); },
-            py::arg("input"),
-            py::arg("end"),
-            py::arg("weight"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt});
+            ttnn::pybind_overload_t{
+                [](const ternary_operation_t& self,
+                   const Tensor& input,
+                   const Tensor& end,
+                   float weight,
+                   const std::optional<MemoryConfig>& memory_config) {
+                    return self(input, end, weight, memory_config);
+                },
+                py::arg("input"),
+                py::arg("end"),
+                py::arg("weight"),
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt});
 }
 
 template <typename ternary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
@@ -43,9 +43,8 @@ Tensor where_impl(
     };
 
     return ttnn::add(
-
-        get_multiplied(ttnn::gtzpredicate, memory_config), value_true),
-        get_multiplied(ttnn::lezpredicate, memory_config), value_false),
+        get_multiplied(ttnn::gtz(predicate, memory_config), value_true),
+        get_multiplied(ttnn::lez(predicate, memory_config), value_false),
         dtype,
         memory_config,
         output,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.hpp
@@ -8,7 +8,6 @@
 #include <variant>
 
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn {
 
@@ -18,7 +17,6 @@ namespace ternary {
 
 struct WhereOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& predicate,
         const std::variant<float, Tensor>& value_true,
         const std::variant<float, Tensor>& value_false,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -80,9 +80,9 @@ std::vector<OptionalTensor> WhereBackwardOperation::invoke(
     std::vector<OptionalTensor> result;
     if (are_required_outputs.at(0)) {
         if (input_grad.has_value()) {
-            wherecondition, grad, 0.0f, output_mem_config, input_grad);
+            where(condition, grad, 0.0f, output_mem_config, input_grad);
         } else {
-            input_grad = wherecondition, grad, 0.0f, output_mem_config);
+            input_grad = where(condition, grad, 0.0f, output_mem_config);
         }
         result.emplace_back(input_grad);
     } else {
@@ -90,9 +90,9 @@ std::vector<OptionalTensor> WhereBackwardOperation::invoke(
     }
     if (are_required_outputs.at(1)) {
         if (other_grad.has_value()) {
-            wherecondition, 0.0f, grad, output_mem_config, other_grad);
+            where(condition, 0.0f, grad, output_mem_config, other_grad);
         } else {
-            other_grad = wherecondition, 0.0f, grad, output_mem_config);
+            other_grad = where(condition, 0.0f, grad, output_mem_config);
         }
         result.emplace_back(other_grad);
     } else {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -69,7 +69,6 @@ std::vector<Tensor> AddcdivBackwardOperation::invoke(
 }
 
 std::vector<OptionalTensor> WhereBackwardOperation::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& condition,
     const Tensor& input,
@@ -81,9 +80,9 @@ std::vector<OptionalTensor> WhereBackwardOperation::invoke(
     std::vector<OptionalTensor> result;
     if (are_required_outputs.at(0)) {
         if (input_grad.has_value()) {
-            where(queue_id, condition, grad, 0.0f, output_mem_config, input_grad);
+            wherecondition, grad, 0.0f, output_mem_config, input_grad);
         } else {
-            input_grad = where(queue_id, condition, grad, 0.0f, output_mem_config);
+            input_grad = wherecondition, grad, 0.0f, output_mem_config);
         }
         result.emplace_back(input_grad);
     } else {
@@ -91,9 +90,9 @@ std::vector<OptionalTensor> WhereBackwardOperation::invoke(
     }
     if (are_required_outputs.at(1)) {
         if (other_grad.has_value()) {
-            where(queue_id, condition, 0.0f, grad, output_mem_config, other_grad);
+            wherecondition, 0.0f, grad, output_mem_config, other_grad);
         } else {
-            other_grad = where(queue_id, condition, 0.0f, grad, output_mem_config);
+            other_grad = wherecondition, 0.0f, grad, output_mem_config);
         }
         result.emplace_back(other_grad);
     } else {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp
@@ -35,7 +35,6 @@ struct AddcdivBackwardOperation {
 
 struct WhereBackwardOperation {
     static std::vector<OptionalTensor> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.cpp
@@ -269,15 +269,15 @@ void bind_ternary_backward_optional_output(
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& input_a_grad,
                const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<std::optional<ttnn::Tensor>> {
-            return self(
-                grad_tensor,
-                input_tensor_a,
-                input_tensor_b,
-                input_tensor_c,
-                memory_config,
-                are_required_outputs,
-                input_a_grad,
-                input_b_grad);
+                return self(
+                    grad_tensor,
+                    input_tensor_a,
+                    input_tensor_b,
+                    input_tensor_c,
+                    memory_config,
+                    are_required_outputs,
+                    input_a_grad,
+                    input_b_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -287,7 +287,7 @@ void bind_ternary_backward_optional_output(
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
             py::arg("input_a_grad") = std::nullopt,
-            py::arg("input_b_grad") = std::nullopt);
+            py::arg("input_b_grad") = std::nullopt});
 }
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.cpp
@@ -226,7 +226,6 @@ void bind_ternary_backward_optional_output(
             are_required_outputs (List[bool], optional): list of required outputs. Defaults to `[True, True]`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -271,18 +270,16 @@ void bind_ternary_backward_optional_output(
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(
-                    queue_id,
-                    grad_tensor,
-                    input_tensor_a,
-                    input_tensor_b,
-                    input_tensor_c,
-                    memory_config,
-                    are_required_outputs,
-                    input_a_grad,
-                    input_b_grad);
+               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<std::optional<ttnn::Tensor>> {
+            return self(
+                grad_tensor,
+                input_tensor_a,
+                input_tensor_b,
+                input_tensor_c,
+                memory_config,
+                are_required_outputs,
+                input_a_grad,
+                input_b_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -292,8 +289,7 @@ void bind_ternary_backward_optional_output(
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
             py::arg("input_a_grad") = std::nullopt,
-            py::arg("input_b_grad") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("input_b_grad") = std::nullopt);
 }
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.cpp
@@ -29,7 +29,6 @@ void bind_ternary_backward(
     const std::string_view note = "") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:
@@ -213,7 +212,6 @@ void bind_ternary_backward_optional_output(
     const std::string& supported_dtype = "BFLOAT16") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -402,8 +402,8 @@ std::vector<Tensor> split_tensor_for_glu(
     ttnn::SmallVector<uint32_t> e_b = {inshape[0], inshape[1], inshape[2], inshape[3]};
 
     auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
-    Tensor t_a = ttnn::sliceinput_a, s_a, e_a, step, output_mem_config);
-    Tensor t_b = ttnn::sliceinput_a, s_b, e_b, step, output_mem_config);
+    Tensor t_a = ttnn::slice(input_a, s_a, e_a, step, output_mem_config);
+    Tensor t_b = ttnn::slice(input_a, s_b, e_b, step, output_mem_config);
 
     t_split.emplace_back(t_a);
     t_split.emplace_back(t_b);
@@ -531,8 +531,8 @@ Tensor ExecuteRdiv::invoke(
         (round_mode == std::nullopt || round_mode == "trunc" || round_mode == "floor"),
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
     float t_inf = std::numeric_limits<float>::infinity();
-    Tensor recip_result = ttnn::reciprocalinput_tensor, memory_config, optional_output_tensor);
-    Tensor result = ttnn::multiplyrecip_result, value, std::nullopt, memory_config, optional_output_tensor);
+    Tensor recip_result = ttnn::reciprocal(input_tensor, memory_config, optional_output_tensor);
+    Tensor result = ttnn::multiply(recip_result, value, std::nullopt, memory_config, optional_output_tensor);
 
     if (round_mode == "trunc") {
         result = ttnn::trunc(result);
@@ -540,7 +540,7 @@ Tensor ExecuteRdiv::invoke(
         result = ttnn::floor(result);
     }
     return ttnn::where(
-        ttnn::eqzinput_tensor, memory_config), t_inf * value, result, memory_config, optional_output_tensor);
+        ttnn::eqz(input_tensor, memory_config), t_inf * value, result, memory_config, optional_output_tensor);
 }
 
 // logit(input, eps)=log(input / 1 - input)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
@@ -32,7 +32,6 @@ Tensor Tanh_accurate::invoke(
                                     : memory_config.value_or(input_tensor.memory_config());
 
     return prim::tanh_accurate(
-
         input_tensor,
         output_dtype,
         output_memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
@@ -5,7 +5,6 @@
 #include "tanh_accurate.hpp"
 
 #include "device/tanh_accurate_device_operation.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn {
 
@@ -14,7 +13,6 @@ namespace operations {
 namespace unary {
 
 Tensor Tanh_accurate::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
@@ -34,7 +32,7 @@ Tensor Tanh_accurate::invoke(
                                     : memory_config.value_or(input_tensor.memory_config());
 
     return prim::tanh_accurate(
-        queue_id,
+
         input_tensor,
         output_dtype,
         output_memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
@@ -14,7 +14,6 @@ namespace unary {
 
 struct Tanh_accurate {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -5,7 +5,6 @@
 #include "unary.hpp"
 
 #include "common/unary_op_types.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "device/unary_device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -19,7 +18,6 @@ namespace ttnn::operations::unary {
 namespace detail {
 
 inline Tensor unary_impl(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::vector<UnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -38,7 +36,6 @@ inline Tensor unary_impl(
                                     ? optional_output_tensor.value().memory_config()
                                     : memory_config.value_or(input_tensor.memory_config());
     return prim::unary(
-        queue_id,
         input_tensor,
         op_chain,
         output_dtype,
@@ -53,12 +50,10 @@ inline Tensor unary_impl(
 
 template <UnaryOpType... unary_op_types>
 Tensor ExecuteUnary<unary_op_types...>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    return detail::unary_impl(
-        queue_id, input_tensor, {UnaryWithParam{unary_op_types}...}, memory_config, optional_output_tensor);
+    return detail::unary_impl(input_tensor, {UnaryWithParam{unary_op_types}...}, memory_config, optional_output_tensor);
 }
 
 template <>
@@ -124,13 +119,11 @@ template struct ExecuteUnary<UnaryOpType::SOFTSIGN>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFastAndApproximateMode<unary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const bool parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<float>(parameter)}},
         memory_config,
@@ -145,13 +138,11 @@ template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::RSQRT>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFastAndApproximateModeTrue<unary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const bool parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<float>(parameter)}},
         memory_config,
@@ -165,14 +156,12 @@ template struct ExecuteUnaryWithFastAndApproximateModeTrue<UnaryOpType::LOG1P>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithVectorAndFastAndApproximateMode<unary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const int mode,
     const bool parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, {static_cast<float>(mode), static_cast<float>(parameter)}}},
         memory_config,
@@ -183,13 +172,11 @@ template struct ExecuteUnaryWithVectorAndFastAndApproximateMode<UnaryOpType::SIG
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFloatParameter<unary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const float parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<float>(parameter)}},
         memory_config,
@@ -198,14 +185,12 @@ Tensor ExecuteUnaryWithFloatParameter<unary_op_type>::invoke(
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithTwoFloatParameter<unary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const float parameter_a,
     const float parameter_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, {static_cast<float>(parameter_a), static_cast<float>(parameter_b)}}},
         memory_config,
@@ -215,13 +200,11 @@ Tensor ExecuteUnaryWithTwoFloatParameter<unary_op_type>::invoke(
 template <UnaryOpType unary_op_type>
 template <typename T>
 Tensor ExecuteUnaryWithVariantFloatIntParameter<unary_op_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const T parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<T>(parameter)}},
         memory_config,
@@ -249,24 +232,22 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::CELU>;
 template struct ExecuteUnaryWithTwoFloatParameter<UnaryOpType::THRESHOLD>;
 
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM>::invoke<float>(
-    QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+    const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM>::invoke<int32_t>(
-    QueueId, const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+    const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<float>(
-    QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+    const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<int32_t>(
-    QueueId, const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+    const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 Tensor Sigmoid_accurate::invoke(
-    QueueId queue_id,
     const Tensor& input,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input,
         {UnaryWithParam(UnaryOpType::NEG),
          UnaryWithParam(UnaryOpType::EXP, 1.0f),
@@ -278,12 +259,10 @@ Tensor Sigmoid_accurate::invoke(
 
 template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;
 Tensor LogSigmoid::invoke(
-    QueueId queue_id,
     const Tensor& input,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input,
         {UnaryWithParam(UnaryOpType::SIGMOID, {(int)VecMode::RC, false}), UnaryWithParam(UnaryOpType::LOG)},
         memory_config,
@@ -291,67 +270,56 @@ Tensor LogSigmoid::invoke(
 }
 
 Tensor Eqz::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::EQZ;
-    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor Unary_chain::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::vector<UnaryWithParam>& ops_chain,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     TT_FATAL(ops_chain.size() > 0, "Op chain cannot be empty");
-    return detail::unary_impl(queue_id, input_tensor, ops_chain, memory_config, optional_output_tensor);
+    return detail::unary_impl(input_tensor, ops_chain, memory_config, optional_output_tensor);
 }
 
 Tensor Softplus::invoke(
-    QueueId queue_id,
     const Tensor& input,
     const float beta,
     const float threshold,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
-        input,
-        {UnaryWithParam{UnaryOpType::SOFTPLUS, {beta, threshold}}},
-        memory_config,
-        optional_output_tensor);
+        input, {UnaryWithParam{UnaryOpType::SOFTPLUS, {beta, threshold}}}, memory_config, optional_output_tensor);
 }
 
 // tanh[x] = (exp[2x] - 1) / (exp[2x] + 1)
 Tensor Tanh::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     bool accuracy) {
     UnaryOpType op_type = UnaryOpType::TANH;
     if (!accuracy) {
-        return detail::unary_impl(
-            queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+        return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
     } else {
-        return ttnn::tanh_accurate(queue_id, input_tensor, memory_config, optional_output_tensor);
+        return ttnn::tanh_accurate(input_tensor, memory_config, optional_output_tensor);
     }
 }
 
 Tensor Prelu::invoke(
-    QueueId queue_id,
     const Tensor& input,
     float value,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id, input, {UnaryWithParam{UnaryOpType::PRELU_SFPU, value}}, memory_config, optional_output_tensor);
+        input, {UnaryWithParam{UnaryOpType::PRELU_SFPU, value}}, memory_config, optional_output_tensor);
 }
 
 Tensor Identity::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
@@ -359,15 +327,13 @@ Tensor Identity::invoke(
     DataType input_dtype = input_tensor.dtype();
 
     if (input_dtype != DataType::UINT8) {
-        return detail::unary_impl(
-            queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+        return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
     } else {
         TT_THROW("ttnn.identity doesn't support uint8 datatype");
     }
 }
 
 Tensor Abs::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
@@ -375,7 +341,7 @@ Tensor Abs::invoke(
     if (input_tensor.dtype() == DataType::INT32) {
         op_type = UnaryOpType::ABS_INT32;
     }
-    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor Abs::invoke(const ComplexTensor& input_tensor, const MemoryConfig& output_mem_config) {
@@ -383,26 +349,23 @@ Tensor Abs::invoke(const ComplexTensor& input_tensor, const MemoryConfig& output
 }
 
 Tensor Mish::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::MISH;
 
-    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor Tanhshrink::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::TANHSHRINK;
-    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor Hardshrink::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const float lambda,
     const std::optional<MemoryConfig>& memory_config,
@@ -410,15 +373,10 @@ Tensor Hardshrink::invoke(
     UnaryOpType op_type = UnaryOpType::HARDSHRINK;
     TT_ASSERT(lambda >= 0);
     return detail::unary_impl(
-        queue_id,
-        input_tensor,
-        {UnaryWithParam{op_type, static_cast<float>(lambda)}},
-        memory_config,
-        optional_output_tensor);
+        input_tensor, {UnaryWithParam{op_type, static_cast<float>(lambda)}}, memory_config, optional_output_tensor);
 }
 
 Tensor Hardtanh::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const float min_val,
     const float max_val,
@@ -426,7 +384,6 @@ Tensor Hardtanh::invoke(
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::HARDTANH;
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{op_type, std::vector<float>{static_cast<float>(min_val), static_cast<float>(max_val)}}},
         memory_config,
@@ -434,7 +391,6 @@ Tensor Hardtanh::invoke(
 }
 
 Tensor Softshrink::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const float lambda,
     const std::optional<MemoryConfig>& memory_config,
@@ -442,21 +398,15 @@ Tensor Softshrink::invoke(
     UnaryOpType op_type = UnaryOpType::SOFTSHRINK;
     TT_ASSERT(lambda >= 0);
     return detail::unary_impl(
-        queue_id,
-        input_tensor,
-        {UnaryWithParam{op_type, static_cast<float>(lambda)}},
-        memory_config,
-        optional_output_tensor);
+        input_tensor, {UnaryWithParam{op_type, static_cast<float>(lambda)}}, memory_config, optional_output_tensor);
 }
 
 Tensor Deg2Rad::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     constexpr float DEG_TO_RAD = 0.017453292519943295f;  // pi/180
     return binary::BinaryOperation<operations::binary::BinaryOpType::MUL>::invoke(
-        queue_id,
         input_tensor,
         DEG_TO_RAD,
         input_tensor.dtype(),
@@ -469,13 +419,11 @@ Tensor Deg2Rad::invoke(
 }
 
 Tensor Rad2Deg::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     constexpr float RAD_TO_DEG = 57.29577951308232f;  // 180/pi
     return binary::BinaryOperation<operations::binary::BinaryOpType::MUL>::invoke(
-        queue_id,
         input_tensor,
         RAD_TO_DEG,
         input_tensor.dtype(),
@@ -489,13 +437,11 @@ Tensor Rad2Deg::invoke(
 
 template <UnaryOpType unary_op_type, typename T>
 Tensor ExecuteUnaryWithIntegerParameter<unary_op_type, T>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     T parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<float>(parameter)}},
         memory_config,
@@ -511,13 +457,11 @@ template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_XOR, int32
 
 template <UnaryOpType unary_op_type, typename T>
 Tensor ExecuteUnaryWithOptionalIntegerParameter<unary_op_type, T>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<T>& parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<float>(parameter.value_or(0))}},
         memory_config,
@@ -528,13 +472,11 @@ template struct ExecuteUnaryWithOptionalIntegerParameter<UnaryOpType::ROUND, int
 
 template <UnaryOpType unary_op_type, typename T>
 Tensor SymmetricBinop<unary_op_type, T>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     T param,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam(unary_op_type, static_cast<float>(param))},
         memory_config,
@@ -543,13 +485,11 @@ Tensor SymmetricBinop<unary_op_type, T>::invoke(
 
 template <UnaryOpType unary_op_type, typename T>
 Tensor SymmetricBinop<unary_op_type, T>::invoke(
-    QueueId queue_id,
     T param,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam(unary_op_type, static_cast<float>(param))},
         memory_config,
@@ -562,13 +502,11 @@ template struct SymmetricBinop<UnaryOpType::MUL_UNARY_SFPU>;
 
 template <UnaryOpType unary_op_type, UnaryOpType unary_op_rev_type>
 Tensor AsymmetricBinop<unary_op_type, unary_op_rev_type>::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     float param,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam(unary_op_type, static_cast<float>(param))},
         memory_config,
@@ -577,13 +515,11 @@ Tensor AsymmetricBinop<unary_op_type, unary_op_rev_type>::invoke(
 
 template <UnaryOpType unary_op_type, UnaryOpType unary_op_rev_type>
 Tensor AsymmetricBinop<unary_op_type, unary_op_rev_type>::invoke(
-    QueueId queue_id,
     float param,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        queue_id,
         input_tensor,
         {UnaryWithParam(unary_op_rev_type, static_cast<float>(param))},
         memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -23,7 +23,6 @@ struct ExecuteUnaryInvokeResult {
 template <UnaryOpType... unary_op_types>
 struct ExecuteUnary {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -35,7 +34,6 @@ struct ExecuteUnary {
 template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithFastAndApproximateMode {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         bool parameter = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -45,7 +43,6 @@ struct ExecuteUnaryWithFastAndApproximateMode {
 template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithFastAndApproximateModeTrue {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         bool parameter = true,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -55,7 +52,6 @@ struct ExecuteUnaryWithFastAndApproximateModeTrue {
 template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithVectorAndFastAndApproximateMode {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         int vector_mode = (int32_t)VecMode::RC,
         bool parameter = false,
@@ -66,7 +62,6 @@ struct ExecuteUnaryWithVectorAndFastAndApproximateMode {
 template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithFloatParameter {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float parameter,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -76,7 +71,6 @@ struct ExecuteUnaryWithFloatParameter {
 template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithTwoFloatParameter {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float parameter_a,
         float parameter_b,
@@ -88,7 +82,6 @@ template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithVariantFloatIntParameter {
     template <typename T>
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         T parameter,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -97,7 +90,6 @@ struct ExecuteUnaryWithVariantFloatIntParameter {
 
 struct LogSigmoid {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -105,14 +97,12 @@ struct LogSigmoid {
 
 struct Sigmoid_accurate {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 struct Unary_chain {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::vector<UnaryWithParam>& ops_chain,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -121,7 +111,6 @@ struct Unary_chain {
 
 struct Softplus {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         float beta,
         float threshold,
@@ -131,7 +120,6 @@ struct Softplus {
 
 struct Prelu {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         float value,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -140,7 +128,6 @@ struct Prelu {
 
 struct Identity {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -148,7 +135,6 @@ struct Identity {
 
 struct Abs {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -158,7 +144,6 @@ struct Abs {
 
 struct Eqz {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -166,7 +151,6 @@ struct Eqz {
 
 struct Floor {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -174,7 +158,6 @@ struct Floor {
 
 struct Trunc {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -182,7 +165,6 @@ struct Trunc {
 
 struct Frac {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -190,7 +172,6 @@ struct Frac {
 
 struct Ceil {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -208,7 +189,6 @@ struct Dropout {
 template <UnaryOpType unary_op_type, typename T = int32_t>
 struct ExecuteUnaryWithIntegerParameter {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         T parameter,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -218,7 +198,6 @@ struct ExecuteUnaryWithIntegerParameter {
 template <UnaryOpType unary_op_type, typename T = int32_t>
 struct ExecuteUnaryWithOptionalIntegerParameter {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<T>& parameter,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -228,14 +207,12 @@ struct ExecuteUnaryWithOptionalIntegerParameter {
 template <UnaryOpType unary_op_type, typename T = float>
 struct SymmetricBinop {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         T param,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         T param,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -245,14 +222,12 @@ struct SymmetricBinop {
 template <UnaryOpType unary_op_type, UnaryOpType unary_op_rev_type>
 struct AsymmetricBinop {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float param,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
-        QueueId queue_id,
         float param,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -261,7 +236,6 @@ struct AsymmetricBinop {
 
 struct Mish {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -269,7 +243,6 @@ struct Mish {
 
 struct Tanhshrink {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -277,7 +250,6 @@ struct Tanhshrink {
 
 struct Hardshrink {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float lambda = 0.5f,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -286,7 +258,6 @@ struct Hardshrink {
 
 struct Hardtanh {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float min_val = -1.0f,
         float max_val = 1.0f,
@@ -296,7 +267,6 @@ struct Hardtanh {
 
 struct Softshrink {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float lambda = 0.5f,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -305,7 +275,6 @@ struct Softshrink {
 
 struct Deg2Rad {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -313,7 +282,6 @@ struct Deg2Rad {
 
 struct Rad2Deg {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
@@ -321,7 +289,6 @@ struct Rad2Deg {
 
 struct Tanh {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -91,7 +91,6 @@ struct ExecuteUnaryCompositeOpWithInt {
 
 struct ExecuteRdiv {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         float value,
         const std::optional<std::string>& round_mode = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -561,12 +561,13 @@ void bind_unary_operation_with_float_parameter_default(
                const float parameter,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor) {
-            return self(input_tensor, parameter, memory_config, output_tensor); },
+                return self(input_tensor, parameter, memory_config, output_tensor);
+            },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg(parameter_name.data()) = parameter_default,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -627,22 +628,23 @@ void bind_unary_operation_with_int_parameter(
             supported_dtype,
             note);
 
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input_tensor,
-               const std::optional<int>& parameter,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor) {
-                return self(input_tensor, parameter, memory_config, output_tensor); },
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg(parameter_name.c_str()) = 0,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+        bind_registered_operation(
+            module,
+            operation,
+            doc,
+            ttnn::pybind_overload_t{
+                [](const unary_operation_t& self,
+                   const Tensor& input_tensor,
+                   const std::optional<int>& parameter,
+                   const std::optional<MemoryConfig>& memory_config,
+                   const std::optional<ttnn::Tensor>& output_tensor) {
+                    return self(input_tensor, parameter, memory_config, output_tensor);
+                },
+                py::arg("input_tensor"),
+                py::kw_only(),
+                py::arg(parameter_name.c_str()) = 0,
+                py::arg("memory_config") = std::nullopt,
+                py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -776,25 +778,25 @@ void bind_unary_rdiv(
                 supported_dtype,
                 note);
 
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const ttnn::Tensor& input_tensor,
-               float parameter_a,
-               const std::optional<std::string> parameter_b,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor) {
-                    return self(input_tensor, parameter_a, parameter_b, memory_config, output_tensor);
-            },
-            py::arg("input_tensor"),
-            py::arg(parameter_name_a.c_str()),
-            py::kw_only(),
-            py::arg(parameter_name_b.c_str()) = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            bind_registered_operation(
+                module,
+                operation,
+                doc,
+                ttnn::pybind_overload_t{
+                    [](const unary_operation_t& self,
+                       const ttnn::Tensor& input_tensor,
+                       float parameter_a,
+                       const std::optional<std::string> parameter_b,
+                       const std::optional<MemoryConfig>& memory_config,
+                       const std::optional<ttnn::Tensor>& output_tensor) {
+                        return self(input_tensor, parameter_a, parameter_b, memory_config, output_tensor);
+                    },
+                    py::arg("input_tensor"),
+                    py::arg(parameter_name_a.c_str()),
+                    py::kw_only(),
+                    py::arg(parameter_name_b.c_str()) = std::nullopt,
+                    py::arg("memory_config") = std::nullopt,
+                    py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -839,24 +841,25 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
                     ttnn::softplus.base_name(),
                     ttnn::softplus.python_fully_qualified_name());
 
-    bind_registered_operation(
-        module,
-        ttnn::softplus,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input,
-               const float beta,
-               const float threshold,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor) {
-                        return self(input, beta, threshold, memory_config, output_tensor); },
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg("beta") = 1.0f,
-            py::arg("threshold") = 20.0f,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+                bind_registered_operation(
+                    module,
+                    ttnn::softplus,
+                    doc,
+                    ttnn::pybind_overload_t{
+                        [](const unary_operation_t& self,
+                           const Tensor& input,
+                           const float beta,
+                           const float threshold,
+                           const std::optional<MemoryConfig>& memory_config,
+                           const std::optional<Tensor>& output_tensor) {
+                            return self(input, beta, threshold, memory_config, output_tensor);
+                        },
+                        py::arg("input_tensor"),
+                        py::kw_only(),
+                        py::arg("beta") = 1.0f,
+                        py::arg("threshold") = 20.0f,
+                        py::arg("memory_config") = std::nullopt,
+                        py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -900,22 +903,21 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
                         ttnn::tanh.base_name(),
                         ttnn::tanh.python_fully_qualified_name());
 
-    bind_registered_operation(
-        module,
-        ttnn::tanh,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               bool accuracy) {
-                            return self(input, memory_config, output_tensor, accuracy); },
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("accuracy") = false);
+                    bind_registered_operation(
+                        module,
+                        ttnn::tanh,
+                        doc,
+                        ttnn::pybind_overload_t{
+                            [](const unary_operation_t& self,
+                               const Tensor& input,
+                               const std::optional<MemoryConfig>& memory_config,
+                               const std::optional<Tensor>& output_tensor,
+                               bool accuracy) { return self(input, memory_config, output_tensor, accuracy); },
+                            py::arg("input_tensor"),
+                            py::kw_only(),
+                            py::arg("memory_config") = std::nullopt,
+                            py::arg("output_tensor") = std::nullopt,
+                            py::arg("accuracy") = false});
 }
 
 template <typename unary_operation_t>
@@ -958,21 +960,21 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
                             ttnn::sigmoid_accurate.base_name(),
                             ttnn::sigmoid_accurate.python_fully_qualified_name());
 
-    bind_registered_operation(
-        module,
-        ttnn::sigmoid_accurate,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input_tensor,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
-                                return self(input_tensor, memory_config, output_tensor);
-            },
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+                        bind_registered_operation(
+                            module,
+                            ttnn::sigmoid_accurate,
+                            doc,
+                            ttnn::pybind_overload_t{
+                                [](const unary_operation_t& self,
+                                   const Tensor& input_tensor,
+                                   const std::optional<MemoryConfig>& memory_config,
+                                   const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                                    return self(input_tensor, memory_config, output_tensor);
+                                },
+                                py::arg("input_tensor"),
+                                py::kw_only(),
+                                py::arg("memory_config") = std::nullopt,
+                                py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -1017,25 +1019,25 @@ void bind_sigmoid_mode_appx(py::module& module, const unary_operation_t& operati
                                 ttnn::sigmoid.base_name(),
                                 ttnn::sigmoid.python_fully_qualified_name());
 
-    bind_registered_operation(
-        module,
-        ttnn::sigmoid,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input_tensor,
-               const int vector_mode,
-               const bool parameter,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
-                                    return self(input_tensor, vector_mode, parameter, memory_config, output_tensor);
-            },
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg("vector_mode") = 4,
-            py::arg("fast_and_approximate_mode") = false,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+                            bind_registered_operation(
+                                module,
+                                ttnn::sigmoid,
+                                doc,
+                                ttnn::pybind_overload_t{
+                                    [](const unary_operation_t& self,
+                                       const Tensor& input_tensor,
+                                       const int vector_mode,
+                                       const bool parameter,
+                                       const std::optional<MemoryConfig>& memory_config,
+                                       const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                                        return self(input_tensor, vector_mode, parameter, memory_config, output_tensor);
+                                    },
+                                    py::arg("input_tensor"),
+                                    py::kw_only(),
+                                    py::arg("vector_mode") = 4,
+                                    py::arg("fast_and_approximate_mode") = false,
+                                    py::arg("memory_config") = std::nullopt,
+                                    py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -1081,25 +1083,24 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
                                     ttnn::unary_chain.base_name(),
                                     ttnn::unary_chain.python_fully_qualified_name());
 
-    bind_registered_operation(
-        module,
-        ttnn::unary_chain,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input_tensor,
-               const FusedActivations& ops_chain,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor) {
-                                        return self(input_tensor, ops_chain, memory_config, output_tensor);
-            },
-            py::arg("input_tensor"),
-            py::arg("ops_chain"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+                                bind_registered_operation(
+                                    module,
+                                    ttnn::unary_chain,
+                                    doc,
+                                    ttnn::pybind_overload_t{
+                                        [](const unary_operation_t& self,
+                                           const Tensor& input_tensor,
+                                           const FusedActivations& ops_chain,
+                                           const std::optional<MemoryConfig>& memory_config,
+                                           const std::optional<Tensor>& output_tensor) {
+                                            return self(input_tensor, ops_chain, memory_config, output_tensor);
+                                        },
+                                        py::arg("input_tensor"),
+                                        py::arg("ops_chain"),
+                                        py::kw_only(),
+                                        py::arg("memory_config") = std::nullopt,
+                                        py::arg("output_tensor") = std::nullopt});
 }
-
 template <typename unary_operation_t>
 void bind_identity(py::module& module, const unary_operation_t& operation) {
                                     auto doc = fmt::format(
@@ -1141,20 +1142,21 @@ void bind_identity(py::module& module, const unary_operation_t& operation) {
                                         ttnn::identity.base_name(),
                                         ttnn::identity.python_fully_qualified_name());
 
-    bind_registered_operation(
-        module,
-        ttnn::identity,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_operation_t& self,
-               const Tensor& input_tensor,
-               const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor) {
-                                            return self(input_tensor, memory_config, output_tensor); },
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+                                    bind_registered_operation(
+                                        module,
+                                        ttnn::identity,
+                                        doc,
+                                        ttnn::pybind_overload_t{
+                                            [](const unary_operation_t& self,
+                                               const Tensor& input_tensor,
+                                               const std::optional<MemoryConfig>& memory_config,
+                                               const std::optional<Tensor>& output_tensor) {
+                                                return self(input_tensor, memory_config, output_tensor);
+                                            },
+                                            py::arg("input_tensor"),
+                                            py::kw_only(),
+                                            py::arg("memory_config") = std::nullopt,
+                                            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -1639,7 +1641,6 @@ void bind_unary_composite_rpow(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt});
 }
-
 }  // namespace
 
 void py_module(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -143,7 +143,6 @@ void bind_unary_operation(
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -183,13 +182,13 @@ void bind_unary_operation(
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor { return self(queue_id, input_tensor, memory_config, output_tensor); },
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, memory_config, output_tensor);
+            },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -212,7 +211,7 @@ void bind_unary_operation_overload_complex(
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -250,13 +249,14 @@ void bind_unary_operation_overload_complex(
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor { return self(queue_id, input_tensor, memory_config, output_tensor); },
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, memory_config, output_tensor);
+            },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         ttnn::pybind_overload_t{
             [](const unary_operation_t& self,
@@ -286,7 +286,7 @@ void bind_unary_operation_overload_complex_return_complex(
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -324,13 +324,14 @@ void bind_unary_operation_overload_complex_return_complex(
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor { return self(queue_id, input_tensor, memory_config, output_tensor); },
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, memory_config, output_tensor);
+            },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
+        },
 
         ttnn::pybind_overload_t{
             [](const unary_operation_t& self,
@@ -363,7 +364,7 @@ void bind_unary_operation_with_fast_and_approximate_mode(
             fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -403,16 +404,14 @@ void bind_unary_operation_with_fast_and_approximate_mode(
                const Tensor& input_tensor,
                const bool parameter,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, parameter, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, parameter, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("fast_and_approximate_mode") = fast_approx_mode,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -440,7 +439,7 @@ void bind_unary_operation_with_float_parameter(
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -482,14 +481,14 @@ void bind_unary_operation_with_float_parameter(
                const Tensor& input_tensor,
                const float parameter,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) { return self(queue_id, input_tensor, parameter, memory_config, output_tensor); },
+               const std::optional<ttnn::Tensor>& output_tensor) {
+                return self(input_tensor, parameter, memory_config, output_tensor);
+            },
             py::arg("input_tensor"),
             py::arg(parameter_name.c_str()),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>
@@ -518,7 +517,7 @@ void bind_unary_operation_with_float_parameter_default(
             {2} (float): Defaults to `{3}`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -561,14 +560,13 @@ void bind_unary_operation_with_float_parameter_default(
                const Tensor& input_tensor,
                const float parameter,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) { return self(queue_id, input_tensor, parameter, memory_config, output_tensor); },
+               const std::optional<ttnn::Tensor>& output_tensor) {
+            return self(input_tensor, parameter, memory_config, output_tensor); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg(parameter_name.data()) = parameter_default,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
@@ -580,8 +578,8 @@ void bind_unary_operation_with_int_parameter(
     const std::string& info_doc,
     const std::string& supported_dtype = "BFLOAT16",
     const std::string& note = "") {
-    auto doc = fmt::format(
-        R"doc(
+        auto doc = fmt::format(
+            R"doc(
         Applies {0} to :attr:`input_tensor` element-wise with {2}.
 
         {4}
@@ -596,7 +594,7 @@ void bind_unary_operation_with_int_parameter(
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -621,13 +619,13 @@ void bind_unary_operation_with_int_parameter(
             >>> {2} = 3
             >>> output = {1}(tensor, {2})
         )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        parameter_name,
-        parameter_doc,
-        info_doc,
-        supported_dtype,
-        note);
+            operation.base_name(),
+            operation.python_fully_qualified_name(),
+            parameter_name,
+            parameter_doc,
+            info_doc,
+            supported_dtype,
+            note);
 
     bind_registered_operation(
         module,
@@ -638,14 +636,13 @@ void bind_unary_operation_with_int_parameter(
                const Tensor& input_tensor,
                const std::optional<int>& parameter,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) { return self(queue_id, input_tensor, parameter, memory_config, output_tensor); },
+               const std::optional<ttnn::Tensor>& output_tensor) {
+                return self(input_tensor, parameter, memory_config, output_tensor); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg(parameter_name.c_str()) = 0,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
@@ -731,8 +728,8 @@ void bind_unary_rdiv(
     const std::string& description,
     const std::string& supported_dtype = "BFLOAT16",
     const std::string& note = "") {
-    auto doc = fmt::format(
-        R"doc(
+            auto doc = fmt::format(
+                R"doc(
         {7}
 
         Args:
@@ -743,7 +740,7 @@ void bind_unary_rdiv(
             {4} (string): {5}. Can be  None, "trunc", "floor". Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -768,16 +765,16 @@ void bind_unary_rdiv(
             >>> {2} = 2
             >>> output = {1}(tensor, {2}, {4} = None)
         )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        parameter_name_a,
-        parameter_a_doc,
-        parameter_name_b,
-        parameter_b_doc,
-        parameter_b_value,
-        description,
-        supported_dtype,
-        note);
+                operation.base_name(),
+                operation.python_fully_qualified_name(),
+                parameter_name_a,
+                parameter_a_doc,
+                parameter_name_b,
+                parameter_b_doc,
+                parameter_b_value,
+                description,
+                supported_dtype,
+                note);
 
     bind_registered_operation(
         module,
@@ -789,23 +786,21 @@ void bind_unary_rdiv(
                float parameter_a,
                const std::optional<std::string> parameter_b,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, input_tensor, parameter_a, parameter_b, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor) {
+                    return self(input_tensor, parameter_a, parameter_b, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg(parameter_name_a.c_str()),
             py::kw_only(),
             py::arg(parameter_name_b.c_str()) = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
 void bind_softplus(py::module& module, const unary_operation_t& operation) {
-    auto doc = fmt::format(
-        R"doc(
+                auto doc = fmt::format(
+                    R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::
@@ -819,7 +814,7 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
             threshold (float, optional): Used to switch to a linear function for large values to improve numerical stability. This avoids issues with floating-point representation for very large values. Defaults to `20`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -841,8 +836,8 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor, beta = 1.0, threshold = 20.0)
         )doc",
-        ttnn::softplus.base_name(),
-        ttnn::softplus.python_fully_qualified_name());
+                    ttnn::softplus.base_name(),
+                    ttnn::softplus.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -854,21 +849,20 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
                const float beta,
                const float threshold,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               const QueueId queue_id) { return self(queue_id, input, beta, threshold, memory_config, output_tensor); },
+               const std::optional<Tensor>& output_tensor) {
+                        return self(input, beta, threshold, memory_config, output_tensor); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("beta") = 1.0f,
             py::arg("threshold") = 20.0f,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
 void bind_tanh(py::module& module, const unary_operation_t& operation) {
-    auto doc = fmt::format(
-        R"doc(
+                    auto doc = fmt::format(
+                        R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::
@@ -881,7 +875,7 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             accuracy (Boolean, optional): provides better accuracy for input range -3 to 3, for dtype BFLOAT16. Defaults to `False`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -903,8 +897,8 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor, accuracy=False)
         )doc",
-        ttnn::tanh.base_name(),
-        ttnn::tanh.python_fully_qualified_name());
+                        ttnn::tanh.base_name(),
+                        ttnn::tanh.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -915,20 +909,19 @@ void bind_tanh(py::module& module, const unary_operation_t& operation) {
                const Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<Tensor>& output_tensor,
-               bool accuracy,
-               const QueueId queue_id) { return self(queue_id, input, memory_config, output_tensor, accuracy); },
+               bool accuracy) {
+                            return self(input, memory_config, output_tensor, accuracy); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("accuracy") = false,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("accuracy") = false);
 }
 
 template <typename unary_operation_t>
 void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operation) {
-    auto doc = fmt::format(
-        R"doc(
+                        auto doc = fmt::format(
+                            R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::
@@ -940,7 +933,7 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -962,8 +955,8 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor)
         )doc",
-        ttnn::sigmoid_accurate.base_name(),
-        ttnn::sigmoid_accurate.python_fully_qualified_name());
+                            ttnn::sigmoid_accurate.base_name(),
+                            ttnn::sigmoid_accurate.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -973,21 +966,19 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               const QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, memory_config, output_tensor);
+               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                                return self(input_tensor, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
 void bind_sigmoid_mode_appx(py::module& module, const unary_operation_t& operation) {
-    auto doc = fmt::format(
-        R"doc(
+                            auto doc = fmt::format(
+                                R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::
@@ -1001,7 +992,7 @@ void bind_sigmoid_mode_appx(py::module& module, const unary_operation_t& operati
             fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -1023,8 +1014,8 @@ void bind_sigmoid_mode_appx(py::module& module, const unary_operation_t& operati
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor, vector_mode=4, fast_and_approximate_mode=True)
         )doc",
-        ttnn::sigmoid.base_name(),
-        ttnn::sigmoid.python_fully_qualified_name());
+                                ttnn::sigmoid.base_name(),
+                                ttnn::sigmoid.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -1036,23 +1027,21 @@ void bind_sigmoid_mode_appx(py::module& module, const unary_operation_t& operati
                const int vector_mode,
                const bool parameter,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               const QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor, vector_mode, parameter, memory_config, output_tensor);
+               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                                    return self(input_tensor, vector_mode, parameter, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("vector_mode") = 4,
             py::arg("fast_and_approximate_mode") = false,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
 void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
-    auto doc = fmt::format(
-        R"doc(
+                                auto doc = fmt::format(
+                                    R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::
@@ -1065,7 +1054,7 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -1089,8 +1078,8 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
             >>> ops_chain = [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False), ttnn.UnaryWithParam(ttnn.UnaryOpType.POWER, 2)]
             >>> output = {1}(tensor, ops_chain)
         )doc",
-        ttnn::unary_chain.base_name(),
-        ttnn::unary_chain.python_fully_qualified_name());
+                                    ttnn::unary_chain.base_name(),
+                                    ttnn::unary_chain.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -1101,22 +1090,20 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
                const Tensor& input_tensor,
                const FusedActivations& ops_chain,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               const QueueId queue_id) {
-                return self(queue_id, input_tensor, ops_chain, memory_config, output_tensor);
+               const std::optional<Tensor>& output_tensor) {
+                                        return self(input_tensor, ops_chain, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("ops_chain"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>
 void bind_identity(py::module& module, const unary_operation_t& operation) {
-    auto doc = fmt::format(
-        R"doc(
+                                    auto doc = fmt::format(
+                                        R"doc(
         Returns a copy of the :attr:`input_tensor`; useful for profiling the SFPU.
         This shouldn't normally be used. Users should normally use clone operation instead for the same functionality since this results in lower performance.
 
@@ -1129,7 +1116,7 @@ void bind_identity(py::module& module, const unary_operation_t& operation) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -1151,8 +1138,8 @@ void bind_identity(py::module& module, const unary_operation_t& operation) {
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.float16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor)
         )doc",
-        ttnn::identity.base_name(),
-        ttnn::identity.python_fully_qualified_name());
+                                        ttnn::identity.base_name(),
+                                        ttnn::identity.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -1162,13 +1149,12 @@ void bind_identity(py::module& module, const unary_operation_t& operation) {
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<Tensor>& output_tensor,
-               const QueueId queue_id) { return self(queue_id, input_tensor, memory_config, output_tensor); },
+               const std::optional<Tensor>& output_tensor) {
+                                            return self(input_tensor, memory_config, output_tensor); },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 template <typename unary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include <tt-metalium/constants.hpp>
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
@@ -238,7 +237,6 @@ std::vector<Tensor> ExecuteUnaryBackwardRdiv::invoke(
 // unary_pow:
 // grad_input = grad * exponent * torch.pow(input, exponent - 1)
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardPow::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     float exponent,
@@ -254,29 +252,22 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardPow::invoke(
         return grad_tensor;
     }
 
-    Tensor power_input = ttnn::pow(queue_id, input, std::fabs(exponent - 1.0f), output_mem_config);
+    Tensor power_input = ttnn::pow(input, std::fabs(exponent - 1.0f), output_mem_config);
     if (exponent < 1.0f) {
-        power_input = ttnn::reciprocal(queue_id, power_input, output_mem_config);
+        power_input = ttnn::reciprocal(power_input, output_mem_config);
     }
 
-    Tensor result = ttnn::multiply(queue_id, power_input, exponent, std::nullopt, output_mem_config);
+    Tensor result = ttnn::multiply(power_input, exponent, std::nullopt, output_mem_config);
     power_input.deallocate();
-    Tensor final_result = ttnn::multiply(queue_id, result, grad, std::nullopt, output_mem_config);
+    Tensor final_result = ttnn::multiply(result, grad, std::nullopt, output_mem_config);
     result.deallocate();
     // Handle negative inputs by returning infinity
-    where(
-        queue_id,
-        ttnn::lez(queue_id, input),
-        std::numeric_limits<float>::infinity(),
-        final_result,
-        output_mem_config,
-        input_grad);
+    where(ttnn::lez(input), std::numeric_limits<float>::infinity(), final_result, output_mem_config, input_grad);
     grad_tensor.emplace_back(input_grad);
     return grad_tensor;
 }
 
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardExp::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -284,14 +275,13 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardExp::invoke(
     std::vector<std::optional<Tensor>> grad_tensor;
 
     input_grad = input_grad.value_or(ttnn::empty_like(input));
-    Tensor exp_result = ttnn::exp(queue_id, input, false, output_mem_config);
-    Tensor result = ttnn::multiply(queue_id, grad, exp_result, std::nullopt, output_mem_config, input_grad);
+    Tensor exp_result = ttnn::exp(input, false, output_mem_config);
+    Tensor result = ttnn::multiply(grad, exp_result, std::nullopt, output_mem_config, input_grad);
     grad_tensor.emplace_back(input_grad);
     return grad_tensor;
 }
 
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardTanh::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -299,16 +289,15 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardTanh::invoke(
     std::vector<std::optional<Tensor>> grad_tensor;
 
     input_grad = input_grad.value_or(ttnn::empty_like(input));
-    Tensor tanh_res = ttnn::tanh(queue_id, input, output_mem_config);
-    tanh_res = ttnn::square(queue_id, tanh_res, output_mem_config);
-    tanh_res = ttnn::rsub(queue_id, tanh_res, 1.0f, std::nullopt, output_mem_config);
-    ttnn::multiply(queue_id, grad, tanh_res, std::nullopt, output_mem_config, input_grad);
+    Tensor tanh_res = ttnn::tanh(input, output_mem_config);
+    tanh_res = ttnn::square(tanh_res, output_mem_config);
+    tanh_res = ttnn::rsub(tanh_res, 1.0f, std::nullopt, output_mem_config);
+    ttnn::multiply(grad, tanh_res, std::nullopt, output_mem_config, input_grad);
     grad_tensor.emplace_back(input_grad);
     return grad_tensor;
 }
 
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSqrt::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -319,44 +308,24 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSqrt::invoke(
     float t_inf = std::numeric_limits<float>::infinity();
 
     input_grad = input_grad.value_or(ttnn::empty_like(input));
-    ttnn::sqrt(queue_id, input, output_mem_config, input_grad);
+    ttnn::sqrt(input, output_mem_config, input_grad);
     ttnn::multiply(
-        queue_id,
         grad,
-        ttnn::reciprocal(
-            queue_id,
-            ttnn::multiply(queue_id, input_grad.value(), 2.0, std::nullopt, output_mem_config),
-            output_mem_config),
+        ttnn::reciprocal(ttnn::multiply(input_grad.value(), 2.0, std::nullopt, output_mem_config), output_mem_config),
         std::nullopt,
         output_mem_config,
         input_grad);
+    where(ttnn::lez(input, output_mem_config), t_nan, input_grad.value(), output_mem_config, input_grad);
     where(
-        queue_id,
-        ttnn::lez(queue_id, input, output_mem_config),
-        t_nan,
-        input_grad.value(),
-        output_mem_config,
-        input_grad);
-    where(
-        queue_id,
         ttnn::logical_and(
-            queue_id,
-            ttnn::eqz(queue_id, input, output_mem_config),
-            ttnn::ltz(queue_id, grad, output_mem_config),
-            std::nullopt,
-            output_mem_config),
+            ttnn::eqz(input, output_mem_config), ttnn::ltz(grad, output_mem_config), std::nullopt, output_mem_config),
         -t_inf,
         input_grad.value(),
         output_mem_config,
         input_grad);
     where(
-        queue_id,
         ttnn::logical_and(
-            queue_id,
-            ttnn::eqz(queue_id, input, output_mem_config),
-            ttnn::gtz(queue_id, grad, output_mem_config),
-            std::nullopt,
-            output_mem_config),
+            ttnn::eqz(input, output_mem_config), ttnn::gtz(grad, output_mem_config), std::nullopt, output_mem_config),
         t_inf,
         input_grad.value(),
         output_mem_config,
@@ -492,7 +461,6 @@ std::vector<Tensor> ExecuteUnaryBackwardSigmoid::invoke(
 }
 
 std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -504,37 +472,19 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
 
-    ttnn::rsqrt(queue_id, input, true, output_mem_config, input_grad);
-    ttnn::power(queue_id, input_grad.value(), 3, output_mem_config, input_grad);
+    ttnn::rsqrt(input, true, output_mem_config, input_grad);
+    ttnn::power(input_grad.value(), 3, output_mem_config, input_grad);
     ttnn::multiply(
-        queue_id,
-        ttnn::multiply(queue_id, grad, input_grad.value(), std::nullopt, output_mem_config),
+        ttnn::multiply(grad, input_grad.value(), std::nullopt, output_mem_config),
         -0.5,
         std::nullopt,
         output_mem_config,
         input_grad);
+    where(ttnn::eqz(input, output_mem_config), t_inf, input_grad.value(), output_mem_config, input_grad);
+    where(ttnn::ltz(input, output_mem_config), t_nan, input_grad.value(), output_mem_config, input_grad);
     where(
-        queue_id,
-        ttnn::eqz(queue_id, input, output_mem_config),
-        t_inf,
-        input_grad.value(),
-        output_mem_config,
-        input_grad);
-    where(
-        queue_id,
-        ttnn::ltz(queue_id, input, output_mem_config),
-        t_nan,
-        input_grad.value(),
-        output_mem_config,
-        input_grad);
-    where(
-        queue_id,
         ttnn::logical_and(
-            queue_id,
-            ttnn::eqz(queue_id, input, output_mem_config),
-            ttnn::eqz(queue_id, grad, output_mem_config),
-            std::nullopt,
-            output_mem_config),
+            ttnn::eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
         t_nan,
         input_grad.value(),
         output_mem_config,
@@ -545,14 +495,13 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(
 }
 
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt};
     input_grad = input_grad.value_or(ttnn::empty_like(input));
-    result[0] = ttnn::neg(queue_id, grad, output_mem_config, input_grad);
+    result[0] = ttnn::neg(grad, output_mem_config, input_grad);
     return result;
 }
 
@@ -569,7 +518,6 @@ std::vector<Tensor> ExecuteUnaryBackwardRelu::invoke(
 // self: zeros_like(grad)
 // result: at::fill(self_t, 0)
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardFill::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -917,7 +865,6 @@ std::vector<Tensor> _abs_bw(
 // Silu
 // result:  grad * sigmoid_result * (1 + input * (1 - sigmoid_result))
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSilu::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -927,19 +874,14 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSilu::invoke(
     input_grad = input_grad.value_or(ttnn::empty_like(input));
     bool approximate_mode = false;
     Tensor sigmoid_res = ttnn::sigmoid(input, (int)unary::VecMode::RC, approximate_mode, output_mem_config);
-    Tensor grad_sigmoid = ttnn::multiply(queue_id, grad, sigmoid_res, std::nullopt, output_mem_config);
+    Tensor grad_sigmoid = ttnn::multiply(grad, sigmoid_res, std::nullopt, output_mem_config);
     Tensor add_sub = ttnn::add(
-        queue_id,
         ttnn::multiply(
-            queue_id,
-            ttnn::rsub(sigmoid_res, 1.0f, std::nullopt, output_mem_config),
-            input,
-            std::nullopt,
-            output_mem_config),
+            ttnn::rsub(sigmoid_res, 1.0f, std::nullopt, output_mem_config), input, std::nullopt, output_mem_config),
         1.0f,
         std::nullopt,
         output_mem_config);
-    ttnn::multiply(queue_id, grad_sigmoid, add_sub, std::nullopt, output_mem_config, input_grad);
+    ttnn::multiply(grad_sigmoid, add_sub, std::nullopt, output_mem_config, input_grad);
 
     result[0] = input_grad;
     return result;
@@ -1603,7 +1545,6 @@ std::vector<Tensor> ExecuteUnaryBackwardDeg2rad::invoke(
 }
 
 std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
-    QueueId queue_id,
     const Tensor& grad,
     const Tensor& input,
     const std::string& approximate,
@@ -1660,12 +1601,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
             output_memory_config);
 
         ttnn::multiply(
-            queue_id,
-            grad,
-            (ttnn::add(left_derivative, right_derivative)),
-            std::nullopt,
-            output_memory_config,
-            input_grad);
+            grad, (ttnn::add(left_derivative, right_derivative)), std::nullopt, output_memory_config, input_grad);
         result.push_back(input_grad);
     } else {
         float kAlpha = M_SQRT1_2;
@@ -1683,7 +1619,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
             std::nullopt,
             output_memory_config);
         ttnn::multiply(
-            queue_id, grad, ttnn::add(cdf, ttnn::multiply(input, pdf)), std::nullopt, output_memory_config, input_grad);
+            grad, ttnn::add(cdf, ttnn::multiply(input, pdf)), std::nullopt, output_memory_config, input_grad);
         result.push_back(input_grad);
     }
 
@@ -1794,7 +1730,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
             ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
             ttnn::SmallVector<uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[2]};
-            Tensor new_slice_tensor = ttnn::slice(DefaultQueueId, required, start_index, end_index, step, std::nullopt);
+            Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             after_permute_dims = {0, 2, 3, 1};
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
             if (updated_grad.storage_type() != StorageType::DEVICE) {
@@ -1808,7 +1744,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
             ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
             ttnn::SmallVector<uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[3]};
-            Tensor new_slice_tensor = ttnn::slice(DefaultQueueId, required, start_index, end_index, step, std::nullopt);
+            Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
             if (updated_grad.layout() == Layout::ROW_MAJOR) {
                 updated_grad =
@@ -1826,23 +1762,13 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
         temp = ttnn::operations::unary_backward::change_layout_to_tile(temp, output_memory_config);
     }
     if (*dim == 3 || *dim == -1) {
-        Tensor grad_result = ttnn::bcast(
-            ttnn::DefaultQueueId,
-            reciprocal_input,
-            temp,
-            ttnn::BcastOpMath::MUL,
-            ttnn::BcastOpDim::W,
-            output_memory_config);
+        Tensor grad_result =
+            ttnn::bcast(reciprocal_input, temp, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::W, output_memory_config);
         grad_tensor.emplace_back(grad_result);
         return grad_tensor;
     } else if (*dim == 2 || *dim == -2) {
-        Tensor grad_result = ttnn::bcast(
-            ttnn::DefaultQueueId,
-            reciprocal_input,
-            temp,
-            ttnn::BcastOpMath::MUL,
-            ttnn::BcastOpDim::H,
-            output_memory_config);
+        Tensor grad_result =
+            ttnn::bcast(reciprocal_input, temp, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::H, output_memory_config);
         grad_tensor.emplace_back(grad_result);
         return grad_tensor;
     } else if (*dim == 1 || *dim == -3) {
@@ -1863,13 +1789,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
 
         after_permute_dims = {0, 3, 1, 2};
         Tensor result = permute(
-            ttnn::bcast(
-                ttnn::DefaultQueueId,
-                tensor_1,
-                tensor_2,
-                ttnn::BcastOpMath::MUL,
-                ttnn::BcastOpDim::W,
-                output_memory_config),
+            ttnn::bcast(tensor_1, tensor_2, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::W, output_memory_config),
             after_permute_dims,
             output_memory_config);
         Tensor grad_result = result;
@@ -1878,7 +1798,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
             ttnn::SmallVector<uint32_t> end_index = {
                 input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
             auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
-            grad_result = ttnn::slice(DefaultQueueId, result, start_index, end_index, step, std::nullopt);
+            grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
         }
         grad_tensor.emplace_back(grad_result);
         return grad_tensor;
@@ -1900,13 +1820,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
         tensor_2, tensor_1.device(), tensor_1.layout(), tensor_1.memory_config());
 
     Tensor result = ttnn::permute(
-        ttnn::bcast(
-            ttnn::DefaultQueueId,
-            tensor_1,
-            tensor_2,
-            ttnn::BcastOpMath::MUL,
-            ttnn::BcastOpDim::W,
-            output_memory_config),
+        ttnn::bcast(tensor_1, tensor_2, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::W, output_memory_config),
         after_permute_dims,
         output_memory_config);
     Tensor grad_result = result;
@@ -1914,7 +1828,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
         ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         ttnn::SmallVector<uint32_t> end_index = {
             input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
-        grad_result = ttnn::slice(DefaultQueueId, result, start_index, end_index, step, std::nullopt);
+        grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
     }
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -16,7 +16,6 @@ Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_
 
 struct ExecuteUnaryBackwardNeg {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -432,7 +431,6 @@ struct ExecuteUnaryBackwardErf {
 
 struct ExecuteUnaryBackwardRsqrt {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -490,7 +488,6 @@ struct ExecuteUnaryBackwardRepeat {
 
 struct ExecuteUnaryBackwardPow {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         float parameter,
@@ -500,7 +497,6 @@ struct ExecuteUnaryBackwardPow {
 
 struct ExecuteUnaryBackwardExp {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -509,7 +505,6 @@ struct ExecuteUnaryBackwardExp {
 
 struct ExecuteUnaryBackwardTanh {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -518,7 +513,6 @@ struct ExecuteUnaryBackwardTanh {
 
 struct ExecuteUnaryBackwardSqrt {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -527,7 +521,6 @@ struct ExecuteUnaryBackwardSqrt {
 
 struct ExecuteUnaryBackwardSilu {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -536,7 +529,6 @@ struct ExecuteUnaryBackwardSilu {
 
 struct ExecuteUnaryBackwardFill {
     static std::vector<std::optional<Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -575,7 +567,6 @@ struct ExecuteUnaryBackwardAbs {
 
 struct ExecuteUnaryBackwardGelu {
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        QueueId queue_id,
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
         const std::string& parameter_a,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.cpp
@@ -181,7 +181,7 @@ void bind_unary_backward_rsqrt(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (uint8, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -222,16 +222,14 @@ void bind_unary_backward_rsqrt(
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+            py::arg("input_grad") = std::nullopt});
 }
 
 template <typename unary_backward_operation_t>
@@ -822,7 +820,7 @@ void bind_unary_backward_unary_optional_float(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -866,17 +864,15 @@ void bind_unary_backward_unary_optional_float(
                const ttnn::Tensor& input_tensor,
                float parameter,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, parameter, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor, parameter, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::arg(parameter_name.c_str()),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("input_grad") = std::nullopt});
 }
 
 template <typename unary_backward_operation_t>
@@ -970,7 +966,7 @@ void bind_unary_backward_optional(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -1012,16 +1008,14 @@ void bind_unary_backward_optional(
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+            py::arg("input_grad") = std::nullopt});
 }
 
 template <typename unary_backward_operation_t>
@@ -1042,7 +1036,7 @@ void bind_unary_backward_neg(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -1083,16 +1077,14 @@ void bind_unary_backward_neg(
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+            py::arg("input_grad") = std::nullopt});
 }
 
 template <typename unary_backward_operation_t>
@@ -1180,7 +1172,7 @@ void bind_unary_backward_gelu(
             {2} (string): {3}. Defaults to `{4}`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (uint8, optional): command queue id. Defaults to `0`.
+
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -1225,17 +1217,15 @@ void bind_unary_backward_gelu(
                const ttnn::Tensor& input_tensor,
                std::string parameter_a,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& input_grad,
-               QueueId queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, parameter_a, memory_config, input_grad);
+               const std::optional<ttnn::Tensor>& input_grad) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor, parameter_a, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg(parameter_name_a.c_str()) = parameter_a_value,
             py::arg("memory_config") = std::nullopt,
-            py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+            py::arg("input_grad") = std::nullopt});
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.cpp
@@ -30,7 +30,6 @@ void bind_unary_backward_two_float(
     const std::string& note = "") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:
@@ -171,7 +170,6 @@ void bind_unary_backward_rsqrt(
     const std::string& note = "") {
     auto doc = fmt::format(
         R"doc(
-
         {2}
 
         Args:

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -6,7 +6,6 @@
 
 #include <utility>
 #include "ttnn/operations/core/core.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/embedding/device/embedding_device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
@@ -14,7 +13,6 @@
 namespace ttnn::operations::embedding {
 
 ttnn::Tensor EmbeddingOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_arg,
     const Tensor& weight_arg,
     const std::optional<int>& pad_token,

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.hpp
@@ -15,7 +15,6 @@ namespace embedding {
 
 struct EmbeddingOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_arg,
         const Tensor& weight_arg,
         const std::optional<int>& pad_token = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/embedding/embedding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding_pybind.cpp
@@ -32,7 +32,6 @@ void py_module(py::module& module) {
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
             padding_idx (int, optional): the padding token. Default to `None`.
             layout (ttnn.Layout): the layout of the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
             embeddings_type (ttnn.EmbeddingsType): the type of embeddings. Defaults to `ttnn._ttnn.operations.embedding.EmbeddingsType.GENERIC`.
@@ -73,18 +72,16 @@ void py_module(py::module& module) {
                EmbeddingsType embeddings_type,
                const std::optional<const DataType> dtype,
                std::optional<ttnn::Tensor>& optional_output_tensor,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    weight,
-                    padding_idx,
-                    layout,
-                    embeddings_type,
-                    dtype,
-                    memory_config,
-                    optional_output_tensor);
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+            return self(
+                input_tensor,
+                weight,
+                padding_idx,
+                layout,
+                embeddings_type,
+                dtype,
+                memory_config,
+                optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("weight").noconvert(),
@@ -94,8 +91,7 @@ void py_module(py::module& module) {
             py::arg("embeddings_type").noconvert() = EmbeddingsType::GENERIC,
             py::arg("dtype").noconvert() = std::nullopt,
             py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::embedding

--- a/ttnn/cpp/ttnn/operations/embedding/embedding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding_pybind.cpp
@@ -72,15 +72,15 @@ void py_module(py::module& module) {
                const std::optional<const DataType> dtype,
                std::optional<ttnn::Tensor>& optional_output_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config) {
-            return self(
-                input_tensor,
-                weight,
-                padding_idx,
-                layout,
-                embeddings_type,
-                dtype,
-                memory_config,
-                optional_output_tensor);
+                return self(
+                    input_tensor,
+                    weight,
+                    padding_idx,
+                    layout,
+                    embeddings_type,
+                    dtype,
+                    memory_config,
+                    optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("weight").noconvert(),
@@ -90,7 +90,7 @@ void py_module(py::module& module) {
             py::arg("embeddings_type").noconvert() = EmbeddingsType::GENERIC,
             py::arg("dtype").noconvert() = std::nullopt,
             py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("memory_config") = std::nullopt);
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::embedding

--- a/ttnn/cpp/ttnn/operations/embedding/embedding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding_pybind.cpp
@@ -21,7 +21,6 @@ void py_module(py::module& module) {
 
     const auto doc =
         R"doc(
-
         Retrieves word embeddings using input_tensor. The input_tensor is a list of indices, and the embedding matrix, and the output is the corresponding word embeddings.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
@@ -14,7 +14,6 @@
 namespace ttnn::operations::embedding_backward {
 
 Tensor EmbeddingBackwardOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_arg,
     const Tensor& weight_tensor_arg,
     const Tensor& output_gradient_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.hpp
@@ -14,7 +14,6 @@ namespace embedding_backward {
 
 struct EmbeddingBackwardOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_arg,
         const Tensor& weight_tensor_arg,
         const Tensor& output_gradient_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
@@ -16,7 +16,6 @@ namespace py = pybind11;
 void py_bind_embedding_backward(py::module& module) {
     const auto doc =
         R"doc(
-
         Returns the input gradients of the output gradients tensor with respect to the input indices.
 
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
@@ -29,7 +29,6 @@ void py_bind_embedding_backward(py::module& module) {
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
             dtype (ttnn.DataType, optional): the data type for the output tensor. Defaults to `None`.
 
 
@@ -70,16 +69,9 @@ void py_bind_embedding_backward(py::module& module) {
                const ttnn::Tensor& output_gradient_tensor,
                const std::optional<const DataType> dtype,
                std::optional<ttnn::Tensor>& optional_output_tensor,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) {
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
                 return self(
-                    queue_id,
-                    input_tensor,
-                    weight_tensor,
-                    output_gradient_tensor,
-                    dtype,
-                    memory_config,
-                    optional_output_tensor);
+                    input_tensor, weight_tensor, output_gradient_tensor, dtype, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("weight_tensor").noconvert(),
@@ -87,8 +79,7 @@ void py_bind_embedding_backward(py::module& module) {
             py::kw_only(),
             py::arg("dtype").noconvert() = std::nullopt,
             py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -127,9 +127,7 @@ struct ExampleDeviceOperation {
     // API call to map user arguments to operation attributes and tensor args.
     // This is the only method that is called by the user
     // The user will be able to call the operation using `tensor_return_value_t output =
-    // ttnn::prim::example(input_tensor)` after the op is registered Keep in mind that the the overload with `queue_id`
-    // argument will be added automatically for primitive operations So, the user can also call this operation using
-    // `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
+    // ttnn::prim::example(input_tensor)` after the op is registered
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
 
     // Optional methods

--- a/ttnn/cpp/ttnn/operations/examples/example/example_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example_pybind.cpp
@@ -21,9 +21,8 @@ void bind_example_operation(py::module& module) {
 
         // Add pybind overloads for the C++ APIs that should be exposed to python
         // There should be no logic here, just a call to `self` with the correct arguments
-        // The overload with `queue_id` argument will be added automatically for primitive operations
         // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or
-        // `ttnn.prim.example(input_tensor, queue_id=queue_id)`
+        // `ttnn.prim.example(input_tensor)`
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
                 return self(input_tensor);

--- a/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
@@ -22,9 +22,8 @@ void bind_example_operation(py::module& module) {
 
         // Add pybind overloads for the C++ APIs that should be exposed to python
         // There should be no logic here, just a call to `self` with the correct arguments
-        // The overload with `queue_id` argument will be added automatically for primitive operations
         // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or
-        // `ttnn.prim.example(input_tensor, queue_id=queue_id)`
+        // `ttnn.prim.example(input_tensor)`
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
                 return self(input_tensor);

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
@@ -107,9 +107,8 @@ struct ExampleMultipleReturnDeviceOperation {
     // API call to map user arguments to operation attributes and tensor args.
     // This is the only method that is called by the user
     // The user will be able to call the operation using `tensor_return_value_t output =
-    // ttnn::prim::example(input_tensor)` after the op is registered Keep in mind that the the overload with `queue_id`
-    // argument will be added automatically for primitive operations So, the user can also call this operation using
-    // `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
+    // ttnn::prim::example(input_tensor)` after the op is registered
+    // `tensor_return_value_t output = ttnn::prim::exampleinput_tensor)`
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor, bool return_output1, bool return_output2);
 

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -127,7 +127,6 @@ Tensor AutoFormat::format_input_tensor(
         } else if (!convert_layout && pad_input) {
             if (formatted_input.layout() == Layout::ROW_MAJOR || formatted_input.layout() == Layout::TILE) {
                 return ttnn::pad(
-                    DefaultQueueId,
                     (const ttnn::Tensor)formatted_input,
                     padded_shape.to_array_4D(),
                     tt::tt_metal::Array4D({0, 0, 0, 0}),
@@ -148,7 +147,6 @@ Tensor AutoFormat::format_input_tensor(
             } else if (formatted_input.layout() == Layout::TILE && target_layout == Layout::ROW_MAJOR) {
                 formatted_input = ttnn::untilize(formatted_input, mem_config);
                 return ttnn::pad(
-                    DefaultQueueId,
                     (const ttnn::Tensor)formatted_input,
                     padded_shape.to_array_4D(),
                     tt::tt_metal::Array4D({0, 0, 0, 0}),

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
@@ -54,7 +54,6 @@ auto check_shape(const ttnn::Tensor& input, const ttnn::Shape& output_shape) {
 
 namespace ttnn::operations::experimental {
 Tensor BcastTo::invoke(
-    QueueId queue_id,
     const Tensor& input,
     const Shape& output_shape,
     const std::optional<MemoryConfig>& memory_config,
@@ -73,6 +72,6 @@ Tensor BcastTo::invoke(
             output.value().dtype());
     }
 
-    return ttnn::prim::bcast_to(queue_id, input, output_shape, memory_config, output);
+    return ttnn::prim::bcast_toinput, output_shape, memory_config, output);
 }
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
@@ -72,6 +72,6 @@ Tensor BcastTo::invoke(
             output.value().dtype());
     }
 
-    return ttnn::prim::bcast_toinput, output_shape, memory_config, output);
+    return ttnn::prim::bcast_to(input, output_shape, memory_config, output);
 }
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.hpp
@@ -9,7 +9,6 @@
 namespace ttnn::operations::experimental {
 struct BcastTo {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const Shape& output_shape,
         const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to_pybind.cpp
@@ -50,12 +50,12 @@ void py_bind_broadcast_to(py::module& module) {
                const ttnn::Shape& output_shape,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
-            return self(input, output_shape, memory_config, output_tensor);
+                return self(input, output_shape, memory_config, output_tensor);
             },
             py::arg("input"),
             py::arg("output_shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output") = std::nullopt);
+            py::arg("output") = std::nullopt});
 }
 }  // namespace ttnn::operations::experimental::broadcast_to::detail

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to_pybind.cpp
@@ -49,15 +49,13 @@ void py_bind_broadcast_to(py::module& module) {
                const ttnn::Tensor& input,
                const ttnn::Shape& output_shape,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, input, output_shape, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+            return self(input, output_shape, memory_config, output_tensor);
             },
             py::arg("input"),
             py::arg("output_shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output") = std::nullopt);
 }
 }  // namespace ttnn::operations::experimental::broadcast_to::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async_pybind.cpp
@@ -51,7 +51,6 @@ void py_bind_all_broadcast_async(pybind11::module& module) {
         module,
         ttnn::experimental::all_broadcast_async,
         R"doc(
-
         Performs an all-broadcast operation on multi-device :attr:`input_tensor` across all devices.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
@@ -175,7 +175,6 @@ void py_bind_all_gather_async(pybind11::module& module) {
         module,
         ttnn::experimental::all_gather_async,
         R"doc(
-
         Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
@@ -11,7 +11,6 @@
 namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor ExecuteAllGatherConcat::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& buffer_tensor,
     const int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::ccl {
 
 struct ExecuteAllGatherConcat {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         ttnn::Tensor& buffer_tensor,
         int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
@@ -39,19 +39,19 @@ void bind_all_gather_concat(pybind11::module& module, const ccl_operation_t& ope
                const std::optional<uint32_t> num_links,
                const ttnn::ccl::Topology topology,
                std::optional<tt::tt_metal::SubDeviceId> subdevice_id) -> ttnn::Tensor {
-            return self(
-                input_tensor,
-                buffer_tensor,
-                dim,
-                cluster_axis,
-                mesh_device,
-                global_semaphore,
-                num_heads,
-                memory_config,
-                use_noc1_only,
-                num_links,
-                topology,
-                subdevice_id);
+                return self(
+                    input_tensor,
+                    buffer_tensor,
+                    dim,
+                    cluster_axis,
+                    mesh_device,
+                    global_semaphore,
+                    num_heads,
+                    memory_config,
+                    use_noc1_only,
+                    num_links,
+                    topology,
+                    subdevice_id);
             },
             py::arg("input_tensor"),
             py::arg("buffer_tensor"),
@@ -65,7 +65,7 @@ void bind_all_gather_concat(pybind11::module& module, const ccl_operation_t& ope
             py::arg("use_noc1_only") = false,
             py::arg("num_links") = 1,
             py::arg("topology") = ttnn::ccl::Topology::Linear,
-            py::arg("subdevice_id") = std::nullopt);
+            py::arg("subdevice_id") = std::nullopt});
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
@@ -38,22 +38,20 @@ void bind_all_gather_concat(pybind11::module& module, const ccl_operation_t& ope
                const bool use_noc1_only,
                const std::optional<uint32_t> num_links,
                const ttnn::ccl::Topology topology,
-               std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    buffer_tensor,
-                    dim,
-                    cluster_axis,
-                    mesh_device,
-                    global_semaphore,
-                    num_heads,
-                    memory_config,
-                    use_noc1_only,
-                    num_links,
-                    topology,
-                    subdevice_id);
+               std::optional<tt::tt_metal::SubDeviceId> subdevice_id) -> ttnn::Tensor {
+            return self(
+                input_tensor,
+                buffer_tensor,
+                dim,
+                cluster_axis,
+                mesh_device,
+                global_semaphore,
+                num_heads,
+                memory_config,
+                use_noc1_only,
+                num_links,
+                topology,
+                subdevice_id);
             },
             py::arg("input_tensor"),
             py::arg("buffer_tensor"),
@@ -67,8 +65,7 @@ void bind_all_gather_concat(pybind11::module& module, const ccl_operation_t& ope
             py::arg("use_noc1_only") = false,
             py::arg("num_links") = 1,
             py::arg("topology") = ttnn::ccl::Topology::Linear,
-            py::arg("subdevice_id") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("subdevice_id") = std::nullopt);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
@@ -146,7 +146,6 @@ void py_bind_all_reduce_async(pybind11::module& module) {
         module,
         ttnn::experimental::all_reduce_async,
         R"doc(
-
         Performs an all_reduce operation on multi-device :attr:`input_tensor` across all devices.  This operation requires a persistent
         fabric to be enabled in order to function.
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/llama_all_gather_matmul_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/llama_all_gather_matmul_async_pybind.cpp
@@ -86,7 +86,6 @@ void py_bind_llama_all_gather_matmul_async(pybind11::module& module) {
         module,
         ttnn::experimental::llama_all_gather_matmul_async,
         R"doc(
-
         Performs an all-gather-matml operation on multi-device :attr:`input_tensor0` and :attr:`input_tensor1` across all devices.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
-
 #include <tt-metalium/constants.hpp>
 
 #include "llama_reduce_scatter.hpp"
@@ -16,7 +14,6 @@ namespace ttnn::operations::experimental::ccl {
 namespace detail {}  // namespace detail
 
 ttnn::Tensor ExecuteLlamaReduceScatter::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& intermediate_packet_buffer,
     const int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.hpp
@@ -14,7 +14,6 @@ namespace operations::experimental::ccl {
 
 struct ExecuteLlamaReduceScatter {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         ttnn::Tensor& intermediate_packet_buffer,
         int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
@@ -71,18 +71,18 @@ void py_bind_llama_reduce_scatter(py::module& module) {
                const std::optional<ttnn::MemoryConfig>& memory_config,
                tt::tt_fabric::Topology topology,
                bool use_noc1_only) {
-            return self(
-                input_tensor,
-                intermediate_packet_buffer,
-                dim,
-                cross_device_semaphore,
-                subdevice_id,
-                cluster_axis,
-                mesh_device,
-                num_links,
-                memory_config,
-                topology,
-                use_noc1_only);
+                return self(
+                    input_tensor,
+                    intermediate_packet_buffer,
+                    dim,
+                    cross_device_semaphore,
+                    subdevice_id,
+                    cluster_axis,
+                    mesh_device,
+                    num_links,
+                    memory_config,
+                    topology,
+                    use_noc1_only);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("intermediate_packet_buffer").noconvert(),
@@ -95,7 +95,7 @@ void py_bind_llama_reduce_scatter(py::module& module) {
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
             py::arg("topology") = tt::tt_fabric::Topology::Linear,
-            py::arg("use_noc1_only") = false);
+            py::arg("use_noc1_only") = false});
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
@@ -20,7 +20,7 @@ namespace ttnn::operations::experimental::ccl {
 
 void py_bind_llama_reduce_scatter(py::module& module) {
     auto doc =
-        R"doc(llama_reduce_scatter(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+        R"doc(llama_reduce_scatter(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt) -> ttnn.Tensor
 
             Reduce_scatter after FF1/3 for Llama70B.
 
@@ -36,7 +36,6 @@ void py_bind_llama_reduce_scatter(py::module& module) {
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
            Returns:
                ttnn.Tensor: the output tensor.
@@ -71,21 +70,19 @@ void py_bind_llama_reduce_scatter(py::module& module) {
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                tt::tt_fabric::Topology topology,
-               bool use_noc1_only,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    intermediate_packet_buffer,
-                    dim,
-                    cross_device_semaphore,
-                    subdevice_id,
-                    cluster_axis,
-                    mesh_device,
-                    num_links,
-                    memory_config,
-                    topology,
-                    use_noc1_only);
+               bool use_noc1_only) {
+            return self(
+                input_tensor,
+                intermediate_packet_buffer,
+                dim,
+                cross_device_semaphore,
+                subdevice_id,
+                cluster_axis,
+                mesh_device,
+                num_links,
+                memory_config,
+                topology,
+                use_noc1_only);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("intermediate_packet_buffer").noconvert(),
@@ -98,8 +95,7 @@ void py_bind_llama_reduce_scatter(py::module& module) {
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
             py::arg("topology") = tt::tt_fabric::Topology::Linear,
-            py::arg("use_noc1_only") = false,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("use_noc1_only") = false);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
-
 #include <tt-metalium/constants.hpp>
 
 #include "llama_reduce_scatter_create_heads.hpp"
@@ -16,7 +14,6 @@ namespace ttnn::operations::experimental::ccl {
 namespace detail {}  // namespace detail
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteLlamaReduceScatterCreateHeads::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& intermediate_packet_buffer,
     const int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads.hpp
@@ -14,7 +14,6 @@ namespace operations::experimental::ccl {
 
 struct ExecuteLlamaReduceScatterCreateHeads {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         ttnn::Tensor& intermediate_packet_buffer,
         int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_pybind.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 
 void py_bind_llama_rs_create_heads(py::module& module) {
     auto doc =
-        R"doc(llama_rs_create_heads(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+        R"doc(llama_rs_create_heads(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt) -> ttnn.Tensor
 
             Reduce_scatter after FF1/3 for Llama70B.
 
@@ -26,7 +26,6 @@ void py_bind_llama_rs_create_heads(py::module& module) {
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
            Returns:
                ttnn.Tensor: the output tensor.
@@ -65,10 +64,8 @@ void py_bind_llama_rs_create_heads(py::module& module) {
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::MemoryConfig>& qkv_memory_config,
                const bool use_noc1_only,
-               const bool use_optimal_ccl_for_llama,
-               QueueId queue_id) {
+               const bool use_optimal_ccl_for_llama) {
                 return self(
-                    queue_id,
                     input_tensor,
                     intermediate_packet_buffer,
                     dim,
@@ -100,9 +97,7 @@ void py_bind_llama_rs_create_heads(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("qkv_memory_config") = std::nullopt,
             py::arg("use_noc1_only") = false,
-            py::arg("use_optimal_ccl_for_llama") = false,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("use_optimal_ccl_for_llama") = false});
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.cpp
@@ -8,7 +8,6 @@
 namespace ttnn::operations::experimental::ccl {
 
 std::vector<ttnn::Tensor> ExecuteLlamaReduceScatterMatmul::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,               // mm0 used
     const ttnn::Tensor& weight_tensor,              // mm1 used
     ttnn::Tensor& intermediate_packet_buffer,       // rs2

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.hpp
@@ -14,7 +14,6 @@ namespace operations::experimental::ccl {
 
 struct ExecuteLlamaReduceScatterMatmul {
     static std::vector<ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,               // mm0 used
         const ttnn::Tensor& weight_tensor,              // mm1 used
         ttnn::Tensor& intermediate_packet_buffer,       // rs2

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
@@ -76,37 +76,35 @@ void py_bind_rs_matmul(pybind11::module& module) {
                const std::optional<const std::string>& activation,                                  // mm7 set false
                const std::optional<const tt::tt_metal::Tile>& output_tile,                          // mm10 std::nullopt
                std::optional<Tensor>& optional_output_tensor,                                       // mm11 std::nullopt
-               bool use_noc1_only,
-               QueueId queue_id  // rs 9 default DefaultQueueId
+               bool use_noc1_only
 
                ) -> std::vector<ttnn::Tensor> {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    weight_tensor,
-                    intermediate_packet_buffer,
-                    dim,
-                    cross_device_semaphore,
-                    cluster_axis,
-                    mesh_device,
-                    num_links,
-                    subdevice_id,
-                    second_weight_tensor,
-                    rs_tensor,
-                    topology,
-                    memory_config_rs,
-                    memory_config_mm,
-                    compute_kernel_config,
-                    global_cb,
-                    core_grid,
-                    transpose_a,
-                    transpose_b,
-                    dtype,
-                    program_config,
-                    activation,
-                    output_tile,
-                    optional_output_tensor,
-                    use_noc1_only);
+            return self(
+                input_tensor,
+                weight_tensor,
+                intermediate_packet_buffer,
+                dim,
+                cross_device_semaphore,
+                cluster_axis,
+                mesh_device,
+                num_links,
+                subdevice_id,
+                second_weight_tensor,
+                rs_tensor,
+                topology,
+                memory_config_rs,
+                memory_config_mm,
+                compute_kernel_config,
+                global_cb,
+                core_grid,
+                transpose_a,
+                transpose_b,
+                dtype,
+                program_config,
+                activation,
+                output_tile,
+                optional_output_tensor,
+                use_noc1_only);
             },
             py::arg("input_tensor"),
             py::arg("weight_tensor"),
@@ -133,8 +131,7 @@ void py_bind_rs_matmul(pybind11::module& module) {
             py::arg("activation") = std::nullopt,
             py::arg("output_tile") = std::nullopt,
             py::arg("optional_output_tensor") = std::nullopt,
-            py::arg("use_noc1_only") = false,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("use_noc1_only") = false);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
@@ -79,32 +79,32 @@ void py_bind_rs_matmul(pybind11::module& module) {
                bool use_noc1_only
 
                ) -> std::vector<ttnn::Tensor> {
-            return self(
-                input_tensor,
-                weight_tensor,
-                intermediate_packet_buffer,
-                dim,
-                cross_device_semaphore,
-                cluster_axis,
-                mesh_device,
-                num_links,
-                subdevice_id,
-                second_weight_tensor,
-                rs_tensor,
-                topology,
-                memory_config_rs,
-                memory_config_mm,
-                compute_kernel_config,
-                global_cb,
-                core_grid,
-                transpose_a,
-                transpose_b,
-                dtype,
-                program_config,
-                activation,
-                output_tile,
-                optional_output_tensor,
-                use_noc1_only);
+                return self(
+                    input_tensor,
+                    weight_tensor,
+                    intermediate_packet_buffer,
+                    dim,
+                    cross_device_semaphore,
+                    cluster_axis,
+                    mesh_device,
+                    num_links,
+                    subdevice_id,
+                    second_weight_tensor,
+                    rs_tensor,
+                    topology,
+                    memory_config_rs,
+                    memory_config_mm,
+                    compute_kernel_config,
+                    global_cb,
+                    core_grid,
+                    transpose_a,
+                    transpose_b,
+                    dtype,
+                    program_config,
+                    activation,
+                    output_tile,
+                    optional_output_tensor,
+                    use_noc1_only);
             },
             py::arg("input_tensor"),
             py::arg("weight_tensor"),
@@ -131,7 +131,6 @@ void py_bind_rs_matmul(pybind11::module& module) {
             py::arg("activation") = std::nullopt,
             py::arg("output_tile") = std::nullopt,
             py::arg("optional_output_tensor") = std::nullopt,
-            py::arg("use_noc1_only") = false);
+            py::arg("use_noc1_only") = false});
 }
-
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/fabric.hpp>
 #include "ttnn/global_semaphore.hpp"
+#include "ttnn/run_operation.hpp"
 
 #include <ranges>
 #include <algorithm>
@@ -297,7 +298,7 @@ Tensor reduce_scatter_impl(
         rank - 1,
         dim);
 
-    return operation::run(
+    return tt::tt_metal::operation::run(
                ttnn::ReduceScatterAsync(
                    devices,
                    /*mesh_device=*/nullptr,
@@ -344,7 +345,7 @@ Tensor reduce_scatter_impl(
         persistent_output_tensors
             ? std::vector<std::optional<Tensor>>(persistent_output_tensors->begin(), persistent_output_tensors->end())
             : std::vector<std::optional<Tensor>>{};
-    return operation::run(
+    return tt::tt_metal::operation::run(
                ttnn::ReduceScatterAsync(
                    /*devices=*/{},
                    &mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
@@ -107,7 +107,6 @@ void py_bind_reduce_scatter_async(pybind11::module& module) {
         module,
         ttnn::experimental::reduce_scatter_async,
         R"doc(
-
         Performs an reduce_scatter operation on multi-device :attr:`input_tensor` across all devices.  This operation requires a persistent
         fabric to be enabled in order to function.
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_pybind.cpp
@@ -81,7 +81,6 @@ void py_bind_reduce_scatter_minimal_async(pybind11::module& module) {
         module,
         ttnn::experimental::reduce_scatter_minimal_async,
         R"doc(
-
         Performs an reduce-scatter operation on multi-device :attr:`input_tensor` across all devices.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/ring_attention_all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/ring_attention_all_gather_async_pybind.cpp
@@ -67,7 +67,6 @@ void py_bind_ring_attention_all_gather_async(pybind11::module& module) {
         module,
         ttnn::experimental::ring_attention_all_gather_async,
         R"doc(
-
         Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/recv_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/recv_async_pybind.cpp
@@ -38,7 +38,6 @@ void py_bind_recv_async(pybind11::module& module) {
         module,
         ttnn::experimental::recv_async,
         R"doc(
-
         Performs a recv operation from a :attr:`mesh_socket`.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/send_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/send_async_pybind.cpp
@@ -38,7 +38,6 @@ void py_bind_send_async(pybind11::module& module) {
         module,
         ttnn::experimental::send_async,
         R"doc(
-
         Performs a send operation on multi-device :attr:`input_tensor` to a :attr:`mesh_socket`.
 
         Args:

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.cpp
@@ -5,17 +5,13 @@
 #include "convert_to_chw.hpp"
 
 #include "device/convert_to_chw_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn::operations::experimental::cnn {
 
 ttnn::Tensor ExecuteConvertToCHW::invoke(
-    QueueId queue_id,
-    const Tensor& a,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DataType>& dtype) {
+    const Tensor& a, const std::optional<MemoryConfig>& memory_config, const std::optional<DataType>& dtype) {
     auto program = ConvertToCHW{memory_config.value_or(a.memory_config()), dtype.value_or(a.dtype())};
-    return tt::tt_metal::operation::run(program, {a}, {}, {}, queue_id).at(0);
+    return tt::tt_metal::operation::run(program, {a}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.hpp
@@ -11,7 +11,6 @@ namespace ttnn::operations::experimental::cnn {
 
 struct ExecuteConvertToCHW {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& a,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<DataType>& dtype = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
@@ -31,12 +31,11 @@ void bind_convert_to_chw(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<DataType> dtype) {
-            return self(input, memory_config, dtype); },
+               const std::optional<DataType> dtype) { return self(input, memory_config, dtype); },
             py::arg("input"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("dtype") = std::nullopt);
+            py::arg("dtype") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
@@ -31,13 +31,12 @@ void bind_convert_to_chw(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<DataType> dtype,
-               QueueId queue_id) { return self(queue_id, input, memory_config, dtype); },
+               const std::optional<DataType> dtype) {
+            return self(input, memory_config, dtype); },
             py::arg("input"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("dtype") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("dtype") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -5,17 +5,13 @@
 #include "convert_to_hwc.hpp"
 
 #include "device/convert_to_hwc_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn::operations::experimental::cnn {
 
 ttnn::Tensor ExecuteConvertToHWC::invoke(
-    QueueId queue_id,
-    const Tensor& a,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DataType>& dtype) {
+    const Tensor& a, const std::optional<MemoryConfig>& memory_config, const std::optional<DataType>& dtype) {
     auto program = ConvertToHWC{memory_config.value_or(a.memory_config()), dtype.value_or(a.dtype())};
-    return tt::tt_metal::operation::run(program, {a}, {}, {}, queue_id).at(0);
+    return tt::tt_metal::operation::run(program, {a}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.hpp
@@ -11,7 +11,6 @@ namespace ttnn::operations::experimental::cnn {
 
 struct ExecuteConvertToHWC {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& a,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<DataType>& dtype = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -31,12 +31,11 @@ void bind_convert_to_hwc(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<DataType> dtype) {
-            return self(input, memory_config, dtype); },
+               const std::optional<DataType> dtype) { return self(input, memory_config, dtype); },
             py::arg("input"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("dtype") = std::nullopt);
+            py::arg("dtype") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -31,13 +31,12 @@ void bind_convert_to_hwc(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<DataType> dtype,
-               QueueId queue_id) { return self(queue_id, input, memory_config, dtype); },
+               const std::optional<DataType> dtype) {
+            return self(input, memory_config, dtype); },
             py::arg("input"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("dtype") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("dtype") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -17,7 +17,6 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::experimental::conv3d {
 
 ttnn::Tensor ExecuteConv3d::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const std::optional<ttnn::Tensor>& bias_tensor,
@@ -34,8 +33,7 @@ ttnn::Tensor ExecuteConv3d::invoke(
                    .compute_kernel_config = kernel_config_val},
                {input_tensor, weight_tensor},
                {bias_tensor},
-               {},
-               queue_id)
+               {})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
@@ -17,7 +17,6 @@ namespace ttnn::operations::experimental::conv3d {
 
 struct ExecuteConv3d {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         const std::optional<ttnn::Tensor>& bias_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
@@ -35,7 +35,6 @@ void py_bind_conv3d(py::module& module) {
         :param ttnn.Conv3dConfig config: Configuration for the Conv3D operation.
         :param ttnn.MemoryConfig memory_config: Memory configuration for the output of the Conv3D operation.
         :param ttnn.DeviceComputeKernelConfig compute_kernel_config: Compute kernel configuration for the Conv3D operation.
-        :param queue_id: Queue ID for the Conv3D operation.
 
         :return: Output tensor after applying the Conv3D operation.
         :rtype: ttnn.Tensor
@@ -47,10 +46,8 @@ void py_bind_conv3d(py::module& module) {
                const std::optional<ttnn::Tensor>& bias_tensor,
                const Conv3dConfig& config,
                const std::optional<const MemoryConfig>& memory_config,
-               const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-               const QueueId& queue_id) {
-                return self(
-                    queue_id, input_tensor, weight_tensor, bias_tensor, config, memory_config, compute_kernel_config);
+               const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+                return self(input_tensor, weight_tensor, bias_tensor, config, memory_config, compute_kernel_config);
             },
             py::kw_only(),
             py::arg("input_tensor"),
@@ -58,8 +55,7 @@ void py_bind_conv3d(py::module& module) {
             py::arg("bias_tensor") = std::nullopt,
             py::arg("config"),
             py::arg("memory_config") = std::nullopt,
-            py::arg("compute_kernel_config") = std::nullopt,
-            py::arg("queue_id") = 0});
+            py::arg("compute_kernel_config") = std::nullopt});
 
     auto py_conv3d_config = py::class_<Conv3dConfig>(
                                 module,

--- a/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
 #include "typecast.hpp"
@@ -11,7 +10,6 @@
 namespace ttnn::operations::experimental::copy {
 
 ttnn::Tensor TypecastOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const DataType& dtype,
     const std::optional<MemoryConfig>& output_mem_config,
@@ -21,8 +19,7 @@ ttnn::Tensor TypecastOperation::invoke(
                    output_mem_config.value_or(input_tensor.memory_config()), dtype},
                {input_tensor},
                {},
-               {optional_output_tensor},
-               queue_id)
+               {optional_output_tensor})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::copy {
 
 struct TypecastOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const DataType& dtype,
         const std::optional<MemoryConfig>& output_mem_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast_pybind.cpp
@@ -41,13 +41,13 @@ void py_bind_typecast(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const ttnn::DataType dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& optional_output_tensor,
-               QueueId queue_id) { return self(queue_id, input_tensor, dtype, memory_config, optional_output_tensor); },
+               const std::optional<ttnn::Tensor>& optional_output_tensor) {
+                return self(input_tensor, dtype, memory_config, optional_output_tensor);
+            },
             py::arg("input_tensor").noconvert(),
             py::arg("dtype").noconvert(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("optional_output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("optional_output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::copy::detail

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout_pybind.cpp
@@ -28,7 +28,6 @@ void bind_experimental_dropout_operation(py::module& module) {
             scale (float): Scales output tensor. In general scale = 1.0/(1.0-probability).
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout_pybind.cpp
@@ -13,7 +13,6 @@ namespace py = pybind11;
 void bind_experimental_dropout_operation(py::module& module) {
     auto doc = fmt::format(
         R"doc(
-
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
@@ -12,7 +12,6 @@
 namespace ttnn::operations::experimental::matmul {
 
 ttnn::Tensor AttnMatmulOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const CoreCoord& compute_with_storage_grid_size,
@@ -34,14 +33,12 @@ ttnn::Tensor AttnMatmulOperation::invoke(
                    kernel_config_val},
                {input_tensor_a, input_tensor_b},
                {},
-               {std::move(optional_output_tensor)},
-               queue_id)
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 
 // TODO: Should we support option to read directly from cache (with optional transpose_hw)?
 ttnn::Tensor AttnMatmulFromCacheOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const uint32_t num_tokens,
@@ -70,8 +67,7 @@ ttnn::Tensor AttnMatmulFromCacheOperation::invoke(
                    kernel_config_val},
                {input_tensor_a, input_tensor_b},
                {},
-               {std::move(optional_output_tensor)},
-               queue_id)
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.hpp
@@ -14,7 +14,6 @@ namespace operations::experimental::matmul {
 // KV heads = 1) a special case of group_attn_matmul and run the same op
 struct AttnMatmulOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const CoreCoord& compute_with_storage_grid_size,
@@ -26,7 +25,6 @@ struct AttnMatmulOperation {
 
 struct AttnMatmulFromCacheOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         uint32_t num_tokens,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_pybind.cpp
@@ -25,10 +25,8 @@ void bind_attn_matmul(pybind11::module& module) {
                std::optional<const DataType> output_dtype,
                std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> optional_output_tensor,
-               QueueId queue_id) {
+               std::optional<Tensor> optional_output_tensor) {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     compute_with_storage_grid_size,
@@ -44,8 +42,7 @@ void bind_attn_matmul(pybind11::module& module) {
             pybind11::arg("dtype").noconvert() = std::nullopt,
             pybind11::arg("compute_kernel_config").noconvert() = std::nullopt,
             pybind11::arg("memory_config") = std::nullopt,
-            pybind11::arg("output_tensor") = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensor") = std::nullopt});
 }
 
 void bind_attn_matmul_from_cache(pybind11::module& module) {
@@ -65,10 +62,8 @@ void bind_attn_matmul_from_cache(pybind11::module& module) {
                const CoreCoord& compute_with_storage_grid_size,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<const DataType> dtype,
-               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     num_tokens,
@@ -86,8 +81,7 @@ void bind_attn_matmul_from_cache(pybind11::module& module) {
             pybind11::arg("compute_with_storage_grid_size").noconvert(),
             pybind11::arg("memory_config") = std::nullopt,
             pybind11::arg("dtype") = std::nullopt,
-            pybind11::arg("compute_kernel_config") = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("compute_kernel_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::matmul::detail

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
@@ -12,7 +12,6 @@
 namespace ttnn::operations::experimental::matmul {
 
 ttnn::Tensor GroupAttnMatmulOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const CoreCoord& compute_with_storage_grid_size,
@@ -69,8 +68,7 @@ ttnn::Tensor GroupAttnMatmulOperation::invoke(
                    kernel_config_val},
                {input_tensor_a, input_tensor_b},
                {},
-               {std::move(optional_output_tensor)},
-               queue_id)
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.hpp
@@ -14,7 +14,6 @@ namespace operations::experimental::matmul {
 // KV heads = 1) a special case of group_attn_matmul and run the same op
 struct GroupAttnMatmulOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const CoreCoord& compute_with_storage_grid_size,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul_pybind.cpp
@@ -25,10 +25,8 @@ void bind_group_attn_matmul(pybind11::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                std::optional<const DataType> output_dtype,
                std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-               std::optional<Tensor> optional_output_tensor,
-               QueueId queue_id) {
+               std::optional<Tensor> optional_output_tensor) {
                 return self(
-                    queue_id,
                     input_tensor_a,
                     input_tensor_b,
                     compute_with_storage_grid_size,
@@ -44,8 +42,7 @@ void bind_group_attn_matmul(pybind11::module& module) {
             pybind11::arg("memory_config").noconvert() = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             pybind11::arg("dtype").noconvert() = std::nullopt,
             pybind11::arg("compute_kernel_config").noconvert() = std::nullopt,
-            pybind11::arg("optional_output_tensor").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("optional_output_tensor").noconvert() = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::matmul::detail

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
@@ -6,7 +6,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include "ttnn/run_operation.hpp"
 #include "ttnn/common/constants.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -19,7 +18,6 @@ namespace ttnn::operations::experimental {
 
 template <typename T>
 ttnn::Tensor PaddedSliceOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const T> begins,
     tt::stl::Span<const T> ends,
@@ -132,8 +130,7 @@ ttnn::Tensor PaddedSliceOperation::invoke(
                 ttnn::Shape(modified_begins), ttnn::Shape(padded_ends), ttnn::Shape(modified_step), memory_config},
             {input_tensor},
             {},
-            {optional_output_tensor},
-            queue_id)
+            {optional_output_tensor})
             .at(0);
 
     // If padded_slice should return a sharded tensor, then the op must created the sharded tensor in the requested
@@ -153,7 +150,6 @@ ttnn::Tensor PaddedSliceOperation::invoke(
 }
 
 template ttnn::Tensor PaddedSliceOperation::invoke<int>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const int> begins,
     tt::stl::Span<const int> ends,
@@ -163,7 +159,6 @@ template ttnn::Tensor PaddedSliceOperation::invoke<int>(
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor PaddedSliceOperation::invoke<uint32_t>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const uint32_t> begins,
     tt::stl::Span<const uint32_t> ends,

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.hpp
@@ -13,7 +13,6 @@ namespace experimental {
 struct PaddedSliceOperation {
     template <typename T>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const T> begins,
         tt::stl::Span<const T> ends,
@@ -24,7 +23,6 @@ struct PaddedSliceOperation {
 
     template <typename T>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::SmallVector<T>& begins,
         const ttnn::SmallVector<T>& ends,
@@ -33,7 +31,6 @@ struct PaddedSliceOperation {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<float>& pad_value = std::nullopt) {
         return invoke(
-            queue_id,
             input_tensor,
             tt::stl::Span<const T>(begins),
             tt::stl::Span<const T>(ends),

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice_pybind.cpp
@@ -22,9 +22,6 @@ void bind_padded_slice(py::module& module) {
                 padded_slice_step: (Optional[List[int[tensor rank]]) Step size for each dim. Default is None, which works out be 1 for each dimension.
                 memory_config: Memory Config of the output tensor. This must be either height or block sharded.
 
-            Keyword Args:
-                queue_id (uint8, optional):command queue id
-
             Returns:
                 ttnn.Tensor: the output tensor.
 
@@ -53,11 +50,9 @@ void bind_padded_slice(py::module& module) {
                const std::optional<ttnn::SmallVector<int>>& step,
                const MemoryConfig& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
-               const std::optional<float>& pad_value,
-               QueueId queue_id) {
+               const std::optional<float>& pad_value) {
                 const auto step_value = step.value_or(ttnn::SmallVector<int>(padded_slice_end.size(), 1));
                 return self(
-                    queue_id,
                     input_tensor,
                     padded_slice_start,
                     padded_slice_end,
@@ -72,8 +67,6 @@ void bind_padded_slice(py::module& module) {
             py::kw_only(),
             py::arg("memory_config"),
             py::arg("output_tensor") = std::nullopt,
-            py::arg("pad_value") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("pad_value") = std::nullopt});
 }
 }  // namespace ttnn::operations::experimental::padded_slice

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
@@ -58,7 +58,6 @@ void bind_experimental_paged_cache_operations(py::module& module) {
 
     auto paged_fused_update_cache_doc =
         R"doc(
-
             Updates the cache tensors `cache_tensor1` and `cache_tensor2` in parallel with values derived from the corresponding input tensors. This function supports fine-grained updates using specified index lists or tensors.
 
             Positional Arguments:

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
@@ -11,9 +11,8 @@
 
 namespace ttnn::operations::experimental {
 
-ttnn::Tensor PlusOneOperation::invoke(
-    QueueId queue_id, const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids) {
-    return tt::tt_metal::operation::run(PlusOne{sub_core_grids}, {input_tensor}, {}, {}, queue_id).at(0);
+ttnn::Tensor PlusOneOperation::invoke(const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids) {
+    return tt::tt_metal::operation::run(PlusOne{sub_core_grids}, {input_tensor}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
@@ -13,7 +13,7 @@ namespace operations::experimental {
 
 struct PlusOneOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id, const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+        const Tensor& input_tensor, const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -97,7 +97,7 @@ Tensor fast_reduce_nc(
             _fast_reduce_nc(temp_input, sorted_dims[i], std::nullopt, output_mem_config, compute_kernel_config);
         temp_input = temp_output;
     }
-    return _fast_reduce_nctemp_input, sorted_dims.front(), output, output_mem_config, compute_kernel_config);
+    return _fast_reduce_nc(temp_input, sorted_dims.front(), output, output_mem_config, compute_kernel_config);
 }
 
 }  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -13,7 +13,6 @@
 namespace ttnn::operations::experimental::reduction::detail {
 
 Tensor _fast_reduce_nc(
-    QueueId queue_id,
     const ttnn::Tensor& input,
     const int32_t& dim,
     const std::optional<const ttnn::Tensor>& output,
@@ -28,8 +27,7 @@ Tensor _fast_reduce_nc(
                    .dim = dim, .output_mem_config = output_mem_config, .compute_kernel_config = kernel_config_val},
                {input},
                {},
-               {output},
-               queue_id)
+               {output})
         .at(0);
 }
 
@@ -85,7 +83,6 @@ operation::ProgramWithCallbacks FastReduceNCDeviceOperation::create_program(
 }
 
 Tensor fast_reduce_nc(
-    QueueId queue_id,
     const ttnn::Tensor& input,
     tt::stl::Span<const int32_t> dims,
     const std::optional<const ttnn::Tensor>& output,
@@ -96,11 +93,11 @@ Tensor fast_reduce_nc(
 
     auto temp_input = input;
     for (uint32_t i = dims.size() - 1; i > 0; i--) {
-        auto temp_output = _fast_reduce_nc(
-            queue_id, temp_input, sorted_dims[i], std::nullopt, output_mem_config, compute_kernel_config);
+        auto temp_output =
+            _fast_reduce_nc(temp_input, sorted_dims[i], std::nullopt, output_mem_config, compute_kernel_config);
         temp_input = temp_output;
     }
-    return _fast_reduce_nc(queue_id, temp_input, sorted_dims.front(), output, output_mem_config, compute_kernel_config);
+    return _fast_reduce_nctemp_input, sorted_dims.front(), output, output_mem_config, compute_kernel_config);
 }
 
 }  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -28,7 +27,6 @@ struct FastReduceNCDeviceOperation {
 };
 
 Tensor fast_reduce_nc(
-    QueueId queue_id,
     const ttnn::Tensor& input,
     tt::stl::Span<const int32_t> dims,
     const std::optional<const ttnn::Tensor>& output = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
@@ -17,7 +17,7 @@ ttnn::Tensor FastReduceNCOperation::invoke(
     const std::optional<const Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    return detail::fast_reduce_ncinput, dims, output, memory_config, compute_kernel_config);
+    return detail::fast_reduce_nc(input, dims, output, memory_config, compute_kernel_config);
 }
 
 }  // namespace operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
@@ -12,13 +12,12 @@ namespace ttnn {
 namespace operations::experimental::reduction {
 
 ttnn::Tensor FastReduceNCOperation::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input,
     tt::stl::Span<const int32_t> dims,
     const std::optional<const Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    return detail::fast_reduce_nc(queue_id, input, dims, output, memory_config, compute_kernel_config);
+    return detail::fast_reduce_ncinput, dims, output, memory_config, compute_kernel_config);
 }
 
 }  // namespace operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
@@ -14,7 +14,6 @@ namespace operations::experimental::reduction {
 
 struct FastReduceNCOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input,
         tt::stl::Span<const int32_t> dims,
         const std::optional<const Tensor>& output,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.cpp
@@ -23,15 +23,15 @@ void bind_fast_reduce_nc(pybind11::module& module) {
                const ttnn::SmallVector<int32_t>& dims,
                const std::optional<const Tensor>& output,
                const ttnn::MemoryConfig& memory_config,
-               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) { return self(queue_id, input, dims, output, memory_config, compute_kernel_config); },
+               std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+                return self(input, dims, output, memory_config, compute_kernel_config);
+            },
             pybind11::arg("input").noconvert(),
             pybind11::kw_only(),
             pybind11::arg("dims").noconvert() = ttnn::SmallVector<int32_t>(),
             pybind11::arg("output").noconvert() = std::nullopt,
             pybind11::arg("memory_config").noconvert() = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            pybind11::arg("compute_kernel_config").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("compute_kernel_config").noconvert() = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -4,7 +4,6 @@
 
 #include "view.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include <tt-metalium/constants.hpp>
 #include <ttnn/operations/functions.hpp>

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -8,7 +8,6 @@
 #include "tt-metalium/constants.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "tt-metalium/math.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation.hpp"
@@ -21,7 +20,6 @@ namespace ttnn::operations::experimental {
 // Specialization for uint32_t and N=4
 template <>
 ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor,
     const std::array<uint32_t, 4>& begins,
@@ -122,7 +120,7 @@ ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
             in_place_unpad &= begins[3] == 0 && ends[3] == padded_output_shape[3];
             if (in_place_unpad) {
                 log_info(tt::LogOp, "In-place unpad optimization via copy");
-                ttnn::copy(DefaultQueueId, input_tensor, output_tensor);
+                ttnn::copyinput_tensor, output_tensor);
                 return output_tensor;
             }
         }
@@ -132,8 +130,7 @@ ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
             SliceWriteDeviceOperation{ttnn::Shape(begins), ttnn::Shape(padded_ends), ttnn::Shape(step)},
             {input},
             {},
-            {output_tensor},
-            queue_id)[0];
+            {output_tensor})[0];
         return output_tensor;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -120,7 +120,7 @@ ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
             in_place_unpad &= begins[3] == 0 && ends[3] == padded_output_shape[3];
             if (in_place_unpad) {
                 log_info(tt::LogOp, "In-place unpad optimization via copy");
-                ttnn::copyinput_tensor, output_tensor);
+                ttnn::copy(input_tensor, output_tensor);
                 return output_tensor;
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -13,7 +13,6 @@ namespace experimental {
 struct SliceWriteOperation {
     template <typename T, std::size_t N>
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& output_tensor,
         const std::array<T, N>& output_tensor_start,

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
@@ -39,7 +39,6 @@ void bind_slice_write(py::module& module) {
 
             Keyword Args:
                 memory_config Memory Config of the output tensor
-                queue_id (uint8, optional) command queue id
 
             Returns:
                 ttnn.Tensor: the output tensor after writing the input tensor to it.
@@ -61,15 +60,12 @@ void bind_slice_write(py::module& module) {
                const ttnn::Tensor& output_tensor,
                const std::array<uint32_t, 4>& start,
                const std::array<uint32_t, 4>& end,
-               const std::array<uint32_t, 4>& step,
-               QueueId queue_id) { return self(queue_id, input_tensor, output_tensor, start, end, step); },
+               const std::array<uint32_t, 4>& step) { return self(input_tensor, output_tensor, start, end, step); },
             py::arg("input_tensor"),
             py::arg("output_tensor"),
             py::arg("start"),
             py::arg("end"),
             py::arg("step"),
-            py::kw_only(),
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::kw_only()});
 }
 }  // namespace ttnn::operations::experimental::slice_write

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
@@ -4,7 +4,6 @@
 
 #include "hc_sum_reduce_program_factory.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce.cpp
@@ -5,14 +5,12 @@
 #include "hc_sum_reduce.hpp"
 
 #include "device/hc_sum_reduce_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::ssm {
 
 ttnn::Tensor ExecuteHCSumReduce::invoke(
-    QueueId queue_id,
     const Tensor& input,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DataType> dtype,
@@ -21,7 +19,7 @@ ttnn::Tensor ExecuteHCSumReduce::invoke(
         memory_config.value_or(input.memory_config()),
         dtype.value_or(input.dtype()),
         math_fidelity.value_or(MathFidelity::HiFi4)};
-    return operation::run(program, {input}, {}, {}, queue_id).at(0);
+    return operation::run(program, {input}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental::ssm

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce.hpp
@@ -11,7 +11,6 @@ namespace ttnn::operations::experimental::ssm {
 
 struct ExecuteHCSumReduce {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DataType> dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.cpp
@@ -32,12 +32,13 @@ void bind_hc_sum_reduce(py::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType> dtype,
                const std::optional<MathFidelity> math_fidelity) {
-            return self(input, memory_config, dtype, math_fidelity); },
+                return self(input, memory_config, dtype, math_fidelity);
+            },
             py::arg("input"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("math_fidelity") = std::nullopt);
+            py::arg("math_fidelity") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::ssm::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.cpp
@@ -31,14 +31,13 @@ void bind_hc_sum_reduce(py::module& module) {
                const ttnn::Tensor& input,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType> dtype,
-               const std::optional<MathFidelity> math_fidelity,
-               QueueId queue_id) { return self(queue_id, input, memory_config, dtype, math_fidelity); },
+               const std::optional<MathFidelity> math_fidelity) {
+            return self(input, memory_config, dtype, math_fidelity); },
             py::arg("input"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("math_fidelity") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("math_fidelity") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::ssm::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.cpp
@@ -5,14 +5,12 @@
 #include "prefix_scan.hpp"
 
 #include "device/prefix_scan_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::ssm {
 
 ttnn::Tensor ExecutePrefixScan::invoke(
-    QueueId queue_id,
     const Tensor& a,
     const Tensor& bx,
     const Tensor& h_prev,
@@ -23,7 +21,7 @@ ttnn::Tensor ExecutePrefixScan::invoke(
         memory_config.value_or(a.memory_config()),
         dtype.value_or(a.dtype()),
         math_fidelity.value_or(MathFidelity::HiFi4)};
-    return operation::run(program, {a, bx, h_prev}, {}, {}, queue_id).at(0);
+    return operation::run(program, {a, bx, h_prev}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental::ssm

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.hpp
@@ -11,7 +11,6 @@ namespace ttnn::operations::experimental::ssm {
 
 struct ExecutePrefixScan {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& a,
         const Tensor& bx,
         const Tensor& h_prev,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_pybind.cpp
@@ -31,16 +31,15 @@ void bind_prefix_scan(py::module& module) {
                const ttnn::Tensor& h_prev,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType> dtype,
-               const std::optional<MathFidelity> math_fidelity,
-               QueueId queue_id) { return self(queue_id, a, bx, h_prev, memory_config, dtype, math_fidelity); },
+               const std::optional<MathFidelity> math_fidelity) {
+            return self(a, bx, h_prev, memory_config, dtype, math_fidelity); },
             py::arg("a"),
             py::arg("bx"),
             py::arg("h_prev"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("math_fidelity") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("math_fidelity") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::ssm::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_pybind.cpp
@@ -32,14 +32,15 @@ void bind_prefix_scan(py::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType> dtype,
                const std::optional<MathFidelity> math_fidelity) {
-            return self(a, bx, h_prev, memory_config, dtype, math_fidelity); },
+                return self(a, bx, h_prev, memory_config, dtype, math_fidelity);
+            },
             py::arg("a"),
             py::arg("bx"),
             py::arg("h_prev"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("math_fidelity") = std::nullopt);
+            py::arg("math_fidelity") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::ssm::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -6,7 +6,6 @@
 
 #include "repeat_and_interleave_eltwise_mul_program_factory.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul.cpp
@@ -5,14 +5,12 @@
 #include "repeat_and_interleave_eltwise_mul.hpp"
 
 #include "device/repeat_and_interleave_eltwise_mul_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::ssm {
 
 ttnn::Tensor ExecuteRepeatAndInterleaveEltwiseMul::invoke(
-    QueueId queue_id,
     const Tensor& a,
     const Tensor& b,
     const std::optional<MemoryConfig>& memory_config,
@@ -22,7 +20,7 @@ ttnn::Tensor ExecuteRepeatAndInterleaveEltwiseMul::invoke(
         memory_config.value_or(a.memory_config()),
         dtype.value_or(a.dtype()),
         math_fidelity.value_or(MathFidelity::HiFi4)};
-    return operation::run(program, {a, b}, {}, {}, queue_id).at(0);
+    return operation::run(program, {a, b}, {}, {}).at(0);
 }
 
 }  // namespace ttnn::operations::experimental::ssm

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul.hpp
@@ -12,7 +12,6 @@ namespace ttnn::operations::experimental::ssm {
 
 struct ExecuteRepeatAndInterleaveEltwiseMul {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& a,
         const Tensor& b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_pybind.cpp
@@ -32,13 +32,14 @@ void bind_repeat_and_interleave_eltwise_mul(py::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType> dtype,
                const std::optional<MathFidelity> math_fidelity) {
-            return self(a, b, memory_config, dtype, math_fidelity); },
+                return self(a, b, memory_config, dtype, math_fidelity);
+            },
             py::arg("a"),
             py::arg("b"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("math_fidelity") = std::nullopt);
+            py::arg("math_fidelity") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::ssm::detail

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_pybind.cpp
@@ -31,15 +31,14 @@ void bind_repeat_and_interleave_eltwise_mul(py::module& module) {
                const ttnn::Tensor& b,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<DataType> dtype,
-               const std::optional<MathFidelity> math_fidelity,
-               QueueId queue_id) { return self(queue_id, a, b, memory_config, dtype, math_fidelity); },
+               const std::optional<MathFidelity> math_fidelity) {
+            return self(a, b, memory_config, dtype, math_fidelity); },
             py::arg("a"),
             py::arg("b"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("math_fidelity") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("math_fidelity") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::ssm::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/all_reduce_create_qkv_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/all_reduce_create_qkv_heads_pybind.cpp
@@ -95,7 +95,6 @@ void py_bind_all_reduce_create_qkv_heads(pybind11::module& module) {
             cluster_axis (int): Provided a MeshTensor, the axis corresponding to MeshDevice to perform the operation on
             mesh_device (MeshDevice): Device mesh to perform the operation on
             multi_device_global_semaphore (MultiDeviceGlobalSemaphore): Semaphore for multi-device synchronization
-            queue_id (QueueId): Queue identifier for the operation
             num_heads (int): Number of attention heads
 
         Keyword Args:

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::transformer {
 
 struct ConcatenateHeadsOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const CoreCoord& compute_with_storage_grid_size,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -23,8 +22,7 @@ struct ConcatenateHeadsOperation {
                        compute_with_storage_grid_size, memory_config.value_or(input_tensor.memory_config())},
                    {input_tensor},
                    {},
-                   {optional_output_tensor},
-                   queue_id)
+                   {optional_output_tensor})
             .at(0);
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads_pybind.cpp
@@ -39,17 +39,14 @@ void bind_concatenate_heads(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const CoreCoord& compute_with_storage_grid_size,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id, input_tensor, compute_with_storage_grid_size, memory_config, optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(input_tensor, compute_with_storage_grid_size, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("compute_with_storage_grid_size").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads_pybind.cpp
@@ -40,13 +40,13 @@ void bind_concatenate_heads(py::module& module) {
                const CoreCoord& compute_with_storage_grid_size,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(input_tensor, compute_with_storage_grid_size, memory_config, optional_output_tensor);
+                return self(input_tensor, compute_with_storage_grid_size, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("compute_with_storage_grid_size").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.cpp
@@ -8,12 +8,10 @@
 #include "device/create_qkv_heads_device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> CreateQKVHeadsOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const uint32_t num_q_heads,
     const std::optional<uint32_t> num_kv_heads,
@@ -40,8 +38,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> CreateQKVHeadsOperation::in
         CreateQKVHeadsDeviceOperation{num_q_heads, num_kv_heads_val, head_dim, transpose_k_heads, output_mem_config},
         {input_tensor},
         {},
-        optional_outputs,
-        queue_id);
+        optional_outputs);
     return {output_tensors.at(0), output_tensors.at(1), output_tensors.at(2)};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.hpp
@@ -12,7 +12,6 @@ namespace operations::experimental::transformer {
 
 struct CreateQKVHeadsOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t num_q_heads,
         std::optional<uint32_t> num_kv_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads_pybind.cpp
@@ -24,16 +24,9 @@ void bind_create_qkv_heads_template(pybind11::module& module, const transformer_
                const std::optional<uint32_t> num_kv_heads,
                const bool transpose_k_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::array<Tensor, 3>> optional_output_tensors,
-               QueueId queue_id) {
+               std::optional<std::array<Tensor, 3>> optional_output_tensors) {
                 return self(
-                    queue_id,
-                    input_tensor_q,
-                    num_heads,
-                    num_kv_heads,
-                    transpose_k_heads,
-                    memory_config,
-                    optional_output_tensors);
+                    input_tensor_q, num_heads, num_kv_heads, transpose_k_heads, memory_config, optional_output_tensors);
             },
             pybind11::arg("input").noconvert(),
             pybind11::kw_only(),
@@ -41,8 +34,7 @@ void bind_create_qkv_heads_template(pybind11::module& module, const transformer_
             pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
             pybind11::arg("transpose_k_heads").noconvert() = true,
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 
 void bind_create_qkv_heads(pybind11::module& module) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.cpp
@@ -8,12 +8,10 @@
 #include "device/create_qkv_heads_from_separate_tensors_device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> CreateQKVHeadsSeparateTensorsOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_q,
     const Tensor& input_tensor_kv,
     const uint32_t num_q_heads,
@@ -43,8 +41,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> CreateQKVHeadsSeparateTenso
             memory_config.value_or(input_tensor_q.memory_config())},
         {input_tensor_q, input_tensor_kv},
         {},
-        optional_outputs,
-        queue_id);
+        optional_outputs);
     return {output_tensors.at(0), output_tensors.at(1), output_tensors.at(2)};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.hpp
@@ -12,7 +12,6 @@ namespace operations::experimental::transformer {
 
 struct CreateQKVHeadsSeparateTensorsOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const Tensor& input_tensor_kv,
         uint32_t num_q_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors_pybind.cpp
@@ -26,10 +26,8 @@ void bind_create_qkv_heads_from_separate_tensors_template(
                const std::optional<uint32_t> num_kv_heads,
                const bool transpose_k_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::array<Tensor, 3>> optional_output_tensors,
-               QueueId queue_id) {
+               std::optional<std::array<Tensor, 3>> optional_output_tensors) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_kv,
                     num_heads,
@@ -45,8 +43,7 @@ void bind_create_qkv_heads_from_separate_tensors_template(
             pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
             pybind11::arg("transpose_k_heads").noconvert() = true,
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 
 void bind_create_qkv_heads_from_separate_tensors(pybind11::module& module) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.cpp
@@ -12,7 +12,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 ttnn::Tensor NLPConcatHeadsOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp
@@ -11,7 +11,6 @@ namespace operations::experimental::transformer {
 
 struct NLPConcatHeadsOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads_pybind.cpp
@@ -22,13 +22,12 @@ void bind_nlp_concat_heads(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) { return self(queue_id, input_tensor, memory_config, optional_output_tensor); },
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(input_tensor, memory_config, optional_output_tensor); },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads_pybind.cpp
@@ -23,11 +23,12 @@ void bind_nlp_concat_heads(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(input_tensor, memory_config, optional_output_tensor); },
+                return self(input_tensor, memory_config, optional_output_tensor);
+            },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz.cpp
@@ -11,7 +11,6 @@
 
 namespace ttnn::operations::experimental::transformer {
 ttnn::Tensor NLPConcatHeadsBoltzOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz.hpp
@@ -10,7 +10,6 @@ namespace ttnn {
 namespace operations::experimental::transformer {
 struct NLPConcatHeadsBoltzOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz_pybind.cpp
@@ -21,13 +21,12 @@ void bind_nlp_concat_heads_boltz(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) { return self(queue_id, input_tensor, memory_config, optional_output_tensor); },
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(input_tensor, memory_config, optional_output_tensor); },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz_pybind.cpp
@@ -22,11 +22,12 @@ void bind_nlp_concat_heads_boltz(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(input_tensor, memory_config, optional_output_tensor); },
+                return self(input_tensor, memory_config, optional_output_tensor);
+            },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.cpp
@@ -12,7 +12,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 ttnn::Tensor NLPConcatHeadsDecodeOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const uint32_t num_heads,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
@@ -11,7 +11,6 @@ namespace operations::experimental::transformer {
 
 struct NLPConcatHeadsDecodeOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t num_heads,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_pybind.cpp
@@ -24,13 +24,13 @@ void bind_nlp_concat_heads_decode(py::module& module) {
                const uint32_t num_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(input_tensor, num_heads, memory_config, optional_output_tensor);
+                return self(input_tensor, num_heads, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("num_heads").noconvert(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_pybind.cpp
@@ -23,16 +23,14 @@ void bind_nlp_concat_heads_decode(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const uint32_t num_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, input_tensor, num_heads, memory_config, optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(input_tensor, num_heads, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("num_heads").noconvert(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -9,7 +9,6 @@
 #include "ttnn/run_operation.hpp"
 #include <variant>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/decorators.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
@@ -9,7 +9,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_q,
     const std::optional<Tensor>& input_tensor_kv,
     const uint32_t num_q_heads,
@@ -33,7 +32,6 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsOperation::in
     }
 
     return ttnn::prim::nlp_create_qkv_heads(
-        queue_id,
         input_tensor_q,
         input_tensor_kv,
         num_q_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::transformer {
 
 struct NlpCreateHeadsOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_q,
         const std::optional<Tensor>& input_tensor_kv,
         uint32_t num_q_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads_pybind.cpp
@@ -25,10 +25,8 @@ void bind_nlp_create_qkv_heads_template(pybind11::module& module, const transfor
                const std::optional<uint32_t> num_kv_heads,
                const bool transpose_k_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors,
-               QueueId queue_id) {
+               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_kv,
                     num_heads,
@@ -44,8 +42,7 @@ void bind_nlp_create_qkv_heads_template(pybind11::module& module, const transfor
             pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
             pybind11::arg("transpose_k_heads").noconvert() = true,
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 
 void bind_nlp_create_qkv_heads(pybind11::module& module) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
@@ -8,7 +8,6 @@
 #include "ttnn/run_operation.hpp"
 #include <variant>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/decorators.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/nlp_create_qkv_heads_boltz.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/nlp_create_qkv_heads_boltz.cpp
@@ -7,7 +7,6 @@
 #include <utility>
 namespace ttnn::operations::experimental::transformer {
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsBoltzOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_q,
     const std::optional<Tensor>& input_tensor_kv,
     const uint32_t num_q_heads,
@@ -31,7 +30,6 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsBoltzOperatio
     }
 
     return ttnn::prim::nlp_create_qkv_heads_boltz(
-        queue_id,
         input_tensor_q,
         input_tensor_kv,
         num_q_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/nlp_create_qkv_heads_boltz.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/nlp_create_qkv_heads_boltz.hpp
@@ -12,7 +12,6 @@ namespace ttnn {
 namespace operations::experimental::transformer {
 struct NlpCreateHeadsBoltzOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_q,
         const std::optional<Tensor>& input_tensor_kv,
         uint32_t num_q_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/nlp_create_qkv_heads_boltz_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/nlp_create_qkv_heads_boltz_pybind.cpp
@@ -24,10 +24,8 @@ void bind_nlp_create_qkv_heads_boltz_template(pybind11::module& module, const tr
                const std::optional<uint32_t> num_kv_heads,
                const bool transpose_k_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors,
-               QueueId queue_id) {
+               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_kv,
                     num_heads,
@@ -43,8 +41,7 @@ void bind_nlp_create_qkv_heads_boltz_template(pybind11::module& module, const tr
             pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
             pybind11::arg("transpose_k_heads").noconvert() = true,
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 
 void bind_nlp_create_qkv_heads_boltz(pybind11::module& module) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
@@ -8,12 +8,10 @@
 #include "device/nlp_create_qkv_heads_decode_device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const uint32_t num_heads,
     const std::optional<const uint32_t> num_kv_heads,
@@ -71,8 +69,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperati
             output_mem_config},
         {input_tensor},
         {batch_offset},
-        optional_outputs,
-        queue_id);
+        optional_outputs);
     return {out.at(0), out.at(1), out.at(2)};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
@@ -12,7 +12,6 @@ namespace operations::experimental::transformer {
 
 struct NLPCreateHeadsDecodeOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t num_heads,
         std::optional<const uint32_t> num_kv_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_pybind.cpp
@@ -26,10 +26,8 @@ void bind_nlp_create_qkv_heads_decode(pybind11::module& module) {
                const std::optional<const Tensor>& batch_offset,
                const std::optional<const uint32_t> slice_size,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::array<Tensor, 3>> optional_output_tensors,
-               QueueId queue_id) {
+               std::optional<std::array<Tensor, 3>> optional_output_tensors) {
                 return self(
-                    queue_id,
                     input_tensor,
                     num_q_heads,
                     num_kv_heads,
@@ -47,8 +45,7 @@ void bind_nlp_create_qkv_heads_decode(pybind11::module& module) {
             pybind11::arg("batch_offset").noconvert() = std::nullopt,
             pybind11::arg("slice_size").noconvert() = std::nullopt,
             pybind11::arg("memory_config") = std::nullopt,
-            pybind11::arg("output_tensors") = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.hpp
@@ -9,7 +9,6 @@
 #include "ttnn/run_operation.hpp"
 #include <variant>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b.cpp
@@ -9,7 +9,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsFalcon7bOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_q,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::transformer {
 
 struct NLPCreateHeadsFalcon7bOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_q,
         const std::optional<MemoryConfig>& memory_config,
         std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b_pybind.cpp
@@ -20,12 +20,12 @@ void bind_nlp_create_qkv_heads_falcon7b(pybind11::module& module) {
             [](const decltype(ttnn::experimental::nlp_create_qkv_heads_falcon7b)& self,
                const ttnn::Tensor& input_tensor_q,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors,
-               QueueId queue_id) { return self(queue_id, input_tensor_q, memory_config, optional_output_tensors); },
+               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors) {
+                return self(input_tensor_q, memory_config, optional_output_tensors);
+            },
             pybind11::arg("input").noconvert(),
             pybind11::kw_only(),
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.hpp
@@ -9,7 +9,6 @@
 #include "ttnn/run_operation.hpp"
 #include <variant>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer.cpp
@@ -9,7 +9,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsSegformerOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_q,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::transformer {
 
 struct NLPCreateHeadsSegformerOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_q,
         const std::optional<MemoryConfig>& memory_config,
         std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer_pybind.cpp
@@ -20,12 +20,12 @@ void bind_nlp_create_qkv_heads_segformer(pybind11::module& module) {
             [](const decltype(ttnn::experimental::nlp_create_qkv_heads_segformer)& self,
                const ttnn::Tensor& input_tensor_q,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors,
-               QueueId queue_id) { return self(queue_id, input_tensor_q, memory_config, optional_output_tensors); },
+               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors) {
+                return self(input_tensor_q, memory_config, optional_output_tensors);
+            },
             pybind11::arg("input").noconvert(),
             pybind11::kw_only(),
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.hpp
@@ -9,7 +9,6 @@
 #include "ttnn/run_operation.hpp"
 #include <variant>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit.cpp
@@ -9,7 +9,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsVitOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor_q,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::transformer {
 
 struct NLPCreateHeadsVitOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor_q,
         const std::optional<MemoryConfig>& memory_config,
         std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit_pybind.cpp
@@ -20,12 +20,12 @@ void bind_nlp_create_qkv_heads_vit(pybind11::module& module) {
             [](const decltype(ttnn::experimental::nlp_create_qkv_heads_vit)& self,
                const ttnn::Tensor& input_tensor_q,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors,
-               QueueId queue_id) { return self(queue_id, input_tensor_q, memory_config, optional_output_tensors); },
+               std::optional<std::vector<std::optional<ttnn::Tensor>>>& optional_output_tensors) {
+                return self(input_tensor_q, memory_config, optional_output_tensors);
+            },
             pybind11::arg("input").noconvert(),
             pybind11::kw_only(),
             pybind11::arg("memory_config").noconvert() = std::nullopt,
-            pybind11::arg("output_tensors").noconvert() = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensors").noconvert() = std::nullopt});
 };
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.cpp
@@ -12,7 +12,6 @@
 namespace ttnn::operations::experimental::transformer {
 
 ttnn::Tensor NLPKVCacheLoadSliceOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const uint32_t seq_len_start,
     const uint32_t seq_len_end,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.hpp
@@ -11,7 +11,6 @@ namespace operations::experimental::transformer {
 
 struct NLPKVCacheLoadSliceOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t seq_len_start,
         uint32_t seq_len_end,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice_pybind.cpp
@@ -23,17 +23,15 @@ void bind_nlp_kv_cache_load_slice(pybind11::module& module) {
                const uint32_t seq_len_start,
                const uint32_t seq_len_end,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, input_tensor, seq_len_start, seq_len_end, memory_config, optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+                return self(input_tensor, seq_len_start, seq_len_end, memory_config, optional_output_tensor);
             },
             pybind11::arg("input_tensor").noconvert(),
             pybind11::kw_only(),
             pybind11::arg("seq_len_start").noconvert(),
             pybind11::arg("seq_len_end").noconvert(),
             pybind11::arg("memory_config") = std::nullopt,
-            pybind11::arg("output_tensor") = std::nullopt,
-            pybind11::arg("queue_id") = DefaultQueueId});
+            pybind11::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/rotary_embedding_llama_fused_qk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/rotary_embedding_llama_fused_qk_pybind.cpp
@@ -20,7 +20,6 @@ void py_bind_rotary_embedding_llama_fused_qk(pybind11::module& module) {
         module,
         ttnn::experimental::rotary_embedding_llama_fused_qk,
         R"doc(
-
             Applies rotary embeddings to both `q_input_tensor` and `k_input_tensor` in parallel using precomputed sine and cosine values. This function is optimized for parallel execution, and both input tensors should share the same batch size and head dimensions.
 
             Args:

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.cpp
@@ -5,6 +5,8 @@
 #include "rotate_half.hpp"
 
 #include "device/rotate_half_device_operation.hpp"
+#include "ttnn/operations/experimental/auto_format/auto_format.hpp"
+#include "ttnn/run_operation.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp
@@ -13,7 +13,6 @@ namespace operations::experimental::transformer {
 
 struct SplitFusedQKVAndSplitHeadsOperation {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const CoreCoord& compute_with_storage_grid_size,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -24,8 +23,7 @@ struct SplitFusedQKVAndSplitHeadsOperation {
                 compute_with_storage_grid_size, memory_config.value_or(input_tensor.memory_config()), num_heads},
             {input_tensor},
             {},
-            optional_output_tensors.value_or(std::vector<std::optional<ttnn::Tensor>>{}),
-            queue_id);
+            optional_output_tensors.value_or(std::vector<std::optional<ttnn::Tensor>>{}));
         return {result.at(0), result.at(1), result.at(2)};
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads_pybind.cpp
@@ -32,7 +32,6 @@ void bind_split_qkv(py::module& module) {
                 * :attr:`num_heads`: Number of heads to split the tensor into
                 * :attr:`memory_config`: Memory Config of the output tensor, if None then it gets set to input_tensor.memory_config()
                 * :attr:`output_tensors`: preallocated output tensors
-                * :attr:`queue_id`: command queue id
         )doc",
         ttnn::pybind_overload_t{
             [](const SplitOperationType& self,
@@ -40,23 +39,16 @@ void bind_split_qkv(py::module& module) {
                const CoreCoord& compute_with_storage_grid_size,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const uint32_t num_heads,
-               std::optional<std::vector<std::optional<ttnn::Tensor>>> optional_output_tensors,
-               QueueId queue_id) {
+               std::optional<std::vector<std::optional<ttnn::Tensor>>> optional_output_tensors) {
                 return self(
-                    queue_id,
-                    input_tensor,
-                    compute_with_storage_grid_size,
-                    memory_config,
-                    num_heads,
-                    optional_output_tensors);
+                    input_tensor, compute_with_storage_grid_size, memory_config, num_heads, optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("compute_with_storage_grid_size").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("num_heads") = 16,
-            py::arg("output_tensors") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensors") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.cpp
@@ -8,7 +8,6 @@
 namespace ttnn::operations::experimental {
 
 Tensor GeluBackwardOperation::invoke(
-    QueueId queue_id,
     const Tensor& grad_output_tensor,
     const Tensor& input_tensor,
     const std::string& approximate,
@@ -19,6 +18,6 @@ Tensor GeluBackwardOperation::invoke(
                                                               : memory_config.value_or(input_tensor.memory_config());
 
     return ttnn::prim::gelu_bw(
-        queue_id, grad_output_tensor, input_tensor, approximate, output_dtype, output_memory_config, input_grad_tensor);
+        grad_output_tensor, input_tensor, approximate, output_dtype, output_memory_config, input_grad_tensor);
 }
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp
@@ -11,7 +11,6 @@ namespace ttnn::operations::experimental {
 
 struct GeluBackwardOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& grad_output_tensor,
         const Tensor& input_tensor,
         const std::string& approximate,

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.cpp
@@ -25,7 +25,6 @@ void bind_experimental_gelu_backward_operation(py::module& module) {
             approximate (str, optional): "tanh" or "none" (default). The gelu approximation algorithm to use.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for this operation. Defaults to None.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor. Defaults to None.
-            queue_id (int, optional): Command queue ID. Defaults to 0.
 
         Returns:
             ttnn.Tensor: The output tensor.
@@ -68,16 +67,14 @@ void bind_experimental_gelu_backward_operation(py::module& module) {
                const Tensor& input_tensor,
                const std::string& approximate,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor>& input_grad_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, grad_output_tensor, input_tensor, approximate, memory_config, input_grad_tensor);
+               std::optional<Tensor>& input_grad_tensor) -> ttnn::Tensor {
+                return self(grad_output_tensor, input_tensor, approximate, memory_config, input_grad_tensor);
             },
             py::arg("grad_output_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("approximate") = "none",
             py::arg("memory_config") = std::nullopt,
-            py::arg("input_grad") = std::nullopt,
-            py::arg("queue_id") = ttnn::DefaultQueueId});
+            py::arg("input_grad") = std::nullopt});
 }
 }  // namespace ttnn::operations::experimental::gelu_backward::detail

--- a/ttnn/cpp/ttnn/operations/experimental/where/where.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/where.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 #include "ttnn/operations/experimental/where/device/where_device_operation.hpp"
 
@@ -18,7 +17,6 @@ namespace operations::experimental::ternary {
 struct WhereOperation {
     template <FloatOrTensorConcept T, FloatOrTensorConcept U>
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& condition,
         const T& value_true,
         const U& value_false,
@@ -34,8 +32,7 @@ struct WhereOperation {
         if constexpr (std::is_same_v<T, Tensor> and std::is_same_v<U, Tensor>) {
             auto [operation_attributes, tensor_args] = WhereDeviceOperation::invoke(
                 condition, value_true, value_false, output_dtype, memory_config, std::move(output_tensor));
-            return ttnn::device_operation::detail::invoke<WhereDeviceOperation>(
-                queue_id, operation_attributes, tensor_args);
+            return ttnn::device_operation::detail::invoke<WhereDeviceOperation>(operation_attributes, tensor_args);
 
         } else {
             TT_FATAL((!std::is_same_v<T, Tensor> || !std::is_same_v<U, Tensor>), "Scalar values are not supported!");

--- a/ttnn/cpp/ttnn/operations/experimental/where/where_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/where_pybind.cpp
@@ -26,7 +26,6 @@ void bind_where(pybind11::module& pymodule) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
 
         Note:
@@ -56,100 +55,52 @@ void bind_where(pybind11::module& pymodule) {
         operation,
         doc,
         ttnn::pybind_overload_t{
-            [](const OperationType& self,
-               const Tensor& condition,
-               const Tensor& true_value,
-               const Tensor& false_value,
-               std::optional<const DataType> output_dtype,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    condition,
-                    true_value,
-                    false_value,
-                    output_dtype,
-                    memory_config,
-                    std::move(output_tensor));
-            },
-            py::arg("condition"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::kw_only(),
-            py::arg("dtype").noconvert() = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
-        ttnn::pybind_overload_t{
+        [](const OperationType& self,
+           const Tensor& condition,
+           const Tensor& true_value,
+           const Tensor& false_value,
+           std::optional<const DataType> output_dtype,
+           const std::optional<MemoryConfig>& memory_config,
+           std::optional<Tensor> output_tensor) {
+            return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
+        },
+            py::arg("condition"), py::arg("true_value"), py::arg("false_value"), py::kw_only(),
+            py::arg("dtype").noconvert() = std::nullopt, py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt, ttnn::pybind_overload_t {
             [](const OperationType& self,
                const Tensor& condition,
                const float true_value,
                const Tensor& false_value,
                std::optional<const DataType> output_dtype,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    condition,
-                    true_value,
-                    false_value,
-                    output_dtype,
-                    memory_config,
-                    std::move(output_tensor));
+               std::optional<Tensor> output_tensor) {
+                return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
             },
-            py::arg("condition"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::kw_only(),
-            pybind11::arg("dtype").noconvert() = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
-        ttnn::pybind_overload_t{
-            [](const OperationType& self,
-               const Tensor& condition,
-               const Tensor& true_value,
-               const float false_value,
-               std::optional<const DataType> output_dtype,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    condition,
-                    true_value,
-                    false_value,
-                    output_dtype,
-                    memory_config,
-                    std::move(output_tensor));
-            },
-            py::arg("condition"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::kw_only(),
-            py::arg("dtype").noconvert() = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
-        ttnn::pybind_overload_t{
+                py::arg("condition"), py::arg("true_value"), py::arg("false_value"), py::kw_only(),
+                pybind11::arg("dtype").noconvert() = std::nullopt, py::arg("memory_config") = std::nullopt,
+                py::arg("output_tensor") = std::nullopt, ttnn::pybind_overload_t {
+                [](const OperationType& self,
+                   const Tensor& condition,
+                   const Tensor& true_value,
+                   const float false_value,
+                   std::optional<const DataType> output_dtype,
+                   const std::optional<MemoryConfig>& memory_config,
+                   std::optional<Tensor> output_tensor) {
+                    return self(
+                        condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
+                },
+                    py::arg("condition"), py::arg("true_value"), py::arg("false_value"), py::kw_only(),
+                    py::arg("dtype").noconvert() = std::nullopt, py::arg("memory_config") = std::nullopt,
+                    py::arg("output_tensor") = std::nullopt, ttnn::pybind_overload_t {
             [](const OperationType& self,
                const Tensor& condition,
                const float true_value,
                const float false_value,
                std::optional<const DataType> output_dtype,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    condition,
-                    true_value,
-                    false_value,
-                    output_dtype,
-                    memory_config,
-                    std::move(output_tensor));
+               std::optional<Tensor> output_tensor) {
+                        return self(
+                            condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
             },
             py::arg("condition"),
             py::arg("true_value"),
@@ -157,8 +108,7 @@ void bind_where(pybind11::module& pymodule) {
             py::kw_only(),
             py::arg("dtype").noconvert() = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
-}
+            py::arg("output_tensor") = std::nullopt);
+                }
 
-}  // namespace ttnn::operations::experimental::ternary::detail
+            }  // namespace ttnn::operations::experimental::ternary::detail

--- a/ttnn/cpp/ttnn/operations/experimental/where/where_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/where_pybind.cpp
@@ -55,18 +55,23 @@ void bind_where(pybind11::module& pymodule) {
         operation,
         doc,
         ttnn::pybind_overload_t{
-        [](const OperationType& self,
-           const Tensor& condition,
-           const Tensor& true_value,
-           const Tensor& false_value,
-           std::optional<const DataType> output_dtype,
-           const std::optional<MemoryConfig>& memory_config,
-           std::optional<Tensor> output_tensor) {
-            return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
-        },
-            py::arg("condition"), py::arg("true_value"), py::arg("false_value"), py::kw_only(),
-            py::arg("dtype").noconvert() = std::nullopt, py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt, ttnn::pybind_overload_t {
+            [](const OperationType& self,
+               const Tensor& condition,
+               const Tensor& true_value,
+               const Tensor& false_value,
+               std::optional<const DataType> output_dtype,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<Tensor> output_tensor) {
+                return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
+            },
+            py::arg("condition"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::kw_only(),
+            py::arg("dtype").noconvert() = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt},
+        ttnn::pybind_overload_t{
             [](const OperationType& self,
                const Tensor& condition,
                const float true_value,
@@ -76,31 +81,22 @@ void bind_where(pybind11::module& pymodule) {
                std::optional<Tensor> output_tensor) {
                 return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
             },
-                py::arg("condition"), py::arg("true_value"), py::arg("false_value"), py::kw_only(),
-                pybind11::arg("dtype").noconvert() = std::nullopt, py::arg("memory_config") = std::nullopt,
-                py::arg("output_tensor") = std::nullopt, ttnn::pybind_overload_t {
-                [](const OperationType& self,
-                   const Tensor& condition,
-                   const Tensor& true_value,
-                   const float false_value,
-                   std::optional<const DataType> output_dtype,
-                   const std::optional<MemoryConfig>& memory_config,
-                   std::optional<Tensor> output_tensor) {
-                    return self(
-                        condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
-                },
-                    py::arg("condition"), py::arg("true_value"), py::arg("false_value"), py::kw_only(),
-                    py::arg("dtype").noconvert() = std::nullopt, py::arg("memory_config") = std::nullopt,
-                    py::arg("output_tensor") = std::nullopt, ttnn::pybind_overload_t {
+            py::arg("condition"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::kw_only(),
+            pybind11::arg("dtype").noconvert() = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt},
+        ttnn::pybind_overload_t{
             [](const OperationType& self,
                const Tensor& condition,
-               const float true_value,
+               const Tensor& true_value,
                const float false_value,
                std::optional<const DataType> output_dtype,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<Tensor> output_tensor) {
-                        return self(
-                            condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
+                return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
             },
             py::arg("condition"),
             py::arg("true_value"),
@@ -108,7 +104,24 @@ void bind_where(pybind11::module& pymodule) {
             py::kw_only(),
             py::arg("dtype").noconvert() = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
-                }
+            py::arg("output_tensor") = std::nullopt},
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const Tensor& condition,
+               const float true_value,
+               const float false_value,
+               std::optional<const DataType> output_dtype,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<Tensor> output_tensor) {
+                return self(condition, true_value, false_value, output_dtype, memory_config, std::move(output_tensor));
+            },
+            py::arg("condition"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::kw_only(),
+            py::arg("dtype").noconvert() = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
+}
 
-            }  // namespace ttnn::operations::experimental::ternary::detail
+}  // namespace ttnn::operations::experimental::ternary::detail

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_pybind.cpp
@@ -12,6 +12,7 @@
 #include <pybind11/stl.h>
 
 #include "kv_cache.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn-pybind/decorators.hpp"
 #include "ttnn/types.hpp"
 
@@ -85,10 +86,15 @@ void bind_update_cache_for_token_(py::module& module, const kv_cache_operation_t
                const ttnn::Tensor& cache,
                const ttnn::Tensor& input,
                const uint32_t update_index,
-               const uint32_t batch_offset) -> ttnn::Tensor { return self(cache, input, update_index, batch_offset); },
+               const uint32_t batch_offset,
+               std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) -> ttnn::Tensor {
+                return self(cache, input, update_index, batch_offset, compute_kernel_config);
+            },
             py::arg("cache"),
             py::arg("input"),
-            py::arg("update_index")});
+            py::arg("update_index"),
+            py::arg("batch_offset"),
+            py::arg("compute_kernel_config") = std::nullopt});
 }
 
 template <typename update_cache_operation_t>

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_pybind.cpp
@@ -88,8 +88,7 @@ void bind_update_cache_for_token_(py::module& module, const kv_cache_operation_t
                const uint32_t batch_offset) -> ttnn::Tensor { return self(cache, input, update_index, batch_offset); },
             py::arg("cache"),
             py::arg("input"),
-            py::arg("update_index"),
-            py::arg("batch_offset") = DefaultQueueId});
+            py::arg("update_index")});
 }
 
 template <typename update_cache_operation_t>

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -23,7 +23,6 @@ using ttnn::operations::unary::UnaryOpType;
 using ttnn::operations::unary::UnaryWithParam;
 
 Tensor loss_function(
-    QueueId queue_id,
     const Tensor& ref,
     const Tensor& prediction,
     const LossFunction loss_kind,
@@ -36,8 +35,7 @@ Tensor loss_function(
         case LossFunction::MSE: fused_ops.push_back(UnaryWithParam{UnaryOpType::SQUARE}); break;
         default: TT_THROW("unsupported loss function {}. Please change.", loss_kind);
     }
-    Tensor result =
-        ttnn::subtract(queue_id, ref, prediction, std::nullopt, memory_config, optional_output_tensor, fused_ops);
+    Tensor result = ttnn::subtract(ref, prediction, std::nullopt, memory_config, optional_output_tensor, fused_ops);
 
     switch (reduce_mode) {
         case LossReductionMode::SUM:
@@ -58,25 +56,23 @@ Tensor loss_function(
 }  // namespace loss_utils
 
 Tensor MseLossOperation::invoke(
-    QueueId queue_id,
     const Tensor& ref,
     const Tensor& prediction,
     const LossReductionMode mode,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
     return loss_utils::loss_function(
-        queue_id, ref, prediction, LossFunction::MSE, mode, memory_config, std::move(optional_output_tensor));
+        ref, prediction, LossFunction::MSE, mode, memory_config, std::move(optional_output_tensor));
 }
 
 Tensor MaeLossOperation::invoke(
-    QueueId queue_id,
     const Tensor& ref,
     const Tensor& prediction,
     const LossReductionMode mode,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
     return loss_utils::loss_function(
-        queue_id, ref, prediction, LossFunction::MAE, mode, memory_config, std::move(optional_output_tensor));
+        ref, prediction, LossFunction::MAE, mode, memory_config, std::move(optional_output_tensor));
 }
 
 }  // namespace operations::loss

--- a/ttnn/cpp/ttnn/operations/loss/loss.hpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.hpp
@@ -9,7 +9,6 @@
 
 #include "loss_types.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn {
 
@@ -17,7 +16,6 @@ namespace operations::loss {
 
 struct MseLossOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& ref,
         const Tensor& prediction,
         LossReductionMode mode = LossReductionMode::NONE,
@@ -27,7 +25,6 @@ struct MseLossOperation {
 
 struct MaeLossOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& ref,
         const Tensor& prediction,
         LossReductionMode mode = LossReductionMode::NONE,

--- a/ttnn/cpp/ttnn/operations/loss/loss_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss_pybind.cpp
@@ -60,14 +60,14 @@ void bind_mse_loss_function(py::module& module) {
                const LossReductionMode mode,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<Tensor> optional_output_tensor) -> ttnn::Tensor {
-            return self(ref, prediction, mode, memory_config, optional_output_tensor);
+                return self(ref, prediction, mode, memory_config, optional_output_tensor);
             },
             py::arg("input_reference"),
             py::arg("input_prediction"),
             py::kw_only(),
             py::arg("reduction") = LossReductionMode::NONE,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 void bind_mae_loss_function(py::module& module) {
@@ -97,25 +97,25 @@ void bind_mae_loss_function(py::module& module) {
             ttnn::l1_loss.base_name());
 
         using OperationType = decltype(ttnn::l1_loss);
-    bind_registered_operation(
-        module,
-        ttnn::l1_loss,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const OperationType& self,
-               const Tensor& ref,
-               const Tensor& prediction,
-               const LossReductionMode mode,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> optional_output_tensor) -> ttnn::Tensor {
-                return self(ref, prediction, mode, memory_config, optional_output_tensor);
-            },
-            py::arg("input_reference"),
-            py::arg("input_prediction"),
-            py::kw_only(),
-            py::arg("reduction") = LossReductionMode::NONE,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+        bind_registered_operation(
+            module,
+            ttnn::l1_loss,
+            doc,
+            ttnn::pybind_overload_t{
+                [](const OperationType& self,
+                   const Tensor& ref,
+                   const Tensor& prediction,
+                   const LossReductionMode mode,
+                   const std::optional<MemoryConfig>& memory_config,
+                   std::optional<Tensor> optional_output_tensor) -> ttnn::Tensor {
+                    return self(ref, prediction, mode, memory_config, optional_output_tensor);
+                },
+                py::arg("input_reference"),
+                py::arg("input_prediction"),
+                py::kw_only(),
+                py::arg("reduction") = LossReductionMode::NONE,
+                py::arg("memory_config") = std::nullopt,
+                py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/loss/loss_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss_pybind.cpp
@@ -36,7 +36,6 @@ void bind_mse_loss_function(py::module& module) {
                 reduction (bool, optional): Loss Reduction Mode. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -60,22 +59,20 @@ void bind_mse_loss_function(py::module& module) {
                const Tensor& prediction,
                const LossReductionMode mode,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> optional_output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, ref, prediction, mode, memory_config, optional_output_tensor);
+               std::optional<Tensor> optional_output_tensor) -> ttnn::Tensor {
+            return self(ref, prediction, mode, memory_config, optional_output_tensor);
             },
             py::arg("input_reference"),
             py::arg("input_prediction"),
             py::kw_only(),
             py::arg("reduction") = LossReductionMode::NONE,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 void bind_mae_loss_function(py::module& module) {
-    auto doc = fmt::format(
-        R"doc(
+        auto doc = fmt::format(
+            R"doc(
             Returns mean absolute error loss function for `input_reference` and `input_prediction`
 
             Args:
@@ -87,7 +84,6 @@ void bind_mae_loss_function(py::module& module) {
                 reduction (bool, optional): Loss Reduction Mode. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -98,9 +94,9 @@ void bind_mae_loss_function(py::module& module) {
                 >>> input_prediction = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
                 >>> output = ttnn.l1_loss(input_reference, input_prediction, reduction)
         )doc",
-        ttnn::l1_loss.base_name());
+            ttnn::l1_loss.base_name());
 
-    using OperationType = decltype(ttnn::l1_loss);
+        using OperationType = decltype(ttnn::l1_loss);
     bind_registered_operation(
         module,
         ttnn::l1_loss,
@@ -111,17 +107,15 @@ void bind_mae_loss_function(py::module& module) {
                const Tensor& prediction,
                const LossReductionMode mode,
                const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> optional_output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(queue_id, ref, prediction, mode, memory_config, optional_output_tensor);
+               std::optional<Tensor> optional_output_tensor) -> ttnn::Tensor {
+                return self(ref, prediction, mode, memory_config, optional_output_tensor);
             },
             py::arg("input_reference"),
             py::arg("input_prediction"),
             py::kw_only(),
             py::arg("reduction") = LossReductionMode::NONE,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1436,7 +1436,6 @@ Tensor matmul(
     const Tensor& input_tensor_b,
     const std::optional<const Tensor>& bias,
     const struct Matmul& parameters,
-    const QueueId queue_id,
     const std::optional<Tensor>& optional_output_tensor) {
     std::vector<std::optional<const Tensor>> optional_input_tensors = {};
     if (bias.has_value()) {
@@ -1449,8 +1448,7 @@ Tensor matmul(
                create_matmul_struct(input_tensor_a, input_tensor_b, parameters, {optional_output_tensor}),
                {input_tensor_a, input_tensor_b},
                optional_input_tensors,
-               {optional_output_tensor},
-               queue_id)
+               {optional_output_tensor})
         .at(0);
 }
 
@@ -1459,7 +1457,6 @@ std::vector<Tensor> matmul_batched_weights(
     const std::vector<Tensor>& input_tensors_b,
     const std::optional<const Tensor>& bias,
     const struct Matmul& parameters,
-    const QueueId queue_id,
     const std::optional<Tensor>& optional_output_tensor) {
     std::vector<std::optional<const Tensor>> optional_input_tensors = {};
     if (bias.has_value()) {
@@ -1475,8 +1472,7 @@ std::vector<Tensor> matmul_batched_weights(
         create_matmul_struct(input_tensor_a, input_tensors_b[0], parameters, {optional_output_tensor}),
         input_tensors,
         optional_input_tensors,
-        {optional_output_tensor},
-        queue_id);
+        {optional_output_tensor});
 }
 
 ttnn::Shape compute_sparse_matmul_output_shape(const Tensor& input_tensor_a, const Tensor& input_tensor_b) {
@@ -1554,15 +1550,13 @@ Tensor sparse_matmul(
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
     const struct SparseMatmul& parameters,
-    const QueueId queue_id,
     const std::optional<Tensor>& optional_output_tensor) {
     return operation::run(
                create_sparse_matmul_struct(
                    input_tensor_a, input_tensor_b, sparsity, parameters, {optional_output_tensor}),
                {input_tensor_a, input_tensor_b, sparsity},
                {},
-               {optional_output_tensor},
-               queue_id)
+               {optional_output_tensor})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -356,20 +356,22 @@ Tensor matmul(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const std::optional<const Tensor>& bias = std::nullopt,
-    const struct Matmul& parameters = Matmul {} const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const struct Matmul& parameters = Matmul{},
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 std::vector<Tensor> matmul_batched_weights(
     const Tensor& input_tensor_a,
     const std::vector<Tensor>& input_tensors_b,
     const std::optional<const Tensor>& bias = std::nullopt,
-    const struct Matmul& parameters = Matmul {} const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const struct Matmul& parameters = Matmul{},
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 Tensor sparse_matmul(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
-    const struct SparseMatmul& parameters = SparseMatmul {
-    } const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const struct SparseMatmul& parameters = SparseMatmul{},
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 }  // namespace matmul
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -356,25 +356,20 @@ Tensor matmul(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const std::optional<const Tensor>& bias = std::nullopt,
-    const struct Matmul& parameters = Matmul{},
-    QueueId queue_id = DefaultQueueId,
-    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const struct Matmul& parameters = Matmul {} const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 std::vector<Tensor> matmul_batched_weights(
     const Tensor& input_tensor_a,
     const std::vector<Tensor>& input_tensors_b,
     const std::optional<const Tensor>& bias = std::nullopt,
-    const struct Matmul& parameters = Matmul{},
-    QueueId queue_id = DefaultQueueId,
-    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const struct Matmul& parameters = Matmul {} const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 Tensor sparse_matmul(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const Tensor& sparsity,
-    const struct SparseMatmul& parameters = SparseMatmul{},
-    QueueId queue_id = DefaultQueueId,
-    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const struct SparseMatmul& parameters = SparseMatmul {
+    } const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
 }  // namespace matmul
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -4,7 +4,6 @@
 
 #include "matmul.hpp"
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
@@ -87,7 +86,6 @@ ttnn::Tensor bound_matmul(
     const ttnn::Tensor& input_tensor_b,
     const std::optional<const ttnn::Tensor>& bias,
     const struct Matmul& parameters,
-    const uint8_t& queue_id,
     std::optional<ttnn::Tensor>& optional_output_tensor) {
     if (input_tensor_a.logical_shape().rank() == 0 || input_tensor_b.logical_shape().rank() == 0) [[unlikely]] {
         TT_THROW(
@@ -141,7 +139,6 @@ ttnn::Tensor bound_matmul(
         input_tensor_b_adjusted,
         post_process_bias ? std::nullopt : bias,
         parameters,
-        DefaultQueueId,
         optional_output_tensor);
 
     if (input_tensor_b.logical_shape().rank() == 1) [[unlikely]] {
@@ -213,7 +210,6 @@ Tensor MatmulOperation::invoke(
             output_tile,
             global_cb,
             sub_device_id},
-        /*queue_id=*/0,
         optional_output_tensor);
 }
 
@@ -259,7 +255,6 @@ Tensor LinearOperation::invoke(
             output_tile,
             global_cb,
             sub_device_id},
-        /*queue_id=*/0,
         optional_output_tensor);
 }
 
@@ -308,7 +303,6 @@ std::vector<Tensor> MatmulBatchedWeightsOperation::invoke(
             output_tile,
             global_cb,
             sub_device_id},
-        DefaultQueueId,
         optional_output_tensor);
 }
 
@@ -354,8 +348,7 @@ Tensor AddmmOperation::invoke(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<const CoreGrid> core_grid,
     const std::optional<const tt::tt_metal::Tile>& output_tile,
-    std::optional<Tensor> optional_output_tensor,
-    QueueId queue_id) {
+    std::optional<Tensor> optional_output_tensor) {
     TT_FATAL(!output_tile.has_value(), "output_tile must not be provided");
 
     std::optional<CoreCoord> user_core_coord;
@@ -384,11 +377,10 @@ Tensor AddmmOperation::invoke(
             output_tile,
             /*global_cb=*/std::nullopt,
             /*sub_device_id=*/std::nullopt},
-        /*queue_id=*/0,
         optional_output_tensor);
 
     if (alpha != 1.0) {
-        multiply_(queue_id, out_tensor, alpha);
+        multiply_(out_tensor, alpha);
     }
 
     if (beta != 0.0) {
@@ -429,7 +421,6 @@ Tensor SparseMatmulOperation::invoke(
             output_tile,
             global_cb,
             sub_device_id},
-        DefaultQueueId,
         optional_output_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -33,7 +33,6 @@ ttnn::Tensor bound_matmul(
     const ttnn::Tensor& input_tensor_b,
     const std::optional<const ttnn::Tensor>& bias,
     const struct Matmul& parameters,
-    const uint8_t& queue_id,
     std::optional<ttnn::Tensor>& optional_output_tensor);
 
 struct MatmulOperation {
@@ -106,8 +105,7 @@ struct AddmmOperation {
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         std::optional<const CoreGrid> core_grid = std::nullopt,
         const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt,
-        QueueId queue_id = DefaultQueueId);
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
 };
 
 struct SparseMatmulOperation {

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -601,8 +601,7 @@ void py_module(py::module& module) {
                const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
                const std::optional<const CoreGrid> core_grid,
                const std::optional<const tt::tt_metal::Tile>& output_tile,
-               const std::optional<Tensor> optional_output_tensor,
-               QueueId queue_id) -> ttnn::Tensor {
+               const std::optional<Tensor> optional_output_tensor) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     mat1_tensor,
@@ -615,8 +614,7 @@ void py_module(py::module& module) {
                     compute_kernel_config,
                     core_grid,
                     output_tile,
-                    optional_output_tensor,
-                    queue_id);
+                    optional_output_tensor);
             },
             py::arg("input_tensor"),
             py::arg("mat1_tensor"),
@@ -630,9 +628,7 @@ void py_module(py::module& module) {
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("core_grid") = std::nullopt,
             py::arg("output_tile") = std::nullopt,
-            py::arg("optional_output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("optional_output_tensor") = std::nullopt});
 
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -36,8 +36,7 @@ Tensor BatchNorm::invoke(
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    QueueId queue_id) {
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL(
         input.logical_shape().rank() >= 4,
         "batch_norm not supported for tensors with rank < 4. (rank={})",

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
@@ -20,8 +20,7 @@ struct BatchNorm {
         const std::optional<Tensor>& bias = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-        QueueId queue_id = DefaultQueueId);
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 };
 }  // namespace operations::normalization
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -19,7 +19,6 @@ void bind_batch_norm_operation(py::module& module) {
         module,
         ttnn::batch_norm,
         R"doc(
-
         Applies batch norm over each channel on :attr:`input_tensor`.
         See `Spatial Batch Normalization <https://arxiv.org/abs/1502.03167>`_ for more details.
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -46,7 +46,6 @@ void bind_batch_norm_operation(py::module& module) {
             output (ttnn.Tensor, optional): Preallocated output tensor to store batch norm result of shape `[N, C, H, W]`. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): device compute kernel configuration for the operation. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to 0.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -104,7 +103,6 @@ void bind_batch_norm_operation(py::module& module) {
             py::arg("bias") = std::nullopt,
             py::arg("output") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("compute_kernel_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("compute_kernel_config") = std::nullopt);
 }
 }  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -102,6 +102,6 @@ void bind_batch_norm_operation(py::module& module) {
             py::arg("bias") = std::nullopt,
             py::arg("output") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("compute_kernel_config") = std::nullopt);
+            py::arg("compute_kernel_config") = std::nullopt});
 }
 }  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/point_to_point/point_to_point.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/point_to_point.cpp
@@ -10,7 +10,6 @@
 namespace ttnn::operations::point_to_point {
 
 ttnn::Tensor ExecutePointToPoint::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     const MeshCoordinate& receiver_coord,
     const MeshCoordinate& sender_coord,

--- a/ttnn/cpp/ttnn/operations/point_to_point/point_to_point.hpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/point_to_point.hpp
@@ -15,7 +15,6 @@ namespace operations::point_to_point {
 
 struct ExecutePointToPoint {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const MeshCoordinate& receiver_coord,
         const MeshCoordinate& sender_coord,

--- a/ttnn/cpp/ttnn/operations/point_to_point/point_to_point_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/point_to_point_pybind.cpp
@@ -28,7 +28,6 @@ void py_bind_point_to_point(py::module& module) {
                 semaphore (ttnn.GlobalSemaphore): Semaphore allocated on all devices
 
             Keyword Args:
-                queue_id (int, optional): command queue id. Defaults to `0`.
                 optional_output_tensoe (ttnn.Tensor,optional): Optional output tensor.
 
            Returns:
@@ -67,10 +66,8 @@ void py_bind_point_to_point(py::module& module) {
                const MeshCoordinate& sender_coord,
                const ccl::Topology topology,
                const GlobalSemaphore& semaphore,
-               const std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id, input_tensor, receiver_coord, sender_coord, topology, semaphore, optional_output_tensor);
+               const std::optional<ttnn::Tensor> optional_output_tensor) {
+                return self(input_tensor, receiver_coord, sender_coord, topology, semaphore, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("receiver_coord"),
@@ -78,8 +75,6 @@ void py_bind_point_to_point(py::module& module) {
             py::arg("topology"),
             py::arg("semaphore"),
             py::kw_only(),
-            py::arg("optional_output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("optional_output_tensor") = std::nullopt});
 }
 }  // namespace ttnn::operations::point_to_point

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -22,7 +22,6 @@ namespace operations::pool {
 // dilation which is set to (1,1) for avg pool and count_include_pad and divisor_override which have no effect on
 // maxpool.
 static Tensor pool2d_invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     Pool2DType pool_type,
     uint32_t batch_size,
@@ -197,7 +196,7 @@ static Tensor pool2d_invoke(
 
     // Call the halo uop
     auto haloed_tensor = ttnn::halo(
-        queue_id,
+
         input_tensor_sharded,
         sliding_window_config,
         get_bf16_pool_init_value(pool_type),  // pad_val
@@ -219,7 +218,7 @@ static Tensor pool2d_invoke(
         haloed_tensor.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
 
     auto output_tensor = ttnn::prim::pool2d(
-        queue_id,
+
         haloed_tensor,
         sliding_window_config,
         pool_type,
@@ -237,7 +236,6 @@ static Tensor pool2d_invoke(
 }
 
 Tensor MaxPool2DOp::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     uint32_t batch_size,
     uint32_t input_h,
@@ -254,7 +252,7 @@ Tensor MaxPool2DOp::invoke(
     bool deallocate_input,
     bool reallocate_halo_output) {
     return pool2d_invoke(
-        queue_id,
+
         input_tensor,
         Pool2DType::MAX_POOL2D,
         batch_size,
@@ -276,7 +274,6 @@ Tensor MaxPool2DOp::invoke(
 }
 
 Tensor AvgPool2DOp::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     uint32_t batch_size,
     uint32_t input_h,
@@ -294,7 +291,7 @@ Tensor AvgPool2DOp::invoke(
     bool deallocate_input,
     bool reallocate_halo_output) {
     return pool2d_invoke(
-        queue_id,
+
         input_tensor,
         Pool2DType::AVG_POOL2D,
         batch_size,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -196,7 +196,6 @@ static Tensor pool2d_invoke(
 
     // Call the halo uop
     auto haloed_tensor = ttnn::halo(
-
         input_tensor_sharded,
         sliding_window_config,
         get_bf16_pool_init_value(pool_type),  // pad_val
@@ -218,7 +217,6 @@ static Tensor pool2d_invoke(
         haloed_tensor.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
 
     auto output_tensor = ttnn::prim::pool2d(
-
         haloed_tensor,
         sliding_window_config,
         pool_type,
@@ -252,7 +250,6 @@ Tensor MaxPool2DOp::invoke(
     bool deallocate_input,
     bool reallocate_halo_output) {
     return pool2d_invoke(
-
         input_tensor,
         Pool2DType::MAX_POOL2D,
         batch_size,
@@ -291,7 +288,6 @@ Tensor AvgPool2DOp::invoke(
     bool deallocate_input,
     bool reallocate_halo_output) {
     return pool2d_invoke(
-
         input_tensor,
         Pool2DType::AVG_POOL2D,
         batch_size,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -16,7 +16,6 @@ namespace operations::pool {
 
 struct MaxPool2DOp {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t batch_size,
         uint32_t input_h,
@@ -35,7 +34,6 @@ struct MaxPool2DOp {
 };
 struct AvgPool2DOp {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t batch_size,
         uint32_t input_h,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -44,7 +44,6 @@ void bind_max_pool2d_operation(py::module& module) {
             in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
-            queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: the max pool convolved output tensor.
@@ -100,25 +99,23 @@ void bind_max_pool2d_operation(py::module& module) {
                const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
                bool in_place_halo,
                bool deallocate_input,
-               bool reallocate_halo_output,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    batch_size,
-                    input_h,
-                    input_w,
-                    channels,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    ceil_mode,
-                    memory_config,
-                    applied_shard_scheme,
-                    in_place_halo,
-                    deallocate_input,
-                    reallocate_halo_output);
+               bool reallocate_halo_output) -> ttnn::Tensor {
+            return self(
+                input_tensor,
+                batch_size,
+                input_h,
+                input_w,
+                channels,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                memory_config,
+                applied_shard_scheme,
+                in_place_halo,
+                deallocate_input,
+                reallocate_halo_output);
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -135,15 +132,14 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("applied_shard_scheme") = std::nullopt,
             py::arg("in_place_halo") = false,
             py::arg("deallocate_input") = false,
-            py::arg("reallocate_halo_output") = true,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("reallocate_halo_output") = true);
 }
 
 void bind_avg_pool2d_operation(py::module& module) {
-    bind_registered_operation(
-        module,
-        ttnn::avg_pool2d,
-        R"doc(
+        bind_registered_operation(
+            module,
+            ttnn::avg_pool2d,
+            R"doc(
         Applies an average pool convolution to the input tensor. The resulting output Tensor will contain the average
         value for each channel within a kernel window. The input tensor is expected to be in [NHW, C] format and
         should be on the device. Height, width and block sharding schemes are supported.
@@ -167,7 +163,6 @@ void bind_avg_pool2d_operation(py::module& module) {
             in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
-            queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: the average pool convolved output tensor.
@@ -206,62 +201,59 @@ void bind_avg_pool2d_operation(py::module& module) {
                             reallocate_halo_output=True,
                         )
         )doc",
-        ttnn::pybind_overload_t{
-            [](const decltype(ttnn::avg_pool2d)& self,
-               const ttnn::Tensor& input_tensor,
-               uint32_t batch_size,
-               uint32_t input_h,
-               uint32_t input_w,
-               uint32_t channels,
-               std::array<uint32_t, 2> kernel_size,
-               std::array<uint32_t, 2> stride,
-               std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
-               bool ceil_mode,
-               bool count_include_pad,
-               std::optional<int32_t> divisor_override,
-               const std::optional<const MemoryConfig>& memory_config,
-               const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
-               bool in_place_halo,
-               bool deallocate_input,
-               bool reallocate_halo_output,
-               QueueId queue_id) -> ttnn::Tensor {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    batch_size,
-                    input_h,
-                    input_w,
-                    channels,
-                    kernel_size,
-                    stride,
-                    padding,
-                    ceil_mode,
-                    count_include_pad,
-                    divisor_override,
-                    memory_config,
-                    applied_shard_scheme,
-                    in_place_halo,
-                    deallocate_input,
-                    reallocate_halo_output);
-            },
-            py::arg("input_tensor"),
-            py::arg("batch_size"),
-            py::arg("input_h"),
-            py::arg("input_w"),
-            py::arg("channels"),
-            py::arg("kernel_size"),
-            py::arg("stride"),
-            py::arg("padding"),
-            py::arg("ceil_mode") = false,
-            py::arg("count_include_pad") = true,
-            py::arg("divisor_override") = std::nullopt,
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("applied_shard_scheme") = std::nullopt,
-            py::arg("in_place_halo") = false,
-            py::arg("deallocate_input") = false,
-            py::arg("reallocate_halo_output") = true,
-            py::arg("queue_id") = 0});
+            ttnn::pybind_overload_t{
+                [](const decltype(ttnn::avg_pool2d)& self,
+                   const ttnn::Tensor& input_tensor,
+                   uint32_t batch_size,
+                   uint32_t input_h,
+                   uint32_t input_w,
+                   uint32_t channels,
+                   std::array<uint32_t, 2> kernel_size,
+                   std::array<uint32_t, 2> stride,
+                   std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+                   bool ceil_mode,
+                   bool count_include_pad,
+                   std::optional<int32_t> divisor_override,
+                   const std::optional<const MemoryConfig>& memory_config,
+                   const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
+                   bool in_place_halo,
+                   bool deallocate_input,
+                   bool reallocate_halo_output) -> ttnn::Tensor {
+                    return self(
+                        input_tensor,
+                        batch_size,
+                        input_h,
+                        input_w,
+                        channels,
+                        kernel_size,
+                        stride,
+                        padding,
+                        ceil_mode,
+                        count_include_pad,
+                        divisor_override,
+                        memory_config,
+                        applied_shard_scheme,
+                        in_place_halo,
+                        deallocate_input,
+                        reallocate_halo_output);
+                },
+                py::arg("input_tensor"),
+                py::arg("batch_size"),
+                py::arg("input_h"),
+                py::arg("input_w"),
+                py::arg("channels"),
+                py::arg("kernel_size"),
+                py::arg("stride"),
+                py::arg("padding"),
+                py::arg("ceil_mode") = false,
+                py::arg("count_include_pad") = true,
+                py::arg("divisor_override") = std::nullopt,
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt,
+                py::arg("applied_shard_scheme") = std::nullopt,
+                py::arg("in_place_halo") = false,
+                py::arg("deallocate_input") = false,
+                py::arg("reallocate_halo_output") = true});
 }
 
 void py_module(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -100,22 +100,22 @@ void bind_max_pool2d_operation(py::module& module) {
                bool in_place_halo,
                bool deallocate_input,
                bool reallocate_halo_output) -> ttnn::Tensor {
-            return self(
-                input_tensor,
-                batch_size,
-                input_h,
-                input_w,
-                channels,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                ceil_mode,
-                memory_config,
-                applied_shard_scheme,
-                in_place_halo,
-                deallocate_input,
-                reallocate_halo_output);
+                return self(
+                    input_tensor,
+                    batch_size,
+                    input_h,
+                    input_w,
+                    channels,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil_mode,
+                    memory_config,
+                    applied_shard_scheme,
+                    in_place_halo,
+                    deallocate_input,
+                    reallocate_halo_output);
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -132,7 +132,7 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("applied_shard_scheme") = std::nullopt,
             py::arg("in_place_halo") = false,
             py::arg("deallocate_input") = false,
-            py::arg("reallocate_halo_output") = true);
+            py::arg("reallocate_halo_output") = true});
 }
 
 void bind_avg_pool2d_operation(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -54,8 +54,8 @@ Tensor HaloTensorCreation(const Tensor& input) {
     Shape new_shape({1, 1, input_shape[0] * input_shape[1] * input_shape[2], input_shape[3]});
     input_tensor = ttnn::reshape(input_tensor, new_shape);
 
-    auto halo_output = ttnn::halo(
-        DefaultQueueId, input_tensor, sliding_window_config, 0, false, false, input_tensor.memory_config(), false);
+    auto halo_output =
+        ttnn::halo(input_tensor, sliding_window_config, 0, false, false, input_tensor.memory_config(), false);
 
     return halo_output;
 }

--- a/ttnn/cpp/ttnn/operations/rand/rand.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand.cpp
@@ -13,7 +13,6 @@
 namespace ttnn::operations::rand {
 
 Tensor Rand::invoke(
-    QueueId queue_id,
     const ttnn::Shape& shape,
     MeshDevice& device,
     const DataType dtype,

--- a/ttnn/cpp/ttnn/operations/rand/rand.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand.hpp
@@ -8,7 +8,6 @@
 namespace ttnn::operations::rand {
 struct Rand {
     static Tensor invoke(
-        QueueId queue_id,
         const ttnn::Shape& size,
         MeshDevice& device,
         DataType dtype = DataType::BFLOAT16,

--- a/ttnn/cpp/ttnn/operations/rand/rand_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand_pybind.cpp
@@ -55,9 +55,7 @@ void bind_rand_operation(py::module& pymodule) {
                const MemoryConfig& memory_config,
                float from,
                float to,
-               uint32_t seed) {
-            return self(shape, device, dtype, layout, memory_config, from, to, seed);
-            },
+               uint32_t seed) { return self(shape, device, dtype, layout, memory_config, from, to, seed); },
             py::arg("shape"),
             py::arg("device"),
             py::kw_only(),
@@ -66,6 +64,6 @@ void bind_rand_operation(py::module& pymodule) {
             py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG,
             py::arg("low") = 0.0f,
             py::arg("high") = 1.0f,
-            py::arg("seed") = 0);
+            py::arg("seed") = 0});
 }
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/rand_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand_pybind.cpp
@@ -55,9 +55,8 @@ void bind_rand_operation(py::module& pymodule) {
                const MemoryConfig& memory_config,
                float from,
                float to,
-               uint32_t seed,
-               QueueId queue_id) {
-                return self(queue_id, shape, device, dtype, layout, memory_config, from, to, seed);
+               uint32_t seed) {
+            return self(shape, device, dtype, layout, memory_config, from, to, seed);
             },
             py::arg("shape"),
             py::arg("device"),
@@ -67,7 +66,6 @@ void bind_rand_operation(py::module& pymodule) {
             py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG,
             py::arg("low") = 0.0f,
             py::arg("high") = 1.0f,
-            py::arg("seed") = 0,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("seed") = 0);
 }
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -113,7 +113,6 @@ Tensor accumulation_invoke(
     int32_t accumulation_axis;
     wip_tensor = common::preprocess_input_tensor(wip_tensor, cum_axis, permutation, accumulation_axis, dtype);
     wip_tensor = ttnn::prim::accumulation(
-
         wip_tensor,
         accumulation_axis,
         dtype,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -80,7 +80,6 @@ void validate_output_tensor(const Tensor& input_tensor, const Tensor& output_ten
 }
 
 Tensor accumulation_invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     int64_t dim,
     std::optional<ttnn::DataType> dtype,
@@ -114,7 +113,7 @@ Tensor accumulation_invoke(
     int32_t accumulation_axis;
     wip_tensor = common::preprocess_input_tensor(wip_tensor, cum_axis, permutation, accumulation_axis, dtype);
     wip_tensor = ttnn::prim::accumulation(
-        queue_id,
+
         wip_tensor,
         accumulation_axis,
         dtype,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.hpp
@@ -35,7 +35,6 @@ Tensor postprocess_output_tensor(
     const int32_t& original_rank);
 
 Tensor accumulation_invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     int64_t dim,
     std::optional<ttnn::DataType> dtype,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod.cpp
@@ -17,7 +17,6 @@
 namespace ttnn::operations::reduction::accumulation {
 
 Tensor CumprodOperation::invoke(
-    const QueueId& queue_id,
     const Tensor& input_tensor,
     const int32_t& dim,
     std::optional<DataType>& dtype,
@@ -25,7 +24,7 @@ Tensor CumprodOperation::invoke(
     std::optional<Tensor> optional_out,
     const std::optional<MemoryConfig>& memory_config) {
     return common::accumulation_invoke(
-        queue_id, input_tensor, dim, dtype, optional_out, reverse_order, memory_config, AccumulationOp::CUMPROD);
+        input_tensor, dim, dtype, optional_out, reverse_order, memory_config, AccumulationOp::CUMPROD);
 }
 
 }  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod.hpp
@@ -14,7 +14,6 @@ namespace operations::reduction::accumulation {
 
 struct CumprodOperation {
     static Tensor invoke(
-        const QueueId& queue_id,
         const Tensor& input_tensor,
         const int32_t& dim,
         std::optional<DataType>& dtype,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -93,7 +93,7 @@ void bind_reduction_cumprod_operation(py::module& module) {
                const bool& reverse_order,
                std::optional<Tensor> optional_out,
                const std::optional<MemoryConfig>& memory_config) -> Tensor {
-            return self(input_tensor, dim, dtype, reverse_order, optional_out, memory_config);
+                return self(input_tensor, dim, dtype, reverse_order, optional_out, memory_config);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim"),
@@ -101,7 +101,7 @@ void bind_reduction_cumprod_operation(py::module& module) {
             py::arg("dtype") = std::nullopt,
             py::arg("reverse_order") = false,
             py::arg("out") = std::nullopt,
-            py::arg("memory_config") = std::nullopt);
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::accumulation::detail

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -13,7 +13,6 @@
 #include "ttnn-pybind/decorators.hpp"
 #include "ttnn/operations/reduction/accumulation/cumprod/cumprod.hpp"
 #include "ttnn/types.hpp"
-#include "ttnn/common/queue_id.hpp"
 
 namespace ttnn::operations::reduction::accumulation::detail {
 void bind_reduction_cumprod_operation(py::module& module) {
@@ -93,9 +92,8 @@ void bind_reduction_cumprod_operation(py::module& module) {
                std::optional<DataType>& dtype,
                const bool& reverse_order,
                std::optional<Tensor> optional_out,
-               const std::optional<MemoryConfig>& memory_config,
-               const QueueId& queue_id = DefaultQueueId) -> Tensor {
-                return self(queue_id, input_tensor, dim, dtype, reverse_order, optional_out, memory_config);
+               const std::optional<MemoryConfig>& memory_config) -> Tensor {
+            return self(input_tensor, dim, dtype, reverse_order, optional_out, memory_config);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim"),
@@ -103,8 +101,7 @@ void bind_reduction_cumprod_operation(py::module& module) {
             py::arg("dtype") = std::nullopt,
             py::arg("reverse_order") = false,
             py::arg("out") = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::reduction::accumulation::detail

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum.cpp
@@ -11,14 +11,12 @@
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/small_vector.hpp>
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 
 namespace ttnn::operations::reduction::accumulation {
 
 Tensor CumsumOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const int32_t& dim,
     std::optional<ttnn::DataType> dtype,
@@ -26,7 +24,7 @@ Tensor CumsumOperation::invoke(
     std::optional<Tensor> optional_out,
     const std::optional<MemoryConfig>& memory_config) {
     return common::accumulation_invoke(
-        queue_id, input_tensor, dim, dtype, optional_out, reverse_order, memory_config, AccumulationOp::CUMSUM);
+        input_tensor, dim, dtype, optional_out, reverse_order, memory_config, AccumulationOp::CUMSUM);
 }
 
 }  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum.hpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -15,7 +14,6 @@ namespace ttnn::operations::reduction::accumulation {
 
 struct CumsumOperation {
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input,
         const int32_t& dim,
         std::optional<ttnn::DataType> dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -10,7 +10,6 @@
 #include <pybind11/stl.h>
 
 #include "ttnn-pybind/decorators.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/reduction/accumulation/cumsum/cumsum.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -91,9 +90,8 @@ void bind_reduction_cumsum_operation(py::module& module) {
                std::optional<DataType>& dtype,
                const bool& reverse_order,
                std::optional<Tensor> preallocated_tensor,
-               const std::optional<MemoryConfig>& memory_config,
-               QueueId queue_id) {
-                return self(queue_id, input_tensor, dim, dtype, reverse_order, preallocated_tensor, memory_config);
+               const std::optional<MemoryConfig>& memory_config) {
+            return self(input_tensor, dim, dtype, reverse_order, preallocated_tensor, memory_config);
             },
             py::arg("input").noconvert(),
             py::arg("dim"),
@@ -101,8 +99,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
             py::arg("dtype") = std::nullopt,
             py::arg("reverse_order") = false,
             py::arg("out") = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("memory_config") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::reduction::accumulation::detail

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -91,7 +91,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
                const bool& reverse_order,
                std::optional<Tensor> preallocated_tensor,
                const std::optional<MemoryConfig>& memory_config) {
-            return self(input_tensor, dim, dtype, reverse_order, preallocated_tensor, memory_config);
+                return self(input_tensor, dim, dtype, reverse_order, preallocated_tensor, memory_config);
             },
             py::arg("input").noconvert(),
             py::arg("dim"),
@@ -99,7 +99,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
             py::arg("dtype") = std::nullopt,
             py::arg("reverse_order") = false,
             py::arg("out") = std::nullopt,
-            py::arg("memory_config") = std::nullopt);
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::accumulation::detail

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -40,7 +40,6 @@ static Tensor zero_volume_argmax(
 }
 
 ttnn::Tensor ArgMaxOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const std::optional<int> dim,
     const bool keepdim,
@@ -72,8 +71,7 @@ ttnn::Tensor ArgMaxOperation::invoke(
                ArgMax{tt::tt_metal::DataType::UINT32, dim, keepdim, sub_core_grids, use_muticore, output_memory_config},
                {input_tensor},
                {},
-               {std::move(optional_output_tensor)},
-               queue_id)
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
@@ -13,7 +13,6 @@ namespace operations::reduction {
 
 struct ArgMaxOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         std::optional<int> dim = std::nullopt,
         bool keepdim = false,

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -27,7 +27,6 @@ void bind_reduction_argmax_operation(py::module& module) {
                 keepdim (bool, optional): whether to keep the reduced dimension. Defaults to `False`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: Output tensor containing the indices of the maximum value.
@@ -88,17 +87,9 @@ void bind_reduction_argmax_operation(py::module& module) {
                const std::optional<CoreRangeSet>& sub_core_grids,
                const bool use_multicore,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    dim,
-                    keepdim,
-                    sub_core_grids,
-                    use_multicore,
-                    memory_config,
-                    optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(
+                input_tensor, dim, keepdim, sub_core_grids, use_multicore, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim") = std::nullopt,
@@ -107,8 +98,7 @@ void bind_reduction_argmax_operation(py::module& module) {
             py::arg("sub_core_grids") = std::nullopt,
             py::arg("use_multicore") = false,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -87,8 +87,8 @@ void bind_reduction_argmax_operation(py::module& module) {
                const bool use_multicore,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(
-                input_tensor, dim, keepdim, sub_core_grids, use_multicore, memory_config, optional_output_tensor);
+                return self(
+                    input_tensor, dim, keepdim, sub_core_grids, use_multicore, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim") = std::nullopt,
@@ -97,7 +97,7 @@ void bind_reduction_argmax_operation(py::module& module) {
             py::arg("sub_core_grids") = std::nullopt,
             py::arg("use_multicore") = false,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -15,7 +15,6 @@ namespace ttnn::operations::reduction::detail {
 void bind_reduction_argmax_operation(py::module& module) {
     auto doc =
         R"doc(
-
             Returns the indices of the maximum value of elements in the :attr:`input_tensor`.
             If no :attr:`dim` is provided, it will return the indices of maximum value of all elements in given :attr:`input_tensor`.
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -10,6 +10,8 @@
 
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
+#include "ttnn/operations/experimental/auto_format/auto_format.hpp"
+#include "ttnn/run_operation.hpp"
 
 using namespace tt::constants;
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
@@ -16,7 +16,6 @@
 namespace ttnn::operations::reduction {
 
 ttnn::Tensor MoeOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const Tensor& expert_mask_tensor,
     const Tensor& topk_mask_tensor,
@@ -27,8 +26,7 @@ ttnn::Tensor MoeOperation::invoke(
                MoeDeviceOperation{k, memory_config.value_or(input_tensor.memory_config())},
                {input_tensor, expert_mask_tensor, topk_mask_tensor},
                {},
-               {std::move(optional_output_tensor)},
-               queue_id)
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe.hpp
@@ -14,7 +14,6 @@ namespace operations::reduction {
 
 struct MoeOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const Tensor& expert_mask_tensor,
         const Tensor& topk_mask_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -87,7 +87,8 @@ void bind_reduction_moe_operation(py::module& module) {
                const uint16_t k,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(input_tensor, expert_mask_tensor, topk_mask_tensor, k, memory_config, optional_output_tensor);
+                return self(
+                    input_tensor, expert_mask_tensor, topk_mask_tensor, k, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("expert_mask_tensor").noconvert(),
@@ -95,7 +96,7 @@ void bind_reduction_moe_operation(py::module& module) {
             py::arg("k") = 32,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -18,7 +18,7 @@ namespace ttnn::operations::reduction::detail {
 
 void bind_reduction_moe_operation(py::module& module) {
     auto doc =
-        R"doc(moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> ttnn.Tensor
+        R"doc(moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt) -> ttnn.Tensor
 
             Returns the weight of the zero-th MoE expert.
 
@@ -37,7 +37,6 @@ void bind_reduction_moe_operation(py::module& module) {
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensors
                 * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensors
-                * :attr:`queue_id` (Optional[uint8]): command queue id
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -87,16 +86,8 @@ void bind_reduction_moe_operation(py::module& module) {
                const ttnn::Tensor& topk_mask_tensor,
                const uint16_t k,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    expert_mask_tensor,
-                    topk_mask_tensor,
-                    k,
-                    memory_config,
-                    optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(input_tensor, expert_mask_tensor, topk_mask_tensor, k, memory_config, optional_output_tensor);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("expert_mask_tensor").noconvert(),
@@ -104,8 +95,7 @@ void bind_reduction_moe_operation(py::module& module) {
             py::arg("k") = 32,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -11,7 +11,6 @@
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/types.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/core/core.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -18,7 +18,6 @@ template <typename unary_operation_t>
 void bind_reduction_prod_operation(py::module& module, const unary_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
-
             Computes the product of all elements on specified :attr:`dim` of the :attr:`input_tensor` tensor.
 
             If no :attr:`dim` is provided (or :attr:`dim` is set to `None`), it will compute the full product of every element in the :attr:`input_tensor` tensor.

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_op.hpp
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
@@ -14,7 +14,6 @@
 namespace ttnn::operations::reduction {
 
 ttnn::Tensor SamplingOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_values_tensor,
     const Tensor& input_indices_tensor,
     const Tensor& k,
@@ -27,8 +26,7 @@ ttnn::Tensor SamplingOperation::invoke(
                Sampling{seed, sub_core_grids},
                {input_values_tensor, input_indices_tensor, k, p, temp},
                {},
-               {std::move(optional_output_tensor)},
-               queue_id)
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
@@ -13,7 +13,6 @@ namespace operations::reduction {
 
 struct SamplingOperation {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_values_tensor,
         const Tensor& input_indices_tensor,
         const Tensor& k,

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -147,8 +147,15 @@ void bind_reduction_sampling_operation(py::module& module) {
                const std::optional<uint32_t>& seed,
                const std::optional<CoreRangeSet>& sub_core_grids,
                std::optional<ttnn::Tensor> optional_output_tensor) {
-            return self(
-                input_values_tensor, input_indices_tensor, k, p, temp, seed, sub_core_grids, optional_output_tensor);
+                return self(
+                    input_values_tensor,
+                    input_indices_tensor,
+                    k,
+                    p,
+                    temp,
+                    seed,
+                    sub_core_grids,
+                    optional_output_tensor);
             },
             py::arg("input_values_tensor").noconvert(),
             py::arg("input_indices_tensor").noconvert(),
@@ -158,7 +165,7 @@ void bind_reduction_sampling_operation(py::module& module) {
             py::kw_only(),
             py::arg("seed").noconvert() = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt);
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -44,7 +44,6 @@ void bind_reduction_sampling_operation(py::module& module) {
                         temp=temp,
                         seed=seed,
                         optional_output_tensor=optional_output_tensor,
-                        queue_id=queue_id
                     )
 
             Note:
@@ -118,7 +117,6 @@ void bind_reduction_sampling_operation(py::module& module) {
                 seed (int, optional): Seed for sampling randomness. Defaults to `0`.
                 sub_core_grids (ttnn.CoreRangeSet, optional): Core range set for multicore execution. Defaults to `None`.
                 optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-                queue_id (int, optional): Command queue ID for execution. Defaults to `0`.
 
             Returns:
                 ttnn.Tensor: The output tensor containing sampled indices.
@@ -148,18 +146,9 @@ void bind_reduction_sampling_operation(py::module& module) {
                const ttnn::Tensor& temp,
                const std::optional<uint32_t>& seed,
                const std::optional<CoreRangeSet>& sub_core_grids,
-               std::optional<ttnn::Tensor> optional_output_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_values_tensor,
-                    input_indices_tensor,
-                    k,
-                    p,
-                    temp,
-                    seed,
-                    sub_core_grids,
-                    optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor) {
+            return self(
+                input_values_tensor, input_indices_tensor, k, p, temp, seed, sub_core_grids, optional_output_tensor);
             },
             py::arg("input_values_tensor").noconvert(),
             py::arg("input_indices_tensor").noconvert(),
@@ -169,8 +158,7 @@ void bind_reduction_sampling_operation(py::module& module) {
             py::kw_only(),
             py::arg("seed").noconvert() = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("output_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -7,7 +7,6 @@
 #include "topk.hpp"
 #include "device/topk_op.hpp"
 #include "device/topk_constants.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
@@ -102,7 +101,6 @@ std::vector<Tensor> post_topk_transform_tensor(
 }  // namespace
 
 std::vector<Tensor> ExecuteTopK::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const uint32_t k,
     const int8_t dim,
@@ -151,8 +149,7 @@ std::vector<Tensor> ExecuteTopK::invoke(
         {indices_tensor},
         optional_output_tensors.has_value()
             ? reduction_common::tuple_to_vector_optional(optional_output_tensors.value())
-            : std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt},
-        queue_id);
+            : std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt});
 
     return CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
         transposed_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -15,7 +15,6 @@ namespace operations::reduction {
 
 struct ExecuteTopK {
     static std::vector<Tensor> invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         uint32_t k,
         int8_t dim,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -93,16 +93,16 @@ void bind_reduction_topk_operation(py::module& module) {
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::CoreRangeSet>& sub_core_grids,
                const std::optional<ttnn::Tensor>& indices_tensor) {
-            return self(
-                input_tensor,
-                k,
-                dim,
-                largest,
-                sorted,
-                memory_config,
-                sub_core_grids,
-                indices_tensor,
-                optional_output_tensors);
+                return self(
+                    input_tensor,
+                    k,
+                    dim,
+                    largest,
+                    sorted,
+                    memory_config,
+                    sub_core_grids,
+                    indices_tensor,
+                    optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("k") = 32,
@@ -113,7 +113,7 @@ void bind_reduction_topk_operation(py::module& module) {
             py::arg("out") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt,
-            py::arg("indices_tensor") = std::nullopt);
+            py::arg("indices_tensor") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 void bind_reduction_topk_operation(py::module& module) {
     auto doc =
-        R"doc(topk(input_tensor: ttnn.Tensor, k: int, dim: int, largest: bool, sorted: bool, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> Tuple[ttnn.Tensor, ttnn.Tensor]
+        R"doc(topk(input_tensor: ttnn.Tensor, k: int, dim: int, largest: bool, sorted: bool, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, ) -> Tuple[ttnn.Tensor, ttnn.Tensor]
 
             Returns the :attr:`k` largest or :attr:`k` smallest elements of the :attr:`input_tensor` along a given dimension :attr:`dim`.
 
@@ -38,7 +38,6 @@ void bind_reduction_topk_operation(py::module& module) {
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
                 sub_core_grids (ttnn.CoreRangeSet, optional): Core range set to run the operation on. Defaults to `None`.
                 indices_tensor (ttnn.Tensor, optional): Preallocated indices tensor. Defaults to `None`.
 
@@ -93,19 +92,17 @@ void bind_reduction_topk_operation(py::module& module) {
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::CoreRangeSet>& sub_core_grids,
-               const std::optional<ttnn::Tensor>& indices_tensor,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    k,
-                    dim,
-                    largest,
-                    sorted,
-                    memory_config,
-                    sub_core_grids,
-                    indices_tensor,
-                    optional_output_tensors);
+               const std::optional<ttnn::Tensor>& indices_tensor) {
+            return self(
+                input_tensor,
+                k,
+                dim,
+                largest,
+                sorted,
+                memory_config,
+                sub_core_grids,
+                indices_tensor,
+                optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("k") = 32,
@@ -116,8 +113,7 @@ void bind_reduction_topk_operation(py::module& module) {
             py::arg("out") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt,
-            py::arg("indices_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("indices_tensor") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
@@ -8,7 +8,6 @@
 #include "device/halo_device_operation.hpp"
 namespace ttnn::operations::sliding_window::halo {
 Tensor HaloOperation::invoke(
-    QueueId queue_id,
     const Tensor& input_tensor,
     const SlidingWindowConfig& config,
     uint32_t pad_val,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -12,7 +12,6 @@ namespace ttnn::operations::sliding_window::halo {
 struct HaloOperation {
     // This how the user can call the operation
     static Tensor invoke(
-        QueueId queue_id,
         const Tensor& input_tensor,
         const SlidingWindowConfig& config,
         uint32_t pad_val = 0x0,

--- a/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads_pybind.cpp
@@ -18,7 +18,6 @@ void py_bind_concatenate_heads(pybind11::module& module) {
         module,
         ttnn::transformer::concatenate_heads,
         R"doc(
-
             Takes in a tensor of shape ``[batch_size, num_heads, sequence_size, head_size]``, concatenates heads back along the width dimension and returns the tensor of shape ``[batch_size, sequence_size, num_heads * head_size]``
 
             Args:

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -42,8 +42,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
                    .use_mla = false},
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {attn_mask},
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 
@@ -75,8 +74,7 @@ ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
                    .use_mla = false},
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 
@@ -107,8 +105,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ExecuteJointAttention::invoke(
             .compute_kernel_config = kernel_config_val},
         {input_tensor_q, input_tensor_k, input_tensor_v, joint_tensor_q, joint_tensor_k, joint_tensor_v},
         {},
-        {},
-        ttnn::DefaultQueueId);
+        {});
 
     return {results.at(0), results.at(1)};
 }
@@ -196,8 +193,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
             ccl_core_grid_offset},
         input_tensors,
         {},
-        {},
-        ttnn::DefaultQueueId);
+        {});
 
     return {results.at(0), results.at(1), results.at(2)};
 }
@@ -231,8 +227,7 @@ ttnn::Tensor ExecuteFlashMLAPrefill::invoke(
                    .head_dim_v = head_dim_v},
                {input_tensor_q, input_tensor_k},
                {attn_mask},
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 
@@ -265,8 +260,7 @@ ttnn::Tensor ExecuteChunkedFlashMLAPrefill::invoke(
                    .head_dim_v = head_dim_v},
                {input_tensor_q, input_tensor_k},
                {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -9,14 +9,12 @@
 #include "device/sdpa_op.hpp"
 #include "device/joint_sdpa_op.hpp"
 #include "device/ring_joint_sdpa_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.hpp"
 
 namespace ttnn::operations::transformer {
 
 ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -45,12 +43,11 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {attn_mask},
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 
 ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -79,12 +76,11 @@ ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> ExecuteJointAttention::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -112,13 +108,12 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ExecuteJointAttention::invoke(
         {input_tensor_q, input_tensor_k, input_tensor_v, joint_tensor_q, joint_tensor_k, joint_tensor_v},
         {},
         {},
-        queue_id);
+        ttnn::DefaultQueueId);
 
     return {results.at(0), results.at(1)};
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -202,13 +197,12 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
         input_tensors,
         {},
         {},
-        queue_id);
+        ttnn::DefaultQueueId);
 
     return {results.at(0), results.at(1), results.at(2)};
 }
 
 ttnn::Tensor ExecuteFlashMLAPrefill::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const uint32_t head_dim_v,
@@ -238,12 +232,11 @@ ttnn::Tensor ExecuteFlashMLAPrefill::invoke(
                {input_tensor_q, input_tensor_k},
                {attn_mask},
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 
 ttnn::Tensor ExecuteChunkedFlashMLAPrefill::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const uint32_t head_dim_v,
@@ -273,7 +266,7 @@ ttnn::Tensor ExecuteChunkedFlashMLAPrefill::invoke(
                {input_tensor_q, input_tensor_k},
                {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -14,7 +14,6 @@ namespace operations::transformer {
 
 struct ExecuteScaledDotProductAttention {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
@@ -28,7 +27,6 @@ struct ExecuteScaledDotProductAttention {
 
 struct ExecuteChunkedScaledDotProductAttention {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
@@ -42,7 +40,6 @@ struct ExecuteChunkedScaledDotProductAttention {
 
 struct ExecuteJointAttention {
     static std::tuple<ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
@@ -57,7 +54,6 @@ struct ExecuteJointAttention {
 
 struct ExecuteRingJointAttention {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
@@ -83,7 +79,6 @@ struct ExecuteRingJointAttention {
 
 struct ExecuteFlashMLAPrefill {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         uint32_t head_dim_v,
@@ -97,7 +92,6 @@ struct ExecuteFlashMLAPrefill {
 
 struct ExecuteChunkedFlashMLAPrefill {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         uint32_t head_dim_v,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
@@ -190,18 +190,18 @@ void py_bind_sdpa(py::module& module) {
                SDPAProgramConfig program_config,
                std::optional<float> scale,
                std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-            auto outputs = self(
-                input_tensor_q,
-                input_tensor_k,
-                input_tensor_v,
-                joint_tensor_q,
-                joint_tensor_k,
-                joint_tensor_v,
-                joint_strategy,
-                program_config,
-                scale,
-                compute_kernel_config);
-            return outputs;
+                auto outputs = self(
+                    input_tensor_q,
+                    input_tensor_k,
+                    input_tensor_v,
+                    joint_tensor_q,
+                    joint_tensor_k,
+                    joint_tensor_v,
+                    joint_strategy,
+                    program_config,
+                    scale,
+                    compute_kernel_config);
+                return outputs;
             },
             py::arg("input_tensor_q").noconvert(),
             py::arg("input_tensor_k").noconvert(),
@@ -213,9 +213,9 @@ void py_bind_sdpa(py::module& module) {
             py::arg("joint_strategy"),
             py::arg("program_config").noconvert(),
             py::arg("scale").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt);
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
-            auto ring_joint_doc = R"doc(
+    auto ring_joint_doc = R"doc(
         RingJointAttention operation that efficiently performs non-causal attention over two
         sets of query, key, and value tensors, where the first set is sharded across devices in the sequence dimension.
         Internally, these are concatenated in the sequence dimension (joint_strategy = "rear"),
@@ -260,7 +260,7 @@ void py_bind_sdpa(py::module& module) {
               - The final log-sum-exp of the operation.           [b x nh x (N/num_devices + L) x 1]
         )doc";
 
-            using RingJointOperationType = decltype(ttnn::transformer::ring_joint_scaled_dot_product_attention);
+    using RingJointOperationType = decltype(ttnn::transformer::ring_joint_scaled_dot_product_attention);
 
     ttnn::bind_registered_operation(
         module,
@@ -334,10 +334,10 @@ void py_bind_sdpa(py::module& module) {
             py::arg("mesh_device"),
             py::arg("topology"),
             py::arg("subdevice_id") = std::nullopt,
-            py::arg("ccl_core_grid_offset"));
+            py::arg("ccl_core_grid_offset")});
 
-            auto mla_doc =
-                R"doc(
+    auto mla_doc =
+        R"doc(
         Causal MLA attention."
 
         Accepts a `SDPAProgramConfig` which specifies the grid size and chunk tiles in the Q and K sequence lengths. The op parallelizes over `b`, `nqh`, and Q's `s` dimension.
@@ -361,46 +361,46 @@ void py_bind_sdpa(py::module& module) {
 
         )doc";
 
-            using MLAOperationType = decltype(ttnn::transformer::flash_mla_prefill);
-            ttnn::bind_registered_operation(
-                module,
-                ttnn::transformer::flash_mla_prefill,
-                mla_doc,
-                ttnn::pybind_overload_t{
-                    [](const MLAOperationType& self,
-                       const ttnn::Tensor& input_tensor_q,
-                       const ttnn::Tensor& input_tensor_k,
-                       const uint32_t head_dim_v,
-                       std::optional<ttnn::Tensor> attn_mask,
-                       bool is_causal,
-                       std::optional<float> scale,
-                       const std::optional<MemoryConfig>& memory_config,
-                       std::optional<SDPAProgramConfig> program_config,
-                       std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-                        return self(
-                            input_tensor_q,
-                            input_tensor_k,
-                            head_dim_v,
-                            attn_mask,
-                            is_causal,
-                            scale,
-                            memory_config,
-                            program_config,
-                            compute_kernel_config);
-                    },
-                    py::arg("input_tensor_q").noconvert(),
-                    py::arg("input_tensor_k").noconvert(),
-                    py::arg("head_dim_v").noconvert(),
-                    py::kw_only(),
-                    py::arg("attn_mask").noconvert() = std::nullopt,
-                    py::arg("is_causal").noconvert() = true,
-                    py::arg("scale").noconvert() = std::nullopt,
-                    py::arg("memory_config").noconvert() = std::nullopt,
-                    py::arg("program_config").noconvert() = std::nullopt,
-                    py::arg("compute_kernel_config").noconvert() = std::nullopt});
+    using MLAOperationType = decltype(ttnn::transformer::flash_mla_prefill);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::transformer::flash_mla_prefill,
+        mla_doc,
+        ttnn::pybind_overload_t{
+            [](const MLAOperationType& self,
+               const ttnn::Tensor& input_tensor_q,
+               const ttnn::Tensor& input_tensor_k,
+               const uint32_t head_dim_v,
+               std::optional<ttnn::Tensor> attn_mask,
+               bool is_causal,
+               std::optional<float> scale,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<SDPAProgramConfig> program_config,
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+                return self(
+                    input_tensor_q,
+                    input_tensor_k,
+                    head_dim_v,
+                    attn_mask,
+                    is_causal,
+                    scale,
+                    memory_config,
+                    program_config,
+                    compute_kernel_config);
+            },
+            py::arg("input_tensor_q").noconvert(),
+            py::arg("input_tensor_k").noconvert(),
+            py::arg("head_dim_v").noconvert(),
+            py::kw_only(),
+            py::arg("attn_mask").noconvert() = std::nullopt,
+            py::arg("is_causal").noconvert() = true,
+            py::arg("scale").noconvert() = std::nullopt,
+            py::arg("memory_config").noconvert() = std::nullopt,
+            py::arg("program_config").noconvert() = std::nullopt,
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
-            auto chunked_mla_doc =
-                R"doc(
+    auto chunked_mla_doc =
+        R"doc(
         Chunked causal scaled dot product attention for processing long sequences in chunks.
         This variant allows processing of sequences longer than the maximum supported length
         by splitting the input into chunks and maintaining KV cache state.
@@ -424,42 +424,42 @@ void py_bind_sdpa(py::module& module) {
 
         )doc";
 
-            using MLAChunkedOperationType = decltype(ttnn::transformer::chunked_flash_mla_prefill);
-            ttnn::bind_registered_operation(
-                module,
-                ttnn::transformer::chunked_flash_mla_prefill,
-                chunked_mla_doc,
-                ttnn::pybind_overload_t{
-                    [](const MLAChunkedOperationType& self,
-                       const ttnn::Tensor& input_tensor_q,
-                       const ttnn::Tensor& input_tensor_k,
-                       const uint32_t head_dim_v,
-                       const ttnn::Tensor& page_table_tensor,
-                       int64_t chunk_start_idx,
-                       std::optional<float> scale,
-                       const std::optional<MemoryConfig>& memory_config,
-                       std::optional<SDPAProgramConfig> program_config,
-                       std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-                        return self(
-                            input_tensor_q,
-                            input_tensor_k,
-                            head_dim_v,
-                            page_table_tensor,
-                            chunk_start_idx,
-                            scale,
-                            memory_config,
-                            program_config,
-                            compute_kernel_config);
-                    },
-                    py::arg("input_tensor_q").noconvert(),
-                    py::arg("input_tensor_k").noconvert(),
-                    py::arg("head_dim_v").noconvert(),
-                    py::arg("page_table_tensor").noconvert(),
-                    py::arg("chunk_start_idx"),
-                    py::kw_only(),
-                    py::arg("scale").noconvert() = std::nullopt,
-                    py::arg("memory_config").noconvert() = std::nullopt,
-                    py::arg("program_config").noconvert() = std::nullopt,
-                    py::arg("compute_kernel_config").noconvert() = std::nullopt});
+    using MLAChunkedOperationType = decltype(ttnn::transformer::chunked_flash_mla_prefill);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::transformer::chunked_flash_mla_prefill,
+        chunked_mla_doc,
+        ttnn::pybind_overload_t{
+            [](const MLAChunkedOperationType& self,
+               const ttnn::Tensor& input_tensor_q,
+               const ttnn::Tensor& input_tensor_k,
+               const uint32_t head_dim_v,
+               const ttnn::Tensor& page_table_tensor,
+               int64_t chunk_start_idx,
+               std::optional<float> scale,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<SDPAProgramConfig> program_config,
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+                return self(
+                    input_tensor_q,
+                    input_tensor_k,
+                    head_dim_v,
+                    page_table_tensor,
+                    chunk_start_idx,
+                    scale,
+                    memory_config,
+                    program_config,
+                    compute_kernel_config);
+            },
+            py::arg("input_tensor_q").noconvert(),
+            py::arg("input_tensor_k").noconvert(),
+            py::arg("head_dim_v").noconvert(),
+            py::arg("page_table_tensor").noconvert(),
+            py::arg("chunk_start_idx"),
+            py::kw_only(),
+            py::arg("scale").noconvert() = std::nullopt,
+            py::arg("memory_config").noconvert() = std::nullopt,
+            py::arg("program_config").noconvert() = std::nullopt,
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 }
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
@@ -30,7 +30,6 @@ void py_bind_sdpa(py::module& module) {
             attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
             is_causal (bool): Defaults to `true`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
             scale (float, optional): Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
@@ -56,10 +55,8 @@ void py_bind_sdpa(py::module& module) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     input_tensor_v,
@@ -79,9 +76,7 @@ void py_bind_sdpa(py::module& module) {
             py::arg("scale").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
     auto chunked_doc =
         R"doc(
@@ -102,7 +97,6 @@ void py_bind_sdpa(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: the output tensor [b x nqh x s x dh].
@@ -124,10 +118,8 @@ void py_bind_sdpa(py::module& module) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     input_tensor_v,
@@ -147,9 +139,7 @@ void py_bind_sdpa(py::module& module) {
             py::arg("scale").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
     auto joint_doc = R"doc(
         JointAttention operation that efficiently performs non-causal attention over two
@@ -175,7 +165,6 @@ void py_bind_sdpa(py::module& module) {
             program_config (ttnn.SDPAProgramConfig)
             scale (float, optional): Scale factor for QK^T. Defaults to None.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional):Defaults to None.
-            queue_id (int, optional): Command queue ID. Defaults to 0.
 
         Returns:
             (ttnn.Tensor, ttnn.Tensor):
@@ -200,21 +189,19 @@ void py_bind_sdpa(py::module& module) {
                const std::string& joint_strategy,
                SDPAProgramConfig program_config,
                std::optional<float> scale,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
-                auto outputs = self(
-                    queue_id,
-                    input_tensor_q,
-                    input_tensor_k,
-                    input_tensor_v,
-                    joint_tensor_q,
-                    joint_tensor_k,
-                    joint_tensor_v,
-                    joint_strategy,
-                    program_config,
-                    scale,
-                    compute_kernel_config);
-                return outputs;
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+            auto outputs = self(
+                input_tensor_q,
+                input_tensor_k,
+                input_tensor_v,
+                joint_tensor_q,
+                joint_tensor_k,
+                joint_tensor_v,
+                joint_strategy,
+                program_config,
+                scale,
+                compute_kernel_config);
+            return outputs;
             },
             py::arg("input_tensor_q").noconvert(),
             py::arg("input_tensor_k").noconvert(),
@@ -226,10 +213,9 @@ void py_bind_sdpa(py::module& module) {
             py::arg("joint_strategy"),
             py::arg("program_config").noconvert(),
             py::arg("scale").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("compute_kernel_config").noconvert() = std::nullopt);
 
-    auto ring_joint_doc = R"doc(
+            auto ring_joint_doc = R"doc(
         RingJointAttention operation that efficiently performs non-causal attention over two
         sets of query, key, and value tensors, where the first set is sharded across devices in the sequence dimension.
         Internally, these are concatenated in the sequence dimension (joint_strategy = "rear"),
@@ -266,7 +252,6 @@ void py_bind_sdpa(py::module& module) {
             topology (ttnn.ccl.Topology): Communication topology (Ring or Linear).
             subdevice_id (Optional[tt.tt_metal.SubDeviceId]): Sub-device identifier. Defaults to None.
             ccl_core_grid_offset (ttnn.CoreCoord): Core grid offset for CCL operations.
-            queue_id (int, optional): Command queue ID. Defaults to 0.
 
         Returns:
             (ttnn.Tensor, ttnn.Tensor, ttnn.Tensor):
@@ -275,7 +260,7 @@ void py_bind_sdpa(py::module& module) {
               - The final log-sum-exp of the operation.           [b x nh x (N/num_devices + L) x 1]
         )doc";
 
-    using RingJointOperationType = decltype(ttnn::transformer::ring_joint_scaled_dot_product_attention);
+            using RingJointOperationType = decltype(ttnn::transformer::ring_joint_scaled_dot_product_attention);
 
     ttnn::bind_registered_operation(
         module,
@@ -303,10 +288,8 @@ void py_bind_sdpa(py::module& module) {
                const MeshDevice& mesh_device,
                ttnn::ccl::Topology topology,
                std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-               CoreCoord ccl_core_grid_offset,
-               QueueId queue_id) {
+               CoreCoord ccl_core_grid_offset) {
                 auto outputs = self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     input_tensor_v,
@@ -351,11 +334,10 @@ void py_bind_sdpa(py::module& module) {
             py::arg("mesh_device"),
             py::arg("topology"),
             py::arg("subdevice_id") = std::nullopt,
-            py::arg("ccl_core_grid_offset"),
-            py::arg("queue_id") = DefaultQueueId});
+            py::arg("ccl_core_grid_offset"));
 
-    auto mla_doc =
-        R"doc(
+            auto mla_doc =
+                R"doc(
         Causal MLA attention."
 
         Accepts a `SDPAProgramConfig` which specifies the grid size and chunk tiles in the Q and K sequence lengths. The op parallelizes over `b`, `nqh`, and Q's `s` dimension.
@@ -369,7 +351,6 @@ void py_bind_sdpa(py::module& module) {
             attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
             is_causal (bool): Defaults to `true`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
             scale (float, optional): Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
@@ -380,50 +361,46 @@ void py_bind_sdpa(py::module& module) {
 
         )doc";
 
-    using MLAOperationType = decltype(ttnn::transformer::flash_mla_prefill);
-    ttnn::bind_registered_operation(
-        module,
-        ttnn::transformer::flash_mla_prefill,
-        mla_doc,
-        ttnn::pybind_overload_t{
-            [](const MLAOperationType& self,
-               const ttnn::Tensor& input_tensor_q,
-               const ttnn::Tensor& input_tensor_k,
-               const uint32_t head_dim_v,
-               std::optional<ttnn::Tensor> attn_mask,
-               bool is_causal,
-               std::optional<float> scale,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor_q,
-                    input_tensor_k,
-                    head_dim_v,
-                    attn_mask,
-                    is_causal,
-                    scale,
-                    memory_config,
-                    program_config,
-                    compute_kernel_config);
-            },
-            py::arg("input_tensor_q").noconvert(),
-            py::arg("input_tensor_k").noconvert(),
-            py::arg("head_dim_v").noconvert(),
-            py::kw_only(),
-            py::arg("attn_mask").noconvert() = std::nullopt,
-            py::arg("is_causal").noconvert() = true,
-            py::arg("scale").noconvert() = std::nullopt,
-            py::arg("memory_config").noconvert() = std::nullopt,
-            py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            using MLAOperationType = decltype(ttnn::transformer::flash_mla_prefill);
+            ttnn::bind_registered_operation(
+                module,
+                ttnn::transformer::flash_mla_prefill,
+                mla_doc,
+                ttnn::pybind_overload_t{
+                    [](const MLAOperationType& self,
+                       const ttnn::Tensor& input_tensor_q,
+                       const ttnn::Tensor& input_tensor_k,
+                       const uint32_t head_dim_v,
+                       std::optional<ttnn::Tensor> attn_mask,
+                       bool is_causal,
+                       std::optional<float> scale,
+                       const std::optional<MemoryConfig>& memory_config,
+                       std::optional<SDPAProgramConfig> program_config,
+                       std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+                        return self(
+                            input_tensor_q,
+                            input_tensor_k,
+                            head_dim_v,
+                            attn_mask,
+                            is_causal,
+                            scale,
+                            memory_config,
+                            program_config,
+                            compute_kernel_config);
+                    },
+                    py::arg("input_tensor_q").noconvert(),
+                    py::arg("input_tensor_k").noconvert(),
+                    py::arg("head_dim_v").noconvert(),
+                    py::kw_only(),
+                    py::arg("attn_mask").noconvert() = std::nullopt,
+                    py::arg("is_causal").noconvert() = true,
+                    py::arg("scale").noconvert() = std::nullopt,
+                    py::arg("memory_config").noconvert() = std::nullopt,
+                    py::arg("program_config").noconvert() = std::nullopt,
+                    py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
-    auto chunked_mla_doc =
-        R"doc(
+            auto chunked_mla_doc =
+                R"doc(
         Chunked causal scaled dot product attention for processing long sequences in chunks.
         This variant allows processing of sequences longer than the maximum supported length
         by splitting the input into chunks and maintaining KV cache state.
@@ -441,53 +418,48 @@ void py_bind_sdpa(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: the output tensor [b x nqh x s x dh].
 
         )doc";
 
-    using MLAChunkedOperationType = decltype(ttnn::transformer::chunked_flash_mla_prefill);
-    ttnn::bind_registered_operation(
-        module,
-        ttnn::transformer::chunked_flash_mla_prefill,
-        chunked_mla_doc,
-        ttnn::pybind_overload_t{
-            [](const MLAChunkedOperationType& self,
-               const ttnn::Tensor& input_tensor_q,
-               const ttnn::Tensor& input_tensor_k,
-               const uint32_t head_dim_v,
-               const ttnn::Tensor& page_table_tensor,
-               int64_t chunk_start_idx,
-               std::optional<float> scale,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
-                return self(
-                    queue_id,
-                    input_tensor_q,
-                    input_tensor_k,
-                    head_dim_v,
-                    page_table_tensor,
-                    chunk_start_idx,
-                    scale,
-                    memory_config,
-                    program_config,
-                    compute_kernel_config);
-            },
-            py::arg("input_tensor_q").noconvert(),
-            py::arg("input_tensor_k").noconvert(),
-            py::arg("head_dim_v").noconvert(),
-            py::arg("page_table_tensor").noconvert(),
-            py::arg("chunk_start_idx"),
-            py::kw_only(),
-            py::arg("scale").noconvert() = std::nullopt,
-            py::arg("memory_config").noconvert() = std::nullopt,
-            py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            using MLAChunkedOperationType = decltype(ttnn::transformer::chunked_flash_mla_prefill);
+            ttnn::bind_registered_operation(
+                module,
+                ttnn::transformer::chunked_flash_mla_prefill,
+                chunked_mla_doc,
+                ttnn::pybind_overload_t{
+                    [](const MLAChunkedOperationType& self,
+                       const ttnn::Tensor& input_tensor_q,
+                       const ttnn::Tensor& input_tensor_k,
+                       const uint32_t head_dim_v,
+                       const ttnn::Tensor& page_table_tensor,
+                       int64_t chunk_start_idx,
+                       std::optional<float> scale,
+                       const std::optional<MemoryConfig>& memory_config,
+                       std::optional<SDPAProgramConfig> program_config,
+                       std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+                        return self(
+                            input_tensor_q,
+                            input_tensor_k,
+                            head_dim_v,
+                            page_table_tensor,
+                            chunk_start_idx,
+                            scale,
+                            memory_config,
+                            program_config,
+                            compute_kernel_config);
+                    },
+                    py::arg("input_tensor_q").noconvert(),
+                    py::arg("input_tensor_k").noconvert(),
+                    py::arg("head_dim_v").noconvert(),
+                    py::arg("page_table_tensor").noconvert(),
+                    py::arg("chunk_start_idx"),
+                    py::kw_only(),
+                    py::arg("scale").noconvert() = std::nullopt,
+                    py::arg("memory_config").noconvert() = std::nullopt,
+                    py::arg("program_config").noconvert() = std::nullopt,
+                    py::arg("compute_kernel_config").noconvert() = std::nullopt});
 }
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -81,8 +81,7 @@ ttnn::Tensor ExecuteScaledDotProductAttentionDecode::invoke(
                    .paged_attention = false},
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {cur_pos_tensor, std::nullopt, attn_mask, attention_sink},
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 
@@ -133,8 +132,7 @@ ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
                    .paged_attention = true},
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {cur_pos_tensor, page_table_tensor, attn_mask, attention_sink},
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 
@@ -190,8 +188,7 @@ ttnn::Tensor ExecuteFlashMultiLatentAttentionDecode::invoke(
                    .head_dim_v = head_dim_v},
                {input_tensor_q, input_tensor_k},
                {cur_pos_tensor, std::nullopt, attn_mask, attention_sink},
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 
@@ -244,8 +241,7 @@ ttnn::Tensor ExecutePagedFlashMultiLatentAttentionDecode::invoke(
                    .head_dim_v = head_dim_v},
                {input_tensor_q, input_tensor_k},
                {cur_pos_tensor, page_table_tensor, attn_mask, attention_sink},
-               {},
-               ttnn::DefaultQueueId)
+               {})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -7,7 +7,6 @@
 #include <utility>
 
 #include "device/sdpa_decode_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
 
 using namespace tt::tt_metal;
@@ -33,7 +32,6 @@ inline uint32_t get_chunk_size(uint32_t s) {
 namespace ttnn::operations::transformer {
 
 ttnn::Tensor ExecuteScaledDotProductAttentionDecode::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -84,12 +82,11 @@ ttnn::Tensor ExecuteScaledDotProductAttentionDecode::invoke(
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {cur_pos_tensor, std::nullopt, attn_mask, attention_sink},
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 
 ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -137,12 +134,11 @@ ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {cur_pos_tensor, page_table_tensor, attn_mask, attention_sink},
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 
 ttnn::Tensor ExecuteFlashMultiLatentAttentionDecode::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const uint32_t head_dim_v,
@@ -195,12 +191,11 @@ ttnn::Tensor ExecuteFlashMultiLatentAttentionDecode::invoke(
                {input_tensor_q, input_tensor_k},
                {cur_pos_tensor, std::nullopt, attn_mask, attention_sink},
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 
 ttnn::Tensor ExecutePagedFlashMultiLatentAttentionDecode::invoke(
-    QueueId queue_id,
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const uint32_t head_dim_v,
@@ -250,7 +245,7 @@ ttnn::Tensor ExecutePagedFlashMultiLatentAttentionDecode::invoke(
                {input_tensor_q, input_tensor_k},
                {cur_pos_tensor, page_table_tensor, attn_mask, attention_sink},
                {},
-               queue_id)
+               ttnn::DefaultQueueId)
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -13,7 +13,6 @@ namespace operations::transformer {
 
 struct ExecuteScaledDotProductAttentionDecode {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
@@ -30,7 +29,6 @@ struct ExecuteScaledDotProductAttentionDecode {
 
 struct ExecutePagedScaledDotProductAttentionDecode {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
@@ -47,7 +45,6 @@ struct ExecutePagedScaledDotProductAttentionDecode {
 
 struct ExecuteFlashMultiLatentAttentionDecode {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         uint32_t head_dim_v,
@@ -64,7 +61,6 @@ struct ExecuteFlashMultiLatentAttentionDecode {
 
 struct ExecutePagedFlashMultiLatentAttentionDecode {
     static ttnn::Tensor invoke(
-        QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         uint32_t head_dim_v,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
@@ -33,7 +33,6 @@ void py_bind_sdpa_decode(py::module& module) {
             attn_mask (ttnn.Tensor, optional): the input tensor [b x 1 x s x s]. Defaults to `None`.
             cur_pos (List of int, optional): list of integers of length b. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-            queue_id (int, optional): command queue id. Defaults to `0`.
             cur_pos_tensor (ttnn.Tensor, optional): [b] tensor of integers of length b. Defaults to `None`.
             scale (float, optional): Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
@@ -66,10 +65,8 @@ void py_bind_sdpa_decode(py::module& module) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     input_tensor_v,
@@ -95,9 +92,7 @@ void py_bind_sdpa_decode(py::module& module) {
             py::arg("scale").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
     using PagedOperationType = decltype(ttnn::transformer::paged_scaled_dot_product_attention_decode);
     ttnn::bind_registered_operation(
@@ -117,10 +112,8 @@ void py_bind_sdpa_decode(py::module& module) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     input_tensor_v,
@@ -146,9 +139,7 @@ void py_bind_sdpa_decode(py::module& module) {
             py::arg("scale").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
     using MLAOperationType = decltype(ttnn::transformer::flash_multi_latent_attention_decode);
     ttnn::bind_registered_operation(
@@ -168,10 +159,8 @@ void py_bind_sdpa_decode(py::module& module) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     head_dim_v,
@@ -197,9 +186,7 @@ void py_bind_sdpa_decode(py::module& module) {
             py::arg("scale").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 
     using PagedMLAOperationType = decltype(ttnn::transformer::paged_flash_multi_latent_attention_decode);
     ttnn::bind_registered_operation(
@@ -219,10 +206,8 @@ void py_bind_sdpa_decode(py::module& module) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-               QueueId queue_id) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
                 return self(
-                    queue_id,
                     input_tensor_q,
                     input_tensor_k,
                     head_dim_v,
@@ -248,8 +233,6 @@ void py_bind_sdpa_decode(py::module& module) {
             py::arg("scale").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId,
-        });
+            py::arg("compute_kernel_config").noconvert() = std::nullopt});
 }
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads_pybind.cpp
@@ -19,7 +19,6 @@ void py_bind_split_query_key_value_and_split_heads(pybind11::module& module) {
         module,
         ttnn::transformer::split_query_key_value_and_split_heads,
         R"doc(
-
             Splits :attr:`input_tensor` of shape ``[batch_size, sequence_size, 3 * hidden_size]`` into 3 tensors (Query, Key, Value) of shape ``[batch_size, sequence_size, hidden_size]``.
             Then, reshapes and permutes the output tensors, to make them ready for computing attention scores.
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Half of the ops don't have QueueId argument.
Half of the rest don't actually pass queue_id to runtime.
Many don't fully propagate this argument through composites.
This feature is a mess.

### What's changed
Now its gone.
This PR works in concert with
https://github.com/tenstorrent/tt-metal/pull/27558