### PR TITLE
removing variables from tests/tt_metal

### DIFF
--- a/tests/tt_metal/test_utils/print_helpers.hpp
+++ b/tests/tt_metal/test_utils/print_helpers.hpp
@@ -12,7 +12,6 @@ namespace test_utils {
 /// @param const std::vector<T>& vec
 template <typename T>
 void print_vector(const std::vector<T>& vec) {
-    int idx = 0;
     for (int i = 0; i < vec.size(); i++) {
         std::cout << vec.at(i) << ", ";
     }
@@ -23,7 +22,6 @@ void print_vector(const std::vector<T>& vec) {
 /// @param const std::vector<T>& vec
 template <typename T>
 void print_vector_fixed_numel_per_row(const std::vector<T>& vec, const unsigned int numel_per_row) {
-    int idx = 0;
     for (int i = 0; i < vec.size(); i++) {
         if ((i % numel_per_row) == 0) {
             std::cout << std::endl;

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -323,7 +323,6 @@ static Correctness run_output_check(
     const std::vector<uint32_t>& all_zeros,
     const std::vector<uint32_t>& inputs,
     std::shared_ptr<Buffer>& output_buffer) {
-    constexpr bool debug_mode = true;
     std::vector<uint32_t> readback_data_vec(all_zeros.size(), 0);  // init to 0 data for easier debug
 
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
@@ -490,11 +489,11 @@ static void generate_fabric_test_kernels(
     std::vector<uint32_t> sender_worker_reader_runtime_args{dram_input_buffer_base_addr};
 
     log_trace(tt::LogTest, "\tSenderReader CT Args");
-    for (const auto& arg : sender_worker_reader_compile_args) {
+    for ([[maybe_unused]] const auto& arg : sender_worker_reader_compile_args) {
         log_trace(tt::LogTest, "\t\t{}", arg);
     }
     log_trace(tt::LogTest, "\tSenderReader RT Args");
-    for (const auto& arg : sender_worker_reader_runtime_args) {
+    for ([[maybe_unused]] const auto& arg : sender_worker_reader_runtime_args) {
         log_trace(tt::LogTest, "\t\t{}", arg);
     }
 
@@ -524,11 +523,11 @@ static void generate_fabric_test_kernels(
 
     uint32_t src0_cb_index = CBIndex::c_0;
     log_trace(tt::LogTest, "\tSenderWriter CT Args");
-    for (const auto& arg : sender_worker_writer_compile_args) {
+    for ([[maybe_unused]] const auto& arg : sender_worker_writer_compile_args) {
         log_trace(tt::LogTest, "\t\t{}", arg);
     }
     log_trace(tt::LogTest, "\tSenderWriter RT Args");
-    for (const auto& arg : sender_worker_writer_runtime_args) {
+    for ([[maybe_unused]] const auto& arg : sender_worker_writer_runtime_args) {
         log_trace(tt::LogTest, "\t\t{}", arg);
     }
 
@@ -539,7 +538,7 @@ static void generate_fabric_test_kernels(
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(2 * num_pages_per_edm_buffer * page_size, {{src0_cb_index, df}})
             .set_page_size(src0_cb_index, page_size);
-    CBHandle sender_workers_cb = CreateCircularBuffer(sender_program, worker_core, cb_src0_config);
+    CreateCircularBuffer(sender_program, worker_core, cb_src0_config);
     auto sender_worker_reader_kernel = tt_metal::CreateKernel(
         sender_program,
         "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_erisc_datamover_sender_worker_reader.cpp",
@@ -875,7 +874,6 @@ static int TestLoopbackEntrypoint(
     std::vector<Program> programs(2);
 
     IDevice* sender_device = device_0;
-    IDevice* receiver_device = device_1;
 
     log_info(tt::LogTest, "{} programs ", programs.size());
     bool success = false;
@@ -1442,7 +1440,6 @@ void Run1DFabricPacketSendTest(
     bool use_t3k = num_devices == 8;
     bool use_galaxy = num_devices == 32;
     bool use_tg = use_galaxy && tt::tt_metal::GetNumPCIeDevices() == 4;
-    bool is_6u_galaxy = use_galaxy && tt::tt_metal::GetNumPCIeDevices() == 32;
     if (num_devices < 4) {
         log_info(tt::LogTest, "This test can only be run on T3000 devices");
         return;
@@ -1473,10 +1470,6 @@ void Run1DFabricPacketSendTest(
         case FabricTestMode::FullRing:
         case FabricTestMode::RingAsLinear: topology = tt::tt_fabric::Topology::Ring; break;
     }
-
-    const auto edm_buffer_config = get_edm_buffer_config_helper(fabric_mode, line_size);
-
-    auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
 
     // static constexpr size_t source_l1_buffer_address = 1000000;
     static constexpr uint32_t source_payload_cb_index = tt::CB::c_in1;
@@ -1605,7 +1598,7 @@ void Run1DFabricPacketSendTest(
             tt_metal::CircularBufferConfig cb_src1_config =
                 tt_metal::CircularBufferConfig(max_packet_payload_size_bytes, {{source_payload_cb_index, cb_df}})
                     .set_page_size(source_payload_cb_index, max_packet_payload_size_bytes);
-            CBHandle sender_workers_payload_cb = CreateCircularBuffer(program, worker_cores, cb_src1_config);
+            CreateCircularBuffer(program, worker_cores, cb_src1_config);
 
             std::vector<uint32_t> worker_ct_args = {params.line_sync, params.line_sync};
 
@@ -1628,9 +1621,6 @@ void Run1DFabricPacketSendTest(
                     .noc = tt_metal::NOC::NOC_0,
                     .compile_args = worker_ct_args});
             worker_kernel_ids.push_back(worker_kernel_id);
-            auto device_fabric_node_id =
-                tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(
-                    device->id());
             auto build_connection_args =
                 [device, &program](
                     CoreCoord& worker_core,
@@ -1669,8 +1659,6 @@ void Run1DFabricPacketSendTest(
 
             for (size_t l = 0; l < params.num_links; l++) {
                 auto worker_core = worker_cores_vec[l];
-                const size_t dest_noc_x = device->worker_core_from_logical_core(dest_core_coord[l]).x;
-                const size_t dest_noc_y = device->worker_core_from_logical_core(dest_core_coord[l]).y;
 
                 // RT ARGS
                 bool disable_sends_for_worker =
@@ -1868,7 +1856,6 @@ static void validate_fabric_packet_send_test_params(const FullMeshTestParams& fu
 static void validate_fabric_packet_send_test_params(
     const std::variant<WriteThroughputStabilityTestWithPersistentFabricParams, FullMeshTestParams>& params) {
     if (std::holds_alternative<WriteThroughputStabilityTestWithPersistentFabricParams>(params)) {
-        const auto& write_throughput_params = std::get<WriteThroughputStabilityTestWithPersistentFabricParams>(params);
         TT_THROW("Not commonized yet");
     } else {
         const auto& full_mesh_params = std::get<FullMeshTestParams>(params);
@@ -2205,7 +2192,6 @@ void Run1DFullMeshFabricPacketSendTest(
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_firmware_context_switch_interval) {
     log_info(tt::LogTest, "Running 1D Full Mesh Fabric Packet Send Test");
 
-    static constexpr bool enable_persistent_fabric_mode = true;
     static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
     constexpr size_t MAX_NUM_AXES = FullMeshTestParams::MAX_NUM_AXES;
 
@@ -2228,7 +2214,6 @@ void Run1DFullMeshFabricPacketSendTest(
 
     const bool use_galaxy = num_devices == 32;
     const bool use_tg = use_galaxy && tt::tt_metal::GetNumPCIeDevices() == 4;
-    const bool is_6u_galaxy = use_galaxy && tt::tt_metal::GetNumPCIeDevices() == 32;
 
     create_fabric_fixture<FABRIC_DEVICE_FIXTURE>(test_fixture_, use_galaxy);
     auto &mesh_device = *(test_fixture_->mesh_device_);
@@ -2304,17 +2289,11 @@ void Run1DFullMeshFabricPacketSendTest(
     for (size_t axis = 0; axis < MAX_NUM_AXES; axis++) {
         const uint32_t source_payload_cb_index = axis == 0 ? tt::CB::c_in1 : tt::CB::c_in3;
         auto line_size = params.line_size[axis];
-        auto fabric_mode = fabric_modes[axis];
-        auto topology = topologies[axis];
         auto& dest_core_coord = dest_core_coord_per_axis[axis];
         auto num_devices_with_workers = params.num_devices_with_workers[axis];
         if (num_devices_with_workers == 0) {
             num_devices_with_workers = line_size;
         }
-        auto num_links = params.num_links[axis];
-        auto first_link_offset = params.first_link_offset[axis];
-        auto num_op_invocations = params.num_op_invocations;
-        auto senders_are_unidirectional = params.senders_are_unidirectional[axis];
         size_t num_messages = (test_specs.num_messages * line_size) / max_line_size;
 
         for (size_t fabric_index = 0; fabric_index < fabrics_under_test_devices_per_axis[axis].size(); fabric_index++) {
@@ -2338,8 +2317,7 @@ void Run1DFullMeshFabricPacketSendTest(
                 tt_metal::CircularBufferConfig cb_src1_config =
                     tt_metal::CircularBufferConfig(max_packet_payload_size_bytes, {{source_payload_cb_index, cb_df}})
                         .set_page_size(source_payload_cb_index, max_packet_payload_size_bytes);
-                CBHandle sender_workers_payload_cb =
-                    CreateCircularBuffer(program, worker_cores_per_axis[axis], cb_src1_config);
+                CreateCircularBuffer(program, worker_cores_per_axis[axis], cb_src1_config);
 
                 auto worker_kernel_id = tt_metal::CreateKernel(
                     program,
@@ -2430,13 +2408,13 @@ static size_t get_number_of_links_for_ring_deadlock_stability_test(
         if (cluster_type == ClusterType::GALAXY) {
             for (size_t i = 0; i < mesh_device.shape()[0]; i++) {
                 size_t cluster_axis = 1;
-                auto nl =
+                [[maybe_unused]] auto nl =
                     tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, cluster_axis, i);
                 log_debug(tt::LogTest, "Number of links for Galaxy cluster_axis 0, row {}: {}", i, nl);
             }
             for (size_t i = 0; i < mesh_device.shape()[1]; i++) {
                 size_t cluster_axis = 0;
-                auto nl =
+                [[maybe_unused]] auto nl =
                     tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, cluster_axis, i);
                 log_debug(tt::LogTest, "Number of links for Galaxy cluster_axis 1, row {}: {}", i, nl);
             }
@@ -2511,8 +2489,6 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     bool has_backward_connection,
     size_t packet_payload_size_bytes = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
     std::optional<size_t> row_or_col = std::nullopt) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     switch (cluster_type) {
         case ClusterType::T3K:
@@ -2530,8 +2506,6 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
         default: log_debug(tt::LogTest, "This test can only be run on T3000 or Galaxy devices"); return;
     }
 
-    auto topology = tt::tt_fabric::Topology::Ring;
-    constexpr size_t num_unicasts = 0;
     size_t line_size = num_devices;
     size_t num_devices_with_workers = line_size;
     constexpr bool line_sync = false;
@@ -2616,7 +2590,6 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     uint32_t num_dirs = (uint32_t)has_forward_connection + (uint32_t)has_backward_connection;
     log_debug(tt::LogTest, "Initializing worker programs");
     for (size_t i = 0; i < num_devices_with_workers; i++) {
-        const size_t line_index = i;
         auto& program = programs[i];
         auto* device = devices[i];
         const size_t sync_core_noc_x = device->worker_core_from_logical_core(sync_core_coord).x;
@@ -2638,7 +2611,7 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
         tt_metal::CircularBufferConfig cb_src1_config =
             tt_metal::CircularBufferConfig(packet_payload_size_bytes, {{source_payload_cb_index, cb_df}})
                 .set_page_size(source_payload_cb_index, packet_payload_size_bytes);
-        CBHandle sender_workers_payload_cb = CreateCircularBuffer(program, worker_cores, cb_src1_config);
+        CreateCircularBuffer(program, worker_cores, cb_src1_config);
 
         std::vector<uint32_t> worker_ct_args = {line_sync, line_sync};
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -58,7 +58,6 @@ WorkerMemMap generate_worker_mem_map(tt_metal::IDevice* device, Topology topolog
     constexpr uint32_t PACKET_HEADER_RESERVED_BYTES = 45056;
     constexpr uint32_t DATA_SPACE_RESERVED_BYTES = 851968;
     constexpr uint32_t TEST_RESULTS_SIZE_BYTES = 128;
-    uint32_t NOTIFICATION_MAILBOX_ADDR_SIZE_BYTES = tt::tt_metal::hal::get_l1_alignment();
 
     uint32_t base_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     uint32_t source_l1_buffer_address = base_addr + PACKET_HEADER_RESERVED_BYTES;
@@ -213,7 +212,6 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     CoreCoord receiver_logical_core = {1, 0};  // Data will be forwarded to this core on al chips in the mcast group
 
     const auto& fabric_context = control_plane.get_fabric_context();
-    const auto topology = fabric_context.get_fabric_topology();
     const auto& edm_config = fabric_context.get_fabric_router_config();
     uint32_t is_2d_fabric = edm_config.topology == Topology::Mesh;
 
@@ -225,7 +223,6 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
         mcast_group_devices.push_back(DevicePool::instance().get_active_device(id));
     }
 
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core = mcast_start_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
@@ -363,8 +360,6 @@ void RunTestUnicastRaw(
 
     FabricNodeId src_fabric_node_id(MeshId{0}, 0);
     FabricNodeId dst_fabric_node_id(MeshId{0}, 0);
-    chip_id_t not_used_1;
-    chip_id_t not_used_2;
     // Find a device num_hops away in specified direction.
     std::unordered_map<RoutingDirection, uint32_t> fabric_hops;
     std::unordered_map<RoutingDirection, std::vector<FabricNodeId>> end_fabric_node_ids_by_dir;
@@ -403,7 +398,6 @@ void RunTestUnicastRaw(
         }
     } else {
         const auto& devices = fixture->get_devices();
-        auto num_devices = devices.size();
         // create a list of available deive ids in a random order
         // In 2D routing the source and desitnation devices can be anywhere on the mesh.
         auto random_dev_list = get_random_numbers_from_range(0, devices.size() - 1, devices.size());
@@ -444,7 +438,6 @@ void RunTestUnicastRaw(
 
     auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
@@ -578,7 +571,6 @@ void run_unicast_test_bw_chips(
 
     auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
@@ -873,12 +865,10 @@ void RunTestMCastConnAPI(
 
     auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
     auto* left_recv_device = DevicePool::instance().get_active_device(left_recv_phys_chip_id);
-    auto* right_recv_device = DevicePool::instance().get_active_device(right_recv_phys_chip_id);
 
     auto left_fabric_node_id = end_fabric_node_ids_by_dir[fwd_dir][fwd_hops - 1];
     auto right_fabric_node_id = end_fabric_node_ids_by_dir[bwd_dir][bwd_hops - 1];
 
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
@@ -1325,7 +1315,6 @@ void RunTest2DMCastConnAPI(
     auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
     auto* dst_recv_device = DevicePool::instance().get_active_device(dst_recv_phys_chip_id);
 
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core = dst_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
@@ -1673,7 +1662,6 @@ void RunTestChipMCast1D(
 
     tt::tt_metal::distributed::MeshShape mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
     auto last_recv_phys_chip_id = physical_end_device_ids_by_dir[dir][range - 1];
-    auto first_recv_phys_chip_id = physical_end_device_ids_by_dir[dir][0];
 
     auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
     auto* last_recv_device = DevicePool::instance().get_active_device(last_recv_phys_chip_id);
@@ -1681,7 +1669,6 @@ void RunTestChipMCast1D(
     auto first_recv_fabric_node_id = end_fabric_node_ids_by_dir[dir][0];
     auto last_recv_fabric_node_id = end_fabric_node_ids_by_dir[dir][range - 1];
 
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core =
         last_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
@@ -1880,10 +1867,6 @@ void RunEDMConnectionStressTest(
     auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     log_debug(tt::LogTest, "Control plane found");
 
-    std::pair<MeshId, chip_id_t> src_mesh_chip_id;
-    std::pair<MeshId, chip_id_t> dst_mesh_chip_id;
-    chip_id_t not_used_1;
-    chip_id_t not_used_2;
     // use control plane to find a mesh with 3 devices
     auto user_meshes = control_plane.get_user_physical_mesh_ids();
     std::optional<MeshId> mesh_id;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -130,7 +130,6 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         auto* src_device = devices[src_idx];
         auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_device->id());
-        uint32_t src_fabric_chip_id = src_fabric_node_id.chip_id;
 
         std::vector<uint32_t> result_data;
         tt::tt_metal::detail::ReadFromBuffer(result_buffers[src_idx], result_data);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -50,7 +50,6 @@ WorkerMemMap generate_worker_mem_map(tt_metal::IDevice* device, Topology topolog
     constexpr uint32_t PACKET_HEADER_RESERVED_BYTES = 45056;
     constexpr uint32_t DATA_SPACE_RESERVED_BYTES = 851968;
     constexpr uint32_t TEST_RESULTS_SIZE_BYTES = 128;
-    uint32_t NOTIFICATION_MAILBOX_ADDR_SIZE_BYTES = tt::tt_metal::hal::get_l1_alignment();
 
     uint32_t base_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     uint32_t source_l1_buffer_address = base_addr + PACKET_HEADER_RESERVED_BYTES;
@@ -91,7 +90,6 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
     auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
 
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
     CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     // Get fabric context and topology

--- a/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
@@ -50,7 +50,6 @@ TEST(IntermeshAPIs, BasicQueries) {
 }
 
 TEST(IntermeshAPIs, ConsistencyChecks) {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Get all links via get_all_intermesh_eth_links

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -471,8 +471,6 @@ void run_test(
         set_worker_runtime_args(test_resources, local_sender_worker_kernels, remote_sender_worker_kernels, config);
     }
 
-    auto start_time = std::chrono::high_resolution_clock::now();
-
     log_info(tt::LogAlways, "Launching programs");
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
         std::thread th2 = std::thread([&] {
@@ -493,9 +491,6 @@ void run_test(
         tt_metal::Finish(test_resources.local_device.device->command_queue());
         tt_metal::Finish(test_resources.remote_device.device->command_queue());
     }
-
-    auto end_time = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
 
     //
     // Timing Stats Readback

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -43,10 +43,8 @@ constexpr size_t data_buffer_size = cb_n_pages * cb_n_pages;
 
 std::vector<std::shared_ptr<Buffer>> create_output_buffers(
     distributed::MeshWorkload& workload, std::shared_ptr<distributed::MeshDevice> mesh_device) {
-    auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto& program = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 
     std::vector<std::shared_ptr<Buffer>> output_buffers;
@@ -92,7 +90,6 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferNonBlockingAPIs) {
         Program program;
         distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
         auto& program_ = workload.get_programs().at(device_range);
-        auto device = mesh_device->get_devices()[0];
 
         const auto master_semaphore = CreateSemaphore(program_, worker_core, 0, CoreType::WORKER);
         const auto subordinate_semaphore = CreateSemaphore(program_, worker_core, 0, CoreType::WORKER);

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -284,7 +284,6 @@ TEST_F(MeshDeviceFixture, TensixIncrementStreamRegWrite) {
         tt_metal::Program program = tt_metal::CreateProgram();
         distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
         auto& program_ = workload.get_programs().at(device_range);
-        auto device = mesh_device->get_devices()[0];
 
         CoreCoord logical_grid_size = mesh_device->compute_with_storage_grid_size();
         CoreCoord end_core{logical_grid_size.x - 1, logical_grid_size.y - 1};

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -513,7 +513,6 @@ TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsVaryingLengthPerCore) {
 TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
-        auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         CoreRange first_core_range(CoreCoord(1, 1), CoreCoord(2, 2));

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -172,7 +172,6 @@ TEST_F(MeshDeviceFixture, TensixInitializeIllegalSemaphores) {
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = tt_metal::CreateProgram();
         distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
-        auto& program_ = workload.get_programs().at(device_range);
         CoreRange core_range({0, 0}, {1, 1});
         unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(
             devices_.at(id), workload, core_range);

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -352,8 +352,6 @@ void custom_test(
     uint32_t num_of_transactions_per_subordinate,
     uint32_t pages_per_transaction,
     uint32_t num_virtual_channels) {
-    NOC noc_id = NOC::NOC_1;
-
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
         unit_tests::dm::compute_physical_constraints(mesh_device);

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -359,7 +359,6 @@ void custom_test(
     uint32_t pages_per_transaction,
     uint32_t num_virtual_channels) {
     auto device = mesh_device->get_device(0);
-    NOC noc_id = NOC::NOC_0;
 
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -178,7 +178,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackDirectedIdeal) {
     auto mesh_device = get_mesh_device();
-    auto device = mesh_device->get_device(0);
 
     uint32_t test_id = 55;
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -143,7 +143,6 @@ void directed_ideal_test(
     CoreCoord master_core_coord,
     CoreCoord subordinate_core_coord,
     NOC noc_id = NOC::RISCV_1_default) {
-    IDevice* device = mesh_device->get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -49,7 +49,7 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
     virtual_core = device->ethernet_core_from_logical_core(logical_core);
     log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
 
-    auto eth_link_kernel = CreateKernel(
+    CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/watcher_eth_link_check.cpp",
         logical_core,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -2351,29 +2351,6 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestSimplePrograms) {
     Finish(device_->mesh_command_queue());
 }
 
-TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestSimplePrograms) {
-    for (const auto& device : device_->get_devices()) {
-        if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
-        }
-    }
-
-    for (uint32_t i = 0; i < NUM_WORKLOADS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        distributed::MeshWorkload workload;
-        Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
-        auto& program_ = workload.get_programs().at(device_range_);
-        this->create_kernel(program_, CoreType::WORKER, true);
-        distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
-    }
-
-    Finish(device_->mesh_command_queue());
-}
-
 TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
@@ -2406,22 +2383,6 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
     Finish(device_->mesh_command_queue());
 }
 
-TEST_F(UnitMeshRandomProgramFixture, TensixTestPrograms) {
-    for (uint32_t i = 0; i < NUM_WORKLOADS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        distributed::MeshWorkload workload;
-        Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
-        auto& program_ = workload.get_programs().at(device_range_);
-        this->create_kernel(program_, CoreType::WORKER, true);
-        distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
-    }
-
-    Finish(device_->mesh_command_queue());
-}
-
 TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
@@ -2443,7 +2404,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
         kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
-        this->create_kernel(program_, CoreType::WORKER, true);
+        this->create_kernel(program_, CoreType::ETH, true);
         distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
     }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -2351,6 +2351,29 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestSimplePrograms) {
     Finish(device_->mesh_command_queue());
 }
 
+TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestSimplePrograms) {
+    for (const auto& device : device_->get_devices()) {
+        if (!does_device_have_active_eth_cores(device)) {
+            GTEST_SKIP() << "Skipping test because device " << device->id()
+                         << " does not have any active ethernet cores";
+        }
+    }
+
+    for (uint32_t i = 0; i < NUM_WORKLOADS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        distributed::MeshWorkload workload;
+        Program program = CreateProgram();
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        auto& program_ = workload.get_programs().at(device_range_);
+        this->create_kernel(program_, CoreType::WORKER, true);
+        distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
+    }
+
+    Finish(device_->mesh_command_queue());
+}
+
 TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
@@ -2383,6 +2406,22 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
     Finish(device_->mesh_command_queue());
 }
 
+TEST_F(UnitMeshRandomProgramFixture, TensixTestPrograms) {
+    for (uint32_t i = 0; i < NUM_WORKLOADS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        distributed::MeshWorkload workload;
+        Program program = CreateProgram();
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        auto& program_ = workload.get_programs().at(device_range_);
+        this->create_kernel(program_, CoreType::WORKER, true);
+        distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
+    }
+
+    Finish(device_->mesh_command_queue());
+}
+
 TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
@@ -2404,7 +2443,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
         kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
-        this->create_kernel(program_, CoreType::ETH, true);
+        this->create_kernel(program_, CoreType::WORKER, true);
         distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
     }
 

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -339,7 +339,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
     const auto& sender_mesh_device = devices_.at(0);
     const auto& receiver_mesh_device = devices_.at(1);
     const auto sender_device = sender_mesh_device->get_devices()[0];
-    const auto receiver_device = receiver_mesh_device->get_devices()[0];
 
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
@@ -386,7 +385,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
     const auto& sender_mesh_device = devices_.at(1);
     const auto& receiver_mesh_device = devices_.at(0);
     const auto sender_device = sender_mesh_device->get_devices()[0];
-    const auto receiver_device = receiver_mesh_device->get_devices()[0];
 
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -682,7 +682,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
     const auto device_0 = mesh_device_0->get_devices()[0];
-    const auto device_1 = mesh_device_1->get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -796,7 +795,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRepeatedDirectSends) {
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
     const auto device_0 = mesh_device_0->get_devices()[0];
-    const auto device_1 = mesh_device_1->get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -126,7 +126,6 @@ bool single_core_binary(
     Program program = tt::tt_metal::CreateProgram();
     distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
     auto& program_ = workload.get_programs().at(device_range);
-    auto device = mesh_device->get_devices()[0];
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM, .bottom_up = false};

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -69,11 +69,9 @@ void create_CBs_for_fused_matmul(
     uint32_t untilize_mode_reblock_cb = 27;
     uint32_t out0_cb = 16;
 
-    auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
-    auto device = mesh_device->get_devices()[0];
 
     uint32_t single_tile_size = num_bytes_for_df * 1024;
 

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -250,7 +250,6 @@ void run_single_core_unary_broadcast(
     Program program = tt_metal::CreateProgram();
     distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
     auto& program_ = workload.get_programs().at(device_range);
-    const auto device = mesh_device->get_devices()[0];
     CoreCoord core = {0, 0};
 
     constexpr uint32_t num_tiles = 32;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -209,7 +209,7 @@ create_programs(
         tt_metal::CircularBufferConfig(in0_reader_cb_size, {{in0_reader_cb_index, tile_format}})
             .set_page_size(in0_reader_cb_index, single_tile_size)
             .set_globally_allocated_address(*in0_buffer->get_backing_buffer());
-    auto in0_reader_cb = tt_metal::CreateCircularBuffer(receiver_program, l1_receiver_cores, in0_reader_cb_config);
+    tt_metal::CreateCircularBuffer(receiver_program, l1_receiver_cores, in0_reader_cb_config);
 
     // in1 receiver CB
     uint32_t in1_receiver_cb_index = 31;
@@ -229,7 +229,7 @@ create_programs(
         tt_metal::CircularBufferConfig(output_cb_size, {{output_cb_index, tile_format}})
             .set_page_size(output_cb_index, single_tile_size)
             .set_globally_allocated_address(*output_buffer->get_backing_buffer());
-    auto output_cb = tt_metal::CreateCircularBuffer(receiver_program, l1_receiver_cores, output_cb_config);
+    tt_metal::CreateCircularBuffer(receiver_program, l1_receiver_cores, output_cb_config);
 
     // sync CB
     uint32_t sync_cb_index = 2;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -1007,14 +1007,14 @@ tt_metal::Program create_program_single_core(
         tt_metal::CircularBufferConfig(in0_CB_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
             .set_page_size(src0_cb_index, single_tile_size)
             .set_globally_allocated_address(*in0_cb_addr->get_backing_buffer());
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(in1_CB_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
             .set_page_size(src1_cb_index, single_tile_size)
             .set_globally_allocated_address(*in1_cb_addr->get_backing_buffer());
-    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     uint32_t out_cb_index = tt::CBIndex::c_16;
     uint32_t interm0_cb_index = tt::CBIndex::c_24;
@@ -1036,7 +1036,7 @@ tt_metal::Program create_program_single_core(
             tt_metal::CircularBufferConfig(out_CB_size, {{out_cb_index, cb_data_format}})
                 .set_page_size(out_cb_index, single_tile_size)
                 .set_globally_allocated_address(*out_cb_addr->get_backing_buffer());
-        auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
     } else if (packer_l1 and cb_data_format == tt::DataFormat::Bfp8_b) {
         tt_metal::CircularBufferConfig cb_interm_config =
             tt_metal::CircularBufferConfig(out_CB_tiles * 2048, {{interm0_cb_index, tt::DataFormat::Float16_b}})
@@ -1047,7 +1047,7 @@ tt_metal::Program create_program_single_core(
             tt_metal::CircularBufferConfig(out_CB_size, {{out_cb_index, cb_data_format}})
                 .set_page_size(out_cb_index, single_tile_size)
                 .set_globally_allocated_address(*out_cb_addr->get_backing_buffer());
-        auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
     } else {
         std::map<uint8_t, tt::DataFormat> partials_and_out_data_format_spec = {
             {out_cb_index, cb_data_format}, {interm0_cb_index, cb_data_format}};
@@ -1056,7 +1056,7 @@ tt_metal::Program create_program_single_core(
                 .set_page_size(interm0_cb_index, single_tile_size)
                 .set_page_size(out_cb_index, single_tile_size)
                 .set_globally_allocated_address(*out_cb_addr->get_backing_buffer());
-        auto cb_out = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), cb_out_config);
+        tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), cb_out_config);
     }
 
     log_debug(tt::LogTest, "in0_CB_size: {}", in0_CB_tiles * single_tile_size);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1618,9 +1618,6 @@ void gen_relay_linear_h_test(
             // Add the CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH with the dispatch command as payload
             add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
 
-            // Now generate the CQ_PREFETCH_CMD_RELAY_LINEAR_H command to fetch data from NOC
-            auto prior_end = prefetch_cmds.size();
-
             // Create the relay linear H command
             CQPrefetchCmd cmd{};
             cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR_H;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -124,8 +124,6 @@ public:
         std::vector<chip_id_t> ids(this->num_devices, 0);
         std::iota(ids.begin(), ids.end(), 0);
 
-        const auto& dispatch_core_config =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         this->devices_map = tt::tt_metal::detail::CreateDevices(ids);
         this->devices = tt::DevicePool::instance().get_all_active_devices();
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
@@ -266,8 +266,6 @@ inline CoreCoord TestDeviceResources::reserve_receiver_core(const std::optional<
 
 inline CoreResources& TestDeviceResources::get_or_create_core_resources(const CoreCoord& core, CoreType core_type) {
     if (core_resources_.find(core) == core_resources_.end()) {
-        CoreAllocationConfig policy = core_pools_[static_cast<size_t>(core_type)].policy;
-
         core_resources_.emplace(
             core,
             CoreResources(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -659,8 +659,6 @@ private:
     }
 
     void trace_traffic_path(const FabricNodeId& src_node_id, const TestTrafficSenderConfig& config) {
-        const auto& hops = config.hops;
-
         // Use proper topology detection from fixture
         if (fixture_->get_topology() == Topology::Ring) {
             // Ring topology - use ring traversal logic with boundary turning
@@ -791,7 +789,7 @@ private:
         log_debug(tt::LogTest, "Performance profiling results:");
         // Results are automatically sorted by device ID and core coordinates
         for (const auto& [device_id, core_cycles] : device_core_cycles_) {
-            for (const auto& [core, cycles] : core_cycles) {
+            for ([[maybe_unused]] const auto& [core, cycles] : core_cycles) {
                 log_debug(tt::LogTest, "Device {} Core ({},{}) Cycles: {}", device_id.chip_id, core.x, core.y, cycles);
             }
         }

--- a/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
@@ -39,7 +39,7 @@ bool runTest(
 
     auto program(tt::tt_metal::CreateProgram());
     distributed::MeshWorkload workload = distributed::CreateMeshWorkload();
-    auto kernel = CreateKernel(
+    CreateKernel(
         program,
         path,
         coord,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23444

### Problem description
unused variables can cause compiler warnings

### What's changed
deleted unused variables

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17297640119
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes