### PR TITLE
[deepseek] Add support for 5 layers, pcc=0.99

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -103,3 +103,11 @@ def set_deterministic_env():
     """
     torch.manual_seed(5)
     torch.use_deterministic_algorithms(True)
+
+
+@pytest.fixture(scope="session")
+def deepseek_cache_path():
+    """
+    Fixture to set the cache path for DeepSeek tests.
+    """
+    return Path(os.getenv("DEEPSEEK_V3_CACHE", "/proj_sw/user_dev/deepseek-v3-cache"))

--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -1057,6 +1057,7 @@ class DeepseekV3DecoderLayer(nn.Module):
         )
         self.input_layernorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        print
 
     def forward(
         self,

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -102,6 +102,7 @@ def test_forward_pass(
     deepseek_cache_path,
 ):
     tensor_cache_path = deepseek_cache_path / "ttnn_tensors_cache"
+    mesh_device.disable_and_clear_program_cache()
     mesh_shape = list(mesh_device.shape)
     num_rows, sdpa_dp_factor = mesh_shape
 

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -49,7 +49,7 @@ def create_whole_model_state_dict(model_path, hf_config):
 @pytest.fixture
 def hf_config(hf_config):
     """Load DeepSeek config for testing."""
-    hf_config.num_hidden_layers = 4
+    hf_config.num_hidden_layers = 9
     hf_config.max_seq_len = 5 * 1024  # Set max sequence length for testing
     return hf_config
 
@@ -85,7 +85,7 @@ def load_reference_model(hf_config):
 )
 @pytest.mark.parametrize(
     "weights_type",
-    ["random", "real"],
+    ["real"],
 )
 def test_forward_pass(
     module_path,
@@ -114,11 +114,13 @@ def test_forward_pass(
     logger.info("Setting up reference model")
     reference_model = load_reference_model(hf_config)
     if weights_type == "random":
+        logger.info("Using random weights")
         state_dict = add_inv_scale_to_state_dict(
             reference_model.to(torch.bfloat16).state_dict(),
             block_shape=hf_config.quantization_config["weight_block_size"],
         )
     else:
+        logger.info("Loading weights from the pretrained model")
         state_dict = create_whole_model_state_dict(model_path, hf_config)
         dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
         reference_model.load_state_dict(dequantized_state_dict)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -170,9 +170,11 @@ def test_forward_pass(
         weight_config = Model1D.convert_weights(hf_config, state_dict, tensor_cache_path, mesh_device)
         with open(weight_config_path, "w") as f:
             json.dump(weight_config, f)
+        logger.info(f"Saved weight config to {weight_config_path}")
     else:
         with open(weight_config_path, "r") as f:
             weight_config = json.load(f)
+        logger.info(f"Loaded weight config from {weight_config_path}")
 
     if mode == "prefill":
         model_config = Model1D.prefill_model_config(hf_config, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -49,7 +49,7 @@ def create_whole_model_state_dict(model_path, hf_config):
 @pytest.fixture
 def hf_config(hf_config):
     """Load DeepSeek config for testing."""
-    hf_config.num_hidden_layers = 9
+    hf_config.num_hidden_layers = 5  # NOTE: remove this for full model
     hf_config.max_seq_len = 5 * 1024  # Set max sequence length for testing
     return hf_config
 
@@ -85,7 +85,7 @@ def load_reference_model(hf_config):
 )
 @pytest.mark.parametrize(
     "weights_type",
-    ["real"],
+    ["random"],
 )
 def test_forward_pass(
     module_path,
@@ -102,7 +102,6 @@ def test_forward_pass(
     deepseek_cache_path,
 ):
     tensor_cache_path = deepseek_cache_path / "ttnn_tensors_cache"
-    mesh_device.disable_and_clear_program_cache()
     mesh_shape = list(mesh_device.shape)
     num_rows, sdpa_dp_factor = mesh_shape
 
@@ -165,8 +164,7 @@ def test_forward_pass(
     ############################
     logger.info("Setting up TTNN configs")
 
-    weight_config_path = tensor_cache_path / "moe_model_weight_config.json"
-    # For now, since we're only loading one layer, we can replicate
+    weight_config_path = tensor_cache_path / f"model_{hf_config.num_hidden_layers}_layers_weight_config.json"
     # save this weight config to json file if it doesn't exist
     if not weight_config_path.exists():
         weight_config = Model1D.convert_weights(hf_config, state_dict, tensor_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -49,7 +49,7 @@ def create_whole_model_state_dict(model_path, hf_config):
 @pytest.fixture
 def hf_config(hf_config):
     """Load DeepSeek config for testing."""
-    hf_config.num_hidden_layers = 3
+    hf_config.num_hidden_layers = 4
     hf_config.max_seq_len = 5 * 1024  # Set max sequence length for testing
     return hf_config
 
@@ -99,7 +99,7 @@ def test_forward_pass(
     ccl,
     reset_seeds,
     weights_type,
-    deepseek_cache_path
+    deepseek_cache_path,
 ):
     tensor_cache_path = deepseek_cache_path / "ttnn_tensors_cache"
     mesh_device.disable_and_clear_program_cache()
@@ -163,7 +163,7 @@ def test_forward_pass(
     ############################
     logger.info("Setting up TTNN configs")
 
-    weight_config_path = tensor_cache_path / "model_weight_config.json"
+    weight_config_path = tensor_cache_path / "moe_model_weight_config.json"
     # For now, since we're only loading one layer, we can replicate
     # save this weight config to json file if it doesn't exist
     if not weight_config_path.exists():

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -33,7 +33,7 @@ from models.tt_transformers.tt.common import PagedAttentionConfig
 class Model1D(SharedStateAddOn, AbstractModule):
     NUM_MLP_META_LAYERS = 1
     NUM_MLP_ROWS = 3
-    NUM_MOE_META_LAYERS = 2
+    NUM_MOE_META_LAYERS = 1  # NOTE: change to 15 for full model
     NUM_MOE_ROWS = 4
 
     @classmethod
@@ -260,9 +260,6 @@ class Model1D(SharedStateAddOn, AbstractModule):
                 )
                 for ml in range(cls.NUM_MOE_META_LAYERS)
             ],
-            "transfer_row": {
-                "semaphore": ccl.get_point_to_point_sem(0),
-            },
             "norm": DistributedRMSNorm.create_state(hf_config, mesh_device, ccl),
             "metalayer_padding_map": metalayer_padding_map,
         }

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -82,13 +82,13 @@ class Model1D(SharedStateAddOn, AbstractModule):
             ),
             "mlp_decoder_block": [
                 DecoderBlock.convert_weights(
-                    hf_config, mlp_decoder_block_state_dicts[ml], output_path / "mlp_decoder_block", mesh_device
+                    hf_config, mlp_decoder_block_state_dicts[ml], output_path / f"mlp_decoder_block_{ml}", mesh_device
                 )
                 for ml in range(cls.NUM_MLP_META_LAYERS)
             ],
             "moe_decoder_block": [
                 MoEDecoderBlock.convert_weights(
-                    hf_config, moe_decoder_block_state_dicts[ml], output_path / "moe_decoder_block", mesh_device
+                    hf_config, moe_decoder_block_state_dicts[ml], output_path / f"moe_decoder_block_{ml}", mesh_device
                 )
                 for ml in range(cls.NUM_MOE_META_LAYERS)
             ],

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -592,7 +592,7 @@ def save_and_get_path(path, tensor):
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         logger.warning(f"Overwriting existing cache file: {path}")
-    ttnn.dump_tensor(path, tensor, enable_multihost_format=True)
+    ttnn.dump_tensor(path, tensor)
     ttnn.deallocate(tensor)
     return str(path)
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -9,7 +9,6 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 
 # Constants
 NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
@@ -593,12 +592,9 @@ def save_and_get_path(path, tensor):
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         logger.warning(f"Overwriting existing cache file: {path}")
-    memory_config = tensor.memory_config()
-    ttnn.dump_tensor(path, tensor)
+    ttnn.dump_tensor(path, tensor, enable_multihost_format=True)
     ttnn.deallocate(tensor)
-    return SavedWeight(
-        path=path, memory_config=memory_config
-    )  # TODO: bring regular tensor saving back once Issue #26763 is resolved
+    return str(path)
 
 
 def get_mesh_coords(mesh_shape: list[int], row: int = None, col: int = None) -> list[ttnn.MeshCoordinate]:

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -131,7 +131,10 @@ def _merge_model_config_state_items(model_config_item: Any, state_item: Any, mb_
 
 def _merge_run_config(model_state_config_item: Any, weight_config_item: Any, _: ttnn.Device | None) -> Any:
     if isinstance(model_state_config_item, FromWeightConfig) and isinstance(weight_config_item, str):
-        return ttnn.load_tensor(weight_config_item, device=model_state_config_item.mesh_device)
+        # Always use multihost format since that's what the test is using
+        return ttnn.load_tensor(
+            weight_config_item, device=model_state_config_item.mesh_device, enable_multihost_format=True
+        )
 
     if weight_config_item is None:
         assert not isinstance(

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -11,15 +11,19 @@ from typing import Any, overload
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, OpConfigBase, SavedWeight
+from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, OpConfigBase
 
 MESH_DEVICE_STATE_DICT_KEY = "mesh_device"
 
+<<<<<<< HEAD
 WeightConfig = (
     dict[str, "WeightConfig | SavedWeight | None"]
     | list["WeightConfig | SavedWeight | None"]
     | tuple["WeightConfig | SavedWeight | None"]  # TODO: bring regular tensor saving back once Issue #26763 is resolved
 )
+=======
+WeightConfig = dict[str, "WeightConfig | str | None"] | list["WeightConfig | str | None"]
+>>>>>>> 97c8faed3a (enable weight caching)
 
 _PRIMITIVE_COPYABLE_TYPES = bool | int | float | complex | str | bytes | None | Enum
 # In general, we require ModelConfig to be serializable (NOTE: mesh device and classes that hold references to the objects on it are NOT serializable).
@@ -126,10 +130,8 @@ def _merge_model_config_state_items(model_config_item: Any, state_item: Any, mb_
 
 
 def _merge_run_config(model_state_config_item: Any, weight_config_item: Any, _: ttnn.Device | None) -> Any:
-    if isinstance(model_state_config_item, FromWeightConfig) and isinstance(
-        weight_config_item, SavedWeight
-    ):  # TODO: bring regular tensor saving back once Issue #26763 is resolved
-        return load_weight(weight_config_item, model_state_config_item.mesh_device)
+    if isinstance(model_state_config_item, FromWeightConfig) and isinstance(weight_config_item, str):
+        return ttnn.load_tensor(weight_config_item, device=model_state_config_item.mesh_device)
 
     if weight_config_item is None:
         assert not isinstance(
@@ -332,6 +334,7 @@ def _convert_run_config_to_pretty_print(run_config_item: Any, indent: int = 0) -
 def is_op_config(obj: Any) -> bool:
     """Check if the object is an op config instance."""
     return issubclass(type(obj), OpConfigBase) and is_dataclass(obj)
+<<<<<<< HEAD
 
 
 def load_weight(saved_weight: SavedWeight, device: ttnn.Device) -> ttnn.Tensor:
@@ -345,3 +348,5 @@ def load_weight(saved_weight: SavedWeight, device: ttnn.Device) -> ttnn.Tensor:
         device=device,
         mem_config=saved_weight.memory_config,
     )
+=======
+>>>>>>> 97c8faed3a (enable weight caching)

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -15,15 +15,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, Me
 
 MESH_DEVICE_STATE_DICT_KEY = "mesh_device"
 
-<<<<<<< HEAD
-WeightConfig = (
-    dict[str, "WeightConfig | SavedWeight | None"]
-    | list["WeightConfig | SavedWeight | None"]
-    | tuple["WeightConfig | SavedWeight | None"]  # TODO: bring regular tensor saving back once Issue #26763 is resolved
-)
-=======
 WeightConfig = dict[str, "WeightConfig | str | None"] | list["WeightConfig | str | None"]
->>>>>>> 97c8faed3a (enable weight caching)
 
 _PRIMITIVE_COPYABLE_TYPES = bool | int | float | complex | str | bytes | None | Enum
 # In general, we require ModelConfig to be serializable (NOTE: mesh device and classes that hold references to the objects on it are NOT serializable).
@@ -132,9 +124,7 @@ def _merge_model_config_state_items(model_config_item: Any, state_item: Any, mb_
 def _merge_run_config(model_state_config_item: Any, weight_config_item: Any, _: ttnn.Device | None) -> Any:
     if isinstance(model_state_config_item, FromWeightConfig) and isinstance(weight_config_item, str):
         # Always use multihost format since that's what the test is using
-        return ttnn.load_tensor(
-            weight_config_item, device=model_state_config_item.mesh_device, enable_multihost_format=True
-        )
+        return ttnn.load_tensor(weight_config_item, device=model_state_config_item.mesh_device)
 
     if weight_config_item is None:
         assert not isinstance(
@@ -337,19 +327,3 @@ def _convert_run_config_to_pretty_print(run_config_item: Any, indent: int = 0) -
 def is_op_config(obj: Any) -> bool:
     """Check if the object is an op config instance."""
     return issubclass(type(obj), OpConfigBase) and is_dataclass(obj)
-<<<<<<< HEAD
-
-
-def load_weight(saved_weight: SavedWeight, device: ttnn.Device) -> ttnn.Tensor:
-    """
-    Load a weight tensor from a SavedWeight object to a given mesh device.
-    """
-
-    return ttnn.load_tensor(
-        saved_weight.path,
-    ).to(
-        device=device,
-        mem_config=saved_weight.memory_config,
-    )
-=======
->>>>>>> 97c8faed3a (enable weight caching)


### PR DESCRIPTION
### Ticket
None

### What's changed
Three MLA+MLP decoder block and one MLA+ two MOE decoder block = Five layers of decoder integrated and working now. This give PCC of 0.99 for Deepseek model

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
