### PR TITLE
[POOL] Output channels padded calculation inconsistency fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -91,9 +91,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     uint32_t out_c_padded = tt::round_up(out_c, tt::constants::TILE_WIDTH / 2);
     if (mem_config.is_sharded()) {
         if (layout == TensorMemoryLayout::WIDTH_SHARDED || layout == TensorMemoryLayout::BLOCK_SHARDED) {
-            out_c_padded =
-                tt::round_up(tt::div_up(out_c, sliding_window_config.num_cores_c), tt::constants::TILE_WIDTH / 2) *
-                sliding_window_config.num_cores_c;
+            out_c_padded = tt::round_up(out_c, sliding_window_config.num_cores_c * tt::constants::TILE_WIDTH / 2);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -88,11 +88,12 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     auto layout = mem_config.memory_layout();
 
     uint32_t out_nhw_padded = tt::round_up(out_nhw, tile_rows * num_cores_nhw);
-    uint32_t out_c_padded = tt::round_up(out_c, 16);
+    uint32_t out_c_padded = tt::round_up(out_c, tt::constants::TILE_WIDTH / 2);
     if (mem_config.is_sharded()) {
         if (layout == TensorMemoryLayout::WIDTH_SHARDED || layout == TensorMemoryLayout::BLOCK_SHARDED) {
             out_c_padded =
-                tt::round_up(out_c / sliding_window_config.num_cores_c, 16) * sliding_window_config.num_cores_c;
+                tt::round_up(tt::div_up(out_c, sliding_window_config.num_cores_c), tt::constants::TILE_WIDTH / 2) *
+                sliding_window_config.num_cores_c;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -5,6 +5,7 @@
 #include "generic_pools.hpp"
 
 #include "tt-metalium/constants.hpp"
+#include <cmath>
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -170,7 +171,7 @@ static Tensor pool2d_invoke(
     uint32_t output_c = channels;
     uint32_t output_c_padded = tt::round_up(output_c, tt::constants::TILE_WIDTH / 2);
     if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED || shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        output_c_padded = tt::round_up(output_c / num_cores_c, 16) * num_cores_c;
+        output_c_padded = tt::round_up(tt::div_up(output_c, num_cores_c), tt::constants::TILE_WIDTH / 2) * num_cores_c;
     }
     uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -169,6 +169,9 @@ static Tensor pool2d_invoke(
     uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
     uint32_t output_c = channels;
     uint32_t output_c_padded = tt::round_up(output_c, tt::constants::TILE_WIDTH / 2);
+    if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED || shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        output_c_padded = tt::round_up(output_c / num_cores_c, 16) * num_cores_c;
+    }
     uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -171,7 +171,7 @@ static Tensor pool2d_invoke(
     uint32_t output_c = channels;
     uint32_t output_c_padded = tt::round_up(output_c, tt::constants::TILE_WIDTH / 2);
     if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED || shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        output_c_padded = tt::round_up(tt::div_up(output_c, num_cores_c), tt::constants::TILE_WIDTH / 2) * num_cores_c;
+        output_c_padded = tt::round_up(output_c, num_cores_c * tt::constants::TILE_WIDTH / 2);
     }
     uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(


### PR DESCRIPTION
### Ticket
There is no specific issue regarding this so it hasn't manifested as a bug

### Problem description
Calculation for the output padded channels should match in invoke function and compute output specs function. This change ensures that.

### What's changed
Correcting the rounding of the output padded channels when number of shards across channels dimension is greater than 1

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17238349417)
- [x] [Blackhole nightly ](https://github.com/tenstorrent/tt-metal/actions/runs/17238368868)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17238403018)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17238356483)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17238362790)
