### PR TITLE
handle empty tensor in row major layout

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -58,6 +58,11 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (output.physical_volume() == 0) {
+        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
+    }
+
     CoreRange core({0, 0}, {0, 0});
 
     // This should allocate a DRAM buffer on the device
@@ -234,6 +239,11 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
 operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interleaved(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (output.physical_volume() == 0) {
+        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
+    }
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
@@ -505,6 +515,11 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (output.physical_volume() == 0) {
+        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
+    }
+
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -700,6 +715,11 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
 operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (output.physical_volume() == 0) {
+        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
+    }
 
     bool src_sharded = a.memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -58,11 +58,6 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
-    // Handle empty tensors - no tiling needed for tensors with no data
-    if (output.physical_volume() == 0) {
-        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
-    }
-
     CoreRange core({0, 0}, {0, 0});
 
     // This should allocate a DRAM buffer on the device
@@ -239,11 +234,6 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
 operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interleaved(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
-    // Handle empty tensors - no tiling needed for tensors with no data
-    if (output.physical_volume() == 0) {
-        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
-    }
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
@@ -515,11 +505,6 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
-    // Handle empty tensors - no tiling needed for tensors with no data
-    if (output.physical_volume() == 0) {
-        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
-    }
-
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -715,11 +700,6 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
 operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
-    // Handle empty tensors - no tiling needed for tensors with no data
-    if (output.physical_volume() == 0) {
-        return {.program = std::move(program), .override_runtime_arguments_callback = std::nullopt};
-    }
 
     bool src_sharded = a.memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -60,6 +60,18 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore) {
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (input_tensor.physical_volume() == 0) {
+        // Create output tensor with same properties
+        TensorSpec spec(
+            output_padded_shape,
+            TensorLayout(
+                output_dtype.value_or(input_tensor.dtype()),
+                PageConfig(Layout::TILE),
+                memory_config.value_or(input_tensor.memory_config())));
+        return allocate_tensor_on_device(spec, input_tensor.device());
+    }
+
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
     uint32_t output_single_tile_size =
@@ -102,6 +114,18 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore) {
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (input_tensor.physical_volume() == 0) {
+        // Create output tensor with same properties
+        TensorSpec spec(
+            ttnn::Shape{output_padded_shape},
+            TensorLayout(
+                output_dtype.value_or(input_tensor.dtype()),
+                PageConfig(Layout::TILE),
+                memory_config.value_or(input_tensor.memory_config())));
+        return allocate_tensor_on_device(spec, input_tensor.device());
+    }
+
     return invoke(
         queue_id,
         input_tensor,
@@ -126,6 +150,18 @@ ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
 
     padded_shape[-2] = tt::round_up(padded_shape[-2], input_tile_height);
     padded_shape[-1] = tt::round_up(padded_shape[-1], input_tile_width);
+
+    // Handle empty tensors - no tiling needed for tensors with no data
+    if (input_tensor.physical_volume() == 0) {
+        // Create output tensor with same properties
+        TensorSpec spec(
+            padded_shape,
+            TensorLayout(
+                output_dtype.value_or(input_tensor.dtype()),
+                PageConfig(Layout::TILE),
+                memory_config.value_or(input_tensor.memory_config())));
+        return allocate_tensor_on_device(spec, input_tensor.device());
+    }
 
     PadValue pad_value;
     if (input_tensor.dtype() == DataType::BFLOAT16 or input_tensor.dtype() == DataType::FLOAT32) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27554

### Problem description
empty tensors will throw div by 0 segmentation fault when using RM layout

### What's changed
Add a check that will return the program without any operations

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes